### PR TITLE
feat: add OLLAMA_API_TIMEOUT config variable

### DIFF
--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -47,6 +47,7 @@ from config import (
     SRC_LOG_LEVELS,
     OLLAMA_BASE_URLS,
     ENABLE_OLLAMA_API,
+    OLLAMA_API_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT,
     ENABLE_MODEL_FILTER,
     MODEL_FILTER_LIST,
@@ -73,6 +74,7 @@ app.state.config.ENABLE_MODEL_FILTER = ENABLE_MODEL_FILTER
 app.state.config.MODEL_FILTER_LIST = MODEL_FILTER_LIST
 
 app.state.config.ENABLE_OLLAMA_API = ENABLE_OLLAMA_API
+app.state.config.OLLAMA_API_TIMEOUT = OLLAMA_API_TIMEOUT
 app.state.config.OLLAMA_BASE_URLS = OLLAMA_BASE_URLS
 app.state.MODELS = {}
 
@@ -132,7 +134,8 @@ async def update_ollama_api_url(form_data: UrlUpdateForm, user=Depends(get_admin
 
 
 async def fetch_url(url):
-    timeout = aiohttp.ClientTimeout(total=5)
+    timeout_seconds = float(app.state.config.OLLAMA_API_TIMEOUT)
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     try:
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.get(url) as response:

--- a/backend/config.py
+++ b/backend/config.py
@@ -564,6 +564,12 @@ ENABLE_OLLAMA_API = PersistentConfig(
     os.environ.get("ENABLE_OLLAMA_API", "True").lower() == "true",
 )
 
+OLLAMA_API_TIMEOUT = PersistentConfig(
+    "OLLAMA_API_TIMEOUT",
+    "ollama.api_timeout",
+    os.environ.get("OLLAMA_API_TIMEOUT", "5.0"),
+)
+
 OLLAMA_API_BASE_URL = os.environ.get(
     "OLLAMA_API_BASE_URL", "http://localhost:11434/api"
 )


### PR DESCRIPTION
Address https://github.com/open-webui/open-webui/issues/2337 by allowing the user to manually configure a ollama request timeout. If the ollama server is is powered off, the UI will just hang until the `/ollama/api/version` request times out. My ollama server is not always running, but I still want to use the openai api.

I think this should be a configuration item because while `OLLAMA_API_TIMEOUT=.1` may work for me, others my run their ollama on remote servers.

# Changelog Entry

### Added

- Add `OLLAMA_API_TIMEOUT` config variable