### PR TITLE
feat: Add toggle to read/write perms on access control

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -213,8 +213,8 @@ async def update_knowledge_by_id(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
-
-    if knowledge.user_id != user.id and user.role != "admin":
+    # Is the user the original creator, in a group with write access, or an admin
+    if knowledge.user_id != user.id and not has_access(user.id, "write", knowledge.access_control) and user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -111,8 +111,9 @@ async def update_prompt_by_command(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
-
-    if prompt.user_id != user.id and user.role != "admin":
+    
+    # Is the user the original creator, in a group with write access, or an admin
+    if prompt.user_id != user.id and not has_access(user.id, "write", prompt.access_control) and user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -165,7 +165,8 @@ async def update_tools_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if tools.user_id != user.id and user.role != "admin":
+    # Is the user the original creator, in a group with write access, or an admin
+    if tools.user_id != user.id and not has_access(user.id, "write", tools.access_control) and user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -21,6 +21,7 @@
 	} from '$lib/apis/models';
 
 	import { getModels } from '$lib/apis';
+	import { getGroups } from '$lib/apis/groups';
 
 	import EllipsisHorizontal from '../icons/EllipsisHorizontal.svelte';
 	import ModelMenu from './Models/ModelMenu.svelte';
@@ -46,6 +47,8 @@
 	let selectedModel = null;
 
 	let showModelDeleteConfirm = false;
+
+	let group_ids = [];
 
 	$: if (models) {
 		filteredModels = models.filter(
@@ -151,6 +154,9 @@
 
 	onMount(async () => {
 		models = await getWorkspaceModels(localStorage.token);
+		let groups = await getGroups(localStorage.token);
+		group_ids = groups.map(group => group.id);
+		
 
 		loaded = true;
 
@@ -308,7 +314,7 @@
 								</button>
 							</Tooltip>
 						{:else}
-							{#if $user?.role === 'admin' || model.user_id === $user?.id}
+							{#if $user?.role === 'admin' || model.user_id === $user?.id || model.access_control.write.group_ids.some(wg => group_ids.includes(wg))} 
 								<a
 									class="self-center w-fit text-sm px-2 py-2 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
 									type="button"

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -8,6 +8,7 @@
 	import Plus from '$lib/components/icons/Plus.svelte';
 	import UserCircleSolid from '$lib/components/icons/UserCircleSolid.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import Badge from '$lib/components/common/Badge.svelte';
 
 	export let onChange: Function = () => {};
 
@@ -91,6 +92,9 @@
 							accessControl = {
 								read: {
 									group_ids: []
+								},
+								write: {
+									group_ids: []
 								}
 							};
 						}
@@ -110,7 +114,6 @@
 			</div>
 		</div>
 	</div>
-
 	{#if accessControl !== null}
 		{@const accessGroups = groups.filter((group) =>
 			accessControl.read.group_ids.includes(group.id)
@@ -138,6 +141,27 @@
 								</div>
 
 								<div class="w-full flex justify-end">
+									<button
+										class=" translate-y-0.5"
+										type="button"
+										on:click={() => {
+											if (accessControl.write.group_ids.includes(group.id)) {
+												accessControl.write.group_ids = accessControl.write.group_ids.filter(
+													(group_id) => group_id !== group.id)
+											} else {
+												accessControl.write.group_ids = [
+												...accessControl.write.group_ids,
+												group.id
+												];
+											}
+										}}
+									>
+									<Badge	
+										type={accessControl.write.group_ids.includes(group.id) ? 'info' : 'success'}
+										content={$i18n.t(accessControl.write.group_ids.includes(group.id) ? "Write" : "Read")}
+									/>
+									</button>
+
 									<button
 										class=" rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-850 transition"
 										type="button"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

Associated but slightly different discussion post: https://github.com/open-webui/open-webui/discussions/8373

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
  - None
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:

  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

Adding the ability for users who create private models/knowledge/prompts/tools in the workspace to also choose which groups can modify the created model/knowledge/prompt/tool. The user can only choose between groups they are already in. This change allows users to allow others to edit their custom data, while still maintaining the read-only aspects by default.

### Added

Adding the ability for users who create private models/knowledge/prompts/tools in the workspace to also choose which groups can modify the created model/knowledge/prompt/tool. 

---

### Screenshots or Videos

Walk-through example:

Users t2 and t3 are in the group "multi-edit-test" together, with all workspace permissions:
<img width="667" alt="Screenshot 2025-01-10 at 1 52 54 PM" src="https://github.com/user-attachments/assets/9dd106c0-6a18-4aa8-9700-cdf1fd19aab4" />


User t3 decides to create a knowledge(can also be a model, prompt or tool) and share it to the group "multi-edit-test", with only read access (the default):

<img width="556" alt="Screenshot 2025-01-10 at 2 01 27 PM" src="https://github.com/user-attachments/assets/a654fc50-ba1c-49e6-8ff5-011dc97982d7" />


User t2 cannot see the knowledge but can use it when making a model:
<img width="592" alt="Screenshot 2025-01-10 at 2 02 01 PM" src="https://github.com/user-attachments/assets/e76afb10-5b2b-46af-aabd-9a274b8efec9" />

<img width="757" alt="Screenshot 2025-01-10 at 2 04 30 PM" src="https://github.com/user-attachments/assets/e8c05dd7-d6f8-4964-8f37-bd04db13a7ab" />


User t3 decides to make the knowledge writeable by the group by clicking the "read" badge:
<img width="476" alt="Screenshot 2025-01-10 at 2 05 19 PM" src="https://github.com/user-attachments/assets/b497ea3f-b7b2-4b0a-bac3-71aa7810e197" />

User t2 can now see the knowledge in the workspace and edit it, as well as use it in models:
<img width="542" alt="Screenshot 2025-01-10 at 2 06 16 PM" src="https://github.com/user-attachments/assets/9c1a5d70-f4ab-4add-8899-70d5a5c4791f" />

