### PR TITLE
fix get groups by member id postgres

### DIFF
--- a/backend/open_webui/apps/webui/models/groups.py
+++ b/backend/open_webui/apps/webui/models/groups.py
@@ -11,7 +11,7 @@ from open_webui.apps.webui.models.files import FileMetadataResponse
 
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import BigInteger, Column, String, Text, JSON
+from sqlalchemy import BigInteger, Column, String, Text, JSON, func
 
 
 log = logging.getLogger(__name__)
@@ -128,7 +128,8 @@ class GroupTable:
             return [
                 GroupModel.model_validate(group)
                 for group in db.query(Group)
-                .filter(Group.user_ids.contains([user_id]))
+                .filter(func.json_array_length(Group.user_ids) > 0)  # Ensure array exists
+                .filter(Group.user_ids.cast(String).like(f'%"{user_id}"%'))  # String-based check
                 .order_by(Group.updated_at.desc())
                 .all()
             ]


### PR DESCRIPTION
### Description

calling get_groups_by_member_id() using postgres

This was the error produced
```
open-webui-1  | INFO  [open_webui.apps.webui.models.auths] authenticate_user: MY_USER
postgres-1    | 2024-11-17 13:01:45.295 UTC [29561] ERROR:  operator does not exist: json ~~ text at character 388
postgres-1    | 2024-11-17 13:01:45.295 UTC [29561] HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
postgres-1    | 2024-11-17 13:01:45.295 UTC [29561] STATEMENT:  SELECT "group".id AS group_id, "group".user_id AS group_user_id, "group".name AS group_name, "group".description AS group_description, "group".data AS group_data, "group".meta AS group_meta, "group".permissions AS group_permissions, "group".user_ids AS group_user_ids, "group".created_at AS group_created_at, "group".updated_at AS group_updated_at 
postgres-1    |         FROM "group" 
postgres-1    |         WHERE ("group".user_ids LIKE '%' || '["5f43aa4d-eb75-4fc5-b4d6-6352192f386d"]' || '%') ORDER BY "group".updated_at DESC
open-webui-1  | DEBUG [open_webui.main] Commit session after request
open-webui-1  | INFO:     172.16.4.34:0 - "POST /api/v1/auths/signin HTTP/1.1" 500 Internal Server Error
```



### Fixed

- calling get_groups_by_member_id() using postgres

tested with sqlite and postgres
