### PR TITLE
fix: remove max_completion_tokens restriction when using o1 models

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1571,7 +1571,7 @@ Artificial Intelligence in Healthcare
             {"max_tokens": 50}
             if app.state.MODELS[task_model_id]["owned_by"] == "ollama"
             else {
-                "max_completion_tokens": 50,
+                pass
             }
         ),
         "chat_id": form_data.get("chat_id", None),

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1570,9 +1570,11 @@ Artificial Intelligence in Healthcare
         **(
             {"max_tokens": 50}
             if app.state.MODELS[task_model_id]["owned_by"] == "ollama"
-            else {
-                pass
-            }
+        else (
+                {}
+                if "o1" in task_model_id
+                else {"max_completion_tokens": 50}
+            )
         ),
         "chat_id": form_data.get("chat_id", None),
         "metadata": {"task": str(TASKS.TITLE_GENERATION), "task_body": form_data},

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1570,7 +1570,7 @@ Artificial Intelligence in Healthcare
         **(
             {"max_tokens": 50}
             if app.state.MODELS[task_model_id]["owned_by"] == "ollama"
-        else (
+            else (
                 {}
                 if "o1" in task_model_id
                 else {"max_completion_tokens": 50}


### PR DESCRIPTION
# Changelog Entry

### Description

- This commit removes the max_completion_token restriction only when using o1 models. The restriction was causing issues where reasoning tokens were consuming significantly more and preventing valid titles from being generated. This fix is needed to allow title generation when using o1 models.

### Fixed

- #5729 
