### PR TITLE
Fixed: openai-edge-tts speaking markdown issue

### DIFF
--- a/backend/open_webui/apps/audio/main.py
+++ b/backend/open_webui/apps/audio/main.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import uuid
+import re
 from functools import lru_cache
 from pathlib import Path
 from pydub import AudioSegment
@@ -46,11 +47,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from open_webui.utils.auth import get_admin_user, get_verified_user
+import markdown2
 
 # Constants
 MAX_FILE_SIZE_MB = 25
 MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024  # Convert MB to bytes
 
+
+# Markdown Patterns to detect Markdown for audio output.
+markdown_patterns = ['#', '-', '*', '_', '`', '[', '![']
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["AUDIO"])
@@ -293,6 +298,22 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             body = json.dumps(body).encode("utf-8")
         except Exception:
             pass
+
+
+        # Check if the Input is markdown or normal word if its markdown convert markdown to normal word format.
+        # Simple heuristic to detect Markdown (checks for common Markdown characters)
+        
+        is_markdown = any(pattern in body["input"] for pattern in markdown_patterns)
+
+        if is_markdown:
+            # Convert Markdown to HTML
+            html_text = markdown2.markdown(input_text)
+            
+            # Strip HTML tags to get plain text
+            body["input"] = re.sub(r'<[^>]+>', '', html_text)
+        else:
+            pass
+
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/backend/open_webui/apps/audio/main.py
+++ b/backend/open_webui/apps/audio/main.py
@@ -307,7 +307,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
 
         if is_markdown:
             # Convert Markdown to HTML
-            html_text = markdown2.markdown(input_text)
+            html_text = markdown2.markdown(body["input"])
             
             # Strip HTML tags to get plain text
             body["input"] = re.sub(r'<[^>]+>', '', html_text)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -88,6 +88,7 @@ pytube==15.0.0
 
 extract_msg
 pydub
+markdown2==2.5.2
 duckduckgo-search~=6.3.5
 
 ## Tests


### PR DESCRIPTION
I've used simple markdown2 and re libraries to convert AI response which is in markdown format to which leads to edge-tts voice starts with ("hashtag hashtag hashtag.... <Ai response>") so I used Simple heuristic to detect Markdown and convert it to plain text