### PR TITLE
Kubernetes: WebUI Persistent Volume Claim

### DIFF
--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -5,11 +5,14 @@ ollama:
   image: ollama/ollama:latest
   servicePort: 11434
   resources:
-    limits:
+    requests:
       cpu: "2000m"
       memory: "2Gi"
+    limits:
+      cpu: "4000m"
+      memory: "4Gi"
       nvidia.com/gpu: "0"
-  volumeSize: 1Gi
+  volumeSize: 30Gi
   nodeSelector: {}
   tolerations: []
   service:
@@ -22,16 +25,19 @@ webui:
   image: ghcr.io/ollama-webui/ollama-webui:main
   servicePort: 8080
   resources:
-    limits:
+    requests:
       cpu: "500m"
       memory: "500Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
   ingress:
     enabled: true
     annotations:
     # Use appropriate annotations for your Ingress controller, e.g., for NGINX:
       # nginx.ingress.kubernetes.io/rewrite-target: /
     host: ollama.minikube.local
-  volumeSize: 1Gi
+  volumeSize: 2Gi
   nodeSelector: {}
   tolerations: []
   service:

--- a/kubernetes/manifest/base/ollama-statefulset.yaml
+++ b/kubernetes/manifest/base/ollama-statefulset.yaml
@@ -20,9 +20,13 @@ spec:
         ports:
         - containerPort: 11434
         resources:
-          limits:
+          requests:
             cpu: "2000m"
             memory: "2Gi"
+          limits:
+            cpu: "4000m"
+            memory: "4Gi"
+            nvidia.com/gpu: "0"
         volumeMounts:
         - name: ollama-volume
           mountPath: /root/.ollama
@@ -34,4 +38,4 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 1Gi
+          storage: 30Gi

--- a/kubernetes/manifest/base/webui-deployment.yaml
+++ b/kubernetes/manifest/base/webui-deployment.yaml
@@ -19,9 +19,12 @@ spec:
         ports:
         - containerPort: 8080
         resources:
-          limits:
+          requests:
             cpu: "500m"
             memory: "500Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
         env:
         - name: OLLAMA_API_BASE_URL
           value: "http://ollama-service.ollama-namespace.svc.cluster.local:11434/api"

--- a/kubernetes/manifest/base/webui-deployment.yaml
+++ b/kubernetes/manifest/base/webui-deployment.yaml
@@ -26,3 +26,10 @@ spec:
         - name: OLLAMA_API_BASE_URL
           value: "http://ollama-service.ollama-namespace.svc.cluster.local:11434/api"
         tty: true
+        volumeMounts:
+        - name: webui-volume
+          mountPath: /app/backend/data
+      volumes:
+      - name: webui-volume
+        persistentVolumeClaim:
+          claimName: ollama-webui-pvc          

--- a/kubernetes/manifest/base/webui-pvc.yaml
+++ b/kubernetes/manifest/base/webui-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: ollama-webui
+  name: ollama-webui-pvc
+  namespace: ollama-namespace
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/manifest/base/webui-pvc.yaml
+++ b/kubernetes/manifest/base/webui-pvc.yaml
@@ -9,4 +9,4 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 1Gi
+      storage: 2Gi


### PR DESCRIPTION
**Summary:**
- Added Kubernetes Persistent Volume Claim (PVC) for Ollama WebUI.
- Added Volume and Volume Mount to attach the PVC to Ollama WebUI deployment.

**Note:**
- This is for #742 .
- Tested on GKE (review attached screenshots).
<img width="472" alt="Screenshot 2024-02-16 at 19 49 30" src="https://github.com/ollama-webui/ollama-webui/assets/39132143/210901e9-0567-40c4-abcc-58388a9e0ef8">
<img width="1335" alt="Screenshot 2024-02-16 at 19 50 18" src="https://github.com/ollama-webui/ollama-webui/assets/39132143/a76cb802-7e7a-41aa-9490-dc38fbf41538">
