### PR TITLE
✨fix an issue where images downloaded in safari browser on iphone are text files

### DIFF
--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -323,9 +323,11 @@ def save_b64_image(b64_str):
             header, encoded = b64_str.split(",", 1)
             mime_type = header.split(";")[0].split(":")[1]
             img_data = base64.b64decode(encoded)
-            image_format = ('.webp' if mime_type == 'image/webp' 
-                            else mimetypes.guess_extension(mime_type) 
-                            or '.png')
+            image_format = (
+                ".webp"
+                if mime_type == "image/webp"
+                else mimetypes.guess_extension(mime_type) or ".png"
+            )
             image_filename = f"{image_id}{image_format}"
             file_path = IMAGE_CACHE_DIR / f"{image_filename}"
             with open(file_path, "wb") as f:

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -321,11 +321,11 @@ def save_b64_image(b64_str):
 
         if "," in b64_str:
             header, encoded = b64_str.split(",", 1)
-            mime_type = header.split(";")[0]
-
+            mime_type = header.split(";")[0].split(":")[1]
             img_data = base64.b64decode(encoded)
-            image_format = mimetypes.guess_extension(mime_type)
-
+            image_format = ('.webp' if mime_type == 'image/webp' 
+                            else mimetypes.guess_extension(mime_type) 
+                            or '.png')
             image_filename = f"{image_id}{image_format}"
             file_path = IMAGE_CACHE_DIR / f"{image_filename}"
             with open(file_path, "wb") as f:

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -3,11 +3,40 @@
 	export let src = '';
 	export let alt = '';
 
-	const downloadImage = (url, filename) => {
+	const MimeTypes: { [index: string]: string } = {
+		jpeg: 'image/jpeg',
+		jpg: 'image/jpeg',
+		png: 'image/png',
+		gif: 'image/gif',
+		bmp: 'image/bmp',
+		ico: 'image/x-icon',
+		tif: 'image/tiff',
+		tiff: 'image/tiff',
+		webp: 'image/webp',
+		svg: 'image/svg+xml',
+		avif: 'image/avif',
+		heic: 'image/heic',
+		heif: 'image/heif',
+		raw: 'image/x-raw'
+	};
+
+	function getMimeType(extension: string) {
+		return MimeTypes[extension.toLowerCase()] || 'image/png';
+	}
+
+	const downloadImage = (url) => {
+		const urlParts = url.split('/');
+		const fileNameWithExt = urlParts.pop().trim() || '';
+		const splitted = fileNameWithExt.split('.');
+		const extension = `${(splitted[splitted.length - 1] || 'png').toLowerCase()}`;
+		const filename = `image.${extension}`;
+
 		fetch(url)
 			.then((response) => response.blob())
 			.then((blob) => {
-				const objectUrl = window.URL.createObjectURL(blob);
+				const mimeType = getMimeType(extension);
+				const newBlob = new Blob([blob], { type: mimeType });
+				const objectUrl = window.URL.createObjectURL(newBlob);
 				const link = document.createElement('a');
 				link.href = objectUrl;
 				link.download = filename;
@@ -51,7 +80,7 @@
 				<button
 					class=" p-5"
 					on:click={() => {
-						downloadImage(src, 'Image.png');
+						downloadImage(src);
 					}}
 				>
 					<svg

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -29,7 +29,7 @@
 		const fileNameWithExt = urlParts.pop().trim() || '';
 		const splitted = fileNameWithExt.split('.');
 		const extension = `${(splitted[splitted.length - 1] || 'png').toLowerCase()}`;
-		const filename = `image.${extension}`;
+		const filename = `Image.${extension}`;
 
 		fetch(url)
 			.then((response) => response.blob())


### PR DESCRIPTION
## Pull Request Checklist

---

## Description

✨fix an issue where images downloaded in safari browser on iphone are text files

---

### Changelog Entry

### Added

- Not specifically cited Mime-types, i created a MimeTypes to get MimeType from file name suffixes. 

### Fixed

- fix an issue where images downloaded in safari browser on iphone are text files

<img src="https://github.com/open-webui/open-webui/assets/132346501/8ab6463b-7120-4c83-9c88-6923a6758a89" height="400">

---

### Additional Information

- Through the self-test, now i can download the corresponding file

<img src="https://github.com/open-webui/open-webui/assets/132346501/76b7c394-550d-415d-8d7a-81861fc22050" height="400">

