### PR TITLE
fix: scrollToBottom button container obstructing clicks on buttons beneath it

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -291,9 +291,9 @@
 		<div class="flex flex-col max-w-6xl px-2.5 md:px-6 w-full">
 			<div class="relative">
 				{#if autoScroll === false && messages.length > 0}
-					<div class=" absolute -top-12 left-0 right-0 flex justify-center z-30">
+					<div class=" absolute -top-12 left-0 right-0 flex justify-center z-30 pointer-events-none">
 						<button
-							class=" bg-white border border-gray-100 dark:border-none dark:bg-white/20 p-1.5 rounded-full"
+							class=" bg-white border border-gray-100 dark:border-none dark:bg-white/20 p-1.5 rounded-full pointer-events-auto"
 							on:click={() => {
 								autoScroll = true;
 								scrollToBottom();


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed problem where scrollToBottom button container obstructing clicks on buttons beneath it. Before this fix, you needed to scroll a few more pixels to the bottom of the container to make it disappear so you could then click the message edit/reroll/etc. buttons.

### Fixed

- scrollToBottom button container obstructing clicks on buttons beneath it

---

### Screenshots or Videos

Before:
https://github.com/open-webui/open-webui/assets/1167575/8b6bb1ab-0228-477f-a3c8-76a0c29ae8dc

After:
https://github.com/open-webui/open-webui/assets/1167575/188d4ba6-4651-4736-ac3f-c14a22813518


