### PR TITLE
feat: add API key support for Qdrant Cloud authentication

### DIFF
--- a/backend/open_webui/apps/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/apps/retrieval/vector/dbs/qdrant.py
@@ -5,7 +5,7 @@ from qdrant_client.http.models import PointStruct
 from qdrant_client.models import models
 
 from open_webui.apps.retrieval.vector.main import VectorItem, SearchResult, GetResult
-from open_webui.config import QDRANT_URI
+from open_webui.config import QDRANT_URI, QDRANT_API_KEY
 
 NO_LIMIT = 999999999
 
@@ -14,7 +14,11 @@ class QdrantClient:
     def __init__(self):
         self.collection_prefix = "open-webui"
         self.QDRANT_URI = QDRANT_URI
-        self.client = Qclient(url=self.QDRANT_URI) if self.QDRANT_URI else None
+        self.QDRANT_API_KEY = QDRANT_API_KEY
+        self.client = Qclient(
+                url=self.QDRANT_URI,
+                api_key=self.QDRANT_API_KEY
+                ) if self.QDRANT_URI else None
 
     def _result_to_get_result(self, points) -> GetResult:
         ids = []

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -954,6 +954,7 @@ MILVUS_URI = os.environ.get("MILVUS_URI", f"{DATA_DIR}/vector_db/milvus.db")
 
 # Qdrant
 QDRANT_URI = os.environ.get("QDRANT_URI", None)
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY", None)
 
 ####################################
 # Information Retrieval (RAG)


### PR DESCRIPTION
This PR adds support for authenticating with Qdrant Cloud using an API key. By setting the `QDRANT_API_KEY` environment variable, users can enable secure, authenticated access to Qdrant Cloud, with the key being passed to the Qdrant client in `qdrant.py`.

#### Changelog Entry
**Added:**
- Environment variable `QDRANT_API_KEY` to support secure API key authentication for Qdrant Cloud.


