### PR TITLE
fix: avoid overriding DATA_DIR and prevent errors when directories are the same

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -196,7 +196,7 @@ if PIP_INSTALL:
     NEW_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     # Check if the data directory exists in the package directory
-    if DATA_DIR.exists():
+    if DATA_DIR.exists() and DATA_DIR != NEW_DATA_DIR::
         log.info(f"Moving {DATA_DIR} to {NEW_DATA_DIR}")
         for item in DATA_DIR.iterdir():
             dest = NEW_DATA_DIR / item.name
@@ -205,7 +205,7 @@ if PIP_INSTALL:
             else:
                 shutil.copy2(item, dest)
 
-    DATA_DIR = OPEN_WEBUI_DIR / "data"
+    DATA_DIR = Path(os.getenv("DATA_DIR", OPEN_WEBUI_DIR / "data"))
 
 
 FRONTEND_BUILD_DIR = Path(os.getenv("FRONTEND_BUILD_DIR", BASE_DIR / "build")).resolve()

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -196,7 +196,7 @@ if PIP_INSTALL:
     NEW_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     # Check if the data directory exists in the package directory
-    if DATA_DIR.exists() and DATA_DIR != NEW_DATA_DIR::
+    if DATA_DIR.exists() and DATA_DIR != NEW_DATA_DIR:
         log.info(f"Moving {DATA_DIR} to {NEW_DATA_DIR}")
         for item in DATA_DIR.iterdir():
             dest = NEW_DATA_DIR / item.name
@@ -209,6 +209,7 @@ if PIP_INSTALL:
 
 
 FRONTEND_BUILD_DIR = Path(os.getenv("FRONTEND_BUILD_DIR", BASE_DIR / "build")).resolve()
+
 if PIP_INSTALL:
     FRONTEND_BUILD_DIR = Path(
         os.getenv("FRONTEND_BUILD_DIR", OPEN_WEBUI_DIR / "frontend")


### PR DESCRIPTION
# Changelog Entry

- Fix a bug related to existing DATA_DIR when using PIP_INSTALL as True

### Description

Previously, the `DATA_DIR` environment variable was always overridden by defaulting to `OPEN_WEBUI_DIR / "data"`, which ignored user-defined `DATA_DIR` values. Additionally, when `DATA_DIR` and `NEW_DATA_DIR` were the same, the script attempted to copy files into themselves, leading to errors or redundant operations.

This commit ensures that:
1. The `DATA_DIR` environment variable is respected and not overridden.
2. Copy operations between `DATA_DIR` and `NEW_DATA_DIR` are only performed if the directories are different, preventing errors when they point to the same location.

These changes resolve potential file copy errors and preserve user configurations.


### Fixed

 - These changes resolve potential file copy errors and preserve user configurations when DATA_DIR is set to already existing data directory of open-webui