### PR TITLE
fix: migrations 007_add_user_last_active_at syntax error

### DIFF
--- a/backend/apps/web/internal/migrations/007_add_user_last_active_at.py
+++ b/backend/apps/web/internal/migrations/007_add_user_last_active_at.py
@@ -47,7 +47,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     # Populate the new fields from an existing 'timestamp' field
     migrator.sql(
-        'UPDATE "user" SET created_at = timestamp, updated_at = timestamp, last_active_at = timestamp WHERE timestamp IS NOT NULL'
+        "UPDATE user SET created_at = timestamp, updated_at = timestamp, last_active_at = timestamp WHERE timestamp IS NOT NULL"
     )
 
     # Now that the data has been copied, remove the original 'timestamp' field
@@ -70,7 +70,7 @@ def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
 
     # Copy the earliest created_at date back into the new timestamp field
     # This assumes created_at was originally a copy of timestamp
-    migrator.sql('UPDATE "user" SET timestamp = created_at')
+    migrator.sql("UPDATE user SET timestamp = created_at")
 
     # Remove the created_at and updated_at fields
     migrator.remove_fields("user", "created_at", "updated_at", "last_active_at")


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Target branch:** Pull requests should target the `dev` branch.
- [x] **Description:** Briefly describe the changes in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for the changes?
- [ ] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

fix  migrations(007_add_user_last_active_at) syntax error in mysql

when i want to run a clean installation with mysql (DATABASE_URL=mysql://xxxxx) , got an syntax error

```
Migration failed: 007_add_user_last_active_at

pymysql.err.ProgrammingError: (1064, 'You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'"user" SET created_at = timestamp, updated_at = timestamp, last_active_at = time\' at line 1')
```

> but i found an [fix](https://github.com/open-webui/open-webui/commit/71a75bccf5e177815d711a102790252139e30d24) here, changed from the right to incorrect
> 
> so im not sure if will be some side effects to restore it :(

---

### Changelog Entry

### Fixed

- Syntax error in 007_add_user_last_active_at
