### PR TITLE
chore: Small Python requirement fixes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,6 @@ psycopg2-binary==2.9.9
 PyMySQL==1.1.0
 bcrypt==4.1.2
 
-litellm==1.35.28
 litellm[proxy]==1.35.28
 
 boto3==1.34.95
@@ -54,7 +53,6 @@ rank-bm25==0.2.2
 
 faster-whisper==1.0.1
 
-PyJWT==2.8.0
 PyJWT[crypto]==2.8.0
 
 black==24.4.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,6 @@ Flask-Cors==4.0.0
 python-socketio==5.11.2
 python-jose==3.3.0
 passlib[bcrypt]==1.7.4
-uuid==1.30
 
 requests==2.31.0
 aiohttp==3.9.5

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -59,4 +59,4 @@ PyJWT[crypto]==2.8.0
 
 black==24.4.2
 langfuse==2.27.3
-youtube-transcript-api
+youtube-transcript-api==0.6.2


### PR DESCRIPTION
## Description

This PR fixes the `backend/requirements.txt` file a bit:

* `youtube-transcript-api` wasn't pinned like the rest of the versions are; it is now.
* some requirements with `[extras]` were duplicated; they don't need to be.
* `uuid` has been a standard library module for 18 years as far as I can see; there should be no need to install a version from 2006 from PyPI.

---

### Changelog Entry

### Fixed

- Backend requirement versions slightly corrected.
