### PR TITLE
fix: Fix KaTeX Rendering

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,23 +8,6 @@ import { TTS_RESPONSE_SPLIT } from '$lib/types';
 // Helper functions
 //////////////////////////
 
-const convertLatexToSingleLine = (content) => {
-	// Patterns to match multiline LaTeX blocks
-	const patterns = [
-		/(\$\$\s[\s\S]*?\s\$\$)/g, // Match $$ ... $$
-		/(\\\[[\s\S]*?\\\])/g, // Match \[ ... \]
-		/(\\begin\{[a-z]+\}[\s\S]*?\\end\{[a-z]+\})/g // Match \begin{...} ... \end{...}
-	];
-
-	patterns.forEach((pattern) => {
-		content = content.replace(pattern, (match) => {
-			return match.replace(/\s*\n\s*/g, ' ').trim();
-		});
-	});
-
-	return content;
-};
-
 export const replaceTokens = (content, char, user) => {
 	const charToken = /{{char}}/gi;
 	const userToken = /{{user}}/gi;
@@ -68,7 +51,6 @@ export const sanitizeResponseContent = (content: string) => {
 };
 
 export const processResponseContent = (content: string) => {
-	content = convertLatexToSingleLine(content);
 	return content.trim();
 };
 

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -1,8 +1,8 @@
 import katex from 'katex';
 
 const DELIMITER_LIST = [
-	{ left: '$$', right: '$$', display: false },
 	{ left: '$', right: '$', display: false },
+	{ left: '$$', right: '$$', display: true },
 	{ left: '\\pu{', right: '}', display: false },
 	{ left: '\\ce{', right: '}', display: false },
 	{ left: '\\(', right: '\\)', display: false },
@@ -28,24 +28,24 @@ function escapeRegex(string) {
 
 function generateRegexRules(delimiters) {
 	delimiters.forEach((delimiter) => {
-		const { left, right } = delimiter;
+		const { left, right, display } = delimiter;
 		// Ensure regex-safe delimiters
 		const escapedLeft = escapeRegex(left);
 		const escapedRight = escapeRegex(right);
 
-		// Inline pattern - Capture group $1, token content, followed by end delimiter and normal punctuation marks.
-		// Example: $text$
-		inlinePatterns.push(
-			`${escapedLeft}((?:\\\\.|[^\\\\\\n])*?(?:\\\\.|[^\\\\\\n${escapedRight}]))${escapedRight}`
-		);
-
-		// Block pattern - Starts and ends with the delimiter on new lines. Example:
-		// $$\ncontent here\n$$
-		blockPatterns.push(`${escapedLeft}\n((?:\\\\[^]|[^\\\\])+?)\n${escapedRight}`);
+		if (!display) {
+			inlinePatterns.push(
+				`${escapedLeft}((?:\\\\.|[^\\\\\\n])*?(?:\\\\.|[^\\\\\\n${escapedRight}]))${escapedRight}`
+			);
+		} else {
+			blockPatterns.push(
+				`${escapedLeft}((?:\\\\.|[^\\\\\\n])*?(?:\\\\.|[^\\\\\\n${escapedRight}]))${escapedRight}`
+			);
+		}
 	});
 
 	const inlineRule = new RegExp(`^(${inlinePatterns.join('|')})(?=[\\s?!.,:？！。，：]|$)`, 'u');
-	const blockRule = new RegExp(`^(${blockPatterns.join('|')})(?:\n|$)`, 'u');
+	const blockRule = new RegExp(`^(${blockPatterns.join('|')})(?=[\\s?!.,:？！。，：]|$)`, 'u');
 
 	return { inlineRule, blockRule };
 }
@@ -55,84 +55,105 @@ const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
 export default function (options = {}) {
 	return {
 		extensions: [
-			inlineKatex(options, createRenderer(options, false)),
-			blockKatex(options, createRenderer(options, true))
+			inlineKatex(options),
+			blockKatex(options),
 		]
 	};
 }
 
-function createRenderer(options, newlineAfter) {
-	return (token) =>
-		katex.renderToString(token.text, { ...options, displayMode: token.displayMode }) +
-		(newlineAfter ? '\n' : '');
+function katexStart(src, displayMode: boolean) {
+	let ruleReg = displayMode ? blockRule : inlineRule;
+
+	let indexSrc = src;
+
+	while (indexSrc) {
+		let index = -1;
+		let startIndex = -1;
+		let startDelimiter = '';
+		let endDelimiter = '';
+		for (let delimiter of DELIMITER_LIST) {
+			if (delimiter.display !== displayMode) {
+				continue;
+			}
+
+			startIndex = indexSrc.indexOf(delimiter.left);
+			if (startIndex === -1) {
+				continue;
+			}
+
+			index = startIndex;
+			startDelimiter = delimiter.left;
+			endDelimiter = delimiter.right;
+		}
+
+		if (index === -1) {
+			return;
+		}
+
+		const f = index === 0 || indexSrc.charAt(index - 1) === ' ';
+		if (f) {
+			const possibleKatex = indexSrc.substring(index);
+
+			if (possibleKatex.match(ruleReg)) {
+				return index;
+			}
+		}
+
+		indexSrc = indexSrc.substring(index + startDelimiter.length).replace(endDelimiter, '');
+	}
 }
 
-function inlineKatex(options, renderer) {
-	const ruleReg = inlineRule;
+function katexTokenizer(src, tokens, displayMode: boolean) {
+	let ruleReg = displayMode ? blockRule : inlineRule;
+	let type = displayMode ? 'blockKatex' : 'inlineKatex';
+
+	const match = src.match(ruleReg);
+
+	if (match) {
+		const text = match
+			.slice(2)
+			.filter((item) => item)
+			.find((item) => item.trim());
+
+		if (displayMode) {
+			console.log("block matched", match[0]);
+		} else {
+			console.log("inline matched", match[0]);
+		}
+
+		return {
+			type,
+			raw: match[0],
+			text: text,
+			displayMode,
+		};
+	}
+}
+
+
+
+function inlineKatex(options) {
 	return {
 		name: 'inlineKatex',
 		level: 'inline',
 		start(src) {
-			let index;
-			let indexSrc = src;
-
-			while (indexSrc) {
-				index = indexSrc.indexOf('$');
-				if (index === -1) {
-					return;
-				}
-				const f = index === 0 || indexSrc.charAt(index - 1) === ' ';
-				if (f) {
-					const possibleKatex = indexSrc.substring(index);
-
-					if (possibleKatex.match(ruleReg)) {
-						return index;
-					}
-				}
-
-				indexSrc = indexSrc.substring(index + 1).replace(/^\$+/, '');
-			}
+			return katexStart(src, false);
 		},
 		tokenizer(src, tokens) {
-			const match = src.match(ruleReg);
-
-			if (match) {
-				const text = match
-					.slice(2)
-					.filter((item) => item)
-					.find((item) => item.trim());
-
-				return {
-					type: 'inlineKatex',
-					raw: match[0],
-					text: text
-				};
-			}
+			return katexTokenizer(src, tokens, false);
 		},
-		renderer
 	};
 }
 
-function blockKatex(options, renderer) {
+function blockKatex(options) {
 	return {
 		name: 'blockKatex',
 		level: 'block',
-		tokenizer(src, tokens) {
-			const match = src.match(blockRule);
-
-			if (match) {
-				const text = match
-					.slice(2)
-					.filter((item) => item)
-					.find((item) => item.trim());
-
-				return {
-					type: 'blockKatex',
-					raw: match[0],
-					text: text
-				};
-			}
+		start(src) {
+			return katexStart(src, true);
 		},
-		renderer
+		tokenizer(src, tokens) {
+			return katexTokenizer(src, tokens, true);
+		},
 	};
 }

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -55,7 +55,7 @@ const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
 export default function (options = {}) {
 	return {
 		extensions: [
-			blockKatex(options),
+			blockKatex(options), // This should be on top to prevent conflict with inline delimiters.
 			inlineKatex(options),
 		]
 	};

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -1,14 +1,14 @@
 import katex from 'katex';
 
 const DELIMITER_LIST = [
+	{ left: '$$\n', right: '\n$$', display: true },
+	{ left: '$$', right: '$$', display: false }, // This should be on top to prevent conflict with $ delimiter
 	{ left: '$', right: '$', display: false },
-	{ left: '$$', right: '$$', display: true },
 	{ left: '\\pu{', right: '}', display: false },
 	{ left: '\\ce{', right: '}', display: false },
 	{ left: '\\(', right: '\\)', display: false },
-	{ left: '( ', right: ' )', display: false },
-	{ left: '\\[', right: '\\]', display: true },
-	{ left: '[ ', right: ' ]', display: true }
+	{ left: '\\[\n', right: '\n\\]', display: true },
+	{ left: '\\[', right: '\\]', display: false },
 ];
 
 // const DELIMITER_LIST = [
@@ -55,8 +55,8 @@ const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
 export default function (options = {}) {
 	return {
 		extensions: [
-			inlineKatex(options),
 			blockKatex(options),
+			inlineKatex(options),
 		]
 	};
 }

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -35,11 +35,11 @@ function generateRegexRules(delimiters) {
 
 		if (!display) {
 			inlinePatterns.push(
-				`${escapedLeft}((?:\\\\.|[^\\\\\\n])*?(?:\\\\.|[^\\\\\\n${escapedRight}]))${escapedRight}`
+				`${escapedLeft}((?:\\\\[^]|[^\\\\])+?)${escapedRight}`
 			);
 		} else {
 			blockPatterns.push(
-				`${escapedLeft}((?:\\\\.|[^\\\\\\n])*?(?:\\\\.|[^\\\\\\n${escapedRight}]))${escapedRight}`
+				`${escapedLeft}((?:\\\\[^]|[^\\\\])+?)${escapedRight}`
 			);
 		}
 	});
@@ -108,6 +108,8 @@ function katexTokenizer(src, tokens, displayMode: boolean) {
 	let type = displayMode ? 'blockKatex' : 'inlineKatex';
 
 	const match = src.match(ruleReg);
+
+	console.log("searching:", src);
 
 	if (match) {
 		const text = match

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -109,8 +109,6 @@ function katexTokenizer(src, tokens, displayMode: boolean) {
 
 	const match = src.match(ruleReg);
 
-	console.log("searching:", src);
-
 	if (match) {
 		const text = match
 			.slice(2)

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -115,12 +115,6 @@ function katexTokenizer(src, tokens, displayMode: boolean) {
 			.filter((item) => item)
 			.find((item) => item.trim());
 
-		if (displayMode) {
-			console.log("block matched", match[0]);
-		} else {
-			console.log("inline matched", match[0]);
-		}
-
 		return {
 			type,
 			raw: match[0],


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR attempts to fix some issues in KaTex rendering, including:
- Inline KaTeX not rendering when using delimiters other than `$...$`
- Block KaTeX rendering as inline KaTeX

### Changed

- `$$...$$` is now correctly registered as displaymath
- Add start token computation for every math delimiter
- Correctly mark block KaTeX

---

### Screenshots or Videos

Here is the screenshot of previous version. The model is Qwen 2.5, which notably uses `\(...\)` and `\[...\]` as math delimiters.
<img width="815" alt="katex_old" src="https://github.com/user-attachments/assets/b1e3a85e-878a-4743-861d-1556054fb965">
Notice that block math equation is rendered as inline math equations, and some inline equations are not rendered.

In comparison, here is the screenshot after this PR:
<img width="809" alt="katex_new" src="https://github.com/user-attachments/assets/95ee84da-2578-4b77-8496-511febde79db">

