### PR TITLE
Bugfix: Fix toast error popup when front end can't figure out file type.

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -149,9 +149,9 @@ def store_doc(
     text_xml=["xml"]
     octet_markdown=["md"]
     known_source_ext=[
-        "go", "py", "java", "sh", "bat", "ps1", "cmd", "js", 
+        "go", "py", "java", "sh", "bat", "ps1", "cmd", "js", "ts",
         "css", "cpp", "hpp","h", "c", "cs", "sql", "log", "ini",
-        "pl" "pm", "r", "dart", "dockerfile", "env", "php", "hs",
+        "pl", "pm", "r", "dart", "dockerfile", "env", "php", "hs",
         "hsc", "lua", "nginxconf", "conf", "m", "mm", "plsql", "perl",
         "rb", "rs", "db2", "scala", "bash", "swift", "vue", "svelte"
         ]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,7 +24,14 @@ export const SUPPORTED_FILE_TYPE = [
 	'text/markdown'
 ];
 
-export const SUPPORTED_FILE_EXTENSIONS = ['md', 'rst'];
+export const SUPPORTED_FILE_EXTENSIONS = [
+	'md', 'rst','go', 'py', 'java', 'sh', 'bat', 'ps1', 'cmd', 'js', 
+	'ts', 'css', 'cpp', 'hpp','h', 'c', 'cs', 'sql', 'log', 'ini',
+	'pl', 'pm', 'r', 'dart', 'dockerfile', 'env', 'php', 'hs',
+	'hsc', 'lua', 'nginxconf', 'conf', 'm', 'mm', 'plsql', 'perl',
+	'rb', 'rs', 'db2', 'scala', 'bash', 'swift', 'vue', 'svelte',
+	'doc','docx', 'pdf', 'csv', 'txt'
+];
 
 // Source: https://kit.svelte.dev/docs/modules#$env-static-public
 // This feature, akin to $env/static/private, exclusively incorporates environment variables


### PR DESCRIPTION
Was getting error toasts with RAG because file['type'] on front end was empty string sometimes in doc upload. Back end parsed them as expected though. 

Copied list of file ext from back end to front end added in #547 and also added typescript extension to both lists.