### PR TITLE
fix: add backwards compat with older searxng urls

### DIFF
--- a/backend/apps/rag/search/searxng.py
+++ b/backend/apps/rag/search/searxng.py
@@ -10,47 +10,53 @@ log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
 
 
-def search_searxng(query_url: str, query: str, count: int, **kwargs) -> List[SearchResult]:
+def search_searxng(
+    query_url: str, query: str, count: int, **kwargs
+) -> List[SearchResult]:
     """
     Search a SearXNG instance for a given query and return the results as a list of SearchResult objects.
-    
+
     The function allows passing additional parameters such as language or time_range to tailor the search result.
 
     Args:
-        query_url (str): The base URL of the SearXNG server with a placeholder for the query "<query>".
+        query_url (str): The base URL of the SearXNG server.
         query (str): The search term or question to find in the SearXNG database.
         count (int): The maximum number of results to retrieve from the search.
-        
+
     Keyword Args:
         language (str): Language filter for the search results; e.g., "en-US". Defaults to an empty string.
         time_range (str): Time range for filtering results by date; e.g., "2023-04-05..today" or "all-time". Defaults to ''.
         categories: (Optional[List[str]]): Specific categories within which the search should be performed, defaulting to an empty string if not provided.
-    
+
     Returns:
         List[SearchResult]: A list of SearchResults sorted by relevance score in descending order.
-        
+
     Raise:
         requests.exceptions.RequestException: If a request error occurs during the search process.
     """
-    
+
     # Default values for optional parameters are provided as empty strings or None when not specified.
-    language = kwargs.get('language', 'en-US')
-    time_range = kwargs.get('time_range', '')
-    categories = ''.join(kwargs.get('categories', []))
+    language = kwargs.get("language", "en-US")
+    time_range = kwargs.get("time_range", "")
+    categories = "".join(kwargs.get("categories", []))
 
     params = {
         "q": query,
         "format": "json",
         "pageno": 1,
         "results_per_page": count,
-        'language': language,
-        'time_range': time_range,
-        'engines': '',
-        'categories': categories,
-        'theme': 'simple',
-        'image_proxy': 0
-
+        "language": language,
+        "time_range": time_range,
+        "engines": "",
+        "categories": categories,
+        "theme": "simple",
+        "image_proxy": 0,
     }
+
+    # Legacy query format
+    if "<query>" in query_url:
+        # Strip all query parameters from the URL
+        query_url = query_url.split("?")[0]
 
     log.debug(f"searching {query_url}")
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [ ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Label:** To cleary categorize this pull request, assign a relevant label to the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

https://github.com/open-webui/open-webui/pull/2760 broke compat with existing SearXNG configs, as a config of `https://search.projectsegfau.lt/search?q=<query>` would result in a query `https://search.projectsegfau.lt/search?q=%3Cquery%3E&q=this+is+a+search+query%3F&format=json&pageno=1&results_per_page=5&language=en-US&time_range=&engines=&categories=&theme=simple&image_proxy=0`. Note the duplicated `q` param,