### PR TITLE
Added info about prompt commands @ and / in shortcuts modal

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -209,6 +209,38 @@
 				</div>
 			</div>
 		</div>
+		
+		<section>
+			<header class="flex justify-between dark:text-gray-300 px-5 py-4 border-b border-b-gray-800">
+				<div class="text-lg font-medium self-center">{$i18n.t('Prompt shortcuts')}</div>
+				<hr class=" dark:border-gray-800" />
+			</header>
+			<div class="flex flex-col md:flex-row w-full p-5 md:space-x-4 dark:text-gray-200">
+				<div class="flex flex-col w-full sm:flex-row sm:justify-center sm:space-x-6">
+					<div class="flex flex-col space-y-3 w-full self-start">
+						<div class="w-full flex justify-between items-center">
+							<div class=" text-sm">{$i18n.t('My Prompts')}</div>
+							<div class="flex space-x-1 text-xs">
+								<div class=" h-fit py-1 px-2 flex items-center justify-center rounded border border-black/10 capitalize text-gray-600 dark:border-white/10 dark:text-gray-300" >
+									/
+								</div>
+							</div>						
+						</div>
+					</div>
+					<div class="flex flex-col space-y-3 w-full self-start pt-3 sm:pt-0">
+						<div class="w-full flex justify-between items-center">
+							<div class="text-sm">{$i18n.t('Input from Agent')}</div>
+							<div class="flex space-x-1 text-xs">
+								<div class=" h-fit py-1 px-2 flex items-center justify-center rounded border border-black/10 capitalize text-gray-600 dark:border-white/10 dark:text-gray-300" >
+									@
+								</div>
+							</div>						
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+
 	</div>
 </Modal>
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for the changes?
- [ ] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

As the title says, added info about prompt commands @ and / in the shortcuts modal.

| ![open-webui--feat-prompt-shortcut-help](https://github.com/open-webui/open-webui/assets/1270475/ab8c32fa-a650-4f23-ad8b-bf1aed079f1d) | ![open-webui--feat-prompt-shortcut-help02](https://github.com/open-webui/open-webui/assets/1270475/54998ee4-aec7-4cb6-abd4-0845eb8c3440) |
| - | - |

They're down below on the image. I think this info here is helpful.
On the second image the elements are duplicated to demonstrate the spacing will work if more are added.

---

### Changelog Entry

### Added

- Help info about prompt shortcuts @ and /

---

### Additional Information

CSS: tried with `space-y-3 sm:space-y-0` (tailwind) to separate the columns, but it doesn't work as it *should*, so i added top padding to the second column instead `pt-3 sm:pt-0`.

When I edited this file in place, github added it as a patch to my `open-webui--feat-sortlist` fork, which was only intended for that feature. I would have prefered to have it in another repo, but it probably doesn't matter that much for this small thing.