### PR TITLE
Switch `pip3` to `uv` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,15 +93,16 @@ RUN if [ "$USE_OLLAMA" = "true" ]; then \
 # install python dependencies
 COPY ./backend/requirements.txt ./requirements.txt
 
-RUN if [ "$USE_CUDA" = "true" ]; then \
+RUN pip3 install uv && \
+    if [ "$USE_CUDA" = "true" ]; then \
         # If you use CUDA the whisper and embedding model will be downloaded on first use
         pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/$USE_CUDA_DOCKER_VER --no-cache-dir && \
-        pip3 install -r requirements.txt --no-cache-dir && \
+        uv pip install --system -r requirements.txt --no-cache-dir && \
         python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])" && \
         python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'], device='cpu')"; \
     else \
         pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir && \
-        pip3 install -r requirements.txt --no-cache-dir && \
+        uv pip install --system -r requirements.txt --no-cache-dir && \
         python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])" && \
         python -c "import os; from chromadb.utils import embedding_functions; sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=os.environ['RAG_EMBEDDING_MODEL'], device='cpu')"; \
     fi


### PR DESCRIPTION
Ugh sorry for 3x PRs... that's what I get for trying a new workflow 👎 There was a PR from @lainedfles that's unfortunately not reflected here now, apologies for that as well.

## Description

This PR introduces [`uv`](https://github.com/astral-sh/uv), a new package manager, as a partial replacement for `pip3` in the Docker build process for the "Open WebUI" project. `Uv` is a mostly drop-in compatible substitute for `pip3` with significant performance improvements. In our testing, `uv` has shown to notably reduce build times — by nearly 50% on GitHub Action runners and by approximately 25-30% when building locally across various platforms. While the resultant build sizes have varied, showing both increases and decreases depending on the build environment, this change aims to leverage `uv`'s efficiency gains to enhance the development workflow and process efficiency. It's important to note that `pip3` has not been completely removed; it remains necessary for installing PyTorch and its dependencies, as `uv` has not yet reliably resolved them across all build environments. As this is an evolving integration, more opinions and testing are highly encouraged to ensure a smooth transition. For further details on `uv`, please refer to the [uv documentation](https://github.com/astral-sh/uv) and [this introductory blog post](https://astral.sh/blog/uv).

---

### Changelog Entry

#### Added
- Introduced [`uv`](https://github.com/astral-sh/uv) as the new package manager in the Docker build process for certain dependencies, aiming to improve build times and efficiency.

#### Fixed
- N/A

#### Changed
- Partially replaced `pip3` with [`uv`](https://github.com/astral-sh/uv) in the Docker build

#### Using `pip3`:

<img width="1115" alt="Screenshot_2024-04-05_at_10 19 46_PM" src="https://github.com/open-webui/open-webui/assets/52832301/013a38e0-df8a-4a2e-8b5f-e28b3af497ea">

---

#### Using `uv`:

<img width="1115" alt="Screenshot_2024-04-05_at_10 19 23_PM" src="https://github.com/open-webui/open-webui/assets/52832301/2824a3bd-b0bf-47f6-b0ce-f1690b951c8d">

---

### Changelog Entry

#### Added
- Introduced `uv` as the new package manager in the Docker build process for certain dependencies, aiming to improve build times and efficiency.

#### Fixed
- N/A

#### Changed
- Partially replaced `pip3` with `uv` in the Docker build process. This does not yet cover PyTorch and its dependencies, which still rely on `pip3` due to resolution issues in some environments.

#### Removed
- N/A

---

## Pull Request Checklist

- [x] **Description:** This PR partially introduces `uv` as a replacement for `pip3` in the Docker build process, aimed at improving build times and efficiency for certain dependencies. `Pip3` remains in use for installing PyTorch and its dependencies, due to current limitations with `uv`.
- [x] **Changelog:** A detailed changelog entry has been added, highlighting the introduction of `uv`, the partial replacement of `pip3`, and noting the continued use of `pip3` for specific dependencies.
