### PR TITLE
fix: Knowledge Base Detachment from Models

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -25,6 +25,7 @@ from open_webui.utils.access_control import has_access, has_permission
 
 
 from open_webui.env import SRC_LOG_LEVELS
+from open_webui.models.models import Models, ModelForm
 
 
 log = logging.getLogger(__name__)
@@ -473,6 +474,36 @@ async def delete_knowledge_by_id(id: str, user=Depends(get_verified_user)):
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
+    log.info(f"Deleting knowledge base: {id} (name: {knowledge.name})")
+
+    # Get all models
+    models = Models.get_all_models()
+    log.info(f"Found {len(models)} models to check for knowledge base {id}")
+
+    # Update models that reference this knowledge base
+    for model in models:
+        if model.meta and hasattr(model.meta, "knowledge"):
+            knowledge_list = model.meta.knowledge or []
+            # Filter out the deleted knowledge base
+            updated_knowledge = [k for k in knowledge_list if k.get("id") != id]
+            
+            # If the knowledge list changed, update the model
+            if len(updated_knowledge) != len(knowledge_list):
+                log.info(f"Updating model {model.id} to remove knowledge base {id}")
+                model.meta.knowledge = updated_knowledge
+                # Create a ModelForm for the update
+                model_form = ModelForm(
+                    id=model.id,
+                    name=model.name,
+                    base_model_id=model.base_model_id,
+                    meta=model.meta,
+                    params=model.params,
+                    access_control=model.access_control,
+                    is_active=model.is_active
+                )
+                Models.update_model_by_id(model.id, model_form)
+
+    # Clean up vector DB
     try:
         VECTOR_DB_CLIENT.delete_collection(collection_name=id)
     except Exception as e:

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -486,7 +486,7 @@ async def delete_knowledge_by_id(id: str, user=Depends(get_verified_user)):
             knowledge_list = model.meta.knowledge or []
             # Filter out the deleted knowledge base
             updated_knowledge = [k for k in knowledge_list if k.get("id") != id]
-            
+
             # If the knowledge list changed, update the model
             if len(updated_knowledge) != len(knowledge_list):
                 log.info(f"Updating model {model.id} to remove knowledge base {id}")
@@ -499,7 +499,7 @@ async def delete_knowledge_by_id(id: str, user=Depends(get_verified_user)):
                     meta=model.meta,
                     params=model.params,
                     access_control=model.access_control,
-                    is_active=model.is_active
+                    is_active=model.is_active,
                 )
                 Models.update_model_by_id(model.id, model_form)
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -74,7 +74,6 @@ export const processResponseContent = (content: string) => {
 	return content.trim();
 };
 
-
 export function unescapeHtml(html: string) {
 	const doc = new DOMParser().parseFromString(html, 'text/html');
 	return doc.documentElement.textContent;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry 
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title

# Changelog Entry

### Description
Fixed an issue where knowledge bases remained linked to models after being deleted from the Knowledge area. This ensures data consistency by properly cleaning up all references when a knowledge base is deleted, preventing orphaned references in models.

An explanation of the scenario _before_ the patch:

When a user wanted to remove a knowledge base from their system, the following scenario would occur:

1. **Initial State**:
   - A knowledge base (KB) exists in the "Knowledge" area
   - One or more models have this KB attached to them
   - The KB is stored in three places:
     - The knowledge base database table
     - The vector database (for storing embeddings)
     - References in models' metadata (`model.meta.knowledge`)

2. **User Action**:
   - User goes to the "Knowledge" area
   - Selects a KB
   - Clicks delete
   - Confirms deletion

3. **What Actually Happened**:
   - The KB would be deleted from the knowledge base database table
   - The vector database collection would be cleaned up
   - BUT: The references in models' metadata remained untouched
   
4. **Resulting Problems**:
   - Models still showed the deleted KB in their knowledge list
   - These were now "ghost" references - pointing to a KB that no longer existed
   - The model's configuration became inconsistent with the actual system state

5. **Technical Issue**:
   - The `delete_knowledge_by_id` endpoint only handled:
     - Deleting the KB from the database
     - Cleaning up the vector DB collection
   - It didn't:
     - Check which models referenced the KB
     - Update those models to remove the references

This created a data consistency issue where models maintained references to non-existent knowledge bases, leading to a confusing user experience and potential issues with model operation.


### Fixed
- Fixed knowledge base references remaining in models after deletion
- Fixed model update process to use proper ModelForm structure
- Fixed potential data inconsistency between Knowledge area and model references

The changes ensure that when a knowledge base is deleted:
1. All models are checked for references to the deleted knowledge base
2. Any found references are properly removed using Pydantic model attribute access
3. Models are correctly updated using ModelForm
4. Vector database collections are cleaned up
5. The knowledge base itself is deleted only after all references are cleaned up
