### PR TITLE
feat: allow a docs directory coming from env

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -162,7 +162,7 @@ Path(CACHE_DIR).mkdir(parents=True, exist_ok=True)
 # Docs DIR
 ####################################
 
-DOCS_DIR = f"{DATA_DIR}/docs"
+DOCS_DIR = os.getenv("DOCS_DIR", f"{DATA_DIR}/docs")
 Path(DOCS_DIR).mkdir(parents=True, exist_ok=True)
 
 
@@ -359,7 +359,7 @@ When answer to user:
 - If you don't know when you are not sure, ask for clarification.
 Avoid mentioning that you obtained the information from the context.
 And answer according to the language of the user's question.
-        
+
 Given the context information, answer the query.
 Query: [query]"""
 


### PR DESCRIPTION
Current config assumes /data/docs to be part of the current data directory.

## Pull Request Checklist

- [ ] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

This allows DOCS_DIR to be mounted from a different path, outside of DATA_DIR, or falls back to the previous behaviour if DOCS_DIR is not in the environment.

A simple use case: the WebUI data is in a volume, but all docs are in a shared network volume, used by both Ollama and a file navigator to upload documents.

Alternatives explored:
- link the data folder to a shared mount: network mounts won't follow links
- hard links: not possible for a directory
- link a shared mount into /data/docs: `Path.mkdir` fails if called on a path to a symlink, even if `exists_ok=True`.
- Subfolders inside /data/docs are ignored
---

### Changelog Entry

### Added

- New environment variable `DOCS_DIR` to specify the full path for RAG documents.
