### PR TITLE
fix: don't overwrite source.name with an URL, keep name so user can decide what should be visible

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -15,11 +15,6 @@
 				source = { ...source, name: metadata.name };
 			}
 
-			// Check if ID looks like a URL
-			if (id.startsWith('http://') || id.startsWith('https://')) {
-				source = { name: id };
-			}
-
 			const existingSource = acc.find((item) => item.id === id);
 
 			if (existingSource) {


### PR DESCRIPTION
I am setting up an external RAG system with URLs. But I don't want teh full URL shown in the Chat message.
In my opinion it is better not to overwrite the name. So the user can set it to the URL or a name, but when it is overwritten we can't set a custom name.
![image](https://github.com/user-attachments/assets/3edcdbd2-5d1e-4514-b952-c5fc316f37de)

In addition, when removing the overwrite it will be handled as in the detail dialog.
