### PR TITLE
This script can now be run from any directory

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR" || exit
+
 PORT="${PORT:-8080}"
-uvicorn main:app --host 0.0.0.0 --port $PORT --forwarded-allow-ips '*'
+uvicorn main:app --host 0.0.0.0 --port "$PORT" --forwarded-allow-ips '*'


### PR DESCRIPTION
The current version of `backend/start.sh` requires that it be invoked from the `backend` directory.