### PR TITLE
Add functionality to retrive picture for microsoft oauth

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -487,6 +487,7 @@ def load_oauth_providers():
             "server_metadata_url": f"https://login.microsoftonline.com/{MICROSOFT_CLIENT_TENANT_ID.value}/v2.0/.well-known/openid-configuration",
             "scope": MICROSOFT_OAUTH_SCOPE.value,
             "redirect_uri": MICROSOFT_REDIRECT_URI.value,
+            "picture_url": "https://graph.microsoft.com/v1.0/me/photo/$value",
         }
 
     if (

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -255,7 +255,9 @@ class OAuthManager:
                     raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
                 picture_claim = auth_manager_config.OAUTH_PICTURE_CLAIM
-                picture_url = user_data.get(picture_claim, "")
+                picture_url = user_data.get(
+                    picture_claim, OAUTH_PROVIDERS[provider].get("picture_url", "")
+                )
                 if picture_url:
                     # Download the profile image into a base64 string
                     try:


### PR DESCRIPTION
Microsoft oauth does not send the `picture` claim like other providers do. This PR enables the retrieval of the profile picture in those cases. 
Is quite simple TBH, there is a standard given by the Microsfot Graph API to retrieve it:
- https://learn.microsoft.com/en-us/graph/api/profilephoto-get?view=graph-rest-1.0&tabs=http#request

It is not a breaking change as the other providers still behave exactly in the same way.

I have tested  with my company credentials and it works. 

Solves: #8425 
