### PR TITLE
feat: reduce document selection overhead

### DIFF
--- a/backend/apps/webui/models/documents.py
+++ b/backend/apps/webui/models/documents.py
@@ -112,6 +112,13 @@ class DocumentsTable:
                 DocumentModel.model_validate(doc) for doc in db.query(Document).all()
             ]
 
+    def get_docs_by_tag(self, tag: str) -> List[DocumentModel]:
+        return [
+            DocumentModel(**model_to_dict(doc))
+            for doc in Document.select().where(Document.content.contains(tag))
+            # .limit(limit).offset(skip)
+        ]
+
     def update_doc_by_name(
         self, name: str, form_data: DocumentUpdateForm
     ) -> Optional[DocumentModel]:

--- a/backend/apps/webui/models/documents.py
+++ b/backend/apps/webui/models/documents.py
@@ -113,11 +113,13 @@ class DocumentsTable:
             ]
 
     def get_docs_by_tag(self, tag: str) -> List[DocumentModel]:
-        return [
-            DocumentModel(**model_to_dict(doc))
-            for doc in Document.select().where(Document.content.contains(tag))
-            # .limit(limit).offset(skip)
-        ]
+        with get_db() as db:
+            return [
+                DocumentModel.model_validate(doc)
+                for doc in db.query(Document)
+                .filter(Document.content.contains(tag))
+                .all()
+            ]
 
     def update_doc_by_name(
         self, name: str, form_data: DocumentUpdateForm

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -678,10 +678,14 @@
 		files = [
 			...files,
 			...(lastUserMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(
+					item.type
+				)
 			) ?? []),
 			...(responseMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(
+					item.type
+				)
 			) ?? [])
 		].filter(
 			// Remove duplicates
@@ -923,10 +927,14 @@
 		files = [
 			...files,
 			...(lastUserMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(
+					item.type
+				)
 			) ?? []),
 			...(responseMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(
+					item.type
+				)
 			) ?? [])
 		].filter(
 			// Remove duplicates

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -678,10 +678,10 @@
 		files = [
 			...files,
 			...(lastUserMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
 			) ?? []),
 			...(responseMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
 			) ?? [])
 		].filter(
 			// Remove duplicates
@@ -923,10 +923,10 @@
 		files = [
 			...files,
 			...(lastUserMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
 			) ?? []),
 			...(responseMessage?.files?.filter((item) =>
-				['doc', 'file', 'collection', 'web_search_results'].includes(item.type)
+				['doc', 'file', 'collection', 'web_search_results', 'tag', 'all_documents'].includes(item.type)
 			) ?? [])
 		].filter(
 			// Remove duplicates

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -613,7 +613,7 @@
 														<div class=" text-gray-500 text-sm">{$i18n.t('Document')}</div>
 													</div>
 												</div>
-											{:else if file.type === 'collection'}
+											{:else if file.type === 'all_documents' || file.type === 'tag'}
 												<div
 													class="h-16 w-[15rem] flex items-center space-x-3 px-2.5 dark:bg-gray-600 rounded-xl border border-gray-200 dark:border-none"
 												>

--- a/src/lib/components/chat/MessageInput/Documents.svelte
+++ b/src/lib/components/chat/MessageInput/Documents.svelte
@@ -22,10 +22,8 @@
 		...($documents.length > 0
 			? [
 					{
-						name: 'All Documents',
-						type: 'collection',
-						title: $i18n.t('All Documents'),
-						collection_names: $documents.map((doc) => doc.collection_name)
+						name: $i18n.t('All Documents'),
+						type: 'all_documents'
 					}
 			  ]
 			: []),
@@ -34,11 +32,8 @@
 				return [...new Set([...a, ...(e?.content?.tags ?? []).map((tag) => tag.name)])];
 			}, [])
 			.map((tag) => ({
-				name: tag,
-				type: 'collection',
-				collection_names: $documents
-					.filter((doc) => (doc?.content?.tags ?? []).map((tag) => tag.name).includes(tag))
-					.map((doc) => doc.collection_name)
+				type: 'tag',
+				name: tag
 			}))
 	];
 
@@ -136,13 +131,21 @@
 							}}
 							on:focus={() => {}}
 						>
-							{#if doc.type === 'collection'}
+							{#if doc.type === 'all_documents'}
 								<div class=" font-medium text-black dark:text-gray-100 line-clamp-1">
 									{doc?.title ?? `#${doc.name}`}
 								</div>
 
 								<div class=" text-xs text-gray-600 dark:text-gray-100 line-clamp-1">
 									{$i18n.t('Collection')}
+								</div>
+							{:else if doc.type === 'tag'}
+								<div class=" font-medium text-black dark:text-gray-100 line-clamp-1">
+									#{doc.name}
+								</div>
+
+								<div class=" text-xs text-gray-600 dark:text-gray-100 line-clamp-1">
+									{$i18n.t('Tag')}
 								</div>
 							{:else}
 								<div class=" font-medium text-black dark:text-gray-100 line-clamp-1">

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -170,7 +170,36 @@
 										<div class=" text-gray-500 text-sm">{$i18n.t('Document')}</div>
 									</div>
 								</button>
-							{:else if file.type === 'collection'}
+							{:else if file.type === 'all_documents'}
+								<button
+									class="h-16 w-72 flex items-center space-x-3 px-2.5 dark:bg-gray-600 rounded-xl border border-gray-200 dark:border-none text-left"
+									type="button"
+								>
+									<div class="p-2.5 bg-red-400 text-white rounded-lg">
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 24 24"
+											fill="currentColor"
+											class="w-6 h-6"
+										>
+											<path
+												d="M7.5 3.375c0-1.036.84-1.875 1.875-1.875h.375a3.75 3.75 0 0 1 3.75 3.75v1.875C13.5 8.161 14.34 9 15.375 9h1.875A3.75 3.75 0 0 1 21 12.75v3.375C21 17.16 20.16 18 19.125 18h-9.75A1.875 1.875 0 0 1 7.5 16.125V3.375Z"
+											/>
+											<path
+												d="M15 5.25a5.23 5.23 0 0 0-1.279-3.434 9.768 9.768 0 0 1 6.963 6.963A5.23 5.23 0 0 0 17.25 7.5h-1.875A.375.375 0 0 1 15 7.125V5.25ZM4.875 6H6v10.125A3.375 3.375 0 0 0 9.375 19.5H16.5v1.125c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V7.875C3 6.839 3.84 6 4.875 6Z"
+											/>
+										</svg>
+									</div>
+
+									<div class="flex flex-col justify-center -space-y-0.5">
+										<div class=" dark:text-gray-100 text-sm font-medium line-clamp-1">
+											{`#${$i18n.t('All Documents')}`}
+										</div>
+
+										<div class=" text-gray-500 text-sm">{$i18n.t('Collection')}</div>
+									</div>
+								</button>
+							{:else if file.type === 'collection' || file.type === 'tag'}
 								<button
 									class="h-16 w-72 flex items-center space-x-3 px-2.5 dark:bg-gray-600 rounded-xl border border-gray-200 dark:border-none text-left"
 									type="button"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Each document that is part of the chat is stored within the chat data and is part of each chat completion request
- With this change this overhead is reduced
- For queries with all documents, the collection names are extracted in the backend
- For queries with tags, the collection names are extracted in the backend
- No change for single file selection
- Benefit: Much faster request/response handling. Please see the screenshots of before and after.

### Changed

- Reduce the request size and chat history storage size by removing the file checksums from the request

---

### Additional Information

- *Example with 10,000 documents*
- Browser used: Google Chrome
- Environment: Localhost on MacOS


* Headers before the change. Request size is 88785. Also the UI was a bit lagging around with computing the payload
![headers-before](https://github.com/open-webui/open-webui/assets/165899591/22b669f8-218b-403f-a196-9bc2007b007b)

* Headers after the change. Request size is just 237. UI is very usable
![headers-after](https://github.com/open-webui/open-webui/assets/165899591/cbecc097-4afa-488b-8b3b-1dfdaf025404)

* Payload before the change. Quite a long list of checksum in payload
![payload-before](https://github.com/open-webui/open-webui/assets/165899591/e22a20fb-6b69-4ac5-80eb-f2422dd3150b)

* Payload after the change. Just the collection type is required
![payload-after](https://github.com/open-webui/open-webui/assets/165899591/863c9831-048e-446b-98c2-d90e2833aa92)

* Timing before the change. Processing the request took 35s
![timing-before](https://github.com/open-webui/open-webui/assets/165899591/78af2eec-afed-445c-afdd-047fe47de51f)

* Timing after the change. Processing the request took 8s. Side note: I did also a prove of concept by using just one single collection in ChromaDB and got the request down to under a second (after filling some caches, which is not possible storing it in different collections)
![timing-after](https://github.com/open-webui/open-webui/assets/165899591/1a11deff-1c67-47c2-9c51-0fc466c06460)

### Script used to create the files
```
for i in {1..100000}
do
echo "Test file $i" > files/"test-$i.txt"
done

```