### PR TITLE
fix: decode the message to render them onto UI

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -240,7 +240,7 @@
 								if (responseMessage.content == '' && data.message.content == '\n') {
 									continue;
 								} else {
-									responseMessage.content += data.message.content;
+									responseMessage.content += decodeURIComponent(data.message.content);
 									messages = messages;
 								}
 							} else {


### PR DESCRIPTION
Fixes this bug https://github.com/ollama-webui/ollama-webui/issues/267. The received response contains raw characters which we have to decode to convert "\u003c" to "<". 

```json
{
    "model": "deepseek-coder:6.7b",
    "created_at": "2023-12-23T14:16:01.764806Z",
    "message": {
        "role": "assistant",
        "content": "\u003c"
    },
    "done": false
}
```

**Before**
<img width="785" alt="image" src="https://github.com/ollama-webui/ollama-webui/assets/4705103/b4a99245-7ecf-4b93-99d3-8d7b3cdc2e45">


**After**

![image](https://github.com/ollama-webui/ollama-webui/assets/4705103/71ab73e4-31f7-456f-9fd9-f7075fe969f2)
