### PR TITLE
feat: A new parameter model called "native_tool_call" is added.

### DIFF
--- a/backend/open_webui/apps/ollama/main.py
+++ b/backend/open_webui/apps/ollama/main.py
@@ -730,6 +730,7 @@ async def generate_completion(
 class ChatMessage(BaseModel):
     role: str
     content: str
+    tool_calls: Optional[list[dict]] = None
     images: Optional[list[str]] = None
 
 
@@ -741,6 +742,7 @@ class GenerateChatCompletionForm(BaseModel):
     template: Optional[str] = None
     stream: Optional[bool] = True
     keep_alive: Optional[Union[int, str]] = None
+    tools: Optional[list[dict]] = None
 
 
 def get_ollama_url(url_idx: Optional[int], model: str):

--- a/backend/open_webui/apps/openai/main.py
+++ b/backend/open_webui/apps/openai/main.py
@@ -433,6 +433,10 @@ async def generate_chat_completion(
         if "max_tokens" in payload and "max_completion_tokens" in payload:
             del payload["max_tokens"]
 
+    # openai.com fails if it gets unknown arguments
+    if 'native_tool_call' in payload:
+        del payload['native_tool_call']
+
     # Fix: O1 does not support the "system" parameter, Modify "system" to "user"
     if is_o1 and payload["messages"][0]["role"] == "system":
         payload["messages"][0]["role"] = "user"

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -9,7 +9,7 @@ import sys
 import time
 import random
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, Callable
 
 import aiohttp
 import requests
@@ -367,6 +367,252 @@ async def get_content_from_response(response) -> Optional[str]:
         content = response["choices"][0]["message"]["content"]
     return content
 
+def get_tools_body(
+    body: dict, user: UserModel, extra_params: dict
+) -> tuple[dict, dict]:
+    metadata = body.get("metadata", {})
+
+    tool_ids = metadata.get("tool_ids", None)
+    log.debug(f"{tool_ids=}")
+    if not tool_ids:
+        return body, {}
+
+    task_model_id = get_task_model_id(body["model"])
+    tools = get_tools(
+        webui_app,
+        tool_ids,
+        user,
+        {
+            **extra_params,
+            "__model__": app.state.MODELS[task_model_id],
+            "__messages__": body["messages"],
+            "__files__": metadata.get("files", []),
+        },
+    )
+    log.info(f"{tools=}")
+
+    specs = [tool["spec"] for tool in tools.values()]
+
+    tools_args = [ { "type" : "function", "function" : spec } \
+            for spec in specs ]
+    body["tools"] = tools_args
+
+    return body, tools
+
+def update_body_request(request: Request,
+                        body: dict) -> None:
+    modified_body_bytes = json.dumps(body).encode("utf-8")
+    # Replace the request body with the modified one
+    request._body = modified_body_bytes
+    # Set custom header to ensure content-length matches new body length
+    request.headers.__dict__["_list"] = [
+        (b"content-length", str(len(modified_body_bytes)).encode("utf-8")),
+        *[(k, v) for k, v in request.headers.raw if k.lower() != b"content-length"],
+        ]
+    return None
+
+def extract_json(binary:bytes)->dict:
+    try:
+        s = binary.decode("utf-8")
+        return json.loads(s[ s.find("{") : s.rfind("}") + 1 ])
+    except Exception as e:
+        return None
+
+def fill_with_delta(fcall_dict:dict, delta:dict) -> None:
+    if not 'delta' in delta['choices'][0]:
+        return
+    j = delta['choices'][0]['delta']['tool_calls'][0]
+    if 'id' in j:
+        fcall_dict["id"] += j["id"] or ''
+    if 'function' in j:
+        if 'name' in j['function']:
+            fcall_dict['function']['name'] += j['function']['name'] or ''
+        if 'arguments' in j['function']:
+            fcall_dict['function']['arguments'] += j['function']['arguments'] or ''
+
+async def handle_streaming_response(request: Request, response: Response, 
+                                    tools: dict,
+                                    data_items: list,
+                                    call_next: Callable,
+                                    user : UserModel) -> StreamingResponse:
+
+    content_type = response.headers["Content-Type"]
+    is_openai = "text/event-stream" in content_type
+    is_ollama = "application/x-ndjson" in content_type
+    def wrap_item(item):
+        return f"data: {item}\n\n" if is_openai else f"{item}\n"
+
+    async def stream_wrapper(original_generator, data_items):
+        for item in data_items:
+            yield wrap_item(json.dumps(item))
+
+        citations = []
+        body = json.loads(request._body)
+        generator = original_generator
+        try:
+            while True:
+                peek = await anext(generator)
+                peek_json = extract_json(peek)
+                if peek == b'data: [DONE]\n' and len(citations) > 0 :
+                    yield wrap_item(json.dumps({ "citations" : citations}))
+
+                if peek_json is None or \
+                        not 'choices' in peek_json or \
+                        not 'tool_calls' in peek_json['choices'][0]['delta']:
+                    yield peek
+                    continue
+
+                # We reached a tool call we consume all the messages to assemble it
+                log.debug("async tool call detected")
+                tool_calls = [] # id, name, arguments
+                tool_calls.append({'id':'', 'type': 'function', 'function' : {'name':'', 'arguments':''}})
+                current_index = peek_json['choices'][0]['delta']['tool_calls'][0]['index']
+                fill_with_delta(tool_calls[current_index], peek_json)
+
+                async for data in generator:
+                    delta = extract_json(data)
+
+                    if delta is None or \
+                            not 'choices' in delta or \
+                            not 'tool_calls' in delta['choices'][0]['delta']  or \
+                            delta['choices'][0].get('finish_reason', None) is not None:
+                        continue
+
+                    i = delta['choices'][0]['delta']['tool_calls'][0]['index']
+                    if i != current_index:
+                        tool_calls.append({'id':'', 'type': 'function', 'function' : {'name':'', 'arguments':''}})
+                        current_index = i
+
+                    fill_with_delta(tool_calls[i], delta)
+
+                log.debug(f"tools to call { [ t['function']['name'] for t in tool_calls] }")
+
+                body["messages"].append( {'role': 'assistant',
+                                          'content': None,
+                                          'refusal': None,
+                                          'tool_calls': tool_calls })
+
+                for tool_call in tool_calls:
+                    tool_function_name = tool_call["function"]["name"]
+                    tool_function_params = extract_json(tool_call["function"]["arguments"])
+
+                    if not tool_call["function"]["arguments"]:
+                        tool_function_params = {}
+                    else:
+                        tool_function_params = json.loads(tool_call["function"]["arguments"]) 
+
+                    log.debug(f"calling {tool_function_name} with params {tool_function_params}")
+                    try:
+                        tool_output = await tools[tool_function_name]["callable"](**tool_function_params)
+                    except Exception as e:
+                        tool_output = str(e)
+
+                    # With several tools potentially called together may be this doesn't make sense
+                    if tools[tool_function_name]["file_handler"] and "files" in body.get("metadata", {}):
+                        del body["metadata"]["files"]
+
+                    if tools[tool_function_name]["citation"]:
+                        citations.append( {
+                            "source": {
+                                "name": f"TOOL:{tools[tool_function_name]['toolkit_id']}/{tool_function_name}"
+                            },
+                            "document": [tool_output],
+                            "metadata": [{"source": tool_function_name}],
+                           })
+                    # Append the tool output to the messages
+                    body["messages"].append({
+                        "role": "tool",
+                        "tool_call_id" : tool_call["id"],
+                        "name": tool_function_name,
+                        "content": tool_output
+                    })
+
+                # Make another request to the model with the updated context
+                log.debug("calling the model again with tool output included")
+                update_body_request(request, body)
+                response = await generate_chat_completions(form_data = body, user = user )
+                # body_iterator here does not have __anext_() so it has to be done this way
+                generator = response.body_iterator.__aiter__()
+
+        except StopAsyncIteration:
+            pass
+        except Exception as e:
+            log.exception(f"Error: {e}")
+
+    return StreamingResponse(
+            stream_wrapper(response.body_iterator, data_items),
+            headers=dict(response.headers),
+        )
+
+async def handle_nonstreaming_response(request: Request, response: Response,
+                                       tools: dict, user: UserModel, data_items: list) -> JSONResponse:
+    # It only should be one response since we are in the non streaming scenario
+    content = ''
+    async for data in response.body_iterator:
+        content += data.decode()
+    citations = []
+    response_dict = json.loads(content)
+    body = json.loads(request._body)
+
+    is_ollama = False
+    if app.state.MODELS[body["model"]]["owned_by"] == "ollama":
+        is_ollama = True
+    is_openai = not is_ollama
+
+    while (is_ollama and "tool_calls" in response_dict.get("message", {})) or \
+          (is_openai and "tool_calls" in response_dict.get("choices", [{}])[0].get("message",{}) ):
+        if is_ollama:
+            message = response_dict.get("message", {})
+            tool_calls = message.get("tool_calls", [])
+            if message:
+                body["messages"].append(message)
+        else:
+            body["messages"].append(response_dict["choices"][0]["message"])
+            tool_calls = response_dict["choices"][0]["message"].get("tool_calls", [])
+
+        for tool_call in tool_calls:
+            # fix for cohere
+            if 'index' in tool_call:
+                del tool_call['index']
+
+            tool_function_name = tool_call["function"]["name"]
+            if not tool_call["function"]["arguments"]:
+                tool_function_params = {}
+            else:
+                if is_openai:
+                    tool_function_params = json.loads(tool_call["function"]["arguments"])
+                if is_ollama:
+                    tool_function_params = tool_call["function"]["arguments"]
+
+            try:
+                tool_output = await tools[tool_function_name]["callable"](**tool_function_params)
+            except Exception as e:
+                tool_output = str(e)
+
+            if tools.get(tool_function_name, {}).get("citation", False):
+                citations.append( {
+                            "source": {
+                                "name": f"TOOL:{tools[tool_function_name]['toolkit_id']}/{tool_function_name}"
+                            },
+                            "document": [tool_output],
+                            "metadata": [{"source": tool_function_name}],
+                           })
+
+            # Append the tool output to the messages
+            body["messages"].append({
+                "role": "tool",
+                "tool_call_id" : tool_call.get("id",""),
+                "name": tool_function_name,
+                "content": tool_output
+            })
+
+        # Make another request to the model with the updated context
+        update_body_request(request, body)
+        response_dict = await generate_chat_completions(form_data = body, user = user, as_openai = is_openai)
+
+    #FIXME: is it possible to handle citations?
+    return JSONResponse(content = response_dict)
+
 
 async def chat_completion_tools_handler(
     body: dict, user: UserModel, extra_params: dict
@@ -554,6 +800,7 @@ class ChatCompletionMiddleware(BaseHTTPMiddleware):
             "session_id": body.pop("session_id", None),
             "tool_ids": body.get("tool_ids", None),
             "files": body.get("files", None),
+            "native_tool_call": body.pop("native_tool_call", False),
         }
         body["metadata"] = metadata
 
@@ -591,12 +838,22 @@ class ChatCompletionMiddleware(BaseHTTPMiddleware):
         }
         body["metadata"] = metadata
 
-        try:
-            body, flags = await chat_completion_tools_handler(body, user, extra_params)
-            contexts.extend(flags.get("contexts", []))
-            citations.extend(flags.get("citations", []))
-        except Exception as e:
-            log.exception(e)
+        body, tools = get_tools_body(body, user, extra_params)
+
+        if model["owned_by"] == "ollama" and \
+                body["metadata"]["native_tool_call"] and \
+                body.get("stream", False):
+            log.info("Ollama models don't support function calling in streaming yet. forcing native_tool_call to False")
+            body["metadata"]["native_tool_call"] = False
+
+        if not body["metadata"]["native_tool_call"]:
+            del body["tools"] # we won't use those
+            try:
+                body, flags = await chat_completion_tools_handler(body, user, extra_params)
+                contexts.extend(flags.get("contexts", []))
+                citations.extend(flags.get("citations", []))
+            except Exception as e:
+                log.exception(e)
 
         try:
             body, flags = await chat_completion_files_handler(body)
@@ -641,39 +898,37 @@ class ChatCompletionMiddleware(BaseHTTPMiddleware):
         if len(citations) > 0:
             data_items.append({"citations": citations})
 
-        modified_body_bytes = json.dumps(body).encode("utf-8")
-        # Replace the request body with the modified one
-        request._body = modified_body_bytes
-        # Set custom header to ensure content-length matches new body length
-        request.headers.__dict__["_list"] = [
-            (b"content-length", str(len(modified_body_bytes)).encode("utf-8")),
-            *[(k, v) for k, v in request.headers.raw if k.lower() != b"content-length"],
-        ]
-
+        update_body_request(request, body)
         response = await call_next(request)
-        if not isinstance(response, StreamingResponse):
-            return response
 
-        content_type = response.headers["Content-Type"]
-        is_openai = "text/event-stream" in content_type
-        is_ollama = "application/x-ndjson" in content_type
-        if not is_openai and not is_ollama:
-            return response
+        if not body["metadata"]["native_tool_call"]:
 
-        def wrap_item(item):
-            return f"data: {item}\n\n" if is_openai else f"{item}\n"
+            if not isinstance(response, StreamingResponse):
+                return response
+            content_type = response.headers["Content-Type"]
+            is_openai = "text/event-stream" in content_type
+            is_ollama = "application/x-ndjson" in content_type
+            if not is_openai and not is_ollama:
+               return response
 
-        async def stream_wrapper(original_generator, data_items):
-            for item in data_items:
-                yield wrap_item(json.dumps(item))
+            def wrap_item(item):
+                return f"data: {item}\n\n" if is_openai else f"{item}\n"
 
-            async for data in original_generator:
-                yield data
+            async def stream_wrapper(original_generator, data_items):
+                for item in data_items:
+                    yield wrap_item(json.dumps(item))
 
-        return StreamingResponse(
-            stream_wrapper(response.body_iterator, data_items),
-            headers=dict(response.headers),
-        )
+                async for data in original_generator:
+                    yield data
+
+            return StreamingResponse(
+                stream_wrapper(response.body_iterator, data_items),
+                headers=dict(response.headers),
+            )
+        else:
+            if not body.get("stream", False):
+                return await handle_nonstreaming_response(request, response, tools, user, data_items)
+            return await handle_streaming_response(request, response, tools, data_items, call_next, user)
 
     async def _receive(self, body: bytes):
         return {"type": "http.request", "body": body, "more_body": False}
@@ -1095,9 +1350,8 @@ async def get_models(user=Depends(get_verified_user)):
 
 
 @app.post("/api/chat/completions")
-async def generate_chat_completions(
-    form_data: dict, user=Depends(get_verified_user), bypass_filter: bool = False
-):
+async def generate_chat_completions(form_data: dict, user=Depends(get_verified_user),
+                                    bypass_filter: bool = False, as_openai:bool = True):
     model_id = form_data["model"]
 
     if model_id not in app.state.MODELS:
@@ -1166,6 +1420,7 @@ async def generate_chat_completions(
     if model["owned_by"] == "ollama":
         # Using /ollama/api/chat endpoint
         form_data = convert_payload_openai_to_ollama(form_data)
+        log.debug(f"{form_data=}")
         form_data = GenerateChatCompletionForm(**form_data)
         response = await generate_ollama_chat_completion(
             form_data=form_data, user=user, bypass_filter=True
@@ -1173,11 +1428,11 @@ async def generate_chat_completions(
         if form_data.stream:
             response.headers["content-type"] = "text/event-stream"
             return StreamingResponse(
-                convert_streaming_response_ollama_to_openai(response),
+                convert_streaming_response_ollama_to_openai(response) if as_openai else response,
                 headers=dict(response.headers),
             )
         else:
-            return convert_response_ollama_to_openai(response)
+            return convert_response_ollama_to_openai(response) if as_openai else response
     else:
         return await generate_openai_chat_completion(form_data, user=user)
 

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -153,6 +153,8 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
         openai_payload.get("messages")
     )
     ollama_payload["stream"] = openai_payload.get("stream", False)
+    if "tools" in openai_payload:
+        ollama_payload["tools"] = openai_payload["tools"]
 
     # If there are advanced parameters in the payload, format them in Ollama's options field
     ollama_options = {}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1165,8 +1165,14 @@
 			$settings?.params?.stream_response ??
 			params?.stream_response ??
 			true;
+		const native_tool_call =
+			model?.info?.params?.native_tool_call ??
+			$settings?.params?.native_tool_call ??
+			params?.native_tool_call ??
+			false;
 		const [res, controller] = await generateChatCompletion(localStorage.token, {
 			stream: stream,
+			native_tool_call: native_tool_call,
 			model: model.id,
 			messages: messagesBody,
 			options: {
@@ -1495,10 +1501,17 @@
 				params?.stream_response ??
 				true;
 
+			const native_tool_call =
+				model?.info?.params?.native_tool_call ??
+				$settings?.params?.native_tool_call ??
+				params?.native_tool_call ??
+				true;
+
 			const [res, controller] = await generateOpenAIChatCompletion(
 				localStorage.token,
 				{
 					stream: stream,
+					native_tool_call : native_tool_call,
 					model: model.id,
 					...(stream && (model.info?.meta?.capabilities?.usage ?? false)
 						? {

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -12,6 +12,7 @@
 	export let params = {
 		// Advanced
 		stream_response: null, // Set stream responses for this model individually
+		native_tool_call: null,
 		seed: null,
 		stop: null,
 		temperature: null,
@@ -79,6 +80,36 @@
 			</div>
 		</Tooltip>
 	</div>
+	<div>
+		<div class=" py-0.5 flex w-full justify-between">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Native Tool Calls')}
+			</div>
+
+			<button
+				class="p-1 px-3 text-xs flex rounded transition"
+				on:click={() => {
+					params.native_tool_call=
+						(params?.native_tool_call?? null) === null
+							? true
+							: params.native_tool_call
+								? false
+								: null;
+				}}
+				type="button"
+			>
+				{#if params.native_tool_call === true}
+					<span class="ml-2 self-center">{$i18n.t('On')}</span>
+				{:else if params.native_tool_call === false}
+					<span class="ml-2 self-center">{$i18n.t('Off')}</span>
+				{:else}
+					<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+				{/if}
+			</button>
+		</div>
+	</div>
+
+
 
 	<div class=" py-0.5 w-full justify-between">
 		<Tooltip


### PR DESCRIPTION
(squashed commit for easier review)

A new parameter model called "native_tool_call" is added.

If false (the default), the behaviour when there are tools enabled doesn't change: a prompt is built which asks the model to generate a function call compatible with the offered tools. If it's valid the ouput is the added to the context.

If true, the native mechanism that the API has is used instead. That means that the responses have to be inspected to detect if a tool_call has to be handled and act accordingly. This allows more complex  behaviours where the model can try several strategies and call tools knowing the output of others.

Ollama tool calling API only supports non streaming requests. In case both streaming and native_tool call are present, native tool calling is silently ignored.

## Testing

The feature has been tested through the ui and using a script which calls these endpoints using
/api/chat/completions 
/ollama/api/chat

With the OpenAI API, these models have been tested, with varying success
- OK
    gpt-4o-mini
    qwen/qwen-2.5-72b-instruct (OpenRouter endpoint)
    anthropic/claude-3-haiku  (OpenRouter endpoint)
    deepseek/deepseek-chat  (OpenRouter endpoint)
    google/gemini-pro  (OpenRouter endpoint)
- Partial support
   cohere/command-r-plus (OpenRouter endpoint)

-Fails
   meta-llama/llama-3.1-70b-instruct  (OpenRouter endpoint)

With the Ollama API, only  llama3.2:3b has been tested.

These are  prompts used with two functions provided:
 - get_current_time
 - get_sensor_data with a single argument which just returns the sensorid multiplied by two.

```
("what is the first letter of the latin alphabet",  "no tools needed"),
("what is the date of today (use the get_current_time function)", " 1 tool no args"),
("what is the value of sensor 1", " 1 tool with args"),
("what are the value of sensors 1 and 4", " 2 tools (the may be run in parallel if the API supports it )"),
("if the value of sensors 1 is less that 5 m/s report the value of sensor 4. Otherwise report sensor 3", " 2 tools (in s
equence if the model does it )"),
("choose a integer between 1 an 10 write it here. If it's bigger that 5 report sensor 4. Otherwise report sensor 1", " tool call after having generated some text"),
("what is the value of sensor 'HELLO' ",  "tool call raises an exception")
```
The full output is attached to the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [-] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
If the PR gets accepted, I will update the docs accordingly.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the docume
ntation?
- [X] **Testing:** Have you written and run sufficient tests for validating the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
A new parameter model called "native_tool_call" is added. If set to true, the tool calls are performed using the API and not the prompt based approach used until now.

[output.txt](https://github.com/user-attachments/files/17691240/output.txt)
