### PR TITLE
chore: add googleapis-common-protos dep

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -86,3 +86,5 @@ duckduckgo-search~=6.2.13
 docker~=7.1.0
 pytest~=8.3.2
 pytest-docker~=3.1.1
+
+googleapis-common-protos=1.63.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "sentence-transformers==3.0.1",
     "colbert-ai==0.2.21",
     "einops==0.8.0",
-    
 
     "ftfy==6.2.3",
     "pypdf==4.3.1",
@@ -91,7 +90,9 @@ dependencies = [
 
     "docker~=7.1.0",
     "pytest~=8.3.2",
-    "pytest-docker~=3.1.1"
+    "pytest-docker~=3.1.1",
+
+    "googleapis-common-protos=1.63.2"
 ]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.12.0a1"


### PR DESCRIPTION
Fix #6207 - add missing dep from uv.lock to pyproject.toml

# Changelog Entry

### Description

- Added dep missing from pyproject.toml to resolve running app on NixOS