### PR TITLE
feat: functionality to clone shared chats

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -469,6 +469,8 @@ class ChatTable:
     def get_chat_by_share_id(self, id: str) -> Optional[ChatModel]:
         try:
             with get_db() as db:
+                # it is possible that the shared link was deleted. hence,
+                # we check if the chat is still shared by checkng if a chat with the share_id exists
                 chat = db.query(Chat).filter_by(share_id=id).first()
 
                 if chat:

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -464,6 +464,31 @@ async def clone_chat_by_id(id: str, user=Depends(get_verified_user)):
 
 
 ############################
+# CloneChatByShareId
+############################
+
+
+@router.post("/{share_id}/clone_shared", response_model=Optional[ChatResponse])
+async def clone_chat_by_share_id(share_id: str, user=Depends(get_verified_user)):
+    chat = Chats.get_chat_by_share_id(share_id)
+    if chat:
+        updated_chat = {
+            **chat.chat,
+            "originalChatId": chat.id,
+            "branchPointMessageId": chat.chat["history"]["currentId"],
+            "title": f"Clone of {chat.title}",
+        }
+
+        chat = Chats.insert_new_chat(user.id, ChatForm(**{"chat": updated_chat}))
+        return ChatResponse(**chat.model_dump())
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT()
+        )
+
+
+
+############################
 # ArchiveChat
 ############################
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -464,13 +464,13 @@ async def clone_chat_by_id(id: str, user=Depends(get_verified_user)):
 
 
 ############################
-# CloneChatByShareId
+# CloneSharedChatById
 ############################
 
 
-@router.post("/{share_id}/clone_shared", response_model=Optional[ChatResponse])
-async def clone_chat_by_share_id(share_id: str, user=Depends(get_verified_user)):
-    chat = Chats.get_chat_by_share_id(share_id)
+@router.post("/{id}/clone/shared", response_model=Optional[ChatResponse])
+async def clone_shared_chat_by_id(id: str, user=Depends(get_verified_user)):
+    chat = Chats.get_chat_by_share_id(id)
     if chat:
         updated_chat = {
             **chat.chat,
@@ -485,7 +485,6 @@ async def clone_chat_by_share_id(share_id: str, user=Depends(get_verified_user))
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT()
         )
-
 
 
 ############################

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -618,10 +618,10 @@ export const cloneChatById = async (token: string, id: string) => {
 	return res;
 };
 
-export const cloneChatByShareId = async (token: string, share_id: string) => {
+export const cloneSharedChatById = async (token: string, id: string) => {
 	let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${share_id}/clone_shared`, {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/clone/shared`, {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -618,6 +618,44 @@ export const cloneChatById = async (token: string, id: string) => {
 	return res;
 };
 
+export const cloneChatByShareId = async (token: string, share_id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${share_id}/clone_shared`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err;
+
+			if ('detail' in err) {
+				error = err.detail;
+			} else {
+				error = err;
+			}
+
+			console.log(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const shareChatById = async (token: string, id: string) => {
 	let error = null;
 

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -16,6 +16,8 @@
 
 	const i18n = getContext('i18n');
 
+	export let className = 'h-full flex pt-8';
+
 	export let chatId = '';
 	export let user = $_user;
 
@@ -333,7 +335,7 @@
 	};
 </script>
 
-<div class="h-full flex pt-8">
+<div class={className}>
 	{#if Object.keys(history?.messages ?? {}).length == 0}
 		<ChatPlaceholder
 			modelIds={selectedModels}

--- a/src/routes/s/[id]/+page.svelte
+++ b/src/routes/s/[id]/+page.svelte
@@ -8,12 +8,12 @@
 	import { settings, chatId, WEBUI_NAME, models } from '$lib/stores';
 	import { convertMessagesToHistory, createMessagesList } from '$lib/utils';
 
-	import { getChatByShareId, cloneChatByShareId } from '$lib/apis/chats';
+	import { getChatByShareId, cloneSharedChatById } from '$lib/apis/chats';
 
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/layout/Navbar.svelte';
+
 	import { getUserById } from '$lib/apis/users';
-	import { error } from '@sveltejs/kit';
 	import { getModels } from '$lib/apis';
 	import { toast } from 'svelte-sonner';
 
@@ -104,8 +104,8 @@
 
 	const cloneSharedChat = async () => {
 		if (!chat) return;
-		
-		const res = await cloneChatByShareId(localStorage.token, chat.id).catch((error) => {
+
+		const res = await cloneSharedChatById(localStorage.token, chat.id).catch((error) => {
 			toast.error(error);
 			return null;
 		});
@@ -128,33 +128,26 @@
 	<div
 		class="min-h-screen max-h-screen w-full flex flex-col text-gray-700 dark:text-gray-100 bg-white dark:bg-gray-900"
 	>
-		<div class="flex flex-col flex-auto justify-center py-8">
-			<div class="px-3 w-full max-w-5xl mx-auto">
-				<div>
-					<div class=" text-3xl font-semibold line-clamp-1">
-						{title}
-					</div>
-
-					<div class="flex justify-between items-center mt-1">
-						<div class="text-gray-400">
-							{dayjs(chat.chat.timestamp).format($i18n.t('MMMM DD, YYYY'))}
+		<div class="flex flex-col flex-auto justify-center relative">
+			<div class=" flex flex-col w-full flex-auto overflow-auto h-0" id="messages-container">
+				<div class="pt-5 px-2 w-full max-w-5xl mx-auto">
+					<div class="px-3">
+						<div class=" text-2xl font-semibold line-clamp-1">
+							{title}
 						</div>
-						<button
-							class="px-4 py-2 text-sm font-medium bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl transition"
-							on:click={cloneSharedChat}
-						>
-							{$i18n.t('Clone in OpenWebUI')}
-						</button>
+
+						<div class="flex text-sm justify-between items-center mt-1">
+							<div class="text-gray-400">
+								{dayjs(chat.chat.timestamp).format($i18n.t('MMMM DD, YYYY'))}
+							</div>
+						</div>
 					</div>
 				</div>
 
-				<hr class="border-gray-50 dark:border-gray-850 mt-6 mb-2" />
-			</div>
-
-			<div class=" flex flex-col w-full flex-auto overflow-auto h-0" id="messages-container">
-				<div class=" h-full w-full flex flex-col py-4">
-					<div class="py-2">
+				<div class=" h-full w-full flex flex-col py-2">
+					<div class="">
 						<Messages
+							className="h-full flex pt-4 pb-8"
 							{user}
 							chatId={$chatId}
 							readOnly={true}
@@ -169,6 +162,19 @@
 							regenerateResponse={() => {}}
 						/>
 					</div>
+				</div>
+			</div>
+
+			<div
+				class="absolute bottom-0 right-0 left-0 flex justify-center w-full bg-gradient-to-b from-transparent to-gray-900"
+			>
+				<div class="pb-5">
+					<button
+						class="px-4 py-2 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+						on:click={cloneSharedChat}
+					>
+						{$i18n.t('Clone Chat')}
+					</button>
 				</div>
 			</div>
 		</div>

--- a/src/routes/s/[id]/+page.svelte
+++ b/src/routes/s/[id]/+page.svelte
@@ -8,13 +8,14 @@
 	import { settings, chatId, WEBUI_NAME, models } from '$lib/stores';
 	import { convertMessagesToHistory, createMessagesList } from '$lib/utils';
 
-	import { getChatByShareId } from '$lib/apis/chats';
+	import { getChatByShareId, cloneChatByShareId } from '$lib/apis/chats';
 
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/layout/Navbar.svelte';
 	import { getUserById } from '$lib/apis/users';
 	import { error } from '@sveltejs/kit';
 	import { getModels } from '$lib/apis';
+	import { toast } from 'svelte-sonner';
 
 	const i18n = getContext('i18n');
 
@@ -100,6 +101,19 @@
 			}
 		}
 	};
+
+	const cloneSharedChat = async () => {
+		if (!chat) return;
+		
+		const res = await cloneChatByShareId(localStorage.token, chat.id).catch((error) => {
+			toast.error(error);
+			return null;
+		});
+
+		if (res) {
+			goto(`/c/${res.id}`);
+		}
+	};
 </script>
 
 <svelte:head>
@@ -121,8 +135,16 @@
 						{title}
 					</div>
 
-					<div class=" mt-1 text-gray-400">
-						{dayjs(chat.chat.timestamp).format($i18n.t('MMMM DD, YYYY'))}
+					<div class="flex justify-between items-center mt-1">
+						<div class="text-gray-400">
+							{dayjs(chat.chat.timestamp).format($i18n.t('MMMM DD, YYYY'))}
+						</div>
+						<button
+							class="px-4 py-2 text-sm font-medium bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl transition"
+							on:click={cloneSharedChat}
+						>
+							{$i18n.t('Clone in OpenWebUI')}
+						</button>
 					</div>
 				</div>
 


### PR DESCRIPTION
Pull request for: https://github.com/open-webui/open-webui/discussions/8285
> I often find myself sharing chats back and forth with friends and often find myself extending the chats they were having. Would like to implement a button on the shared chat that automatically clones the chat so i can start talking to it


### Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following

### Description

This PR adds a button (top right) to the shared chat page:
![image](https://github.com/user-attachments/assets/5c128a18-eb84-4f36-94d1-974c6d94f162)

When clicked, a new chat is created for the user with the contents of the shared chat. The user also is also navigated to the newly created chat. Here's a small video illustrating the feature:

https://github.com/user-attachments/assets/3b416426-f287-4718-8d91-45662efb1722



Happy to take suggestions on the frontend aspect of this change! I believe this change does not require a documentation change.
