### PR TITLE
feat: Allow setting the initial vector length on pgvector document_chunk table

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1211,6 +1211,9 @@ if VECTOR_DB == "pgvector" and not PGVECTOR_DB_URL.startswith("postgres"):
     raise ValueError(
         "Pgvector requires setting PGVECTOR_DB_URL or using Postgres with vector extension as the primary database."
     )
+PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH = int(
+    os.environ.get("PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH", "1536")
+)
 
 ####################################
 # Information Retrieval (RAG)


### PR DESCRIPTION
# Changelog Entry

### Description
- Allow setting the initial vector length on pgvector document_chunk table.

### Added

- New environment variable `PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH`
- Check to be sure it remains consistent.
