### PR TITLE
fix: close temporary file after creating it

### DIFF
--- a/backend/open_webui/apps/webui/utils.py
+++ b/backend/open_webui/apps/webui/utils.py
@@ -87,7 +87,7 @@ def load_toolkit_module_by_id(toolkit_id, content=None):
     # Create a temporary file and use it to define `__file__` so
     # that it works as expected from the module's perspective.
     temp_file = tempfile.NamedTemporaryFile(delete=False)
-
+    temp_file.close()
     try:
         with open(temp_file.name, "w", encoding="utf-8") as f:
             f.write(content)
@@ -131,6 +131,7 @@ def load_function_module_by_id(function_id, content=None):
     # Create a temporary file and use it to define `__file__` so
     # that it works as expected from the module's perspective.
     temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_file.close()
     try:
         with open(temp_file.name, "w", encoding="utf-8") as f:
             f.write(content)


### PR DESCRIPTION
This fixes "The process cannot access the file because it is being used by another process" errors on Windows.

The file is still automatically deleted by the `os.unlink` call later in the function.

Updates #5606
Fixes #5642

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** `dev`
- [x] **Description:** See above.
- [x] **Changelog:** See below.
- [x] **Documentation:** No documentation to update.
- [x] **Dependencies:**: No new dependencies.
- [x] **Testing:**: Manually verified in a Windows VM that calling `os.unlink(temp_file.name)` before calling `temp_file.close()` causes this error, and that calling `temp_file.close()` before `os.unlink(temp_file.name)` does not.
- [x] **Code review:**: OK.
- [x] **Prefix:** `fix`

# Changelog Entry

### Fixed

- Fix "The process cannot access the file because it is being used by another process" issue when adding functions/tools on Windows.