### PR TITLE
LDAP auth fixes: do not store LDAP password, use default user role on first auth, allow ldap only form.

### DIFF
--- a/backend/open_webui/apps/webui/routers/auths.py
+++ b/backend/open_webui/apps/webui/routers/auths.py
@@ -238,10 +238,20 @@ async def ldap_auth(request: Request, response: Response, form_data: LdapForm):
 
             user = Users.get_user_by_email(mail)
             if not user:
-
                 try:
-                    hashed = get_password_hash(form_data.password)
-                    user = Auths.insert_new_auth(mail, hashed, cn)
+                    role = (
+                        "admin"
+                        if Users.get_num_users() == 0
+                        else request.app.state.config.DEFAULT_USER_ROLE
+                    )
+
+                    user = Auths.insert_new_auth(
+                        mail,
+                        str(uuid.uuid4()),
+                        cn,
+                        None,
+                        role,
+                    )
 
                     if not user:
                         raise HTTPException(
@@ -253,7 +263,7 @@ async def ldap_auth(request: Request, response: Response, form_data: LdapForm):
                 except Exception as err:
                     raise HTTPException(500, detail=ERROR_MESSAGES.DEFAULT(err))
 
-            user = Auths.authenticate_user(mail, password=str(form_data.password))
+            user = Auths.authenticate_user_by_trusted_header(mail)
 
             if user:
                 token = create_token(

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -203,7 +203,7 @@
 								{/if}
 							</div>
 
-							{#if $config?.features.enable_login_form}
+							{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
 								<div class="flex flex-col mt-4">
 									{#if mode === 'signup'}
 										<div class="mb-2">
@@ -227,6 +227,7 @@
 												type="text"
 												class="my-0.5 w-full text-sm outline-none bg-transparent"
 												autocomplete="username"
+												name="username"
 												placeholder={$i18n.t('Enter Your Username')}
 												required
 											/>
@@ -239,6 +240,7 @@
 												type="email"
 												class="my-0.5 w-full text-sm outline-none bg-transparent"
 												autocomplete="email"
+												name="email"
 												placeholder={$i18n.t('Enter Your Email')}
 												required
 											/>
@@ -254,13 +256,14 @@
 											class="my-0.5 w-full text-sm outline-none bg-transparent"
 											placeholder={$i18n.t('Enter Your Password')}
 											autocomplete="current-password"
+											name="current-password"
 											required
 										/>
 									</div>
 								</div>
 							{/if}
 							<div class="mt-5">
-								{#if $config?.features.enable_login_form}
+								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
 									{#if mode === 'ldap'}
 										<button
 											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
@@ -309,7 +312,7 @@
 						{#if Object.keys($config?.oauth?.providers ?? {}).length > 0}
 							<div class="inline-flex items-center justify-center w-full">
 								<hr class="w-32 h-px my-4 border-0 dark:bg-gray-100/10 bg-gray-700/10" />
-								{#if $config?.features.enable_login_form}
+								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
 									<span
 										class="px-3 text-sm font-medium text-gray-900 dark:text-white bg-transparent"
 										>{$i18n.t('or')}</span
@@ -401,7 +404,7 @@
 							</div>
 						{/if}
 
-						{#if $config?.features.enable_ldap}
+						{#if $config?.features.enable_ldap && $config?.features.enable_login_form}
 							<div class="mt-2">
 								<button
 									class="flex justify-center items-center text-xs w-full text-center underline"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- LDAP authorization is now work like trusted header: it will not store user password, trusting LDAP server.
This also fixing login after LDAP password was changed.
If you need both LDAP and e-mail authorizations: register e-mail first or set password in user settings after LDAP first login.
- LDAP user role is now working accordingly to DEFAULT_USER_ROLE. Also, if this is first user on server, user will get admin rights.
- ENABLE_LOGIN_FORM = false now will disable only standard (e-mail) login form. If ENABLE_LDAP is true, then LDAP form only will be shown.
- Fixed Chrome autocompletion (added "name" property to fields).

### Added

- Added "name" property to login fields, for Chrome autocompletion.

### Changed

- LDAP authorization is now bypassing pasword, like trusted header auth.
- Default password is now randomized, like in trusted header auth.
- LDAP default user role is now work like in other auths, first user will be an admin, other will get DEFAULT_USER_ROLE from setings.

### Fixed

- LDAP authorization is now not storing user's passwords hashes.

### Security

- LDAP authorization is now not storing user's passwords hashes.
