### PR TITLE
Changed the sizing of the users table

### DIFF
--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -81,7 +81,7 @@
 	class=" bg-white dark:bg-gray-800 dark:text-gray-100 min-h-screen w-full flex justify-center font-mona"
 >
 	{#if loaded}
-		<div class="w-full max-w-3xl px-10 md:px-16 min-h-screen flex flex-col">
+		<div class="w-full max-w-6xl px-10 md:px-16 min-h-screen flex flex-col">
 			<div class="py-10 w-full">
 				<div class=" flex flex-col justify-center">
 					<div class=" flex justify-between items-center">


### PR DESCRIPTION
Sometimes, if your users have a too long mail / name the table cuts off at the right end. Changed the size.

Looked like this with 3xl:


![image](https://github.com/ollama-webui/ollama-webui/assets/69747628/48c62876-08bf-44aa-ada1-f13848a34623)


Now its bigger and shows the full content (Exept someone has a way too big mail or name)

![image](https://github.com/ollama-webui/ollama-webui/assets/69747628/6e9066ef-3095-4210-a609-0e0ff718e3a2)



