### PR TITLE
fix: use WEBUI_API_BASE_URL for file download links in Citations

### DIFF
--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -2,6 +2,7 @@
 	import { getContext, onMount, tick } from 'svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	const i18n = getContext('i18n');
 
@@ -91,7 +92,7 @@
 									<a
 										class="hover:text-gray-500 hover:dark:text-gray-100 underline flex-grow"
 										href={document?.metadata?.file_id
-											? `/api/v1/files/${document?.metadata?.file_id}/content${document?.metadata?.page !== undefined ? `#page=${document.metadata.page + 1}` : ''}`
+											? `${WEBUI_API_BASE_URL}/files/${document?.metadata?.file_id}/content${document?.metadata?.page !== undefined ? `#page=${document.metadata.page + 1}` : ''}`
 											: document.source?.url?.includes('http')
 												? document.source.url
 												: `#`}


### PR DESCRIPTION
# Pull Request Checklist
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:

# Changelog Entry

## Description
When clicking on file links in the Citations component, the requests were being sent to the frontend server port (default: 5173) instead of the backend API port (default: 8080), resulting in 404 errors (in dev mode).

This PR fixes the issue by using the `WEBUI_API_BASE_URL` constant for constructing the file download URLs in the Citations component.

## Changes
- Updated the file download URL construction in CitationsModal.svelte to use WEBUI_API_BASE_URL

## Testing
1. Upload a file that can be referenced in chat (e.g., a PDF or DOCX)
2. Ask a question about the file content
3. Click on the source link in the Citations component
4. Verify that the file downloads correctly instead of getting a 404 error
