### PR TITLE
A11y: Add missing aria labels for buttons

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -504,6 +504,7 @@
 										<button
 											class="bg-gray-50 hover:bg-gray-100 text-gray-800 dark:bg-gray-850 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-2 outline-none focus:outline-none"
 											type="button"
+											aria-label="More"
 										>
 											<svg
 												xmlns="http://www.w3.org/2000/svg"
@@ -720,6 +721,7 @@
 														toast.error($i18n.t('Permission denied when accessing microphone'));
 													}
 												}}
+												aria-label="Voice Input"
 											>
 												<svg
 													xmlns="http://www.w3.org/2000/svg"
@@ -779,6 +781,7 @@
 														toast.error($i18n.t('Permission denied when accessing media devices'));
 													}
 												}}
+												aria-label="Call"
 											>
 												<Headphone className="size-6" />
 											</button>

--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -63,6 +63,7 @@
 							on:click={() => {
 								selectedModels = [...selectedModels, ''];
 							}}
+							aria-label="Add Model"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -86,6 +87,7 @@
 								selectedModels.splice(selectedModelIdx, 1);
 								selectedModels = selectedModels;
 							}}
+							aria-label="Remove Model"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -54,6 +54,7 @@
 					on:click={() => {
 						showSidebar.set(!$showSidebar);
 					}}
+					aria-label="Toggle Sidebar"
 				>
 					<div class=" m-auto self-center">
 						<MenuLines />
@@ -111,6 +112,7 @@
 						on:click={() => {
 							showControls = !showControls;
 						}}
+						aria-label="Controls"
 					>
 						<div class=" m-auto self-center">
 							<AdjustmentsHorizontal className=" size-5" strokeWidth="0.5" />
@@ -127,6 +129,7 @@
 						on:click={() => {
 							initNewChat();
 						}}
+						aria-label="New Chat"
 					>
 						<div class=" m-auto self-center">
 							<svg

--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -39,6 +39,7 @@
 						on:click={() => {
 							showSidebar.set(!$showSidebar);
 						}}
+						aria-label="Toggle Sidebar"
 					>
 						<div class=" m-auto self-center">
 							<MenuLines />

--- a/src/routes/(app)/playground/+layout.svelte
+++ b/src/routes/(app)/playground/+layout.svelte
@@ -29,6 +29,7 @@
 					on:click={() => {
 						showSidebar.set(!$showSidebar);
 					}}
+					aria-label="Toggle Sidebar"
 				>
 					<div class=" m-auto self-center">
 						<MenuLines />

--- a/src/routes/(app)/workspace/+layout.svelte
+++ b/src/routes/(app)/workspace/+layout.svelte
@@ -39,6 +39,7 @@
 						on:click={() => {
 							showSidebar.set(!$showSidebar);
 						}}
+						aria-label="Toggle Sidebar"
 					>
 						<div class=" m-auto self-center">
 							<MenuLines />


### PR DESCRIPTION
# Changelog Entry

### Description

This PR adds some missing aria labels on button elements that Lighthouse warned about. This was previously part of a slightly bigger PR #4942 which fixed all problematic elements on the login and start page but as per your suggestions I created a new PR without style changes in case this is part of a larger redesign for a future release.

### Fixed

- Missing aria labels on buttons have been added, enhancing the Lighthouse accessibility test results.

---

### Additional Information

Partly fixes #2790 
