### PR TITLE
Add max_tokens workaround for gpt-4-vision-preview model

### DIFF
--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -87,7 +87,8 @@ async def proxy(path: str, request: Request, user=Depends(get_current_user)):
         # Check if the model is "gpt-4-vision-preview" and set "max_tokens" to 4000
         # This is a workaround until OpenAI fixes the issue with this model
         if body.get("model") == "gpt-4-vision-preview":
-            body["max_tokens"] = 4000
+            if "max_tokens" not in body:
+                body["max_tokens"] = 4000
             print("Modified body_dict:", body)
 
         # Convert the modified body back to JSON

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -99,10 +99,10 @@ async def proxy(path: str, request: Request, user=Depends(get_current_user)):
             print("Error loading request body into a dictionary:", e)
             raise HTTPException(status_code=400, detail="Invalid JSON in request body")
         
-        # Check if the model is "gpt-4-vision-preview" and set "max_tokens" to 10000
+        # Check if the model is "gpt-4-vision-preview" and set "max_tokens" to 4000
         # This is a workaround until OpenAI fixes the issue with this model
         if body_dict.get("model") == "gpt-4-vision-preview":
-            body_dict["max_tokens"] = 10000
+            body_dict["max_tokens"] = 4000
             print("Modified body_dict:", body_dict)
         
         # Try to convert the modified body back to JSON


### PR DESCRIPTION

This commit adds a workaround for the gpt-4-vision-preview model in the OpenAI API. 

Due to an issue with this model, it's necessary to set the 'max_tokens' parameter  in the request body. The changes in this commit check if the model is 'gpt-4-vision-preview' and, if so, set 'max_tokens' to 4000. 

This workaround is temporary and should be removed once the issue with the model is fixed by OpenAI.

A screenshot has been added as a reference to show that the gpt-4-vision-preview model is now working with this workaround. The screenshot can be found in the related pull request or issue.

<img width="1418" alt="image" src="https://github.com/ollama-webui/ollama-webui/assets/46842909/7e5953da-120f-4f50-a0cf-8845ec65b48b">
