### PR TITLE
feat: Add RAG support for XML and various programming languages

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -166,7 +166,7 @@ def store_doc(
         "css", "cpp", "hpp","h", "c", "cs", "sql", "log", "ini",
         "pl" "pm", "r", "dart", "dockerfile", "env", "php", "hs",
         "hsc", "lua", "nginxconf", "conf", "m", "mm", "plsql", "perl",
-        "rb", "rs", "db2", "scala", "bash", "swift", "vue"
+        "rb", "rs", "db2", "scala", "bash", "swift", "vue", "svelte"
         ]
     file_ext=file.filename.split(".")[-1].lower()
     if file.content_type == "application/octet-stream" and file_ext not in (octet_markdown + octet_plain):

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -149,16 +149,17 @@ def store_doc(
         "text/plain",
         "text/csv",
         "text/xml",
-        "text/html",
         "text/x-python",
+        "text/css",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/octet-stream",
+        "application/x-javascript",
     ]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.FILE_NOT_SUPPORTED,
         )
-    text_xml=["text/html", "text/xml"]
+    text_xml=["text/xml"]
     octet_markdown=["md"]
     octet_plain=[
         "go", "py", "java", "sh", "bat", "ps1", "cmd", "js", 
@@ -206,6 +207,8 @@ def store_doc(
                 loader = UnstructuredMarkdownLoader(file_path)
             if file_ext in octet_plain:
                 loader = TextLoader(file_path)
+        elif file.content_type == "application/x-javascript":
+            loader = TextLoader(file_path)
 
         data = loader.load()
         result = store_data_in_vector_db(data, collection_name)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,10 +13,14 @@ export const REQUIRED_OLLAMA_VERSION = '0.1.16';
 
 export const SUPPORTED_FILE_TYPE = [
 	'application/pdf',
-	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-	'text/markdown',
 	'text/plain',
-	'text/csv'
+	'text/csv',
+	'text/xml',
+	'text/x-python',
+	'text/css',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	'application/octet-stream',
+	'application/x-javascript',
 ];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_FILE_TYPE = [
 	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 	'application/octet-stream',
 	'application/x-javascript',
+	'text/markdown',
 ];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public


### PR DESCRIPTION
Allows XML, python, css, javascript, java, golang, sql, c/c++/c#, ruby, rust, php, perl, and more files to be uploaded and parsed for RAG.

