### PR TITLE
📌 fixed a bug where RAG would not reply after not reading the file correctly

### DIFF
--- a/backend/apps/rag/utils.py
+++ b/backend/apps/rag/utils.py
@@ -321,8 +321,12 @@ def rag_messages(
 
     context_string = ""
     for context in relevant_contexts:
-        items = context["documents"][0]
-        context_string += "\n\n".join(items)
+        try:
+            if "documents" in context:
+                items = [item for item in context["documents"][0] if item is not None]
+                context_string += "\n\n".join(items)
+        except Exception as e:
+            log.exception(e)
     context_string = context_string.strip()
 
     ra_content = rag_template(


### PR DESCRIPTION
## Pull Request Checklist

## Description

fix #1869 

📌 fixed a bug where RAG would not reply after not reading the file correctly

---

### Changelog Entry

### Fixed

optimize open-webui/backend/apps/rag/utils.py 

resolved the error in 

```
  File "/app/backend/apps/rag/utils.py", line 325, in rag_messages
    context_string += "\n\n".join(items)
                      ^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, NoneType found
```

### Changed

- fixed a bug where RAG would not reply after not reading the file correctly

---

### Additional Information

At present, it can self-test and run normal operation and reply !!!
