### PR TITLE
fix: Update color theme on system change

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -22,6 +22,10 @@
 		<script>
 			// On page load or when changing themes, best to add inline in `head` to avoid FOUC
 			(() => {
+				if (!localStorage?.theme) {
+					localStorage.theme = 'system';
+				}
+
 				if (localStorage?.theme && localStorage?.theme.includes('oled')) {
 					document.documentElement.style.setProperty('--color-gray-800', '#101010');
 					document.documentElement.style.setProperty('--color-gray-850', '#050505');


### PR DESCRIPTION
# Changelog Entry

### Description

Currently, the theme logic uses the theme 'system' if nothing is found in the browser's local storage. However, when the system theme changes, the new theme isn't applied until the page is refreshed. By setting `localStorage.theme = 'system'`, the theme will now automatically update when the system theme changes.

### Fixed

- Update the app theme when the OS theme changes.

---

### Screenshots or Videos

Old behavior:

https://github.com/user-attachments/assets/9b849e12-49a0-4652-ae0b-a93a4c332994

New behavior:

https://github.com/user-attachments/assets/4eeed7e3-0b98-4728-9c0b-13a271e2b3af
