### PR TITLE
fix: Propagate file processing error to UI

### DIFF
--- a/backend/open_webui/apps/webui/routers/files.py
+++ b/backend/open_webui/apps/webui/routers/files.py
@@ -73,6 +73,7 @@ def upload_file(file: UploadFile = File(...), user=Depends(get_verified_user)):
         except Exception as e:
             log.exception(e)
             log.error(f"Error processing file: {file_item.id}")
+            raise e
 
         if file_item:
             return file_item


### PR DESCRIPTION
File processing may fall due to many reasons (fwiw, in my case it was old .doc upload - note, I'm not for supporting this format).  Now file processing error is logged, but not propagated. So, UI looks like everything is fine.  I think it's worth to throw through the underneath error, at least to display alarm box informing about troubles.

# Pull Request Checklist


**Before submitting, make sure you've checked the following:**

- [v] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [v] **Description:** Provide a concise description of the changes made in this pull request.
- [v] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [-] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [-] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [-] **Testing:** Have you written and run sufficient tests for validating the changes?
- [v] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [v] **Prefix:** 

# Changelog Entry

### Description

- Propagate processing error for uploaded files.

### Fixed

- Bug: uploaded file processing error silently ignored and just logged.  

---

### Additional Information 

that how it's logged (when fixed):

```
INFO  [open_webui.apps.webui.routers.files] file.content_type: application/msword
DEBUG [open_webui.apps.retrieval.main] text_content: 
INFO  [open_webui.apps.retrieval.main] save_docs_to_vector_db [Document(metadata={'source': '/app/backend/data/uploads/b3a3bef4-d7c9-42b9-a828-b7ae7537a1d0_1_3Polit2_T_Dmitr2.doc'}, page_content='')] file-b3a3bef4-d7c9-42b9-a828-b7ae7537a1d0
ERROR [open_webui.apps.retrieval.main] The content provided is empty. Please ensure that there is text or data present before proceeding.
Traceback (most recent call last):
  File "/app/backend/open_webui/apps/retrieval/main.py", line 858, in process_file
    raise e
  File "/app/backend/open_webui/apps/retrieval/main.py", line 832, in process_file
    result = save_docs_to_vector_db(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/apps/retrieval/main.py", line 663, in save_docs_to_vector_db
    raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
ValueError: The content provided is empty. Please ensure that there is text or data present before proceeding.
ERROR [open_webui.apps.webui.routers.files] 400: The content provided is empty. Please ensure that there is text or data present before proceeding.
Traceback (most recent call last):
  File "/app/backend/open_webui/apps/retrieval/main.py", line 858, in process_file
    raise e
  File "/app/backend/open_webui/apps/retrieval/main.py", line 832, in process_file
    result = save_docs_to_vector_db(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/apps/retrieval/main.py", line 663, in save_docs_to_vector_db
    raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
ValueError: The content provided is empty. Please ensure that there is text or data present before proceeding.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/backend/open_webui/apps/webui/routers/files.py", line 71, in upload_file
    process_file(ProcessFileForm(file_id=id))
  File "/app/backend/open_webui/apps/retrieval/main.py", line 867, in process_file
    raise HTTPException(
fastapi.exceptions.HTTPException: 400: The content provided is empty. Please ensure that there is text or data present before proceeding.
ERROR [open_webui.apps.webui.routers.files] Error processing file: b3a3bef4-d7c9-42b9-a828-b7ae7537a1d0
ERROR [open_webui.apps.webui.routers.files] 400: The content provided is empty. Please ensure that there is text or data present before proceeding.
Traceback (most recent call last):
  File "/app/backend/open_webui/apps/retrieval/main.py", line 858, in process_file
    raise e
  File "/app/backend/open_webui/apps/retrieval/main.py", line 832, in process_file
    result = save_docs_to_vector_db(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/apps/retrieval/main.py", line 663, in save_docs_to_vector_db
    raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
ValueError: The content provided is empty. Please ensure that there is text or data present before proceeding.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/backend/open_webui/apps/webui/routers/files.py", line 76, in upload_file
    raise e
  File "/app/backend/open_webui/apps/webui/routers/files.py", line 71, in upload_file
    process_file(ProcessFileForm(file_id=id))
  File "/app/backend/open_webui/apps/retrieval/main.py", line 867, in process_file
    raise HTTPException(
fastapi.exceptions.HTTPException: 400: The content provided is empty. Please ensure that there is text or data present before proceeding.
DEBUG [open_webui.main] Commit session after request
Collection file-b3a3bef4-d7c9-42b9-a828-b7ae7537a1d0 does not exist.
INFO:     172.17.0.1:49574 - "POST /api/v1/files/ HTTP/1.1" 400 Bad Request
```

### Screenshots or Videos

![Screenshot from 2024-10-26 15-20-14](https://github.com/user-attachments/assets/8b0cec31-07e6-4712-b9a5-c2c868f46701)
