### PR TITLE
refac: remove docker warnings during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG UID=0
 ARG GID=0
 
 ######## WebUI frontend ########
-FROM --platform=$BUILDPLATFORM node:21-alpine3.19 as build
+FROM --platform=$BUILDPLATFORM node:21-alpine3.19 AS build
 ARG BUILD_HASH
 
 WORKDIR /app
@@ -30,7 +30,7 @@ ENV APP_BUILD_HASH=${BUILD_HASH}
 RUN npm run build
 
 ######## WebUI backend ########
-FROM python:3.11-slim-bookworm as base
+FROM python:3.11-slim-bookworm AS base
 
 # Use args
 ARG USE_CUDA
@@ -82,7 +82,7 @@ ENV HF_HOME="/app/backend/data/cache/embedding/models"
 
 WORKDIR /app/backend
 
-ENV HOME /root
+ENV HOME=/root
 # Create user and group if not root
 RUN if [ $UID -ne 0 ]; then \
     if [ $GID -ne 0 ]; then \
@@ -161,6 +161,6 @@ USER $UID:$GID
 
 ARG BUILD_HASH
 ENV WEBUI_BUILD_VERSION=${BUILD_HASH}
-ENV DOCKER true
+ENV DOCKER=true
 
 CMD [ "bash", "start.sh"]


### PR DESCRIPTION

# Changelog Entry

Remove docker warnings to ensure compatibility with future versions of Docker

### Description

- The official syntax for Dockerfile is described [here](https://docs.docker.com/reference/dockerfile/#env)
- ENV must use '='
- AS must be in upper case

