### PR TITLE
chore/fix: re-enable linting for backend

### DIFF
--- a/.github/workflows/format-backend.yaml
+++ b/.github/workflows/format-backend.yaml
@@ -28,12 +28,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black
+        run: grep '^ruff' backend/requirements.txt | xargs python -m pip install
 
       - name: Format backend
         run: npm run format:backend
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
       - name: Check for changes after format
         run: git diff --exit-code

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Use Bun
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pylint
+        run: grep '^ruff' backend/requirements.txt | xargs python -m pip install
       - name: Lint backend
         run: bun run lint:backend
+        env:
+          RUFF_OUTPUT_FORMAT: github

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -1,55 +1,49 @@
-import os
-import logging
-from fastapi import (
-    FastAPI,
-    Request,
-    Depends,
-    HTTPException,
-    status,
-    UploadFile,
-    File,
-    Form,
-)
-
-from fastapi.responses import StreamingResponse, JSONResponse, FileResponse
-
-from fastapi.middleware.cors import CORSMiddleware
-from faster_whisper import WhisperModel
-from pydantic import BaseModel
-
-import uuid
-import requests
 import hashlib
-from pathlib import Path
 import json
+import logging
+import os
+import uuid
+from pathlib import Path
 
-from constants import ERROR_MESSAGES
-from utils.utils import (
-    decode_token,
-    get_current_user,
-    get_verified_user,
-    get_admin_user,
-)
-from utils.misc import calculate_sha256
-
+import requests
 from config import (
-    SRC_LOG_LEVELS,
-    CACHE_DIR,
-    UPLOAD_DIR,
-    WHISPER_MODEL,
-    WHISPER_MODEL_DIR,
-    WHISPER_MODEL_AUTO_UPDATE,
-    DEVICE_TYPE,
-    AUDIO_STT_OPENAI_API_BASE_URL,
-    AUDIO_STT_OPENAI_API_KEY,
-    AUDIO_TTS_OPENAI_API_BASE_URL,
-    AUDIO_TTS_OPENAI_API_KEY,
     AUDIO_STT_ENGINE,
     AUDIO_STT_MODEL,
+    AUDIO_STT_OPENAI_API_BASE_URL,
+    AUDIO_STT_OPENAI_API_KEY,
     AUDIO_TTS_ENGINE,
     AUDIO_TTS_MODEL,
+    AUDIO_TTS_OPENAI_API_BASE_URL,
+    AUDIO_TTS_OPENAI_API_KEY,
     AUDIO_TTS_VOICE,
+    CACHE_DIR,
+    DEVICE_TYPE,
+    SRC_LOG_LEVELS,
+    WHISPER_MODEL,
+    WHISPER_MODEL_AUTO_UPDATE,
+    WHISPER_MODEL_DIR,
     AppConfig,
+)
+from constants import ERROR_MESSAGES
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    Request,
+    UploadFile,
+    status,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from faster_whisper import WhisperModel
+from pydantic import BaseModel
+from pydub import AudioSegment
+from pydub.utils import mediainfo
+from utils.utils import (
+    get_admin_user,
+    get_current_user,
+    get_verified_user,
 )
 
 log = logging.getLogger(__name__)
@@ -103,10 +97,6 @@ class STTConfigForm(BaseModel):
 class AudioConfigUpdateForm(BaseModel):
     tts: TTSConfigForm
     stt: STTConfigForm
-
-
-from pydub import AudioSegment
-from pydub.utils import mediainfo
 
 
 def is_mp4_audio(file_path):
@@ -204,7 +194,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
         body = json.loads(body)
         body["model"] = app.state.config.TTS_MODEL
         body = json.dumps(body).encode("utf-8")
-    except Exception as e:
+    except Exception:
         pass
 
     r = None

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -219,12 +219,12 @@ class ImageStepsUpdateForm(BaseModel):
 
 
 @app.get("/steps")
-async def get_image_size(user=Depends(get_admin_user)):
-    return {"IMAGE_STEPS": app.state.config.IMAGE_STEPS}
+async def get_image_steps(user=Depends(get_admin_user)):
+    return {"IMAGE_STEPS": app.state.IMAGE_STEPS}
 
 
 @app.post("/steps/update")
-async def update_image_size(
+async def update_image_steps(
     form_data: ImageStepsUpdateForm, user=Depends(get_admin_user)
 ):
     if form_data.steps >= 0:

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -134,7 +134,7 @@ async def update_engine_url(
     else:
         url = form_data.AUTOMATIC1111_BASE_URL.strip("/")
         try:
-            r = requests.head(url)
+            requests.head(url)
             app.state.config.AUTOMATIC1111_BASE_URL = url
         except Exception as e:
             raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(e))
@@ -145,7 +145,7 @@ async def update_engine_url(
         url = form_data.COMFYUI_BASE_URL.strip("/")
 
         try:
-            r = requests.head(url)
+            requests.head(url)
             app.state.config.COMFYUI_BASE_URL = url
         except Exception as e:
             raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(e))

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -391,7 +391,7 @@ def save_url_image(url):
                     image_file.write(chunk)
             return image_filename
         else:
-            log.error(f"Url does not point to an image.")
+            log.error("Url does not point to an image.")
             return None
 
     except Exception as e:

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -119,7 +119,6 @@ async def get_engine_url(user=Depends(get_admin_user)):
 async def update_engine_url(
     form_data: EngineUrlUpdateForm, user=Depends(get_admin_user)
 ):
-
     if form_data.AUTOMATIC1111_BASE_URL == None:
         app.state.config.AUTOMATIC1111_BASE_URL = AUTOMATIC1111_BASE_URL
     else:
@@ -240,7 +239,6 @@ def get_models(user=Depends(get_current_user)):
                 {"id": "dall-e-3", "name": "DALL·E 3"},
             ]
         elif app.state.config.ENGINE == "comfyui":
-
             r = requests.get(url=f"{app.state.config.COMFYUI_BASE_URL}/object_info")
             info = r.json()
 
@@ -367,7 +365,6 @@ def save_url_image(url):
         r = requests.get(url)
         r.raise_for_status()
         if r.headers["content-type"].split("/")[0] == "image":
-
             mime_type = r.headers["content-type"]
             image_format = mimetypes.guess_extension(mime_type)
 
@@ -395,13 +392,11 @@ def generate_image(
     form_data: GenerateImageForm,
     user=Depends(get_current_user),
 ):
-
     width, height = tuple(map(int, app.state.config.IMAGE_SIZE.split("x")))
 
     r = None
     try:
         if app.state.config.ENGINE == "openai":
-
             headers = {}
             headers["Authorization"] = f"Bearer {app.state.config.OPENAI_API_KEY}"
             headers["Content-Type"] = "application/json"
@@ -442,7 +437,6 @@ def generate_image(
             return images
 
         elif app.state.config.ENGINE == "comfyui":
-
             data = {
                 "prompt": form_data.prompt,
                 "width": width,

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -1,54 +1,45 @@
-import re
-import requests
-from fastapi import (
-    FastAPI,
-    Request,
-    Depends,
-    HTTPException,
-    status,
-    UploadFile,
-    File,
-    Form,
-)
-from fastapi.middleware.cors import CORSMiddleware
-from faster_whisper import WhisperModel
-
-from constants import ERROR_MESSAGES
-from utils.utils import (
-    get_current_user,
-    get_admin_user,
-)
-
-from apps.images.utils.comfyui import ImageGenerationPayload, comfyui_generate_image
-from utils.misc import calculate_sha256
-from typing import Optional
-from pydantic import BaseModel
-from pathlib import Path
-import mimetypes
-import uuid
 import base64
 import json
 import logging
+import mimetypes
+import re
+import uuid
+from pathlib import Path
+from typing import Optional
 
+import requests
+from apps.images.utils.comfyui import ImageGenerationPayload, comfyui_generate_image
 from config import (
-    SRC_LOG_LEVELS,
-    CACHE_DIR,
-    IMAGE_GENERATION_ENGINE,
-    ENABLE_IMAGE_GENERATION,
     AUTOMATIC1111_BASE_URL,
+    CACHE_DIR,
     COMFYUI_BASE_URL,
     COMFYUI_CFG_SCALE,
     COMFYUI_SAMPLER,
     COMFYUI_SCHEDULER,
     COMFYUI_SD3,
-    IMAGES_OPENAI_API_BASE_URL,
-    IMAGES_OPENAI_API_KEY,
+    ENABLE_IMAGE_GENERATION,
+    IMAGE_GENERATION_ENGINE,
     IMAGE_GENERATION_MODEL,
     IMAGE_SIZE,
     IMAGE_STEPS,
+    IMAGES_OPENAI_API_BASE_URL,
+    IMAGES_OPENAI_API_KEY,
+    SRC_LOG_LEVELS,
     AppConfig,
 )
-
+from constants import ERROR_MESSAGES
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    Request,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from utils.utils import (
+    get_admin_user,
+    get_current_user,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["IMAGES"])

--- a/backend/apps/images/utils/comfyui.py
+++ b/backend/apps/images/utils/comfyui.py
@@ -1,19 +1,16 @@
-import websocket  # NOTE: websocket-client (https://github.com/websocket-client/websocket-client)
-import uuid
 import json
-import urllib.request
-import urllib.parse
-import random
 import logging
+import random
+import urllib.parse
+import urllib.request
+from typing import Optional
 
+import websocket  # NOTE: websocket-client (https://github.com/websocket-client/websocket-client)
 from config import SRC_LOG_LEVELS
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["COMFYUI"])
-
-from pydantic import BaseModel
-
-from typing import Optional
 
 COMFYUI_DEFAULT_PROMPT = """
 {

--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -337,8 +337,6 @@ async def pull_model(
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    r = None
-
     # Admin should be able to pull models from any source
     payload = {**form_data.model_dump(exclude_none=True), "insecure": True}
 
@@ -1034,7 +1032,6 @@ def parse_huggingface_url(hf_url):
         path_components = parsed_url.path.split("/")
 
         # Extract the desired output
-        user_repo = "/".join(path_components[1:3])
         model_file = path_components[-1]
 
         return model_file

--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -260,7 +260,6 @@ async def get_ollama_tags(
 async def get_ollama_versions(url_idx: Optional[int] = None):
     if app.state.config.ENABLE_OLLAMA_API:
         if url_idx == None:
-
             # returns lowest version
             tasks = [
                 fetch_url(f"{url}/api/version")
@@ -578,7 +577,6 @@ def generate_ollama_embeddings(
     form_data: GenerateEmbeddingsForm,
     url_idx: Optional[int] = None,
 ):
-
     log.info(f"generate_ollama_embeddings {form_data}")
 
     if url_idx == None:
@@ -649,7 +647,6 @@ async def generate_completion(
     url_idx: Optional[int] = None,
     user=Depends(get_verified_user),
 ):
-
     if url_idx == None:
         model = form_data.model
 
@@ -695,7 +692,6 @@ async def generate_chat_completion(
     url_idx: Optional[int] = None,
     user=Depends(get_verified_user),
 ):
-
     log.debug(
         "form_data.model_dump_json(exclude_none=True).encode(): {0} ".format(
             form_data.model_dump_json(exclude_none=True).encode()
@@ -727,7 +723,6 @@ async def generate_chat_completion(
                 )
 
             if model_info.params.get("mirostat_tau", None):
-
                 payload["options"]["mirostat_tau"] = model_info.params.get(
                     "mirostat_tau", None
                 )
@@ -863,7 +858,6 @@ async def generate_openai_chat_completion(
     url_idx: Optional[int] = None,
     user=Depends(get_verified_user),
 ):
-
     payload = {
         **form_data.model_dump(exclude_none=True),
     }
@@ -1082,7 +1076,6 @@ async def download_model(
     url_idx: Optional[int] = None,
     user=Depends(get_admin_user),
 ):
-
     allowed_hosts = ["https://huggingface.co/", "https://github.com/"]
 
     if not any(form_data.url.startswith(host) for host in allowed_hosts):

--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -1,58 +1,44 @@
-from fastapi import (
-    FastAPI,
-    Request,
-    Response,
-    HTTPException,
-    Depends,
-    status,
-    UploadFile,
-    File,
-    BackgroundTasks,
-)
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
-from fastapi.concurrency import run_in_threadpool
-
-from pydantic import BaseModel, ConfigDict
-
-import os
-import re
-import copy
-import random
-import requests
-import json
-import uuid
-import aiohttp
 import asyncio
+import json
 import logging
+import os
+import random
+import re
 import time
+from typing import List, Optional, Union
 from urllib.parse import urlparse
-from typing import Optional, List, Union
 
-from starlette.background import BackgroundTask
-
+import aiohttp
+import requests
 from apps.webui.models.models import Models
-from apps.webui.models.users import Users
-from constants import ERROR_MESSAGES
-from utils.utils import (
-    decode_token,
-    get_current_user,
-    get_verified_user,
-    get_admin_user,
-)
-
-
 from config import (
-    SRC_LOG_LEVELS,
-    OLLAMA_BASE_URLS,
-    ENABLE_OLLAMA_API,
     AIOHTTP_CLIENT_TIMEOUT,
     ENABLE_MODEL_FILTER,
+    ENABLE_OLLAMA_API,
     MODEL_FILTER_LIST,
+    OLLAMA_BASE_URLS,
+    SRC_LOG_LEVELS,
     UPLOAD_DIR,
     AppConfig,
 )
+from constants import ERROR_MESSAGES
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict
+from starlette.background import BackgroundTask
 from utils.misc import calculate_sha256
+from utils.utils import (
+    get_admin_user,
+    get_verified_user,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["OLLAMA"])

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -1,40 +1,34 @@
-from fastapi import FastAPI, Request, Response, HTTPException, Depends
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse, JSONResponse, FileResponse
-
-import requests
-import aiohttp
 import asyncio
+import hashlib
 import json
 import logging
-
-from pydantic import BaseModel
-from starlette.background import BackgroundTask
-
-from apps.webui.models.models import Models
-from apps.webui.models.users import Users
-from constants import ERROR_MESSAGES
-from utils.utils import (
-    decode_token,
-    get_current_user,
-    get_verified_user,
-    get_admin_user,
-)
-from config import (
-    SRC_LOG_LEVELS,
-    ENABLE_OPENAI_API,
-    OPENAI_API_BASE_URLS,
-    OPENAI_API_KEYS,
-    CACHE_DIR,
-    ENABLE_MODEL_FILTER,
-    MODEL_FILTER_LIST,
-    AppConfig,
-)
+from pathlib import Path
 from typing import List, Optional
 
-
-import hashlib
-from pathlib import Path
+import aiohttp
+import requests
+from apps.webui.models.models import Models
+from config import (
+    CACHE_DIR,
+    ENABLE_MODEL_FILTER,
+    ENABLE_OPENAI_API,
+    MODEL_FILTER_LIST,
+    OPENAI_API_BASE_URLS,
+    OPENAI_API_KEYS,
+    SRC_LOG_LEVELS,
+    AppConfig,
+)
+from constants import ERROR_MESSAGES
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, StreamingResponse
+from pydantic import BaseModel
+from starlette.background import BackgroundTask
+from utils.utils import (
+    get_admin_user,
+    get_current_user,
+    get_verified_user,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["OPENAI"])

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -873,7 +873,6 @@ def store_web_search(form_data: SearchForm, user=Depends(get_current_user)):
 
 
 def store_data_in_vector_db(data, collection_name, overwrite: bool = False) -> bool:
-
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=app.state.config.CHUNK_SIZE,
         chunk_overlap=app.state.config.CHUNK_OVERLAP,
@@ -1116,7 +1115,6 @@ def store_text(
     form_data: TextRAGForm,
     user=Depends(get_current_user),
 ):
-
     collection_name = form_data.collection_name
     if collection_name == None:
         collection_name = calculate_sha256_string(form_data.content)

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -1,132 +1,118 @@
-from fastapi import (
-    FastAPI,
-    Depends,
-    HTTPException,
-    status,
-    UploadFile,
-    File,
-    Form,
-)
-from fastapi.middleware.cors import CORSMiddleware
-import requests
-import os, shutil, logging, re
-from datetime import datetime
-
-from pathlib import Path
-from typing import List, Union, Sequence, Iterator, Any
-
-from chromadb.utils.batch_utils import create_batches
-from langchain_core.documents import Document
-
-from langchain_community.document_loaders import (
-    WebBaseLoader,
-    TextLoader,
-    PyPDFLoader,
-    CSVLoader,
-    BSHTMLLoader,
-    Docx2txtLoader,
-    UnstructuredEPubLoader,
-    UnstructuredWordDocumentLoader,
-    UnstructuredMarkdownLoader,
-    UnstructuredXMLLoader,
-    UnstructuredRSTLoader,
-    UnstructuredExcelLoader,
-    UnstructuredPowerPointLoader,
-    YoutubeLoader,
-    OutlookMessageLoader,
-)
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-
-import validators
-import urllib.parse
-import socket
-
-
-from pydantic import BaseModel
-from typing import Optional
-import mimetypes
-import uuid
 import json
+import logging
+import mimetypes
+import os
+import shutil
+import socket
+import urllib.parse
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, List, Optional, Sequence, Union
 
 import sentence_transformers
-
-from apps.webui.models.documents import (
-    Documents,
-    DocumentForm,
-    DocumentResponse,
-)
-
-from apps.rag.utils import (
-    get_model_path,
-    get_embedding_function,
-    query_doc,
-    query_doc_with_hybrid_search,
-    query_collection,
-    query_collection_with_hybrid_search,
-)
-
+import validators
 from apps.rag.search.brave import search_brave
+from apps.rag.search.duckduckgo import search_duckduckgo
 from apps.rag.search.google_pse import search_google_pse
 from apps.rag.search.main import SearchResult
 from apps.rag.search.searxng import search_searxng
 from apps.rag.search.serper import search_serper
-from apps.rag.search.serpstack import search_serpstack
 from apps.rag.search.serply import search_serply
-from apps.rag.search.duckduckgo import search_duckduckgo
+from apps.rag.search.serpstack import search_serpstack
 from apps.rag.search.tavily import search_tavily
-
-from utils.misc import (
-    calculate_sha256,
-    calculate_sha256_string,
-    sanitize_filename,
-    extract_folders_after_data_docs,
+from apps.rag.utils import (
+    get_embedding_function,
+    get_model_path,
+    query_collection,
+    query_collection_with_hybrid_search,
+    query_doc,
+    query_doc_with_hybrid_search,
 )
-from utils.utils import get_current_user, get_admin_user
-
+from apps.webui.models.documents import (
+    DocumentForm,
+    Documents,
+)
+from chromadb.utils.batch_utils import create_batches
 from config import (
-    AppConfig,
-    ENV,
-    SRC_LOG_LEVELS,
-    UPLOAD_DIR,
+    BRAVE_SEARCH_API_KEY,
+    CHROMA_CLIENT,
+    CHUNK_OVERLAP,
+    CHUNK_SIZE,
+    DEVICE_TYPE,
     DOCS_DIR,
-    RAG_TOP_K,
-    RAG_RELEVANCE_THRESHOLD,
+    ENABLE_RAG_HYBRID_SEARCH,
+    ENABLE_RAG_LOCAL_WEB_FETCH,
+    ENABLE_RAG_WEB_LOADER_SSL_VERIFICATION,
+    ENABLE_RAG_WEB_SEARCH,
+    ENV,
+    GOOGLE_PSE_API_KEY,
+    GOOGLE_PSE_ENGINE_ID,
+    PDF_EXTRACT_IMAGES,
     RAG_EMBEDDING_ENGINE,
     RAG_EMBEDDING_MODEL,
     RAG_EMBEDDING_MODEL_AUTO_UPDATE,
     RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
-    ENABLE_RAG_HYBRID_SEARCH,
-    ENABLE_RAG_WEB_LOADER_SSL_VERIFICATION,
-    RAG_RERANKING_MODEL,
-    PDF_EXTRACT_IMAGES,
-    RAG_RERANKING_MODEL_AUTO_UPDATE,
-    RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
+    RAG_EMBEDDING_OPENAI_BATCH_SIZE,
     RAG_OPENAI_API_BASE_URL,
     RAG_OPENAI_API_KEY,
-    DEVICE_TYPE,
-    CHROMA_CLIENT,
-    CHUNK_SIZE,
-    CHUNK_OVERLAP,
+    RAG_RELEVANCE_THRESHOLD,
+    RAG_RERANKING_MODEL,
+    RAG_RERANKING_MODEL_AUTO_UPDATE,
+    RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
     RAG_TEMPLATE,
-    ENABLE_RAG_LOCAL_WEB_FETCH,
-    YOUTUBE_LOADER_LANGUAGE,
-    ENABLE_RAG_WEB_SEARCH,
+    RAG_TOP_K,
+    RAG_WEB_SEARCH_CONCURRENT_REQUESTS,
     RAG_WEB_SEARCH_ENGINE,
+    RAG_WEB_SEARCH_RESULT_COUNT,
     SEARXNG_QUERY_URL,
-    GOOGLE_PSE_API_KEY,
-    GOOGLE_PSE_ENGINE_ID,
-    BRAVE_SEARCH_API_KEY,
-    SERPSTACK_API_KEY,
-    SERPSTACK_HTTPS,
     SERPER_API_KEY,
     SERPLY_API_KEY,
+    SERPSTACK_API_KEY,
+    SERPSTACK_HTTPS,
+    SRC_LOG_LEVELS,
     TAVILY_API_KEY,
-    RAG_WEB_SEARCH_RESULT_COUNT,
-    RAG_WEB_SEARCH_CONCURRENT_REQUESTS,
-    RAG_EMBEDDING_OPENAI_BATCH_SIZE,
+    UPLOAD_DIR,
+    YOUTUBE_LOADER_LANGUAGE,
+    AppConfig,
 )
-
 from constants import ERROR_MESSAGES
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    UploadFile,
+    status,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import (
+    BSHTMLLoader,
+    CSVLoader,
+    Docx2txtLoader,
+    OutlookMessageLoader,
+    PyPDFLoader,
+    TextLoader,
+    UnstructuredEPubLoader,
+    UnstructuredExcelLoader,
+    UnstructuredMarkdownLoader,
+    UnstructuredPowerPointLoader,
+    UnstructuredRSTLoader,
+    UnstructuredXMLLoader,
+    WebBaseLoader,
+    YoutubeLoader,
+)
+from langchain_core.documents import Document
+from pydantic import BaseModel
+from utils.misc import (
+    calculate_sha256,
+    calculate_sha256_string,
+    extract_folders_after_data_docs,
+    sanitize_filename,
+)
+from utils.utils import get_admin_user, get_current_user
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/apps/rag/search/brave.py
+++ b/backend/apps/rag/search/brave.py
@@ -1,7 +1,6 @@
 import logging
 
 import requests
-
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/duckduckgo.py
+++ b/backend/apps/rag/search/duckduckgo.py
@@ -1,8 +1,8 @@
 import logging
 
 from apps.rag.search.main import SearchResult
-from duckduckgo_search import DDGS
 from config import SRC_LOG_LEVELS
+from duckduckgo_search import DDGS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/apps/rag/search/google_pse.py
+++ b/backend/apps/rag/search/google_pse.py
@@ -1,8 +1,6 @@
-import json
 import logging
 
 import requests
-
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/searxng.py
+++ b/backend/apps/rag/search/searxng.py
@@ -1,8 +1,7 @@
 import logging
-import requests
-
 from typing import List
 
+import requests
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/serper.py
+++ b/backend/apps/rag/search/serper.py
@@ -2,7 +2,6 @@ import json
 import logging
 
 import requests
-
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/serply.py
+++ b/backend/apps/rag/search/serply.py
@@ -1,9 +1,7 @@
-import json
 import logging
-
-import requests
 from urllib.parse import urlencode
 
+import requests
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/serpstack.py
+++ b/backend/apps/rag/search/serpstack.py
@@ -1,8 +1,6 @@
-import json
 import logging
 
 import requests
-
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/search/tavily.py
+++ b/backend/apps/rag/search/tavily.py
@@ -1,7 +1,6 @@
 import logging
 
 import requests
-
 from apps.rag.search.main import SearchResult
 from config import SRC_LOG_LEVELS
 

--- a/backend/apps/rag/utils.py
+++ b/backend/apps/rag/utils.py
@@ -1,27 +1,29 @@
-import os
 import logging
+import operator
+import os
+from typing import Any, List, Optional, Sequence, Union
+
 import requests
-
-from typing import List, Union
-
 from apps.ollama.main import (
-    generate_ollama_embeddings,
     GenerateEmbeddingsForm,
+    generate_ollama_embeddings,
 )
-
+from config import (
+    CHROMA_CLIENT,
+    SRC_LOG_LEVELS,
+)
 from huggingface_hub import snapshot_download
-
-from langchain_core.documents import Document
-from langchain_community.retrievers import BM25Retriever
 from langchain.retrievers import (
     ContextualCompressionRetriever,
     EnsembleRetriever,
 )
-
-from typing import Optional
-
-from utils.misc import get_last_user_message, add_or_update_system_message
-from config import SRC_LOG_LEVELS, CHROMA_CLIENT
+from langchain_community.retrievers import BM25Retriever
+from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
+from langchain_core.documents import BaseDocumentCompressor, Document
+from langchain_core.pydantic_v1 import Extra
+from langchain_core.retrievers import BaseRetriever
+from sentence_transformers import util
+from utils.misc import get_last_user_message
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
@@ -394,13 +396,6 @@ def generate_openai_batch_embeddings(
         print(e)
         return None
 
-
-from typing import Any
-
-from langchain_core.retrievers import BaseRetriever
-from langchain_core.callbacks import CallbackManagerForRetrieverRun
-
-
 class ChromaRetriever(BaseRetriever):
     collection: Any
     embedding_function: Any
@@ -432,18 +427,6 @@ class ChromaRetriever(BaseRetriever):
                 )
             )
         return results
-
-
-import operator
-
-from typing import Optional, Sequence
-
-from langchain_core.documents import BaseDocumentCompressor, Document
-from langchain_core.callbacks import Callbacks
-from langchain_core.pydantic_v1 import Extra
-
-from sentence_transformers import util
-
 
 class RerankCompressor(BaseDocumentCompressor):
     embedding_function: Any

--- a/backend/apps/rag/utils.py
+++ b/backend/apps/rag/utils.py
@@ -396,6 +396,7 @@ def generate_openai_batch_embeddings(
         print(e)
         return None
 
+
 class ChromaRetriever(BaseRetriever):
     collection: Any
     embedding_function: Any
@@ -427,6 +428,7 @@ class ChromaRetriever(BaseRetriever):
                 )
             )
         return results
+
 
 class RerankCompressor(BaseDocumentCompressor):
     embedding_function: Any

--- a/backend/apps/socket/main.py
+++ b/backend/apps/socket/main.py
@@ -1,7 +1,6 @@
-import socketio
 import asyncio
 
-
+import socketio
 from apps.webui.models.users import Users
 from utils.utils import decode_token
 

--- a/backend/apps/socket/main.py
+++ b/backend/apps/socket/main.py
@@ -51,7 +51,6 @@ async def user_join(sid, data):
             user = Users.get_user_by_id(data["id"])
 
         if user:
-
             SESSION_POOL[sid] = user.id
             if user.id in USER_POOL:
                 USER_POOL[user.id].append(sid)
@@ -79,7 +78,6 @@ def get_models_in_use():
 
 @sio.on("usage")
 async def usage(sid, data):
-
     model_id = data["model"]
 
     # Cancel previous callback if there is one

--- a/backend/apps/webui/internal/db.py
+++ b/backend/apps/webui/internal/db.py
@@ -1,11 +1,11 @@
 import json
+import logging
+import os
 
-from peewee import *
+from config import BACKEND_DIR, DATA_DIR, DATABASE_URL, SRC_LOG_LEVELS
+from peewee import TextField
 from peewee_migrate import Router
 from playhouse.db_url import connect
-from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL, BACKEND_DIR
-import os
-import logging
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["DB"])

--- a/backend/apps/webui/internal/migrations/001_initial_schema.py
+++ b/backend/apps/webui/internal/migrations/001_initial_schema.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/002_add_local_sharing.py
+++ b/backend/apps/webui/internal/migrations/002_add_local_sharing.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/003_add_auth_api_key.py
+++ b/backend/apps/webui/internal/migrations/003_add_auth_api_key.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/004_add_archived.py
+++ b/backend/apps/webui/internal/migrations/004_add_archived.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/005_add_updated_at.py
+++ b/backend/apps/webui/internal/migrations/005_add_updated_at.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/006_migrate_timestamps_and_charfields.py
+++ b/backend/apps/webui/internal/migrations/006_migrate_timestamps_and_charfields.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/007_add_user_last_active_at.py
+++ b/backend/apps/webui/internal/migrations/007_add_user_last_active_at.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/008_add_memory.py
+++ b/backend/apps/webui/internal/migrations/008_add_memory.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/009_add_models.py
+++ b/backend/apps/webui/internal/migrations/009_add_models.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/010_migrate_modelfiles_to_models.py
+++ b/backend/apps/webui/internal/migrations/010_migrate_modelfiles_to_models.py
@@ -24,16 +24,15 @@ Some examples (model - class or model name)::
 
 """
 
+import json
 from contextlib import suppress
 
 import peewee as pw
 from peewee_migrate import Migrator
-import json
-
 from utils.misc import parse_ollama_modelfile
 
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/011_add_user_settings.py
+++ b/backend/apps/webui/internal/migrations/011_add_user_settings.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/012_add_tools.py
+++ b/backend/apps/webui/internal/migrations/012_add_tools.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/internal/migrations/013_add_user_info.py
+++ b/backend/apps/webui/internal/migrations/013_add_user_info.py
@@ -29,9 +29,8 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
-
 with suppress(ImportError):
-    import playhouse.postgres_ext as pw_pext
+    pass
 
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):

--- a/backend/apps/webui/main.py
+++ b/backend/apps/webui/main.py
@@ -1,36 +1,34 @@
-from fastapi import FastAPI, Depends
-from fastapi.routing import APIRoute
-from fastapi.middleware.cors import CORSMiddleware
 from apps.webui.routers import (
     auths,
-    users,
     chats,
+    configs,
     documents,
-    tools,
+    memories,
     models,
     prompts,
-    configs,
-    memories,
+    tools,
+    users,
     utils,
 )
 from config import (
-    WEBUI_BUILD_HASH,
-    SHOW_ADMIN_DETAILS,
     ADMIN_EMAIL,
-    WEBUI_AUTH,
     DEFAULT_MODELS,
     DEFAULT_PROMPT_SUGGESTIONS,
     DEFAULT_USER_ROLE,
+    ENABLE_COMMUNITY_SHARING,
     ENABLE_SIGNUP,
+    JWT_EXPIRES_IN,
+    SHOW_ADMIN_DETAILS,
     USER_PERMISSIONS,
     WEBHOOK_URL,
+    WEBUI_AUTH,
     WEBUI_AUTH_TRUSTED_EMAIL_HEADER,
     WEBUI_AUTH_TRUSTED_NAME_HEADER,
-    JWT_EXPIRES_IN,
     WEBUI_BANNERS,
-    ENABLE_COMMUNITY_SHARING,
     AppConfig,
 )
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 

--- a/backend/apps/webui/models/auths.py
+++ b/backend/apps/webui/models/auths.py
@@ -1,16 +1,13 @@
-from pydantic import BaseModel
-from typing import List, Union, Optional
-import time
-import uuid
 import logging
-from peewee import *
-
-from apps.webui.models.users import UserModel, Users
-from utils.utils import verify_password
+import uuid
+from typing import Optional
 
 from apps.webui.internal.db import DB
-
+from apps.webui.models.users import UserModel, Users
 from config import SRC_LOG_LEVELS
+from peewee import BooleanField, CharField, Model, TextField
+from pydantic import BaseModel
+from utils.utils import verify_password
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/models/chats.py
+++ b/backend/apps/webui/models/chats.py
@@ -1,13 +1,12 @@
-from pydantic import BaseModel
-from typing import List, Union, Optional
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-
 import json
-import uuid
 import time
+import uuid
+from typing import List, Optional
 
 from apps.webui.internal.db import DB
+from peewee import BigIntegerField, BooleanField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 ####################
 # Chat DB Schema

--- a/backend/apps/webui/models/chats.py
+++ b/backend/apps/webui/models/chats.py
@@ -326,7 +326,6 @@ class ChatTable:
 
     def delete_chats_by_user_id(self, user_id: str) -> bool:
         try:
-
             self.delete_shared_chats_by_user_id(user_id)
 
             query = Chat.delete().where(Chat.user_id == user_id)

--- a/backend/apps/webui/models/documents.py
+++ b/backend/apps/webui/models/documents.py
@@ -1,18 +1,13 @@
-from pydantic import BaseModel
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-from typing import List, Union, Optional
-import time
+import json
 import logging
-
-from utils.utils import decode_token
-from utils.misc import get_gravatar_url
+import time
+from typing import List, Optional
 
 from apps.webui.internal.db import DB
-
-import json
-
 from config import SRC_LOG_LEVELS
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/models/memories.py
+++ b/backend/apps/webui/models/memories.py
@@ -1,13 +1,11 @@
-from pydantic import BaseModel
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-from typing import List, Union, Optional
-
-from apps.webui.internal.db import DB
-from apps.webui.models.chats import Chats
-
 import time
 import uuid
+from typing import List, Optional
+
+from apps.webui.internal.db import DB
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 ####################
 # Memory DB Schema

--- a/backend/apps/webui/models/models.py
+++ b/backend/apps/webui/models/models.py
@@ -1,19 +1,13 @@
-import json
 import logging
-from typing import Optional
+import time
+from typing import List, Optional
 
 import peewee as pw
-from peewee import *
-
+from apps.webui.internal.db import DB, JSONField
+from config import SRC_LOG_LEVELS
+from peewee import BigIntegerField
 from playhouse.shortcuts import model_to_dict
 from pydantic import BaseModel, ConfigDict
-
-from apps.webui.internal.db import DB, JSONField
-
-from typing import List, Union, Optional
-from config import SRC_LOG_LEVELS
-
-import time
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/models/prompts.py
+++ b/backend/apps/webui/models/prompts.py
@@ -1,15 +1,10 @@
-from pydantic import BaseModel
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-from typing import List, Union, Optional
 import time
-
-from utils.utils import decode_token
-from utils.misc import get_gravatar_url
+from typing import List, Optional
 
 from apps.webui.internal.db import DB
-
-import json
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 ####################
 # Prompts DB Schema

--- a/backend/apps/webui/models/prompts.py
+++ b/backend/apps/webui/models/prompts.py
@@ -42,7 +42,6 @@ class PromptForm(BaseModel):
 
 
 class PromptsTable:
-
     def __init__(self, db):
         self.db = db
         self.db.create_tables([Prompt])

--- a/backend/apps/webui/models/tags.py
+++ b/backend/apps/webui/models/tags.py
@@ -1,16 +1,13 @@
-from pydantic import BaseModel
-from typing import List, Union, Optional
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-
-import json
-import uuid
-import time
 import logging
+import time
+import uuid
+from typing import List, Optional
 
 from apps.webui.internal.db import DB
-
 from config import SRC_LOG_LEVELS
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/models/tags.py
+++ b/backend/apps/webui/models/tags.py
@@ -88,7 +88,7 @@ class TagTable:
                 return tag
             else:
                 return None
-        except Exception as e:
+        except Exception:
             return None
 
     def get_tag_by_name_and_user_id(
@@ -97,7 +97,7 @@ class TagTable:
         try:
             tag = Tag.get(Tag.name == name, Tag.user_id == user_id)
             return TagModel(**model_to_dict(tag))
-        except Exception as e:
+        except Exception:
             return None
 
     def add_tag_to_chat(

--- a/backend/apps/webui/models/tools.py
+++ b/backend/apps/webui/models/tools.py
@@ -1,14 +1,12 @@
-from pydantic import BaseModel
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-from typing import List, Union, Optional
-import time
 import logging
+import time
+from typing import List, Optional
+
 from apps.webui.internal.db import DB, JSONField
-
-import json
-
 from config import SRC_LOG_LEVELS
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/models/users.py
+++ b/backend/apps/webui/models/users.py
@@ -1,12 +1,11 @@
-from pydantic import BaseModel, ConfigDict
-from peewee import *
-from playhouse.shortcuts import model_to_dict
-from typing import List, Union, Optional
 import time
-from utils.misc import get_gravatar_url
+from typing import List, Optional
 
 from apps.webui.internal.db import DB, JSONField
 from apps.webui.models.chats import Chats
+from peewee import BigIntegerField, CharField, Model, TextField
+from playhouse.shortcuts import model_to_dict
+from pydantic import BaseModel, ConfigDict
 
 ####################
 # User DB Schema

--- a/backend/apps/webui/routers/auths.py
+++ b/backend/apps/webui/routers/auths.py
@@ -1,4 +1,3 @@
-
 import re
 import uuid
 
@@ -233,7 +232,6 @@ async def signup(request: Request, form_data: SignupForm):
 
 @router.post("/add", response_model=SigninResponse)
 async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
-
     if not validate_email_format(form_data.email.lower()):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INVALID_EMAIL_FORMAT
@@ -243,7 +241,6 @@ async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
         raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
     try:
-
         print(form_data)
         hashed = get_password_hash(form_data.password)
         user = Auths.insert_new_auth(

--- a/backend/apps/webui/routers/auths.py
+++ b/backend/apps/webui/routers/auths.py
@@ -1,43 +1,36 @@
-import logging
 
-from fastapi import Request, UploadFile, File
-from fastapi import Depends, HTTPException, status
-
-from fastapi import APIRouter
-from pydantic import BaseModel
 import re
 import uuid
-import csv
-
 
 from apps.webui.models.auths import (
-    SigninForm,
-    SignupForm,
     AddUserForm,
-    UpdateProfileForm,
-    UpdatePasswordForm,
-    UserResponse,
-    SigninResponse,
-    Auths,
     ApiKey,
+    Auths,
+    SigninForm,
+    SigninResponse,
+    SignupForm,
+    UpdatePasswordForm,
+    UpdateProfileForm,
+    UserResponse,
 )
 from apps.webui.models.users import Users
-
-from utils.utils import (
-    get_password_hash,
-    get_current_user,
-    get_admin_user,
-    create_token,
-    create_api_key,
-)
-from utils.misc import parse_duration, validate_email_format
-from utils.webhook import post_webhook
-from constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
 from config import (
     WEBUI_AUTH,
     WEBUI_AUTH_TRUSTED_EMAIL_HEADER,
     WEBUI_AUTH_TRUSTED_NAME_HEADER,
 )
+from constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from utils.misc import parse_duration, validate_email_format
+from utils.utils import (
+    create_api_key,
+    create_token,
+    get_admin_user,
+    get_current_user,
+    get_password_hash,
+)
+from utils.webhook import post_webhook
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/chats.py
+++ b/backend/apps/webui/routers/chats.py
@@ -1,34 +1,24 @@
-from fastapi import Depends, Request, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
-from utils.utils import get_current_user, get_admin_user
-from fastapi import APIRouter
-from pydantic import BaseModel
 import json
 import logging
+from typing import List, Optional
 
-from apps.webui.models.users import Users
 from apps.webui.models.chats import (
-    ChatModel,
-    ChatResponse,
-    ChatTitleForm,
     ChatForm,
-    ChatTitleIdResponse,
+    ChatResponse,
     Chats,
+    ChatTitleIdResponse,
 )
-
-
 from apps.webui.models.tags import (
-    TagModel,
-    ChatIdTagModel,
     ChatIdTagForm,
-    ChatTagsResponse,
+    ChatIdTagModel,
+    TagModel,
     Tags,
 )
-
+from config import ENABLE_ADMIN_EXPORT, SRC_LOG_LEVELS
 from constants import ERROR_MESSAGES
-
-from config import SRC_LOG_LEVELS, ENABLE_ADMIN_EXPORT
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from utils.utils import get_admin_user, get_current_user
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/routers/chats.py
+++ b/backend/apps/webui/routers/chats.py
@@ -119,7 +119,7 @@ async def get_user_chats(user=Depends(get_current_user)):
 
 
 @router.get("/all/archived", response_model=List[ChatResponse])
-async def get_user_chats(user=Depends(get_current_user)):
+async def get_user_archived_chats(user=Depends(get_current_user)):
     return [
         ChatResponse(**{**chat.model_dump(), "chat": json.loads(chat.chat)})
         for chat in Chats.get_archived_chats_by_user_id(user.id)

--- a/backend/apps/webui/routers/chats.py
+++ b/backend/apps/webui/routers/chats.py
@@ -45,7 +45,6 @@ async def get_session_user_chat_list(
 
 @router.delete("/", response_model=bool)
 async def delete_all_user_chats(request: Request, user=Depends(get_current_user)):
-
     if (
         user.role == "user"
         and not request.app.state.config.USER_PERMISSIONS["chat"]["deletion"]
@@ -196,7 +195,6 @@ class TagNameForm(BaseModel):
 async def get_user_chat_list_by_tag_name(
     form_data: TagNameForm, user=Depends(get_current_user)
 ):
-
     print(form_data)
     chat_ids = [
         chat_id_tag.chat_id
@@ -276,7 +274,6 @@ async def update_chat_by_id(
 
 @router.delete("/{id}", response_model=bool)
 async def delete_chat_by_id(request: Request, id: str, user=Depends(get_current_user)):
-
     if user.role == "admin":
         result = Chats.delete_chat_by_id(id)
         return result
@@ -300,7 +297,6 @@ async def delete_chat_by_id(request: Request, id: str, user=Depends(get_current_
 async def clone_chat_by_id(id: str, user=Depends(get_current_user)):
     chat = Chats.get_chat_by_id_and_user_id(id, user.id)
     if chat:
-
         chat_body = json.loads(chat.chat)
         updated_chat = {
             **chat_body,

--- a/backend/apps/webui/routers/configs.py
+++ b/backend/apps/webui/routers/configs.py
@@ -1,25 +1,12 @@
-from fastapi import Response, Request
-from fastapi import Depends, FastAPI, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union
-
-from fastapi import APIRouter
-from pydantic import BaseModel
-import time
-import uuid
+from typing import List
 
 from config import BannerModel
-
-from apps.webui.models.users import Users
-
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
 from utils.utils import (
-    get_password_hash,
-    get_current_user,
     get_admin_user,
-    create_token,
+    get_current_user,
 )
-from utils.misc import get_gravatar_url, validate_email_format
-from constants import ERROR_MESSAGES
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/documents.py
+++ b/backend/apps/webui/routers/documents.py
@@ -1,21 +1,16 @@
-from fastapi import Depends, FastAPI, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
-
-from fastapi import APIRouter
-from pydantic import BaseModel
 import json
+from typing import List, Optional
 
 from apps.webui.models.documents import (
-    Documents,
     DocumentForm,
-    DocumentUpdateForm,
-    DocumentModel,
     DocumentResponse,
+    Documents,
+    DocumentUpdateForm,
 )
-
-from utils.utils import get_current_user, get_admin_user
 from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from utils.utils import get_admin_user, get_current_user
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/memories.py
+++ b/backend/apps/webui/routers/memories.py
@@ -1,18 +1,11 @@
-from fastapi import Response, Request
-from fastapi import Depends, FastAPI, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
-
-from fastapi import APIRouter
-from pydantic import BaseModel
 import logging
+from typing import List, Optional
 
 from apps.webui.models.memories import Memories, MemoryModel
-
+from config import CHROMA_CLIENT, SRC_LOG_LEVELS
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
 from utils.utils import get_verified_user
-from constants import ERROR_MESSAGES
-
-from config import SRC_LOG_LEVELS, CHROMA_CLIENT
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/routers/models.py
+++ b/backend/apps/webui/routers/models.py
@@ -1,14 +1,9 @@
-from fastapi import Depends, FastAPI, HTTPException, status, Request
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
+from typing import List, Optional
 
-from fastapi import APIRouter
-from pydantic import BaseModel
-import json
-from apps.webui.models.models import Models, ModelModel, ModelForm, ModelResponse
-
-from utils.utils import get_verified_user, get_admin_user
+from apps.webui.models.models import ModelForm, ModelModel, ModelResponse, Models
 from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from utils.utils import get_admin_user, get_verified_user
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/prompts.py
+++ b/backend/apps/webui/routers/prompts.py
@@ -1,15 +1,9 @@
-from fastapi import Depends, FastAPI, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
+from typing import List, Optional
 
-from fastapi import APIRouter
-from pydantic import BaseModel
-import json
-
-from apps.webui.models.prompts import Prompts, PromptForm, PromptModel
-
-from utils.utils import get_current_user, get_admin_user
+from apps.webui.models.prompts import PromptForm, PromptModel, Prompts
 from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, status
+from utils.utils import get_admin_user, get_current_user
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/tools.py
+++ b/backend/apps/webui/routers/tools.py
@@ -42,7 +42,7 @@ async def get_toolkits(user=Depends(get_current_user)):
 
 
 @router.get("/export", response_model=List[ToolModel])
-async def get_toolkits(user=Depends(get_admin_user)):
+async def export_toolkits(user=Depends(get_admin_user)):
     toolkits = [toolkit for toolkit in Tools.get_tools()]
     return toolkits
 

--- a/backend/apps/webui/routers/tools.py
+++ b/backend/apps/webui/routers/tools.py
@@ -1,23 +1,13 @@
-from fastapi import Depends, FastAPI, HTTPException, status, Request
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
-
-from fastapi import APIRouter
-from pydantic import BaseModel
-import json
-
-from apps.webui.models.tools import Tools, ToolForm, ToolModel, ToolResponse
-from apps.webui.utils import load_toolkit_module_by_id
-
-from utils.utils import get_current_user, get_admin_user
-from utils.tools import get_tools_specs
-from constants import ERROR_MESSAGES
-
-from importlib import util
 import os
+from typing import List, Optional
 
+from apps.webui.models.tools import ToolForm, ToolModel, ToolResponse, Tools
+from apps.webui.utils import load_toolkit_module_by_id
 from config import DATA_DIR
-
+from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from utils.tools import get_tools_specs
+from utils.utils import get_admin_user, get_current_user
 
 TOOLS_DIR = f"{DATA_DIR}/tools"
 os.makedirs(TOOLS_DIR, exist_ok=True)

--- a/backend/apps/webui/routers/users.py
+++ b/backend/apps/webui/routers/users.py
@@ -138,7 +138,7 @@ async def get_user_info_by_session_user(user=Depends(get_verified_user)):
 
 
 @router.post("/user/info/update", response_model=Optional[dict])
-async def update_user_settings_by_session_user(
+async def update_user_info_by_session_user(
     form_data: dict, user=Depends(get_verified_user)
 ):
     user = Users.get_user_by_id(user.id)

--- a/backend/apps/webui/routers/users.py
+++ b/backend/apps/webui/routers/users.py
@@ -60,7 +60,6 @@ async def update_user_permissions(
 
 @router.post("/update/role", response_model=Optional[UserModel])
 async def update_user_role(form_data: UserRoleUpdateForm, user=Depends(get_admin_user)):
-
     if user.id != form_data.id and form_data.id != Users.get_first_user().id:
         return Users.update_user_role_by_id(form_data.id, form_data.role)
 
@@ -164,7 +163,6 @@ class UserResponse(BaseModel):
 
 @router.get("/{user_id}", response_model=UserResponse)
 async def get_user_by_id(user_id: str, user=Depends(get_verified_user)):
-
     # Check if user_id is a shared chat
     # If it is, get the user_id from the chat
     if user_id.startswith("shared-"):

--- a/backend/apps/webui/routers/users.py
+++ b/backend/apps/webui/routers/users.py
@@ -1,33 +1,24 @@
-from fastapi import Response, Request
-from fastapi import Depends, FastAPI, HTTPException, status
-from datetime import datetime, timedelta
-from typing import List, Union, Optional
-
-from fastapi import APIRouter
-from pydantic import BaseModel
-import time
-import uuid
 import logging
+from typing import List, Optional
 
-from apps.webui.models.users import (
-    UserModel,
-    UserUpdateForm,
-    UserRoleUpdateForm,
-    UserSettings,
-    Users,
-)
 from apps.webui.models.auths import Auths
 from apps.webui.models.chats import Chats
-
-from utils.utils import (
-    get_verified_user,
-    get_password_hash,
-    get_current_user,
-    get_admin_user,
+from apps.webui.models.users import (
+    UserModel,
+    UserRoleUpdateForm,
+    Users,
+    UserSettings,
+    UserUpdateForm,
 )
-from constants import ERROR_MESSAGES
-
 from config import SRC_LOG_LEVELS
+from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from utils.utils import (
+    get_admin_user,
+    get_password_hash,
+    get_verified_user,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/apps/webui/routers/utils.py
+++ b/backend/apps/webui/routers/utils.py
@@ -1,22 +1,17 @@
-from fastapi import APIRouter, UploadFile, File, Response
-from fastapi import Depends, HTTPException, status
-from peewee import SqliteDatabase
-from starlette.responses import StreamingResponse, FileResponse
-from pydantic import BaseModel
-
-
-from fpdf import FPDF
-import markdown
-import black
-
-
-from apps.webui.internal.db import DB
-from utils.utils import get_admin_user
-from utils.misc import calculate_sha256, get_gravatar_url
-
-from config import OLLAMA_BASE_URLS, DATA_DIR, UPLOAD_DIR, ENABLE_ADMIN_EXPORT
-from constants import ERROR_MESSAGES
 from typing import List
+
+import black
+import markdown
+from apps.webui.internal.db import DB
+from config import DATA_DIR, ENABLE_ADMIN_EXPORT
+from constants import ERROR_MESSAGES
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fpdf import FPDF
+from peewee import SqliteDatabase
+from pydantic import BaseModel
+from starlette.responses import FileResponse
+from utils.misc import get_gravatar_url
+from utils.utils import get_admin_user
 
 router = APIRouter()
 

--- a/backend/apps/webui/routers/utils.py
+++ b/backend/apps/webui/routers/utils.py
@@ -103,7 +103,7 @@ async def download_chat_as_pdf(
     return Response(
         content=bytes(pdf_bytes),
         media_type="application/pdf",
-        headers={"Content-Disposition": f"attachment;filename=chat.pdf"},
+        headers={"Content-Disposition": "attachment;filename=chat.pdf"},
     )
 
 

--- a/backend/apps/webui/utils.py
+++ b/backend/apps/webui/utils.py
@@ -1,5 +1,5 @@
-from importlib import util
 import os
+from importlib import util
 
 from config import TOOLS_DIR
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,26 +1,21 @@
-import os
-import sys
-import logging
 import importlib.metadata
-import pkgutil
-import chromadb
-from chromadb import Settings
-from base64 import b64encode
-from bs4 import BeautifulSoup
-from typing import TypeVar, Generic, Union
-from pydantic import BaseModel
-from typing import Optional
-
-from pathlib import Path
 import json
-import yaml
+import logging
+import os
+import pkgutil
+import shutil
+import sys
+from pathlib import Path
+from typing import Generic, Optional, TypeVar
 
+import chromadb
 import markdown
 import requests
-import shutil
-
-from secrets import token_bytes
+import yaml
+from bs4 import BeautifulSoup
+from chromadb import Settings
 from constants import ERROR_MESSAGES
+from pydantic import BaseModel
 
 ####################################
 # Load .env file
@@ -32,7 +27,7 @@ BASE_DIR = BACKEND_DIR.parent  # the path containing the backend/
 print(BASE_DIR)
 
 try:
-    from dotenv import load_dotenv, find_dotenv
+    from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv(str(BASE_DIR / ".env")))
 except ImportError:

--- a/backend/config.py
+++ b/backend/config.py
@@ -775,7 +775,7 @@ RAG_EMBEDDING_MODEL = PersistentConfig(
     "rag.embedding_model",
     os.environ.get("RAG_EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"),
 )
-log.info(f"Embedding model set: {RAG_EMBEDDING_MODEL.value}"),
+log.info(f"Embedding model set: {RAG_EMBEDDING_MODEL.value}")
 
 RAG_EMBEDDING_MODEL_AUTO_UPDATE = (
     os.environ.get("RAG_EMBEDDING_MODEL_AUTO_UPDATE", "").lower() == "true"
@@ -797,7 +797,7 @@ RAG_RERANKING_MODEL = PersistentConfig(
     os.environ.get("RAG_RERANKING_MODEL", ""),
 )
 if RAG_RERANKING_MODEL.value != "":
-    log.info(f"Reranking model set: {RAG_RERANKING_MODEL.value}"),
+    log.info(f"Reranking model set: {RAG_RERANKING_MODEL.value}")
 
 RAG_RERANKING_MODEL_AUTO_UPDATE = (
     os.environ.get("RAG_RERANKING_MODEL_AUTO_UPDATE", "").lower() == "true"

--- a/backend/data/config.json
+++ b/backend/data/config.json
@@ -4,33 +4,55 @@
 		"default_locale": "en-US",
 		"prompt_suggestions": [
 			{
-				"title": ["Help me study", "vocabulary for a college entrance exam"],
+				"title": [
+					"Help me study",
+					"vocabulary for a college entrance exam"
+				],
 				"content": "Help me study vocabulary: write a sentence for me to fill in the blank, and I'll try to pick the correct option."
 			},
 			{
-				"title": ["Give me ideas", "for what to do with my kids' art"],
+				"title": [
+					"Give me ideas",
+					"for what to do with my kids' art"
+				],
 				"content": "What are 5 creative things I could do with my kids' art? I don't want to throw them away, but it's also so much clutter."
 			},
 			{
-				"title": ["Tell me a fun fact", "about the Roman Empire"],
+				"title": [
+					"Tell me a fun fact",
+					"about the Roman Empire"
+				],
 				"content": "Tell me a random fun fact about the Roman Empire"
 			},
 			{
-				"title": ["Show me a code snippet", "of a website's sticky header"],
+				"title": [
+					"Show me a code snippet",
+					"of a website's sticky header"
+				],
 				"content": "Show me a code snippet of a website's sticky header in CSS and JavaScript."
 			},
 			{
-				"title": ["Explain options trading", "if I'm familiar with buying and selling stocks"],
+				"title": [
+					"Explain options trading",
+					"if I'm familiar with buying and selling stocks"
+				],
 				"content": "Explain options trading in simple terms if I'm familiar with buying and selling stocks."
 			},
 			{
-				"title": ["Overcome procrastination", "give me tips"],
+				"title": [
+					"Overcome procrastination",
+					"give me tips"
+				],
 				"content": "Could you start by asking me about instances when I procrastinate the most and then give me some suggestions to overcome it?"
 			},
 			{
-				"title": ["Grammar check", "rewrite it for better readability "],
+				"title": [
+					"Grammar check",
+					"rewrite it for better readability "
+				],
 				"content": "Check the following sentence for grammar and clarity: \"[sentence]\". Rewrite it for better readability while maintaining its original meaning."
 			}
-		]
+		],
+		"default_models": "llama3:latest"
 	}
 }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1464,7 +1464,7 @@ async def update_webhook_url(form_data: UrlForm, user=Depends(get_admin_user)):
 
 
 @app.get("/api/version")
-async def get_app_config():
+async def get_app_version():
     return {
         "version": VERSION,
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1255,7 +1255,7 @@ async def get_pipelines(urlIdx: Optional[int] = None, user=Depends(get_admin_use
 async def get_pipeline_valves(
     urlIdx: Optional[int], pipeline_id: str, user=Depends(get_admin_user)
 ):
-    models = await get_all_models()
+    models = await get_all_models()  # noqa: F841  # TODO: is this required? `models` is not used.
     r = None
     try:
         url = openai_app.state.config.OPENAI_API_BASE_URLS[urlIdx]
@@ -1292,7 +1292,7 @@ async def get_pipeline_valves(
 async def get_pipeline_valves_spec(
     urlIdx: Optional[int], pipeline_id: str, user=Depends(get_admin_user)
 ):
-    models = await get_all_models()
+    models = await get_all_models()  # noqa: F841  # TODO: is this required? `models` is not used.
 
     r = None
     try:
@@ -1332,7 +1332,7 @@ async def update_pipeline_valves(
     form_data: dict,
     user=Depends(get_admin_user),
 ):
-    models = await get_all_models()
+    models = await get_all_models()  # noqa: F841  # TODO: is this required? `models` is not used.
 
     r = None
     try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1139,7 +1139,6 @@ class AddPipelineForm(BaseModel):
 
 @app.post("/api/pipelines/add")
 async def add_pipeline(form_data: AddPipelineForm, user=Depends(get_admin_user)):
-
     r = None
     try:
         urlIdx = form_data.urlIdx
@@ -1182,7 +1181,6 @@ class DeletePipelineForm(BaseModel):
 
 @app.delete("/api/pipelines/delete")
 async def delete_pipeline(form_data: DeletePipelineForm, user=Depends(get_admin_user)):
-
     r = None
     try:
         urlIdx = form_data.urlIdx
@@ -1260,7 +1258,6 @@ async def get_pipeline_valves(
     models = await get_all_models()
     r = None
     try:
-
         url = openai_app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = openai_app.state.config.OPENAI_API_KEYS[urlIdx]
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,3 +61,4 @@ pytube==15.0.0
 extract_msg
 pydub
 duckduckgo-search~=6.1.5
+ruff==0.4.5

--- a/backend/utils/misc.py
+++ b/backend/utils/misc.py
@@ -1,9 +1,8 @@
-from pathlib import Path
 import hashlib
-import json
 import re
 from datetime import timedelta
-from typing import Optional, List
+from pathlib import Path
+from typing import List, Optional
 
 
 def get_last_user_message(messages: List[dict]) -> str:

--- a/backend/utils/task.py
+++ b/backend/utils/task.py
@@ -1,6 +1,5 @@
-import re
 import math
-
+import re
 from datetime import datetime
 from typing import Optional
 

--- a/backend/utils/task.py
+++ b/backend/utils/task.py
@@ -76,7 +76,6 @@ def title_generation_template(
 def search_query_generation_template(
     template: str, prompt: str, user: Optional[dict] = None
 ) -> str:
-
     def replacement_function(match):
         full_match = match.group(0)
         start_length = match.group(1)

--- a/backend/utils/tools.py
+++ b/backend/utils/tools.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import get_type_hints, List, Dict, Any
+from typing import List, get_type_hints
 
 
 def doc_to_dict(docstring):

--- a/backend/utils/utils.py
+++ b/backend/utils/utils.py
@@ -1,18 +1,15 @@
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from fastapi import HTTPException, status, Depends
-
-from apps.webui.models.users import Users
-
-from pydantic import BaseModel
-from typing import Union, Optional
-from constants import ERROR_MESSAGES
-from passlib.context import CryptContext
-from datetime import datetime, timedelta
-import requests
-import jwt
-import uuid
 import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import Optional, Union
+
 import config
+import jwt
+from apps.webui.models.users import Users
+from constants import ERROR_MESSAGES
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from passlib.context import CryptContext
 
 logging.getLogger("passlib").setLevel(logging.ERROR)
 

--- a/backend/utils/utils.py
+++ b/backend/utils/utils.py
@@ -53,7 +53,7 @@ def decode_token(token: str) -> Optional[dict]:
     try:
         decoded = jwt.decode(token, SESSION_SECRET, algorithms=[ALGORITHM])
         return decoded
-    except Exception as e:
+    except Exception:
         return None
 
 

--- a/backend/utils/webhook.py
+++ b/backend/utils/webhook.py
@@ -1,7 +1,7 @@
 import json
-import requests
 import logging
 
+import requests
 from config import SRC_LOG_LEVELS, VERSION, WEBUI_FAVICON_URL, WEBUI_NAME
 
 log = logging.getLogger(__name__)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"lint": "npm run lint:frontend ; npm run lint:types ; npm run lint:backend",
 		"lint:frontend": "eslint . --fix",
 		"lint:types": "npm run check",
-		"lint:backend": "pylint backend/",
+		"lint:backend": "ruff check backend/",
 		"format": "prettier --plugin-search-dir --write \"**/*.{js,ts,svelte,css,md,html,json}\"",
 		"format:backend": "black . --exclude \".venv/|/venv/\"",
 		"i18n:parse": "i18next --config i18next-parser.config.ts && prettier --write \"src/lib/i18n/**/*.{js,json}\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"lint:types": "npm run check",
 		"lint:backend": "ruff check backend/",
 		"format": "prettier --plugin-search-dir --write \"**/*.{js,ts,svelte,css,md,html,json}\"",
-		"format:backend": "black . --exclude \".venv/|/venv/\"",
+		"format:backend": "ruff format . --exclude \"/venv/\"",
 		"i18n:parse": "i18next --config i18next-parser.config.ts && prettier --write \"src/lib/i18n/**/*.{js,json}\"",
 		"cy:open": "cypress open",
 		"test:frontend": "vitest --passWithNoTests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,18 @@ exclude = [
     "chroma.sqlite3",
 ]
 force-include = { "CHANGELOG.md" = "open_webui/CHANGELOG.md", build = "open_webui/frontend" }
+
+[tool.ruff.lint]
+extend-select = [
+    "I",
+]
+extend-ignore = [
+    "E711", # Comparison to None (TODO: enable & fix!)
+    "E712", # Comparison to bools (TODO: enable & fix!)
+    "E722", # Do not use bare except (TODO: enable & fix!)
+    "E731", # Do not assign lambda expression
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+# Let imports in auto-generated files be as-is
+"backend/apps/web/internal/migrations/*" = ["I",  "F401"]


### PR DESCRIPTION
## Description

This PR re-enables linting for the backend (disabled 4 months ago in https://github.com/open-webui/open-webui/pull/368 because "too many issues") using [Ruff](https://github.com/astral-sh/ruff), and fixes the issues it finds. Each commit should be fine to review in isolation, if this PR otherwise feels too large. Most of the cumulative diff is reordering imports.

I deliberately disabled some rules for the time being, though, with TODO notes that they really ought to be fixed; bare `try:except:`s for one are a bad habit, since they catch e.g. `KeyboardInterrupt`s, so chances are the backend will ignore attempts of stopping it if the signal lands in a suitable place 😅 
Conversely, more rules could be added later.

It also switches formatting from `black` to `ruff` (they're 99.x% compatible, but `ruff` is a lot faster and formats some things in a neater way). The formatting actually found a couple of stray commas that inadvertently turned some logging statements into no-op 1-tuple constructions... 😄 

For CI, I made sure that the pinned versions from `requirements.txt` are used for Ruff – before this, CI could install a different version of Black than what `requirements.txt` said.

## Testing

Since there is no test suite, all I really could do is test the app runs fine with these changes.

I ran under `coverage` (`coverage run -m uvicorn main:app ...`), which gave me a coverage of about 49%.

## Dependencies

`black` was dropped in favor of `ruff`; technically, Ruff should be a development-time dependency only, but there is no `requirements-dev.txt` or similar and Black was in the runtime deps, so I didn't change that.

---

### Changelog Entry

### Changed

- Python code is now linted and formatted using Ruff.

---
