### PR TITLE
Adding Helm chart link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ After installation, you can access Open WebUI at [http://localhost:3000](http://
 
 ### Other Installation Methods
 
-We offer various installation alternatives, including non-Docker native installation methods, Docker Compose, Kustomize, and Helm. Visit our [Open WebUI Documentation](https://docs.openwebui.com/getting-started/) or join our [Discord community](https://discord.gg/5rJgQTnV4s) for comprehensive guidance.
+We offer various installation alternatives, including non-Docker native installation methods, Docker Compose, Kustomize, and [Helm](https://app.trustshepherd.com/docs/3952be81-ac1f-49e9-a86e-0bdfeee983d3). Visit our [Open WebUI Documentation](https://docs.openwebui.com/getting-started/) or join our [Discord community](https://discord.gg/5rJgQTnV4s) for comprehensive guidance.
 
 ### Troubleshooting
 


### PR DESCRIPTION
# Changelog Entry
Added Helm chart link to readme

### Description

I couldn't find a Helm chart to deploy open-webui, despite the Github readme stating there are [instructions in the docs](https://github.com/open-webui/open-webui?tab=readme-ov-file#other-installation-methods)

I've created a Helm chart and documentation page for this here: https://app.trustshepherd.com/docs/3952be81-ac1f-49e9-a86e-0bdfeee983d3

I'm raising this PR to add a link to this to the readme

### Added

This PR adds a Helm chart link to the Github readme

### Changed

Github readme documentation 

### Deprecated

N/A
### Removed

N/A
### Fixed

N/A
### Security

N/A
### Breaking Changes

N/A
---

### Additional Information

N/A
### Screenshots or Videos

N/A