### PR TITLE
feat: User Feedback UI for Admins

### DIFF
--- a/backend/open_webui/migrations/versions/790ecce592df_add_chat_id_to_feedback.py
+++ b/backend/open_webui/migrations/versions/790ecce592df_add_chat_id_to_feedback.py
@@ -1,0 +1,30 @@
+"""add_chat_id_to_feedback
+
+Revision ID: 790ecce592df
+Revises: 3781e22d8b01
+Create Date: 2025-01-08 15:13:16.063379
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import open_webui.internal.db
+
+revision: str = '790ecce592df'
+down_revision: Union[str, None] = '3781e22d8b01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+
+    # Add chat_id column to feedback
+    op.add_column(
+        "feedback",
+        sa.Column("chat_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("feedback", "chat_id")

--- a/backend/open_webui/migrations/versions/96dcb0b3212f_migrate_chat_id_in_feedback.py
+++ b/backend/open_webui/migrations/versions/96dcb0b3212f_migrate_chat_id_in_feedback.py
@@ -1,0 +1,50 @@
+"""migrate_chat_id_in_feedback
+
+Revision ID: 96dcb0b3212f
+Revises: 790ecce592df
+Create Date: 2025-01-13 08:08:22.582335
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import open_webui.internal.db
+
+revision: str = '96dcb0b3212f'
+down_revision: Union[str, None] = '790ecce592df'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+
+    # Migrate chat_id data from meta to new chat_id column
+    conn = op.get_bind()
+    feedback = sa.table(
+        'feedback',
+        sa.column('id', sa.String),
+        sa.column('chat_id', sa.Text),
+        sa.column('meta', sa.JSON)
+    )
+    
+    result = conn.execute(
+        sa.select(feedback.c.id, feedback.c.meta)
+        .where(sa.and_(
+            feedback.c.chat_id.is_(None),
+            feedback.c.meta.isnot(None)
+        ))
+    )
+    
+    for row in result:
+        if row.meta and 'chat_id' in row.meta:
+            chat_id = row.meta['chat_id']
+            conn.execute(
+                feedback.update()
+                .where(feedback.c.id == row.id)
+                .values(chat_id=chat_id)
+            )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/open_webui/migrations/versions/e56c262570d7_make_chat_id_in_feedback_required.py
+++ b/backend/open_webui/migrations/versions/e56c262570d7_make_chat_id_in_feedback_required.py
@@ -1,0 +1,42 @@
+"""make_chat_id_in_feedback_required
+
+Revision ID: e56c262570d7
+Revises: 96dcb0b3212f
+Create Date: 2025-01-13 08:18:51.348376
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import open_webui.internal.db
+
+revision: str = 'e56c262570d7'
+down_revision: Union[str, None] = '96dcb0b3212f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+
+    # Check if there are feedbacks with NULL chat_ids, if not, make chat_id required
+    conn = op.get_bind()
+    feedback = sa.table('feedback', sa.column('chat_id', sa.Text))
+    result = conn.execute(sa.select(feedback).where(feedback.c.chat_id.is_(None)))
+    
+    if result.first() is not None:
+        raise Exception(
+            "There are feedbacks with NULL chat_ids. Previous migration failed."
+        )
+    
+    with op.batch_alter_table('feedback') as batch_op:
+        batch_op.alter_column('chat_id',
+                            existing_type=sa.Text(),
+                            nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('feedback') as batch_op:
+        batch_op.alter_column('chat_id',
+                            existing_type=sa.Text(),
+                            nullable=True)

--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -157,3 +157,13 @@ async def delete_feedback_by_id(id: str, user=Depends(get_verified_user)):
         )
 
     return success
+
+@router.get("/feedbacks/chat/{id}", response_model=list[FeedbackUserResponse])
+async def get_feedbacks_by_chat_id(id: str, user=Depends(get_admin_user)):
+    feedbacks = Feedbacks.get_feedbacks_by_chat_id(chat_id=id)
+    return [
+        FeedbackUserResponse(
+            **feedback.model_dump(), user=Users.get_user_by_id(feedback.user_id)
+        )
+        for feedback in feedbacks
+    ]

--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -62,11 +62,9 @@ class FeedbackUserResponse(FeedbackResponse):
 
 @router.get("/feedbacks/all", response_model=list[FeedbackUserResponse])
 async def get_all_feedbacks(user=Depends(get_admin_user)):
-    feedbacks = Feedbacks.get_all_feedbacks()
+    feedbacks = Feedbacks.get_all_feedbacks_with_user()
     return [
-        FeedbackUserResponse(
-            **feedback.model_dump(), user=Users.get_user_by_id(feedback.user_id)
-        )
+        FeedbackUserResponse(**feedback.model_dump())
         for feedback in feedbacks
     ]
 

--- a/src/lib/apis/evaluations/index.ts
+++ b/src/lib/apis/evaluations/index.ts
@@ -186,6 +186,37 @@ export const getFeedbackById = async (token: string, feedbackId: string) => {
 	return res;
 };
 
+export const getFeedbacksByChatId = async (token: string = '', chatId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/evaluations/feedbacks/chat/${chatId}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.log(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const updateFeedbackById = async (token: string, feedbackId: string, feedback: object) => {
 	let error = null;
 

--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -20,7 +20,7 @@
 	import FeedbackMenu from './FeedbackMenu.svelte';
 	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
 
-	export let feedbacks = [];
+	export let feedbacks: Feedback[] = [];
 
 	let page = 1;
 	$: paginatedFeedbacks = feedbacks.slice((page - 1) * 10, page * 10);
@@ -35,9 +35,18 @@
 			comment: string;
 			tags: string[];
 		};
+		meta: {
+			chat_id: string;
+			message_id?: string;
+		};
 		user: {
 			name: string;
 			profile_image_url: string;
+		};
+		snapshot: {
+			chat: {
+				title: string;
+			}
 		};
 		updated_at: number;
 	};
@@ -152,6 +161,10 @@
 						{$i18n.t('Models')}
 					</th>
 
+					<th scope="col" class="px-3 pr-1.5 cursor-pointer select-none">
+						{$i18n.t('Chat')}
+					</th>
+
 					<th scope="col" class="px-3 py-1.5 text-right cursor-pointer select-none w-fit">
 						{$i18n.t('Result')}
 					</th>
@@ -211,6 +224,15 @@
 								</div>
 							</div>
 						</td>
+
+						<td class="px-3 py-1 font-medium text-sm text-gray-900 dark:text-white">
+							<a href="/s/{feedback.meta.chat_id}?showFeedback=true" target="_blank">
+								<div class="underline line-clamp-1 max-w-96">
+									{feedback.snapshot?.chat?.title}
+								</div>
+							</a>
+						</td>
+
 						<td class="px-3 py-1 text-right font-medium text-gray-900 dark:text-white w-max">
 							<div class=" flex justify-end">
 								{#if feedback.data.rating.toString() === '1'}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -12,6 +12,8 @@
 	import Loader from '../common/Loader.svelte';
 	import Spinner from '../common/Spinner.svelte';
 
+	import Feedback from '$lib/components/admin/Evaluations/Feedbacks.svelte';
+
 	import ChatPlaceholder from './ChatPlaceholder.svelte';
 
 	const i18n = getContext('i18n');
@@ -333,6 +335,8 @@
 			}, 100);
 		}
 	};
+
+	export let feedbacks: Feedback[] = [];
 </script>
 
 <div class={className}>
@@ -410,6 +414,7 @@
 							{addMessages}
 							{triggerScroll}
 							{readOnly}
+							feedback={feedbacks.find(f => f.meta.message_id === message.id)}
 						/>
 					{/each}
 				</div>

--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -11,6 +11,9 @@
 	import MultiResponseMessages from './MultiResponseMessages.svelte';
 	import ResponseMessage from './ResponseMessage.svelte';
 	import UserMessage from './UserMessage.svelte';
+	import Badge from '$lib/components/common/Badge.svelte';
+
+	import  Feedback from '$lib/components/admin/Evaluations/Feedbacks.svelte';
 
 	export let chatId;
 	export let idx = 0;
@@ -38,6 +41,8 @@
 	export let addMessages;
 	export let triggerScroll;
 	export let readOnly = false;
+
+	export let feedback: Feedback | undefined = undefined;
 </script>
 
 <div
@@ -46,62 +51,120 @@
 		: 'max-w-5xl'} mx-auto rounded-lg group"
 >
 	{#if history.messages[messageId]}
-		{#if history.messages[messageId].role === 'user'}
-			<UserMessage
-				{user}
-				{history}
-				{messageId}
-				isFirstMessage={idx === 0}
-				siblings={history.messages[messageId].parentId !== null
-					? (history.messages[history.messages[messageId].parentId]?.childrenIds ?? [])
-					: (Object.values(history.messages)
-							.filter((message) => message.parentId === null)
-							.map((message) => message.id) ?? [])}
-				{showPreviousMessage}
-				{showNextMessage}
-				{editMessage}
-				{deleteMessage}
-				{readOnly}
-			/>
-		{:else if (history.messages[history.messages[messageId].parentId]?.models?.length ?? 1) === 1}
-			<ResponseMessage
-				{chatId}
-				{history}
-				{messageId}
-				isLastMessage={messageId === history.currentId}
-				siblings={history.messages[history.messages[messageId].parentId]?.childrenIds ?? []}
-				{showPreviousMessage}
-				{showNextMessage}
-				{updateChat}
-				{editMessage}
-				{saveMessage}
-				{rateMessage}
-				{actionMessage}
-				{submitMessage}
-				{continueResponse}
-				{regenerateResponse}
-				{addMessages}
-				{readOnly}
-			/>
-		{:else}
-			<MultiResponseMessages
-				bind:history
-				{chatId}
-				{messageId}
-				isLastMessage={messageId === history?.currentId}
-				{updateChat}
-				{editMessage}
-				{saveMessage}
-				{rateMessage}
-				{actionMessage}
-				{submitMessage}
-				{continueResponse}
-				{regenerateResponse}
-				{mergeResponses}
-				{triggerScroll}
-				{addMessages}
-				{readOnly}
-			/>
+		<div style="border: {feedback ? feedback.data.rating === 1 ? '2px solid green' : '2px solid red' : 'none'}; border-radius: 10px; padding: 10px;">
+			{#if history.messages[messageId].role === 'user'}
+				<UserMessage
+					{user}
+					{history}
+					{messageId}
+					isFirstMessage={idx === 0}
+					siblings={history.messages[messageId].parentId !== null
+						? (history.messages[history.messages[messageId].parentId]?.childrenIds ?? [])
+						: (Object.values(history.messages)
+								.filter((message) => message.parentId === null)
+								.map((message) => message.id) ?? [])}
+					{showPreviousMessage}
+					{showNextMessage}
+					{editMessage}
+					{deleteMessage}
+					{readOnly}
+				/>
+			{:else if (history.messages[history.messages[messageId].parentId]?.models?.length ?? 1) === 1}
+				<ResponseMessage
+					{chatId}
+					{history}
+					{messageId}
+					isLastMessage={messageId === history.currentId}
+					siblings={history.messages[history.messages[messageId].parentId]?.childrenIds ?? []}
+					{showPreviousMessage}
+					{showNextMessage}
+					{updateChat}
+					{editMessage}
+					{saveMessage}
+					{rateMessage}
+					{actionMessage}
+					{submitMessage}
+					{continueResponse}
+					{regenerateResponse}
+					{addMessages}
+					{readOnly}
+				/>
+			{:else}
+				<MultiResponseMessages
+					bind:history
+					{chatId}
+					{messageId}
+					isLastMessage={messageId === history?.currentId}
+					{updateChat}
+					{editMessage}
+					{saveMessage}
+					{rateMessage}
+					{actionMessage}
+					{submitMessage}
+					{continueResponse}
+					{regenerateResponse}
+					{mergeResponses}
+					{triggerScroll}
+					{addMessages}
+					{readOnly}
+				/>
+			{/if}
+		</div>
+
+		{#if feedback}
+			<div class="flex gap-2 mt-2">
+				<div class="flex items-start mt-1">
+					{#if feedback.data?.rating === 1}
+						<Badge type="success" content={$i18n.t('Feedback')} />
+					{:else if feedback.data?.rating === 0}
+						<Badge type="info" content={$i18n.t('Feedback')} />
+					{:else if feedback.data?.rating === -1}
+						<Badge type="error" content={$i18n.t('Feedback')} />
+					{/if}
+				</div>
+				<div class="flex flex-col gap-1">
+					<div>
+						{$i18n.t('Comment')}: {feedback.data?.comment}
+					</div>
+					<div>
+						{$i18n.t('Reason')}: 
+						{#if feedback.data?.reason === 'accurate_information'}
+							{$i18n.t('Accurate information')}
+						{:else if feedback.data?.reason === 'followed_instructions_perfectly'}
+							{$i18n.t('Followed instructions perfectly')}
+						{:else if feedback.data?.reason === 'showcased_creativity'}
+							{$i18n.t('Showcased creativity')}
+						{:else if feedback.data?.reason === 'positive_attitude'}
+							{$i18n.t('Positive attitude')}
+						{:else if feedback.data?.reason === 'attention_to_detail'}
+							{$i18n.t('Attention to detail')}
+						{:else if feedback.data?.reason === 'thorough_explanation'}
+							{$i18n.t('Thorough explanation')}
+						{:else if feedback.data?.reason === 'dont_like_the_style'}
+							{$i18n.t("Don't like the style")}
+						{:else if feedback.data?.reason === 'too_verbose'}
+							{$i18n.t('Too verbose')}
+						{:else if feedback.data?.reason === 'not_helpful'}
+							{$i18n.t('Not helpful')}
+						{:else if feedback.data?.reason === 'not_factually_correct'}
+							{$i18n.t('Not factually correct')}
+						{:else if feedback.data?.reason === 'didnt_fully_follow_instructions'}
+							{$i18n.t("Didn't fully follow instructions")}
+						{:else if feedback.data?.reason === 'refused_when_it_shouldnt_have'}
+							{$i18n.t("Refused when it shouldn't have")}
+						{:else if feedback.data?.reason === 'being_lazy'}
+							{$i18n.t('Being lazy')}
+						{:else if feedback.data?.reason === 'other'}
+							{$i18n.t('Other')}
+						{:else}
+							{feedback.data?.reason}
+						{/if}
+					</div>
+					<div>
+						{$i18n.t('Rating')}: {feedback.data?.details?.rating}/10
+					</div>
+				</div>
+			</div>
 		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
# Changelog Entry

### Description

- This feature was added because the Feedback functionality does not allow administrators to see user feedbacks. They could see that a model somehow won or lost, but could not collect the specific information.
- This feature allows admins to go to the specific chats from the Feedbacks section in the Admin Panel using a new column with the chat title in it, and see the highlited messages that have user feedback on them. These messages are highlited by a border (green for positive, red for negative feedback), a badge, and have the necessary feedback information under them, including the rating, reason and comment. This allows admins to receive straight forward feedback they can work on and improve the particular models if needed.
- This feedback is added into the /s/ page used for sharing read-only chats, it is only fetched if the current user is an administrator, and has a URL property to make sure the feedback doesn't automatically appear when sharing chats outside of the Feedbacks section.
- The PR includes 3 new migrations - one to add the new column chat_id to feedback (I know it's already in the meta property, however meta being a JSON, I could not find a way to filter feedbacks from the DB using that), one to migrate the chat_id information from meta to the new column for already existing feedbacks, and one for making the chat_id column required. This has been split into 3 migrations due to safety, because of a previous experience of a migration not being able to add a column and populate it all in one migration.
- The flow is as follows: In the Evaluations/Feedbacks section in the Admin Panel, the chat title where the feedback occured is shown. When clicked, the chat is shown using the /s/ sharing page, all feedbacks for that particular chat id are fetched if the user is admin, the URL property showFeedback is added, and it is determined for each message if it has feedback or not. If it does, style and additional info are added to it.

### Added

- Required chat_id column to the feedback table in DB
- Methods in DB, routing and evaluation index.ts to fetch feedbacks for a particulat chat id
- New column in the Feedbacks section with clickable chat titles
- Feedback visualization for admins when clicked through the Feedbacks section, highlighting messages with feedback and showing necessary information about the feedback

### Changed

- /s/ chat sharing page to include feedbacks, if clicked from the Feedbacks section (using a URL parameter) and only if user is admin
- feedback db model, added chat_id column populated from the meta property

### Deprecated


### Removed


### Fixed


### Security


### Breaking Changes


---

### Additional Information

- The screenshots and a video bellow show how the feature looks and how it works.

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/b61137e1-8b0c-4b13-8c2e-8289e54c795a)
![image](https://github.com/user-attachments/assets/20b6cb1b-67a0-4618-b9e4-4733ca9fbc05)

https://github.com/user-attachments/assets/7c86a40c-f707-48e0-ac04-fd0a82637a7a



