### PR TITLE
Add Python 3.11 venv and Open-WebUI setup scripts for Windows and Unix-like systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,4 @@ dist
 cypress/videos
 cypress/screenshots
 .vscode/settings.json
+myenv

--- a/run-pip.bat
+++ b/run-pip.bat
@@ -1,0 +1,28 @@
+@echo off
+
+:: Check if Python 3.11 is installed
+where python3.11.exe >nul 2>&1
+if "%ERRORLEVEL%"=="0" (
+    echo "Python 3.11 is already installed."
+) else (
+    echo "Installing Python 3.11..."
+    powershell -Command "Add-Type -AssemblyName PresentationCore; [void][System.Reflection.Assembly]::Load('PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35');"
+    powershell -Command "& { Invoke-WebRequest -Uri https://www.python.org/ftp/python/3.11.0/python-3.11.0-amd64.exe -OutFile python311.exe; Start-Process 'python311.exe' '-quiet -install -noconsole' };"
+)
+
+:: Create and activate the virtual environment
+set ENV_DIR=myenv
+if not exist "%ENV_DIR%" (
+    echo "Creating a virtual environment..."
+    powershell -Command "& { python3.11.exe -m venv '%ENV_DIR%'; }"
+)
+echo "Activating the virtual environment..."
+call "%ENV_DIR%\Scripts\activate"
+
+:: Install open-webui
+echo "Installing open-webui..."
+powershell -Command "& { pip install open-webui; }"
+
+:: Run open-webui
+echo "Running open-webui..."
+powershell -Command "& { open-webui serve; }"

--- a/run-pip.sh
+++ b/run-pip.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if Python 3.11 is installed
+if command -v python3.11 &> /dev/null; then
+    echo "Python 3.11 is already installed."
+else
+    echo "Installing Python 3.11..."
+    sudo add-apt-repository ppa:deadsnakes/ppa -y
+    sudo apt-get update
+    sudo apt-get install -y python3.11 python3.11-venv
+fi
+
+# Create and activate the virtual environment
+ENV_DIR="myenv"
+if [ ! -d "$ENV_DIR" ]; then
+    echo "Creating a virtual environment..."
+    python3.11 -m venv "$ENV_DIR"
+fi
+
+# Activate the virtual environment
+source "$ENV_DIR/bin/activate"
+
+# Install open-webui
+echo "Installing open-webui..."
+pip install open-webui
+
+# Run open-webui
+echo "Running open-webui..."
+open-webui serve


### PR DESCRIPTION
This change adds two new setup scripts to facilitate the creation of a virtual environment with Python 3.11 and installation of Open-WebUI on both Windows and Unix-like systems.

The first script, written in bash, checks if Python 3.11 is installed, creates a venv environment, activates it, installs Open-WebUI, and runs the server.

The second script, written in batch for Windows, performs similar tasks using PowerShell to interact with the system.

With this change, users can easily set up their project environments with Python 3.11 and Open-WebUI, regardless of their operating system.

**Changes made:**

* Added bash script for Unix-like systems to create venv environment with Python 3.11 and install Open-WebUI
* Added batch script for Windows to create venv environment with Python 3.11 and install Open-WebUI