### PR TITLE
fix: Enable RAG_WEB_SEARCH_CONCURRENT_REQUESTS

### DIFF
--- a/backend/open_webui/apps/retrieval/main.py
+++ b/backend/open_webui/apps/retrieval/main.py
@@ -1283,9 +1283,11 @@ def process_web_search(form_data: SearchForm, user=Depends(get_verified_user)):
         urls = [result.link for result in web_results]
 
         loader = get_web_loader(
-            urls, verify_ssl=app.state.config.ENABLE_RAG_WEB_LOADER_SSL_VERIFICATION
+            urls,
+            verify_ssl=app.state.config.ENABLE_RAG_WEB_LOADER_SSL_VERIFICATION,
+            requests_per_second=app.state.config.RAG_WEB_SEARCH_CONCURRENT_REQUESTS
         )
-        docs = loader.load()
+        docs = loader.aload()
 
         save_docs_to_vector_db(docs, collection_name, overwrite=True)
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **fix**: Bug fix or error correction


# Changelog Entry

### Description

- The RAG_WEB_SEARCH_CONCURRENT_REQUESTS environment variable is not passed as the requests_per_second parameter in get_web_loader, causing it to not function properly.
- According to Langchain code [here](https://github.com/langchain-ai/langchain/blob/d9d689572a23b590b1134d30740b50b5e553c8ef/libs/community/langchain_community/document_loaders/web_base.py#L247), requests_per_second is used as an asyncio.Semaphore and is only effective in loader.aload(). However, since loader.load() is being used instead, it does not work concurrently and is therefore slow. For example, loading 10 sites takes 13.9 seconds.

### Test
Setting RAG_WEB_SEARCH_CONCURRENT_REQUESTS to 10 and loading 10 sites reduced the time from 13.9s to 2.3s, making it 6 times faster.
![Screenshot_20241118_205844_Chrome](https://github.com/user-attachments/assets/6192ec50-1115-4edf-a6f9-0321108c5d36)

