### PR TITLE
fix: Dockerfile Healthcheck unexpected exit code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY --chown=$UID:$GID ./backend .
 
 EXPOSE 8080
 
-HEALTHCHECK CMD curl --silent --fail http://localhost:8080/health | jq -e '.status == true' || exit 1
+HEALTHCHECK CMD curl --silent --fail http://localhost:${PORT:-8080}/health | jq -ne 'input.status == true' || exit 1
 
 USER $UID:$GID
 


### PR DESCRIPTION
# Changelog Entry

### Description

- added `PORT` to the curl command. This makes the healthcheck send requests to the correct [port](https://docs.openwebui.com/getting-started/env-configuration#port). the expression returns 8080 if `PORT` is unspecified
- curl silently fails and return no output if openwebui was down so I added `-n` option to `jq` to return non-zero exit code if the input was null/empty.  [stackoverflow](https://stackoverflow.com/questions/66468950/exit-with-non-zero-if-input-is-empty) [jq github issue](https://github.com/jqlang/jq/issues/1497)

### Why/How I stumbled upon this problem:

I ran open-webui with `PORT` set to 80 (I like using tailscale to avoid having to painfully deal with reverse proxies) yet docker reported that container was healthy


### Added

### Changed


### Deprecated


### Removed


### Fixed

- Fixed healthcheck

### Security


### Breaking Changes


---

### Additional Information


### Screenshots or Videos
