### PR TITLE
improve url handling in citations

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -15,6 +15,11 @@
 				source = { ...source, name: metadata.name };
 			}
 
+			// Check if ID looks like a URL
+			if (id.startsWith('http://') || id.startsWith('https://')) {
+				source = { ...source, url: id };
+			}
+
 			const existingSource = acc.find((item) => item.id === id);
 
 			if (existingSource) {

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -15,11 +15,6 @@
 				source = { ...source, name: metadata.name };
 			}
 
-			// Check if ID looks like a URL
-			if (id.startsWith('http://') || id.startsWith('https://')) {
-				source = { name: id };
-			}
-
 			const existingSource = acc.find((item) => item.id === id);
 
 			if (existingSource) {

--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -66,8 +66,8 @@
 										class="hover:text-gray-500 hover:dark:text-gray-100 underline"
 										href={document?.metadata?.file_id
 											? `/api/v1/files/${document?.metadata?.file_id}/content${document?.metadata?.page !== undefined ? `#page=${document.metadata.page + 1}` : ''}`
-											: document.source.name.includes('http')
-												? document.source.name
+											: document.source?.url?.includes('http')
+												? document.source.url
 												: `#`}
 										target="_blank"
 									>


### PR DESCRIPTION
Make the use of urls more explicit in the handling of citations, this fixes the overwrite of the name when an id is an url.