### PR TITLE
downgrade authlib to 1.3.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,7 +69,7 @@ rank-bm25==0.2.2
 faster-whisper==1.0.3
 
 PyJWT[crypto]==2.9.0
-authlib==1.3.2
+authlib==1.3.1
 
 black==24.8.0
 langfuse==2.44.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "faster-whisper==1.0.3",
 
     "PyJWT[crypto]==2.9.0",
-    "authlib==1.3.2",
+    "authlib==1.3.1",
 
     "black==24.8.0",
     "langfuse==2.44.0",


### PR DESCRIPTION
#5544 fixing issue that crated due to bug in authlib 1.3.2 that prevent using any client id that have ":" in it