### PR TITLE
fix: [knowledge/rag] properly delete files from filesystem when removed from knowledge base

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -348,7 +348,8 @@ async def delete_file_by_id(id: str, user=Depends(get_verified_user)):
         result = Files.delete_file_by_id(id)
         if result:
             try:
-                Storage.delete_file(file.filename)
+                filename = f"{id}_{file.filename}"
+                Storage.delete_file(filename)
             except Exception as e:
                 log.exception(e)
                 log.error(f"Error deleting files")

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -11,13 +11,13 @@ from open_webui.models.knowledge import (
 )
 from open_webui.models.files import Files, FileModel
 from open_webui.retrieval.vector.connector import VECTOR_DB_CLIENT
+from open_webui.routers.files import delete_file_by_id
 from open_webui.routers.retrieval import (
     process_file,
     ProcessFileForm,
     process_files_batch,
     BatchProcessFilesForm,
 )
-
 
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.auth import get_verified_user
@@ -389,7 +389,7 @@ def update_file_from_knowledge_by_id(
 
 
 @router.post("/{id}/file/remove", response_model=Optional[KnowledgeFilesResponse])
-def remove_file_from_knowledge_by_id(
+async def remove_file_from_knowledge_by_id(
     id: str,
     form_data: KnowledgeFileIdForm,
     user=Depends(get_verified_user),
@@ -419,12 +419,7 @@ def remove_file_from_knowledge_by_id(
         collection_name=knowledge.id, filter={"file_id": form_data.file_id}
     )
 
-    result = VECTOR_DB_CLIENT.query(
-        collection_name=knowledge.id,
-        filter={"file_id": form_data.file_id},
-    )
-
-    Files.delete_file_by_id(form_data.file_id)
+    await delete_file_by_id(form_data.file_id, user)
 
     if knowledge:
         data = knowledge.data or {}


### PR DESCRIPTION
# Pull Request Checklist
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following...

# Changelog Entry

- Fixed files not being properly deleted from filesystem when removed from knowledge base, preventing orphaned files

### Description

When removing a file from a knowledge base, the system was attempting to delete the file from the filesystem (`backend/data/uploads`) using only the filename, without including the file ID prefix. This resulted in files becoming orphaned in the filesystem since the actual stored files use the format `{id}_{filename}`.

Changes:
- Updated file deletion logic to use the correct filename format (`{id}_{filename}`)
- Used existing delete_file_by_id endpoint to ensure consistent file deletion behavior across the application

This fix ensures proper cleanup of files both from the database and filesystem when they are removed from a knowledge base.