### PR TITLE
Disable Polling Transport When WebSockets Are Enabled and Implement Cleanup Locking Mechanism

### DIFF
--- a/backend/open_webui/apps/socket/main.py
+++ b/backend/open_webui/apps/socket/main.py
@@ -13,7 +13,7 @@ from open_webui.env import (
     WEBSOCKET_REDIS_URL,
 )
 from open_webui.utils.auth import decode_token
-from open_webui.apps.socket.utils import RedisDict
+from open_webui.apps.socket.utils import RedisDict, RedisLock
 
 from open_webui.env import (
     GLOBAL_LOG_LEVEL,
@@ -32,7 +32,7 @@ if WEBSOCKET_MANAGER == "redis":
         cors_allowed_origins=[],
         async_mode="asgi",
         transports=(
-            ["polling", "websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]
+            ["websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]
         ),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,
         always_connect=True,
@@ -43,54 +43,75 @@ else:
         cors_allowed_origins=[],
         async_mode="asgi",
         transports=(
-            ["polling", "websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]
+            ["websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]
         ),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,
         always_connect=True,
     )
 
 
+# Timeout duration in seconds
+TIMEOUT_DURATION = 3
+
 # Dictionary to maintain the user pool
 
+run_cleanup = True
 if WEBSOCKET_MANAGER == "redis":
+    log.debug("Using Redis to manage websockets.")
     SESSION_POOL = RedisDict("open-webui:session_pool", redis_url=WEBSOCKET_REDIS_URL)
     USER_POOL = RedisDict("open-webui:user_pool", redis_url=WEBSOCKET_REDIS_URL)
     USAGE_POOL = RedisDict("open-webui:usage_pool", redis_url=WEBSOCKET_REDIS_URL)
+
+    clean_up_lock = RedisLock(redis_url=WEBSOCKET_REDIS_URL, lock_name="usage_cleanup_lock", timeout_secs=TIMEOUT_DURATION*2)
+    run_cleanup = clean_up_lock.aquire_lock()
+    renew_func = clean_up_lock.renew_lock
+    release_func = clean_up_lock.release_lock
 else:
     SESSION_POOL = {}
     USER_POOL = {}
     USAGE_POOL = {}
-
-
-# Timeout duration in seconds
-TIMEOUT_DURATION = 3
+    release_func = renew_func = lambda: True
 
 
 async def periodic_usage_pool_cleanup():
-    while True:
-        now = int(time.time())
-        for model_id, connections in list(USAGE_POOL.items()):
-            # Creating a list of sids to remove if they have timed out
-            expired_sids = [
-                sid
-                for sid, details in connections.items()
-                if now - details["updated_at"] > TIMEOUT_DURATION
-            ]
+    if not run_cleanup:
+        log.debug("Usage pool cleanup lock already exists. Not running it.")
+        return
+    log.debug("Running periodic_usage_pool_cleanup")
+    try:
+        while True:
+            if not renew_func():
+                log.error(f"Unable to renew cleanup lock. Exiting usage pool cleanup.")
+                raise Exception("Unable to renew usage pool cleanup lock.")
 
-            for sid in expired_sids:
-                del connections[sid]
+            now = int(time.time())
+            send_usage = False
+            for model_id, connections in list(USAGE_POOL.items()):
+                # Creating a list of sids to remove if they have timed out
+                expired_sids = [
+                    sid
+                    for sid, details in connections.items()
+                    if now - details["updated_at"] > TIMEOUT_DURATION
+                ]
 
-            if not connections:
-                log.debug(f"Cleaning up model {model_id} from usage pool")
-                del USAGE_POOL[model_id]
-            else:
-                USAGE_POOL[model_id] = connections
+                for sid in expired_sids:
+                    del connections[sid]
 
-            # Emit updated usage information after cleaning
-            await sio.emit("usage", {"models": get_models_in_use()})
+                if not connections:
+                    log.debug(f"Cleaning up model {model_id} from usage pool")
+                    del USAGE_POOL[model_id]
+                else:
+                    USAGE_POOL[model_id] = connections
 
-        await asyncio.sleep(TIMEOUT_DURATION)
+                send_usage = True
 
+            if send_usage:
+                # Emit updated usage information after cleaning
+                await sio.emit("usage", {"models": get_models_in_use()})
+
+            await asyncio.sleep(TIMEOUT_DURATION)
+    finally:
+        release_func()
 
 app = socketio.ASGIApp(
     sio,

--- a/backend/open_webui/apps/socket/utils.py
+++ b/backend/open_webui/apps/socket/utils.py
@@ -1,6 +1,30 @@
 import json
 import redis
+import uuid
 
+class RedisLock:
+    def __init__(self, redis_url, lock_name, timeout_secs):
+        self.lock_name = lock_name
+        self.lock_id = str(uuid.uuid4())
+        self.timeout_secs = timeout_secs
+        self.lock_obtained = False
+        self.redis = redis.Redis.from_url(redis_url, decode_responses=True)
+
+    def aquire_lock(self):
+        # nx=True will only set this key if it _hasn't_ already been set
+        self.lock_obtained = self.redis.set(
+            self.lock_name, self.lock_id, nx=True, ex=self.timeout_secs)
+        return self.lock_obtained
+
+    def renew_lock(self):
+        # xx=True will only set this key if it _has_ already been set
+        return self.redis.set(
+            self.lock_name, self.lock_id, xx=True, ex=self.timeout_secs)
+
+    def release_lock(self):
+        lock_value = self.redis.get(self.lock_name)
+        if lock_value and lock_value.decode('utf-8') == self.lock_id:
+            self.redis.delete(self.lock_name)
 
 class RedisDict:
     def __init__(self, name, redis_url):

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -111,6 +111,7 @@ from open_webui.env import (
     WEBUI_SECRET_KEY,
     WEBUI_SESSION_COOKIE_SAME_SITE,
     WEBUI_SESSION_COOKIE_SECURE,
+    ENABLE_WEBSOCKET_SUPPORT,
     WEBUI_URL,
     BYPASS_MODEL_ACCESS_CONTROL,
     RESET_CONFIG_ON_START,
@@ -2608,6 +2609,7 @@ async def get_app_config(request: Request):
             "enable_api_key": webui_app.state.config.ENABLE_API_KEY,
             "enable_signup": webui_app.state.config.ENABLE_SIGNUP,
             "enable_login_form": webui_app.state.config.ENABLE_LOGIN_FORM,
+            "disable_websocket_polling": ENABLE_WEBSOCKET_SUPPORT,
             **(
                 {
                     "enable_web_search": retrieval_app.state.config.ENABLE_RAG_WEB_SEARCH,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,13 +38,15 @@
 	let loaded = false;
 	const BREAKPOINT = 768;
 
-	const setupSocket = () => {
+	const setupSocket = (disableWebSocketPolling) => {
+		console.log('Disabled websocket polling', disableWebSocketPolling);
 		const _socket = io(`${WEBUI_BASE_URL}` || undefined, {
 			reconnection: true,
 			reconnectionDelay: 1000,
 			reconnectionDelayMax: 5000,
 			randomizationFactor: 0.5,
 			path: '/ws/socket.io',
+			transports: disableWebSocketPolling ? ['websocket'] : ['polling', 'websocket'],
 			auth: { token: localStorage.token }
 		});
 
@@ -125,8 +127,9 @@
 			await config.set(backendConfig);
 			await WEBUI_NAME.set(backendConfig.name);
 
+			const disableWebSocketPolling = backendConfig.features.disable_websocket_polling === true;
 			if ($config) {
-				setupSocket();
+				setupSocket(disableWebSocketPolling);
 
 				if (localStorage.token) {
 					// Get Session User Info


### PR DESCRIPTION
## Overview
  
This merge request introduces changes to optimize WebSocket usage and ensure proper operation in distributed environments.

1. **Disable the "polling" transport when WebSocket support is enabled** to reduce unnecessary overhead and prevent connectivity issues in multi-replica deployments without sticky sessions.
2. **Implement a Redis-based locking mechanism** to synchronize the `periodic_usage_pool_cleanup` task across multiple instances in a distributed deployment.

## Changes
  
### 1. Disable Polling Transport When WebSockets Are Enabled

**Rationale:**

By default, Socket.IO uses both `polling` and `websocket` transports. In environments with multiple application instances (replicas) behind a load balancer without sticky sessions, the `polling` transport can lead to connectivity issues:

- **400 Errors Without Sticky Sessions:**
  - The `polling` transport relies on HTTP long-polling requests that must consistently reach the same server instance. Without sticky sessions, requests from the same client may be routed to different instances, causing the server to not recognize the session and respond with HTTP 400 errors.
  - This happens because the initial HTTP request that establishes the Socket.IO session and the subsequent polling requests are handled by different servers, leading to mismatches in session IDs and authentication tokens.
  - As a result, clients experience failed connections and errors in the application.

- **Solution:**
  - By disabling the `polling` transport and using only `websocket`, which operates over a persistent TCP connection, we avoid the need for sticky sessions.
  - WebSocket connections are maintained over the same TCP connection, ensuring that all communication is directed to the same server instance.
  - Most modern load balancers support WebSocket connections and can route them correctly without sticky sessions.

**Benefits:**

- **Improved Stability:** Eliminates 400 errors caused by misrouted polling requests in non-sticky environments.
- **Better Performance:** Reduces overhead associated with the fallback polling mechanism, leading to more efficient resource utilization.
- **Simplified Deployment:** Removes the requirement for sticky sessions or additional load balancer configuration, making it easier to deploy in scalable environments.

### 2. Implement Redis-Based Locking for `periodic_usage_pool_cleanup`

**Rationale:**

In a distributed deployment with multiple instances of the application, running the `periodic_usage_pool_cleanup` task concurrently can lead to race conditions and inconsistent state in the `USAGE_POOL`. By introducing a Redis-based lock:

- **Ensures Single Instance Execution:**
  - Only one instance acquires the lock and performs the cleanup at any given time.
  - Prevents conflicts and potential data corruption due to simultaneous access.

- **Compatibility with Distributed Systems:**
  - Redis serves as a centralized coordination point accessible by all instances.
  - The lock mechanism leverages Redis's atomic operations to manage concurrency.

