### PR TITLE
fix: no internet connection for whisper if you use docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ ENV SCARF_NO_ANALYTICS true
 ENV DO_NOT_TRACK true
 
 #Whisper TTS Settings
-ENV WHISPER_DIR="/app/backend/data/cache/whisper/models"
 ENV WHISPER_MODEL="base"
+ENV WHISPER_MODEL_DIR="/app/backend/data/cache/whisper/models"
 
 WORKDIR /app/backend
 
@@ -49,7 +49,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # RUN python -c "from sentence_transformers import SentenceTransformer; model = SentenceTransformer('all-MiniLM-L6-v2')"
-RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_DIR'])"
+RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
 
 
 # copy embedding weight from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ ENV WEBUI_SECRET_KEY ""
 ENV SCARF_NO_ANALYTICS true
 ENV DO_NOT_TRACK true
 
+#Whisper TTS Settings
+ENV WHISPER_DIR="/app/backend/data/cache/whisper/models"
+ENV WHISPER_MODEL="base"
+
 WORKDIR /app/backend
 
 # install python dependencies
@@ -45,6 +49,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # RUN python -c "from sentence_transformers import SentenceTransformer; model = SentenceTransformer('all-MiniLM-L6-v2')"
+RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_DIR'])"
+
 
 # copy embedding weight from build
 RUN mkdir -p /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import (
     FastAPI,
     Request,
@@ -53,12 +54,14 @@ def transcribe(
             f.write(contents)
             f.close()
 
-        model_name = WHISPER_MODEL_NAME
+        model_name = os.getenv('WHISPER_MODEL', WHISPER_MODEL_NAME)
+        download_root = os.getenv('WHISPER_DIR', f"{CACHE_DIR}/whisper/models")
+
         model = WhisperModel(
             model_name,
             device="cpu",
             compute_type="int8",
-            download_root=f"{CACHE_DIR}/whisper/models",
+            download_root=download_root,
         )
 
         segments, info = model.transcribe(file_path, beam_size=5)

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -21,7 +21,7 @@ from utils.utils import (
 )
 from utils.misc import calculate_sha256
 
-from config import CACHE_DIR, UPLOAD_DIR, WHISPER_MODEL_NAME
+from config import CACHE_DIR, UPLOAD_DIR, WHISPER_MODEL, WHISPER_MODEL_DIR
 
 app = FastAPI()
 app.add_middleware(
@@ -54,14 +54,11 @@ def transcribe(
             f.write(contents)
             f.close()
 
-        model_name = os.getenv('WHISPER_MODEL', WHISPER_MODEL_NAME)
-        download_root = os.getenv('WHISPER_DIR', f"{CACHE_DIR}/whisper/models")
-
         model = WhisperModel(
-            model_name,
+            WHISPER_MODEL,
             device="cpu",
             compute_type="int8",
-            download_root=download_root,
+            download_root=WHISPER_MODEL_DIR,
         )
 
         segments, info = model.transcribe(file_path, beam_size=5)

--- a/backend/config.py
+++ b/backend/config.py
@@ -136,4 +136,6 @@ CHUNK_OVERLAP = 100
 ####################################
 # Transcribe
 ####################################
-WHISPER_MODEL_NAME = "base"
+
+WHISPER_MODEL = os.getenv("WHISPER_MODEL", "base")
+WHISPER_MODEL_DIR = os.getenv("WHISPER_MODEL_DIR", f"{CACHE_DIR}/whisper/models")


### PR DESCRIPTION
If you use docker, there is no internetconnection now needed to load the whisper model on first use since it is preloaded in the Docker Image buildtime.

Added env variables in the Dockerfile to change the whisper model and the location where its stored.