### PR TITLE
Feat: Allow All Users Access to Docs Upload and Prompts

### DIFF
--- a/backend/apps/web/routers/documents.py
+++ b/backend/apps/web/routers/documents.py
@@ -35,7 +35,7 @@ async def get_documents(user=Depends(get_current_user)):
 
 @router.post("/create", response_model=Optional[DocumentModel])
 async def create_new_doc(form_data: DocumentForm, user=Depends(get_current_user)):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -86,7 +86,7 @@ async def get_doc_by_name(name: str, user=Depends(get_current_user)):
 async def update_doc_by_name(
     name: str, form_data: DocumentUpdateForm, user=Depends(get_current_user)
 ):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -109,7 +109,7 @@ async def update_doc_by_name(
 
 @router.delete("/name/{name}/delete", response_model=bool)
 async def delete_doc_by_name(name: str, user=Depends(get_current_user)):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/backend/apps/web/routers/prompts.py
+++ b/backend/apps/web/routers/prompts.py
@@ -30,7 +30,7 @@ async def get_prompts(user=Depends(get_current_user)):
 
 @router.post("/create", response_model=Optional[PromptModel])
 async def create_new_prompt(form_data: PromptForm, user=Depends(get_current_user)):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -81,7 +81,7 @@ async def get_prompt_by_command(command: str, user=Depends(get_current_user)):
 async def update_prompt_by_command(
     command: str, form_data: PromptForm, user=Depends(get_current_user)
 ):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -104,7 +104,7 @@ async def update_prompt_by_command(
 
 @router.delete("/command/{command}/delete", response_model=bool)
 async def delete_prompt_by_command(command: str, user=Depends(get_current_user)):
-    if user.role != "admin":
+    if user.role == "pending":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -116,6 +116,66 @@
 			</button>
 		</div>
 
+		<div class="px-2.5 flex justify-center">
+			<button
+				class="flex-grow flex space-x-3 rounded-md px-3 py-2 hover:bg-gray-900 transition"
+				on:click={async () => {
+					goto('/prompts');
+				}}
+			>
+				<div class="self-center">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke-width="1.5"
+						stroke="currentColor"
+						class="w-4 h-4"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
+						/>
+					</svg>
+				</div>
+
+				<div class="flex self-center">
+					<div class=" self-center font-medium text-sm">Prompts</div>
+				</div>
+			</button>
+		</div>
+
+		<div class="px-2.5 flex justify-center mb-1">
+			<button
+				class="flex-grow flex space-x-3 rounded-md px-3 py-2 hover:bg-gray-900 transition"
+				on:click={async () => {
+					goto('/documents');
+				}}
+			>
+				<div class="self-center">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke-width="1.5"
+						stroke="currentColor"
+						class="w-4 h-4"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+						/>
+					</svg>
+				</div>
+
+				<div class="flex self-center">
+					<div class=" self-center font-medium text-sm">Documents</div>
+				</div>
+			</button>
+		</div>
+
 		{#if $user?.role === 'admin'}
 			<div class="px-2.5 flex justify-center mt-0.5">
 				<button
@@ -143,66 +203,6 @@
 
 					<div class="flex self-center">
 						<div class=" self-center font-medium text-sm">Modelfiles</div>
-					</div>
-				</button>
-			</div>
-
-			<div class="px-2.5 flex justify-center">
-				<button
-					class="flex-grow flex space-x-3 rounded-md px-3 py-2 hover:bg-gray-900 transition"
-					on:click={async () => {
-						goto('/prompts');
-					}}
-				>
-					<div class="self-center">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke-width="1.5"
-							stroke="currentColor"
-							class="w-4 h-4"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
-							/>
-						</svg>
-					</div>
-
-					<div class="flex self-center">
-						<div class=" self-center font-medium text-sm">Prompts</div>
-					</div>
-				</button>
-			</div>
-
-			<div class="px-2.5 flex justify-center mb-1">
-				<button
-					class="flex-grow flex space-x-3 rounded-md px-3 py-2 hover:bg-gray-900 transition"
-					on:click={async () => {
-						goto('/documents');
-					}}
-				>
-					<div class="self-center">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke-width="1.5"
-							stroke="currentColor"
-							class="w-4 h-4"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
-							/>
-						</svg>
-					</div>
-
-					<div class="flex self-center">
-						<div class=" self-center font-medium text-sm">Documents</div>
 					</div>
 				</button>
 			</div>


### PR DESCRIPTION
## New Feature Request

Requesting to implement a new feature.

### User Story

I would like to use this webui for a small team to share content for chat conversations.  I am currently not able to upload documents as a user.

Only users with admin are able to upload documents and create prompts.  Thus, requiring all users to have admin access.  This could lead to unintended consequences with a user accidentally deleting or change access that only an admin should have access.

### Bonus Benefits

With a small team of users, this allows users to see and share the types of prompts other users are creating.  Resulting in increase of efficiency in prompt engineering and collaboration.

### Solution

1.  Allow UI to rending Documents and Prompts in sidebar.  Edit side bar svelte.
2. Allow Admin and Users to upload, edit Documents as well as Prompts add/edit. Edit routers accordingly.

Tested locally on my machine, building in docker.  User 'admin' in one browser, and test 'user' in another browser.  Both sessions updated accordingly.  Documents and prompts shared between Admin and User accounts.

## Request Review

Requesting review and feedback as required.  If there is a better implementation or a `user.roles` check that I missed, I am happy to assist with a change.

Thank you for your time and reviewing this update.
