### PR TITLE
Snap packaging

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -29,4 +29,4 @@ if [ "$USE_CUDA_DOCKER" = "true" ]; then
   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/torch/lib:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib"
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host 0.0.0.0 --port "$PORT" --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+snapctl stop "$SNAP_INSTANCE_NAME"
+snapctl start "$SNAP_INSTANCE_NAME"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+snapctl set host="0.0.0.0"
+snapctl set port="8080"
+snapctl set secret-key=$(head -c 12 /dev/random | base64)
+
+snapctl set ollama-api-base-url="http://localhost:11434/api"
+snapctl set openai-api-base-url="https://api.openai.com/v1"
+snapctl set openai-api-key=""
+
+snapctl set enable-signup="true"
+snapctl set data-dir="$SNAP_COMMON/data"
+

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mkdir -p $SNAP_COMMON/data

--- a/snap/local/info.sh
+++ b/snap/local/info.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+HOST=$(snapctl get host)
+PORT=$(snapctl get port)
+
+SERVICE_INFO=$(snapctl services $SNAP_INSTANCE_NAME.listener)
+
+STATUS=$(echo "$SERVICE_INFO" | awk '/open-webui.listener/{print $3}')
+
+echo "$SNAP_INSTANCE_NAME.listener: $STATUS"
+
+if [ "$STATUS" == "active" ]; then
+  echo ''
+  echo "To use $SNAP_INSTANCE_NAME, open the following URL in your browser: http://$HOST:$PORT"
+else
+  echo ''
+  echo "If you expected the service to be up, check that the port $PORT is available, not bound by some other service."
+fi
+
+echo ''
+echo 'For documentation, see https://docs.openwebui.com'
+echo ''
+echo "You can use a local AI model with $SNAP_INSTANCE_NAME with ollama (http://ollama.com)."
+echo ' - You can install ollama with `sudo snap install ollama --channel=beta`'
+echo ' - ollama is by default expected to be serving at 'http://localhost:11434/api'. To customize that, do `sudo snap set open-webui ollama-api-base-url=...`'
+echo ' - for all available configuration parameters, see `sudo snap get open-webui`'
+echo ''
+echo "You can access any OpenAI compatible API endpoint with $SNAP_INSTANCE_NAME."
+echo ' - To configure the OpenAI endpoint (by default expected to be "https://api.openai.com/v1"), do `sudo snap set open-webui openai-api-base-url=...`'
+echo ' - To configure the OpenAI API key (by default an empty string), do `sudo snap set open-webui openai-api-key=...`'

--- a/snap/local/run-snap.sh
+++ b/snap/local/run-snap.sh
@@ -2,8 +2,11 @@
 
 set -e
 
+STATIC_DIR=$SNAP_DATA/static
+mkdir -p $STATIC_DIR
+
 DATA_DIR=$(snapctl get data-dir) \
-STATIC_DIR=$SNAP_DATA/static \
+STATIC_DIR=$STATIC_DIR \
 FRONTEND_BUILD_DIR=$SNAP/build \
 HOST=$(snapctl get host) \
 PORT=$(snapctl get port) \

--- a/snap/local/run-snap.sh
+++ b/snap/local/run-snap.sh
@@ -3,12 +3,13 @@
 set -e
 
 DATA_DIR=$(snapctl get data-dir) \
-PORT=$(snapctl get port) \
+STATIC_DIR=$SNAP_DATA/static \
+FRONTEND_BUILD_DIR=$SNAP/build \
 HOST=$(snapctl get host) \
+PORT=$(snapctl get port) \
 WEBUI_SECRET_KEY=$(snapctl get secret-key) \
 OLLAMA_API_BASE_URL=$(snapctl get ollama-api-base-url) \
 OPENAI_API_BASE_URL=$(snapctl get openai-api-base-url) \
 OPENAI_API_KEY=$(snapctl get openai-api-key) \
 ENABLE_SIGNUP=$(snapctl get enable-signup) \
-FRONTEND_BUILD_DIR=$SNAP/build \
-$SNAP/backend/start.sh $@
+    $SNAP/backend/start.sh $@

--- a/snap/local/run-snap.sh
+++ b/snap/local/run-snap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+DATA_DIR=$(snapctl get data-dir) \
+PORT=$(snapctl get port) \
+HOST=$(snapctl get host) \
+WEBUI_SECRET_KEY=$(snapctl get secret-key) \
+OLLAMA_API_BASE_URL=$(snapctl get ollama-api-base-url) \
+OPENAI_API_BASE_URL=$(snapctl get openai-api-base-url) \
+OPENAI_API_KEY=$(snapctl get openai-api-key) \
+ENABLE_SIGNUP=$(snapctl get enable-signup) \
+FRONTEND_BUILD_DIR=$SNAP/build \
+$SNAP/backend/start.sh $@

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,105 @@
+---
+name: open-webui
+base: core22
+version: '0'  # no released version yet
+summary: ChatGPT-Style Web UI Client for Ollama 🦙 (formerly Ollama WebUI)
+description: |
+  The Open WebUI consists of two primary components:
+  the frontend and the backend (which serves as a reverse proxy,
+  handling static frontend files, and additional features).
+  Both are set up.
+adopt-info: backend
+grade: stable
+confinement: strict
+license: MIT
+architectures:
+  - build-on: [amd64]
+    build-for: [amd64]
+  - build-on: [arm64]
+    build-for: [arm64]
+
+apps:
+  open-webui:
+    command: bin/info.sh
+  listener:
+    command: bin/run-snap.sh
+    daemon: simple
+    install-mode: enable
+    restart-condition: on-failure
+    plugs:
+      - home
+      - removable-media
+      - network
+      - network-bind
+      - opengl
+    environment:
+      ENV: prod
+      SCARF_NO_ANALYTICS: 'true'
+      DO_NOT_TRACK: 'true'
+parts:
+  launcher:
+    plugin: dump
+    source: ./snap/local
+    organize:
+      info.sh: bin/info.sh
+      run-snap.sh: bin/run-snap.sh
+  minilm:
+    plugin: dump
+    source: https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz
+    organize:
+      onnx: root/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx
+  frontend:
+    after: [launcher, minilm]
+    plugin: nil
+    source: .
+    source-type: git
+    override-build: |
+      craftctl default
+      npm ci
+      npm run build
+      cp -r build $CRAFT_PART_INSTALL/build
+    stage-snaps:
+      - node/20/stable
+  backend:
+    after: [frontend]
+    plugin: python
+    source: .
+    source-type: git
+    build-packages:
+      - netcat-openbsd
+      - python3.10
+      - python3.10-venv
+      - python3.10-dev
+      - python3-pip
+      - git
+      - execstack
+    stage-packages:
+      - python3.10
+      - python3.10-venv
+      - pandoc
+      - libavcodec58
+      - libavformat58
+      - libavdevice58
+      - libavfilter7
+    python-requirements:
+      - backend/requirements.txt
+    override-pull: |
+      craftctl default
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      craftctl set version="$(git describe --tags | sed 's/v//')"
+    override-build: |
+      craftctl default
+      pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir
+      cp -r backend $CRAFT_PART_INSTALL
+    override-prime: |
+      craftctl default
+
+      # libctranslate2.so... is caught with an executable stack (something to investigate)
+      # for now forcibly cleared below.
+      #
+      # see https://forum.snapcraft.io/t/snap-and-executable-stacks/1812 for more info on the check
+      for f in `find $CRAFT_PRIME | grep -e libctranslate2.*\.so\..*`; do
+        strip --strip-all $f;
+        execstack --clear-execstack $f;
+      done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 ---
 name: open-webui
 base: core22
-version: '0'  # no released version yet
+version: "0" # no released version yet
 summary: ChatGPT-Style Web UI Client for Ollama 🦙 (formerly Ollama WebUI)
 description: |
   The Open WebUI consists of two primary components:
@@ -34,8 +34,8 @@ apps:
       - opengl
     environment:
       ENV: prod
-      SCARF_NO_ANALYTICS: 'true'
-      DO_NOT_TRACK: 'true'
+      SCARF_NO_ANALYTICS: "true"
+      DO_NOT_TRACK: "true"
 parts:
   launcher:
     plugin: dump
@@ -67,15 +67,15 @@ parts:
     source-type: git
     build-packages:
       - netcat-openbsd
-      - python3.10
-      - python3.10-venv
-      - python3.10-dev
+      - python3.11
+      - python3.11-venv
+      - python3.11-dev
       - python3-pip
       - git
       - execstack
     stage-packages:
-      - python3.10
-      - python3.10-venv
+      - python3.11
+      - python3.11-venv
       - pandoc
       - libavcodec58
       - libavformat58


### PR DESCRIPTION
Adds strictly confined snap packaging of ollama-webui for x86-64 as an alternative to docker & k8s, presently published on the channel `latest/beta` (`sudo snap install ollama-webui --beta`).

This is proposed as a nice alternative to docker (no need to install and configure the nvidia docker runtime for example, systemd service is set up automatically, over-the-air updates, straightforward to access resources and data from user's host system within the limits of the application's confinement) and safer of course than bare installation onto host system.

Installable with:

```bash
sudo snap install ollama --channel beta # or ollama installed any other method, or on another host
sudo snap install ollama-webui --channel beta
```

As you might guess from above I also packaged up [ollama](https://github.com/ollama/ollama/pull/2432) as a snap (this snapped version of ollama-webui does not require it, demonstrating this mostly just to note the ease of installing both).


- strict confinement used with [`network`](https://snapcraft.io/docs/network-interface), [`network-bind`](https://snapcraft.io/docs/network-bind-interface), [`home`](https://snapcraft.io/docs/home-interface), [`removable-media`](https://snapcraft.io/docs/removable-media-interface), [`opengl`](https://snapcraft.io/docs/opengl-interface) interfaces in use, i.e. it can access and serve a port, access home directory and `/media`, and access the GPU (the `opengl` interface also grants access to CUDA etc).
- starts up a systemd service automatically for the service.
- if removable media access is needed (e.g. user prefers storing data under a disk mounted under `/media`), `sudo snap connect ollama:removable-media` achieves that (for security reasons, removable media access not granted without user action).

If this looks interesting, I'm happy to hand over the package on snapcraft.io to a maintainer, and can contribute CI integration to make it easy to keep the snap package up to date whenever you release.

If you want to build this locally, [after installing `snapcraft` and either the multipass or LXD provider for it](https://snapcraft.io/docs/snapcraft-setup) go to the root directory of the repository, and ...:

```bash
snapcraft
```


## Configuration

Offers the following configuration keys and default values, configurable with `sudo snap set ollama-webui key=value`:

- `data-dir`: /var/snap/ollama-webui/common/data
- `enable-signup`: true
- `host`: 0.0.0.0
- `ollama-api-base-url`: http://localhost:11434/api
- `openai-api-base-url`: https://api.openai.com/v1
- `openai-api-key`: (blank)
- `port`: 8080
- `secret-key` (randomized)