### PR TITLE
Lighthouse seo score and error fixes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,7 @@
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" crossorigin="use-credentials" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 		<meta name="robots" content="noindex,nofollow" />
+		<meta name="description" content="Open WebUI" />
 		<link
 			rel="search"
 			type="application/opensearchdescription+xml"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
# Changelog Entry

### Description

No errors are reported for the SEO tests and it is now scored at 66, up from 50. Only way to improve it is to allow search engines to index which is probably unwanted for most people.

### Fixed

- Added robots.txt file with Disallow All addresses a Lighthouse SEO error while still preventing content indexing by search engines.
- A meta description has been added, addressing a Lighthouse recommendation and positively impacting the SEO score.

### Misc

I updated the description to only "Open WebUI" as per your recommendation in the previous PR☺️