### PR TITLE
Replaced Ollama´s old .ai TLD with new .com TLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Don't forget to explore our sibling project, [OllamaHub](https://ollamahub.com/)
 
 2. **Ensure You Have the Latest Version of Ollama:**
 
-   - Download the latest version from [https://ollama.ai/](https://ollama.ai/).
+   - Download the latest version from [https://ollama.com/](https://ollama.com/).
 
 3. **Verify Ollama Installation:**
    - After installing Ollama, check if it's working by visiting [http://127.0.0.1:11434/](http://127.0.0.1:11434/) in your web browser. Remember, the port number might be different for you.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -20,7 +20,7 @@ docker run -d --network=host -v ollama-webui:/app/backend/data -e OLLAMA_API_BAS
 
 ### General Connection Errors
 
-**Ensure Ollama Version is Up-to-Date**: Always start by checking that you have the latest version of Ollama. Visit [Ollama's official site](https://ollama.ai/) for the latest updates.
+**Ensure Ollama Version is Up-to-Date**: Always start by checking that you have the latest version of Ollama. Visit [Ollama's official site](https://ollama.com/) for the latest updates.
 
 **Troubleshooting Steps**:
 

--- a/docs/apache.md
+++ b/docs/apache.md
@@ -74,7 +74,7 @@ On your latest installation of Ollama, make sure that you have setup your api se
 
 The guide doesn't seem to match the current updated service file on linux. So, we will address it here:
 
-Unless when you're compiling Ollama from source, installing with the standard install `curl https://ollama.ai/install.sh | sh` creates a file called `ollama.service` in /etc/systemd/system. You can use nano to edit the file:
+Unless when you're compiling Ollama from source, installing with the standard install `curl https://ollama.com/install.sh | sh` creates a file called `ollama.service` in /etc/systemd/system. You can use nano to edit the file:
 
 ```
 sudo nano /etc/systemd/system/ollama.service

--- a/src/lib/components/chat/Settings/Models.svelte
+++ b/src/lib/components/chat/Settings/Models.svelte
@@ -291,7 +291,7 @@
 <div class="flex flex-col h-full justify-between text-sm">
 	<div class=" space-y-3 pr-1.5 overflow-y-scroll h-80">
 		<div>
-			<div class=" mb-2.5 text-sm font-medium">Pull a model from Ollama.ai</div>
+			<div class=" mb-2.5 text-sm font-medium">Pull a model from Ollama.com</div>
 			<div class="flex w-full">
 				<div class="flex-1 mr-2">
 					<input
@@ -354,7 +354,7 @@
 			<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
 				To access the available model names for downloading, <a
 					class=" text-gray-500 dark:text-gray-300 font-medium"
-					href="https://ollama.ai/library"
+					href="https://ollama.com/library"
 					target="_blank">click here.</a
 				>
 			</div>

--- a/src/routes/(app)/modelfiles/create/+page.svelte
+++ b/src/routes/(app)/modelfiles/create/+page.svelte
@@ -497,7 +497,7 @@ SYSTEM """${system}"""`.replace(/^\s*\n/gm, '');
 							<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
 								To access the available model names for downloading, <a
 									class=" text-gray-500 dark:text-gray-300 font-medium"
-									href="https://ollama.ai/library"
+									href="https://ollama.com/library"
 									target="_blank">click here.</a
 								>
 							</div>


### PR DESCRIPTION
Not long ago https://ollama.ai switched TLD to https://ollama.com. Adapted this change in code.