### PR TITLE
fix: use exec the uvicorn process to handle Docker's SIGTERM correctly

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -4,4 +4,4 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit
 
 PORT="${PORT:-8080}"
-uvicorn main:app --host 0.0.0.0 --port "$PORT" --forwarded-allow-ips '*'
+exec uvicorn main:app --host 0.0.0.0 --port "$PORT" --forwarded-allow-ips '*'


### PR DESCRIPTION
Replace the shell with the uvicorn process, so it becomes PID 1 and receives the signals directly