### PR TITLE
fix: Make PWA icon maskable

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2264,7 +2264,7 @@ async def get_manifest_json():
         "display": "standalone",
         "background_color": "#343541",
         "orientation": "portrait-primary",
-        "icons": [{"src": "/static/logo.png", "type": "image/png", "sizes": "500x500"}],
+        "icons": [{"src": "/static/logo.png", "type": "image/png", "sizes": "500x500", "purpose": "any maskable"}],
     }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2264,7 +2264,20 @@ async def get_manifest_json():
         "display": "standalone",
         "background_color": "#343541",
         "orientation": "portrait-primary",
-        "icons": [{"src": "/static/logo.png", "type": "image/png", "sizes": "500x500", "purpose": "any maskable"}],
+        "icons": [
+            {
+                "src": "/static/logo.png",
+                "type": "image/png",
+                "sizes": "500x500",
+                "purpose": "any",
+            },
+            {
+                "src": "/static/logo.png",
+                "type": "image/png",
+                "sizes": "500x500",
+                "purpose": "maskable",
+            },
+        ],
     }
 
 


### PR DESCRIPTION
# Changelog Entry

### Description

This PR adds the `maskable` purpose, in addition to the default `any`.

### Added

### Changed

- Added the `maskable` purpose to the icon in manifest.json, in addition to the default `any`.

### Deprecated

### Removed

### Fixed

Fixes #4461 where the icon would be square when the PWA was installed via Chromium-based browsers under macOS.

### Security

### Breaking Changes

---

### Additional Information

Fixes #4461 where the icon would be square when the PWA was installed via Chromium-based browsers under macOS.

### Screenshots or Videos

<img width="55" alt="image" src="https://github.com/user-attachments/assets/786868df-5093-43eb-b229-9734a3e7ebb5">

