### PR TITLE
Correct text for empty OpenAI API URL Field

### DIFF
--- a/src/lib/components/chat/Settings/External.svelte
+++ b/src/lib/components/chat/Settings/External.svelte
@@ -63,7 +63,7 @@
 				<div class="flex-1">
 					<input
 						class="w-full rounded py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-800 outline-none"
-						placeholder="Enter OpenAI API Key"
+						placeholder="Enter OpenAI API Base URL"
 						bind:value={OPENAI_API_BASE_URL}
 						autocomplete="off"
 					/>


### PR DESCRIPTION
<img width="478" alt="Bildschirmfoto 2024-02-16 um 18 44 23" src="https://github.com/ollama-webui/ollama-webui/assets/98665507/88bbfbd2-a5e7-4504-adb8-5fd9aa0fbd42">
As you see, the text for no input for the url is wrong. Corrected it to match the heading