### PR TITLE
fix: Include Authorization header in /api/pull and /api/chat requests

### DIFF
--- a/backend/open_webui/apps/ollama/main.py
+++ b/backend/open_webui/apps/ollama/main.py
@@ -195,7 +195,10 @@ async def post_streaming_url(
             trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
         )
 
-        api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+        parsed_url = urlparse(url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+        api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
         key = api_config.get("key", None)
 
         headers = {"Content-Type": "application/json"}
@@ -210,13 +213,13 @@ async def post_streaming_url(
         r.raise_for_status()
 
         if stream:
-            headers = dict(r.headers)
+            response_headers = dict(r.headers)
             if content_type:
-                headers["Content-Type"] = content_type
+                response_headers["Content-Type"] = content_type
             return StreamingResponse(
                 r.content,
                 status_code=r.status,
-                headers=headers,
+                headers=response_headers,
                 background=BackgroundTask(
                     cleanup_response, response=r, session=session
                 ),
@@ -324,7 +327,10 @@ async def get_ollama_tags(
     else:
         url = app.state.config.OLLAMA_BASE_URLS[url_idx]
 
-        api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+        parsed_url = urlparse(url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+        api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
         key = api_config.get("key", None)
 
         headers = {}
@@ -525,7 +531,10 @@ async def copy_model(
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     key = api_config.get("key", None)
 
     headers = {"Content-Type": "application/json"}
@@ -584,7 +593,10 @@ async def delete_model(
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     key = api_config.get("key", None)
 
     headers = {"Content-Type": "application/json"}
@@ -635,7 +647,10 @@ async def show_model_info(form_data: ModelNameForm, user=Depends(get_verified_us
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     key = api_config.get("key", None)
 
     headers = {"Content-Type": "application/json"}
@@ -730,7 +745,10 @@ async def generate_ollama_embeddings(
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     key = api_config.get("key", None)
 
     headers = {"Content-Type": "application/json"}
@@ -797,7 +815,10 @@ async def generate_ollama_batch_embeddings(
     url = app.state.config.OLLAMA_BASE_URLS[url_idx]
     log.info(f"url: {url}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     key = api_config.get("key", None)
 
     headers = {"Content-Type": "application/json"}
@@ -974,7 +995,10 @@ async def generate_chat_completion(
     log.info(f"url: {url}")
     log.debug(f"generate_chat_completion() - 2.payload = {payload}")
 
-    api_config = app.state.config.OLLAMA_API_CONFIGS.get(url, {})
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    api_config = app.state.config.OLLAMA_API_CONFIGS.get(base_url, {})
     prefix_id = api_config.get("prefix_id", None)
     if prefix_id:
         payload["model"] = payload["model"].replace(f"{prefix_id}.", "")


### PR DESCRIPTION
# Changelog Entry

### Description
This pull request fixes a significant functional issue where the Authorization header was not being passed to certain Ollama API endpoints, specifically `POST /api/pull` and `POST /api/chat.` As a result, these requests failed with a `401 Unauthorized` error when the Ollama server required authentication.

This issue has been highlighted in discussion thread #6856 and has also been confirmed in the [Discord Development Channel](https://discord.com/channels/1170866489302188073/1210732510250541067/1310361188735123508)

### Fixed

- **Authorization Header Not Passed to Certain Ollama API Endpoints**: Resolved an issue where the Authorization header was not being included in requests to the `POST /api/pull` and `POST /api/chat` endpoints. This omission caused requests to fail with a `401 Unauthorized` error when connecting to an Ollama server that requires authentication.
- **Consistent Inclusion of Authorization Header**: Updated the code to ensure that all Ollama API endpoints now correctly include the Authorization header when a bearer token is provided, aligning the behavior with other endpoints like `GET /api/version` and `GET /api/tags`.

Users can now successfully perform actions such as pulling models and initiating chat sessions when connected to authenticated Ollama servers.

---

### Additional Information

Demonstration of Bug (Before Fix)

```
Successful Requests (Authorization header being sent as expected):

66.8.245.246 - - [24/Nov/2024:21:20:40 +0000] "GET /api/version HTTP/1.1" 200 20 "-" "Python/3.11 aiohttp/3.10.8" Authorization: "Bearer [TOKEN]"
66.8.245.246 - - [24/Nov/2024:21:20:54 +0000] "GET /api/tags HTTP/1.1" 200 660 "-" "python-requests/2.32.3" Authorization: "Bearer [TOKEN]"
66.8.245.246 - - [24/Nov/2024:21:21:07 +0000] "DELETE /api/delete HTTP/1.1" 200 0 "-" "python-requests/2.32.3" Authorization: "Bearer [TOKEN]"
66.8.245.246 - - [24/Nov/2024:21:21:08 +0000] "GET /api/tags HTTP/1.1" 200 338 "-" "Python/3.11 aiohttp/3.10.8" Authorization: "Bearer [TOKEN]"

Failed Requests (Authorization header not being sent):

66.8.245.246 - - [24/Nov/2024:21:21:32 +0000] "POST /api/pull HTTP/1.1" 401 188 "-" "Python/3.11 aiohttp/3.10.8" Authorization: "-"
66.8.245.246 - - [24/Nov/2024:21:22:08 +0000] "POST /api/chat HTTP/1.1" 401 188 "-" "Python/3.11 aiohttp/3.10.8" Authorization: "-"

```

