### PR TITLE
Fix/chat imports

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -141,7 +141,7 @@
 	const importChats = async (_chats) => {
 		for (const chat of _chats) {
 			console.log(chat);
-			await createNewChat(localStorage.token, chat);
+			await createNewChat(localStorage.token, chat.chat);
 		}
 
 		await chats.set(await getChatList(localStorage.token));

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -95,8 +95,6 @@
 		});
 
 		if (chat) {
-			console.log("Chat from getChatById1", chat) //Remove
-			console.log("Chat from getChatById2", chat.chat); // Remove
 			const chatContent = chat.chat;
 
 			if (chatContent) {

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	import { page } from '$app/stores';
 
 	import { models, modelfiles, user, settings, chats, chatId, config } from '$lib/stores';
-	import { copyToClipboard, splitStream } from '$lib/utils';
+	import { copyToClipboard, splitStream, convertMessagesToHistory } from '$lib/utils';
 
 	import { generateChatCompletion, generateTitle } from '$lib/apis/ollama';
 	import { createNewChat, getChatById, getChatList, updateChatById } from '$lib/apis/chats';
@@ -95,6 +95,8 @@
 		});
 
 		if (chat) {
+			console.log("Chat from getChatById1", chat) //Remove
+			console.log("Chat from getChatById2", chat.chat); // Remove
 			const chatContent = chat.chat;
 
 			if (chatContent) {
@@ -103,7 +105,7 @@
 				selectedModels =
 					(chatContent?.models ?? undefined) !== undefined
 						? chatContent.models
-						: [chatContent.model ?? ''];
+						: [chatContent.models ?? ''];
 				history =
 					(chatContent?.history ?? undefined) !== undefined
 						? chatContent.history


### PR DESCRIPTION
Relating to this issue: https://github.com/ollama-webui/ollama-webui/issues/337

It seems like chat imports are not working for ollama in general. The fix for this was pretty simple:

1. Send correct object to the backend router to match `insert_new_chat` method
   a.  Instead we send chat.chat, also called chatContent elsewhere in the repo, which matches the dict structure used when creating brand new chats.

** Note **: Maybe we should just create a new class method for importing chats to use in the importChats function in SettingsModal.svelte? As of now, we lose all original information from imports since it uses the `insert_new_chat` method from here `backend/apps/web/models/chats.py`, when instead, we could directly import the original chat id and chat user id and timestamp. But this is a very small QOL difference.

2. Add import of necessary function and correct to chatContent.models.
   a. Model was not loading on import because key is `models`, not `model`, so I fixed that too.
   a.  page.svelte  was missing a function for converting messages to history.

