### PR TITLE
feat: Support Tika for document text extraction

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,7 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 __pycache__
-.env
+.idea
 _old
 uploads
 .ipynb_checkpoints

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 __pycache__
 .idea
+venv
 _old
 uploads
 .ipynb_checkpoints

--- a/backend/config.py
+++ b/backend/config.py
@@ -882,10 +882,10 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
 # RAG document text extraction
 ####################################
 
-DOCUMENT_USE_TIKA = PersistentConfig(
-    "DOCUMENT_USE_TIKA",
-    "rag.document_use_tika",
-    os.environ.get("DOCUMENT_USE_TIKA", "false").lower() == "true"
+TEXT_EXTRACTION_ENGINE = PersistentConfig(
+    "TEXT_EXTRACTION_ENGINE",
+    "rag.text_extraction_engine",
+    os.environ.get("TEXT_EXTRACTION_ENGINE", "").lower()
 )
 
 TIKA_SERVER_URL = PersistentConfig(

--- a/backend/config.py
+++ b/backend/config.py
@@ -879,6 +879,22 @@ if WEBUI_AUTH and WEBUI_SECRET_KEY == "":
     raise ValueError(ERROR_MESSAGES.ENV_VAR_NOT_FOUND)
 
 ####################################
+# RAG document text extraction
+####################################
+
+DOCUMENT_USE_TIKA = PersistentConfig(
+    "DOCUMENT_USE_TIKA",
+    "rag.document_use_tika",
+    os.environ.get("DOCUMENT_USE_TIKA", "false").lower() == "true"
+)
+
+TIKA_SERVER_URL = PersistentConfig(
+    "TIKA_SERVER_URL",
+    "rag.tika_server_url",
+    os.getenv("TIKA_SERVER_URL", "http://tika:9998"),  # Default for sidecar deployment
+)
+
+####################################
 # RAG
 ####################################
 

--- a/src/lib/apis/rag/index.ts
+++ b/src/lib/apis/rag/index.ts
@@ -32,6 +32,11 @@ type ChunkConfigForm = {
 	chunk_overlap: number;
 };
 
+type TextExtractConfigForm = {
+	engine: string;
+	tika_server_url: string | null;
+};
+
 type YoutubeConfigForm = {
 	language: string[];
 	translation?: string | null;
@@ -40,6 +45,7 @@ type YoutubeConfigForm = {
 type RAGConfigForm = {
 	pdf_extract_images?: boolean;
 	chunk?: ChunkConfigForm;
+	text_extraction?: TextExtractConfigForm;
 	web_loader_ssl_verification?: boolean;
 	youtube?: YoutubeConfigForm;
 };

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -37,6 +37,10 @@
 	let embeddingModel = '';
 	let rerankingModel = '';
 
+	let textExtractionEngine = 'default';
+	let tikaServerUrl = '';
+	let showTikaServerUrl = false;
+
 	let chunkSize = 0;
 	let chunkOverlap = 0;
 	let pdfExtractImages = true;
@@ -163,11 +167,20 @@
 			rerankingModelUpdateHandler();
 		}
 
+		if (textExtractionEngine === 'tika' && tikaServerUrl === '') {
+			toast.error($i18n.t('Tika Server URL required.'));
+			return;
+		}
+
 		const res = await updateRAGConfig(localStorage.token, {
 			pdf_extract_images: pdfExtractImages,
 			chunk: {
 				chunk_overlap: chunkOverlap,
 				chunk_size: chunkSize
+			},
+			text_extraction: {
+				engine: textExtractionEngine,
+				tika_server_url: tikaServerUrl
 			}
 		});
 
@@ -213,6 +226,10 @@
 
 			chunkSize = res.chunk.chunk_size;
 			chunkOverlap = res.chunk.chunk_overlap;
+
+			textExtractionEngine = res.text_extraction.engine;
+			tikaServerUrl = res.text_extraction.tika_server_url;
+			showTikaServerUrl = textExtractionEngine === 'tika';
 		}
 	});
 </script>
@@ -388,6 +405,39 @@
 			</div>
 		</div>
 
+		<hr class="dark:border-gray-850" />
+
+		<div class="">
+			<div class="text-sm font-medium">{$i18n.t('Text Extraction')}</div>
+
+			<div class="flex w-full justify-between mt-2">
+				<div class="self-center text-xs font-medium">{$i18n.t('Engine')}</div>
+				<div class="flex items-center relative">
+					<select
+							class="dark:bg-gray-900 w-fit pr-8 rounded px-2 p-1 text-xs bg-transparent outline-none text-right"
+							bind:value={textExtractionEngine}
+							on:change={(e) => {
+								showTikaServerUrl = (e.target.value === 'tika');
+							}}
+					>
+						<option value="default">{$i18n.t('Default')}</option>
+						<option value="tika">{$i18n.t('Tika')}</option>
+					</select>
+				</div>
+			</div>
+
+			{#if showTikaServerUrl}
+				<div class="flex w-full mt-2">
+					<div class="flex-1 mr-2">
+						<input
+								class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-none"
+								placeholder={$i18n.t('Enter Tika Server URL')}
+								bind:value={tikaServerUrl}
+						/>
+					</div>
+				</div>
+			{/if}
+		</div>
 		<hr class=" dark:border-gray-850 my-1" />
 
 		<div class="space-y-2" />


### PR DESCRIPTION
See discussion #3475 for background.

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? *Documentation will be added to the [relevant tutorial](https://docs.openwebui.com/tutorial/rag) via a separate PR once this PR is accepted.*
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests for validating the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Before any non-image files attached to chats can be used by LLMs, their content text must be extracted. This PR adds support to use [Apache Tika](https://tika.apache.org) for this rather than using the Langchain community document loaders.

### Added

- Code in `backend/apps/rag/main.py` and supporting files to conditionally make calls out to an Apache Tika server to extract document text rather than using the community-supported loaders from Langchain.
- Additions to the stored configuration schema to support text extraction engine selection and configuration.
- UI components for the Admin Panel->Settings->Documents page to allow engine selection and configuration.

### Changed

- Minor (incidental) tweak to `.dockerignore` to prevent local virtual environments in `venv` directory from being copied into Docker images. 

### Deprecated

*None*

### Removed

*None*

### Fixed

*None*

### Security

- Note that the use of a new service to which user content will be sent opens up a new attack surface. Apache Tika is a mature product and will typically be deployed in a sidecar container, so the risk is very small.

### Breaking Changes

*None*

---

### Additional Information

[Apache Tika](https://tika.apache.org) is a mature tool for extracting text and metadata from files. It supports hundreds of different document types, is under active development and is well-supported. Features include fully integrated OCR of embedded images in hierarchical documents and output of both plain and structured text.

The Tika server is available as a pre-packaged Docker image for multiple platforms. While this code supports communicating with a server in any network-accessible location, the suggested configuration is to deploy it as a sidecar container along side the Open WebUI server. This can be done by adding the following to the `docker-compose.yaml` file:
```yaml
  tika:
    image: apache/tika:latest-full
```
and updating the configuration for the Open WebUI container with an additional environment variable:
```yaml
  open-webui:
    ...
    environment:
      ...
      - 'TEXT_EXTRACTION_ENGINE=tika'
```



