### PR TITLE
PWA theme colour match dark/light themes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />

--- a/src/app.html
+++ b/src/app.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
@@ -6,6 +6,7 @@
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" crossorigin="use-credentials" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 		<meta name="robots" content="noindex,nofollow" />
+		<meta name="theme-color" id="themeColor" content="#ffffff" />
 		<link
 			rel="search"
 			type="application/opensearchdescription+xml"
@@ -22,6 +23,7 @@
 		<script>
 			// On page load or when changing themes, best to add inline in `head` to avoid FOUC
 			(() => {
+				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 				if (localStorage?.theme && localStorage?.theme.includes('oled')) {
 					document.documentElement.style.setProperty('--color-gray-800', '#101010');
 					document.documentElement.style.setProperty('--color-gray-850', '#050505');
@@ -38,13 +40,19 @@
 						document.documentElement.classList.add(e);
 					});
 				} else if (localStorage.theme && localStorage.theme === 'system') {
-					systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
-					document.documentElement.classList.add(systemTheme ? 'dark' : 'light');
+					document.documentElement.classList.add(isSystemDark ? 'dark' : 'light');
 				} else if (localStorage.theme && localStorage.theme === 'her') {
 					document.documentElement.classList.add('dark');
 					document.documentElement.classList.add('her');
 				} else {
 					document.documentElement.classList.add('dark');
+				}
+
+				if (
+					localStorage?.theme.includes('dark') ||
+					(localStorage.theme === 'system' && isSystemDark)
+				) {
+					window.themeColor.content = '#0d0d0d';
 				}
 
 				window.matchMedia('(prefers-color-scheme: dark)').addListener((e) => {

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -88,10 +88,11 @@
 	});
 
 	const applyTheme = (_theme: string) => {
+		const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 		let themeToApply = _theme === 'oled-dark' ? 'dark' : _theme;
 
 		if (_theme === 'system') {
-			themeToApply = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+			themeToApply = isSystemDark ? 'dark' : 'light';
 		}
 
 		if (themeToApply === 'dark' && !_theme.includes('oled')) {
@@ -99,6 +100,10 @@
 			document.documentElement.style.setProperty('--color-gray-850', '#262626');
 			document.documentElement.style.setProperty('--color-gray-900', '#171717');
 			document.documentElement.style.setProperty('--color-gray-950', '#0d0d0d');
+		}
+
+		if(themeToApply.includes('dark')) {
+			window.themeColor.content = '#0d0d0d';
 		}
 
 		themes


### PR DESCRIPTION
# Changelog Entry

### Description

- When using open-webui as a PWA the bottom and top bars are always white, which doesn't look great if using dark modes.

### Added

- PWA theme colour should now be light or dark depending on the selected theme.
