### PR TITLE
Feat: Add ChatGPT import functionality

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -21,7 +21,7 @@
 	import { WEB_UI_VERSION, WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import { config, models, settings, user, chats } from '$lib/stores';
-	import { splitStream, getGravatarURL, getImportOrigin, convertGptChats } from '$lib/utils';
+	import { splitStream, getGravatarURL, getImportOrigin, convertOpenAIChats } from '$lib/utils';
 
 	import Advanced from './Settings/Advanced.svelte';
 	import Modal from '../common/Modal.svelte';
@@ -132,11 +132,11 @@
 		reader.onload = (event) => {
 			let chats = JSON.parse(event.target.result);
 			console.log(chats);
-			if (getImportOrigin(chats) == 'gpt') {
+			if (getImportOrigin(chats) == 'openai') {
 				try {
-					chats = convertGptChats(chats);
+					chats = convertOpenAIChats(chats);
 				} catch (error) {
-					console.log("Unable to import chats:", error);
+					console.log('Unable to import chats:', error);
 				}
 			}
 			importChats(chats);

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -21,7 +21,7 @@
 	import { WEB_UI_VERSION, WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import { config, models, settings, user, chats } from '$lib/stores';
-	import { splitStream, getGravatarURL } from '$lib/utils';
+	import { splitStream, getGravatarURL, getImportOrigin, convertGptChats } from '$lib/utils';
 
 	import Advanced from './Settings/Advanced.svelte';
 	import Modal from '../common/Modal.svelte';
@@ -132,6 +132,9 @@
 		reader.onload = (event) => {
 			let chats = JSON.parse(event.target.result);
 			console.log(chats);
+			if (getImportOrigin(chats) == 'gpt') {
+				chats = convertGptChats(chats);
+			}
 			importChats(chats);
 		};
 

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -133,7 +133,11 @@
 			let chats = JSON.parse(event.target.result);
 			console.log(chats);
 			if (getImportOrigin(chats) == 'gpt') {
-				chats = convertGptChats(chats);
+				try {
+					chats = convertGptChats(chats);
+				} catch (error) {
+					console.log("Unable to import chats:", error);
+				}
 			}
 			importChats(chats);
 		};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -216,11 +216,11 @@ const convertOpenAIMessages = (convo) => {
 		} else {
 			const new_chat = {
 				id: message_id,
-				parentId: messages.length > 0 ? message['parent'] : null,
+				parentId: messages.length > 0 && message['parent'] in mapping ? message['parent'] : null,
 				childrenIds: message['children'] || [],
 				role: message['message']?.['author']?.['role'] !== 'user' ? 'assistant' : 'user',
 				content: message['message']?.['content']?.['parts']?.[0] || '',
-				model: '',
+				model: 'gpt-3.5-turbo',
 				done: true,
 				context: null
 			};
@@ -236,11 +236,11 @@ const convertOpenAIMessages = (convo) => {
 			currentId: currentId,
 			messages: history // Need to convert this to not a list and instead a json object
 		},
-		models: [''],
+		models: ['gpt-3.5-turbo'],
 		messages: messages,
 		options: {},
 		timestamp: convo['create_time'],
-		title: convo['title']
+		title: convo['title'] ?? 'New Chat'
 	};
 	return chat;
 };
@@ -249,14 +249,17 @@ export const convertOpenAIChats = (_chats) => {
 	// Create a list of dictionaries with each conversation from import
 	const chats = [];
 	for (let convo of _chats) {
-		const chat = {
-			id: convo['id'],
-			user_id: '',
-			title: convo['title'],
-			chat: convertOpenAIMessages(convo),
-			timestamp: convo['timestamp']
-		};
-		chats.push(chat);
+		const chat = convertOpenAIMessages(convo);
+
+		if (Object.keys(chat.history.messages).length > 0) {
+			chats.push({
+				id: convo['id'],
+				user_id: '',
+				title: convo['title'],
+				chat: chat,
+				timestamp: convo['timestamp']
+			});
+		}
 	}
 	return chats;
 };

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -195,68 +195,68 @@ export const calculateSHA256 = async (file) => {
 
 export const getImportOrigin = (_chats) => {
 	// Check what external service chat imports are from
-    if ('mapping' in _chats[0]) {
-        return 'gpt';
-    }
-    return 'webui';
-}
+	if ('mapping' in _chats[0]) {
+		return 'openai';
+	}
+	return 'webui';
+};
 
-const convertGptMessages = (convo) => {
+const convertOpenAIMessages = (convo) => {
 	// Parse OpenAI chat messages and create chat dictionary for creating new chats
-    const mapping = convo["mapping"];
+	const mapping = convo['mapping'];
 	const messages = [];
-	let currentId = "";
+	let currentId = '';
 
-    for (let message_id in mapping) {
-        const message = mapping[message_id];
+	for (let message_id in mapping) {
+		const message = mapping[message_id];
 		currentId = message_id;
-		if (message["message"] == null || message["message"]["content"]["parts"][0] == "") {
+		if (message['message'] == null || message['message']['content']['parts'][0] == '') {
 			// Skip chat messages with no content
 			continue;
 		} else {
 			const new_chat = {
-				"id": message_id,
-				"parentId": messages.length > 0 ? message["parent"] : null,
-				"childrenIds": message["children"] || [],
-				"role": message["message"]?.["author"]?.["role"] !== "user" ? "assistant" : "user",
-				"content": message["message"]?.["content"]?.['parts']?.[0] || "",
-				"model": '',
-				"done": true,
-				"context": null,
-			}
-			messages.push(new_chat)
+				id: message_id,
+				parentId: messages.length > 0 ? message['parent'] : null,
+				childrenIds: message['children'] || [],
+				role: message['message']?.['author']?.['role'] !== 'user' ? 'assistant' : 'user',
+				content: message['message']?.['content']?.['parts']?.[0] || '',
+				model: '',
+				done: true,
+				context: null
+			};
+			messages.push(new_chat);
 		}
-    }
+	}
 
 	let history = {};
-	messages.forEach(obj => history[obj.id] = obj);
+	messages.forEach((obj) => (history[obj.id] = obj));
 
 	const chat = {
-		"history": {
-			"currentId": currentId,
-			"messages": history, // Need to convert this to not a list and instead a json object
+		history: {
+			currentId: currentId,
+			messages: history // Need to convert this to not a list and instead a json object
 		},
-		"models": [""],
-		"messages": messages,
-		"options": {},
-		"timestamp": convo["create_time"],
-		"title": convo["title"],
-	}
-    return chat;
-}
+		models: [''],
+		messages: messages,
+		options: {},
+		timestamp: convo['create_time'],
+		title: convo['title']
+	};
+	return chat;
+};
 
-export const convertGptChats = (_chats) => {
+export const convertOpenAIChats = (_chats) => {
 	// Create a list of dictionaries with each conversation from import
-    const chats = [];
-    for (let convo of _chats) {
-        const chat = {
-			"id": convo["id"],
-        	"user_id": '',
-			"title": convo["title"],
-			"chat": convertGptMessages(convo),
-			"timestamp": convo["timestamp"],
-    	}
-		chats.push(chat)
+	const chats = [];
+	for (let convo of _chats) {
+		const chat = {
+			id: convo['id'],
+			user_id: '',
+			title: convo['title'],
+			chat: convertOpenAIMessages(convo),
+			timestamp: convo['timestamp']
+		};
+		chats.push(chat);
 	}
-    return chats;
-}
+	return chats;
+};

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -696,7 +696,7 @@
 	<div class="min-h-screen w-full flex justify-center">
 		<div class=" py-2.5 flex flex-col justify-between w-full">
 			<div class="max-w-2xl mx-auto w-full px-3 md:px-0 mt-10">
-				<ModelSelector bind:selectedModels disabled={messages.length > 0} />
+				<ModelSelector bind:selectedModels disabled={messages.length > 0 && !selectedModels.includes('')} />
 			</div>
 
 			<div class=" h-full mt-10 mb-32 w-full flex flex-col">

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -200,8 +200,15 @@
 					await chatId.set('local');
 				}
 				await tick();
-			}
+			} else if (chat.chat["models"][0] == "") {
+				// If model is not saved in DB, then save selectedmodel when message is sent
 
+				chat = await updateChatById(localStorage.token, $chatId, {
+						models: selectedModels
+					});
+				await chats.set(await getChatList(localStorage.token));
+			}
+			
 			// Reset chat input textarea
 			prompt = '';
 			files = [];

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -200,7 +200,7 @@
 					await chatId.set('local');
 				}
 				await tick();
-			} else if (chat.chat["models"][0] == "") {
+			} else if (chat.chat["models"] != selectedModels) {
 				// If model is not saved in DB, then save selectedmodel when message is sent
 
 				chat = await updateChatById(localStorage.token, $chatId, {


### PR DESCRIPTION
For this issue: https://github.com/ollama-webui/ollama-webui/issues/337

Enable imports of ChatGPT histories (conversations.json), and ability to choose a new model upon import.

1. Added several functions to `src/lib/utils/index.ts` that are used at import before sending to `createNewChat` api
         a) Identify if import is a chatGPT one or Ollama-webui one (as they are very different)
         b) Parses and iterates through the chatGPT json to match the ollama-webui chat structure

2. Make sure new chats work with existing code
         a) Adjusted the "disabled" tag to let you choose what model to use for new chat 
         b) Add one more check when message is sent that saves selectedModel when current saved model is different
                     - With imported models, messages already exist but no model exists! so need to update. or if you import chats using models that you don't have (i.e. 'gpt-3.5-turbo')


** Note **: When we import from ChatGPT, we don't default to a model so users aren't forced to use chatgpt
Does not import context (i.e. pdf RAG) info from GPT chats. 