### PR TITLE
K8s fixes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -218,8 +218,8 @@ if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
         else OLLAMA_API_BASE_URL
     )
 
-if ENV == "prod" and RUNNING_ON_K8S == "":
-    if OLLAMA_BASE_URL == "/ollama":
+if ENV == "prod":
+    if OLLAMA_BASE_URL == "/ollama" and RUNNING_ON_K8S == "":
         OLLAMA_BASE_URL = "http://host.docker.internal:11434"
     else:
         OLLAMA_BASE_URL = "http://ollama-service.open-webui.svc.cluster.local:11434"

--- a/backend/config.py
+++ b/backend/config.py
@@ -208,8 +208,7 @@ OLLAMA_API_BASE_URL = os.environ.get(
 )
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "")
-
-RUNNING_ON_K8S = os.environ.get("KUBERNETES_SERVICE_HOST", "")
+KUBERNETES_SERVICE_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "")
 
 if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
     OLLAMA_BASE_URL = (
@@ -219,7 +218,7 @@ if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
     )
 
 if ENV == "prod":
-    if OLLAMA_BASE_URL == "/ollama" and RUNNING_ON_K8S == "":
+    if OLLAMA_BASE_URL == "/ollama" and KUBERNETES_SERVICE_HOST == "":
         OLLAMA_BASE_URL = "http://host.docker.internal:11434"
     else:
         OLLAMA_BASE_URL = "http://ollama-service.open-webui.svc.cluster.local:11434"

--- a/backend/config.py
+++ b/backend/config.py
@@ -209,6 +209,7 @@ OLLAMA_API_BASE_URL = os.environ.get(
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "")
 
+RUNNING_ON_K8S = os.environ.get("KUBERNETES_SERVICE_HOST", "")
 
 if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
     OLLAMA_BASE_URL = (
@@ -217,9 +218,23 @@ if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
         else OLLAMA_API_BASE_URL
     )
 
-if ENV == "prod":
+if ENV == "prod" and RUNNING_ON_K8S == "":
     if OLLAMA_BASE_URL == "/ollama":
         OLLAMA_BASE_URL = "http://host.docker.internal:11434"
+    else:
+        OLLAMA_BASE_URL = "http://ollama-service.open-webui.svc.cluster.local:11434"
+    
+
+
+def is_running_in_kubernetes():
+    return 'KUBERNETES_SERVICE_HOST' in os.environ
+
+# Setze EMV auf True, wenn in Kubernetes
+if is_running_in_kubernetes():
+    os.environ['EMV'] = 'True'
+    print("Läuft in Kubernetes, EMV gesetzt auf True.")
+else:
+    print("Läuft nicht in Kubernetes.")
 
 
 OLLAMA_BASE_URLS = os.environ.get("OLLAMA_BASE_URLS", "")

--- a/backend/config.py
+++ b/backend/config.py
@@ -223,18 +223,6 @@ if ENV == "prod" and RUNNING_ON_K8S == "":
         OLLAMA_BASE_URL = "http://host.docker.internal:11434"
     else:
         OLLAMA_BASE_URL = "http://ollama-service.open-webui.svc.cluster.local:11434"
-    
-
-
-def is_running_in_kubernetes():
-    return 'KUBERNETES_SERVICE_HOST' in os.environ
-
-# Setze EMV auf True, wenn in Kubernetes
-if is_running_in_kubernetes():
-    os.environ['EMV'] = 'True'
-    print("Läuft in Kubernetes, EMV gesetzt auf True.")
-else:
-    print("Läuft nicht in Kubernetes.")
 
 
 OLLAMA_BASE_URLS = os.environ.get("OLLAMA_BASE_URLS", "")

--- a/kubernetes/manifest/base/webui-deployment.yaml
+++ b/kubernetes/manifest/base/webui-deployment.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: webui-volume
         persistentVolumeClaim:
-          claimName: ollama-webui-pvc          
+          claimName: open-webui-pvc          

--- a/kubernetes/manifest/base/webui-pvc.yaml
+++ b/kubernetes/manifest/base/webui-pvc.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app: ollama-webui
-  name: ollama-webui-pvc
+    app: open-webui
+  name: open-webui-pvc
   namespace: open-webui
 spec:
   accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
I configured a new Open WebUI instance on my K8S node and i noticed some points.

**Changed**

- Old naming of the Open WebUI PVC


**Added**

- Sometimes the ENV allocated in the webui-deployment.yaml was overwritten by the `OLLAMA_BASE_URL `check in `backend/config.py` and allocated `http://host.docker.internal:11434` which wont work on K8S. Added a check to set the right base URL `http://ollama-service.open-webui.svc.cluster.local:11434` when running on K8S