### PR TITLE
Make chart idempotent.

### DIFF
--- a/kubernetes/helm/templates/webui-pvc.yaml
+++ b/kubernetes/helm/templates/webui-pvc.yaml
@@ -17,7 +17,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.webui.persistence.size }}
+  {{- if .Values.webui.persistence.storageClass }}
   storageClassName: {{ .Values.webui.persistence.storageClass }}
+  {{- end }}
   {{- with .Values.webui.persistence.selector }}
   selector:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Pull Request Checklist

- [ ] **Description:** Fix problem that makes deployment fail when the chart is upgraded and storageClass is not configured, probably because you want to use default storageClass
- [ ] **Changelog:** Done
- [ ] **Documentation:** No documentation
- [ ] **Dependencies:** No dependencies

---

## Description

Fix this problem when `helm upgrade --install` is launched twice:
```
Error: UPGRADE FAILED: cannot patch "open-webui" with kind PersistentVolumeClaim: PersistentVolumeClaim "open-webui" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests for bound claims
  core.PersistentVolumeClaimSpec{
  	... // 2 identical fields
  	Resources:        {Requests: {s"storage": {i: {...}, s: "2Gi", Format: "BinarySI"}}},
  	VolumeName:       "pvc-6316c4dc-cc28-44bc-96cc-8717f9015b9e",
- 	StorageClassName: &"microk8s-hostpath",
+ 	StorageClassName: nil,
  	VolumeMode:       &"Filesystem",
  	DataSource:       nil,
  	DataSourceRef:    nil,
  }
```

---

### Changelog Entry

### Fixed

- pvc management is not idempotent

### Changed

- Force storageClass name only if is configured in values.yaml

