### PR TITLE
fix: change r_score type to float

### DIFF
--- a/backend/apps/rag/utils.py
+++ b/backend/apps/rag/utils.py
@@ -53,7 +53,7 @@ def query_doc_with_hybrid_search(
     embedding_function,
     k: int,
     reranking_function,
-    r: int,
+    r: float,
 ):
     try:
         collection = CHROMA_CLIENT.get_collection(name=collection_name)


### PR DESCRIPTION
fix: Change the type from int to float

## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for the changes?
- [ ] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

Fixed wrong data type in the function `query_doc_with_hybrid_search`

---

### Changelog Entry

### Fixed

- Change the data type of parameter `r` from int to float

