### PR TITLE
Fix Kubernetes Manifest for Web UI

### DIFF
--- a/kubernetes/manifest/base/webui-pvc.yaml
+++ b/kubernetes/manifest/base/webui-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: ollama-webui
   name: ollama-webui-pvc
-  namespace: ollama-namespace
+  namespace: open-webui
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:

--- a/kubernetes/manifest/kustomization.yaml
+++ b/kubernetes/manifest/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - base/webui-deployment.yaml
 - base/webui-service.yaml
 - base/webui-ingress.yaml
+- base/webui-pvc.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
There are currently 2 issues with the Kubernetes manifest:

- open-webui-deployment refers to ollama-webui-pvc but not included in kustomization.yaml, causing issue if using GPU deployment
- ollama-webui-pvc is using the wrong namespace

This commit fixes both issue.