### PR TITLE
Disable Polling Transport When WebSockets Are Enabled and Implement Cleanup Locking Mechanism

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -933,7 +933,7 @@ async def get_app_config(request: Request):
             "enable_api_key": app.state.config.ENABLE_API_KEY,
             "enable_signup": app.state.config.ENABLE_SIGNUP,
             "enable_login_form": app.state.config.ENABLE_LOGIN_FORM,
-            "disable_websocket_polling": ENABLE_WEBSOCKET_SUPPORT,
+            "enable_websocket": ENABLE_WEBSOCKET_SUPPORT,
             **(
                 {
                     "enable_web_search": app.state.config.ENABLE_RAG_WEB_SEARCH,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -264,6 +264,7 @@ from open_webui.env import (
     WEBUI_SESSION_COOKIE_SECURE,
     WEBUI_AUTH_TRUSTED_EMAIL_HEADER,
     WEBUI_AUTH_TRUSTED_NAME_HEADER,
+    ENABLE_WEBSOCKET_SUPPORT,
     BYPASS_MODEL_ACCESS_CONTROL,
     RESET_CONFIG_ON_START,
     OFFLINE_MODE,
@@ -932,6 +933,7 @@ async def get_app_config(request: Request):
             "enable_api_key": app.state.config.ENABLE_API_KEY,
             "enable_signup": app.state.config.ENABLE_SIGNUP,
             "enable_login_form": app.state.config.ENABLE_LOGIN_FORM,
+            "disable_websocket_polling": ENABLE_WEBSOCKET_SUPPORT,
             **(
                 {
                     "enable_web_search": app.state.config.ENABLE_RAG_WEB_SEARCH,

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -1,5 +1,33 @@
 import json
 import redis
+import uuid
+
+
+class RedisLock:
+    def __init__(self, redis_url, lock_name, timeout_secs):
+        self.lock_name = lock_name
+        self.lock_id = str(uuid.uuid4())
+        self.timeout_secs = timeout_secs
+        self.lock_obtained = False
+        self.redis = redis.Redis.from_url(redis_url, decode_responses=True)
+
+    def aquire_lock(self):
+        # nx=True will only set this key if it _hasn't_ already been set
+        self.lock_obtained = self.redis.set(
+            self.lock_name, self.lock_id, nx=True, ex=self.timeout_secs
+        )
+        return self.lock_obtained
+
+    def renew_lock(self):
+        # xx=True will only set this key if it _has_ already been set
+        return self.redis.set(
+            self.lock_name, self.lock_id, xx=True, ex=self.timeout_secs
+        )
+
+    def release_lock(self):
+        lock_value = self.redis.get(self.lock_name)
+        if lock_value and lock_value.decode("utf-8") == self.lock_id:
+            self.redis.delete(self.lock_name)
 
 
 class RedisDict:

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,15 +38,14 @@
 	let loaded = false;
 	const BREAKPOINT = 768;
 
-	const setupSocket = (disableWebSocketPolling) => {
-		console.log('Disabled websocket polling', disableWebSocketPolling);
+	const setupSocket = (enableWebsocket) => {
 		const _socket = io(`${WEBUI_BASE_URL}` || undefined, {
 			reconnection: true,
 			reconnectionDelay: 1000,
 			reconnectionDelayMax: 5000,
 			randomizationFactor: 0.5,
 			path: '/ws/socket.io',
-			transports: disableWebSocketPolling ? ['websocket'] : ['polling', 'websocket'],
+			transports: enableWebsocket ? ['websocket'] : ['polling', 'websocket'],
 			auth: { token: localStorage.token }
 		});
 
@@ -127,9 +126,8 @@
 			await config.set(backendConfig);
 			await WEBUI_NAME.set(backendConfig.name);
 
-			const disableWebSocketPolling = backendConfig.features.disable_websocket_polling === true;
 			if ($config) {
-				setupSocket(disableWebSocketPolling);
+				setupSocket($config.features?.enable_websocket ?? true);
 
 				if (localStorage.token) {
 					// Get Session User Info

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,13 +38,15 @@
 	let loaded = false;
 	const BREAKPOINT = 768;
 
-	const setupSocket = () => {
+	const setupSocket = (disableWebSocketPolling) => {
+		console.log('Disabled websocket polling', disableWebSocketPolling);
 		const _socket = io(`${WEBUI_BASE_URL}` || undefined, {
 			reconnection: true,
 			reconnectionDelay: 1000,
 			reconnectionDelayMax: 5000,
 			randomizationFactor: 0.5,
 			path: '/ws/socket.io',
+			transports: disableWebSocketPolling ? ['websocket'] : ['polling', 'websocket'],
 			auth: { token: localStorage.token }
 		});
 
@@ -125,8 +127,9 @@
 			await config.set(backendConfig);
 			await WEBUI_NAME.set(backendConfig.name);
 
+			const disableWebSocketPolling = backendConfig.features.disable_websocket_polling === true;
 			if ($config) {
-				setupSocket();
+				setupSocket(disableWebSocketPolling);
 
 				if (localStorage.token) {
 					// Get Session User Info


### PR DESCRIPTION
# Changelog
  
Optimize WebSocket usage and ensure proper operation in distributed environments.

### Changed
- **Disable the "polling" transport when WebSocket support is enabled** to reduce unnecessary overhead and prevent connectivity issues in multi-replica deployments without sticky sessions.
- **Implement a Redis-based locking mechanism** to synchronize the `periodic_usage_pool_cleanup` task across multiple instances in a distributed deployment.

  
### 1. Disable Polling Transport When WebSockets Are Enabled

**Rationale:**

By default, Socket.IO uses both `polling` and `websocket` transports. In environments with multiple application instances (replicas) behind a load balancer without sticky sessions, the `polling` transport can lead to connectivity issues:

- **400 Errors Without Sticky Sessions:**
  - The `polling` transport relies on HTTP long-polling requests that must consistently reach the same server instance. Without sticky sessions, requests from the same client may be routed to different instances, causing the server to not recognize the session and respond with HTTP 400 errors.
  - This happens because the initial HTTP request that establishes the Socket.IO session and the subsequent polling requests are handled by different servers, leading to mismatches in session IDs and authentication tokens.
  - As a result, clients experience failed connections and errors in the application.

- **Solution:**
  - By disabling the `polling` transport and using only `websocket`, which operates over a persistent TCP connection, we avoid the need for sticky sessions.
  - WebSocket connections are maintained over the same TCP connection, ensuring that all communication is directed to the same server instance.
  - Most modern load balancers support WebSocket connections and can route them correctly without sticky sessions.

**Benefits:**

- **Improved Stability:** Eliminates 400 errors caused by misrouted polling requests in non-sticky environments.
- **Better Performance:** Reduces overhead associated with the fallback polling mechanism, leading to more efficient resource utilization.
- **Simplified Deployment:** Removes the requirement for sticky sessions or additional load balancer configuration, making it easier to deploy in scalable environments.

### 2. Implement Redis-Based Locking for `periodic_usage_pool_cleanup`

**Rationale:**

In a distributed deployment with multiple instances of the application, running the `periodic_usage_pool_cleanup` task concurrently can lead to race conditions and inconsistent state in the `USAGE_POOL`. By introducing a Redis-based lock:

- **Ensures Single Instance Execution:**
  - Only one instance acquires the lock and performs the cleanup at any given time.
  - Prevents conflicts and potential data corruption due to simultaneous access.

- **Compatibility with Distributed Systems:**
  - Redis serves as a centralized coordination point accessible by all instances.
  - The lock mechanism leverages Redis's atomic operations to manage concurrency.

