### PR TITLE
fix(helm): remove trailing slash

### DIFF
--- a/kubernetes/helm/templates/_helpers.tpl
+++ b/kubernetes/helm/templates/_helpers.tpl
@@ -10,7 +10,7 @@ ollama
 {{- if .Values.ollama.externalHost }}
 {{- printf .Values.ollama.externalHost }}
 {{- else }}
-{{- printf "http://%s.%s.svc.cluster.local:%d/" (include "ollama.name" .) (.Release.Namespace) (.Values.ollama.service.port | int) }}
+{{- printf "http://%s.%s.svc.cluster.local:%d" (include "ollama.name" .) (.Release.Namespace) (.Values.ollama.service.port | int) }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

The [_helper file](https://github.com/open-webui/open-webui/blob/2da7dd67ead27db0f04dd85a77f66fb04a9168be/kubernetes/helm/templates/_helpers.tpl#L13) introduces a trailing `/` to the ollama service url which causes requests to be written with `//` and results in 404 responses from the ollama service.

This results in ollama models being unusable. 

Removing the training slash here resolves the issue.

---

### Changelog Entry

### Fixed

- Removed trailing `/` from ollama url in the helm chart template helper (#1478)

FYI closes #1478 
