### PR TITLE
feat: Use modelfiles with external API instead of ollama

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -512,6 +512,10 @@
 	const sendPromptOpenAI = async (model, userPrompt, parentId, _chatId) => {
 		let responseMessageId = uuidv4();
 
+		const myModel = $models.find((m) => m.name === model);
+		let external = myModel?.external === true;
+		let externalPrompt = external && selectedModelfile.content.split('"""')[1];
+
 		let responseMessage = {
 			parentId: parentId,
 			id: responseMessageId,
@@ -537,12 +541,13 @@
 			model: model,
 			stream: true,
 			messages: [
-				$settings.system
+				$settings.system && !external
 					? {
 							role: 'system',
 							content: $settings.system
 					  }
 					: undefined,
+				external ? { role: 'system', content: externalPrompt } : undefined,
 				...messages
 			]
 				.filter((message) => message)

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -526,6 +526,10 @@
 	const sendPromptOpenAI = async (model, userPrompt, parentId, _chatId) => {
 		let responseMessageId = uuidv4();
 
+		const myModel = $models.find((m) => m.name === model);
+		let external = myModel?.external === true;
+		let externalPrompt = external && selectedModelfile.content.split('"""')[1];
+
 		let responseMessage = {
 			parentId: parentId,
 			id: responseMessageId,
@@ -551,12 +555,13 @@
 			model: model,
 			stream: true,
 			messages: [
-				$settings.system
+				$settings.system && !external
 					? {
 							role: 'system',
 							content: $settings.system
 					  }
 					: undefined,
+				external ? { role: 'system', content: externalPrompt } : undefined,
 				...messages
 			]
 				.filter((message) => message)


### PR DESCRIPTION
With this change a modelfile from the ollama hub can be imported in a way that it uses an external model from openAI compatible API instead of ollama.

A pre requirement is to provide an API key and refresh the page so the models are loaded.

In my testing to achieve this we have to copy an existing model's name to two places:
- the Tag name
- the FROM part of the content

This works in my local instance.

I am rather not so sure about this changes as I never touched svelte before.

Probably a checkbox called: use external and a dropdown list to select from external models would be a more complete solution.

Should relate to #665