### PR TITLE
Always open links in chat in a new tab

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -78,6 +78,13 @@
 		return `<code>${code.replaceAll('&amp;', '&')}</code>`;
 	};
 
+	// Open all links in a new tab/window (from https://github.com/markedjs/marked/issues/655#issuecomment-383226346)
+	const origLinkRenderer = renderer.link;
+	renderer.link =	(href, title, text) => {
+		const html = origLinkRenderer.call(renderer, href, title, text);
+		return html.replace(/^<a /, '<a target="_blank" rel="nofollow" ');
+	};
+
 	const { extensions, ...defaults } = marked.getDefaults() as marked.MarkedOptions & {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		extensions: any;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -36,11 +36,14 @@ export const sanitizeResponseContent = (content: string) => {
 		.replace(/<$/, '')
 		.replaceAll(/<\|[a-z]+\|>/g, ' ')
 		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
 		.trim();
 };
 
 export const revertSanitizedResponseContent = (content: string) => {
-	return content.replaceAll('&lt;', '<');
+	return content
+		.replaceAll('&lt;', '<')
+		.replaceAll('&gt;', '>');
 };
 
 export const capitalizeFirstLetter = (string) => {


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Target branch:** Pull requests should target the `dev` branch.
- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for the changes? -> I did not see any tests
- [x] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

Add `target="_blank" rel="nofollow"` to all links in the chat history window. It is annoying to click a link in a chat and have it unload Open-Webui, so I added this feature. (This)[https://github.com/markedjs/marked/issues/655#issuecomment-383226346] issue in the `marked` repo describes how to do this properly.

This only applies to links within chat messages. For example, asking a model `what is the URL of https://google.com?` and clicking the link in your message or the one it produces.

---

### Changelog Entry

### Changed

- Links in chat open in a new tab instead of the same tab

---