### PR TITLE
fix: automatic1111 typo

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1279,7 +1279,7 @@ AUTOMATIC1111_CFG_SCALE = PersistentConfig(
 
 
 AUTOMATIC1111_SAMPLER = PersistentConfig(
-    "AUTOMATIC1111_SAMPLERE",
+    "AUTOMATIC1111_SAMPLER",
     "image_generation.automatic1111.sampler",
     (
         os.environ.get("AUTOMATIC1111_SAMPLER")


### PR DESCRIPTION
# Changelog Entry

### Description

- The `AUTOMATIC1111_SAMPLER` configuration in the`config.py` has a typo: `AUTOMATIC1111_SAMPLERE`

### Changed

- corrected to `AUTOMATIC1111_SAMPLER`
