### PR TITLE
fix: Prevent crash while setting Strict-Transport-Security security header

### DIFF
--- a/backend/open_webui/utils/security_headers.py
+++ b/backend/open_webui/utils/security_headers.py
@@ -60,7 +60,7 @@ def set_hsts(value: str):
     pattern = r"^max-age=(\d+)(;includeSubDomains)?(;preload)?$"
     match = re.match(pattern, value, re.IGNORECASE)
     if not match:
-        return "max-age=31536000;includeSubDomains"
+        value = "max-age=31536000;includeSubDomains"
     return {"Strict-Transport-Security": value}
 
 


### PR DESCRIPTION
Issue discussion: https://github.com/open-webui/open-webui/discussions/6431

# Changelog Entry

### Fixed

- Prevent crash while setting Strict-Transport-Security header through HSTS environment variable.