### PR TITLE
feat: OLED Dark Theme Option

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -14,7 +14,7 @@
 	export let getModels: Function;
 
 	// General
-	let themes = ['dark', 'light', 'rose-pine dark', 'rose-pine-dawn light'];
+	let themes = ['oled-dark', 'dark', 'light', 'rose-pine dark', 'rose-pine-dawn light'];
 	let selectedTheme = 'system';
 
 	let languages = [];
@@ -134,6 +134,7 @@
 						placeholder="Select a theme"
 						on:change={() => themeChangeHandler(selectedTheme)}
 					>
+						<option value="oled-dark">🌌 {$i18n.t('OLED Dark')}</option>
 						<option value="system">⚙️ {$i18n.t('System')}</option>
 						<option value="dark">🌑 {$i18n.t('Dark')}</option>
 						<option value="light">☀️ {$i18n.t('Light')}</option>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -134,8 +134,8 @@
 						placeholder="Select a theme"
 						on:change={() => themeChangeHandler(selectedTheme)}
 					>
-						<option value="oled-dark">🌌 {$i18n.t('OLED Dark')}</option>
 						<option value="system">⚙️ {$i18n.t('System')}</option>
+						<option value="oled-dark">🌌 {$i18n.t('OLED Dark')}</option>
 						<option value="dark">🌑 {$i18n.t('Dark')}</option>
 						<option value="light">☀️ {$i18n.t('Light')}</option>
 						<option value="rose-pine dark">🪻 {$i18n.t('Rosé Pine')}</option>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,6 +63,7 @@
 	<title>{$WEBUI_NAME}</title>
 	<link rel="icon" href="{WEBUI_BASE_URL}/static/favicon.png" />
 
+	<link rel="stylesheet" type="text/css" href="/themes/oled-dark.css" />
 	<link rel="stylesheet" type="text/css" href="/themes/rosepine.css" />
 	<link rel="stylesheet" type="text/css" href="/themes/rosepine-dawn.css" />
 </svelte:head>

--- a/static/themes/oled-dark.css
+++ b/static/themes/oled-dark.css
@@ -1,0 +1,457 @@
+/* Variables */
+:root {
+  --primary: #000;
+  --secondary: #000;
+  --background: #000;
+  --background-dark: #000;
+  --chat: #000;
+  --fill: #000;
+  --accent-1: #000;
+  --accent-2: #000;
+  --accent-3: #000;
+  --accent-4: #000;
+  --accent-5: #000;
+  --accent-6: #000;
+  --accent-7: #000;
+  --accent-8: #000;
+  --white: #fff;
+  --black: #000;
+}
+
+/* Base */
+.oled-dark * {
+  color: var(--white);
+  stroke: var(--white);
+}
+
+.oled-dark .app > * {
+  background-color: var(--background-dark);
+}
+
+.oled-dark #nav {
+  background-color: var(--background-dark);
+}
+
+.oled-dark .py-2\.5.my-auto.flex.flex-col.justify-between.h-screen {
+  background: var(--black);
+}
+
+.oled-dark .bg-white.dark\:bg-gray-800 {
+  background: var(--accent-1);
+}
+
+.oled-dark .w-4.h-4 {
+  fill: var(--fill);
+}
+
+.oled-dark #chat-textarea {
+  background: var(--chat);
+  margin: 0.3rem;
+  padding: 0.5rem;
+}
+
+.oled-dark .bg-gradient-to-t.from-white.dark\:from-gray-800.from-40\%.pb-2 {
+  background: var(--accent-4);
+  padding-top: 0.6rem;
+}
+
+.oled-dark .text-white.bg-gray-100.dark\:text-gray-800.dark\:bg-gray-600.disabled.transition.rounded-lg.p-1.mr-0\.5.w-7.h-7.self-center {
+  background-color: var(--accent-2);
+  transition: background-color 0.2s ease-out linear;
+}
+
+.oled-dark .bg-black.text-white.hover\:bg-gray-900.dark\:bg-white.dark\:text-black.dark\:hover\:bg-gray-100.transition.rounded-lg.p-1.mr-0\.5.w-7.h-7.self-center {
+  background-color: var(--accent-5);
+  transition: background-color 0.2s ease-out linear;
+}
+
+.oled-dark .bg-black.text-white.hover\:bg-gray-900.dark\:bg-white.dark\:text-black.dark\:hover\:bg-gray-100.transition.rounded-lg.p-1.mr-0\.5.w-7.h-7.self-center > * {
+  fill: var(--accent-6);
+  transition: fill 0.2s ease-out linear;
+}
+
+.oled-dark .w-full.flex.justify-between.rounded-md.px-3.py-2.hover\:bg-gray-900.bg-gray-900.transition.whitespace-nowrap.text-ellipsis {
+  background-color: var(--accent-3);
+  font-weight: bold;
+}
+
+.oled-dark .hover\:bg-gray-900:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(57 53 82 / var(--tw-bg-opacity));
+}
+
+.oled-dark .text-xs.text-gray-700.uppercase.bg-gray-50.dark\:bg-gray-700.dark\:text-gray-400 {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .scrollbar-hidden.relative.overflow-x-auto.whitespace-nowrap.svelte-3g4avz {
+  border-radius: 16px 16px 0 0;
+}
+
+.oled-dark .base.enter.svelte-ug60r4 {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .message.svelte-1nauejd {
+  color: var(--secondary);
+}
+
+.oled-dark #dropdownDots {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .flex.py-2\.5.px-3\.5.w-full.hover\:bg-gray-800.transition:hover {
+  background: var(--accent-3);
+}
+
+.oled-dark .m-auto.rounded-xl.max-w-full.w-\[40rem\].mx-2.bg-gray-50.dark\:bg-gray-900.shadow-3xl {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .w-full.rounded.p-4.text-sm.dark\:text-gray-300.dark\:bg-gray-800.outline-none.resize-none {
+  background-color: var(--accent-3);
+}
+
+.oled-dark .w-full.rounded.py-2.px-4.text-sm.dark\:text-gray-300.dark\:bg-gray-800.outline-none.svelte-1vx7r9s {
+  background-color: var(--accent-3);
+}
+
+.oled-dark .px-2\.5.py-2\.5.min-w-fit.rounded-lg.flex-1.md\:flex-none.flex.text-right.transition.bg-gray-200.dark\:bg-gray-700 {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .px-2\.5.py-2\.5.min-w-fit.rounded-lg.flex-1.md\:flex-none.flex.text-right.transition.hover\:bg-gray-300.dark\:hover\:bg-gray-800:hover {
+  background-color: var(--accent-3);
+}
+
+.oled-dark .px-4.py-2.bg-emerald-600.hover\:bg-emerald-700.text-gray-100.transition.rounded {
+  background-color: var(--accent-5);
+}
+
+.oled-dark #chat-search > * {
+  background-color: var(--accent-4);
+}
+
+.oled-dark .svelte-1ee93ns {
+  --primary: var(--primary);
+  --secondary: var(--secondary);
+}
+
+.oled-dark .svelte-11kvm4p {
+  --primary: var(--accent-6);
+  --secondary: var(--background-dark);
+}
+
+/* New rules */
+.oled-dark #model-dropdown {
+  background-color: var(--accent-4);
+}
+
+.oled-dark #model-dropdown * {
+  color: var(--secondary);
+}
+
+.oled-dark #models {
+  color: var(--white);
+}
+
+.oled-dark button.rounded-xl {
+  background-color: var(--accent-3);
+}
+
+.oled-dark .bg-gray-900 {
+  background-color: var(--black);
+}
+
+.oled-dark button.text-gray-800 {
+  color: var(--black);
+}
+
+.oled-dark button.bg-black {
+  background-color: var(--black);
+}
+
+.oled-dark textarea.rounded-lg {
+  background-color: var(--black);
+  border: 1px solid #fff;
+}
+
+.oled-dark input.rounded {
+  background-color: var(--black);
+  border: 1px solid #fff;
+}
+
+.oled-dark .rounded-l-lg {
+  color: var(--white);
+}
+
+.oled-dark button.bg-gray-100 {
+  background-color: #4CAF50;
+}
+
+.oled-dark button.bg-gray-50 {
+  background-color: #4CAF50;
+}
+
+.oled-dark button.bg-gray-50 svg {
+  fill: var(--white);
+}
+
+.oled-dark .text-lg {
+  color: var(--white);
+}
+
+.oled-dark select.py-2 {
+  background-color: var(--black);
+  color: var(--white);
+  border: 1.0px solid #fff;
+}
+
+.oled-dark .rounded-r-lg {
+  background-color: var(--black);
+  border: 1.0px solid #fff;
+}
+
+.oled-dark .bg-gray-200 {
+  background-color: var(--black);
+}
+
+.oled-dark .dark\:text-gray-300 {
+  color: var(--white);
+}
+
+.oled-dark div.bg-white:nth-child(2) {
+  background-color: var(--accent-4);
+}
+
+.oled-dark form.flex{
+  background-color: var(--black);
+}
+
+.oled-dark div.self-end:nth-child(3) > div:nth-child(2) {
+  color: var(--black);
+}
+
+.oled-dark div.self-end:nth-child(1) > div:nth-child(1) {
+  color: var(--black);
+}
+
+.oled-dark div.hidden:nth-child(4) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.hidden:nth-child(3) > button:nth-child(1) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.hidden:nth-child(4) > button:nth-child(1) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.basis-full:nth-child(1) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.basis-full:nth-child(2) > button:nth-child(1) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.basis-full:nth-child(1) > button:nth-child(1) {
+  color: var(--black);
+  background-color: var(--black);
+}
+
+.oled-dark div.bg-white:nth-child(2) > div:nth-child(1) {
+  background-color: var(--black);
+}
+
+.oled-dark tr.bg-white:nth-child(1) > td:nth-child(1) {
+  color: var(--text-color, black);
+  background-color: var(--bg-color-secondary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(1) > td:nth-child(2) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-primary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(1) > td:nth-child(3) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-tertiary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(1) > td:nth-child(4) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-quaternary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(2) > td:nth-child(1) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-secondary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(2) > td:nth-child(2) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-primary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(2) > td:nth-child(3) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-tertiary, #000000);
+}
+
+.oled-dark tr.bg-white:nth-child(2) > td:nth-child(4) {
+  color: var(--text-color, white);
+  background-color: var(--bg-color-tertiary, #000000);
+}
+
+.oled-dark div.flex-col:nth-child(3) {
+  background-color: rgba(0, 0, 0, 1); /* Solid black */
+}
+
+.oled-dark div.space-y-3:nth-child(2) > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > input:nth-child(1) {
+  background-color: var(--black);
+}
+
+.oled-dark div.space-y-3:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > input:nth-child(1) {
+  background-color: var(--black);
+}
+
+.oled-dark button.cursor-pointer:nth-child(2) {
+  background-color: var(--black);
+  border: 1px solid #1E90FF;
+  color: var(--white);
+}
+
+.oled-dark button.cursor-pointer:nth-child(2) > div:nth-child(1) > svg:nth-child(1) {
+  fill: #1E90FF;
+}
+
+.oled-dark input.w-full:nth-child(1) {
+  color: var(--white);
+  background-color: var(--black);
+  border: 1px solid #fff;
+}
+
+.oled-dark button.bg-gray-200:nth-child(2) {
+  background-color: #4CAF50;
+}
+
+.oled-dark div.space-y-2:nth-child(2) > div:nth-child(2) > div:nth-child(2) > div:nth-child(1) > select:nth-child(1) {
+  color: var(--black);
+}
+
+.oled-dark div.space-y-2:nth-child(2) > div:nth-child(2) {
+  background-color: var(--black);
+}
+
+.oled-dark div.dark\:text-gray-300 > button:nth-child(2) > svg > path {
+  stroke: red;
+  fill: red;
+}
+
+.oled-dark div.space-y-2:nth-child(2) > div:nth-child(2) > div:nth-child(2) > button:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  stroke: var(--white);
+  fill: transparent;
+}
+
+.oled-dark div.space-y-2:nth-child(2) > div:nth-child(1) > div:nth-child(2) > button:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  stroke: var(--white);
+  fill: transparent;
+}
+
+.oled-dark button.bg-gray-200:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  stroke: var(--white);
+  fill: transparent;
+}
+
+.oled-dark .mb-1\.5 > button:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  stroke: var(--white);
+  fill: transparent;
+}
+
+.oled-dark div.mt-2:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > button:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  stroke: var(--white);
+  fill: transparent;
+}
+
+.oled-dark div.text-left:nth-child(2) > button:nth-child(1) {
+  color: var(--white);
+}
+
+.oled-dark .space-x-1 > svg:nth-child(1) > path:nth-child(1) {
+  color: var(--white);
+  fill: transparent;
+}
+
+.oled-dark button.text-xs:nth-child(2) > div:nth-child(2) > svg:nth-child(1) {
+  color: var(--white);
+  fill: transparent;
+}
+
+.oled-dark button.flex:nth-child(3) > div:nth-child(2) > svg:nth-child(1) > path:nth-child(1) {
+  color: var(--white);
+  fill: transparent;
+}
+
+.oled-dark .modal-content > div:nth-child(1) {
+  background-color: var(--black);
+}
+
+.oled-dark div.text-lg {
+  background-color: var(--black);
+}
+
+.oled-dark div.space-y-2:nth-child(2) > div:nth-child(1) > div:nth-child(2) > button:nth-child(2) > svg:nth-child(1) {
+  color: var(--white);
+  fill: transparent;
+}
+
+.oled-dark div.px-2:nth-child(2) > a:nth-child(1) > div:nth-child(1) > svg:nth-child(1) {
+  fill: transparent;
+}
+
+.oled-dark div.px-2:nth-child(3) > a:nth-child(1) > div:nth-child(1) > svg:nth-child(1) {
+  fill: transparent;
+}
+
+.oled-dark div.px-2:nth-child(4) > a:nth-child(1) > div:nth-child(1) > svg:nth-child(1) > path:nth-child(1) {
+  fill: transparent;
+}
+
+.oled-dark button.hover\:text-white:nth-child(2):hover > svg:nth-child(1) {
+  fill: var(--white);
+}
+
+.oled-dark button.hover\:text-white:nth-child(3):hover > svg:nth-child(1) {
+  fill: var(--white);
+}
+
+.oled-dark button.bg-white > svg:nth-child(1) > path:nth-child(1) {
+  fill: var(--black);
+}
+
+.oled-dark button.bg-white {
+  background-color: var(--black);
+}
+
+.oled-dark div.fixed:nth-child(2) {
+  background-color: transparent;
+}
+
+.oled-dark div.fixed:nth-child(2) > div:nth-child(1) {
+  background-color: var(--black);
+}
+
+.oled-dark #new-chat-button > div:nth-child(1) > svg:nth-child(1) {
+  fill: transparent;
+}
+
+.oled-dark #new-chat-button > div:nth-child(1) > svg:nth-child(1) > path:nth-child(2) {
+  fill: var(--white);
+}


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** I have provided relevant documentation.
- [x] **Dependencies:** I have not updated the dependency versions in the documentation, as there are no new dependencies.

---

## Description
This pull request introduces a new OLED Dark theme option in the Theme Settings for Open WebUI. **The newly added `oled-dark.css` theme features mostly black (#000) UI elements like the background with white text with easy-to-read UI elements. This theme offers improved readability in low-light environments, but is still a major work in progress. I call upon all developers to contribute with helping to tidy up the theme's .CSS code.**

---

### Changelog Entry

### Added/Changed/Fixed

- Added a new theme name `oled-dark.css` in `src/lib/components/chat/Settings/General.svelte`.
- Added a Stylesheet path in `src/routes/+layout.svelte` for the theme.
- Created a new CSS file named `oled-dark.css` in `static/themes/` with the classes renamed and colors modified.
- Added many new CSS selectors to the `oled-dark.css` file that aren't present in `Rosé Pine` & `Rosé Pine Dawn` themes.

### Removed

- [No removals in this PR]