### PR TITLE
fix: made the COMFYUI_FLUX_FP8_CLIP environment variable bool instead of str

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1317,7 +1317,7 @@ COMFYUI_FLUX_WEIGHT_DTYPE = PersistentConfig(
 COMFYUI_FLUX_FP8_CLIP = PersistentConfig(
     "COMFYUI_FLUX_FP8_CLIP",
     "image_generation.comfyui.flux_fp8_clip",
-    os.getenv("COMFYUI_FLUX_FP8_CLIP", ""),
+    os.environ.get("COMFYUI_FLUX_FP8_CLIP", "").lower() == "true",
 )
 
 IMAGES_OPENAI_API_BASE_URL = PersistentConfig(


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

in #4300, I accidentally defined COMFYUI_FLUX_FP8_CLIP as a string instead of a boolean in config.py - which upsets Pydantic when it's not set and therefore is an empty string

### Added

n/a

### Changed

COMFYUI_FLUX_FP8_CLIP is now expected to be "true" or "false", defaulting to "false".

### Deprecated

n/a

### Removed

n/a

### Fixed

 this PR should fix #4328

### Security

n/a

### Breaking Changes

n/a

---

### Additional Information

I built the Dockerfile and pushed it to `ghcr.io/johnthenerd/open-webui:comfyui-fix` - something is preventing me from running the GitHub Actions since my last round of PR's (GHCR just 403s in the push stage) and I'd rather get the fix out instead of investigating it.

This does mean I only have the x86 image without CUDA or ollama in that tag above since I just build and push from my laptop, but it should suffice for testing.

### Screenshots or Videos

environment variable not set, before this PR:
![image](https://github.com/user-attachments/assets/a5b07602-9aff-4c1c-bd68-547e13f4fd7c)

I'm not able to provide an "after this PR" screenshot with fp16 (which is the default without the variable set) as I do not have enough RAM/VRAM to do so and therefore my entire server starts thrashing when I try. I can however confirm that the error message no longer appears and the ComfyUI request is set correctly regardless of the environment variable.

