### PR TITLE
ci: fix for cypress error in integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
+        env:
+          LIBGL_ALWAYS_SOFTWARE: 1
         with:
           browser: chrome
           wait-on: 'http://localhost:3000'


### PR DESCRIPTION
Not making any changes to the code. I think I found a fix for the integration tests failure under 24.04 with the error:
```
MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER)
glx: failed to create drisw screen

DevTools listening on ws://127.0.0.1:42827/devtools/browser/d03bdaef-444c-4ce8-bc25-f84b709862cf
```
Github recently changed over to 24.04 for `ubuntu-latest`  
Cypress has an open issue for this error related to ubuntu 24.04. 
https://github.com/cypress-io/cypress/issues/29521
I commented on that issue with my test results. I found that this Environment variable fixed the issue in a 24.04 docker container. 
I did some testing a found a potential fix. If you all will let that workflow run we can find out and maybe the integration tests will work again. 

I did not follow the PR checklist because I was not changing any code or anything that needed tests, just trying to fix one of the tests itself... 