### PR TITLE
feat: Allow RAG on XML and arbitrary text files including source code

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -166,7 +166,7 @@ def store_doc(
         "css", "cpp", "hpp","h", "c", "cs", "sql", "log", "ini",
         "pl" "pm", "r", "dart", "dockerfile", "env", "php", "hs",
         "hsc", "lua", "nginxconf", "conf", "m", "mm", "plsql", "perl",
-        "rb", "rs", "db2", "scala", "bash", "swift", "vue"
+        "rb", "rs", "db2", "scala", "bash", "swift", "vue", "svelte"
         ]
     file_ext=file.filename.split(".")[-1].lower()
     if file.content_type == "application/octet-stream" and file_ext not in (octet_markdown + octet_plain):

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -149,16 +149,17 @@ def store_doc(
         "text/plain",
         "text/csv",
         "text/xml",
-        "text/html",
         "text/x-python",
+        "text/css",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/octet-stream",
+        "application/x-javascript",
     ]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.FILE_NOT_SUPPORTED,
         )
-    text_xml=["text/html", "text/xml"]
+    text_xml=["text/xml"]
     octet_markdown=["md"]
     octet_plain=[
         "go", "py", "java", "sh", "bat", "ps1", "cmd", "js", 
@@ -206,6 +207,8 @@ def store_doc(
                 loader = UnstructuredMarkdownLoader(file_path)
             if file_ext in octet_plain:
                 loader = TextLoader(file_path)
+        elif file.content_type == "application/x-javascript":
+            loader = TextLoader(file_path)
 
         data = loader.load()
         result = store_data_in_vector_db(data, collection_name)

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -173,7 +173,8 @@
 					) {
 						uploadDoc(file);
 					} else {
-						toast.error(`Unsupported File Type '${file['type']}'.`);
+						toast.error(`Unknown File Type '${file['type']}', but accepting and treating as plain text`);
+						uploadDoc(file);
 					}
 				} else {
 					toast.error(`File not found.`);
@@ -308,8 +309,9 @@
 								uploadDoc(file);
 								filesInputElement.value = '';
 							} else {
-								toast.error(`Unsupported File Type '${file['type']}'.`);
-								inputFiles = null;
+								toast.error(`Unknown File Type '${file['type']}', but accepting and treating as plain text`);
+								uploadDoc(file);
+								filesInputElement.value = '';
 							}
 						} else {
 							toast.error(`File not found.`);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,10 +13,14 @@ export const REQUIRED_OLLAMA_VERSION = '0.1.16';
 
 export const SUPPORTED_FILE_TYPE = [
 	'application/pdf',
-	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-	'text/markdown',
 	'text/plain',
-	'text/csv'
+	'text/csv',
+	'text/xml',
+	'text/x-python',
+	'text/css',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	'application/octet-stream',
+	'application/x-javascript',
 ];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_FILE_TYPE = [
 	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 	'application/octet-stream',
 	'application/x-javascript',
+	'text/markdown',
 ];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -73,7 +73,8 @@
 				) {
 					uploadDoc(file);
 				} else {
-					toast.error(`Unsupported File Type '${file['type']}'.`);
+					toast.error(`Unknown File Type '${file['type']}', but accepting and treating as plain text`);
+					uploadDoc(file);
 				}
 			} else {
 				toast.error(`File not found.`);
@@ -153,7 +154,8 @@
 						) {
 							uploadDoc(file);
 						} else {
-							toast.error(`Unsupported File Type '${file['type']}'.`);
+							toast.error(`Unknown File Type '${file['type']}', but accepting and treating as plain text`);
+							uploadDoc(file);
 						}
 
 						inputFiles = null;


### PR DESCRIPTION
Improvement on #495 so we won't have to play wack a mole as browsers change file MIME types for source code files. 

If a user uploads a file with an unknown type it will display a warning toast, but process it as a text file. 


Here the codellama model is able to read the Ollama-webui RAG code and modify it.
![example](https://github.com/ollama-webui/ollama-webui/assets/5996181/c4f6489d-e888-4408-869f-006f47c24c30)
