### PR TITLE
refac: delete message logic

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -228,10 +228,12 @@
 		const messageParentId = messageToDelete.parentId;
 		const messageChildrenIds = messageToDelete.childrenIds ?? [];
 
+		const hasSibling = messageChildrenIds.some(childId => history.messages[childId]?.childrenIds?.length > 0);
+
 		messageChildrenIds.forEach((childId) => {
 			const child = history.messages[childId];
 			if (child && child.childrenIds) {
-				if (child.childrenIds.length == 0) { // if last prompt/response pair
+				if (child.childrenIds.length === 0 && !hasSibling) { // if last prompt/response pair				
 					history.messages[messageParentId].childrenIds = []
 					history.currentId = messageParentId;
 				}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -230,7 +230,6 @@
 			history.messages[messageParentId].childrenIds = []
 		}
 
-		delete history.messages[messageId];
 		history.currentId = messageParentId;
 
 		await tick();

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -342,7 +342,7 @@
 						content: $settings.system
 				  }
 				: undefined,
-			...messages.filter((message) => !message.deleted)
+			...messages
 		]
 			.filter((message) => message)
 			.map((message, idx, arr) => ({
@@ -550,7 +550,7 @@
 								content: $settings.system
 						  }
 						: undefined,
-					...messages.filter((message) => !message.deleted)
+					...messages
 				]
 					.filter((message) => message)
 					.map((message, idx, arr) => ({

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -355,7 +355,7 @@
 						content: $settings.system
 				  }
 				: undefined,
-			...messages.filter((message) => !message.deleted)
+			...messages
 		]
 			.filter((message) => message)
 			.map((message, idx, arr) => ({
@@ -563,7 +563,7 @@
 								content: $settings.system
 						  }
 						: undefined,
-					...messages.filter((message) => !message.deleted)
+					...messages
 				]
 					.filter((message) => message)
 					.map((message, idx, arr) => ({


### PR DESCRIPTION
## Pull Request Checklist

- [✓] **Description:** Briefly describe the changes in this pull request.
- [✓] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [✓] **Documentation:** Have you updated relevant documentation?
- [N/A] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

EDIT (03/04/2024): We decided that the best user experience is to only delete the message/response pair (not all subsequent messages). This pull request manipulates the message `history` object to remove the deleted message/response pair and update the parent/child message relationships.  Refer to below diagram by @tjbck 
![image](https://github.com/open-webui/open-webui/assets/45186464/aab415a0-11bf-4926-b883-bdd01f9be618)

---

### Changelog Entry

### Added

### Fixed

### Changed
- Refactored the message deletion logic by directly manipulating the `history` object, removing message/response pairs and updating parent/child relationships to replace the existing implementation that uses a `isDeleted` flag.

### Removed
- N/A
