### PR TITLE
feat: External databases: reconnect to postgresql & mysql when connection is broken

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -170,6 +170,26 @@ jobs:
               echo "Server has stopped"
               exit 1
           fi
+          
+          # Check that service will reconnect to postgres when connection will be closed
+          status_code=$(curl --write-out %{http_code} -s --output /dev/null http://localhost:8081/api/tags)
+          if [[ "$status_code" -ne 200 ]] ; then
+            echo "Server has failed before postgres reconnect check"
+            exit 1
+          fi
+
+          echo "Terminating all connections to postgres..."
+          python -c "import os, psycopg2 as pg2; \
+            conn = pg2.connect(dsn=os.environ['DATABASE_URL'].replace('+pool', '')); \
+            cur = conn.cursor(); \
+            cur.execute('SELECT pg_terminate_backend(psa.pid) FROM pg_stat_activity psa WHERE datname = current_database() AND pid <> pg_backend_pid();')"
+          
+          status_code=$(curl --write-out %{http_code} -s --output /dev/null http://localhost:8081/api/tags)
+          if [[ "$status_code" -ne 200 ]] ; then
+            echo "Server has not reconnected to postgres after connection was closed: returned status $status_code"
+            exit 1
+          fi
+
 
 #      - name: Test backend with MySQL
 #        if: success() || steps.sqlite.conclusion == 'failure' || steps.postgres.conclusion == 'failure'

--- a/backend/apps/webui/internal/db.py
+++ b/backend/apps/webui/internal/db.py
@@ -1,17 +1,13 @@
+import os
+import logging
 import json
 
 from peewee import *
 from peewee_migrate import Router
 from playhouse.db_url import connect
-from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL, BACKEND_DIR
-import os
-import logging
-
-from peewee_migrate import Router
-from playhouse.db_url import connect
 
 from apps.webui.internal.wrappers import PeeweeConnectionState, register_peewee_databases
-from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL
+from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL, BACKEND_DIR
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["DB"])

--- a/backend/apps/webui/internal/db.py
+++ b/backend/apps/webui/internal/db.py
@@ -7,6 +7,12 @@ from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL, BACKEND_DIR
 import os
 import logging
 
+from peewee_migrate import Router
+from playhouse.db_url import connect
+
+from apps.webui.internal.wrappers import PeeweeConnectionState, register_peewee_databases
+from config import SRC_LOG_LEVELS, DATA_DIR, DATABASE_URL
+
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["DB"])
 
@@ -20,6 +26,8 @@ class JSONField(TextField):
             return json.loads(value)
 
 
+register_peewee_databases()
+
 # Check if the file exists
 if os.path.exists(f"{DATA_DIR}/ollama.db"):
     # Rename the file
@@ -29,6 +37,7 @@ else:
     pass
 
 DB = connect(DATABASE_URL)
+DB._state = PeeweeConnectionState()
 log.info(f"Connected to a {DB.__class__.__name__} database.")
 router = Router(
     DB,

--- a/backend/apps/webui/internal/wrappers.py
+++ b/backend/apps/webui/internal/wrappers.py
@@ -1,8 +1,8 @@
 from contextvars import ContextVar
 
-from peewee import PostgresqlDatabase, InterfaceError as PeeWeeInterfaceError, MySQLDatabase, _ConnectionState
+from peewee import PostgresqlDatabase, InterfaceError as PeeWeeInterfaceError, _ConnectionState
 from playhouse.db_url import register_database
-from playhouse.pool import PooledPostgresqlDatabase, PooledMySQLDatabase
+from playhouse.pool import PooledPostgresqlDatabase
 from playhouse.shortcuts import ReconnectMixin
 from psycopg2 import OperationalError
 from psycopg2.errors import InterfaceError
@@ -26,7 +26,7 @@ class PeeweeConnectionState(_ConnectionState):
 
 class CustomReconnectMixin(ReconnectMixin):
     reconnect_errors = (
-        # default ReconnectMixin exceptions (MySQL specific)
+        # default ReconnectMixin exceptions
         *ReconnectMixin.reconnect_errors,
         # psycopg2
         (OperationalError, 'termin'),
@@ -44,16 +44,6 @@ class ReconnectingPooledPostgresqlDatabase(CustomReconnectMixin, PooledPostgresq
     pass
 
 
-class ReconnectingMySQLDatabase(CustomReconnectMixin, MySQLDatabase):
-    pass
-
-
-class ReconnectingPooledMySQLDatabase(CustomReconnectMixin, PooledMySQLDatabase):
-    pass
-
-
 def register_peewee_databases():
-    register_database(MySQLDatabase, 'mysql')
-    register_database(PooledMySQLDatabase, 'mysql+pool')
     register_database(ReconnectingPostgresqlDatabase, 'postgres', 'postgresql')
     register_database(ReconnectingPooledPostgresqlDatabase, 'postgres+pool', 'postgresql+pool')

--- a/backend/apps/webui/internal/wrappers.py
+++ b/backend/apps/webui/internal/wrappers.py
@@ -1,0 +1,59 @@
+from contextvars import ContextVar
+
+from peewee import PostgresqlDatabase, InterfaceError as PeeWeeInterfaceError, MySQLDatabase, _ConnectionState
+from playhouse.db_url import register_database
+from playhouse.pool import PooledPostgresqlDatabase, PooledMySQLDatabase
+from playhouse.shortcuts import ReconnectMixin
+from psycopg2 import OperationalError
+from psycopg2.errors import InterfaceError
+
+
+db_state_default = {"closed": None, "conn": None, "ctx": None, "transactions": None}
+db_state = ContextVar("db_state", default=db_state_default.copy())
+
+
+class PeeweeConnectionState(_ConnectionState):
+    def __init__(self, **kwargs):
+        super().__setattr__("_state", db_state)
+        super().__init__(**kwargs)
+
+    def __setattr__(self, name, value):
+        self._state.get()[name] = value
+
+    def __getattr__(self, name):
+        return self._state.get()[name]
+
+
+class CustomReconnectMixin(ReconnectMixin):
+    reconnect_errors = (
+        # default ReconnectMixin exceptions (MySQL specific)
+        *ReconnectMixin.reconnect_errors,
+        # psycopg2
+        (OperationalError, 'termin'),
+        (InterfaceError, 'closed'),
+        # peewee
+        (PeeWeeInterfaceError, 'closed'),
+    )
+
+
+class ReconnectingPostgresqlDatabase(CustomReconnectMixin, PostgresqlDatabase):
+    pass
+
+
+class ReconnectingPooledPostgresqlDatabase(CustomReconnectMixin, PooledPostgresqlDatabase):
+    pass
+
+
+class ReconnectingMySQLDatabase(CustomReconnectMixin, MySQLDatabase):
+    pass
+
+
+class ReconnectingPooledMySQLDatabase(CustomReconnectMixin, PooledMySQLDatabase):
+    pass
+
+
+def register_peewee_databases():
+    register_database(MySQLDatabase, 'mysql')
+    register_database(PooledMySQLDatabase, 'mysql+pool')
+    register_database(ReconnectingPostgresqlDatabase, 'postgres', 'postgresql')
+    register_database(ReconnectingPooledPostgresqlDatabase, 'postgres+pool', 'postgresql+pool')


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Label:** To cleary categorize this pull request, assign a relevant label to the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Added

- Auto-reconnection to postgresql/mysql databases, proposed in https://github.com/open-webui/open-webui/issues/2660

---

### Additional Information

Based on https://github.com/open-webui/open-webui/issues/2660

<details>
<summary>Example exception occuring without added reconnect mixin in case of closed connection</summary>

```
ollama        | [GIN] 2024/05/30 - 12:26:40 | 200 |      66.969µs |      172.28.0.4 | GET      "/api/tags"
open-webui    | INFO:     127.0.0.1:43728 - "GET /health HTTP/1.1" 500 Internal Server Error
open-webui    | ERROR:    Exception in ASGI application
open-webui    |   + Exception Group Traceback (most recent call last):
open-webui    |   |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
open-webui    |   |     yield
open-webui    |   |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 190, in __call__
open-webui    |   |     async with anyio.create_task_group() as task_group:
open-webui    |   |   File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 680, in __aexit__
open-webui    |   |     raise BaseExceptionGroup(
open-webui    |   | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
open-webui    |   +-+---------------- 1 ----------------
open-webui    |     | Traceback (most recent call last):
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 435, in run_asgi
open-webui    |     |     result = await app(  # type: ignore[func-returns-value]
open-webui    |     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
open-webui    |     |     return await self.app(scope, receive, send)
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
open-webui    |     |     await super().__call__(scope, receive, send)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
open-webui    |     |     await self.middleware_stack(scope, receive, send)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
open-webui    |     |     raise exc
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
open-webui    |     |     await self.app(scope, receive, _send)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 189, in __call__
open-webui    |     |     with collapse_excgroups():
open-webui    |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
open-webui    |     |     self.gen.throw(typ, value, traceback)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
open-webui    |     |     raise exc
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 191, in __call__
open-webui    |     |     response = await self.dispatch_func(request, call_next)
open-webui    |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/app/backend/main.py", line 365, in update_embedding_function
open-webui    |     |     response = await call_next(request)
open-webui    |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 165, in call_next
open-webui    |     |     raise app_exc
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 151, in coro
open-webui    |     |     await self.app(scope, receive_or_disconnect, send_no_error)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 189, in __call__
open-webui    |     |     with collapse_excgroups():
open-webui    |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
open-webui    |     |     self.gen.throw(typ, value, traceback)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
open-webui    |     |     raise exc
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 191, in __call__
open-webui    |     |     response = await self.dispatch_func(request, call_next)
open-webui    |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/app/backend/main.py", line 351, in check_url
open-webui    |     |     await get_all_models()
open-webui    |     |   File "/app/backend/main.py", line 408, in get_all_models
open-webui    |     |     custom_models = Models.get_all_models()
open-webui    |     |                     ^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/app/backend/apps/webui/models/models.py", line 148, in get_all_models
open-webui    |     |     return [ModelModel(**model_to_dict(model)) for model in Model.select()]
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 7260, in __iter__
open-webui    |     |     self.execute()
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2025, in inner
open-webui    |     |     return method(self, database, *args, **kwargs)
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2096, in execute
open-webui    |     |     return self._execute(database)
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2269, in _execute
open-webui    |     |     cursor = database.execute(self)
open-webui    |     |              ^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3319, in execute
open-webui    |     |     return self.execute_sql(sql, params)
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3309, in execute_sql
open-webui    |     |     with __exception_wrapper__:
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3077, in __exit__
open-webui    |     |     reraise(new_type, new_type(exc_value, *exc_args), traceback)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 196, in reraise
open-webui    |     |     raise value.with_traceback(tb)
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3310, in execute_sql
open-webui    |     |     cursor = self.cursor()
open-webui    |     |              ^^^^^^^^^^^^^
open-webui    |     |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3303, in cursor
open-webui    |     |     return self._state.conn.cursor()
open-webui    |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |     | peewee.InterfaceError: connection already closed
open-webui    |     +------------------------------------
open-webui    | 
open-webui    | During handling of the above exception, another exception occurred:
open-webui    | 
open-webui    | Traceback (most recent call last):
open-webui    |   File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 435, in run_asgi
open-webui    |     result = await app(  # type: ignore[func-returns-value]
open-webui    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
open-webui    |     return await self.app(scope, receive, send)
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
open-webui    |     await super().__call__(scope, receive, send)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
open-webui    |     await self.middleware_stack(scope, receive, send)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
open-webui    |     raise exc
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
open-webui    |     await self.app(scope, receive, _send)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 189, in __call__
open-webui    |     with collapse_excgroups():
open-webui    |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
open-webui    |     self.gen.throw(typ, value, traceback)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
open-webui    |     raise exc
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 191, in __call__
open-webui    |     response = await self.dispatch_func(request, call_next)
open-webui    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/app/backend/main.py", line 365, in update_embedding_function
open-webui    |     response = await call_next(request)
open-webui    |                ^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 165, in call_next
open-webui    |     raise app_exc
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 151, in coro
open-webui    |     await self.app(scope, receive_or_disconnect, send_no_error)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 189, in __call__
open-webui    |     with collapse_excgroups():
open-webui    |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
open-webui    |     self.gen.throw(typ, value, traceback)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
open-webui    |     raise exc
open-webui    |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 191, in __call__
open-webui    |     response = await self.dispatch_func(request, call_next)
open-webui    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/app/backend/main.py", line 351, in check_url
open-webui    |     await get_all_models()
open-webui    |   File "/app/backend/main.py", line 408, in get_all_models
open-webui    |     custom_models = Models.get_all_models()
open-webui    |                     ^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/app/backend/apps/webui/models/models.py", line 148, in get_all_models
open-webui    |     return [ModelModel(**model_to_dict(model)) for model in Model.select()]
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 7260, in __iter__
open-webui    |     self.execute()
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2025, in inner
open-webui    |     return method(self, database, *args, **kwargs)
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2096, in execute
open-webui    |     return self._execute(database)
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 2269, in _execute
open-webui    |     cursor = database.execute(self)
open-webui    |              ^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3319, in execute
open-webui    |     return self.execute_sql(sql, params)
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3309, in execute_sql
open-webui    |     with __exception_wrapper__:
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3077, in __exit__
open-webui    |     reraise(new_type, new_type(exc_value, *exc_args), traceback)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 196, in reraise
open-webui    |     raise value.with_traceback(tb)
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3310, in execute_sql
open-webui    |     cursor = self.cursor()
open-webui    |              ^^^^^^^^^^^^^
open-webui    |   File "/usr/local/lib/python3.11/site-packages/peewee.py", line 3303, in cursor
open-webui    |     return self._state.conn.cursor()
open-webui    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui    | peewee.InterfaceError: connection already closed
```
</details>

### Screenshots or Videos

- none
