### PR TITLE
Add AMD Docker Compose config file

### DIFF
--- a/docker-compose.amdgpu.yaml
+++ b/docker-compose.amdgpu.yaml
@@ -3,6 +3,6 @@ services:
     devices:
       - /dev/kfd:/dev/kfd
       - /dev/dri:/dev/dri
-    image: ollama/ollama:rocm
+    image: ollama/ollama:${OLLAMA_DOCKER_TAG-rocm}
     environment:
-      - 'HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION}'
+      - 'HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION-11.0.0}'

--- a/docker-compose.amdgpu.yaml
+++ b/docker-compose.amdgpu.yaml
@@ -1,0 +1,8 @@
+services:
+  ollama:
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    image: ollama/ollama:rocm
+    environment:
+      - 'HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION}'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     pull_policy: always
     tty: true
     restart: unless-stopped
-    image: ollama/ollama:latest
+    image: ollama/ollama:${OLLAMA_DOCKER_TAG-latest}
 
   open-webui:
     build:
@@ -16,7 +16,7 @@ services:
       args:
         OLLAMA_BASE_URL: '/ollama'
       dockerfile: Dockerfile
-    image: ghcr.io/open-webui/open-webui:main
+    image: ghcr.io/open-webui/open-webui:${WEBUI_DOCKER_TAG-main}
     container_name: open-webui
     volumes:
       - open-webui:/app/backend/data


### PR DESCRIPTION
This Docker Compose will setup Ollama to run with AMD GPU support using the `:rocm` tagged image. Some GPUs seem to require this environment variable: `HSA_OVERRIDE_GFX_VERSION`

Which could require different values:
https://github.com/ollama/ollama/issues/2637

---

- **For AMD GPU Support:** Some AMD GPUs require setting an environment variable for proper functionality:

  ```bash
  HSA_OVERRIDE_GFX_VERSION=11.0.0 docker compose -f docker-compose.yaml -f docker-compose.amdgpu.yaml up -d --build
  ```

  <details>
  <summary>AMD GPU Support with HSA_OVERRIDE_GFX_VERSION</summary>

  For AMD GPU users encountering compatibility issues, setting the `HSA_OVERRIDE_GFX_VERSION` environment variable is crucial. This variable instructs the ROCm platform to emulate a specific GPU architecture, ensuring compatibility with various AMD GPUs not officially supported. Depending on your GPU model, adjust the `HSA_OVERRIDE_GFX_VERSION` as follows:

  - **For RDNA1 & RDNA2 GPUs** (e.g., RX 6700, RX 680M): Use `HSA_OVERRIDE_GFX_VERSION=10.3.0`.
  - **For RDNA3 GPUs**: Set `HSA_OVERRIDE_GFX_VERSION=11.0.0`.
  - **For older GCN (Graphics Core Next) GPUs**: The version to use varies. GCN 4th gen and earlier might require different settings, such as `ROC_ENABLE_PRE_VEGA=1` for GCN4, or `HSA_OVERRIDE_GFX_VERSION=9.0.0` for Vega (GCN5.0) emulation.

  Ensure to replace `<version>` with the appropriate version number based on your GPU model and the guidelines above. For a detailed list of compatible versions and more in-depth instructions, refer to the [ROCm documentation](https://rocm.docs.amd.com) and the [openSUSE Wiki on AMD GPGPU](https://en.opensuse.org/SDB:AMD_GPGPU).

  Example command for RDNA1 & RDNA2 GPUs:
  ```bash
  HSA_OVERRIDE_GFX_VERSION=10.3.0 docker compose -f docker-compose.yaml -f docker-compose.amdgpu.yaml up -d --build
  ```

  </details>

## Pull Request Checklist

- [x] **Description:** This pull request adds an AMD GPU Docker Compose file to the project. The file is configured to run the `ollama/ollama:rocm` Docker container, which should improve performance on systems with AMD GPUs.

- [x] **Changelog:**

  ### Added

  - AMD Docker Compose file for Ollama on AMD GPUs

  ### Changed

  - Updated documentation to include instructions for using the AMD Docker Compose file


---

Please review the changes and let me know if you have any questions or suggestions. Thank you!