### PR TITLE
feat: Add support for routing LLM backend api requests to the same instance among multiple replicas

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -391,3 +391,9 @@ else:
 ####################################
 
 OFFLINE_MODE = os.environ.get("OFFLINE_MODE", "false").lower() == "true"
+
+####################################
+# PASSTHROUGH_SESSION_COOKIES
+####################################
+
+PASSTHROUGH_SESSION_COOKIES = os.environ.get("PASSTHROUGH_SESSION_COOKIES", None)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

When multiple instances of vLLM/OLLAMA are deployed behind a loadbalancer, sticky sessions are enabled in the load balancer to route requests from a client to the backend it originally hit to ensure KV-Cache reuse. One way to implement sticky sessions is via a cookie that the loadbalancer sends to the client.

This adds support for setting an env var named PASSTHROUGH_SESSION_COOKIES that stores a comma separated list of cookie names. Open-Webui already sends back any cookies it receives from the LM backend to the browser. If this var is set, any cookies matching this names in this list that it receives from the browser in subsequent requests will be forwarded on to the LM backend

### Added

- Adds an env var `PASSTHROUGH_SESSION_COOKIES` that is set at runtime. This contains a list of cookie names to passthrough to the LLM backend 

### Changed


### Deprecated

### Removed

### Fixed

### Security

### Breaking Changes

---

### Additional Information
- Implements https://github.com/open-webui/open-webui/discussions/6857
- Tested both OpenAI backend(using vLLM) and Ollama backend and observed that all requests go to the same replica when this feature is enabled
- Made sure that the following tests defined within github actions passed - `format_backend.yaml`, `format-build-frontend-yaml`. `ingegration-test.yaml` failed [here](https://github.com/asrinivasanTT/open-webui/actions/runs/11733096285) but it looks like that was due to the website responding slowly and not related to this commit
- Not sure what extra tests to add for this as it's difficult to test without a multi replica LLM api backend setup and a loadbalancer
- Do I need to add anything to the docs repo as well, documenting this env var? 

### Screenshots or Videos
