### PR TITLE
fix: default to False if stream is unavailable

### DIFF
--- a/backend/open_webui/apps/webui/main.py
+++ b/backend/open_webui/apps/webui/main.py
@@ -335,7 +335,7 @@ async def generate_function_chat_completion(form_data, user):
     pipe = function_module.pipe
     params = get_function_params(function_module, form_data, user, extra_params)
 
-    if form_data["stream"]:
+    if form_data.get("stream", False):
 
         async def stream_content():
             try:


### PR DESCRIPTION
# fix: KeyError in generate_chat_completions function

## Motivation
I've noticed a server error when trying to integrate this with Dify, and realized that, although the API has coded a mechanism to default the `stream` parameter to False if not specified, it is still being checked eagerly without making sure the key exists, causing a KeyError and thus an internal server error.

## Pull Request Checklist
- [x] **Target branch:** This pull request targets the `main` branch.
- [x] **Description:** This PR addresses a KeyError in the `generate_chat_completions` function caused by attempting to access a non-existent 'stream' key in the `form_data` dictionary.
- [x] **Changelog:** A changelog entry has been added at the bottom of this PR description.
- [ ] **Documentation:** No documentation updates were required for this fix.
- [ ] **Dependencies:** No new dependencies were added.
- [x] **Testing:** The fix has been tested with and without the 'stream' key in the form data.
- [x] **Code review:** A self-review of the code has been performed, ensuring adherence to project coding standards.

## Changelog Entry

### Description
- Fixed a KeyError in the `generate_chat_completions` function, improving the robustness of the chat completion generation process.

### Fixed
- Resolved the KeyError occurring when accessing the 'stream' key in `form_data` dictionary within the `generate_chat_completions` function.

### Changed
- Modified the `generate_chat_completions` function to safely check for the existence of the 'stream' key in `form_data`.
- Implemented a fallback mechanism when the 'stream' key is not present in the form data.

### Additional Information
- This fix prevents the application from crashing when the 'stream' key is not provided in the form data.
- Related to issue #[Issue Number] (if applicable)

**Docker Image for Testing:**
https://github.com/monotykamary/open-webui/pkgs/container/open-webui

**Logs:**
```
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/main.py", line 1091, in generate_chat_completions
    return await generate_function_chat_completion(form_data, user=user)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/apps/webui/main.py", line 338, in generate_function_chat_completion
    if form_data["stream"]:
       ~~~~~~~~~^^^^^^^^^^
KeyError: 'stream'
```

### Screenshots or Videos

Before:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/63030388-4716-407d-a569-24e6238bf529">

After:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/81abfb1e-0de7-4995-88ed-7629b4481635">

