### PR TITLE
fix(model-selector): prevent saving empty default model

### DIFF
--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -6,6 +6,11 @@
 	export let disabled = false;
 
 	const saveDefaultModel = () => {
+		const hasEmptyModel = selectedModels.filter(it => it === '');
+		if(hasEmptyModel.length){
+			toast.error('Choose a model before saving...');
+			return;
+		}
 		settings.set({ ...$settings, models: selectedModels });
 		localStorage.setItem('settings', JSON.stringify($settings));
 		toast.success('Default model updated');
@@ -21,7 +26,7 @@
 				bind:value={selectedModel}
 				{disabled}
 			>
-				<option class=" text-gray-700" value="" selected>Select a model</option>
+				<option class=" text-gray-700" value="" selected disabled>Select a model</option>
 
 				{#each $models as model}
 					{#if model.name === 'hr'}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,5 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()],
-	server: {
-		hmr: true
-	}
+	plugins: [sveltekit()]
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		hmr: true
+	}
 });


### PR DESCRIPTION
- throw a toast error when user is trying to click on `set as default` without actually choosing the model(s).
- feat: added hmr for local development. use `npm run dev` and you get page reload + backend functionality without needing to build every time for small changes. 

https://github.com/ollama-webui/ollama-webui/assets/4705103/e72ea83a-4854-4439-9bf3-c325c51ab820

