### PR TITLE
feat: configurable `STATIC_DIR`; fix: mount `CACHE_DIR` to the `/cache` endpoint

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -28,8 +28,6 @@ except ImportError:
 WEBUI_NAME = os.environ.get("WEBUI_NAME", "Open WebUI")
 WEBUI_FAVICON_URL = "https://openwebui.com/favicon.png"
 
-shutil.copyfile("../build/favicon.png", "./static/favicon.png")
-
 ####################################
 # ENV (dev,test,prod)
 ####################################
@@ -103,6 +101,26 @@ for version in soup.find_all("h2"):
 
 CHANGELOG = changelog_json
 
+####################################
+# DATA/FRONTEND BUILD DIR
+####################################
+
+DATA_DIR = str(Path(os.getenv("DATA_DIR", "./data")).resolve())
+FRONTEND_BUILD_DIR = str(Path(os.getenv("FRONTEND_BUILD_DIR", "../build")))
+
+try:
+    with open(f"{DATA_DIR}/config.json", "r") as f:
+        CONFIG_DATA = json.load(f)
+except:
+    CONFIG_DATA = {}
+
+####################################
+# Static DIR
+####################################
+
+STATIC_DIR = str(Path(os.getenv("STATIC_DIR", "./static")).resolve())
+
+shutil.copyfile(f"{FRONTEND_BUILD_DIR}/favicon.png", f"{STATIC_DIR}/favicon.png")
 
 ####################################
 # LOGGING
@@ -165,7 +183,7 @@ if CUSTOM_NAME:
 
                 r = requests.get(url, stream=True)
                 if r.status_code == 200:
-                    with open("./static/favicon.png", "wb") as f:
+                    with open(f"{STATIC_DIR}/favicon.png", "wb") as f:
                         r.raw.decode_content = True
                         shutil.copyfileobj(r.raw, f)
 
@@ -177,18 +195,6 @@ else:
     if WEBUI_NAME != "Open WebUI":
         WEBUI_NAME += " (Open WebUI)"
 
-####################################
-# DATA/FRONTEND BUILD DIR
-####################################
-
-DATA_DIR = str(Path(os.getenv("DATA_DIR", "./data")).resolve())
-FRONTEND_BUILD_DIR = str(Path(os.getenv("FRONTEND_BUILD_DIR", "../build")))
-
-try:
-    with open(f"{DATA_DIR}/config.json", "r") as f:
-        CONFIG_DATA = json.load(f)
-except:
-    CONFIG_DATA = {}
 
 ####################################
 # File Upload DIR

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,8 @@ from config import (
     VERSION,
     CHANGELOG,
     FRONTEND_BUILD_DIR,
+    CACHE_DIR,
+    STATIC_DIR,
     MODEL_FILTER_ENABLED,
     MODEL_FILTER_LIST,
     GLOBAL_LOG_LEVEL,
@@ -282,7 +284,6 @@ async def get_app_latest_release_version():
             detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
         )
 
-
 @app.get("/manifest.json")
 async def get_manifest_json():
     return {
@@ -296,10 +297,8 @@ async def get_manifest_json():
         "icons": [{"src": "/favicon.png", "type": "image/png", "sizes": "844x884"}],
     }
 
-
-app.mount("/static", StaticFiles(directory="static"), name="static")
-app.mount("/cache", StaticFiles(directory="data/cache"), name="cache")
-
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+app.mount("/cache", StaticFiles(directory=CACHE_DIR), name="cache")
 
 app.mount(
     "/",


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Allow to configure `STATIC_DIR` and mount the same to `/static` API endpoint. Also mount `CACHE_DIR` to `/cache`.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
No new dependencies

---

## Description

- Added a new backend ENV `STATIC_DIR` to configure the location of static files
- Mount `/static` API endpoint to `STATIC_DIR` and `/cache` to `CACHE_DIR`

---

### Changelog Entry

### Added

- backend: Add `STATIC_DIR` ENV to configure the location of the static files (like favicon)

### Fixed

- backend: Mount `CACHE_DIR` to the `/cache` API endpoint

### Changed

- [List any changes or updates]

### Removed

- [List any removed features or files]
