### PR TITLE
feat: add HOST to the backend start script

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -6,6 +6,7 @@ cd "$SCRIPT_DIR" || exit
 KEY_FILE=.webui_secret_key
 
 PORT="${PORT:-8080}"
+HOST="${HOST:-0.0.0.0}"
 if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   echo "No WEBUI_SECRET_KEY provided"
 
@@ -29,4 +30,4 @@ if [ "$USE_CUDA_DOCKER" = "true" ]; then
   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/torch/lib:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib"
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host 0.0.0.0 --port "$PORT" --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?

---

## Description

Allow overriding the `--host` arg in the `backend/start.sh` script. When using Open WebUI behind a reverse proxy, especially when used with the trusted email header, you will want to only listen on localhost to avoid users from bypassing the proxy.

---

### Changelog Entry

### Added

- `HOST` can be set in Docker or the `start.sh` script to set the backend listen address.
