### PR TITLE
enh: add configurable log level for uvicorn server

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -6,9 +6,13 @@ from pathlib import Path
 import typer
 import uvicorn
 
+from open_webui.env import (GLOBAL_LOG_LEVEL)
+
 app = typer.Typer()
 
 KEY_FILE = Path.cwd() / ".webui_secret_key"
+
+
 
 
 @app.command()
@@ -55,7 +59,7 @@ def serve(
 
     import open_webui.main  # we need set environment variables before importing main
 
-    uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*")
+    uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*", log_level=GLOBAL_LOG_LEVEL.lower())
 
 
 @app.command()

--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -13,8 +13,6 @@ app = typer.Typer()
 KEY_FILE = Path.cwd() / ".webui_secret_key"
 
 
-
-
 @app.command()
 def serve(
     host: str = "0.0.0.0",


### PR DESCRIPTION
Addresses #7859 

This pull request introduces an enhancement that allows users to configure the log level of the Uvicorn server through the `GLOBAL_LOG_LEVEL` environment variable. By making the log level configurable, developers and users can adjust the verbosity of the server logs according to their needs.

**Changes Made:**

1. **Import `GLOBAL_LOG_LEVEL`:**
   - Added an import statement to bring in the `GLOBAL_LOG_LEVEL` from `open_webui.env`.
     ```python
     + from open_webui.env import GLOBAL_LOG_LEVEL
     ```

2. **Modify `uvicorn.run` Parameters:**
   - Updated the `uvicorn.run` function call to include the `log_level` parameter.
   - Set the `log_level` parameter to `GLOBAL_LOG_LEVEL.lower()` to match Uvicorn's expected log level formats (e.g., 'info', 'debug', 'warning', 'error', 'critical').
     ```python
     - uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*")
     + uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*", log_level=GLOBAL_LOG_LEVEL.lower())
     ```