### PR TITLE
feat: Add group permissions for making workspace features public

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -63,9 +63,13 @@ async def get_user_permissisions(user=Depends(get_verified_user)):
 ############################
 class WorkspacePermissions(BaseModel):
     models: bool
+    make_models_public: bool
     knowledge: bool
+    make_knowledge_public: bool
     prompts: bool
+    make_prompts_public: bool
     tools: bool
+    make_tools_public: bool
 
 
 class ChatPermissions(BaseModel):

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -8,9 +8,13 @@
 	export let permissions = {
 		workspace: {
 			models: false,
+			make_models_public: false,
 			knowledge: false,
+			make_knowledge_public: false,
 			prompts: false,
-			tools: false
+			make_prompts_public: false,
+			tools: false,
+			make_tools_public: false,
 		},
 		chat: {
 			delete: true,
@@ -136,6 +140,13 @@
 
 		<div class="  flex w-full justify-between my-2 pr-2">
 			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Make Models Public')}
+			</div>
+			<Switch bind:state={permissions.workspace.make_models_public} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
 				{$i18n.t('Knowledge Access')}
 			</div>
 			<Switch bind:state={permissions.workspace.knowledge} />
@@ -143,9 +154,23 @@
 
 		<div class="  flex w-full justify-between my-2 pr-2">
 			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Make Knowledge Public')}
+			</div>
+			<Switch bind:state={permissions.workspace.make_knowledge_public} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
 				{$i18n.t('Prompts Access')}
 			</div>
 			<Switch bind:state={permissions.workspace.prompts} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Make Prompts Public')}
+			</div>
+			<Switch bind:state={permissions.workspace.make_prompts_public} />
 		</div>
 
 		<div class=" ">
@@ -161,6 +186,13 @@
 				</div>
 				<Switch bind:state={permissions.workspace.tools} />
 			</Tooltip>
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Make Tools Public')}
+			</div>
+			<Switch bind:state={permissions.workspace.make_tools_public} />
 		</div>
 	</div>
 

--- a/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
@@ -4,6 +4,7 @@
 	const i18n = getContext('i18n');
 
 	import { createNewKnowledge, getKnowledgeBases } from '$lib/apis/knowledge';
+	import { WORKSPACE_VISIBILITY_TYPES } from '$lib/types';
 	import { toast } from 'svelte-sonner';
 	import { knowledge } from '$lib/stores';
 	import AccessControl from '../common/AccessControl.svelte';
@@ -12,7 +13,7 @@
 
 	let name = '';
 	let description = '';
-	let accessControl = null;
+	let accessControl = { type: WORKSPACE_VISIBILITY_TYPES.KNOWLEDGE };
 
 	const submitHandler = async () => {
 		loading = true;

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -1,6 +1,7 @@
-<script lang="ts">
+<script lang="ts" type="module">
 	import { onMount, getContext, tick } from 'svelte';
 	import { models, tools, functions, knowledge as knowledgeCollections, user } from '$lib/stores';
+	import { WORKSPACE_VISIBILITY_TYPES } from '$lib/types';
 
 	import AdvancedParams from '$lib/components/chat/Settings/Advanced/AdvancedParams.svelte';
 	import Tags from '$lib/components/common/Tags.svelte';
@@ -83,7 +84,7 @@
 	let filterIds = [];
 	let actionIds = [];
 
-	let accessControl = {};
+	let accessControl = { type: WORKSPACE_VISIBILITY_TYPES.MODEL };
 
 	const addUsage = (base_model_id) => {
 		const baseModel = $models.find((m) => m.id === base_model_id);

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" type="module">
+<script lang="ts">
 	import { onMount, getContext, tick } from 'svelte';
 	import { models, tools, functions, knowledge as knowledgeCollections, user } from '$lib/stores';
 	import { WORKSPACE_VISIBILITY_TYPES } from '$lib/types';

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -4,6 +4,7 @@
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import { toast } from 'svelte-sonner';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { WORKSPACE_VISIBILITY_TYPES } from '$lib/types';
 	import AccessControl from '../common/AccessControl.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
@@ -20,7 +21,7 @@
 	let command = '';
 	let content = '';
 
-	let accessControl = null;
+	let accessControl = { type: WORKSPACE_VISIBILITY_TYPES.PROMPT };
 
 	let showAccessControlModal = false;
 

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -11,6 +11,7 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
+	import { WORKSPACE_VISIBILITY_TYPES } from '$lib/types';
 
 	const dispatch = createEventDispatcher();
 
@@ -29,7 +30,7 @@
 		description: ''
 	};
 	export let content = '';
-	export let accessControl = null;
+	export let accessControl = { type: WORKSPACE_VISIBILITY_TYPES.TOOL };
 
 	let _content = '';
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,3 +13,11 @@ export enum TTS_RESPONSE_SPLIT {
 	PARAGRAPHS = 'paragraphs',
 	NONE = 'none'
 }
+
+// This enum corresponds to the available workspace permissions from the backend.
+export enum WORKSPACE_VISIBILITY_TYPES {
+	MODEL = "make_models_public",
+	KNOWLEDGE = "make_knowledge_public",
+	PROMPT = "make_prompts_public",
+	TOOL = "make_tools_public",
+}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

Associated discussion: https://github.com/open-webui/open-webui/discussions/8054

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
    - No dependencies
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase
# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]

Added additional permissions for groups in the workspace to prevent/allow specific groups to make models, prompts, knowledge & tools public. This change is brought about because for large scale deployments, having users with workspace access be able to make everything public will end up as a large source of clutter. Admins can always set things to public.

If a user is a part of **any** group with a matching "Public" permission, they can the respective model/prompt/knowledge/tool public.

### Added

- Added additional permissions for groups in the workspace to allow/prevent specific groups to make models, prompts, knowledge & tools public.

### Changed

- Models, knowledge, prompts, & tools all now have "Private" visibility by default.

---

### Screenshots or Videos

New permissions for groups: 
<img width="464" alt="Screenshot 2025-01-06 at 12 20 05 PM" src="https://github.com/user-attachments/assets/f7d6d13b-b1a4-482f-b80f-03d67a22a129" />

As a user without permission, trying to make a model:
<img width="459" alt="Screenshot 2025-01-06 at 12 24 06 PM" src="https://github.com/user-attachments/assets/7c41daf3-93f3-497b-9fec-7f5a3afd9f9e" />

