### PR TITLE
fix: ollama embed support list[str] or str on input

### DIFF
--- a/backend/open_webui/apps/ollama/main.py
+++ b/backend/open_webui/apps/ollama/main.py
@@ -547,7 +547,7 @@ class GenerateEmbeddingsForm(BaseModel):
 
 class GenerateEmbedForm(BaseModel):
     model: str
-    input: list[str]
+    input: list[str]|str
     truncate: Optional[bool] = None
     options: Optional[dict] = None
     keep_alive: Optional[Union[int, str]] = None


### PR DESCRIPTION
### Fixed
/ollama/api/embed

{"detail":[{"type":"list_type","loc":["body","input"],"msg":"Input should be a valid list","input":"some text"}]}

should support both list of string and a string.

always returns `{"embeddings: [[]]}` as direct to ollama