### PR TITLE
fix: modal should not close when dragging from inside of modal

### DIFF
--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -51,7 +51,7 @@
 		bind:this={modalElement}
 		class=" fixed top-0 right-0 left-0 bottom-0 bg-black/60 w-full min-h-screen h-screen flex justify-center z-[9999] overflow-hidden overscroll-contain"
 		in:fade={{ duration: 10 }}
-		on:click={() => {
+		on:mousedown={() => {
 			show = false;
 		}}
 	>
@@ -60,7 +60,7 @@
 				size
 			)} mx-2 bg-gray-50 dark:bg-gray-900 shadow-3xl"
 			in:flyAndScale
-			on:click={(e) => {
+			on:mousedown={(e) => {
 				e.stopPropagation();
 			}}
 		>


### PR DESCRIPTION
## Description

Closes #1852.
Use `mousedown` event instead of `click` event to prevent modal window from closing on `mouseup` unexpectedly.

---

### Fixed

- Settings modal should not close when dragging from inside of modal
