### PR TITLE
Fixed OpenRouter heart beats breaking streaming

### DIFF
--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -31,7 +31,7 @@ async function* openAIStreamToIterator(
 				console.log(line);
 				if (line === 'data: [DONE]') {
 					yield { done: true, value: '' };
-				} if (line.startsWith(':')) {
+				} else if (line.startsWith(':')) {
 					// Events starting with : are comments https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
 					// OpenRouter sends heartbeats like ": OPENROUTER PROCESSING"
 					continue

--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -31,6 +31,10 @@ async function* openAIStreamToIterator(
 				console.log(line);
 				if (line === 'data: [DONE]') {
 					yield { done: true, value: '' };
+				} if (line.startsWith(':')) {
+					// Events starting with : are comments https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+					// OpenRouter sends heartbeats like ": OPENROUTER PROCESSING"
+					continue
 				} else {
 					const data = JSON.parse(line.replace(/^data: /, ''));
 					console.log(data);


### PR DESCRIPTION
## Pull Request Checklist

- [X] **Description:** Briefly describe the changes in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation?
  No need
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
  No

---

## Description

Open WebUI doesn't work with Open Router as advertised in the Readme. When you try to do a chat completion, you can see errors on the front-end like:
![image](https://github.com/open-webui/open-webui/assets/1183449/8e49880e-b50b-42d5-9bdb-5b6f85f9032e)
Underlying reason is OpenRouter, when used in streaming mode sends heart beats in the stream like `: OPENROUTER PROCESSING` but front-end is not ignoring them.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) all events that starts with a colon should be ignored. I simply did that.

---

### Changelog Entry

### Fixed

- Fixed OpenRouter heart beats breaking streaming


