### PR TITLE
fix: handle carriage returns in OpenAI streams

### DIFF
--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -26,7 +26,11 @@ async function* openAIStreamToIterator(
 			break;
 		}
 		const lines = value.split('\n');
-		for (const line of lines) {
+		for (let line of lines) {
+			if (line.endsWith('\r')) {
+				// Remove trailing \r
+				line = line.slice(0, -1);
+			}
 			if (line !== '') {
 				console.log(line);
 				if (line === 'data: [DONE]') {


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

Trim trailing carriage returns from OpenAI responses. Carriage returns won't break after https://github.com/open-webui/open-webui/pull/1780 was merged, but this will prevent errors from being logged.

We should probably switch to using something that is more spec-compliant, like https://github.com/openai/openai-node/blob/master/src/streaming.ts potentially (licensed under Apache)
