### PR TITLE
fix: manually check the docs' filename

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -8,7 +8,7 @@ from fastapi import (
     Form,
 )
 from fastapi.middleware.cors import CORSMiddleware
-import os, shutil, logging
+import os, shutil, logging, re
 
 from pathlib import Path
 from typing import List
@@ -450,7 +450,7 @@ def store_doc(
     try:
         is_valid_filename = True
         unsanitized_filename = file.filename
-        if not unsanitized_filename.isascii():
+        if re.search(r'[\\/:"\*\?<>|\n\t ]', unsanitized_filename) is not None:
             is_valid_filename = False
 
         unvalidated_file_path = f"{UPLOAD_DIR}/{unsanitized_filename}"


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

When uploading documents, the system changed from only allowing ASCII character file names to manually checking for dangerous characters. It allows file names to include non-English characters such as Chinese and Korean. This PR may fix the problem in #1407.

---

### Changelog Entry

### Changed

- Allow non-ASCII characters in docs' file names.
