### PR TITLE
feat: Add netcat to Dockerfile for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ COPY ./backend/requirements.txt ./requirements.txt
 RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
 RUN pip3 install -r requirements.txt --no-cache-dir
 
-# Install pandoc
+# Install pandoc and netcat
 # RUN python -c "import pypandoc; pypandoc.download_pandoc()"
 RUN apt-get update \
-    && apt-get install -y pandoc \
+    && apt-get install -y pandoc netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 # RUN python -c "from sentence_transformers import SentenceTransformer; model = SentenceTransformer('all-MiniLM-L6-v2')"


### PR DESCRIPTION
Adds the netcat-openbsd package while building the image to allow creating a healthcheck.

I couldn't find anything related to Docker's healthcheck implemented. Ollama has commits to use curl and I'm not sure if there's any advantage to use it for healthcheck instead.