### PR TITLE
fix: Fix the SensitiveInput  the browser thought it was a password field

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -154,3 +154,7 @@ input[type='number'] {
 .tippy-box[data-theme~='dark'] {
 	@apply rounded-lg bg-gray-950 text-xs border border-gray-900 shadow-xl;
 }
+
+.password {
+	-webkit-text-security: disc;
+}

--- a/src/lib/components/common/SensitiveInput.svelte
+++ b/src/lib/components/common/SensitiveInput.svelte
@@ -13,8 +13,7 @@
 
 <div class={outerClassName}>
 	<input
-		class={inputClassName}
-		class:dot={!show}
+		class={`${inputClassName} ${show ? '' : 'password'}`}
 		{placeholder}
 		bind:value
 		required={required && !readOnly}
@@ -62,9 +61,3 @@
 		{/if}
 	</button>
 </div>
-
-<style>
-	.dot {
-		-webkit-text-security: disc;
-	}
-</style>

--- a/src/lib/components/common/SensitiveInput.svelte
+++ b/src/lib/components/common/SensitiveInput.svelte
@@ -14,12 +14,13 @@
 <div class={outerClassName}>
 	<input
 		class={inputClassName}
+		class:dot={!show}
 		{placeholder}
 		bind:value
 		required={required && !readOnly}
 		disabled={readOnly}
 		autocomplete="off"
-		{...{ type: show ? 'text' : 'password' }}
+		type="text"
 	/>
 	<button
 		class={showButtonClassName}
@@ -61,3 +62,9 @@
 		{/if}
 	</button>
 </div>
+
+<style>
+	.dot {
+		-webkit-text-security: disc;
+	}
+</style>


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed the `SensitiveInput` component so that Chrome does not mistakenly recognize inputs as passwords.

### Changed

- `SensitiveInput` now uses `-webkit-text-security: disc` instead of `type=password`, causing the browser to not recognize the field as a password.
---

### Additional Information

- I've already checked, `-webkit-text-security` works with all browsers from the last 4 years, and Open WebUI itself doesn't work in a version so old that `-webkit-text-security` isn't supported. I tested it.

### Screenshots or Videos

#### Before

https://github.com/user-attachments/assets/a516daa0-4f06-431b-b739-2368a119a608

#### After

https://github.com/user-attachments/assets/da82e099-3eae-4c87-b1fb-d887d2561cbe