### PR TITLE
Fix mismatch in environment variable assignment

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -383,7 +383,7 @@ OAUTH_USERNAME_CLAIM = PersistentConfig(
 )
 
 OAUTH_PICTURE_CLAIM = PersistentConfig(
-    "OAUTH_USERNAME_CLAIM",
+    "OAUTH_PICTURE_CLAIM",
     "oauth.oidc.avatar_claim",
     os.environ.get("OAUTH_PICTURE_CLAIM", "picture"),
 )


### PR DESCRIPTION
# Changelog Entry

### Description

- This pull request addresses a mismatch in environment variable `OAUTH_PICTURE_CLAIM` assignment that was causing mismatch in the oauth configuration.

### Fixed

- Changed `OAUTH_USERNAME_CLAIM` to `OAUTH_PICTURE_CLAIM`