### PR TITLE
Update requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,3 +44,4 @@ PyJWT
 pyjwt[crypto]
 
 black
+argon2-cffi


### PR DESCRIPTION
For some reason it only worked for me when I explicitly added the argon2-cffi dependency to the backend requirements

## Pull Request Checklist

- [X ] **Description:** Briefly describe the changes in this pull request.
- [ X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

I kept getting the following error when trying to bring up the docker compose.

```
open-webui  |   File "/app/backend/main.py", line 18, in <module>
open-webui  |     from litellm.proxy.proxy_server import ProxyConfig, initialize
open-webui  |   File "/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py", line 12, in <module>
open-webui  |     from argon2 import PasswordHasher
open-webui  | ModuleNotFoundError: No module named 'argon2'
```

I fixed it by adding `argon2-cffi` to the requirements.txt in the backend

---

### Changelog Entry

### Added

- Added argon2-cffi to the requirements

### Fixed

```
open-webui  |   File "/app/backend/main.py", line 18, in <module>
open-webui  |     from litellm.proxy.proxy_server import ProxyConfig, initialize
open-webui  |   File "/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py", line 12, in <module>
open-webui  |     from argon2 import PasswordHasher
open-webui  | ModuleNotFoundError: No module named 'argon2'
```

### Changed

- Added argon2-cffi to the requirements
