### PR TITLE
reduce docker final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ WORKDIR /app/backend
 
 COPY ./backend/requirements.txt ./requirements.txt
 
-RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-RUN pip3 install -r requirements.txt
+RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
+RUN pip3 install -r requirements.txt --no-cache-dir
 
 # RUN python -c "from sentence_transformers import SentenceTransformer; model = SentenceTransformer('all-MiniLM-L6-v2')"
 


### PR DESCRIPTION
Added the option `--no-cache-dir` to the `pip3 install` commands on the Dockerfile to reduce the docker image resulting size to 1.89 GB from 2.27 GB.

Tested this on Docker Desktop under Windows.

This is my first PR! Eager to learn and help! 😊