### PR TITLE
sec: Allow setting CORS origin 

### DIFF
--- a/backend/apps/audio/main.py
+++ b/backend/apps/audio/main.py
@@ -38,6 +38,7 @@ from config import (
     AUDIO_TTS_MODEL,
     AUDIO_TTS_VOICE,
     AppConfig,
+    CORS_ALLOW_ORIGIN,
 )
 from constants import ERROR_MESSAGES
 from utils.utils import (
@@ -52,7 +53,7 @@ log.setLevel(SRC_LOG_LEVELS["AUDIO"])
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -51,6 +51,7 @@ from config import (
     IMAGE_SIZE,
     IMAGE_STEPS,
     AppConfig,
+    CORS_ALLOW_ORIGIN,
 )
 
 log = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/apps/images/main.py
+++ b/backend/apps/images/main.py
@@ -1,15 +1,10 @@
 import re
 import requests
-import base64
 from fastapi import (
     FastAPI,
     Request,
     Depends,
     HTTPException,
-    status,
-    UploadFile,
-    File,
-    Form,
 )
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -20,7 +15,6 @@ from utils.utils import (
 )
 
 from apps.images.utils.comfyui import ImageGenerationPayload, comfyui_generate_image
-from utils.misc import calculate_sha256
 from typing import Optional
 from pydantic import BaseModel
 from pathlib import Path

--- a/backend/apps/ollama/main.py
+++ b/backend/apps/ollama/main.py
@@ -41,6 +41,7 @@ from config import (
     MODEL_FILTER_LIST,
     UPLOAD_DIR,
     AppConfig,
+    CORS_ALLOW_ORIGIN,
 )
 from utils.misc import (
     calculate_sha256,
@@ -55,7 +56,7 @@ log.setLevel(SRC_LOG_LEVELS["OLLAMA"])
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/apps/openai/main.py
+++ b/backend/apps/openai/main.py
@@ -32,6 +32,7 @@ from config import (
     ENABLE_MODEL_FILTER,
     MODEL_FILTER_LIST,
     AppConfig,
+    CORS_ALLOW_ORIGIN,
 )
 from typing import Optional, Literal, overload
 
@@ -45,7 +46,7 @@ log.setLevel(SRC_LOG_LEVELS["OPENAI"])
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/apps/rag/main.py
+++ b/backend/apps/rag/main.py
@@ -129,6 +129,7 @@ from config import (
     RAG_WEB_SEARCH_RESULT_COUNT,
     RAG_WEB_SEARCH_CONCURRENT_REQUESTS,
     RAG_EMBEDDING_OPENAI_BATCH_SIZE,
+    CORS_ALLOW_ORIGIN,
 )
 
 from constants import ERROR_MESSAGES
@@ -240,12 +241,9 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
     app.state.config.RAG_EMBEDDING_OPENAI_BATCH_SIZE,
 )
 
-origins = ["*"]
-
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/apps/webui/main.py
+++ b/backend/apps/webui/main.py
@@ -47,6 +47,7 @@ from config import (
     OAUTH_USERNAME_CLAIM,
     OAUTH_PICTURE_CLAIM,
     OAUTH_EMAIL_CLAIM,
+    CORS_ALLOW_ORIGIN,
 )
 
 from apps.socket.main import get_event_call, get_event_emitter
@@ -58,8 +59,6 @@ from typing import Iterator, Generator, AsyncGenerator
 from pydantic import BaseModel
 
 app = FastAPI()
-
-origins = ["*"]
 
 app.state.config = AppConfig()
 
@@ -93,7 +92,7 @@ app.state.FUNCTIONS = {}
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/config.py
+++ b/backend/config.py
@@ -842,6 +842,7 @@ ENABLE_COMMUNITY_SHARING = PersistentConfig(
     os.environ.get("ENABLE_COMMUNITY_SHARING", "True").lower() == "true",
 )
 
+
 def validate_cors_origins(origins):
     for origin in origins:
         if origin != "*":
@@ -853,7 +854,9 @@ def validate_cors_origin(origin):
 
     # Check if the scheme is either http or https
     if parsed_url.scheme not in ["http", "https"]:
-        raise ValueError(f"Invalid scheme in CORS_ALLOW_ORIGIN: '{origin}'. Only 'http' and 'https' are allowed.")
+        raise ValueError(
+            f"Invalid scheme in CORS_ALLOW_ORIGIN: '{origin}'. Only 'http' and 'https' are allowed."
+        )
 
     # Ensure that the netloc (domain + port) is present, indicating it's a valid URL
     if not parsed_url.netloc:
@@ -868,9 +871,12 @@ def validate_cors_origin(origin):
 CORS_ALLOW_ORIGIN = os.environ.get("CORS_ALLOW_ORIGIN", "*").split(";")
 
 if "*" in CORS_ALLOW_ORIGIN:
-    log.warning("\n\nWARNING: CORS_ALLOW_ORIGIN IS SET TO '*' - NOT RECOMMENDED FOR PRODUCTION DEPLOYMENTS.\n")
+    log.warning(
+        "\n\nWARNING: CORS_ALLOW_ORIGIN IS SET TO '*' - NOT RECOMMENDED FOR PRODUCTION DEPLOYMENTS.\n"
+    )
 
 validate_cors_origins(CORS_ALLOW_ORIGIN)
+
 
 class BannerModel(BaseModel):
     id: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -119,6 +119,7 @@ from config import (
     WEBUI_SESSION_COOKIE_SECURE,
     ENABLE_ADMIN_CHAT_ACCESS,
     AppConfig,
+    CORS_ALLOW_ORIGIN,
 )
 
 from constants import ERROR_MESSAGES, WEBHOOK_MESSAGES, TASKS
@@ -208,8 +209,6 @@ app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE = (
 )
 
 app.state.MODELS = {}
-
-origins = ["*"]
 
 
 ##################################
@@ -833,7 +832,7 @@ app.add_middleware(PipelineMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=CORS_ALLOW_ORIGIN,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -500,7 +500,7 @@
 	"Rosé Pine": "Rosé Pine",
 	"Rosé Pine Dawn": "Rosé Pine Dawn",
 	"RTL": "RTL",
-    "Run": "Запустить",
+	"Run": "Запустить",
 	"Run Llama 2, Code Llama, and other models. Customize and create your own.": "Запустите Llama 2, Code Llama и другие модели. Настройте и создайте свою собственную.",
 	"Running": "Выполняется",
 	"Save": "Сохранить",


### PR DESCRIPTION
# Changelog Entry

### Description

- My semgrep scan pickedup CORS * as a medium level issue, but for open webui, I'd consider it higher since you could have malicious web apps grabbing chat history.

### Added

- CORS_ALLOW_ORIGIN env var with semicolon delimited allowed origins
- Checks to make sure origins are valid urls or * as frontend will silently fail with CORS errors otherwise

### Changed

- Changed all fastapi cors middleware declarations to use the new env var, e.g.

```python
 app.add_middleware(
    CORSMiddleware,
    allow_origins=CORS_ALLOW_ORIGIN,  # used to be ["*"]
...
```

The default value is still `["*"]` so current users should be unaffected

### Security

- Allows setting CORS origin in `.env` for production deployments

### How it was tested

- I tried all functionality with and without setting `CORS_ALLOW_ORIGIN`
- I tried valid and invalid CORS to make sure setting had an effect
  - `http://localhost:5173,http://localhost:8080`
  - `notavalidurl`
- I tested `apps/images`, `apps/audio`, `apps/openai`, and `main.py` in `backend`
- I DID NOT test `apps/ollama`, `apps/rag`, or `apps/webui` as I'm not sure how to trigger those, but the change is identical to the other apps. The middleware is configured on import here, but not exercised in manual tests like the above

### Screenshots or Videos

- Image generation works!
![image](https://github.com/user-attachments/assets/86c16cbe-7a0c-45e6-b1af-263411554769)

### Additional notes

I'll add documentation about the env var in the deploy section
