### PR TITLE
chore(deps): fix pydantic dependency conflict

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.111.0
 uvicorn[standard]==0.22.0
-pydantic==2.7.1
+pydantic==2.8.2
 python-multipart==0.0.9
 
 Flask==3.0.3


### PR DESCRIPTION
update pydantic dependency to avoid installation conflicts 

using old `pydantic@2.7.1` throws the following error 

```
The conflict is caused by:
    The user requested pydantic==2.7.1
    fastapi 0.111.0 depends on pydantic!=1.8, !=1.8.1, !=2.0.0, !=2.0.1, !=2.1.0, <3.0.0 and >=1.7.4
    google-generativeai 0.5.4 depends on pydantic
    langchain 0.2.6 depends on pydantic<3 and >=1
    chromadb 0.5.3 depends on pydantic>=1.9
    langfuse 2.38.0 depends on pydantic<3.0 and >=1.10.7
    langchain-core 0.2.19 depends on pydantic<3.0.0 and >=2.7.4; python_full_version >= "3.12.4"
    The user requested pydantic==2.7.1
```