### PR TITLE
Unhardcode some stuff, flexibilize dotenv requirement

### DIFF
--- a/backend/apps/web/internal/db.py
+++ b/backend/apps/web/internal/db.py
@@ -1,4 +1,6 @@
 from peewee import *
+from config import DATA_DIR
 
-DB = SqliteDatabase("./data/ollama.db")
+
+DB = SqliteDatabase(str(DATA_DIR / "ollama.db"))
 DB.connect()

--- a/backend/apps/web/internal/db.py
+++ b/backend/apps/web/internal/db.py
@@ -2,5 +2,5 @@ from peewee import *
 from config import DATA_DIR
 
 
-DB = SqliteDatabase(str(DATA_DIR / "ollama.db"))
+DB = SqliteDatabase(f"{DATA_DIR}/ollama.db")
 DB.connect()

--- a/backend/apps/web/routers/utils.py
+++ b/backend/apps/web/routers/utils.py
@@ -11,7 +11,7 @@ import json
 
 from utils.misc import calculate_sha256
 
-from config import OLLAMA_API_BASE_URL
+from config import OLLAMA_API_BASE_URL, DATA_DIR, UPLOAD_DIR
 from constants import ERROR_MESSAGES
 
 
@@ -96,8 +96,7 @@ async def download(
     file_name = parse_huggingface_url(url)
 
     if file_name:
-        os.makedirs("./uploads", exist_ok=True)
-        file_path = os.path.join("./uploads", f"{file_name}")
+        file_path = str(UPLOAD_DIR / file_name)
 
         return StreamingResponse(
             download_file_stream(url, file_path, file_name),
@@ -109,16 +108,15 @@ async def download(
 
 @router.post("/upload")
 def upload(file: UploadFile = File(...)):
-    os.makedirs("./data/uploads", exist_ok=True)
-    file_path = os.path.join("./data/uploads", file.filename)
+    file_path = UPLOAD_DIR / file.filename
 
     # Save file in chunks
-    with open(file_path, "wb+") as f:
+    with file_path.open("wb+") as f:
         for chunk in file.file:
             f.write(chunk)
 
     def file_process_stream():
-        total_size = os.path.getsize(file_path)
+        total_size = os.path.getsize(str(file_path))
         chunk_size = 1024 * 1024
         try:
             with open(file_path, "rb") as f:

--- a/backend/apps/web/routers/utils.py
+++ b/backend/apps/web/routers/utils.py
@@ -111,12 +111,12 @@ def upload(file: UploadFile = File(...)):
     file_path = f"{UPLOAD_DIR}/{file.filename}"
 
     # Save file in chunks
-    with file_path.open("wb+") as f:
+    with open(file_path, "wb+") as f:
         for chunk in file.file:
             f.write(chunk)
 
     def file_process_stream():
-        total_size = os.path.getsize(str(file_path))
+        total_size = os.path.getsize(file_path)
         chunk_size = 1024 * 1024
         try:
             with open(file_path, "rb") as f:

--- a/backend/apps/web/routers/utils.py
+++ b/backend/apps/web/routers/utils.py
@@ -96,7 +96,7 @@ async def download(
     file_name = parse_huggingface_url(url)
 
     if file_name:
-        file_path = str(UPLOAD_DIR / file_name)
+        file_path = f"{UPLOAD_DIR}/{file_name}"
 
         return StreamingResponse(
             download_file_stream(url, file_path, file_name),
@@ -108,7 +108,7 @@ async def download(
 
 @router.post("/upload")
 def upload(file: UploadFile = File(...)):
-    file_path = UPLOAD_DIR / file.filename
+    file_path = f"{UPLOAD_DIR}/{file.filename}"
 
     # Save file in chunks
     with file_path.open("wb+") as f:

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,10 +24,12 @@ except ImportError:
 # File Upload
 ####################################
 
+DATA_DIR = Path(os.getenv("DATA_DIR", './data')).resolve()
 
-UPLOAD_DIR = "./data/uploads"
-Path(UPLOAD_DIR).mkdir(parents=True, exist_ok=True)
+UPLOAD_DIR = DATA_DIR / "uploads"
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
+WEB_DIR = Path(os.getenv("WEB_DIR", "../build"))
 
 ####################################
 # ENV (dev,test,prod)
@@ -82,10 +84,10 @@ if WEBUI_AUTH and WEBUI_JWT_SECRET_KEY == "":
 # RAG
 ####################################
 
-CHROMA_DATA_PATH = "./data/vector_db"
+CHROMA_DATA_PATH = DATA_DIR / "vector_db"
 EMBED_MODEL = "all-MiniLM-L6-v2"
 CHROMA_CLIENT = chromadb.PersistentClient(
-    path=CHROMA_DATA_PATH, settings=Settings(allow_reset=True)
+    path=str(CHROMA_DATA_PATH), settings=Settings(allow_reset=True)
 )
 CHUNK_SIZE = 1500
 CHUNK_OVERLAP = 100

--- a/backend/config.py
+++ b/backend/config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 try:
     from dotenv import load_dotenv, find_dotenv
+
     load_dotenv(find_dotenv("../.env"))
 except ImportError:
     print("dotenv not installed, skipping...")
@@ -24,12 +25,12 @@ except ImportError:
 # File Upload
 ####################################
 
-DATA_DIR = Path(os.getenv("DATA_DIR", './data')).resolve()
+DATA_DIR = Path(os.getenv("DATA_DIR", "./data")).resolve()
 
-UPLOAD_DIR = DATA_DIR / "uploads"
+UPLOAD_DIR = f"{DATA_DIR}/uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
-WEB_DIR = Path(os.getenv("WEB_DIR", "../build"))
+FRONTEND_BUILD_DIR = Path(os.getenv("FRONTEND_BUILD_DIR", "../build"))
 
 ####################################
 # ENV (dev,test,prod)
@@ -84,7 +85,7 @@ if WEBUI_AUTH and WEBUI_JWT_SECRET_KEY == "":
 # RAG
 ####################################
 
-CHROMA_DATA_PATH = DATA_DIR / "vector_db"
+CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
 EMBED_MODEL = "all-MiniLM-L6-v2"
 CHROMA_CLIENT = chromadb.PersistentClient(
     path=str(CHROMA_DATA_PATH), settings=Settings(allow_reset=True)

--- a/backend/config.py
+++ b/backend/config.py
@@ -25,12 +25,13 @@ except ImportError:
 # File Upload
 ####################################
 
-DATA_DIR = Path(os.getenv("DATA_DIR", "./data")).resolve()
+DATA_DIR = str(Path(os.getenv("DATA_DIR", "./data")).resolve())
 
 UPLOAD_DIR = f"{DATA_DIR}/uploads"
-UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
-FRONTEND_BUILD_DIR = Path(os.getenv("FRONTEND_BUILD_DIR", "../build"))
+Path(UPLOAD_DIR).mkdir(parents=True, exist_ok=True)
+
+FRONTEND_BUILD_DIR = str(Path(os.getenv("FRONTEND_BUILD_DIR", "../build")))
 
 ####################################
 # ENV (dev,test,prod)
@@ -88,7 +89,7 @@ if WEBUI_AUTH and WEBUI_JWT_SECRET_KEY == "":
 CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
 EMBED_MODEL = "all-MiniLM-L6-v2"
 CHROMA_CLIENT = chromadb.PersistentClient(
-    path=str(CHROMA_DATA_PATH), settings=Settings(allow_reset=True)
+    path=CHROMA_DATA_PATH, settings=Settings(allow_reset=True)
 )
 CHUNK_SIZE = 1500
 CHUNK_OVERLAP = 100

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,16 +1,9 @@
 import os
-
-
 import chromadb
 from chromadb import Settings
-
-
 from secrets import token_bytes
 from base64 import b64encode
-
 from constants import ERROR_MESSAGES
-
-
 from pathlib import Path
 
 try:
@@ -22,22 +15,25 @@ except ImportError:
 
 
 ####################################
-# File Upload
-####################################
-
-DATA_DIR = str(Path(os.getenv("DATA_DIR", "./data")).resolve())
-
-UPLOAD_DIR = f"{DATA_DIR}/uploads"
-
-Path(UPLOAD_DIR).mkdir(parents=True, exist_ok=True)
-
-FRONTEND_BUILD_DIR = str(Path(os.getenv("FRONTEND_BUILD_DIR", "../build")))
-
-####################################
 # ENV (dev,test,prod)
 ####################################
 
 ENV = os.environ.get("ENV", "dev")
+
+
+####################################
+# DATA/FRONTEND BUILD DIR
+####################################
+
+DATA_DIR = str(Path(os.getenv("DATA_DIR", "./data")).resolve())
+FRONTEND_BUILD_DIR = str(Path(os.getenv("FRONTEND_BUILD_DIR", "../build")))
+
+####################################
+# File Upload DIR
+####################################
+
+UPLOAD_DIR = f"{DATA_DIR}/uploads"
+Path(UPLOAD_DIR).mkdir(parents=True, exist_ok=True)
 
 ####################################
 # OLLAMA_API_BASE_URL

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,4 +1,3 @@
-from dotenv import load_dotenv, find_dotenv
 import os
 
 
@@ -14,7 +13,11 @@ from constants import ERROR_MESSAGES
 
 from pathlib import Path
 
-load_dotenv(find_dotenv("../.env"))
+try:
+    from dotenv import load_dotenv, find_dotenv
+    load_dotenv(find_dotenv("../.env"))
+except ImportError:
+    print("dotenv not installed, skipping...")
 
 
 ####################################

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from apps.openai.main import app as openai_app
 from apps.web.main import app as webui_app
 from apps.rag.main import app as rag_app
 
-from config import ENV
+from config import ENV, WEB_DIR
 
 
 class SPAStaticFiles(StaticFiles):
@@ -58,4 +58,4 @@ app.mount("/openai/api", openai_app)
 app.mount("/rag/api/v1", rag_app)
 
 
-app.mount("/", SPAStaticFiles(directory="../build", html=True), name="spa-static-files")
+app.mount("/", SPAStaticFiles(directory=str(WEB_DIR), html=True), name="spa-static-files")

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,6 +60,6 @@ app.mount("/rag/api/v1", rag_app)
 
 app.mount(
     "/",
-    SPAStaticFiles(directory=str(FRONTEND_BUILD_DIR), html=True),
+    SPAStaticFiles(directory=FRONTEND_BUILD_DIR, html=True),
     name="spa-static-files",
 )

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from apps.openai.main import app as openai_app
 from apps.web.main import app as webui_app
 from apps.rag.main import app as rag_app
 
-from config import ENV, WEB_DIR
+from config import ENV, FRONTEND_BUILD_DIR
 
 
 class SPAStaticFiles(StaticFiles):
@@ -58,4 +58,8 @@ app.mount("/openai/api", openai_app)
 app.mount("/rag/api/v1", rag_app)
 
 
-app.mount("/", SPAStaticFiles(directory=str(WEB_DIR), html=True), name="spa-static-files")
+app.mount(
+    "/",
+    SPAStaticFiles(directory=str(FRONTEND_BUILD_DIR), html=True),
+    name="spa-static-files",
+)


### PR DESCRIPTION
- Why dotenv as optional dependency is useful?

Today Docker and Systemd already have ways of mimicking what dotenv does, but for anything that runs under it. It's a detail.

- Unhardcode some paths

I am trying to Nix it. This PR started as I being lazy to patch stuff up to work with my requisites lol.

Even though one can customize some extra values, like the data directory, the defaults are still the same.

I tested the backend using a virtualenv environment to see if it finds stuff and works. I need to test if the ollama integration properly works. 