### PR TITLE
fix: Helm Chart storageClassName typo

### DIFF
--- a/kubernetes/helm/templates/ollama-statefulset.yaml
+++ b/kubernetes/helm/templates/ollama-statefulset.yaml
@@ -88,7 +88,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.ollama.persistence.size | quote }}
-      storageClass: {{ .Values.ollama.persistence.storageClass }}
+      storageClassName: {{ .Values.ollama.persistence.storageClass }}
       {{- with .Values.ollama.persistence.selector }}
       selector:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/helm/templates/webui-pvc.yaml
+++ b/kubernetes/helm/templates/webui-pvc.yaml
@@ -17,7 +17,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.webui.persistence.size }}
-  storageClass: {{ .Values.webui.persistence.storageClass }}
+  storageClassName: {{ .Values.webui.persistence.storageClass }}
   {{- with .Values.webui.persistence.selector }}
   selector:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Pull Request Checklist

- [X] **Description:** Briefly describe the changes in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description
Setting the persistent volume class gets ignored by kubernetes due to a typo. See the [k8s docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reserving-a-persistentvolume). The only reason this worked previously was that it was using the cluster's default storage class.

---

### Changelog Entry

### Fixed
- Helm chart PVC storage class value

### Changed

- Helm chart PVC storage class no longer using cluster default
