### PR TITLE
fix the select model bar

### DIFF
--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -855,6 +855,14 @@
 		/>
 		<div class="flex flex-col flex-auto">
 			<div
+				class="{$settings?.fullScreenMode ?? null
+					? 'max-w-full'
+					: 'max-w-2xl md:px-0'} mx-auto w-full px-4"
+			>
+				<ModelSelector bind:selectedModels />
+			</div>
+
+			<div
 				class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0"
 				id="messages-container"
 				bind:this={messagesContainerElement}
@@ -864,13 +872,7 @@
 						messagesContainerElement.clientHeight + 5;
 				}}
 			>
-				<div
-					class="{$settings?.fullScreenMode ?? null
-						? 'max-w-full'
-						: 'max-w-2xl md:px-0'} mx-auto w-full px-4"
-				>
-					<ModelSelector bind:selectedModels />
-				</div>
+				
 
 				<div class=" h-full w-full flex flex-col py-8">
 					<Messages


### PR DESCRIPTION
## Pull Request Checklist

- [ ] **Description:** Fix the model selection area and separate it from the dialogue area
- [ ] **Changelog:** Adjusted the layout of chat page 


---

## Description

Fix the model selection area and separate it from the chat area, so that the model selection area will always be displayed without the need for manual sliding on top

Issue can be found in: https://github.com/open-webui/open-webui/issues/1350

---

### Changelog Entry

### Added

- None

### Fixed

- None

### Changed

- Adjusted the layout of chat page (/src/routes/(app)/c/[id]/+page.svelte)

### Removed

- None
