### PR TITLE
Fix bug: Header attributes (Host, Authorization, Origin, Referer) not sanitized.

### DIFF
--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -65,10 +65,10 @@ async def proxy(path: str, request: Request, user=Depends(get_current_user)):
     else:
         raise HTTPException(status_code=401, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
 
-    headers.pop("Host", None)
-    headers.pop("Authorization", None)
-    headers.pop("Origin", None)
-    headers.pop("Referer", None)
+    headers.pop("host", None)
+    headers.pop("authorization", None)
+    headers.pop("origin", None)
+    headers.pop("referer", None)
 
     r = None
 


### PR DESCRIPTION
Fix bug: Header attributes (Host, Authorization, Origin, Referer) not sanitized

- Resolved an issue where header attributes Host, Authorization, Origin, and Referer were not being sanitized, resulting in two major issues:
  1. Ollama requests inadvertently exposed user information, leading to data leakage.
  2. When Ollama is deployed on different servers, and the intermediary proxy layer uses the host header to locate downstream services, it fails to find them.

Root Cause:
- In FastAPI, when accessing request.headers, all header names are converted to lowercase. This is because FastAPI, and its underlying framework Starlette, adhere to the HTTP/2 standard, which mandates lowercase header field names for performance and consistency.
- In HTTP/2, enforcing lowercase header field names reduces complexity in header processing as case sensitivity is no longer a concern. Thus, regardless of the case used in client-sent header fields, the server processes them uniformly in lowercase.
- This practice is adopted in FastAPI and other modern HTTP frameworks, even in an HTTP/1.1 context, to maintain consistency with HTTP/2 and improve overall performance. As a result, header field names are always presented in lowercase in FastAPI, even if the original request used capitalization or mixed case.