### PR TITLE
chore/docs: Removing HF_HUB_OFFLINE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ docker run -d -p 3000:8080 -v open-webui:/app/backend/data --name open-webui --a
 
 ### Offline Mode
 
-If you are running Open WebUI in an offline environment, you can set the `HF_HUB_OFFLINE` environment variable to `1` to prevent attempts to download models from the internet.
+If you are running Open WebUI in an offline environment, you can set the `OFFLINE_MODE` environment variable to `True` to prevent attempts to download models from the internet.
 
 ```bash
-export HF_HUB_OFFLINE=1
+export OFFLINE_MODE=True
 ```
 
 ## What's Next? 🌟

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -402,6 +402,3 @@ else:
 ####################################
 
 OFFLINE_MODE = os.environ.get("OFFLINE_MODE", "false").lower() == "true"
-
-if OFFLINE_MODE:
-    os.environ["HF_HUB_OFFLINE"] = "1"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? -> **NOT NEEDED, "HF_HUB_OFFLINE" is not even documented in the docs.** and OFFLINE_MODE is already documented
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition

# Changelog Entry

### Description

- I noticed that the HF_HUB_OFFLINE environment variable is not used anywhere. It was only stored/accessed in the env.py file and documented in the readme. It is not used anywhere else. Therefore, I removed the lines from the env.py file to remove the HF_HUB_OFFLINE environment variable and also changed the readme to instead reference the OFFLINE_MODE variable.

- HF_HUB_OFFLINE was removed as it is unused
