### PR TITLE
feat: multi architecture build added

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      # Required for multi architecture build
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      # Required for multi architecture build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -42,9 +48,11 @@ jobs:
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          builder: ${{ env.REGISTRY }}/buildx-ghcr 
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Added multi-architecture build to the current GitHub Action.
The code was generated using chatGPT [chat](https://chat.openai.com/share/d9050c1e-0716-4321-8c9e-6bfc887c54a1) and the [docker documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/).

I don't understand why `@v<number>` is not being used to define the version of the actions. All the actions I have added are from the documentation and have `@v<number>` for the version.

I don't know how to test this action. Can you please test and merge the changes?
Also, let me know if I need to make any changes.

Edit: I realised a mistake in the commit name, I should have prefixed it with `build:`. Sorry :(