### PR TITLE
Add host.docker.internal overide for docker dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Check our Migration Guide available in our [Open WebUI Documentation](https://do
 If you want to try out the latest bleeding-edge features and are okay with occasional instability, you can use the `:dev` tag like this:
 
 ```bash
-docker run -d -p 3000:8080 -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:dev
+docker run -d -p 3000:8080 -v open-webui:/app/backend/data --name open-webui --add-host=host.docker.internal:host-gateway --restart always ghcr.io/open-webui/open-webui:dev
 ```
 
 ## What's Next? 🌟


### PR DESCRIPTION
Just adding the `host.docker.internal` override to the docker command for the dev branch.

This got me on Linux where docker does not natively support `host.docker.internal` and so open webui could not connect with my local ollama. Adding the override fixes this.