### PR TITLE
feat: show total number of documents

### DIFF
--- a/src/lib/components/workspace/Documents.svelte
+++ b/src/lib/components/workspace/Documents.svelte
@@ -215,7 +215,10 @@
 
 <div class="mb-3">
 	<div class="flex justify-between items-center">
-		<div class=" text-lg font-semibold self-center">{$i18n.t('Documents')}</div>
+		<div class="text-lg font-semibold self-center flex items-center space-x-2">
+			<span>{$i18n.t('Documents')}</span>
+			<span class="text-sm font-normal text-gray-500">({$documents.length})</span>
+		</div>
 	</div>
 </div>
 

--- a/src/lib/components/workspace/Documents.svelte
+++ b/src/lib/components/workspace/Documents.svelte
@@ -215,9 +215,10 @@
 
 <div class="mb-3">
 	<div class="flex justify-between items-center">
-		<div class="text-lg font-semibold self-center flex items-center space-x-2">
-			<span>{$i18n.t('Documents')}</span>
-			<span class="text-sm font-normal text-gray-500">({$documents.length})</span>
+		<div class="flex md:self-center text-lg font-medium px-0.5">
+			{$i18n.t('Documents')}
+			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-200 dark:bg-gray-700" />
+			<span class="text-lg font-medium text-gray-500 dark:text-gray-300">{$documents.length}</span>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
### Description

- Display the total number of documents in the UI. This is useful when uploading a large number of documents to verify that all have been uploaded.

### Screenshots or Videos

![image](https://github.com/user-attachments/assets/2b6dff06-aea1-41f8-9103-15c3aba83e54)
