### PR TITLE
fix: pdf gen static path resolution

### DIFF
--- a/backend/apps/webui/routers/utils.py
+++ b/backend/apps/webui/routers/utils.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import site
+
 from fastapi import APIRouter, UploadFile, File, Response
 from fastapi import Depends, HTTPException, status
 from starlette.responses import StreamingResponse, FileResponse
@@ -64,8 +67,18 @@ async def download_chat_as_pdf(
     pdf = FPDF()
     pdf.add_page()
 
-    STATIC_DIR = "./static"
-    FONTS_DIR = f"{STATIC_DIR}/fonts"
+    # When running in docker, workdir is /app/backend, so fonts is in /app/backend/static/fonts
+    FONTS_DIR = Path("./static/fonts")
+
+    # Non Docker Installation
+
+    # When running using `pip install` the static directory is in the site packages.
+    if not FONTS_DIR.exists():
+        FONTS_DIR = Path(site.getsitepackages()[0]) / "static/fonts"
+    # When running using `pip install -e .` the static directory is in the site packages.
+    # This path only works if `open-webui serve` is run from the root of this project.
+    if not FONTS_DIR.exists():
+        FONTS_DIR = Path("./backend/static/fonts")
 
     pdf.add_font("NotoSans", "", f"{FONTS_DIR}/NotoSans-Regular.ttf")
     pdf.add_font("NotoSans", "b", f"{FONTS_DIR}/NotoSans-Bold.ttf")


### PR DESCRIPTION
# Changelog Entry

## Description
when running in different environments, the static_path is different. This path is now 'determined' at runtime



## Changed

- in the pdf creation endpoint, the static path is determined at runtime by checking if the file exists, and getting the environments site packages directory.

## Fixed
#4236

pdf gen fails because it cant find the static/fonts directory when installed using any method outside of docker (including in dev)

---

# Additional Information
- probably works fine on windows. (if someone would like to test this for me, that would be awesome)
- since the static path resolution can vary, including in dev, it may be better to use a cli arg or environment variable to override the docker behaviour instead of trying to find this directory at runtime.

## verified in: 

- [x] linux `pip install`
- [x] linux `pip install -e .` (dev)
- [x] linux docker
- [ ] **windows** `pip install`/`pip install -e .` 