### PR TITLE
Fix: ".md" documents upload only works for drag n. drop in message.

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -301,7 +301,10 @@
 							const file = inputFiles[0];
 							if (['image/gif', 'image/jpeg', 'image/png'].includes(file['type'])) {
 								reader.readAsDataURL(file);
-							} else if (SUPPORTED_FILE_TYPE.includes(file['type'])) {
+							} else if (
+								SUPPORTED_FILE_TYPE.includes(file['type']) ||
+								['md'].includes(file.name.split('.').at(-1))
+							) {
 								uploadDoc(file);
 								filesInputElement.value = '';
 							} else {
@@ -461,8 +464,8 @@
 							placeholder={chatInputPlaceholder !== ''
 								? chatInputPlaceholder
 								: speechRecognitionListening
-								? 'Listening...'
-								: 'Send a message'}
+									? 'Listening...'
+									: 'Send a message'}
 							bind:value={prompt}
 							on:keypress={(e) => {
 								if (e.keyCode == 13 && !e.shiftKey) {

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -67,7 +67,10 @@
 
 			if (inputFiles && inputFiles.length > 0) {
 				const file = inputFiles[0];
-				if (SUPPORTED_FILE_TYPE.includes(file['type'])) {
+				if (
+					SUPPORTED_FILE_TYPE.includes(file['type']) ||
+					['md'].includes(file.name.split('.').at(-1))
+				) {
 					uploadDoc(file);
 				} else {
 					toast.error(`Unsupported File Type '${file['type']}'.`);
@@ -144,7 +147,10 @@
 				on:change={async (e) => {
 					if (inputFiles && inputFiles.length > 0) {
 						const file = inputFiles[0];
-						if (SUPPORTED_FILE_TYPE.includes(file['type'])) {
+						if (
+							SUPPORTED_FILE_TYPE.includes(file['type']) ||
+							['md'].includes(file.name.split('.').at(-1))
+						) {
 							uploadDoc(file);
 						} else {
 							toast.error(`Unsupported File Type '${file['type']}'.`);


### PR DESCRIPTION
Fix for #502 ...

- Added same logic that was present for in-chat drag-n-drop to in-chat UI button
- Added same logic to Downloads `+` button and drag-n-drop