### PR TITLE
fixing typo MessageInput

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -673,7 +673,7 @@
 								? chatInputPlaceholder
 								: isRecording
 								? $i18n.t('Listening...')
-								: $i18n.t('Send a Messsage')}
+								: $i18n.t('Send a Message')}
 							bind:value={prompt}
 							on:keypress={(e) => {
 								if (e.keyCode == 13 && !e.shiftKey) {


### PR DESCRIPTION
Fixed typo in message input box:

![open-webui](https://github.com/open-webui/open-webui/assets/14093742/c574b79f-22d4-4546-b6b3-c27749fc9dc2)
