### PR TITLE
feat: choose embedding model when using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV WHISPER_MODEL_DIR="/app/backend/data/cache/whisper/models"
 # Leaderboard: https://huggingface.co/spaces/mteb/leaderboard 
 # for better persormance and multilangauge support use "intfloat/multilingual-e5-large"
 # IMPORTANT: If you change the default model (all-MiniLM-L6-v2) and vice versa, you aren't able to use RAG Chat with your previous documents loaded in the WebUI! You need to re-embed them.
-ENV DOCKER_SENTENCE_TRANSFORMER_EMBED_MODEL="all-MiniLM-L6-v2"
+ENV RAG_EMBEDDING_MODEL="all-MiniLM-L6-v2"
 
 WORKDIR /app/backend
 
@@ -55,7 +55,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # preload embedding model
-RUN python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['DOCKER_SENTENCE_TRANSFORMER_EMBED_MODEL'])"
+RUN python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'])"
 # preload tts model
 RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,11 @@ ENV WHISPER_MODEL_DIR="/app/backend/data/cache/whisper/models"
 # for better persormance and multilangauge support use "intfloat/multilingual-e5-large" (~2.5GB) or "intfloat/multilingual-e5-base" (~1.5GB)
 # IMPORTANT: If you change the default model (all-MiniLM-L6-v2) and vice versa, you aren't able to use RAG Chat with your previous documents loaded in the WebUI! You need to re-embed them.
 ENV RAG_EMBEDDING_MODEL="all-MiniLM-L6-v2"
-ENV SENTENCE_TRANSFORMERS_HOME="/app/backend/data/cache/embedding/models"
 # device type for whisper tts and ebbeding models - "cpu" (default), "cuda" (nvidia gpu and CUDA required) or "mps" (apple silicon) - choosing this right can lead to better performance
 ENV RAG_EMBEDDING_MODEL_DEVICE_TYPE="cpu"
+ENV RAG_EMBEDDING_MODEL_DIR="/app/backend/data/cache/embedding/models"
+ENV SENTENCE_TRANSFORMERS_HOME $RAG_EMBEDDING_MODEL_DIR
+
 ######## Preloaded models ########
 
 WORKDIR /app/backend
@@ -64,7 +66,6 @@ RUN apt-get update \
 RUN python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'], device=os.environ['RAG_EMBEDDING_MODEL_DEVICE_TYPE'])"
 # preload tts model
 RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='auto', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
-
 
 # copy embedding weight from build
 RUN mkdir -p /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,21 @@ ENV WEBUI_SECRET_KEY ""
 ENV SCARF_NO_ANALYTICS true
 ENV DO_NOT_TRACK true
 
+######## Preloaded models ########
 # whisper TTS Settings
 ENV WHISPER_MODEL="base"
 ENV WHISPER_MODEL_DIR="/app/backend/data/cache/whisper/models"
 
+# RAG Embedding Model Settings
 # any sentence transformer model; models to use can be found at https://huggingface.co/models?library=sentence-transformers
 # Leaderboard: https://huggingface.co/spaces/mteb/leaderboard 
-# for better persormance and multilangauge support use "intfloat/multilingual-e5-large"
+# for better persormance and multilangauge support use "intfloat/multilingual-e5-large" (~2.5GB) or "intfloat/multilingual-e5-base" (~1.5GB)
 # IMPORTANT: If you change the default model (all-MiniLM-L6-v2) and vice versa, you aren't able to use RAG Chat with your previous documents loaded in the WebUI! You need to re-embed them.
 ENV RAG_EMBEDDING_MODEL="all-MiniLM-L6-v2"
+ENV SENTENCE_TRANSFORMERS_HOME="/app/backend/data/cache/embedding/models"
+# device type for whisper tts and ebbeding models - "cpu" (default), "cuda" (nvidia gpu and CUDA required) or "mps" (apple silicon) - choosing this right can lead to better performance
+ENV RAG_EMBEDDING_MODEL_DEVICE_TYPE="cpu"
+######## Preloaded models ########
 
 WORKDIR /app/backend
 
@@ -55,9 +61,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # preload embedding model
-RUN python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'])"
+RUN python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'], device=os.environ['RAG_EMBEDDING_MODEL_DEVICE_TYPE'])"
 # preload tts model
-RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
+RUN python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='auto', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
 
 
 # copy embedding weight from build

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -56,7 +56,7 @@ def transcribe(
 
         model = WhisperModel(
             WHISPER_MODEL,
-            device="cpu",
+            device="auto",
             compute_type="int8",
             download_root=WHISPER_MODEL_DIR,
         )

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -13,6 +13,7 @@ import os, shutil
 from pathlib import Path
 from typing import List
 
+from sentence_transformers import SentenceTransformer
 from chromadb.utils import embedding_functions
 
 from langchain_community.document_loaders import (
@@ -52,6 +53,7 @@ from config import (
     UPLOAD_DIR,
     DOCS_DIR,
     RAG_EMBEDDING_MODEL,
+    RAG_EMBEDDING_MODEL_DEVICE_TYPE,
     CHROMA_CLIENT,
     CHUNK_SIZE,
     CHUNK_OVERLAP,
@@ -60,10 +62,18 @@ from config import (
 
 from constants import ERROR_MESSAGES
 
+#
+#if RAG_EMBEDDING_MODEL:
+#    sentence_transformer_ef = SentenceTransformer(
+#        model_name_or_path=RAG_EMBEDDING_MODEL,
+#        cache_folder=RAG_EMBEDDING_MODEL_DIR,
+#        device=RAG_EMBEDDING_MODEL_DEVICE_TYPE,
+#    )
 
 if RAG_EMBEDDING_MODEL:
     sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(
-        model_name=RAG_EMBEDDING_MODEL
+        model_name=RAG_EMBEDDING_MODEL,
+        device=RAG_EMBEDDING_MODEL_DEVICE_TYPE,
     )
 
 app = FastAPI()

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -29,10 +29,12 @@ from langchain_community.document_loaders import (
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 
+
 from pydantic import BaseModel
 from typing import Optional
 
 import uuid
+
 
 from utils.misc import calculate_sha256, calculate_sha256_string
 from utils.utils import get_current_user, get_admin_user
@@ -113,12 +115,12 @@ def query_doc(
         # if you use docker use the model from the environment variable
             collection = CHROMA_CLIENT.get_collection(
                 name=form_data.collection_name,
-                embedding_function=sentence_transformer_ef
+                embedding_function=sentence_transformer_ef,
             )
         else:
         # for local development use the default model
-                collection = CHROMA_CLIENT.get_collection(
-                name=form_data.collection_name,
+            collection = CHROMA_CLIENT.get_collection(
+            name=form_data.collection_name,
             )
         result = collection.query(query_texts=[form_data.query], n_results=form_data.k)
         return result
@@ -191,16 +193,16 @@ def query_collection(
     for collection_name in form_data.collection_names:
         try:
             if 'DOCKER_SENTENCE_TRANSFORMER_EMBED_MODEL' in os.environ:
-             # if you use docker use the model from the environment variable
+            # if you use docker use the model from the environment variable
                 collection = CHROMA_CLIENT.get_collection(
-                    name=form_data.collection_name,
-                    embedding_function=sentence_transformer_ef
+                    name=collection_name,
+                    embedding_function=sentence_transformer_ef,
                 )
             else:
             # for local development use the default model
                 collection = CHROMA_CLIENT.get_collection(
-                name=form_data.collection_name,
-            )
+                name=collection_name,
+                )
                 
             result = collection.query(
                 query_texts=[form_data.query], n_results=form_data.k

--- a/backend/config.py
+++ b/backend/config.py
@@ -137,7 +137,7 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
 
 CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
 # this uses the model defined in the Dockerfile ENV variable. If you dont use docker or docker based deployments such as k8s, the default embedding model will be used (all-MiniLM-L6-v2)
-SENTENCE_TRANSFORMER_EMBED_MODEL = os.getenv("DOCKER_SENTENCE_TRANSFORMER_EMBED_MODEL")
+RAG_EMBEDDING_MODEL = os.environ.get("RAG_EMBEDDING_MODEL", "")
 CHROMA_CLIENT = chromadb.PersistentClient(
     path=CHROMA_DATA_PATH,
     settings=Settings(allow_reset=True, anonymized_telemetry=False),

--- a/backend/config.py
+++ b/backend/config.py
@@ -138,6 +138,9 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
 CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
 # this uses the model defined in the Dockerfile ENV variable. If you dont use docker or docker based deployments such as k8s, the default embedding model will be used (all-MiniLM-L6-v2)
 RAG_EMBEDDING_MODEL = os.environ.get("RAG_EMBEDDING_MODEL", "")
+
+# device type ebbeding models - "cpu" (default), "cuda" (nvidia gpu required) or "mps" (apple silicon) - choosing this right can lead to better performance
+RAG_EMBEDDING_MODEL_DEVICE_TYPE = os.environ.get("RAG_EMBEDDING_MODEL_DEVICE_TYPE", "")
 CHROMA_CLIENT = chromadb.PersistentClient(
     path=CHROMA_DATA_PATH,
     settings=Settings(allow_reset=True, anonymized_telemetry=False),

--- a/backend/config.py
+++ b/backend/config.py
@@ -137,10 +137,11 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
 
 CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
 # this uses the model defined in the Dockerfile ENV variable. If you dont use docker or docker based deployments such as k8s, the default embedding model will be used (all-MiniLM-L6-v2)
-RAG_EMBEDDING_MODEL = os.environ.get("RAG_EMBEDDING_MODEL", "")
-
+RAG_EMBEDDING_MODEL = os.environ.get("RAG_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
 # device type ebbeding models - "cpu" (default), "cuda" (nvidia gpu required) or "mps" (apple silicon) - choosing this right can lead to better performance
-RAG_EMBEDDING_MODEL_DEVICE_TYPE = os.environ.get("RAG_EMBEDDING_MODEL_DEVICE_TYPE", "")
+RAG_EMBEDDING_MODEL_DEVICE_TYPE = os.environ.get(
+    "RAG_EMBEDDING_MODEL_DEVICE_TYPE", "cpu"
+)
 CHROMA_CLIENT = chromadb.PersistentClient(
     path=CHROMA_DATA_PATH,
     settings=Settings(allow_reset=True, anonymized_telemetry=False),

--- a/backend/config.py
+++ b/backend/config.py
@@ -128,7 +128,8 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
 ####################################
 
 CHROMA_DATA_PATH = f"{DATA_DIR}/vector_db"
-EMBED_MODEL = "all-MiniLM-L6-v2"
+# this uses the model defined in the Dockerfile ENV variable. If you dont use docker or docker based deployments such as k8s, the default embedding model will be used (all-MiniLM-L6-v2)
+SENTENCE_TRANSFORMER_EMBED_MODEL = os.getenv("DOCKER_SENTENCE_TRANSFORMER_EMBED_MODEL")
 CHROMA_CLIENT = chromadb.PersistentClient(
     path=CHROMA_DATA_PATH,
     settings=Settings(allow_reset=True, anonymized_telemetry=False),


### PR DESCRIPTION
**Changes**
- Added the functionallity to change the default embedding model used (all-MiniLM-L6-v2) in the Dockerfile as an ENV variable
- You can now use any sentence-transformer embedding model which can be found here: https://huggingface.co/models?library=sentence-transformers
- default model `all-MiniLM-L6-v2` has low performance nowerdays and supports only english:
![image](https://github.com/open-webui/open-webui/assets/69747628/1f6f375d-4697-4169-8708-955cbe13812f)
- `all-MiniLM-L6-v2` is still default, please read the important info down below!
- You can change the model to `intfloat/multilingual-e5-large` which is one of the most powerful embedding models aviable (You can also use the instruct version of the multilingual-e5-large `intfloat/multilingual-e5-large-instruct` which is smaller and almost better as the latest from OpenAI ["text-embedding-large-3"](https://openai.com/blog/new-embedding-models-and-api-updates))
![image](https://github.com/open-webui/open-webui/assets/69747628/bf3b1e0d-d164-42a0-b372-790423144a54)
- Embedding models are preloaded in the Dockerfile (like the Whisper TTS model) for "no-internet" support.
- deleted some unused imports in the RAG `main.py`


**Improvements**
In my local testing (in german) the output with `intfloat/multilingual-e5-large` as the embedding model are way more accurate to my question given to the LLM.
Also the load times of the RAG were much shorter, i don't know why and whether that is the case for you too. Maybe you can test this and give feedback.

**Open Points**
- Support not only for sentence-transformer models (e.g. bert)
- Store the embedding model in `/app/backend/data/cache`
for now the model dir should be  `~/.cache/torch/sentence_transformers` which is not in the PVC
I didn't find a parameter to change the location here `sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=SENTENCE_TRANSFORMER_EMBED_MODEL)`
Insted of giving the model name as a string to be downloaded you can also give the param model_name a path. Maybe this would be the way to go.
- there are parameters fot the embedding model and whisper tts model in the preloading to set the device type to `cpu` (our standard for both) ot `cuda` which can lead to better performance when using nvida gpus. We could also set a ENV to change that to the users specific needs
- Maybe implementing an "Auto-re-embed" when the embedding model changes


### **Important Information**
If you have some documents stored under the `/documents` route, changing the embedding model will cause the backend to not be able to read the files. So if you have a lot of docs beeing used for RAG let that by default or re-embed your files.
 I also mentianed this in a Dockerfile comment. 




@tjbck i don't know if
`# wget embedding model weight from alpine (does not exist from slim-buster)
RUN wget "https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz" -O - | \
    tar -xzf - -C /app
`
in the Dockerfile was ever used, but with this update the `all-MiniLM-L6-v2` is declared in the ENV so it is obsolete imo.
If this is the case, deleting this RUN statement would save some buildtime + image size.