### PR TITLE
fix: do not use hardware ID in document ID generation

### DIFF
--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -622,7 +622,7 @@ def store_docs_in_vector_db(docs, collection_name, overwrite: bool = False) -> b
 
         for batch in create_batches(
             api=CHROMA_CLIENT,
-            ids=[str(uuid.uuid1()) for _ in texts],
+            ids=[str(uuid.uuid4()) for _ in texts],
             metadatas=metadatas,
             embeddings=embeddings,
             documents=texts,


### PR DESCRIPTION
## Description

[`uuid.uuid1()`](https://docs.python.org/3.12/library/uuid.html#index-5) uses the machine's hardware ID (among other things) for UUID generation. I see no reason to use partially deterministic IDs here; every other use of UUIDs in the project seems to be using the random `uuid4()` function.

---

### Changelog Entry

### Fixed

- Vector database document IDs no longer use deterministic UUIDv1 identifiers.