### PR TITLE
🎖️Added translations for Fluidly stream large external response chunks and OLED Dark

### DIFF
--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Фокусиране на чат вход",
 	"Format your variables using square brackets like this:": "Форматирайте вашите променливи, като използвате квадратни скоби, както следва:",
 	"From (Base Model)": "От (Базов модел)",
+	"Fluidly stream large external response chunks": "Плавно предаване на големи части от външен отговор",
 	"Full Screen Mode": "На Цял екран",
 	"General": "Основни",
 	"General Settings": "Основни Настройки",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "কিবোর্ড শর্টকাটসমূহ",
 	"Language": "ভাষা",
 	"Light": "লাইট",
+	"OLED Dark": "OLED ডার্ক",
 	"Listening...": "শুনছে...",
 	"LLMs can make mistakes. Verify important information.": "LLM ভুল করতে পারে। গুরুত্বপূর্ণ তথ্য যাচাই করে নিন।",
 	"Made by OpenWebUI Community": "OpenWebUI কমিউনিটিকর্তৃক নির্মিত",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Dreceres de Teclat",
 	"Language": "Idioma",
 	"Light": "Clar",
+	"OLED Dark": "OLED escuro",
 	"Listening...": "Escoltant...",
 	"LLMs can make mistakes. Verify important information.": "Els LLMs poden cometre errors. Verifica la informació important.",
 	"Made by OpenWebUI Community": "Creat per la Comunitat OpenWebUI",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Enfoca l'entrada del xat",
 	"Format your variables using square brackets like this:": "Formata les teves variables utilitzant claudàtors així:",
 	"From (Base Model)": "Des de (Model Base)",
+	"Fluidly stream large external response chunks": "Transmita con fluidez grandes fragmentos de respuesta externa",
 	"Full Screen Mode": "Mode de Pantalla Completa",
 	"General": "General",
 	"General Settings": "Configuració General",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Chat-Eingabe fokussieren",
 	"Format your variables using square brackets like this:": "Formatiere Deine Variablen mit eckigen Klammern wie folgt:",
 	"From (Base Model)": "Von (Basismodell)",
+	"Fluidly stream large external response chunks": "Streamen Sie große externe Antwortblöcke flüssig",
 	"Full Screen Mode": "Vollbildmodus",
 	"General": "Allgemein",
 	"General Settings": "Allgemeine Einstellungen",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Tastenkürzel",
 	"Language": "Sprache",
 	"Light": "Hell",
+	"OLED Dark": "OLED Dunkel",
 	"Listening...": "Hören...",
 	"LLMs can make mistakes. Verify important information.": "LLMs können Fehler machen. Überprüfe wichtige Informationen.",
 	"Made by OpenWebUI Community": "Von der OpenWebUI-Community",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "Keyboard Barkcuts",
 	"Language": "Doge Speak",
 	"Light": "Light",
+	"OLED Dark": "OLED Dark",
 	"Listening...": "Listening...",
 	"LLMs can make mistakes. Verify important information.": "LLMs can make borks. Verify important info.",
 	"Made by OpenWebUI Community": "Made by OpenWebUI Community",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "",
 	"Language": "",
 	"Light": "",
+	"OLED Dark": "",
 	"Listening...": "",
 	"LLMs can make mistakes. Verify important information.": "",
 	"Made by OpenWebUI Community": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "Atajos de teclado",
 	"Language": "Lenguaje",
 	"Light": "Claro",
+	"OLED Dark": "OLED oscuro",
 	"Listening...": "Escuchando...",
 	"LLMs can make mistakes. Verify important information.": "Los LLM pueden cometer errores. Verifica la información importante.",
 	"Made by OpenWebUI Community": "Hecho por la comunidad de OpenWebUI",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "میانبرهای صفحه کلید",
 	"Language": "زبان",
 	"Light": "روشن",
+	"OLED Dark": "OLED تاریک",
 	"Listening...": "در حال گوش دادن...",
 	"LLMs can make mistakes. Verify important information.": "مدل\u200cهای زبانی بزرگ می\u200cتوانند اشتباه کنند. اطلاعات مهم را راستی\u200cآزمایی کنید.",
 	"Made by OpenWebUI Community": "ساخته شده توسط OpenWebUI Community",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "فوکوس کردن ورودی گپ",
 	"Format your variables using square brackets like this:": "متغیرهای خود را با استفاده از براکت مربع به شکل زیر قالب بندی کنید:",
 	"From (Base Model)": "از (مدل پایه)",
+	"Fluidly stream large external response chunks": "تکه های پاسخ خارجی بزرگ را به صورت سیال پخش کنید",
 	"Full Screen Mode": "حالت تمام صفحه",
 	"General": "عمومی",
 	"General Settings": "تنظیمات عمومی",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Se concentrer sur l'entrée de la discussion",
 	"Format your variables using square brackets like this:": "Formatez vos variables en utilisant des crochets comme ceci :",
 	"From (Base Model)": "De (Modèle de base)",
+	"Fluidly stream large external response chunks": "Diffusez de manière fluide de gros morceaux de réponses externes",
 	"Full Screen Mode": "Mode plein écran",
 	"General": "Général",
 	"General Settings": "Paramètres généraux",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Raccourcis clavier",
 	"Language": "Langue",
 	"Light": "Lumière",
+	"OLED Dark": "OLED sombre",
 	"Listening...": "Écoute...",
 	"LLMs can make mistakes. Verify important information.": "Les LLMs peuvent faire des erreurs. Vérifiez les informations importantes.",
 	"Made by OpenWebUI Community": "Réalisé par la communauté OpenWebUI",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Concentrer sur l'entrée du chat",
 	"Format your variables using square brackets like this:": "Formatez vos variables en utilisant des crochets comme ceci :",
 	"From (Base Model)": "De (Modèle de base)",
+	"Fluidly stream large external response chunks": "Diffusez de manière fluide de gros morceaux de réponses externes",
 	"Full Screen Mode": "Mode plein écran",
 	"General": "Général",
 	"General Settings": "Paramètres généraux",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Raccourcis clavier",
 	"Language": "Langue",
 	"Light": "Clair",
+	"OLED Dark": "OLED sombre",
 	"Listening...": "Écoute...",
 	"LLMs can make mistakes. Verify important information.": "Les LLMs peuvent faire des erreurs. Vérifiez les informations importantes.",
 	"Made by OpenWebUI Community": "Réalisé par la communauté OpenWebUI",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Metti a fuoco l'input della chat",
 	"Format your variables using square brackets like this:": "Formatta le tue variabili usando parentesi quadre come questa:",
 	"From (Base Model)": "Da (modello base)",
+	"Fluidly stream large external response chunks": "Trasmetti in modo fluido blocchi di risposta esterni di grandi dimensioni",
 	"Full Screen Mode": "Modalità a schermo intero",
 	"General": "Generale",
 	"General Settings": "Impostazioni generali",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Scorciatoie da tastiera",
 	"Language": "Lingua",
 	"Light": "Chiaro",
+	"OLED Dark": "OLED scuro",
 	"Listening...": "Ascolto...",
 	"LLMs can make mistakes. Verify important information.": "Gli LLM possono commettere errori. Verifica le informazioni importanti.",
 	"Made by OpenWebUI Community": "Realizzato dalla comunità OpenWebUI",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "チャット入力をフォーカス",
 	"Format your variables using square brackets like this:": "次のように角括弧を使用して変数をフォーマットします。",
 	"From (Base Model)": "From (ベースモデル)",
+	"Fluidly stream large external response chunks": "大規模な外部応答チャンクを流動的にストリーミングする",
 	"Full Screen Mode": "フルスクリーンモード",
 	"General": "一般",
 	"General Settings": "一般設定",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "キーボードショートカット",
 	"Language": "言語",
 	"Light": "ライト",
+	"OLED Dark": "OLEDダーク",
 	"Listening...": "聞いています...",
 	"LLMs can make mistakes. Verify important information.": "LLM は間違いを犯す可能性があります。重要な情報を検証してください。",
 	"Made by OpenWebUI Community": "OpenWebUI コミュニティによって作成",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "კლავიატურის მალსახმობები",
 	"Language": "ენა",
 	"Light": "მსუბუქი",
+	"OLED Dark": "OLED მუქი",
 	"Listening...": "გისმენ...",
 	"LLMs can make mistakes. Verify important information.": "შესაძლოა LLM-ებმა შეცდომები დაუშვან. გადაამოწმეთ მნიშვნელოვანი ინფორმაცია.",
 	"Made by OpenWebUI Community": "დამზადებულია OpenWebUI საზოგადოების მიერ",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -153,6 +153,7 @@
 	"File not found.": "ფაილი ვერ მოიძებნა",
 	"Fingerprint spoofing detected: Unable to use initials as avatar. Defaulting to default profile image.": "აღმოჩენილია თითის ანაბეჭდის გაყალბება: ინიციალების გამოყენება ავატარად შეუძლებელია. დეფოლტ პროფილის დეფოლტ სურათი.",
 	"Focus chat input": "ჩეთის შეყვანის ფოკუსი",
+	"Fluidly stream large external response chunks": "თხევადი ნაკადი დიდი გარე საპასუხო ნაწილაკების",
 	"Format your variables using square brackets like this:": "დააფორმატეთ თქვენი ცვლადები კვადრატული ფრჩხილების გამოყენებით:",
 	"From (Base Model)": "(საბაზო მოდელი) დან",
 	"Full Screen Mode": "Სრული ეკრანის რეჟიმი",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "채팅 입력 포커스",
 	"Format your variables using square brackets like this:": "이렇게 대괄호를 사용하여 변수를 형식화하세요:",
 	"From (Base Model)": "출처(기본 모델)",
+	"Fluidly stream large external response chunks": "대규모 외부 응답 청크를 유동적으로 스트리밍",
 	"Full Screen Mode": "전체 화면 모드",
 	"General": "일반",
 	"General Settings": "일반 설정",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "키보드 단축키",
 	"Language": "언어",
 	"Light": "밝음",
+	"OLED Dark": "OLED 다크",
 	"Listening...": "청취 중...",
 	"LLMs can make mistakes. Verify important information.": "LLM은 실수를 할 수 있습니다. 중요한 정보를 확인하세요.",
 	"Made by OpenWebUI Community": "OpenWebUI 커뮤니티에서 제작",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Toetsenbord snelkoppelingen",
 	"Language": "Taal",
 	"Light": "Licht",
+	"OLED Dark": "OLED-donker",
 	"Listening...": "Luisteren...",
 	"LLMs can make mistakes. Verify important information.": "LLMs kunnen fouten maken. Verifieer belangrijke informatie.",
 	"Made by OpenWebUI Community": "Gemaakt door OpenWebUI Community",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Focus chat input",
 	"Format your variables using square brackets like this:": "Formatteer je variabelen met vierkante haken zoals dit:",
 	"From (Base Model)": "Van (Basis Model)",
+	"Fluidly stream large external response chunks": "Stream vloeiend grote externe responsbrokken",
 	"Full Screen Mode": "Volledig Scherm Modus",
 	"General": "Algemeen",
 	"General Settings": "Algemene Instellingen",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "Skróty klawiszowe",
 	"Language": "Język",
 	"Light": "Jasny",
+	"OLED Dark": "Ciemny OLED",
 	"Listening...": "Nasłuchiwanie...",
 	"LLMs can make mistakes. Verify important information.": "LLMy mogą popełniać błędy. Zweryfikuj ważne informacje.",
 	"Made by OpenWebUI Community": "Stworzone przez społeczność OpenWebUI",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -153,6 +153,7 @@
 	"File not found.": "Plik nie został znaleziony.",
 	"Fingerprint spoofing detected: Unable to use initials as avatar. Defaulting to default profile image.": "Wykryto podszywanie się pod odcisk palca: Nie można używać inicjałów jako awatara. Przechodzenie do domyślnego obrazu profilowego.",
 	"Focus chat input": "Skoncentruj na czacie",
+	"Fluidly stream large external response chunks": "Płynnie przesyłaj strumieniowo duże fragmenty odpowiedzi zewnętrznych",
 	"Format your variables using square brackets like this:": "Formatuj swoje zmienne, używając nawiasów kwadratowych, np.",
 	"From (Base Model)": "Z (Model Podstawowy)",
 	"Full Screen Mode": "Tryb pełnoekranowy",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Atalhos de teclado",
 	"Language": "Idioma",
 	"Light": "Claro",
+	"OLED Dark": "OLED escuro",
 	"Listening...": "Ouvindo...",
 	"LLMs can make mistakes. Verify important information.": "LLMs podem cometer erros. Verifique informações importantes.",
 	"Made by OpenWebUI Community": "Feito pela Comunidade OpenWebUI",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Focar entrada de bate-papo",
 	"Format your variables using square brackets like this:": "Formate suas variáveis usando colchetes como este:",
 	"From (Base Model)": "De (Modelo Base)",
+	"Fluidly stream large external response chunks": "Transmita com fluidez grandes blocos de resposta externa",
 	"Full Screen Mode": "Modo de Tela Cheia",
 	"General": "Geral",
 	"General Settings": "Configurações Gerais",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Atalhos de teclado",
 	"Language": "Idioma",
 	"Light": "Claro",
+	"OLED Dark": "OLED escuro",
 	"Listening...": "Ouvindo...",
 	"LLMs can make mistakes. Verify important information.": "LLMs podem cometer erros. Verifique informações importantes.",
 	"Made by OpenWebUI Community": "Feito pela Comunidade OpenWebUI",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Focar entrada de bate-papo",
 	"Format your variables using square brackets like this:": "Formate suas variáveis usando colchetes como este:",
 	"From (Base Model)": "De (Modelo Base)",
+	"Fluidly stream large external response chunks": "Transmita com fluidez grandes blocos de resposta externa",
 	"Full Screen Mode": "Modo de Tela Cheia",
 	"General": "Geral",
 	"General Settings": "Configurações Gerais",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Горячие клавиши",
 	"Language": "Язык",
 	"Light": "Светлый",
+	"OLED Dark": "OLED темный",
 	"Listening...": "Слушаю...",
 	"LLMs can make mistakes. Verify important information.": "LLMs могут допускать ошибки. Проверяйте важную информацию.",
 	"Made by OpenWebUI Community": "Сделано сообществом OpenWebUI",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Фокус ввода чата",
 	"Format your variables using square brackets like this:": "Форматируйте ваши переменные, используя квадратные скобки, как здесь:",
 	"From (Base Model)": "Из (базой модель)",
+	"Fluidly stream large external response chunks": "Плавная потоковая передача больших фрагментов внешних ответов",
 	"Full Screen Mode": "Полноэкранный режим",
 	"General": "Общее",
 	"General Settings": "Общие настройки",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -181,6 +181,7 @@
 	"Keyboard shortcuts": "Klavye kısayolları",
 	"Language": "Dil",
 	"Light": "Açık",
+	"OLED Dark": "OLED Koyu",
 	"Listening...": "Dinleniyor...",
 	"LLMs can make mistakes. Verify important information.": "LLM'ler hata yapabilir. Önemli bilgileri doğrulayın.",
 	"Made by OpenWebUI Community": "OpenWebUI Topluluğu tarafından yapılmıştır",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Фокус вводу чату",
 	"Format your variables using square brackets like this:": "Форматуйте свої змінні квадратними дужками так:",
 	"From (Base Model)": "Від (базова модель)",
+	"Fluidly stream large external response chunks": "Плавно передавати великі фрагменти зовнішніх відповідей",
 	"Full Screen Mode": "Режим повного екрану",
 	"General": "Загальні",
 	"General Settings": "Загальні налаштування",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Клавіатурні скорочення",
 	"Language": "Мова",
 	"Light": "Світла",
+	"OLED Dark": "OLED Темний",
 	"Listening...": "Слухаю...",
 	"LLMs can make mistakes. Verify important information.": "LLMs можуть помилятися. Перевірте важливу інформацію.",
 	"Made by OpenWebUI Community": "Зроблено спільнотою OpenWebUI",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "Phím tắt",
 	"Language": "Ngôn ngữ",
 	"Light": "Sáng",
+	"OLED Dark": "OLED tối",
 	"Listening...": "Đang nghe...",
 	"LLMs can make mistakes. Verify important information.": "Hệ thống có thể tạo ra nội dung không chính xác hoặc sai. Hãy kiểm chứng kỹ lưỡng thông tin trước khi tiếp nhận và sử dụng.",
 	"Made by OpenWebUI Community": "Được tạo bởi Cộng đồng OpenWebUI",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "Tập trung vào nội dung chat",
 	"Format your variables using square brackets like this:": "Định dạng các biến của bạn bằng cách sử dụng dấu ngoặc vuông như thế này:",
 	"From (Base Model)": "Từ (Base Model)",
+	"Fluidly stream large external response chunks": "Truyền tải các khối phản hồi bên ngoài lớn một cách trôi chảy",
 	"Full Screen Mode": "Chế độ Toàn màn hình",
 	"General": "Cài đặt chung",
 	"General Settings": "Cấu hình chung",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -153,6 +153,7 @@
 	"Focus chat input": "聚焦聊天输入",
 	"Format your variables using square brackets like this:": "使用这样的方括号格式化你的变量：",
 	"From (Base Model)": "来自（基础模型）",
+	"Fluidly stream large external response chunks": "流畅地传输大型外部响应块",
 	"Full Screen Mode": "全屏模式",
 	"General": "通用",
 	"General Settings": "通用设置",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -179,6 +179,7 @@
 	"Keyboard shortcuts": "键盘快捷键",
 	"Language": "语言",
 	"Light": "浅色",
+	"OLED Dark": "暗黑色",
 	"Listening...": "监听中...",
 	"LLMs can make mistakes. Verify important information.": "LLM可能会生成错误信息，请验证重要信息。",
 	"Made by OpenWebUI Community": "由OpenWebUI社区制作",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -180,6 +180,7 @@
 	"Keyboard shortcuts": "鍵盤快速鍵",
 	"Language": "語言",
 	"Light": "亮色",
+	"OLED Dark": "暗黑色",
 	"Listening...": "正在聽取...",
 	"LLMs can make mistakes. Verify important information.": "LLM 可能會產生錯誤。請驗證重要資訊。",
 	"Made by OpenWebUI Community": "由 OpenWebUI 社區製作",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -153,6 +153,7 @@
 	"File not found.": "找不到檔案。",
 	"Focus chat input": "聚焦聊天輸入框",
 	"Format your variables using square brackets like this:": "像這樣使用方括號來格式化你的變數：",
+	"Fluidly stream large external response chunks": "流暢地傳輸大型外部響應區塊",
 	"From (Base Model)": "來自（基礎模型）",
 	"Full Screen Mode": "全螢幕模式",
 	"General": "常用",


### PR DESCRIPTION
## Description

🎖️Added translations for `Fluidly stream large external response chunks` and `OLED Dark`
---

### Additional Information

only added `Fluidly stream large external response chunks` and `OLED Dark` by using [google](https://translate.google.com)
