### PR TITLE
Increase-Context-Length

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -493,7 +493,7 @@
 						id="steps-range"
 						type="range"
 						min="1"
-						max="16000"
+						max="256000"
 						step="1"
 						bind:value={options.num_ctx}
 						class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -505,7 +505,7 @@
 						type="number"
 						class=" bg-transparent text-center w-14"
 						min="1"
-						max="16000"
+						max="256000"
 						step="1"
 					/>
 				</div>


### PR DESCRIPTION
Changed max context length slider to go up to 256K now that certain models support that.

I originally posted this as a feature request #1837 and then realized it's just changing two numbers.