### PR TITLE
Added toggle button to sort chats by title, creation date, or recently updated.

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -39,7 +39,7 @@
 	let chatTitleEditId = null;
 	let chatTitle = '';
 
-	enum ChatListSortBy { Title, Created, Updated }
+	enum ChatListSortBy { Updated, Created, Title }
 	let chatListSortBy = ChatListSortBy.Updated
 
 	let showArchivedChatsModal = false;
@@ -391,20 +391,20 @@
 					/>
 					{#if chatListSortBy !== undefined }
 						{@const sortLabel =
-							chatListSortBy === ChatListSortBy.Created ?	$i18n.t("Sort by Creation") :
+							chatListSortBy === ChatListSortBy.Created ? $i18n.t("Sort by Creation") :
 							chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Sort by Update") :
 							$i18n.t("Sort Alphabetically")
 						}
 						{@const sortIcon =
 							chatListSortBy === ChatListSortBy.Created ? // calendar
 							"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
-							:	chatListSortBy === ChatListSortBy.Updated ? // clock
+							: chatListSortBy === ChatListSortBy.Updated ? // clock
 							"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
 							: // arrows-up-down
 							"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
 						}					
 						<button
-							aria-label="Sorting"
+							aria-label="{sortLabel}"
 							class="self-center dark:hover:text-white transition p-2 mr-2"
 							on:click={()=>chatListSortBy= // cycle through enum values
 								(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -39,6 +39,9 @@
 	let chatTitleEditId = null;
 	let chatTitle = '';
 
+	enum ChatListSortBy { Title, Created, Updated }
+	let chatListSortBy = ChatListSortBy.Updated
+
 	let showArchivedChatsModal = false;
 	let showShareChatModal = false;
 	let showDropdown = false;
@@ -317,6 +320,35 @@
 			</div>
 		{/if}
 
+		{#if chatListSortBy !== undefined }
+			{@const sortLabel =
+				chatListSortBy === ChatListSortBy.Created ?	$i18n.t("Creation") :
+				chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Recent") :
+				$i18n.t("Alphabetical")
+			}
+			<div class="px-2 flex justify-center mb-1">
+				<button
+					class="flex-grow flex space-x-3 rounded-xl px-3.5 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+					on:click={()=>chatListSortBy= // cycle through enum values
+						(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)
+					}>
+					<div class="flex self-center">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"	class="w-4 h-4"
+							fill="none" stroke-width="1.5" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" d=
+								"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
+							/>
+						</svg>
+					</div>
+					<div class="flex self-center flex-grow">
+						<div class=" self-center font-medium text-sm">{sortLabel}</div>
+					</div>
+				</button>
+			</div>
+		{/if}
+
 		<div class="relative flex flex-col flex-1 overflow-y-auto">
 			{#if !($settings.saveChatHistory ?? true)}
 				<div class="absolute z-40 w-full h-full bg-gray-50/90 dark:bg-black/90 flex justify-center">
@@ -436,6 +468,10 @@
 
 						return title.includes(query) || contentMatches;
 					}
+				}).sort((a,b)=>{ return (
+					chatListSortBy === ChatListSortBy.Title ? a.title.localeCompare(b.title) :
+					chatListSortBy === ChatListSortBy.Created ? a.created_at - b.created_at :
+					1 ) // unaltered
 				}) as chat, i}
 					<div class=" w-full pr-2 relative group">
 						{#if chatTitleEditId === chat.id}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -382,13 +382,45 @@
 					</div>
 
 					<input
-						class="w-full rounded-r-xl py-1.5 pl-2.5 pr-4 text-sm dark:text-gray-300 dark:bg-gray-950 outline-none"
+						class="w-full rounded-r-xl py-1.5 pl-2.5 text-sm dark:text-gray-300 dark:bg-gray-950 outline-none"
 						placeholder={$i18n.t('Search')}
 						bind:value={search}
 						on:focus={() => {
 							enrichChatsWithContent($chats);
 						}}
 					/>
+					{#if chatListSortBy !== undefined }
+						{@const sortLabel =
+							chatListSortBy === ChatListSortBy.Created ?	$i18n.t("Sort by Creation") :
+							chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Sort by Update") :
+							$i18n.t("Sort Alphabetically")
+						}
+						{@const sortIcon =
+							chatListSortBy === ChatListSortBy.Created ? // calendar
+							"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+							:	chatListSortBy === ChatListSortBy.Updated ? // clock
+							"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+							: // arrows-up-down
+							"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
+						}					
+						<button
+							aria-label="Sorting"
+							class="self-center dark:hover:text-white transition p-2 mr-2"
+							on:click={()=>chatListSortBy= // cycle through enum values
+								(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)
+							}>
+							<Tooltip placement="top" content={sortLabel} touch={false}>
+								<div class="self-center opacity-50 flex flex-row">
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 24 24" class="w-4 h-4"
+										fill="none" stroke-width="1.5" stroke="currentColor">
+										<path stroke-linecap="round" stroke-linejoin="round" d={sortIcon} />
+									</svg>
+								</div>						
+							</Tooltip>
+						</button>
+					{/if}
 				</div>
 			</div>
 
@@ -749,31 +781,6 @@
 									</div>
 									<div class=" self-center font-medium">{$i18n.t('Archived Chats')}</div>
 								</button>
-
-								{#if chatListSortBy !== undefined }
-									{@const sortLabel =
-										chatListSortBy === ChatListSortBy.Created ? $i18n.t("Creation") :
-										chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Recent") :
-										$i18n.t("Alphabetical")
-									}
-									<button
-										class="flex rounded-md py-2.5 px-3.5 w-full hover:bg-gray-100 dark:hover:bg-gray-800 transition"
-										on:click={()=>chatListSortBy= // cycle through enum values
-											(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)
-										}>
-										<div class=" self-center mr-3">
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 24 24"	class="w-5 h-5"
-												fill="none" stroke-width="1.5" stroke="currentColor">
-												<path stroke-linecap="round" stroke-linejoin="round" d=
-													"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
-												/>
-											</svg>
-										</div>
-										<div class=" self-center font-medium">{sortLabel}</div>
-									</button>
-								{/if}
 
 								<button
 									class="flex rounded-md py-2.5 px-3.5 w-full hover:bg-gray-100 dark:hover:bg-gray-800 transition"

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -320,35 +320,6 @@
 			</div>
 		{/if}
 
-		{#if chatListSortBy !== undefined }
-			{@const sortLabel =
-				chatListSortBy === ChatListSortBy.Created ?	$i18n.t("Creation") :
-				chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Recent") :
-				$i18n.t("Alphabetical")
-			}
-			<div class="px-2 flex justify-center mb-1">
-				<button
-					class="flex-grow flex space-x-3 rounded-xl px-3.5 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition"
-					on:click={()=>chatListSortBy= // cycle through enum values
-						(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)
-					}>
-					<div class="flex self-center">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"	class="w-4 h-4"
-							fill="none" stroke-width="1.5" stroke="currentColor">
-							<path stroke-linecap="round" stroke-linejoin="round" d=
-								"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
-							/>
-						</svg>
-					</div>
-					<div class="flex self-center flex-grow">
-						<div class=" self-center font-medium text-sm">{sortLabel}</div>
-					</div>
-				</button>
-			</div>
-		{/if}
-
 		<div class="relative flex flex-col flex-1 overflow-y-auto">
 			{#if !($settings.saveChatHistory ?? true)}
 				<div class="absolute z-40 w-full h-full bg-gray-50/90 dark:bg-black/90 flex justify-center">
@@ -778,6 +749,31 @@
 									</div>
 									<div class=" self-center font-medium">{$i18n.t('Archived Chats')}</div>
 								</button>
+
+								{#if chatListSortBy !== undefined }
+									{@const sortLabel =
+										chatListSortBy === ChatListSortBy.Created ? $i18n.t("Creation") :
+										chatListSortBy === ChatListSortBy.Updated ? $i18n.t("Recent") :
+										$i18n.t("Alphabetical")
+									}
+									<button
+										class="flex rounded-md py-2.5 px-3.5 w-full hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+										on:click={()=>chatListSortBy= // cycle through enum values
+											(chatListSortBy.valueOf()+1) % (Object.keys(ChatListSortBy).length/2)
+										}>
+										<div class=" self-center mr-3">
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"	class="w-5 h-5"
+												fill="none" stroke-width="1.5" stroke="currentColor">
+												<path stroke-linecap="round" stroke-linejoin="round" d=
+													"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"
+												/>
+											</svg>
+										</div>
+										<div class=" self-center font-medium">{sortLabel}</div>
+									</button>
+								{/if}
 
 								<button
 									class="flex rounded-md py-2.5 px-3.5 w-full hover:bg-gray-100 dark:hover:bg-gray-800 transition"


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Added a button on the sidebar to toggle chat list sorting by title, creation date, or recent
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for the changes?
- [x] **Code Review:**  Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

![open-webui--feat-sortlist01](https://github.com/open-webui/open-webui/assets/1270475/9f941ed6-31ab-4d30-bdad-e14f509cc0b1)

I want to be able to sort chats alphabetically.

I copied the changes from my local repo to this fork directly on github web.
It should be fine, but please test. Feel free to correct indentation, if anything went off.

The order of toggle is determined by an enum, so it can be changed easily.

In terms of design, I tried other icons, placements, words, with icon to the right, with reverse button...
This was the most simple and clean solution I found. Open to suggestion.

Also works while list is filtered by search.

3 strings for i18n.

---

### Changelog

### Added

- Button on sidebar to toggle chat list sorting by title, creation date, or recent.