### PR TITLE
feat: (pending closure) separate openai speech API provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+ollama-data/
+

--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,4 @@ dist
 
 ollama-data/
 
+.vscode/

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -100,18 +100,18 @@ async def update_openai_key(form_data: KeysUpdateForm, user=Depends(get_admin_us
 
 @app.post("/audio/speech")
 async def speech(request: Request, user=Depends(get_verified_user)):
-    audio_base_url = os.environ.get("OPENAI_AUDIO_BASE_URL", "")
-    if audio_base_url:
-        print(f"Got OPENAI_AUDIO_BASE_URL: {audio_base_url}")
+    tts_audio_base_url = os.environ.get("TTS_OPENAI_API_BASE_URL", "")
+    if tts_audio_base_url:
+        print(f"Got TTS_OPENAI_API_BASE_URL: {tts_audio_base_url}")
     else:
-        audio_base_url = os.environ["OPENAI_BASE_URL"]
-        print(f"Using OPENAI_BASE_URL for audio: {audio_base_url}")
+        tts_audio_base_url = os.environ["OPENAI_BASE_URL"]
+        print(f"Using OPENAI_BASE_URL for audio: {tts_audio_base_url}")
 
     idx = None
     try:
         is_openedai_speech = True
         if is_openedai_speech: # TODO: check if user wants to use openai cloud service (but why?), and behave accordingly
-            base_url = audio_base_url
+            base_url = tts_audio_base_url
         else:
             idx = app.state.OPENAI_API_BASE_URLS.index("https://api.openai.com/v1")
             base_url = app.state.OPENAI_API_BASE_URLS[idx]

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -121,7 +121,8 @@ async def speech(request: Request, user=Depends(get_verified_user)):
         body = await request.body()
         name = hashlib.sha256(body).hexdigest()
 
-        SPEECH_CACHE_DIR = Path(CACHE_DIR).joinpath("./audio/speech/")
+        # TODO: check how this cache gets pruned
+        SPEECH_CACHE_DIR = Path(CACHE_DIR) / "audio" / "speech"
         SPEECH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         file_path = SPEECH_CACHE_DIR.joinpath(f"{name}.mp3")
         file_body_path = SPEECH_CACHE_DIR.joinpath(f"{name}.json")

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -116,7 +116,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             idx = app.state.OPENAI_API_BASE_URLS.index("https://api.openai.com/v1")
             base_url = app.state.OPENAI_API_BASE_URLS[idx]
 
-        speech_url = urljoin(base_url, "/audio/speech")
+        speech_url = urljoin(base_url, "./audio/speech")
 
         body = await request.body()
         name = hashlib.sha256(body).hexdigest()

--- a/docker-compose.customized.yaml
+++ b/docker-compose.customized.yaml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  open-webui:
+    environment:
+      - 'OPENAI_BASE_URL=$OPENAI_BASE_URL'
+      - 'OPENAI_AUDIO_BASE_URL=$OPENAI_AUDIO_BASE_URL'
+

--- a/docker-compose.customized.yaml
+++ b/docker-compose.customized.yaml
@@ -4,5 +4,4 @@ services:
   open-webui:
     environment:
       - 'OPENAI_BASE_URL=$OPENAI_BASE_URL'
-      - 'OPENAI_AUDIO_BASE_URL=$OPENAI_AUDIO_BASE_URL'
-
+      - 'TTS_OPENAI_API_BASE_URL=$TTS_OPENAI_API_BASE_URL'

--- a/run-customized.sh
+++ b/run-customized.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+. /etc/environment
+
+COMPOSE_BASE_COMMAND="docker compose -f docker-compose.yaml -f docker-compose.gpu.yaml -f docker-compose.api.yaml -f docker-compose.data.yaml -f docker-compose.customized.yaml"
+
+function start_services {
+	$COMPOSE_BASE_COMMAND up --remove-orphans --force-recreate
+}
+
+function stop_services {
+	$COMPOSE_BASE_COMMAND down
+}
+
+if [ "$1" == "up" ]; then
+	start_services
+elif [ "$1" == "down" ]; then
+	stop_services
+else
+	echo 1>&2 "$0: ERROR: invalid argument"
+	exit 1
+fi
+

--- a/src/lib/apis/openai/index.ts
+++ b/src/lib/apis/openai/index.ts
@@ -250,7 +250,8 @@ export const synthesizeOpenAISpeech = async (
 		body: JSON.stringify({
 			model: 'tts-1',
 			input: text,
-			voice: speaker
+			voice: speaker,
+			speed: 1.0,
 		})
 	}).catch((err) => {
 		console.log(err);


### PR DESCRIPTION
WORK IN PROGRESS

FILING THIS PR MORE FOR AWARENESS/TRACKING RIGHT NOW - SUGGESTIONS WELCOME

In particular, I should:

- merge the docker-customized stuff into the repo's own docker files and startup scripts
- probably try to implement authenticated remote openai support (though I don't care for it personally) or just not have stub code in there (is_openedai_speech) that hints at future support, for now.


## Description

Add support for a separate OpenAI-compatible speech API base URL.

This allows the use of Ollama or an OpenAI-compatible service such as Llama.CPP for text gen (which may be faster / easier for text generation), and another API provider like LocalAI or OpenedAI-Speech for the text-to-speech and speech to text functionality.

---

### Changelog Entry

### Added

- Add support for a separate OpenAI-compatible speech API providers, using an OPENAI_AUDIO_BASE_URL environment variable.
- docker-compose.customized.yaml which sets the new env vars
- run_customized.sh which simplifies running openai with the above customized config


### Fixed

- Allows use of llama.cpp or another text-only OpenAI endpoint / model whilst using a separate/dedicated speech API provider

### Changed

- Supports a new OPENAI_AUDIO_BASE_URL, which will be used rather than OPENAI_BASE_URL for speech services, when set.
