### PR TITLE
fix: if cuda is not available fallback to cpu

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -39,6 +39,18 @@ def serve(
                 "/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib",
             ]
         )
+        try:
+            import torch
+            assert torch.cuda.is_available(), "CUDA not available"
+            typer.echo("CUDA seems to be working")
+        except Exception as e:
+            typer.echo(
+                "Error when testing CUDA but USE_CUDA_DOCKER is true. "
+                "Resetting USE_CUDA_DOCKER to false and removing "
+                f"LD_LIBRARY_PATH modifications: {e}"
+            )
+            os.environ["USE_CUDA_DOCKER"] = "false"
+            os.environ["LD_LIBRARY_PATH"] = ":".join(LD_LIBRARY_PATH)
     import open_webui.main  # we need set environment variables before importing main
 
     uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*")

--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -41,6 +41,7 @@ def serve(
         )
         try:
             import torch
+
             assert torch.cuda.is_available(), "CUDA not available"
             typer.echo("CUDA seems to be working")
         except Exception as e:

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -38,6 +38,7 @@ USE_CUDA = os.environ.get("USE_CUDA_DOCKER", "false")
 if USE_CUDA.lower() == "true":
     try:
         import torch
+
         assert torch.cuda.is_available(), "CUDA not available"
         DEVICE_TYPE = "cuda"
     except Exception as e:

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -36,7 +36,18 @@ except ImportError:
 USE_CUDA = os.environ.get("USE_CUDA_DOCKER", "false")
 
 if USE_CUDA.lower() == "true":
-    DEVICE_TYPE = "cuda"
+    try:
+        import torch
+        assert torch.cuda.is_available(), "CUDA not available"
+        DEVICE_TYPE = "cuda"
+    except Exception as e:
+        cuda_error = (
+            "Error when testing CUDA but USE_CUDA_DOCKER is true. "
+            f"Resetting USE_CUDA_DOCKER to false: {e}"
+        )
+        os.environ["USE_CUDA_DOCKER"] = "false"
+        USE_CUDA = "false"
+        DEVICE_TYPE = "cpu"
 else:
     DEVICE_TYPE = "cpu"
 
@@ -55,6 +66,9 @@ else:
 
 log = logging.getLogger(__name__)
 log.info(f"GLOBAL_LOG_LEVEL: {GLOBAL_LOG_LEVEL}")
+
+if "cuda_error" in locals():
+    log.exception(cuda_error)
 
 log_sources = [
     "AUDIO",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [ X ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ X ] **Description:** Provide a concise description of the changes made in this pull request.
- [ X ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ X ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ X ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ X ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ X ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ X ] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- If the user set `USE_CUDA_DOCKER` to `true` and (for one reason or another) CUDA is not available: fallback to CPU.

### Added

- Add check to see if torch.cuda.is_available() is True if USE_CUDA_DOCKER is true, if different then revert to CPU

---

### Additional Information

Related to the issue that caused #5378 in my case. My CUDA was not available for reasons unrelated to Open-WebUI but no check whatsoever was done until something tried to use cuda. In my case it was the hybrid search.

@tjbck I think this too illustrates that Open-WebUI does not have appropriate checks. IMO, asserts are cheap and will save everyone a lot of headache.

<details>
If you you think you're spread too thin over this project and that makes it hard to pay attention to everything in your code then I say all the more reason to use modern coding practices. It's a time saver, not a time drain. In practice: use asserts more, display errors to admins, add optional typechecking. But never forget to take care of yourself :).
<summary>
If I may offer an unsolicited piece of advice, click me.
</summary>
</details>


Edit: Sorry for the mess in the #5396 branch. The relevant code was moved from config.py to env.py. I did a workaround to log the exception when logging was initialized instead of moving the whole code arround. LMK if that's okay with you.
