### PR TITLE
Switch from "docker-compose" to "docker compose" if necessary (Makefile) + Multi file Drag&Drop + minor things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,33 @@
+
+ifneq ($(shell which docker-compose 2>/dev/null),)
+    DOCKER_COMPOSE := docker-compose
+else
+    DOCKER_COMPOSE := docker compose
+endif
+
 install:
-	@docker-compose up -d
+	$(DOCKER_COMPOSE) up -d
 
 remove:
 	@chmod +x confirm_remove.sh
 	@./confirm_remove.sh
 
-
 start:
-	@docker-compose start
+	$(DOCKER_COMPOSE) start
 startAndBuild: 
-	docker-compose up -d --build
+	$(DOCKER_COMPOSE) up -d --build
 
 stop:
-	@docker-compose stop
+	$(DOCKER_COMPOSE) stop
 
 update:
 	# Calls the LLM update script
 	chmod +x update_ollama_models.sh
 	@./update_ollama_models.sh
 	@git pull
-	@docker-compose down
+	$(DOCKER_COMPOSE) down
 	# Make sure the ollama-webui container is stopped before rebuilding
 	@docker stop open-webui || true
-	@docker-compose up --build -d
-	@docker-compose start
+	$(DOCKER_COMPOSE) up --build -d
+	$(DOCKER_COMPOSE) start
 

--- a/confirm_remove.sh
+++ b/confirm_remove.sh
@@ -2,7 +2,12 @@
 echo "Warning: This will remove all containers and volumes, including persistent data. Do you want to continue? [Y/N]"
 read ans
 if [ "$ans" == "Y" ] || [ "$ans" == "y" ]; then
-  docker-compose down -v
+  command docker-compose 2>/dev/null
+  if [ "$?" == "0" ]; then
+    docker-compose down -v
+  else
+    docker compose down -v
+  fi
 else
   echo "Operation cancelled."
 fi

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -313,41 +313,50 @@
 
 		const onDrop = async (e) => {
 			e.preventDefault();
-			console.log(e);
+			//console.log(e);
 
 			if (e.dataTransfer?.files) {
-				let reader = new FileReader();
-
-				reader.onload = (event) => {
-					files = [
-						...files,
-						{
-							type: 'image',
-							url: `${event.target.result}`
-						}
-					];
-				};
-
 				const inputFiles = e.dataTransfer?.files;
 
 				if (inputFiles && inputFiles.length > 0) {
-					const file = inputFiles[0];
-					console.log(file, file.name.split('.').at(-1));
-					if (['image/gif', 'image/jpeg', 'image/png'].includes(file['type'])) {
-						reader.readAsDataURL(file);
-					} else if (
-						SUPPORTED_FILE_TYPE.includes(file['type']) ||
-						SUPPORTED_FILE_EXTENSIONS.includes(file.name.split('.').at(-1))
-					) {
-						uploadDoc(file);
-					} else {
-						toast.error(
-							$i18n.t(
-								`Unknown File Type '{{file_type}}', but accepting and treating as plain text`,
-								{ file_type: file['type'] }
-							)
-						);
-						uploadDoc(file);
+					for (var i = 0; i < inputFiles.length; i += 1) {
+						const file = inputFiles[i];
+						//console.log(file, file.name.split('.').at(-1));
+						if (['image/gif', 'image/jpeg', 'image/png'].includes(file['type'])) {
+							try {
+								let reader = new FileReader();
+								reader.onload = (event) => {
+									files = [
+										...files,
+										{
+											type: 'image',
+											url: `${event.target.result}`
+										}
+									];
+								};
+								reader.readAsDataURL(file);
+								window.setTimeout(() => console.log('Files: (' + i + ')', files), 1000);
+							} catch (exc) {
+								toast.error(
+									$i18n.t(
+										"An image couldn't be loaded. Please try again, try to upload one image at a time or upload a different image."
+									)
+								);
+							}
+						} else if (
+							SUPPORTED_FILE_TYPE.includes(file['type']) ||
+							SUPPORTED_FILE_EXTENSIONS.includes(file.name.split('.').at(-1))
+						) {
+							await uploadDoc(file);
+						} else {
+							toast.error(
+								$i18n.t(
+									`Unknown File Type '{{file_type}}', but accepting and treating as plain text`,
+									{ file_type: file['type'] }
+								)
+							);
+							await uploadDoc(file);
+						}
 					}
 				} else {
 					toast.error($i18n.t(`File not found.`));
@@ -468,38 +477,47 @@
 					type="file"
 					hidden
 					on:change={async () => {
-						let reader = new FileReader();
-						reader.onload = (event) => {
-							files = [
-								...files,
-								{
-									type: 'image',
-									url: `${event.target.result}`
-								}
-							];
-							inputFiles = null;
-							filesInputElement.value = '';
-						};
-
 						if (inputFiles && inputFiles.length > 0) {
-							const file = inputFiles[0];
-							if (['image/gif', 'image/jpeg', 'image/png'].includes(file['type'])) {
-								reader.readAsDataURL(file);
-							} else if (
-								SUPPORTED_FILE_TYPE.includes(file['type']) ||
-								SUPPORTED_FILE_EXTENSIONS.includes(file.name.split('.').at(-1))
-							) {
-								uploadDoc(file);
-								filesInputElement.value = '';
-							} else {
-								toast.error(
-									$i18n.t(
-										`Unknown File Type '{{file_type}}', but accepting and treating as plain text`,
-										{ file_type: file['type'] }
-									)
-								);
-								uploadDoc(file);
-								filesInputElement.value = '';
+							const file = inputFiles[i];
+							for (let i = 0; i < inputFiles.length; i += 1) {
+								if (['image/gif', 'image/jpeg', 'image/png'].includes(file['type'])) {
+									try {
+										let reader = new FileReader();
+										reader.onload = (event) => {
+											files = [
+												...files,
+												{
+													type: 'image',
+													url: `${event.target.result}`
+												}
+											];
+											inputFiles = null;
+											filesInputElement.value = '';
+										};
+										reader.readAsDataURL(file);
+									} catch (exc) {
+										toast.error(
+											$i18n.t(
+												"An image couldn't be loaded. Please try again, try to upload one image at a time or upload a different image."
+											)
+										);
+									}
+								} else if (
+									SUPPORTED_FILE_TYPE.includes(file['type']) ||
+									SUPPORTED_FILE_EXTENSIONS.includes(file.name.split('.').at(-1))
+								) {
+									uploadDoc(file);
+									filesInputElement.value = '';
+								} else {
+									toast.error(
+										$i18n.t(
+											`Unknown File Type '{{file_type}}', but accepting and treating as plain text`,
+											{ file_type: file['type'] }
+										)
+									);
+									uploadDoc(file);
+									filesInputElement.value = '';
+								}
 							}
 						} else {
 							toast.error($i18n.t(`File not found.`));

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -339,21 +339,17 @@
 				return baseMessage;
 			});
 
-		let lastImageIndex = -1;
-
-		// Find the index of the last object with images
-		messagesBody.forEach((item, index) => {
-			if (item.images) {
-				lastImageIndex = index;
-			}
-		});
-
-		// Remove images from all but the last one
-		messagesBody.forEach((item, index) => {
-			if (index !== lastImageIndex) {
+		// 1. Iterate backwards until an image is found, then...
+		// 2. Remove all other images from previous objects
+		var deleteImages = false;
+		for (var i = messagesBody.length - 1; i >= 0; i--) {
+			const item = messagesBody[i];
+			if (deleteImages) {
 				delete item.images;
+			} else if (item.images) {
+				deleteImages = true;
 			}
-		});
+		}
 
 		const docs = messages
 			.filter((message) => message?.files ?? null)


### PR DESCRIPTION
- Detect docker compose using the bash functions "command" and "which" which are at least POSIX compatible.
- Improved a minor code detail in the handling of images in chat messages before they get sent to the server
- Enabled multi file drag & drop
- Improved error handling for images after drag & drop
- I've also added a text to the Drag&Drop code. If someone would be able to tell me if i need to do anything about that, other then committing it, i'll be listening.

## Pull Request Checklist

- [X] **Description:** Briefly describe the changes in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [NO] **Documentation:** Have you updated relevant documentation?
- [NO] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

Added "docker compose" capability to the Makefile

---

### Changelog Entry

### Added

- Added the capability to chose between "docker-compose" and "docker compose" to the "Makefile"
- Handling of multi file drag & drop
- Improved error handling for images after drag & drop

### Changed

- Turned two .forEach() forward loops into one for() backwards loop
