### PR TITLE
feat: optional UID/GID docker build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ ARG USE_CUDA_VER=cu121
 # IMPORTANT: If you change the embedding model (sentence-transformers/all-MiniLM-L6-v2) and vice versa, you aren't able to use RAG Chat with your previous documents loaded in the WebUI! You need to re-embed them.
 ARG USE_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 ARG USE_RERANKING_MODEL=""
+# Override at your own risk - non-root configurations are untested
+ARG UID=0
+ARG GID=0
 
 ######## WebUI frontend ########
 FROM --platform=$BUILDPLATFORM node:21-alpine3.19 as build
@@ -32,6 +35,8 @@ ARG USE_OLLAMA
 ARG USE_CUDA_VER
 ARG USE_EMBEDDING_MODEL
 ARG USE_RERANKING_MODEL
+ARG UID
+ARG GID
 
 ## Basis ##
 ENV ENV=prod \
@@ -76,8 +81,19 @@ ENV HF_HOME="/app/backend/data/cache/embedding/models"
 WORKDIR /app/backend
 
 ENV HOME /root
+# Create user and group if not root
+RUN if [ $UID -ne 0 ]; then \
+      if [ $GID -ne 0 ]; then \
+        addgroup --gid $GID app; \
+      fi; \
+      adduser --uid $UID --gid $GID --home $HOME --disabled-password --no-create-home app; \
+    fi
+
 RUN mkdir -p $HOME/.cache/chroma
 RUN echo -n 00000000-0000-0000-0000-000000000000 > $HOME/.cache/chroma/telemetry_user_id
+
+# Make sure the user has access to the app and root directory
+RUN chown -R $UID:$GID /app $HOME
 
 RUN if [ "$USE_OLLAMA" = "true" ]; then \
     apt-get update && \
@@ -102,7 +118,7 @@ RUN if [ "$USE_OLLAMA" = "true" ]; then \
     fi
 
 # install python dependencies
-COPY ./backend/requirements.txt ./requirements.txt
+COPY --chown=$UID:$GID ./backend/requirements.txt ./requirements.txt
 
 RUN pip3 install uv && \
     if [ "$USE_CUDA" = "true" ]; then \
@@ -125,16 +141,17 @@ RUN pip3 install uv && \
 # COPY --from=build /app/onnx /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx
 
 # copy built frontend files
-COPY --from=build /app/build /app/build
-COPY --from=build /app/CHANGELOG.md /app/CHANGELOG.md
-COPY --from=build /app/package.json /app/package.json
+COPY --chown=$UID:$GID --from=build /app/build /app/build
+COPY --chown=$UID:$GID --from=build /app/CHANGELOG.md /app/CHANGELOG.md
+COPY --chown=$UID:$GID --from=build /app/package.json /app/package.json
 
 # copy backend files
-COPY ./backend .
+COPY --chown=$UID:$GID ./backend .
 
 EXPOSE 8080
 
 HEALTHCHECK CMD curl --silent --fail http://localhost:8080/health | jq -e '.status == true' || exit 1
 
+USER $UID:$GID
 
 CMD [ "bash", "start.sh"]


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Target branch:** Pull requests should target the `dev` branch.
- [x] **Description:** Briefly describe the changes in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for the changes?
- [x] **Code Review:** Have you self-reviewed your code and addressed any coding standard issues?

---

## Description

Adds two new build args  `UID` and `GID` to set the user and group ID of the files in container and to run as that user. This is added with a note that non-root configurations are untested.

To build as non-root: `docker build --build-arg UID=1000 --build-arg GID=1000 --tag=open-webui:nonroot .`

This is a no-op change in the default root configuration, which is why `$HOME` is still set to `/root`. We can't switch to nonroot by default, as this breaks existing users (and we have enough support requests around Docker usage as it is already, and we encourage users to setup Watchtower for automatic updates). We also don't build nonroot containers in CI because we're already running into total concurrency quotas on GitHub Actions. Adding a nonroot variant to the build matrix increases the number of tags from 3 to 6, and the total number of images from 6 to 12.

Test docker build: https://github.com/cheahjs/open-webui-fork/actions/runs/9121520626

Addresses https://github.com/open-webui/open-webui/discussions/1698 and https://github.com/open-webui/open-webui/discussions/1021

Prior attempts: https://github.com/open-webui/open-webui/pull/1533 https://github.com/open-webui/open-webui/pull/2316

Tested locally with base, bundled ollama, and CUDA.