### PR TITLE
Add option to add database schema as env var

### DIFF
--- a/backend/open_webui/apps/webui/internal/db.py
+++ b/backend/open_webui/apps/webui/internal/db.py
@@ -7,6 +7,7 @@ from open_webui.apps.webui.internal.wrappers import register_connection
 from open_webui.env import (
     OPEN_WEBUI_DIR,
     DATABASE_URL,
+    DATABASE_SCHEMA,
     SRC_LOG_LEVELS,
     DATABASE_POOL_MAX_OVERFLOW,
     DATABASE_POOL_RECYCLE,
@@ -14,7 +15,7 @@ from open_webui.env import (
     DATABASE_POOL_TIMEOUT,
 )
 from peewee_migrate import Router
-from sqlalchemy import Dialect, create_engine, types
+from sqlalchemy import Dialect, create_engine, MetaData, types
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import QueuePool, NullPool
@@ -99,7 +100,8 @@ else:
 SessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
 )
-Base = declarative_base()
+metadata_obj = MetaData(schema=DATABASE_SCHEMA)
+Base = declarative_base(metadata=metadata_obj)
 Session = scoped_session(SessionLocal)
 
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -269,6 +269,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL", f"sqlite:///{DATA_DIR}/webui.db")
 if "postgres://" in DATABASE_URL:
     DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://")
 
+DATABASE_SCHEMA = os.environ.get("DATABASE_SCHEMA", None)
+
 DATABASE_POOL_SIZE = os.environ.get("DATABASE_POOL_SIZE", 0)
 
 if DATABASE_POOL_SIZE == "":


### PR DESCRIPTION
# Changelog Entry

### Description

- When using Postgresql as database, there can be conflicts between reserved keywords like "user" and the table names, e.g. "user". I have described this in [this issue](https://github.com/open-webui/open-webui/issues/7750). To fix this problem, I added the option to set DATABASE_SCHEMA as an environment variable, that sets a default schema to use for all tables for the internal database. 

### Added

- The options to use the environment variable DATABASE_SCHEMA. This sets a default schema in the sqlalchemy ORM definition using the MetaData class described [here](https://docs.sqlalchemy.org/en/14/orm/declarative_tables.html#explicit-schema-name-with-declarative-table). 

### Additional information

I have also made [a PR](https://github.com/open-webui/docs/pull/314) updating the docs. 
