### PR TITLE
Add release creation workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,11 +13,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Get commit hash
-      id: get_hash
+    - name: Check for changes in package.json
       run: |
-        HASH=$(git rev-parse --short "$GITHUB_SHA")
-        echo "::set-output name=hash::$HASH"
+        git diff --cached --diff-filter=d package.json || {
+          echo "No changes to package.json"
+          exit 1
+        }
+
+    - name: Get version number from package.json
+      id: get_version
+      run: |
+        VERSION=$(jq -r '.version' package.json)
+        echo "::set-output name=version::$VERSION"
 
     - name: Create GitHub release
       uses: actions/github-script@v5
@@ -27,8 +34,8 @@ jobs:
           const release = await github.rest.repos.createRelease({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            tag_name: `v${{ steps.get_hash.outputs.hash }}`,
-            name: `v${{ steps.get_hash.outputs.hash }}`,
+            tag_name: `v${{ steps.get_version.outputs.version }}`,
+            name: `v${{ steps.get_version.outputs.version }}`,
             body: 'Automatically created new release',
           })
           console.log(`Created release ${release.data.html_url}`)

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main # or whatever branch you want to use
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get commit hash
+      id: get_hash
+      run: |
+        HASH=$(git rev-parse --short "$GITHUB_SHA")
+        echo "::set-output name=hash::$HASH"
+
+    - name: Create GitHub release
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const release = await github.rest.repos.createRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: `v${{ steps.get_hash.outputs.hash }}`,
+            name: `v${{ steps.get_hash.outputs.hash }}`,
+            body: 'Automatically created new release',
+          })
+          console.log(`Created release ${release.data.html_url}`)
+
+    - name: Upload package to GitHub release
+      uses: actions/upload-artifact@v3
+      with:
+        name: package
+        path: .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #255.

This PR add a `build-release.yml` file to automatically create GitHub releases using the commit hash, in it's short form.

This workflow can then be adapted when Open WebUI will use semantic versioning, to use the `package.json` version number.