### PR TITLE
fix/feat: Revert DOMPurify in citations HTML

### DIFF
--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import DOMPurify from 'dompurify';
-
 	import { getContext, onMount, tick } from 'svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -151,11 +149,7 @@
 							{$i18n.t('Content')}
 						</div>
 						<pre class="text-sm dark:text-gray-400 whitespace-pre-line">
-							{#if document.metadata?.html}
-								{@html DOMPurify(document.document)}
-							{:else}
-								{document.document}
-							{/if}
+							{document.document}
 						</pre>
 					</div>
 

--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -149,7 +149,11 @@
 							{$i18n.t('Content')}
 						</div>
 						<pre class="text-sm dark:text-gray-400 whitespace-pre-line">
-							{document.document}
+							{#if document.metadata?.html}
+								{@html document.document}
+							{:else}
+								{document.document}
+							{/if}
 						</pre>
 					</div>
 


### PR DESCRIPTION
Reverts open-webui/open-webui#6879

Is there a reason to use `DOMPurify` here? I had used it originally for security reasons just in case, but now that we've got artifacts that render unsanitised HTML I don't see why sanitising it in citations is necessary.

Or is there another mechanism that prevents artifacts from running malicious code, in which case, can we re-use that?

`DOMPurify` with the default configuration breaks things like `iframe` which can be useful for citations