### PR TITLE
feat: VECTOR_LENGTH configurable through environment variable

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -29,7 +29,7 @@ class DocumentChunk(Base):
     __tablename__ = "document_chunk"
 
     id = Column(Text, primary_key=True)
-    vector = Column(Vector(dim=int(os.getenv("VECTOR_LENGTH", 1536))), nullable=True)
+    vector = Column(Vector(dim=int(os.getenv("PGVECTOR_INITIALIZE_MAX_VECTOR_SIZE", 1536))), nullable=True)
     collection_name = Column(Text, nullable=False)
     text = Column(Text, nullable=True)
     vmetadata = Column(MutableDict.as_mutable(JSONB), nullable=True)
@@ -37,7 +37,7 @@ class DocumentChunk(Base):
 
 class PgvectorClient:
     def __init__(self) -> None:
-        self.vector_length = int(os.getenv("VECTOR_LENGTH", 1536))
+        self.vector_length = int(os.getenv("PGVECTOR_INITIALIZE_MAX_VECTOR_SIZE", 1536))
 
         # if no pgvector uri, use the existing database connection
         if not PGVECTOR_DB_URL:


### PR DESCRIPTION
PR for https://github.com/open-webui/open-webui/discussions/8271

### Description

This pull request introduces several updates and improvements to the backend/open_webui/retrieval/vector.py file. These changes focus on making the system more flexible and configurable by replacing hardcoded values with environment-driven configurations, improving maintainability and adaptability to different deployment environments.

The following changes were made to enhance the functionality and configuration capabilities of the retrieval/vector.py module:

### Added
Import of os and int libraries from os and builtins respectively to enable environment-based configurations.

docs update: https://github.com/open-webui/docs/pull/348

### Changed
* [`backend/open_webui/retrieval/vector/dbs/pgvector.py`](diffhunk://#diff-28a6dc0ae8b8aecb38ddec790ac95fca054271e96eb3ecf2b2cd4cf7a7c1adb2L88-R94): Updated the `adjust_vector_length` method to use `self.vector_length` instead of a hardcoded value.
* [`backend/open_webui/retrieval/vector/dbs/pgvector.py`](diffhunk://#diff-28a6dc0ae8b8aecb38ddec790ac95fca054271e96eb3ecf2b2cd4cf7a7c1adb2L167-R172): Updated the `search` method to use `self.vector_length` for casting vectors.

### Removed
Removed static references to the hardcoded `VECTOR_LENGTH` to increase adaptability and eliminate redundancy.

### Additional Information
- Motivation: The hardcoded approach previously used for VECTOR_LENGTH restricted the flexibility of the system. Making VECTOR_LENGTH configurable allows the retrieval module to adapt to different deployments and environments without requiring code changes.

- Impact: These changes improve configurability and simplify deployment across environments by leveraging environment variables.

Relevant Sections Modified:

* [`backend/open_webui/retrieval/vector/dbs/pgvector.py`](diffhunk://#diff-28a6dc0ae8b8aecb38ddec790ac95fca054271e96eb3ecf2b2cd4cf7a7c1adb2R1): Imported the `os` module to access environment variables.
* [`backend/open_webui/retrieval/vector/dbs/pgvector.py`](diffhunk://#diff-28a6dc0ae8b8aecb38ddec790ac95fca054271e96eb3ecf2b2cd4cf7a7c1adb2L24-R40): Modified the `vector` column in the `DocumentChunk` class to use a configurable vector length from the `VECTOR_LENGTH` environment variable, with a default of 1536.
* [`backend/open_webui/retrieval/vector/dbs/pgvector.py`](diffhunk://#diff-28a6dc0ae8b8aecb38ddec790ac95fca054271e96eb3ecf2b2cd4cf7a7c1adb2L88-R94): Added `self.vector_length` to the `PgvectorClient` class to store the configurable vector length.
