### PR TITLE
fix: fluid stream setting not reflecting current state on load

### DIFF
--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -106,6 +106,7 @@
 		responseAutoCopy = settings.responseAutoCopy ?? false;
 		showUsername = settings.showUsername ?? false;
 		fullScreenMode = settings.fullScreenMode ?? false;
+		splitLargeChunks = settings.splitLargeChunks ?? false;
 	});
 </script>
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for the changes?
- [x] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

`splitLargeChunks` was not being read from settings on mount, so it would always show "Off" regardless of the current setting.
