### PR TITLE
Feat: Support custom redirect url in OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Ability to override default redirect urls when using OAuth with environment variables. You may use `OAUTH_REDIRECT_URL`, `MICROSOFT_REDIRECT_URL`, or `GOOGLE_REDIRECT_URL` to set custom redirect URLs.
+
 ## [0.3.10] - 2024-07-17
 
 ### Fixed

--- a/backend/config.py
+++ b/backend/config.py
@@ -339,6 +339,12 @@ GOOGLE_OAUTH_SCOPE = PersistentConfig(
     os.environ.get("GOOGLE_OAUTH_SCOPE", "openid email profile"),
 )
 
+GOOGLE_REDIRECT_URI = PersistentConfig(
+    "GOOGLE_REDIRECT_URI",
+    "oauth.google.redirect_uri",
+    os.environ.get("GOOGLE_REDIRECT_URI", ""),
+)
+
 MICROSOFT_CLIENT_ID = PersistentConfig(
     "MICROSOFT_CLIENT_ID",
     "oauth.microsoft.client_id",
@@ -363,6 +369,12 @@ MICROSOFT_OAUTH_SCOPE = PersistentConfig(
     os.environ.get("MICROSOFT_OAUTH_SCOPE", "openid email profile"),
 )
 
+MICROSOFT_REDIRECT_URI = PersistentConfig(
+    "MICROSOFT_REDIRECT_URI",
+    "oauth.microsoft.redirect_uri",
+    os.environ.get("MICROSOFT_REDIRECT_URI", ""),
+)
+
 OAUTH_CLIENT_ID = PersistentConfig(
     "OAUTH_CLIENT_ID",
     "oauth.oidc.client_id",
@@ -379,6 +391,12 @@ OPENID_PROVIDER_URL = PersistentConfig(
     "OPENID_PROVIDER_URL",
     "oauth.oidc.provider_url",
     os.environ.get("OPENID_PROVIDER_URL", ""),
+)
+
+OPENID_REDIRECT_URI = PersistentConfig(
+    "OPENID_REDIRECT_URI",
+    "oauth.oidc.redirect_uri",
+    os.environ.get("OPENID_REDIRECT_URI", ""),
 )
 
 OAUTH_SCOPES = PersistentConfig(
@@ -414,6 +432,7 @@ def load_oauth_providers():
             "client_secret": GOOGLE_CLIENT_SECRET.value,
             "server_metadata_url": "https://accounts.google.com/.well-known/openid-configuration",
             "scope": GOOGLE_OAUTH_SCOPE.value,
+            "redirect_uri": GOOGLE_REDIRECT_URI.value,
         }
 
     if (
@@ -426,6 +445,7 @@ def load_oauth_providers():
             "client_secret": MICROSOFT_CLIENT_SECRET.value,
             "server_metadata_url": f"https://login.microsoftonline.com/{MICROSOFT_CLIENT_TENANT_ID.value}/v2.0/.well-known/openid-configuration",
             "scope": MICROSOFT_OAUTH_SCOPE.value,
+            "redirect_uri": MICROSOFT_REDIRECT_URI.value,
         }
 
     if (
@@ -439,6 +459,7 @@ def load_oauth_providers():
             "server_metadata_url": OPENID_PROVIDER_URL.value,
             "scope": OAUTH_SCOPES.value,
             "name": OAUTH_PROVIDER_NAME.value,
+            "redirect_uri": OPENID_REDIRECT_URI.value,
         }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2111,6 +2111,7 @@ for provider_name, provider_config in OAUTH_PROVIDERS.items():
         client_kwargs={
             "scope": provider_config["scope"],
         },
+        redirect_uri=provider_config["redirect_uri"],
     )
 
 # SessionMiddleware is used by authlib for oauth
@@ -2128,7 +2129,10 @@ if len(OAUTH_PROVIDERS) > 0:
 async def oauth_login(provider: str, request: Request):
     if provider not in OAUTH_PROVIDERS:
         raise HTTPException(404)
-    redirect_uri = request.url_for("oauth_callback", provider=provider)
+    # If the provider has a custom redirect URL, use that, otherwise automatically generate one
+    redirect_uri = OAUTH_PROVIDERS[provider].get("redirect_url") or request.url_for(
+        "oauth_callback", provider=provider
+    )
     return await oauth.create_client(provider).authorize_redirect(request, redirect_uri)
 
 


### PR DESCRIPTION
# Changelog Entry

### Added
- Ability to override default redirect urls when using OAuth with environment variables. You may use `OAUTH_REDIRECT_URL`, `MICROSOFT_REDIRECT_URL`, or `GOOGLE_REDIRECT_URL` to set custom redirect URLs.

### Description

This is both a feature and fix to the issues causes therefore by lack of it.

- Professional deployments will often leverage a reverse proxy to protect web resources or introduce TLS encryption at REST, as described in Open WebUI docs. 
- This will break the redirect urls generated by Fast API for OAuth callbacks.
- This PR adds ability to provide custom callback URLs without dwelling into complex solutions using environment variables.

### Added

- `OAUTH_REDIRECT_URL`, `MICROSOFT_REDIRECT_URL`, or `GOOGLE_REDIRECT_URL` to set custom redirect URLs.

### Related issues

https://github.com/open-webui/open-webui/issues/3727
https://github.com/open-webui/open-webui/issues/3945

I would like someone to test it works as expected before merging. Thank you!