### PR TITLE
fix: disallow empty files

### DIFF
--- a/backend/open_webui/apps/webui/routers/files.py
+++ b/backend/open_webui/apps/webui/routers/files.py
@@ -47,6 +47,12 @@ def upload_file(file: UploadFile = File(...), user=Depends(get_verified_user)):
         file_path = f"{UPLOAD_DIR}/{filename}"
 
         contents = file.file.read()
+        if len(contents) == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.EMPTY_CONTENT,
+            )
+
         with open(file_path, "wb") as f:
             f.write(contents)
             f.close()

--- a/src/lib/components/workspace/Knowledge/Collection.svelte
+++ b/src/lib/components/workspace/Knowledge/Collection.svelte
@@ -115,6 +115,11 @@
 			itemId: tempItemId
 		};
 
+		if (fileItem.size == 0) {
+			toast.error($i18n.t('File must have content to be uploaded'));
+			return null;
+		}
+
 		knowledge.files = [...(knowledge.files ?? []), fileItem];
 
 		// Check if the file is an audio file and transcribe/convert it to text file


### PR DESCRIPTION
# Pull Request Checklist
The bound discussion can be found here: https://github.com/open-webui/open-webui/discussions/6108

# Changelog Entry

### Description
Uploading a file does not work on empty files. This causes a few errors and an endless spinny on the ui for that file.

### Added


### Changed
A check on the front end and backend to stop empty files before they get to the database
- [List any changes, updates, refactorings, or optimizations]

### Deprecated

### Removed

### Fixed
Can no longer send empty files

### Security


### Breaking Changes

---

### Additional Information


### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]
