### PR TITLE
build: Allow node to use more RAM during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN npm ci
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
 
 ######## WebUI backend ########


### PR DESCRIPTION
# Changelog Entry

### Description

Allow node to use more RAM during the npm run build step. I'm developing on an M1 Macbook Air with 16 GB of RAM. I've configured Orbstack which I use instead of Docker Desktop to let Docker use 12 GB of RAM. When building the Dockerfile Node only use around 2096 MB of RAM during the npm build step. After some troubleshooting I increased the limit to 4096 MB and the build completed successfully.

Not sure how this value is calculated or if it's fixed for everyone but you can check it with:

```sh
docker run --rm node:21-alpine3.19 node -e "console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024 + ' MB');"
```

### Changed

- Increase the amount of RAM node can use during build

