### PR TITLE
perf: optimize query for chat list

### DIFF
--- a/backend/apps/webui/models/chats.py
+++ b/backend/apps/webui/models/chats.py
@@ -244,13 +244,14 @@ class ChatTable:
                 .all()
             )
             return [ChatModel.model_validate(chat) for chat in all_chats]
+
     def get_chat_title_id_list_by_user_id(
         self,
         user_id: str,
         include_archived: bool = False,
         skip: int = 0,
         limit: int = 50,
-        ) -> List[ChatTitleIdResponse]:
+    ) -> List[ChatTitleIdResponse]:
         with get_db() as db:
             query = db.query(Chat).filter_by(user_id=user_id)
             if not include_archived:
@@ -259,17 +260,24 @@ class ChatTable:
             all_chats = (
                 query.order_by(Chat.updated_at.desc())
                 # limit cols
-                .with_entities(Chat.id, Chat.title, Chat.updated_at, Chat.created_at)
-                .all()
+                .with_entities(
+                    Chat.id, Chat.title, Chat.updated_at, Chat.created_at
+                ).all()
             )
             # result has to be destrctured from sqlalchemy `row` and mapped to a dict since the `ChatModel`is not the returned dataclass.
-            return list(map(lambda row: ChatTitleIdResponse.model_validate({
-                "id": row[0],
-                "title": row[1],
-                "updated_at": row[2],
-                "created_at": row[3]
-            }), all_chats))
-
+            return list(
+                map(
+                    lambda row: ChatTitleIdResponse.model_validate(
+                        {
+                            "id": row[0],
+                            "title": row[1],
+                            "updated_at": row[2],
+                            "created_at": row[3],
+                        }
+                    ),
+                    all_chats,
+                )
+            )
 
     def get_chat_list_by_chat_ids(
         self, chat_ids: List[str], skip: int = 0, limit: int = 50

--- a/backend/apps/webui/models/chats.py
+++ b/backend/apps/webui/models/chats.py
@@ -244,6 +244,32 @@ class ChatTable:
                 .all()
             )
             return [ChatModel.model_validate(chat) for chat in all_chats]
+    def get_chat_title_id_list_by_user_id(
+        self,
+        user_id: str,
+        include_archived: bool = False,
+        skip: int = 0,
+        limit: int = 50,
+        ) -> List[ChatTitleIdResponse]:
+        with get_db() as db:
+            query = db.query(Chat).filter_by(user_id=user_id)
+            if not include_archived:
+                query = query.filter_by(archived=False)
+
+            all_chats = (
+                query.order_by(Chat.updated_at.desc())
+                # limit cols
+                .with_entities(Chat.id, Chat.title, Chat.updated_at, Chat.created_at)
+                .all()
+            )
+            # result has to be destrctured from sqlalchemy `row` and mapped to a dict since the `ChatModel`is not the returned dataclass.
+            return list(map(lambda row: ChatTitleIdResponse.model_validate({
+                "id": row[0],
+                "title": row[1],
+                "updated_at": row[2],
+                "created_at": row[3]
+            }), all_chats))
+
 
     def get_chat_list_by_chat_ids(
         self, chat_ids: List[str], skip: int = 0, limit: int = 50

--- a/backend/apps/webui/routers/chats.py
+++ b/backend/apps/webui/routers/chats.py
@@ -45,7 +45,7 @@ router = APIRouter()
 async def get_session_user_chat_list(
     user=Depends(get_verified_user), skip: int = 0, limit: int = 50
 ):
-    return Chats.get_chat_list_by_user_id(user.id, skip, limit)
+    return Chats.get_chat_title_id_list_by_user_id(user.id, skip=skip, limit=limit)
 
 
 ############################


### PR DESCRIPTION
# Changelog Entry

## Description
Performance issue #4035 has additional details. 
This PR optimizes the query made to the database by selecting only the required columns. 
The images which are stored in the database chat history make the slow down apparent when querying that endpoint, which happens on every reload. 

This change will allow for significantly improved performance with large database sizes. 

This PR doesn't solve the root issue, as the issue is caused by excessive database size. 

## Added

- a function, similar to the existing database query function used in the `/chats` endpoint, which only queries the fields it needs

## Changed

- changed `/chats` and `/chats/list` endpoints to use the new function.
- the function also had a bug which has now been resolved: 
`skip: int` was passed as a positional argument to the function parameter `include_archived: bool`
```python
    # argument #2 should not be "skip"
    return Chats.get_chat_list_by_user_id(user.id, skip, limit) 
```
changed to 
```python
    return Chats.get_chat_title_id_list_by_user_id(user.id, skip=skip, limit=limit)
```
using keyword arguments to safely pass the params. 
## Screenshots or Videos
**test done with 500mb database, artificially bloated with images**
before optimization

https://github.com/user-attachments/assets/16419820-adbe-4b8b-85ec-391dbfdfb129

after optimization


https://github.com/user-attachments/assets/4f0bdd5b-7ab1-438e-bff4-64fa5d530e0c





