### PR TITLE
Fix .js mimetype on Windows 11

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ import sys
 import logging
 import aiohttp
 import requests
+import mimetypes
 
 from fastapi import FastAPI, Request, Depends, status
 from fastapi.staticfiles import StaticFiles
@@ -408,6 +409,7 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 app.mount("/cache", StaticFiles(directory=CACHE_DIR), name="cache")
 
 if os.path.exists(FRONTEND_BUILD_DIR):
+    mimetypes.add_type('text/javascript', '.js')
     app.mount(
         "/",
         SPAStaticFiles(directory=FRONTEND_BUILD_DIR, html=True),


### PR DESCRIPTION
> Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of ""text/plain"". Strict MIME type checking is enforced for module scripts per HTML spec.

Before:

![Screenshot 2024-05-21 230604](https://github.com/open-webui/open-webui/assets/50966051/7d59e84d-d6cb-46cb-8de9-655db2779a31)

After:

![image](https://github.com/open-webui/open-webui/assets/50966051/46af5bbd-0c42-4986-925a-a30990a04c6a)
