### PR TITLE
fix: numbered lists with an additional line between items are rendered incorrectly

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -43,6 +43,10 @@ ol > li {
 	font-weight: 400;
 }
 
+li p {
+	display: inline;
+}
+
 ::-webkit-scrollbar-thumb {
 	--tw-border-opacity: 1;
 	background-color: rgba(217, 217, 227, 0.8);


### PR DESCRIPTION
## Description

update app.css to convert p-tags within li-tags to inline instead of block

---

### Changelog Entry

### Fixed

- numbered lists with an additional newline between items are rendered incorrectly.
