### PR TITLE
fix: complete file cleanup when removing from Knowledge Base

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -17,7 +17,7 @@ from open_webui.routers.retrieval import (
     process_files_batch,
     BatchProcessFilesForm,
 )
-
+from open_webui.storage.provider import Storage
 
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.auth import get_verified_user
@@ -419,6 +419,18 @@ def remove_file_from_knowledge_by_id(
     VECTOR_DB_CLIENT.delete(
         collection_name=knowledge.id, filter={"file_id": form_data.file_id}
     )
+
+    # Remove the file's collection from vector database
+    file_collection = f"file-{form_data.file_id}"
+    if VECTOR_DB_CLIENT.has_collection(collection_name=file_collection):
+        VECTOR_DB_CLIENT.delete_collection(collection_name=file_collection)
+
+    # Delete physical file
+    if file.path:
+        Storage.delete_file(file.path)
+
+    # Delete file from database
+    Files.delete_file_by_id(form_data.file_id)
 
     if knowledge:
         data = knowledge.data or {}


### PR DESCRIPTION
fix: complete file cleanup when removing from Knowledge Base

# Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry 
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title

# Changelog Entry

- Fixed file cleanup when removing from Knowledge Base - files are now properly deleted from storage, database, and vector storage instead of remaining as orphaned resources

### Description

Currently, when removing a file from a Knowledge Base, the system only partially cleans up the resources. This PR implements a complete cleanup by:

1. Removing the file's vectors from the Knowledge Base collection in ChromaDB
2. Removing the file's dedicated collection from ChromaDB (file-{id})
3. Deleting the physical file from storage
4. Removing the file entry from the SQLite database
5. Maintaining the existing security checks and KB data updates

### Changed

- Modified `remove_file_from_knowledge_by_id` in `backend/open_webui/routers/knowledge.py` to:
  - Delete the file's vectors from KB collection in ChromaDB
  - Delete the file's dedicated collection from ChromaDB
  - Delete the physical file from storage
  - Remove the file entry from the database
  - Keep existing permission checks and KB data updates




