### PR TITLE
Update config.py - remove ending slash to avoid 404 error

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -605,6 +605,8 @@ if ENV == "prod":
     elif K8S_FLAG:
         OLLAMA_BASE_URL = "http://ollama-service.open-webui.svc.cluster.local:11434"
 
+# remove the ending slash due to an extra slash would cause 404 error, see https://github.com/open-webui/open-webui/discussions/6065#discussioncomment-11420989
+OLLAMA_BASE_URL = OLLAMA_BASE_URL.rstrip("/") if OLLAMA_BASE_URL else OLLAMA_BASE_URL
 
 OLLAMA_BASE_URLS = os.environ.get("OLLAMA_BASE_URLS", "")
 OLLAMA_BASE_URLS = OLLAMA_BASE_URLS if OLLAMA_BASE_URLS != "" else OLLAMA_BASE_URL


### PR DESCRIPTION
### Pull Request Description

**Title:** fix: Remove trailing slash from OLLAMA_BASE_URL to prevent 404 errors

**Target Branch:** dev

### Description

This pull request addresses an issue where the trailing slash in the `OLLAMA_BASE_URL` configuration was causing 404 errors when making HTTP requests. By using Wireshark to capture the HTTP traffic, I identified that the extra slash was the root cause of the problem.

The fix involves removing the trailing slash from `OLLAMA_BASE_URL` if it exists, which ensures that the URL is correctly formatted and avoids the 404 error.

### Changelog Entry

- **Fixed:** Trailing slash in `OLLAMA_BASE_URL` causing  404 errors

### Testing

- **Manual Testing:** I manually tested the Docker command with the corrected `OLLAMA_BASE_URL` and confirmed that the 404 error no longer occurs.

### Code Review

- **Self-Review:** I have performed a self-review of the changes and ensured adherence to the project's coding standards.

### Documentation

- **Updated:** No documentation updates are required as this fix is internal to the configuration handling.

### Dependencies

- **No New Dependencies:** This fix does not introduce any new dependencies.

### Related Discussion

- **Discussion:** [Discussions#6065](https://github.com/open-webui/open-webui/discussions/6065)

---

Thank you for reviewing this pull request. Your feedback is highly appreciated.