### PR TITLE
feat: Display error returned by ollama

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -655,7 +655,32 @@
 											</div>
 										{:else}
 											<div class="w-full">
-												{@html marked(message.content.replace('\\\\', '\\\\\\'))}
+												{#if message?.error === true}
+													<div
+														class="flex mt-2 mb-4 space-x-2 border px-4 py-3 border-red-800 bg-red-800/30 font-medium rounded-lg"
+													>
+														<svg
+															xmlns="http://www.w3.org/2000/svg"
+															fill="none"
+															viewBox="0 0 24 24"
+															stroke-width="1.5"
+															stroke="currentColor"
+															class="w-5 h-5 self-center"
+														>
+															<path
+																stroke-linecap="round"
+																stroke-linejoin="round"
+																d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+															/>
+														</svg>
+
+														<div class=" self-center">
+															{message.content}
+														</div>
+													</div>
+												{:else}
+													{@html marked(message.content.replace('\\\\', '\\\\\\'))}
+												{/if}
 
 												{#if message.done}
 													<div class=" flex justify-start space-x-1 -mt-2">

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -276,12 +276,20 @@
 				console.log(error);
 				if ('detail' in error) {
 					toast.error(error.detail);
+					responseMessage.content = error.detail;
 				} else {
 					toast.error(error.error);
+					responseMessage.content = error.error;
 				}
 			} else {
 				toast.error(`Uh-oh! There was an issue connecting to Ollama.`);
+				responseMessage.content = `Uh-oh! There was an issue connecting to Ollama.`;
 			}
+
+			responseMessage.error = true;
+			responseMessage.content = `Uh-oh! There was an issue connecting to Ollama.`;
+			responseMessage.done = true;
+			messages = messages;
 		}
 
 		stopResponseFlag = false;

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -189,17 +189,12 @@
 				},
 				format: $settings.requestFormat ?? undefined
 			})
+		}).catch((err) => {
+			console.log(err);
+			return null;
 		});
 
-		if (!res.ok) {
-			const error = await res.json();
-			console.log(error);
-			if ('detail' in error) {
-				toast.error(error.detail);
-			} else {
-				toast.error(error.error);
-			}
-		} else {
+		if (res && res.ok) {
 			const reader = res.body
 				.pipeThrough(new TextDecoderStream())
 				.pipeThrough(splitStream('\n'))
@@ -274,6 +269,18 @@
 					messages: messages,
 					history: history
 				});
+			}
+		} else {
+			if (res !== null) {
+				const error = await res.json();
+				console.log(error);
+				if ('detail' in error) {
+					toast.error(error.detail);
+				} else {
+					toast.error(error.error);
+				}
+			} else {
+				toast.error(`Uh-oh! There was an issue connecting to Ollama.`);
 			}
 		}
 

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -218,80 +218,90 @@
 			})
 		});
 
-		const reader = res.body
-			.pipeThrough(new TextDecoderStream())
-			.pipeThrough(splitStream('\n'))
-			.getReader();
-
-		while (true) {
-			const { value, done } = await reader.read();
-			if (done || stopResponseFlag || _chatId !== $chatId) {
-				responseMessage.done = true;
-				messages = messages;
-				break;
+		if (!res.ok) {
+			const error = await res.json();
+			console.log(error);
+			if ('detail' in error) {
+				toast.error(error.detail);
+			} else {
+				toast.error(error.error);
 			}
+		} else {
+			const reader = res.body
+				.pipeThrough(new TextDecoderStream())
+				.pipeThrough(splitStream('\n'))
+				.getReader();
 
-			try {
-				let lines = value.split('\n');
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done || stopResponseFlag || _chatId !== $chatId) {
+					responseMessage.done = true;
+					messages = messages;
+					break;
+				}
 
-				for (const line of lines) {
-					if (line !== '') {
-						console.log(line);
-						let data = JSON.parse(line);
+				try {
+					let lines = value.split('\n');
 
-						if ('detail' in data) {
-							throw data;
-						}
+					for (const line of lines) {
+						if (line !== '') {
+							console.log(line);
+							let data = JSON.parse(line);
 
-						if (data.done == false) {
-							if (responseMessage.content == '' && data.message.content == '\n') {
-								continue;
+							if ('detail' in data) {
+								throw data;
+							}
+
+							if (data.done == false) {
+								if (responseMessage.content == '' && data.message.content == '\n') {
+									continue;
+								} else {
+									responseMessage.content += data.message.content;
+									messages = messages;
+								}
 							} else {
-								responseMessage.content += data.message.content;
+								responseMessage.done = true;
+								responseMessage.context = data.context ?? null;
+								responseMessage.info = {
+									total_duration: data.total_duration,
+									prompt_eval_count: data.prompt_eval_count,
+									prompt_eval_duration: data.prompt_eval_duration,
+									eval_count: data.eval_count,
+									eval_duration: data.eval_duration
+								};
 								messages = messages;
 							}
-						} else {
-							responseMessage.done = true;
-							responseMessage.context = data.context ?? null;
-							responseMessage.info = {
-								total_duration: data.total_duration,
-								prompt_eval_count: data.prompt_eval_count,
-								prompt_eval_duration: data.prompt_eval_duration,
-								eval_count: data.eval_count,
-								eval_duration: data.eval_duration
-							};
-							messages = messages;
 						}
 					}
+				} catch (error) {
+					console.log(error);
+					if ('detail' in error) {
+						toast.error(error.detail);
+					}
+					break;
 				}
-			} catch (error) {
-				console.log(error);
-				if ('detail' in error) {
-					toast.error(error.detail);
+
+				if (autoScroll) {
+					window.scrollTo({ top: document.body.scrollHeight });
 				}
-				break;
-			}
 
-			if (autoScroll) {
-				window.scrollTo({ top: document.body.scrollHeight });
+				await $db.updateChatById(_chatId, {
+					title: title === '' ? 'New Chat' : title,
+					models: selectedModels,
+					system: $settings.system ?? undefined,
+					options: {
+						seed: $settings.seed ?? undefined,
+						temperature: $settings.temperature ?? undefined,
+						repeat_penalty: $settings.repeat_penalty ?? undefined,
+						top_k: $settings.top_k ?? undefined,
+						top_p: $settings.top_p ?? undefined,
+						num_ctx: $settings.num_ctx ?? undefined,
+						...($settings.options ?? {})
+					},
+					messages: messages,
+					history: history
+				});
 			}
-
-			await $db.updateChatById(_chatId, {
-				title: title === '' ? 'New Chat' : title,
-				models: selectedModels,
-				system: $settings.system ?? undefined,
-				options: {
-					seed: $settings.seed ?? undefined,
-					temperature: $settings.temperature ?? undefined,
-					repeat_penalty: $settings.repeat_penalty ?? undefined,
-					top_k: $settings.top_k ?? undefined,
-					top_p: $settings.top_p ?? undefined,
-					num_ctx: $settings.num_ctx ?? undefined,
-					...($settings.options ?? {})
-				},
-				messages: messages,
-				history: history
-			});
 		}
 
 		stopResponseFlag = false;

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -216,17 +216,12 @@
 				},
 				format: $settings.requestFormat ?? undefined
 			})
+		}).catch((err) => {
+			console.log(err);
+			return null;
 		});
 
-		if (!res.ok) {
-			const error = await res.json();
-			console.log(error);
-			if ('detail' in error) {
-				toast.error(error.detail);
-			} else {
-				toast.error(error.error);
-			}
-		} else {
+		if (res && res.ok) {
 			const reader = res.body
 				.pipeThrough(new TextDecoderStream())
 				.pipeThrough(splitStream('\n'))
@@ -301,6 +296,18 @@
 					messages: messages,
 					history: history
 				});
+			}
+		} else {
+			if (res !== null) {
+				const error = await res.json();
+				console.log(error);
+				if ('detail' in error) {
+					toast.error(error.detail);
+				} else {
+					toast.error(error.error);
+				}
+			} else {
+				toast.error(`Uh-oh! There was an issue connecting to Ollama.`);
 			}
 		}
 

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -303,12 +303,20 @@
 				console.log(error);
 				if ('detail' in error) {
 					toast.error(error.detail);
+					responseMessage.content = error.detail;
 				} else {
 					toast.error(error.error);
+					responseMessage.content = error.error;
 				}
 			} else {
 				toast.error(`Uh-oh! There was an issue connecting to Ollama.`);
+				responseMessage.content = `Uh-oh! There was an issue connecting to Ollama.`;
 			}
+
+			responseMessage.error = true;
+			responseMessage.content = `Uh-oh! There was an issue connecting to Ollama.`;
+			responseMessage.done = true;
+			messages = messages;
 		}
 
 		stopResponseFlag = false;


### PR DESCRIPTION
I tried checking if the response is okay and displaying an error if not for #193

I don't know how to work with svelte (or any framework) so I was not able to remove the loader.
Currently, this is all you see when Ollama returns an error:

![Screenshot 2023-12-11 at 4 04 37 PM](https://github.com/ollama-webui/ollama-webui/assets/43847374/9fc4af79-4529-4e11-bffc-6128a2fec497)

The loader stays there after the toast disappears. 
We can add an additional toast, for now, saying `Please see ollama logs for more information` or `Refresh the page to try again`.
After refreshing, there is a saved chat with no second message. 
Example:
![Screenshot 2023-12-11 at 4 12 51 PM](https://github.com/ollama-webui/ollama-webui/assets/43847374/7fd4832f-520c-4139-a79b-287ce3d163e4)
