### PR TITLE
fixed Docker problem some users experienced

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Some users, including me had this problem when running the Dockerfile since it runs start.sh after the latest changes made to the .sh files:

![image](https://github.com/ollama-webui/ollama-webui/assets/69747628/047f4ff0-e8e3-4a94-8de8-14689ef90174)


This is a problem with the encoding CRLF, I made a .gitattrobutes file to make shure the file stays in LF.





