### PR TITLE
fix: #4158 allow reconnection when websocket is closed

### DIFF
--- a/backend/apps/socket/main.py
+++ b/backend/apps/socket/main.py
@@ -141,6 +141,8 @@ async def disconnect(sid):
 
 
 def get_event_emitter(request_info):
+    if request_info["session_id"] is None:
+        return None
     async def __event_emitter__(event_data):
         await sio.emit(
             "chat-events",
@@ -156,6 +158,8 @@ def get_event_emitter(request_info):
 
 
 def get_event_call(request_info):
+    if request_info["session_id"] is None:
+        return None
     async def __event_call__(event_data):
         response = await sio.call(
             "chat-events",

--- a/backend/main.py
+++ b/backend/main.py
@@ -1177,7 +1177,7 @@ async def chat_completed(form_data: dict, user=Depends(get_verified_user)):
         {
             "chat_id": data["chat_id"],
             "message_id": data["id"],
-            "session_id": data["session_id"],
+            "session_id": data["session_id"] or None,
         }
     )
 
@@ -1185,7 +1185,7 @@ async def chat_completed(form_data: dict, user=Depends(get_verified_user)):
         {
             "chat_id": data["chat_id"],
             "message_id": data["id"],
-            "session_id": data["session_id"],
+            "session_id": data["session_id"] or None,
         }
     )
 
@@ -1312,14 +1312,14 @@ async def chat_action(action_id: str, form_data: dict, user=Depends(get_verified
         {
             "chat_id": data["chat_id"],
             "message_id": data["id"],
-            "session_id": data["session_id"],
+            "session_id": data["session_id"] or None,
         }
     )
     __event_call__ = get_event_call(
         {
             "chat_id": data["chat_id"],
             "message_id": data["id"],
-            "session_id": data["session_id"],
+            "session_id": data["session_id"] or None,
         }
     )
 

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -69,6 +69,7 @@ type ChatCompletedForm = {
 	model: string;
 	messages: string[];
 	chat_id: string;
+	session_id?: string;
 };
 
 export const chatCompleted = async (token: string, body: ChatCompletedForm) => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Prevent the backend from responding http error 500 when session_id is not provided by the client

### Fixed

- Fix issue #4158, ensure `session_id` is optional on the backend side.

---

### Additional Information

- I think this bug has been introduced with the commit https://github.com/open-webui/open-webui/commit/d97a4d687ebc065ae4ec2a45b24c775e052ab38c#diff-c867e0c9c90c94b02a2de567f2210ca9e600180d8fa3d6b121c7eb54da39a4edR345
- we can see that session_id is optional on the client-side (see here: https://github.com/open-webui/open-webui/blob/c869652ef4907dd123a140d9a08a0c239e690b08/src/lib/components/chat/Chat.svelte#L394)
- but this session_id is mandatory on the server-side, thus provoking an http 500 error when session_id is not provided (see here: https://github.com/open-webui/open-webui/blob/c869652ef4907dd123a140d9a08a0c239e690b08/backend/main.py#L1180).

Of course, if the websocket connection is not closed, we don't get this error. Yet, I think it is important to be robust in such situation. Probably the websocket connection should be re-established as well ?

Dear @tjbck , any insight would be welcome!
