### PR TITLE
fix: apple silicon test fails so import pytorch before test and log exception if test fails

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -54,10 +54,11 @@ else:
     DEVICE_TYPE = "cpu"
 
 try:
+    import torch
     if torch.backends.mps.is_available() and torch.backends.mps.is_built():
         DEVICE_TYPE = "mps"
-except Exception:
-    pass
+except Exception as e:
+    print(f"env.py: Apple Silicon test failed {e=}")
 
 ####################################
 # LOGGING


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixing a bug in Apple Silicon detection and setting DEVICE_TYPE="mps" for GPU acceleration on M1-M4 processors
- Add exception logging if there are errors in the check

### Added

- None

### Changed

- None

### Deprecated

- None
### Removed

- None

### Fixed

- In Apple silicon test in env.py, import torch for the check
- Print the error that occurs if the test fails

### Security

- None

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

The current test is, but torch is not imported (this only happens if USE_CUDA=true, there is no top level import. The test fails because torch is not loaded and since the exceptions are ignored, DEVICE_TYPE="cpu" is left as it is and the user gets no explanation

```
try:
  if torch.backends.mps.is available() and torch.backends.mps.is_built():
     DEVICE_TYPE="mps"
except Exception:
  pass
```

The fix (although ugly) is to import torch in the try loop and also to print the actual
exception (it looks like logging is not used in this part of the code and print to stdout)
is what happens

```
try:
  import torch
  if torch.backends.mps.is available() and torch.backends.mps.is_built():
     DEVICE_TYPE="mps"
except Exception as e:
  print(f"Apple Silicon test failed {e=}")
```

This was raised in https://github.com/open-webui/open-webui/discussions/8278 and was raised in https://github.com/open-webui/open-webui/issues/8324 and PR issued in https://github.com/open-webui/open-webui/pull/8328 but the commit https://github.com/open-webui/open-webui/commit/d477f73c7efd590e55b78ee248f0bc8b8ef7d8cf was applied instead which is correct except import torch is not in the try and the errors are ignored.

### Screenshots or Videos

N/A
