### PR TITLE
fix: npm audit fix to install non-vulnerable packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,9 +760,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.25.1.tgz",
-			"integrity": "sha512-pD8XsvNJNgTNkFngNlM60my/X8dXWPKVzN5RghEQr0NjGZmuCjy49AfFu2cGbZjNf5pBcqd2RCNMW912P5fkhA==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.26.0.tgz",
+			"integrity": "sha512-CV/AlTziC05yrz7UjVqEd0pH6+2dnrbmcnHGr2d3jXtmOgzNnlDkXtX8g3BfJ6nntsPD+0jtS2PzhvRHblRz4A==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.4.1",
@@ -772,12 +772,12 @@
 				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.0",
-				"mime": "^3.0.0",
+				"mrmime": "^1.0.1",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "~5.25.0"
+				"undici": "~5.26.2"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -2436,17 +2436,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3676,9 +3665,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.25.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-			"integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+			"version": "5.26.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
+			"integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -4266,9 +4255,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.25.1.tgz",
-			"integrity": "sha512-pD8XsvNJNgTNkFngNlM60my/X8dXWPKVzN5RghEQr0NjGZmuCjy49AfFu2cGbZjNf5pBcqd2RCNMW912P5fkhA==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.26.0.tgz",
+			"integrity": "sha512-CV/AlTziC05yrz7UjVqEd0pH6+2dnrbmcnHGr2d3jXtmOgzNnlDkXtX8g3BfJ6nntsPD+0jtS2PzhvRHblRz4A==",
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.4.1",
 				"@types/cookie": "^0.5.1",
@@ -4277,12 +4266,12 @@
 				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.0",
-				"mime": "^3.0.0",
+				"mrmime": "^1.0.1",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "~5.25.0"
+				"undici": "~5.26.2"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
@@ -5443,11 +5432,6 @@
 				"picomatch": "^2.3.1"
 			}
 		},
-		"mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
-		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6222,9 +6206,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.25.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
-			"integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+			"version": "5.26.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
+			"integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
 			"requires": {
 				"@fastify/busboy": "^2.0.0"
 			}


### PR DESCRIPTION
There are vulnerable packages in the `package-lock.json`. I used `npm audit fix` to address the known issues.