### PR TITLE
Update start.sh

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -36,7 +36,7 @@ if [ -n "$SPACE_ID" ]; then
   echo "Configuring for HuggingFace Space deployment"
   if [ -n "$ADMIN_USER_EMAIL" ] && [ -n "$ADMIN_USER_PASSWORD" ]; then
     echo "Admin user configured, creating"
-    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
+    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" gunicorn main:app --bind "$HOST:$PORT" --worker-class uvicorn.workers.UvicornWorker --forwarded-allow-ips '*' &
     webui_pid=$!
     echo "Waiting for webui to start..."
     while ! curl -s http://localhost:8080/health > /dev/null; do
@@ -55,4 +55,4 @@ if [ -n "$SPACE_ID" ]; then
   export WEBUI_URL=${SPACE_HOST}
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec gunicorn main:app --bind "$HOST:$PORT" --worker-class uvicorn.workers.UvicornWorker --forwarded-allow-ips '*'


### PR DESCRIPTION
**Key Changes**:
Using gunicorn Instead of uvicorn:

Replace uvicorn with gunicorn while using the UvicornWorker to maintain compatibility with ASGI applications.
Command Format for gunicorn:

The uvicorn main:app is replaced by gunicorn main:app --worker-class uvicorn.workers.UvicornWorker.
The --host "$HOST" and --port "$PORT" options for uvicorn are replaced with --bind "$HOST:$PORT" in gunicorn.
Startup and Shutdown Behavior:

The logic for starting and stopping the web server during admin user creation remains the same, just with gunicorn commands.
With this script multiple request can be accepted it a same time.