### PR TITLE
fix: DRY + speed up docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,46 +79,10 @@ ENV HOME /root
 RUN mkdir -p $HOME/.cache/chroma
 RUN echo -n 00000000-0000-0000-0000-000000000000 > $HOME/.cache/chroma/telemetry_user_id
 
-RUN if [ "$USE_OLLAMA" = "true" ]; then \
-        apt-get update && \
-        # Install pandoc and netcat
-        apt-get install -y --no-install-recommends pandoc netcat-openbsd && \
-        # for RAG OCR
-        apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 && \
-        # install helper tools
-        apt-get install -y --no-install-recommends curl && \
-        # install ollama
-        curl -fsSL https://ollama.com/install.sh | sh && \
-        # cleanup
-        rm -rf /var/lib/apt/lists/*; \
-    else \
-        apt-get update && \
-        # Install pandoc and netcat
-        apt-get install -y --no-install-recommends pandoc netcat-openbsd && \
-        # for RAG OCR
-        apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 && \
-        # cleanup
-        rm -rf /var/lib/apt/lists/*; \
-    fi
-
-# install python dependencies
+# install python dependencies & download model
 COPY ./backend/requirements.txt ./requirements.txt
-
-RUN pip3 install uv && \
-    if [ "$USE_CUDA" = "true" ]; then \
-        # If you use CUDA the whisper and embedding model will be downloaded on first use
-        pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/$USE_CUDA_DOCKER_VER --no-cache-dir && \
-        uv pip install --system -r requirements.txt --no-cache-dir && \
-        python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
-        python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
-    else \
-        pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir && \
-        uv pip install --system -r requirements.txt --no-cache-dir && \
-        python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
-        python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
-    fi
-
-
+COPY ./backend/docker_setup.sh ./docker_setup.sh
+RUN env USE_OLLAMA=$USE_OLLAMA USE_CUDA=$USE_CUDA USE_CUDA_VER=$USE_CUDA_VER bash ./docker_setup.sh
 
 # copy embedding weight from build
 # RUN mkdir -p /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2

--- a/backend/docker_setup.sh
+++ b/backend/docker_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -xeuo pipefail
+
+PACKAGES="pandoc netcat-openbsd ffmpeg libsm6 libxext6"
+
+if [ "$USE_OLLAMA" = "true" ]; then
+	PACKAGES="$PACKAGES curl"
+fi
+
+apt-get update
+# shellcheck disable=SC2086
+apt-get install -y --no-install-recommends $PACKAGES
+
+if [ "$USE_OLLAMA" = "true" ]; then
+	curl -fsSL https://ollama.com/install.sh | bash
+fi
+
+rm -rf /var/lib/apt/lists/*
+
+python -m pip install --no-cache uv
+
+if [ "$USE_CUDA" = "true" ]; then
+	PIP_INDEX_URL=https://download.pytorch.org/whl/$USE_CUDA_DOCKER_VER
+else
+	PIP_INDEX_URL=https://download.pytorch.org/whl/cpu
+fi
+
+uv pip install --system torch torchvision torchaudio --index-url "$PIP_INDEX_URL" --no-cache-dir
+uv pip install --system -r requirements.txt --no-cache-dir
+
+# Download models
+python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')"
+python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"
+
+# Ensure model download directories now exist
+ls "$SENTENCE_TRANSFORMERS_HOME" || exit 1
+ls "$WHISPER_MODEL_DIR" || exit 1


### PR DESCRIPTION
## Description

This PR:

* Refactors the Dockerfile to use an in-container setup script instead of commands being mashed into `RUN` statements.
* DRYs out the repeated package lists, PyTorch package index URL determination etc.
* Switches to using `uv` for installing Torch as well (it's faster!)
* Adds a check that the functionality to pre-load whisper and embedding models actually works 

This should have no effect for the end user other than a possibly slightly smaller image.
For developers, this is easier to maintainer.
For CI and builders, this is faster.

## Testing & review

I checked that an image built with and without `USE_OLLAMA` works as before.

I didn't check the CUDA configuration, since I have no CUDA-enabled Docker hardware at hand right now.

---

### Changelog Entry

### Changed

- Optimized Docker build a bit.
