### PR TITLE
doc: note PRs should target `dev`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Pull Request Checklist
 
+- [ ] **Target branch:** Pull requests should target the `dev` branch.
 - [ ] **Description:** Briefly describe the changes in this pull request.
 - [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
 - [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?


### PR DESCRIPTION
## Description

This PR adds a note about the desired PR target branch into the PR template, to make it easier for contributors to target the right branch.

---

### Additional Information

- I'd targeted the wrong branch in #2016. 😅 