### PR TITLE
fix: Fix KaTeX Rendering (Followup)

### DIFF
--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -1,14 +1,13 @@
 import katex from 'katex';
 
 const DELIMITER_LIST = [
-	{ left: '$$\n', right: '\n$$', display: true },
-	{ left: '$$', right: '$$', display: false }, // This should be on top to prevent conflict with $ delimiter
+	{ left: '$$', right: '$$', display: true },
 	{ left: '$', right: '$', display: false },
 	{ left: '\\pu{', right: '}', display: false },
 	{ left: '\\ce{', right: '}', display: false },
 	{ left: '\\(', right: '\\)', display: false },
-	{ left: '\\[\n', right: '\n\\]', display: true },
-	{ left: '\\[', right: '\\]', display: false }
+	{ left: '\\[', right: '\\]', display: true },
+	{ left: '\\begin{equation}', right: '\\end{equation}', display: true }
 ];
 
 // const DELIMITER_LIST = [
@@ -34,14 +33,18 @@ function generateRegexRules(delimiters) {
 		const escapedRight = escapeRegex(right);
 
 		if (!display) {
+			// For inline delimiters, we match everyting
 			inlinePatterns.push(`${escapedLeft}((?:\\\\[^]|[^\\\\])+?)${escapedRight}`);
 		} else {
-			blockPatterns.push(`${escapedLeft}((?:\\\\[^]|[^\\\\])+?)${escapedRight}`);
+			// Block delimiters doubles as inline delimiters when not followed by a newline
+			inlinePatterns.push(`${escapedLeft}(?!\\n)((?:\\\\[^]|[^\\\\])+?)(?!\\n)${escapedRight}`);
+			blockPatterns.push(`${escapedLeft}\\n((?:\\\\[^]|[^\\\\])+?)\\n${escapedRight}`);
 		}
 	});
 
-	const inlineRule = new RegExp(`^(${inlinePatterns.join('|')})(?=[\\s?!.,:？！。，：]|$)`, 'u');
-	const blockRule = new RegExp(`^(${blockPatterns.join('|')})(?=[\\s?!.,:？！。，：]|$)`, 'u');
+	// Math formulas can end in special characters
+	const inlineRule = new RegExp(`^(${inlinePatterns.join('|')})(?=[\\s?。，!-\/:-@[-\`{-~]|$)`, 'u');
+	const blockRule = new RegExp(`^(${blockPatterns.join('|')})(?=[\\s?。，!-\/:-@[-\`{-~]|$)`, 'u');
 
 	return { inlineRule, blockRule };
 }
@@ -51,8 +54,8 @@ const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
 export default function (options = {}) {
 	return {
 		extensions: [
-			blockKatex(options), // This should be on top to prevent conflict with inline delimiters.
-			inlineKatex(options)
+			inlineKatex(options),
+			blockKatex(options),
 		]
 	};
 }
@@ -86,7 +89,9 @@ function katexStart(src, displayMode: boolean) {
 			return;
 		}
 
-		const f = index === 0 || indexSrc.charAt(index - 1) === ' ';
+		// Check if the delimiter is preceded by a special character.
+		// If it does, then it's potentially a math formula.
+		const f = index === 0 || indexSrc.charAt(index - 1).match(/[\s?。，!-\/:-@[-`{-~]/);
 		if (f) {
 			const possibleKatex = indexSrc.substring(index);
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

While most of the KaTeX rendering issues were fixed in #5655, there were some remaining corner cases. 
For example,
```
This was not registered as block math equation:
\[
abc
\]
```
```
But this was.

\[
x
\]
```
Also, mixing inline math and special characters lead to rendering errors, such as `(\(a\))`. This PR attempts to fix them.

### Changed

- Rewrote inline and block math delimiters. Following ChatGPT's behavior, now block math delimiters doubles as inline delimiters by not appending a newline character. For instance, `\[ ... \]` acts as an inline delimiter, and `\[\n ... \n\]` acts as an block delimiter.
- Added more checks to allowed special characters before/after inline math.
- Added `\begin{equation} ... \end{equation}` to the delimiters.

---


### Screenshots or Videos

Before:
<img width="743" alt="katex_old_1" src="https://github.com/user-attachments/assets/661d5a1d-6ec3-4b79-88cf-56bd190e9962">
After:
<img width="745" alt="katex_new_1" src="https://github.com/user-attachments/assets/8a29e717-3392-4ea4-88f4-268ae09596d7">
Before:
<img width="746" alt="katex_old_2" src="https://github.com/user-attachments/assets/0c58ffcd-34c8-4fab-8396-4ecbc56551b4">
After:
<img width="737" alt="katex_new_2" src="https://github.com/user-attachments/assets/d6f06b1d-6bdc-4c32-b8e5-e6151c57bee7">
It also fixes #3577.
Before:
<img width="732" alt="katex_old_3" src="https://github.com/user-attachments/assets/52fc52bb-6515-44b2-89e2-ba8f2d948587">
After:
<img width="737" alt="katex_new_3" src="https://github.com/user-attachments/assets/9c10197d-e401-4a19-8d8e-b719b50f1586">

