### PR TITLE
fix: use bash when starting the Dockerfile's entrypoint script (as th…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY --from=build /app/build /app/build
 # copy backend files
 COPY ./backend .
 
-CMD [ "sh", "start.sh"]
+CMD [ "bash", "start.sh"]


### PR DESCRIPTION
…e script uses BASH_SOURCE that is bash only)