### PR TITLE
Added verbiage for running as container on Apple Silicon

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -39,7 +39,7 @@ docker run -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api -
 Becomes
 
 ```
-docker run -it --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+docker run --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
 ```
 
 ## References

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,11 +31,11 @@ By following these troubleshooting steps, you should be able to identify and res
 If you are running Docker on a M{1..3} based Mac and have taken the steps to run an x86 container, add "--platform linux/amd64" to the docker run command.
 Example:
 ```bash
-docker run -d -p 3000:8080  --env-file=$OLLAMA_ENV_FILE  --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+docker run -d -p 3000:8080 --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
 ```
 Becomes
 ```
-docker run -it --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://10.10.10.20:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+docker run -it --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
 
 ```
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -26,17 +26,20 @@ It is crucial to include the `/api` at the end of the URL to ensure that the Oll
 
 By following these troubleshooting steps, you should be able to identify and resolve connection issues with your Ollama server configuration. If you require further assistance or have additional questions, please don't hesitate to reach out or refer to our documentation for comprehensive guidance.
 
-## Running ollama-webui as a cintainer on Apple Silicon Mac
+## Running ollama-webui as a container on Apple Silicon Mac
 
-If you are running Docker on a M{1..3} based Mac and have taken the steps to run an x86 container, add "--platform linux/amd64" to the docker run command.
+If you are running Docker on a M{1..3} based Mac and have taken the steps to run an x86 container, add "--platform linux/amd64" to the docker run command to prevent a warning.
+
 Example:
+
 ```bash
 docker run -d -p 3000:8080 --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
 ```
+
 Becomes
+
 ```
 docker run -it --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
-
 ```
 
 ## References

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,3 +25,20 @@ Ensure that the Ollama URL is correctly formatted in the application settings. F
 It is crucial to include the `/api` at the end of the URL to ensure that the Ollama Web UI can communicate with the server.
 
 By following these troubleshooting steps, you should be able to identify and resolve connection issues with your Ollama server configuration. If you require further assistance or have additional questions, please don't hesitate to reach out or refer to our documentation for comprehensive guidance.
+
+## Running ollama-webui as a cintainer on Apple Silicon Mac
+
+If you are running Docker on a M{1..3} based Mac and have taken the steps to run an x86 container, add "--platform linux/amd64" to the docker run command.
+Example:
+```bash
+docker run -d -p 3000:8080  --env-file=$OLLAMA_ENV_FILE  --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+```
+Becomes
+```
+docker run -it --platform linux/amd64 -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://10.10.10.20:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+
+```
+
+## References
+[Change Docker Desktop Settings on Mac](https://docs.docker.com/desktop/settings/mac/) Search for "x86" in that page.
+[Run x86 (Intel) and ARM based images on Apple Silicon (M1) Macs?](https://forums.docker.com/t/run-x86-intel-and-arm-based-images-on-apple-silicon-m1-macs/117123)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ If you are running Docker on a M{1..3} based Mac and have taken the steps to run
 Example:
 
 ```bash
-docker run -d -p 3000:8080 --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
+docker run -d -p 3000:8080 -e OLLAMA_API_BASE_URL=http://example.com:11434/api --name ollama-webui --restart always ghcr.io/ollama-webui/ollama-webui:main
 ```
 
 Becomes


### PR DESCRIPTION
Added a section explaining how to run ollama-webui on an Apple Silicon Mac in a container

I may wish to add a stub/pointer in README.md in the Docker section to point to the Apple Silicon tips.  I felt it was not beneficial to put all of this bespoke info in the main README.md doc as it seems like an edge-case.