### PR TITLE
fix: Add missing request parameter to knowledge and retrieval routes

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -520,6 +520,7 @@ async def reset_knowledge_by_id(id: str, user=Depends(get_verified_user)):
 
 @router.post("/{id}/files/batch/add", response_model=Optional[KnowledgeFilesResponse])
 def add_files_to_knowledge_batch(
+    request: Request,
     id: str,
     form_data: list[KnowledgeFileIdForm],
     user=Depends(get_verified_user),
@@ -555,7 +556,9 @@ def add_files_to_knowledge_batch(
     # Process files
     try:
         result = process_files_batch(
-            BatchProcessFilesForm(files=files, collection_name=id)
+            request=request,
+            form_data=BatchProcessFilesForm(files=files, collection_name=id),
+            user=user
         )
     except Exception as e:
         log.error(

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -558,7 +558,7 @@ def add_files_to_knowledge_batch(
         result = process_files_batch(
             request=request,
             form_data=BatchProcessFilesForm(files=files, collection_name=id),
-            user=user
+            user=user,
         )
     except Exception as e:
         log.error(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1458,6 +1458,7 @@ class BatchProcessFilesResponse(BaseModel):
 
 @router.post("/process/files/batch")
 def process_files_batch(
+    request: Request,
     form_data: BatchProcessFilesForm,
     user=Depends(get_verified_user),
 ) -> BatchProcessFilesResponse:
@@ -1504,7 +1505,10 @@ def process_files_batch(
     if all_docs:
         try:
             save_docs_to_vector_db(
-                docs=all_docs, collection_name=collection_name, add=True
+                request=request,
+                docs=all_docs,
+                collection_name=collection_name,
+                add=True,
             )
 
             # Update all files with collection name


### PR DESCRIPTION
# fix: Add missing request parameter to knowledge and retrieval routes

## Pull Request Checklist

- [x] **Target branch:** Targeting `dev` branch
- [x] **Description:** Added missing request parameter to knowledge and retrieval route handlers
- [x] **Changelog:** Added below
- [x] **Documentation:** No documentation updates needed - internal API parameter fix
- [x] **Dependencies:** No new dependencies added
- [x] **Testing:** Manual testing of file upload and processing flows
- [x] **Code review:** Self-review completed
- [x] **Prefix:** Using `fix` prefix as this corrects a parameter omission

## Changelog Entry

### Fixed
- Added missing `request` parameter to knowledge route `/knowledge/{id}/files/batch/add`
- Added missing `request` parameter to retrieval route `/process/files/batch`
- Updated function calls to pass request parameter correctly

## Additional Information
Simple fix to add missing request parameter needed for proper file processing operations. The request object is required for handling file uploads and vector DB operations correctly.

No breaking changes or new dependencies were introduced.