### PR TITLE
Make the links look clickable

### DIFF
--- a/src/lib/components/chat/Settings/Models.svelte
+++ b/src/lib/components/chat/Settings/Models.svelte
@@ -432,7 +432,7 @@
 
 					<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
 						To access the available model names for downloading, <a
-							class=" text-gray-500 dark:text-gray-300 font-medium"
+							class=" text-gray-500 dark:text-gray-300 font-medium underline"
 							href="https://ollama.com/library"
 							target="_blank">click here.</a
 						>
@@ -651,7 +651,7 @@
 						{/if}
 						<div class=" mt-1 text-xs text-gray-400 dark:text-gray-500">
 							To access the GGUF models available for downloading, <a
-								class=" text-gray-500 dark:text-gray-300 font-medium"
+								class=" text-gray-500 dark:text-gray-300 font-medium underline"
 								href="https://huggingface.co/models?search=gguf"
 								target="_blank">click here.</a
 							>
@@ -790,7 +790,7 @@
 					<div class="mb-2 text-xs text-gray-400 dark:text-gray-500">
 						Not sure what to add?
 						<a
-							class=" text-gray-300 font-medium"
+							class=" text-gray-300 font-medium underline"
 							href="https://litellm.vercel.app/docs/proxy/configs#quick-start"
 							target="_blank"
 						>
@@ -913,7 +913,7 @@
 					<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 						Not sure what to add?
 						<a
-							class=" text-gray-300 font-medium"
+							class=" text-gray-300 font-medium underline"
 							href="https://litellm.vercel.app/docs/proxy/configs#quick-start"
 							target="_blank"
 						>


### PR DESCRIPTION
## Pull Request Checklist

- [X] **Description:** Briefly describe the changes in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation? **=> No change**
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? **=> No change**

---

## Description

Currently the links in the settings modal don't look like links and I had no idea they were clickable and completely missed it. I am sure many people would have the same issue, especially since even its color is grayed out. Here's what it currently looks like **(See the "click here" parts)**:

<img width="805" alt="beforee" src="https://github.com/open-webui/open-webui/assets/121128867/71e831e9-6839-4cad-8372-96b9837ff300">

To make them look clickable, I simply added an `underline` class to the links. And now the links look like links:

<img width="794" alt="afterr" src="https://github.com/open-webui/open-webui/assets/121128867/66bb34ef-a9a1-4ea3-a1a3-a982b95eb401">

---

### Changelog Entry

### Added

- "undeline" class to the links in the settings modal

