### PR TITLE
feat: security response headers

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -109,6 +109,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import RedirectResponse, Response, StreamingResponse
 
+from open_webui.utils.security_headers import SecurityHeadersMiddleware
 
 from open_webui.utils.misc import (
     add_or_update_system_message,
@@ -788,6 +789,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 @app.middleware("http")

--- a/backend/open_webui/utils/security_headers.py
+++ b/backend/open_webui/utils/security_headers.py
@@ -23,6 +23,7 @@ def set_security_headers() -> Dict[str, str]:
     - x-content-type-options
     - x-download-options
     - x-frame-options
+    - x-permitted-cross-domain-policies
 
     Each environment variable is associated with a specific setter function
     that constructs the header. If the environment variable is set, the

--- a/backend/open_webui/utils/security_headers.py
+++ b/backend/open_webui/utils/security_headers.py
@@ -1,0 +1,119 @@
+import re
+import os
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from typing import Dict
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers.update(set_security_headers())
+        return response
+
+def set_security_headers() -> Dict[str, str]:
+    """
+    Sets security headers based on environment variables.
+
+    This function reads specific environment variables and uses their values
+    to set corresponding security headers. The headers that can be set are:
+    - cache-control
+    - strict-transport-security
+    - referrer-policy
+    - x-content-type-options
+    - x-download-options
+    - x-frame-options
+
+    Each environment variable is associated with a specific setter function
+    that constructs the header. If the environment variable is set, the
+    corresponding header is added to the options dictionary.
+
+    Returns:
+        dict: A dictionary containing the security headers and their values.
+    """
+    options = {}
+    header_setters = {
+        'CACHE_CONTROL': set_cache_control,
+        'HSTS': set_hsts,
+        'REFERRER_POLICY': set_referrer,
+        'XCONTENT_TYPE': set_xcontent_type,
+        'XDOWNLOAD_OPTIONS': set_xdownload_options,
+        'XFRAME_OPTIONS': set_xframe,
+        'XPERMITTED_CROSS_DOMAIN_POLICIES': set_xpermitted_cross_domain_policies,
+    }
+
+    for env_var, setter in header_setters.items():
+        value = os.environ.get(env_var, None)
+        if value:
+            header = setter(value)
+            if header:
+                options.update(header)
+
+    return options
+
+# Set HTTP Strict Transport Security(HSTS) response header
+def set_hsts(value: str):
+    pattern = r'^max-age=(\d+)(;includeSubDomains)?(;preload)?$'
+    match = re.match(pattern, value, re.IGNORECASE)
+    if not match:
+        return 'max-age=31536000;includeSubDomains'
+    return {
+        'Strict-Transport-Security': value
+    }
+
+# Set X-Frame-Options response header
+def set_xframe(value: str):
+    pattern = r'^(DENY|SAMEORIGIN)$'
+    match = re.match(pattern, value, re.IGNORECASE)
+    if not match:
+        value = 'DENY'
+    return {
+        "X-Frame-Options": value
+    }
+
+# Set Referrer-Policy response header
+def set_referrer(value: str):
+    pattern = r'^(no-referrer|no-referrer-when-downgrade|origin|origin-when-cross-origin|same-origin|strict-origin|strict-origin-when-cross-origin|unsafe-url)$'
+    match = re.match(pattern, value, re.IGNORECASE)
+    if not match:
+        value = 'no-referrer'
+    return {
+        'Referrer-Policy': value
+    }
+
+# Set Cache-Control response header
+def set_cache_control(value: str):
+    pattern = r'^(public|private|no-cache|no-store|must-revalidate|proxy-revalidate|max-age=\d+|s-maxage=\d+|no-transform|immutable)(,\s*(public|private|no-cache|no-store|must-revalidate|proxy-revalidate|max-age=\d+|s-maxage=\d+|no-transform|immutable))*$'
+    match = re.match(pattern, value, re.IGNORECASE)
+    if not match:
+        value = 'no-store, max-age=0'
+
+    return {
+        'Cache-Control': value
+    }
+
+# Set X-Download-Options response header
+def set_xdownload_options(value: str):
+    if value != 'noopen':
+        value = 'noopen'
+    return {
+        'X-Download-Options': value
+    }
+
+# Set X-Content-Type-Options response header
+def set_xcontent_type(value: str):
+    if value != 'nosniff':
+        value = 'nosniff'
+    return {
+        'X-Content-Type-Options': value
+    }
+
+# Set X-Permitted-Cross-Domain-Policies response header
+def set_xpermitted_cross_domain_policies(value: str):
+    pattern = r'^(none|master-only|by-content-type|by-ftp-filename)$'
+    match = re.match(pattern, value, re.IGNORECASE)
+    if not match:
+        value = 'none'
+    return {
+        'X-Permitted-Cross-Domain-Policies': value
+    }


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]
Introduced a middleware to enhance the security of web applications by adding configurable HTTP security headers. These headers can be used to mitigate various common web vulnerabilities and improve the overall security posture of the application.

### Added

- Created middleware to configure certain security response headers on Open-WebUI. The following headers can be configured on the application
  - Cache-Control : Controls browser caching policies. Configurable through the `CACHE_CONTROL` environment variable.
  - Referrer-Policy : Configures the amount of referrer information sent during navigation. Configured through the `REFERRER_POLICY` environment variable.
  - HTTP Strict Transport Security (HSTS) : Enforces HTTPS communication. Configurable via the `HSTS` environment variable.
  - X-Frame-Options : Prevents Clickjacking. Configurable using the `XFRAME_OPTIONS` environment variable to specify options.
  - X-Content-Type-Options : Prevents browsers from MIME-sniffing the content-type, forcing them to use the declared Content-Type header. Configurable using the `XCONTENT_TYPE` environment variable.
  - X-Download-Options : Restricts browser behaviours when handling file downloads to prevent executable downloads from running. Configurable using the `XDOWNLOAD_OPTIONS` environment variable.
  - X-Permitted-Cross-Domain-Policies : Limits permissible cross-domain policies to prevent unauthorized resource loading over domains.  Configurable using the `XPERMITTED_CROSS_DOMAIN_POLICIES` environment variable.

---

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/5e429761-9471-4005-a071-b29d69d219aa)


