### PR TITLE
Use semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "open-webui",
-	"version": "1.0.0-alpha.101",
+	"version": "0.1.0-101",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev --host",


### PR DESCRIPTION
Instead of having the previous `1.0.0-alpha.101`, we could use [semantic versioning](https://semver.org/) as a way to respect global conventions.

In our case, the current version is `1.0.0-alpha.101`. We could consider this a prerelease, so the semantic version string would be `0.1.0-101`

For more info about semantic versioning:
- https://semver.org/
- https://jubianchi.github.io/semver-check/#/version/0.1.0-101 | Allows you to preview a version string and explain each of it's components