### PR TITLE
fix: openai payload

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -542,7 +542,7 @@ async def generate_chat_completion(
         del payload["metadata"]
     if "chat_id" in payload:
         del payload["chat_id"]
-        
+
     model_id = form_data.get("model")
     model_info = Models.get_model_by_id(model_id)
 
@@ -681,14 +681,14 @@ async def generate_chat_completion(
             return response
     except Exception as e:
         log.exception(e)
-        
+
         if r:
             try:
                 error_text = await r.text()
                 log.error(f"OpenAI Error: {error_text}")
             except:
                 pass
-            
+
         detail = None
         if isinstance(response, dict):
             if "error" in response:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -540,7 +540,9 @@ async def generate_chat_completion(
     payload = {**form_data}
     if "metadata" in payload:
         del payload["metadata"]
-
+    if "chat_id" in payload:
+        del payload["chat_id"]
+        
     model_id = form_data.get("model")
     model_info = Models.get_model_by_id(model_id)
 
@@ -679,7 +681,14 @@ async def generate_chat_completion(
             return response
     except Exception as e:
         log.exception(e)
-
+        
+        if r:
+            try:
+                error_text = await r.text()
+                log.error(f"OpenAI Error: {error_text}")
+            except:
+                pass
+            
         detail = None
         if isinstance(response, dict):
             if "error" in response:


### PR DESCRIPTION
# fix: openai payload

## Description
Fixes OpenAI API errors by properly cleaning the payload and improving error logging.

## Changes
- Remove `chat_id` from payload before sending to OpenAI API
- Add detailed error logging for OpenAI API responses

## Related Issues
- Fixes #8263 - Merged Response not working in v0.5.3

## Testing
- Verified chat completions work with cleaned payload
- Confirmed error messages are properly logged