### PR TITLE
feat: support mysql.

### DIFF
--- a/backend/apps/webui/internal/migrations/009_add_models.py
+++ b/backend/apps/webui/internal/migrations/009_add_models.py
@@ -39,7 +39,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Model(pw.Model):
-        id = pw.TextField(unique=True)
+        id = pw.CharField(max_length=255, unique=True)
         user_id = pw.TextField()
         base_model_id = pw.TextField(null=True)
 

--- a/backend/apps/webui/internal/migrations/012_add_tools.py
+++ b/backend/apps/webui/internal/migrations/012_add_tools.py
@@ -39,7 +39,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Tool(pw.Model):
-        id = pw.TextField(unique=True)
+        id = pw.CharField(max_length=255, unique=True)
         user_id = pw.TextField()
 
         name = pw.TextField()

--- a/backend/apps/webui/internal/migrations/014_add_files.py
+++ b/backend/apps/webui/internal/migrations/014_add_files.py
@@ -39,7 +39,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class File(pw.Model):
-        id = pw.TextField(unique=True)
+        id = pw.CharField(max_length=255, unique=True)
         user_id = pw.TextField()
         filename = pw.TextField()
         meta = pw.TextField()

--- a/backend/apps/webui/internal/migrations/015_add_functions.py
+++ b/backend/apps/webui/internal/migrations/015_add_functions.py
@@ -39,7 +39,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Function(pw.Model):
-        id = pw.TextField(unique=True)
+        id = pw.CharField(max_length=255, unique=True)
         user_id = pw.TextField()
 
         name = pw.TextField()

--- a/backend/apps/webui/internal/migrations/017_add_user_oauth_sub.py
+++ b/backend/apps/webui/internal/migrations/017_add_user_oauth_sub.py
@@ -35,7 +35,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     migrator.add_fields(
         "user",
-        oauth_sub=pw.TextField(null=True, unique=True),
+        oauth_sub=pw.CharField(max_length=255, null=True, unique=True),
     )
 
 

--- a/backend/apps/webui/internal/wrappers.py
+++ b/backend/apps/webui/internal/wrappers.py
@@ -1,6 +1,6 @@
 from contextvars import ContextVar
 from peewee import *
-from peewee import PostgresqlDatabase, InterfaceError as PeeWeeInterfaceError
+from peewee import PostgresqlDatabase, MySQLDatabase, InterfaceError as PeeWeeInterfaceError
 
 import logging
 from playhouse.db_url import connect, parse
@@ -41,6 +41,8 @@ class CustomReconnectMixin(ReconnectMixin):
 class ReconnectingPostgresqlDatabase(CustomReconnectMixin, PostgresqlDatabase):
     pass
 
+class ReconnectingMySQLDatabase(CustomReconnectMixin, MySQLDatabase):
+    pass
 
 def register_connection(db_url):
     db = connect(db_url, unquote_password=True)
@@ -61,6 +63,24 @@ def register_connection(db_url):
         db.autoconnect = True
         db.reuse_if_open = True
         log.info("Connected to SQLite database")
+    elif isinstance(db, MySQLDatabase):
+        # Enable autoconnect for MySQL databases, managed by Peewee
+        db.autoconnect = True
+        db.reuse_if_open = True
+        log.info("Connected to MySQL database")
+
+        # Get the connection details
+        connection = parse(db_url)
+
+        # Use our custom database class that supports reconnection
+        db = ReconnectingMySQLDatabase(
+            connection["database"],
+            user=connection["user"],
+            password=connection["passwd"],
+            host=connection["host"],
+            port=connection["port"],
+        )
+        db.connect(reuse_if_open=True)
     else:
         raise ValueError("Unsupported database connection")
     return db

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ peewee-migrate==1.12.2
 psycopg2-binary==2.9.9
 PyMySQL==1.1.1
 bcrypt==4.2.0
+mysqlclient==2.2.4
 
 pymongo
 redis


### PR DESCRIPTION
# Pull Request Checklist
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes? Yes, the testing was performed for postgres, sqlite and mysql successfully.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** The pull request title is prefixed with "FEAT" to indicate a new feature.

# Changelog Entry

### Description
This pull request enhances to support mysql database besides sqlite and postgres. It'll solve the problem or feedback of the below discussions
[How to use MySQL as database not noly sqlite.](https://github.com/open-webui/open-webui/discussions/4544)
[Failed to start with mysql](https://github.com/open-webui/open-webui/discussions/3903)
[Is possible to customize the OpenWebUI application database and Chrom](https://github.com/open-webui/open-webui/discussions/4288)
[May I ask if I can use an external MySQL to store data?](https://github.com/open-webui/open-webui/discussions/2529)

### Changed
- relevant migration scripts under backend/apps/webui/internal/migrations, so that to support sqlite, postgres and mysql during db schema creation and migration.
    - 007_add_user_last_active_at.py added database_type check, when that type is mysql, use `, while postgres or sqlite, use ".
    - for 009_add_models.py, 012_add_tools.py, 014_add_files.py, 015_add_functions.py, all the id = pw.TextField(unique=True) is changed to be pw.CharField(max_length=255, unique=True) so that it wouldn't hit limitation in mysql.
    - 017_add_user_oauth_sub.py the oauth_sub is changed to be pw.CharField(max_length=255, null=True, unique=True), so that it wouldn't hit limitation in mysql.
- regarding backend/apps/webui/internal/wrappers.py, import MySQLDatabase, added reconnecting logic for it also.
- There is new dependency added in backend/requirements.txt, which is mysqlclient==2.2.4. because sqlalchemy relies on it and it's more stable.


### Additional Information
To use mysql database, just like using postgres, specify the DATABASE_URL as mysql://username:passwd@host:port/database

### Screenshots or Videos
Please refer testing screenshots:

For sqlite:
![SQLite1](https://github.com/user-attachments/assets/4e289622-bafe-4c36-9737-4b10641a3e78)
![SQLite2](https://github.com/user-attachments/assets/f2566423-3e6c-49c4-b07e-5604951983e8)


For postgresql:
![Postgresql1](https://github.com/user-attachments/assets/c450c560-4093-4a65-bbb2-b52eb5b79835)
![Postgresql2](https://github.com/user-attachments/assets/94b844bf-47b3-4f4c-b737-68ccd5ae7164)
![Postgresql3](https://github.com/user-attachments/assets/d6f2ebe4-6294-4770-a091-bb5481e05d07)


For mysql:
![MySQL1](https://github.com/user-attachments/assets/bb26b8ea-ae5d-4ae0-8085-6a53d5409295)
![MySQL2](https://github.com/user-attachments/assets/4bfef448-a081-4dce-87ad-41547af8d7e0)
![MySQL3](https://github.com/user-attachments/assets/1f421455-4eaf-455b-8379-47dc3a3a684e)


