### PR TITLE
feat: Allow URL in citations to be different from the displayed name

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -54,7 +54,7 @@
 				}
 
 				if (id.startsWith('http://') || id.startsWith('https://')) {
-					source = { name: id };
+					source = { ..source, url: id };
 				}
 
 				const existingSource = acc.find((item) => item.id === id);

--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -90,8 +90,8 @@
 										class="hover:text-gray-500 hover:dark:text-gray-100 underline flex-grow"
 										href={document?.metadata?.file_id
 											? `/api/v1/files/${document?.metadata?.file_id}/content${document?.metadata?.page !== undefined ? `#page=${document.metadata.page + 1}` : ''}`
-											: document.source.name.includes('http')
-												? document.source.name
+											: document.source?.url?.includes('http')
+												? document.source.url
 												: `#`}
 										target="_blank"
 									>


### PR DESCRIPTION
I have a RAG based Backend which hosts the source documents on a different server. When calling it through the OpenAI Interface, I am returning the citations but currently I was not able to set the displayed name independent of the URL.
I want the displayed name to be something like "myPDF.pdf" but it should link in the modal view to "http://test.de/myPDF.pdf". In order to do that, I had to remove the overwrite of the source.name field. It was getting overwritten as soon as the id is an URL. I now added a separate field url, that is set from the id, if it is an url.

Before:
![image](https://github.com/user-attachments/assets/76267e5a-5d21-4b34-ac73-446a4f9b2847)

After:
![image](https://github.com/user-attachments/assets/b0db4772-a3c7-4441-8067-4ba0c8fe22bd)

The documentation does currently not at all mention this capability of providing citations through the OpenAI Interface.


# Changelog Entry

### Description

- Allow an external URL in citations, but still display the filename to the user.
