### PR TITLE
config: allow custom default user role

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -187,7 +187,7 @@ DEFAULT_PROMPT_SUGGESTIONS = (
 )
 
 
-DEFAULT_USER_ROLE = "pending"
+DEFAULT_USER_ROLE = os.getenv("DEFAULT_USER_ROLE", "pending")
 USER_PERMISSIONS = {"chat": {"deletion": True}}
 
 


### PR DESCRIPTION
For internal (restricted) websites, allow customize the `DEFAULT_USER_ROLE` with ENV values (set to `user` or `admin` for example).
Since at the moment we need to manually enable the user (`pending` -> `user`), I want to allow self-register for quick access.