### PR TITLE
feat: fix clone chat functionality on mobile

### DIFF
--- a/src/routes/s/[id]/+page.svelte
+++ b/src/routes/s/[id]/+page.svelte
@@ -166,7 +166,7 @@
 			</div>
 
 			<div
-				class="absolute bottom-0 right-0 left-0 flex justify-center w-full bg-gradient-to-b from-transparent to-gray-900"
+				class="sticky bottom-0 right-0 left-0 flex justify-center w-full bg-gradient-to-b from-transparent to-gray-900"
 			>
 				<div class="pb-5">
 					<button


### PR DESCRIPTION
Small fix for newly added "clone chat" feature introduced in https://github.com/open-webui/open-webui/pull/8286

### Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following

### Description

This PR makes sure the "Clone Chat" button is visible on mobile. This might not be the best fix, but just wanted _a_ fix out!

Before:
<img src="https://github.com/user-attachments/assets/88f81c00-fafd-40f4-bd01-b1d1bc184e8a" width=35%>

After (not shown, I click on "Clone Chat"):

https://github.com/user-attachments/assets/83400c5a-95ac-40ae-9900-7404b775ebdf



No change in behavior on desktop.

