### PR TITLE
fix: fluid streaming was "pausing" when tab was not visible

### DIFF
--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -73,7 +73,11 @@ async function* streamLargeDeltasAsRandomChunks(
 			const chunkSize = Math.min(Math.floor(Math.random() * 3) + 1, content.length);
 			const chunk = content.slice(0, chunkSize);
 			yield { done: false, value: chunk };
-			await sleep(5);
+			// Do not sleep if the tab is hidden
+			// Timers are throttled to 1s in hidden tabs
+			if (document?.visibilityState !== 'hidden') {
+				await sleep(5);
+			}
 			content = content.slice(chunkSize);
 		}
 	}


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for the changes?
- [x] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

Check if the the page is visible (https://developer.mozilla.org/docs/Web/API/Page_Visibility_API) before sleeping. When the page is not visible, Javascript timers are throttled to once a second, so if the fluid streaming option was turned on, it would barely make any progress when not visible.

---

### Changelog Entry

### Fixed

- The fluid streaming response option will better handle when the page is not visible.


