### PR TITLE
sec: Sanitize 11labs voice id to address semgrep security issue: tainted-path-traversal-stdlib-fastapi

### DIFF
--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -254,6 +254,13 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             raise HTTPException(status_code=400, detail="Invalid JSON payload")
 
         voice_id = payload.get("voice", "")
+
+        if voice_id not in get_available_voices():
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid voice id",
+            )
+
         url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
 
         headers = {

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -1,5 +1,12 @@
-import os
+import hashlib
+import json
 import logging
+import os
+import uuid
+from functools import lru_cache
+from pathlib import Path
+
+import requests
 from fastapi import (
     FastAPI,
     Request,
@@ -8,34 +15,14 @@ from fastapi import (
     status,
     UploadFile,
     File,
-    Form,
 )
-from fastapi.responses import StreamingResponse, JSONResponse, FileResponse
-
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
-
-
-import uuid
-import requests
-import hashlib
-from pathlib import Path
-import json
-
-from constants import ERROR_MESSAGES
-from utils.utils import (
-    decode_token,
-    get_current_user,
-    get_verified_user,
-    get_admin_user,
-)
-from utils.misc import calculate_sha256
-
 
 from config import (
     SRC_LOG_LEVELS,
     CACHE_DIR,
-    UPLOAD_DIR,
     WHISPER_MODEL,
     WHISPER_MODEL_DIR,
     WHISPER_MODEL_AUTO_UPDATE,
@@ -51,6 +38,12 @@ from config import (
     AUDIO_TTS_MODEL,
     AUDIO_TTS_VOICE,
     AppConfig,
+)
+from constants import ERROR_MESSAGES
+from utils.utils import (
+    get_current_user,
+    get_verified_user,
+    get_admin_user,
 )
 
 log = logging.getLogger(__name__)

--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -459,16 +459,18 @@ async def get_models(user=Depends(get_verified_user)):
     return {"models": get_available_models()}
 
 
-def get_available_voices() -> list[dict]:
+def get_available_voices() -> dict:
+    """Returns {voice_id: voice_name} dict"""
+    ret = {}
     if app.state.config.TTS_ENGINE == "openai":
-        return [
-            {"name": "alloy", "id": "alloy"},
-            {"name": "echo", "id": "echo"},
-            {"name": "fable", "id": "fable"},
-            {"name": "onyx", "id": "onyx"},
-            {"name": "nova", "id": "nova"},
-            {"name": "shimmer", "id": "shimmer"},
-        ]
+        ret = {
+            "alloy": "alloy",
+            "echo": "echo",
+            "fable": "fable",
+            "onyx": "onyx",
+            "nova": "nova",
+            "shimmer": "shimmer",
+        }
     elif app.state.config.TTS_ENGINE == "elevenlabs":
         try:
             ret = get_elevenlabs_voices()
@@ -513,4 +515,4 @@ def get_elevenlabs_voices() -> dict:
 
 @app.get("/voices")
 async def get_voices(user=Depends(get_verified_user)):
-    return {"voices": get_available_voices()}
+    return {"voices": [{"id": k, "name": v} for k, v in get_available_voices().items()]}

--- a/backend/config.py
+++ b/backend/config.py
@@ -1410,13 +1410,13 @@ AUDIO_TTS_ENGINE = PersistentConfig(
 AUDIO_TTS_MODEL = PersistentConfig(
     "AUDIO_TTS_MODEL",
     "audio.tts.model",
-    os.getenv("AUDIO_TTS_MODEL", "tts-1"),
+    os.getenv("AUDIO_TTS_MODEL", "tts-1"),  # OpenAI default model
 )
 
 AUDIO_TTS_VOICE = PersistentConfig(
     "AUDIO_TTS_VOICE",
     "audio.tts.voice",
-    os.getenv("AUDIO_TTS_VOICE", "alloy"),
+    os.getenv("AUDIO_TTS_VOICE", "alloy"),  # OpenAI default voice
 )
 
 


### PR DESCRIPTION
# Changelog Entry

### Description

* Voice id's are passed to `/speech` without sanitization. They should be open AI names or elevenlabs id's, so the PR calls `get_elevenlabs_voices()` to ensure the passed ID is one of those. Else an HTTP 400 is returned. 

### Added

* I cached `get_elevenlabs_voices()` with `@lru_cache` to avoid waiting 1 second for every `/speech` call on just that. 

### Changed

* I changed the return of get_elevenlabs_voices to a dict as the number of voices are getting to the point you'd want O(1) lookup: https://api.elevenlabs.io/v1/voices

### Security

* Addressed tainted-path-traversal-stdlib-fastapi within the audio api


### Testing

* I tested TTS from elevenlabs, openai, and the default in-browser synthesize locally with the change

### How to test

* Set elevenlabs env vars
```
    AUDIO_TTS_ENGINE=elevenlabs
    AUDIO_TTS_API_KEY=sk_...  # Your Elevenlabs API key
    AUDIO_TTS_VOICE=EXAVITQu4vr4xnSDxMaL  # Sarah from https://api.elevenlabs.io/v1/voices
    AUDIO_TTS_MODEL=eleven_multilingual_v2
```
* Hit the call button and vibe!
![image](https://github.com/user-attachments/assets/e670168a-6730-4e63-bbf5-16410b426728)
![image](https://github.com/user-attachments/assets/21dca883-7676-4afd-ba54-e0b258aa9d37)
