### PR TITLE
fix: various rag api calls and ui cleanup

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -391,16 +391,16 @@ def query_doc_handler(
             return query_doc_with_hybrid_search(
                 collection_name=form_data.collection_name,
                 query=form_data.query,
-                embeddings_function=app.state.EMBEDDING_FUNCTION,
-                reranking_function=app.state.sentence_transformer_rf,
+                embedding_function=app.state.EMBEDDING_FUNCTION,
                 k=form_data.k if form_data.k else app.state.TOP_K,
+                reranking_function=app.state.sentence_transformer_rf,
                 r=form_data.r if form_data.r else app.state.RELEVANCE_THRESHOLD,
             )
         else:
             return query_doc(
                 collection_name=form_data.collection_name,
                 query=form_data.query,
-                embeddings_function=app.state.EMBEDDING_FUNCTION,
+                embedding_function=app.state.EMBEDDING_FUNCTION,
                 k=form_data.k if form_data.k else app.state.TOP_K,
             )
     except Exception as e:
@@ -429,16 +429,16 @@ def query_collection_handler(
             return query_collection_with_hybrid_search(
                 collection_names=form_data.collection_names,
                 query=form_data.query,
-                embeddings_function=app.state.EMBEDDING_FUNCTION,
-                reranking_function=app.state.sentence_transformer_rf,
+                embedding_function=app.state.EMBEDDING_FUNCTION,
                 k=form_data.k if form_data.k else app.state.TOP_K,
+                reranking_function=app.state.sentence_transformer_rf,
                 r=form_data.r if form_data.r else app.state.RELEVANCE_THRESHOLD,
             )
         else:
             return query_collection(
                 collection_names=form_data.collection_names,
                 query=form_data.query,
-                embeddings_function=app.state.EMBEDDING_FUNCTION,
+                embedding_function=app.state.EMBEDDING_FUNCTION,
                 k=form_data.k if form_data.k else app.state.TOP_K,
             )
 

--- a/src/lib/components/admin/UserChatsModal.svelte
+++ b/src/lib/components/admin/UserChatsModal.svelte
@@ -133,7 +133,10 @@
 						{/each} -->
 					</div>
 				{:else}
-					<div class="text-left text-sm w-full mb-8">{user.name} {$i18n.t('has no conversations.')}</div>
+					<div class="text-left text-sm w-full mb-8">
+						{user.name}
+						{$i18n.t('has no conversations.')}
+					</div>
 				{/if}
 			</div>
 		</div>

--- a/src/lib/components/documents/Settings/General.svelte
+++ b/src/lib/components/documents/Settings/General.svelte
@@ -137,9 +137,15 @@
 		if (res) {
 			console.log('rerankingModelUpdateHandler:', res);
 			if (res.status === true) {
-				toast.success($i18n.t('Reranking model set to "{{reranking_model}}"', res), {
-					duration: 1000 * 10
-				});
+				if (rerankingModel === '') {
+					toast.success($i18n.t('Reranking model disabled', res), {
+						duration: 1000 * 10
+					});
+				} else {
+					toast.success($i18n.t('Reranking model set to "{{reranking_model}}"', res), {
+						duration: 1000 * 10
+					});
+				}
 			}
 		}
 	};
@@ -584,12 +590,12 @@
 
 				<hr class=" dark:border-gray-700 my-3" />
 
-				<div>
+				<div class=" ">
 					<div class=" text-sm font-medium">{$i18n.t('Query Params')}</div>
 
 					<div class=" flex">
 						<div class="  flex w-full justify-between">
-							<div class="self-center text-xs font-medium flex-1">{$i18n.t('Top K')}</div>
+							<div class="self-center text-xs font-medium min-w-fit">{$i18n.t('Top K')}</div>
 
 							<div class="self-center p-3">
 								<input
@@ -602,13 +608,11 @@
 								/>
 							</div>
 						</div>
-					</div>
 
-					{#if querySettings.hybrid === true}
-						<div class=" flex">
-							<div class="  flex w-full justify-between">
-								<div class="self-center text-xs font-medium flex-1">
-									{$i18n.t('Relevance Threshold')}
+						{#if querySettings.hybrid === true}
+							<div class="flex w-full">
+								<div class=" self-center text-xs font-medium min-w-fit">
+									{$i18n.t('Minimum Score')}
 								</div>
 
 								<div class="self-center p-3">
@@ -616,14 +620,25 @@
 										class=" w-full rounded-lg py-1.5 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-none"
 										type="number"
 										step="0.01"
-										placeholder={$i18n.t('Enter Relevance Threshold')}
+										placeholder={$i18n.t('Enter Score')}
 										bind:value={querySettings.r}
 										autocomplete="off"
 										min="0.0"
+										title={$i18n.t('The score should be a value between 0.0 (0%) and 1.0 (100%).')}
 									/>
 								</div>
 							</div>
+						{/if}
+					</div>
+
+					{#if querySettings.hybrid === true}
+						<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
+							{$i18n.t(
+								'Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.'
+							)}
 						</div>
+
+						<hr class=" dark:border-gray-700 my-3" />
 					{/if}
 
 					<div>
@@ -635,8 +650,6 @@
 						/>
 					</div>
 				</div>
-
-				<hr class=" dark:border-gray-700 my-3" />
 
 				{#if showResetConfirm}
 					<div class="flex justify-between rounded-md items-center py-2 px-3.5 w-full transition">

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { DropdownMenu } from 'bits-ui';
 	import { flyAndScale } from '$lib/utils/transitions';
-	import { getContext } from 'svelte'
+	import { getContext } from 'svelte';
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -291,7 +291,7 @@
 	"Profile Image": "Profilbild",
 	"Prompt (e.g. Tell me a fun fact about the Roman Empire)": "Prompt (z.B. Erzähle mir eine interessante Tatsache über das Römische Reich.",
 	"Playground": "Spielplatz",
-									   
+
 	"Profile": "Profil",
 	"Prompt Content": "Prompt-Inhalt",
 	"Prompt suggestions": "Prompt-Vorschläge",


### PR DESCRIPTION
1. Cleaned up the query params to be on the same row (if hybrid search is set)
2. Fixed the api calls to `rag/api/v1/query/collection` which were broken
3. Hybrid search without a reranker uses embeddings with a cosine similarity, so their score is always 0.0 - 1.0; just like a reranking model. So always reverse the filter.

<img width="864" alt="Screenshot 2024-04-29 at 12 18 24 PM" src="https://github.com/open-webui/open-webui/assets/36205263/0f305d8e-c277-470b-8c9d-6af2f5ad10d6">
