### PR TITLE
fix: load i18n before showing error page

### DIFF
--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -37,7 +37,7 @@ const createIsLoadingStore = (i18n: i18nType) => {
 	return isLoading;
 };
 
-export const initI18n = (defaultLocale: string) => {
+export const initI18n = (defaultLocale: string | undefined) => {
 	let detectionOrder = defaultLocale
 		? ['querystring', 'localStorage']
 		: ['querystring', 'localStorage', 'navigator'];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,20 +21,22 @@
 
 	onMount(async () => {
 		theme.set(localStorage.theme);
-		// Check Backend Status
-		const backendConfig = await getBackendConfig();
+		let backendConfig = null;
+		try {
+			backendConfig = await getBackendConfig();
+			console.log("Backend config:", backendConfig);
+		} catch (error) {
+			console.error("Error loading backend config:", error);
+		}
+		// Initialize i18n even if we didn't get a backend config,
+		// so `/error` can show something that's not `undefined`.
+		initI18n(backendConfig?.default_locale);
 
 		if (backendConfig) {
 			// Save Backend Status to Store
 			await config.set(backendConfig);
-			if ($config.default_locale) {
-				initI18n($config.default_locale);
-			} else {
-				initI18n();
-			}
 
 			await WEBUI_NAME.set(backendConfig.name);
-			console.log(backendConfig);
 
 			if ($config) {
 				if (localStorage.token) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Target branch:** Pull requests should target the `dev` branch.
- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.

---

## Description

This PR fixes the initial backend connectivity check to not leave the user looking at the splash screen if there's a network error, and that if there is a network error, some i18n strings are loaded, so the resulting error page doesn't look like:

![Screenshot 2024-05-13 at 18 01 09](https://github.com/open-webui/open-webui/assets/58669/b82abefd-8837-4e20-a830-7aa816848cf4)

---

### Changelog Entry

### Fixed

- Ensured localization is loaded before attempting to show the initial error page.

### Additional Information

- Noticed this while developing stuff and didn't have the backend up and running.