### PR TITLE
fix: Exception raised when new user tries to login through OAuth for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## []
+
+### FIXED
+
+- **OAuth user registration fixed**: Resolved a bug causing exception raised during first user login through OAuth
+
 ## [0.5.4] - 2025-01-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## []
-
-### FIXED
-
-- **OAuth user registration fixed**: Resolved a bug causing exception raised during first user login through OAuth
-
 ## [0.5.4] - 2025-01-05
 
 ### Added

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -34,7 +34,7 @@ from open_webui.config import (
     JWT_EXPIRES_IN,
     AppConfig,
 )
-from open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
 from open_webui.env import WEBUI_SESSION_COOKIE_SAME_SITE, WEBUI_SESSION_COOKIE_SECURE
 from open_webui.utils.misc import parse_duration
 from open_webui.utils.auth import get_password_hash, create_token
@@ -295,10 +295,10 @@ class OAuthManager:
                 if auth_manager_config.WEBHOOK_URL:
                     post_webhook(
                         auth_manager_config.WEBHOOK_URL,
-                        auth_manager_config.WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+                        WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
                         {
                             "action": "signup",
-                            "message": auth_manager_config.WEBHOOK_MESSAGES.USER_SIGNUP(
+                            "message": WEBHOOK_MESSAGES.USER_SIGNUP(
                                 user.name
                             ),
                             "user": user.model_dump_json(exclude_none=True),


### PR DESCRIPTION
# Changelog Entry

### Description

When logging in the first time through OAuth, following exception is raised:

```
  File "/app/backend/open_webui/utils/oauth.py", line 298, in <module>
    auth_manager_config.WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/config.py", line 258, in __setattr__
    self._state[key].value = value
    ~~~~~~~~~~~^^^^^
KeyError: 'WEBHOOK_MESSAGES'
```

This is caused by `WEBHOOK_MESSAGES` supposed to be coming from `constants.py` while this code tries to take it from `auth_manager_config` . 

### Fixed

- Fixed exception raised when first login through OAuth

### Additional Information

This has been reported by another user a month ago, but seems to not be addressed. I'm skipping creating a discussion post due to it.

https://github.com/open-webui/open-webui/discussions/7672
