### PR TITLE
feat: trigger docker build after release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -57,3 +57,14 @@ jobs:
         path: .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Trigger Docker build workflow
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'docker-build.yaml',
+            ref: 'v${{ steps.get_version.outputs.version }}',
+          })

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,6 +3,7 @@ name: Create and publish a Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## Pull Request Checklist

- [ ] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

Fixes the Docker workflow not building tagged images.

This was because releases are programatically created via GitHub Actions, and it is designed specifically such that any events originating from an action cannot trigger another action, as such the release action creating a new tag wasn't triggering the tagged Docker build (only the `main` branch build would have been triggered on push).

This fixes the inability to trigger by allowing the Docker workflow to be triggered by `workflow_dispatch` events, and the release workflow will manually trigger a tagged Docker build once it's done creating the release.

Test example:

* Tagged Docker build: https://github.com/cheahjs/open-webui-fork/actions/runs/8574795311/job/23502387401
    * <img width="473" alt="image" src="https://github.com/open-webui/open-webui/assets/818368/e0c7d248-e9a7-407c-b00f-71306bb4aee5">
* Release workflow triggering tagged Docker build: https://github.com/cheahjs/open-webui-fork/actions/runs/8574789343/job/23502369111
* Tagged Docker image: https://github.com/cheahjs/open-webui-fork/pkgs/container/open-webui-fork/200277278?tag=v0.1.118-dockertest

This still isn't ideal, since Docker builds are triggered twice, and you end up with different Docker images for what is effectively the same underlying Git commit (`main`, `git-<hash>`, `<tag>` should all ideally point to the same image).
