### PR TITLE
feat: select model with arrow keys

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -17,7 +17,6 @@
 	import { getModels } from '$lib/apis';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import WebParams from '$lib/components/documents/Settings/WebParams.svelte';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -44,7 +44,7 @@
 	let searchValue = '';
 	let ollamaVersion = null;
 
-	let pseudoSelectedIndex = 0;
+	let selectedModelIdx = 0;
 
 	$: filteredItems = items.filter(
 		(item) =>
@@ -205,7 +205,7 @@
 	bind:open={show}
 	onOpenChange={async () => {
 		searchValue = '';
-		pseudoSelectedIndex = 0; // when the dropdown is closed, reset the selected index
+		selectedModelIdx = 0;
 		window.setTimeout(() => document.getElementById('model-search-input')?.focus(), 0);
 	}}
 	closeFocus={false}
@@ -244,19 +244,19 @@
 						autocomplete="off"
 						on:keydown={(e) => {
 							if (e.code === 'Enter') {
-								value = filteredItems[pseudoSelectedIndex].value;
+								value = filteredItems[selectedModelIdx].value;
 								show = false;
 								return; // dont need to scroll on selection
 							} else if (e.code === 'ArrowDown') {
-								pseudoSelectedIndex = Math.min(pseudoSelectedIndex + 1, filteredItems.length - 1);
+								selectedModelIdx = Math.min(selectedModelIdx + 1, filteredItems.length - 1);
 							} else if (e.code === 'ArrowUp') {
-								pseudoSelectedIndex = Math.max(pseudoSelectedIndex - 1, 0);
+								selectedModelIdx = Math.max(selectedModelIdx - 1, 0);
 							} else {
 								// if the user types something, reset to the top selection.
-								pseudoSelectedIndex = 0;
+								selectedModelIdx = 0;
 							}
 
-							const item = document.querySelector(`[data-pseudo-selected="true"]`);
+							const item = document.querySelector(`[data-arrow-selected="true"]`);
 							item?.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' });
 						}}
 					/>
@@ -270,13 +270,13 @@
 					<button
 						aria-label="model-item"
 						class="flex w-full text-left font-medium line-clamp-1 select-none items-center rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-none transition-all duration-75 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg cursor-pointer data-[highlighted]:bg-muted {index ===
-						pseudoSelectedIndex
+						selectedModelIdx
 							? 'bg-gray-100 dark:bg-gray-800 group-hover:bg-transparent'
 							: ''}"
-						data-pseudo-selected={index === pseudoSelectedIndex}
+						data-arrow-selected={index === selectedModelIdx}
 						on:click={() => {
 							value = item.value;
-							pseudoSelectedIndex = index;
+							selectedModelIdx = index;
 
 							show = false;
 						}}

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -243,7 +243,7 @@
 						placeholder={searchPlaceholder}
 						autocomplete="off"
 						on:keydown={(e) => {
-							if (e.code === 'Enter') {
+							if (e.code === 'Enter' && filteredItems.length > 0) {
 								value = filteredItems[selectedModelIdx].value;
 								show = false;
 								return; // dont need to scroll on selection

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -45,7 +45,6 @@
 	let ollamaVersion = null;
 
 	let pseudoSelectedIndex = 0;
-	let autoScrollTimeout;
 
 	$: filteredItems = items.filter(
 		(item) =>
@@ -206,6 +205,7 @@
 	bind:open={show}
 	onOpenChange={async () => {
 		searchValue = '';
+		pseudoSelectedIndex = 0; // when the dropdown is closed, reset the selected index
 		window.setTimeout(() => document.getElementById('model-search-input')?.focus(), 0);
 	}}
 	closeFocus={false}


### PR DESCRIPTION
# Changelog Entry

## Description
implements enhancement outlined in #4049
in the model selection dialog, the user can press enter to select the model currently selected in the list. (#3962)
this PR adds the ability to move the selected model using the arrow keys, and to select it with the enter key. 

## Changed

- refactored `on:keydown` and related components to keep track of the currently selected model via arrow keys. 

# Additional Information

- models that are out of view will be scrolled to when they are selected with arrow keys.
- if the user clicks out of the modal, or selects a model, or opens a new chat, the `pseusoSelectedIndex` is reset. 
  - this was done to avoid the state of this from lingering across selections. For example, if the user selects a model, then opens a new chat, the pseudoSelectedIndex could be off screen. This could be solved by resetting the state utilizing a store, but that could have possible side effects so i've decided to keep it contained within the component.
- holding the arrow keys down does not cause any unexpected behaviour 
# Screenshots or Videos
https://github.com/user-attachments/assets/4ccc2225-9b1e-4fdd-a724-3b3b8b8670a2


