### PR TITLE
Fix: updated get_chat_list_by_user_id method to return all user cha…

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -393,7 +393,7 @@ class ChatTable:
         limit: int = 50,
     ) -> list[ChatModel]:
         with get_db() as db:
-            query = db.query(Chat).filter_by(user_id=user_id).filter_by(folder_id=None)
+            query = db.query(Chat).filter_by(user_id=user_id)
             if not include_archived:
                 query = query.filter_by(archived=False)
 


### PR DESCRIPTION
Implements https://github.com/open-webui/open-webui/discussions/7949 and https://github.com/open-webui/open-webui/issues/8553

When admin checks chats list created by users, the chats that have been moved to the folders are not included into the list

This PR modifies the _get_chat_list_by_user_id_ method removing the filter (folder_id=None) from the very first query


# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes an issue where the admin's chat list view was not showing chats that had been moved to folders. The change ensures that all chats are visible in the admin view, regardless of their folder status.

### Fixed

- Fixed admin chat list view to show all chats, including those moved to folders, by removing the `folder_id=None` filter from the `get_chat_list_by_user_id` query

### Additional Information

- Implements the feature requests from:
  - https://github.com/open-webui/open-webui/discussions/7949
  - https://github.com/open-webui/open-webui/issues/8553
- The change is minimal and only affects the chat list query, with no breaking changes to the API or database schema

### Screenshots or Videos
1st screenshot (before PR) admin account on the left, user account on the right.
Admin sees only single chat "test3"
![image](https://github.com/user-attachments/assets/c1a9d2cf-8dc7-403c-aa06-a62fffd4760b)

2nd screenshot (with PR) admin account on the left, user account on the right.
Admin sees all 3 chats "test1", "test2" and "test3"
![image](https://github.com/user-attachments/assets/014a88bd-f283-4de4-ac78-044193335773)

