### PR TITLE
fix: auto scroll fails to stop with small scroll amounts

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -813,7 +813,7 @@
 			on:scroll={(e) => {
 				autoScroll =
 					messagesContainerElement.scrollHeight - messagesContainerElement.scrollTop <=
-					messagesContainerElement.clientHeight + 50;
+					messagesContainerElement.clientHeight + 5;
 			}}
 		>
 			<div

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -845,7 +845,7 @@
 				on:scroll={(e) => {
 					autoScroll =
 						messagesContainerElement.scrollHeight - messagesContainerElement.scrollTop <=
-						messagesContainerElement.clientHeight + 50;
+						messagesContainerElement.clientHeight + 5;
 				}}
 			>
 				<div


### PR DESCRIPTION
## Description

Reduce scroll threshold required to disable auto scroll from 50px to 5px

---

### Changelog Entry

### Fixed

- auto scroll fails to stop with small scroll amounts
