### PR TITLE
Fix OpenAI integration: allow OpenAI to make chat completion calls with a valid API key

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,6 +52,7 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=git-
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
 

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -146,6 +146,15 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
                 body["max_tokens"] = 4000
             print("Modified body_dict:", body)
 
+        # Fix for ChatGPT calls failing because the num_ctx key is in body
+        if 'num_ctx' in body:
+            # If 'num_ctx' is in the dictionary, delete it
+            # Leaving it there generates an error with the
+            # OpenAI API (Feb 2024)
+            del body['num_ctx']
+        # OpenAI API (Feb 2024) accepts max_tokens
+        body["max_tokens"] = 1600
+
         # Convert the modified body back to JSON
         body = json.dumps(body)
     except json.JSONDecodeError as e:

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -147,13 +147,11 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
             print("Modified body_dict:", body)
 
         # Fix for ChatGPT calls failing because the num_ctx key is in body
-        if 'num_ctx' in body:
+        if "num_ctx" in body:
             # If 'num_ctx' is in the dictionary, delete it
             # Leaving it there generates an error with the
             # OpenAI API (Feb 2024)
-            del body['num_ctx']
-        # OpenAI API (Feb 2024) accepts max_tokens
-        body["max_tokens"] = 1600
+            del body["num_ctx"]
 
         # Convert the modified body back to JSON
         body = json.dumps(body)


### PR DESCRIPTION
From docker on mac get errors since num_ctx not recognized; remove num_ctx from, and add max_tokens to, body in API calls.

## Pull Request Checklist

- [ ] **Description:** 
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

Model file calls to the OpenAI API works fine, but chat completions fail withan error related to num_ctx in the body of the call.

backend/openai/main.py has a change to the main route to remove num_ctx from the body; this is replaced with max_tokens.

Chat completions now work.

---

### Changelog Entry

### Fixed

- Bug fix to allow chat completion API calls to OpenAI to work without num_ctx parameter error.

