### PR TITLE
feat: custom HOST env variable on windows

### DIFF
--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -8,6 +8,7 @@ cd /d "%SCRIPT_DIR%" || exit /b
 
 SET "KEY_FILE=.webui_secret_key"
 IF "%PORT%"=="" SET PORT=8080
+IF "%HOST%"=="" SET HOST=0.0.0.0
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
 SET "WEBUI_JWT_SECRET_KEY=%WEBUI_JWT_SECRET_KEY%"
 
@@ -29,4 +30,4 @@ IF "%WEBUI_SECRET_KEY%%WEBUI_JWT_SECRET_KEY%" == " " (
 
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
-uvicorn main:app --host 0.0.0.0 --port "%PORT%" --forwarded-allow-ips '*'
+uvicorn main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*'


### PR DESCRIPTION
### Description

Currently you can customize the HOST with an environment variable in non-windows environments https://github.com/open-webui/open-webui/blob/main/backend/start.sh#L9 but this is not implemented on Windows. On windows it's using a hardcoded value of 0.0.0.0 https://github.com/open-webui/open-webui/blob/main/backend/start_windows.bat#L32 

Ironically it is Windows where we need the ability to use custom HOST because 0.0.0.0 sometimes has trouble on windows and need to use 127.0.0.1

### Added

Just replicated the custom HOST feature in start.sh into start_windows.bat

