### PR TITLE
feat: add indicator for enter-triggered model selection

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -244,18 +244,20 @@
 								show = false;
 							}
 						}}
-
 					/>
 				</div>
 
 				<hr class="border-gray-100 dark:border-gray-800" />
 			{/if}
 
-			<div class="px-3 my-2 max-h-64 overflow-y-auto scrollbar-hidden">
-				{#each filteredItems as item}
+			<div class="px-3 my-2 max-h-64 overflow-y-auto scrollbar-hidden group">
+				{#each filteredItems as item, index}
 					<button
 						aria-label="model-item"
-						class="flex w-full text-left font-medium line-clamp-1 select-none items-center rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-none transition-all duration-75 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg cursor-pointer data-[highlighted]:bg-muted"
+						class="flex w-full text-left font-medium line-clamp-1 select-none items-center rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-none transition-all duration-75 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg cursor-pointer data-[highlighted]:bg-muted {index ===
+						0
+							? 'bg-gray-100 dark:bg-gray-800 group-hover:bg-transparent'
+							: ''}"
 						on:click={() => {
 							value = item.value;
 


### PR DESCRIPTION
**pr edited after feedback**
# Changelog Entry

### Description
This PR is an extension of #3962 (discussion #3960), adding an indicator to inform the user which model is currently selected for the enter shortcut. 

- Add the hover styles to the base styles for the top result in the query. 

### Changed
- iterator for displaying the query results provides the item and index
- styles for the `button` now highlights the top result, background is transparent on `group-hover`
- add `group` to parent div for `group-hover` handling

### Screenshots or Videos
https://private-user-images.githubusercontent.com/87589047/350181957-f610aac6-572d-41d7-ae2c-19bfc58a0b69.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjEzNTA1OTIsIm5iZiI6MTcyMTM1MDI5MiwicGF0aCI6Ii84NzU4OTA0Ny8zNTAxODE5NTctZjYxMGFhYzYtNTcyZC00MWQ3LWFlMmMtMTliZmM1OGEwYjY5Lm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzE5VDAwNTEzMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZkNmJmZjgwNzNlNTMwYzM3YmViZGY2YjJjYTNlM2ZiYjQ2YWQwYzBhNmUyZTkxZmNhYWQ2NDg3NzMxMWJiYTQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.OP3uk0T9-W75PYN_1EL6Ngs8_WDSmqflsu5ipDgx5fQ

# Other
- this also fixes the formatting error in #3962 on line 247 caused by forgetting to run prettier