### PR TITLE
fix(i18n): Correct capitalization typo in Dutch localization

### DIFF
--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -441,7 +441,7 @@
 	"Group Description": "Groepsbeschrijving",
 	"Group Name": "Groepsnaam",
 	"Group updated successfully": "Groep succesvol bijgewerkt",
-	"Groups": "GRoepen",
+	"Groups": "Groepen",
 	"h:mm a": "h:mm a",
 	"Haptic Feedback": "Haptische feedback",
 	"has no conversations.": "heeft geen gesprekken.",


### PR DESCRIPTION
### **Pull Request Title**  
`fix(i18n): Correct capitalization typo in Dutch localization`

---

### **Description**  
This pull request fixes a minor typo in the Dutch localization file. The word "GRoepen" has been corrected to "Groepen" to ensure proper capitalization and adherence to Dutch language standards.  

**Details of the change:**  
- Fixed the incorrect capitalization in `translation.json` under the Dutch localization folder (`lib/i18n/locales/nl-NL/translation.json`).

---

### **Changelog**  
**Fixed**:
- Corrected the capitalization typo in Dutch localization for "Groepen" (was "GRoepen").

---

### **Additional Context**  
- This is a non-breaking change that impacts UI text consistency for Dutch users.
- No dependencies or additional updates required.

---