### PR TITLE
Fix hover and selected state issues for reason buttons in light theme.

### DIFF
--- a/src/lib/components/chat/Messages/RateComment.svelte
+++ b/src/lib/components/chat/Messages/RateComment.svelte
@@ -81,9 +81,9 @@
 		<div class="flex flex-wrap gap-2 text-sm mt-2.5">
 			{#each reasons as reason}
 				<button
-					class="px-3.5 py-1 border dark:border-gray-850 dark:hover:bg-gray-850 {selectedReason ===
+					class="px-3.5 py-1 border dark:border-gray-850 hover:bg-gray-100 dark:hover:bg-gray-850 {selectedReason ===
 					reason
-						? 'dark:bg-gray-800'
+						? 'bg-gray-200 dark:bg-gray-800'
 						: ''} transition rounded-lg"
 					on:click={() => {
 						selectedReason = reason;


### PR DESCRIPTION
## Description

This pull request fixes the issue where the reason buttons in the light theme did not display hover and selected states
![fixed-bug](https://github.com/open-webui/open-webui/assets/2045117/100c4e6f-121a-42f0-9ce8-3431a2f888fe)


---

### Changelog Entry

### Added

- Enhanced interaction feedback for reason buttons in the light theme.

### Fixed

- Corrected the hover and selected state behaviors for reason buttons in the light theme.

### Changed

- Updated in file /src/lib/components/chat/Messages/RateComment.svelte

### Removed

- None