### PR TITLE
Skip email validation for header-based auth

### DIFF
--- a/backend/apps/web/routers/auths.py
+++ b/backend/apps/web/routers/auths.py
@@ -168,7 +168,9 @@ async def signup(request: Request, form_data: SignupForm):
             status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED
         )
 
-    if not validate_email_format(form_data.email.lower()):
+    if not WEBUI_AUTH_TRUSTED_EMAIL_HEADER and not validate_email_format(
+        form_data.email.lower()
+    ):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INVALID_EMAIL_FORMAT
         )


### PR DESCRIPTION
## Pull Request Checklist

- [X] **Target branch:** Pull requests should target the `dev` branch.
- [X] **Description:** Briefly describe the changes in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests for the changes?
- [X] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

When authenticating via HTTP headers, I think email format validation should be skipped. Using header-based auth implies that user credentials have been validated elsewhere by the application passing the headers and I would also like to be able to provide arbitrary usernames via headers rather than being restricted to email addresses.

---

### Changelog Entry

### Added

- Ability to provide non-email address usernames when using header-based authentication.