### PR TITLE
fix: use only non empty collections for completions

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1509,10 +1509,13 @@
 			...(responseMessage?.files ?? []).filter((item) => ['web_search_results'].includes(item.type))
 		);
 		// Remove duplicates
-		files = files.filter(
-			(item, index, array) =>
-				array.findIndex((i) => JSON.stringify(i) === JSON.stringify(item)) === index
-		);
+		files = files
+			.filter(
+				(item, index, array) =>
+					array.findIndex((i) => JSON.stringify(i) === JSON.stringify(item)) === index
+			)
+			// Use only non empty collections
+			.filter((item) => item.type !== 'collection' || item.files.length > 0);
 
 		scrollToBottom();
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Pull request targets the `dev` branch
- [x] **Description:** Filter out empty collections from completions to improve response quality
- [x] **Changelog:** Added below
- [x] **Documentation:** No documentation updates needed
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Code changes have been tested
- [x] **Code review:** Self-review completed
- [x] **Prefix:** Using `fix:` prefix as this addresses a bug/improvement

# Changelog Entry

### Description

This PR filters out empty collections from the completions to ensure only meaningful collections are included in the chat responses. This fixes the error for hybrid search.

### Changed

- Updated collection filtering logic in Chat.svelte to exclude empty collections

### Fixed

- Fixed issue where empty collections were being included in completions, causing error in hybrid search
