### PR TITLE
Remove extra 'S' in 'ASSISTANT'

### DIFF
--- a/src/lib/components/chat/Settings/Models.svelte
+++ b/src/lib/components/chat/Settings/Models.svelte
@@ -45,7 +45,7 @@
 	let modelUploadMode = 'file';
 	let modelInputFile = '';
 	let modelFileUrl = '';
-	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER: {{ .Prompt }}\nASSISTANT: """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER:"\nPARAMETER stop "ASSSISTANT:"`;
+	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER {{ .Prompt }}\nASSISTANT """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER"\nPARAMETER stop "ASSISTANT"`;
 	let modelFileDigest = '';
 	let uploadProgress = null;
 

--- a/src/lib/components/chat/Settings/Models.svelte
+++ b/src/lib/components/chat/Settings/Models.svelte
@@ -45,7 +45,7 @@
 	let modelUploadMode = 'file';
 	let modelInputFile = '';
 	let modelFileUrl = '';
-	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER {{ .Prompt }}\nASSISTANT """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER"\nPARAMETER stop "ASSISTANT"`;
+	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER: {{ .Prompt }}\nASSISTANT: """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER:"\nPARAMETER stop "ASSISTANT:"`;
 	let modelFileDigest = '';
 	let uploadProgress = null;
 

--- a/src/lib/components/chat/Settings/Models.svelte
+++ b/src/lib/components/chat/Settings/Models.svelte
@@ -45,7 +45,7 @@
 	let modelUploadMode = 'file';
 	let modelInputFile = '';
 	let modelFileUrl = '';
-	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER: {{ .Prompt }}\nASSSISTANT: """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER:"\nPARAMETER stop "ASSSISTANT:"`;
+	let modelFileContent = `TEMPLATE """{{ .System }}\nUSER: {{ .Prompt }}\nASSISTANT: """\nPARAMETER num_ctx 4096\nPARAMETER stop "</s>"\nPARAMETER stop "USER:"\nPARAMETER stop "ASSSISTANT:"`;
 	let modelFileDigest = '';
 	let uploadProgress = null;
 


### PR DESCRIPTION
## Description

This pull request fixes a syntax error in `Models.svelte` file of the `open-webui` project (Addresses #1061), where the model file content string was incorrectly formatted. The error was identified by a community member, beegie, on Discord. The correction involves updating the template string to ensure correct parameter definitions for the chat model settings.

---

### Changelog Entry

### Added

- N/A

### Fixed

- Fixed syntax error in the Modelfile 'ASSISTANT' parameter string of `Models.svelte`, ensuring correct parameter definitions for chat model settings.

### Changed

- Updated `Models.svelte` to correct the format of the Modelfile.

### Removed

- N/A