### PR TITLE
fix: enforce formatters on GitHub Actions

### DIFF
--- a/.github/workflows/format-backend.yaml
+++ b/.github/workflows/format-backend.yaml
@@ -25,3 +25,5 @@ jobs:
           pip install yapf
       - name: Format backend
         run: bun run format:backend
+      - name: Check for changes after format
+        run: git diff --exit-code

--- a/.github/workflows/format-build-frontend.yaml
+++ b/.github/workflows/format-build-frontend.yaml
@@ -18,5 +18,8 @@ jobs:
         run: bun install
       - name: Format frontend
         run: bun run format
+      - name: Check for changes after format
+        run: git diff --exit-code
       - name: Build frontend
+        if: always()
         run: bun run build


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.

---

## Description

Workflows are not currently failing when the formatters produce a diff. This PR modifies the workflows to  run a `git diff` after the formatters run to catch any unformatted code that was formatted.

As this hasn't been enforced in a while, this produces a massive diff that would need to be applied to actually merge the change in, and would likely result in merge conflicts for any in-flight PRs.

The frontend build is set to always run even if the format step fails, as it's useful to know if it's just a formatting issue, or if the PR doesn't build at all.

Example runs:

* Python: https://github.com/cheahjs/open-webui-fork/actions/runs/8475065194/job/23222525498
* JS: https://github.com/cheahjs/open-webui-fork/actions/runs/8475065195/job/23222525488
