### PR TITLE
Fix building usercontext from memories

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -529,12 +529,12 @@
 							});
 							if (res) {
 								if (res.documents[0].length > 0) {
-									userContext = res.documents.reduce((acc, doc, index) => {
-										const createdAtTimestamp = res.metadatas[index][0].created_at;
+									userContext = res.documents[0].reduce((acc, doc, index) => {
+										const createdAtTimestamp = res.metadatas[0][index].created_at;
 										const createdAtDate = new Date(createdAtTimestamp * 1000)
 											.toISOString()
 											.split('T')[0];
-										acc.push(`${index + 1}. [${createdAtDate}]. ${doc[0]}`);
+										acc.push(`${index + 1}. [${createdAtDate}]. ${doc}`);
 										return acc;
 									}, []);
 								}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed an issue only one memory was being used for building the user context, even if multiple were retrieved. 

### Fixed

- Only one memory could be used for building the user context, even if multiple were retrieved

---

### Additional Information

After @shadowdoggie found out how to change the number of queried memories from Chroma [here](https://github.com/open-webui/open-webui/blob/465c3a99879d34526f1c70ad89af44652e783e85/backend/apps/webui/routers/memories.py#L115), he noticed that models were still only ever referring to a single memory.

I was able to track it down to this part of the code in the frontend that would do a `reduce` on an array that seems to always have only one element. The data structure of the return type `queryMemory` in this case is for example

```json
{
    "ids": [
        [
            "024afdfb-4964-427a-aaab-3a2e006cdb7f",
            "77a7e0c4-dc32-4e69-98df-fa1230b49b6e"
        ]
    ],
    "distances": [
        [
            0.9557429871345975,
            1.2739408007827933
        ]
    ],
    "metadatas": [
        [
            {
                "created_at": 1719259838
            },
            {
                "created_at": 1719259826
            }
        ]
    ],
    "embeddings": null,
    "documents": [
        [
            "The second word is \"grape\"",
            "The first word is \"automotive\""
        ]
    ],
    "uris": null,
    "data": null
}
```

I should note that this PR by itself does not allow the use of more than one memory, as the value for the number of memories queried remains hard coded to 1. Perhaps something for a future PR.