### PR TITLE
fix: Remove max_completion_tokens restriction in title generation handler

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1571,7 +1571,7 @@ Artificial Intelligence in Healthcare
             {"max_tokens": 50}
             if app.state.MODELS[task_model_id]["owned_by"] == "ollama"
             else {
-                "max_completion_tokens": 50,
+                pass
             }
         ),
         "chat_id": form_data.get("chat_id", None),


### PR DESCRIPTION
# Changelog Entry

### Description

- This commit removes the `"max_completion_tokens": 50` line in `backend/open_webui/main.py` at line 1574. The restriction was causing issues with o1 models, where reasoning tokens were consuming significantly more and preventing valid titles from being generated. By setting the value to `pass` (removing the cap), the token limit is no longer enforced, preventing models from hitting the token ceiling before completion. This fix is needed to allow title generation when using o1 models.

### Changed

- Updated line 1574 in backend/open_webui/main.py


### Fixed

- #5729 
