### PR TITLE
fix: ComfyUI generation no longer causes FastAPI to stall for all users

### DIFF
--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -514,7 +514,7 @@ async def image_generations(
 
             data = ImageGenerationPayload(**data)
 
-            res = comfyui_generate_image(
+            res = await comfyui_generate_image(
                 app.state.config.MODEL,
                 data,
                 user.id,

--- a/backend/apps/images/utils/comfyui.py
+++ b/backend/apps/images/utils/comfyui.py
@@ -1,3 +1,4 @@
+import asyncio
 import websocket  # NOTE: websocket-client (https://github.com/websocket-client/websocket-client)
 import uuid
 import json
@@ -328,7 +329,7 @@ class ImageGenerationPayload(BaseModel):
     flux_fp8_clip: Optional[bool] = None
 
 
-def comfyui_generate_image(
+async def comfyui_generate_image(
     model: str, payload: ImageGenerationPayload, client_id, base_url
 ):
     ws_url = base_url.replace("http://", "ws://").replace("https://", "wss://")
@@ -397,7 +398,7 @@ def comfyui_generate_image(
         return None
 
     try:
-        images = get_images(ws, comfyui_prompt, client_id, base_url)
+        images = await asyncio.to_thread(get_images, ws, comfyui_prompt, client_id, base_url)
     except Exception as e:
         log.exception(f"Error while receiving images: {e}")
         images = None


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

as the get_images() function involves a `while True` loop while waiting for a response from ComfyUI and is not async, when image generation is running the entire UI becomes unresponsive for all users.

furthermore, when image generation takes too long, the Docker health check starts failing.

this is certainly a bad fix as it does not convert everything to async, but rather just puts the blocking loop in a separate thread. however, it at least fixes the problem for now.

### Added

n/a

### Changed

started running ComfyUI's image generation in a separate thread, instead of blocking the FastAPI thread

### Deprecated

n/a

### Removed

n/a

### Fixed

- the UI no longer becomes fully inaccessible for all users while image generation runs
- Open WebUI no longer crashes when running an image generation request that takes longer than the health check timeout

### Security

n/a

### Breaking Changes

n/a

---

### Additional Information

- simultaneous image generation requests seem to fail after this PR. in contrast, it's way better to fail gracefully than simply hang or crash

- this is certainly an ugly fix that I put together just to stop my server from continuously crashing (I share my instance with my friends, and since many people liked Flux which itself is a massive model, my server was down more often than it was up).

- a proper fix involves running the ComfyUI stuff in a separate thread, queuing things inside Open-WebUI itself. however, I don't really have time to look at it right now and it's quite bad UX to have the UI hang/crash, so here's an upstream PR until I get to a better fix.

### Screenshots or Videos

n/a
