### PR TITLE
💄 Fix the issue of image preview being blocked

### DIFF
--- a/src/lib/components/common/Image.svelte
+++ b/src/lib/components/common/Image.svelte
@@ -1,22 +1,24 @@
 <script lang="ts">
 	import { WEBUI_BASE_URL } from '$lib/constants';
 	import ImagePreview from './ImagePreview.svelte';
+	import { showSidebar } from '$lib/stores';
 
 	export let src = '';
 	export let alt = '';
+	export let showImagePreview = false;
 
 	let _src = '';
+	let isShowSidebar = $showSidebar;
 
 	$: _src = src.startsWith('/') ? `${WEBUI_BASE_URL}${src}` : src;
-
-	let showImagePreview = false;
 </script>
 
-<ImagePreview bind:show={showImagePreview} src={_src} {alt} />
+<ImagePreview bind:show={showImagePreview} src={_src} {alt} {isShowSidebar} />
 <button
 	on:click={() => {
 		console.log('image preview');
 		showImagePreview = true;
+		showSidebar.set(false);
 	}}
 >
 	<img src={_src} {alt} class=" max-h-96 rounded-lg" draggable="false" data-cy="image" />

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { showSidebar, mobile } from '$lib/stores';
 
 	export let show = false;
 	export let src = '';
 	export let alt = '';
+	export let isShowSidebar = false;
 
 	let mounted = false;
 
 	let previewElement = null;
+
+	const closeShow = () => {
+		if ($mobile) {
+			showSidebar.set(false);
+		} else {
+			showSidebar.set(isShowSidebar);
+		}
+		console.log(isShowSidebar);
+		show = false;
+	};
 
 	const downloadImage = (url, filename) => {
 		fetch(url)
@@ -28,7 +40,7 @@
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Escape') {
 			console.log('Escape');
-			show = false;
+			closeShow();
 		}
 	};
 
@@ -59,7 +71,7 @@
 				<button
 					class=" p-5"
 					on:click={() => {
-						show = false;
+						closeShow();
 					}}
 				>
 					<svg


### PR DESCRIPTION
# Pull Request Checklist

# Changelog Entry

### Description

The issue of image preview being blocked is resolved by dynamically deleting the showsidebar

### Screenshots or Videos

#### Previous

![image](https://github.com/user-attachments/assets/5bdc3a8b-d91e-4f20-ad73-f16e29df0635)

#### Now

https://github.com/user-attachments/assets/df5191f1-94ef-4d9c-b369-f5f399640fc2

