### PR TITLE
Feat: Enable imports of ChatGPT chat history

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -21,7 +21,7 @@
 	import { WEB_UI_VERSION, WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import { config, models, settings, user, chats } from '$lib/stores';
-	import { splitStream, getGravatarURL } from '$lib/utils';
+	import { splitStream, getGravatarURL, getImportOrigin, convertGptChats } from '$lib/utils';
 
 	import Advanced from './Settings/Advanced.svelte';
 	import Modal from '../common/Modal.svelte';
@@ -132,6 +132,9 @@
 		reader.onload = (event) => {
 			let chats = JSON.parse(event.target.result);
 			console.log(chats);
+			if (getImportOrigin(chats) == 'gpt') {
+				chats = convertGptChats(chats);
+			}
 			importChats(chats);
 		};
 

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -133,7 +133,11 @@
 			let chats = JSON.parse(event.target.result);
 			console.log(chats);
 			if (getImportOrigin(chats) == 'gpt') {
-				chats = convertGptChats(chats);
+				try {
+					chats = convertGptChats(chats);
+				} catch (error) {
+					console.log("Unable to import chats:", error);
+				}
 			}
 			importChats(chats);
 		};

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -696,7 +696,7 @@
 	<div class="min-h-screen w-full flex justify-center">
 		<div class=" py-2.5 flex flex-col justify-between w-full">
 			<div class="max-w-2xl mx-auto w-full px-3 md:px-0 mt-10">
-				<ModelSelector bind:selectedModels disabled={messages.length > 0} />
+				<ModelSelector bind:selectedModels disabled={messages.length > 0 && !selectedModels.includes('')} />
 			</div>
 
 			<div class=" h-full mt-10 mb-32 w-full flex flex-col">


### PR DESCRIPTION
For this issue: https://github.com/ollama-webui/ollama-webui/issues/337

Enable imports of ChatGPT histories (conversations.json), and the ability to choose a new model to use upon import.

1. Added several functions to `src/lib/utils/index.ts` that are used at import time before sending to the `createNewChat` api
        a) Identify if import is a chatGPT one or Ollama-webui one (as they are very different)
        b) Parses and iterates through the chatGPT json to match the ollama-webui chat structure
2. Adjusted the "disabled" tag for model selector element at `src/routes/(app)/c/[id]/+page.svelte`
        a) This makes sure that we can select a new model to chat with when a model is not currently selected (upon import)
        
        
** Note **: When we import from ChatGPT, we don't default to a model so 1. users aren't forced to use chatgpt and 2. because actually collecting which chatGPT model was used is not clear from the chatgpt json.
Does not import context (i.e. pdf RAG) info from GPT chats. Maybe would be nice in future but would take some investment.