### PR TITLE
Remove unnecessary decode statement from release_lock method

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -26,7 +26,7 @@ class RedisLock:
 
     def release_lock(self):
         lock_value = self.redis.get(self.lock_name)
-        if lock_value and lock_value.decode("utf-8") == self.lock_id:
+        if lock_value and lock_value == self.lock_id:
             self.redis.delete(self.lock_name)
 
 


### PR DESCRIPTION
# Changelog Entry

### Description
- Remove unnecessary decode statement from release_lock method. Since our Redis instance is created with `decode_responses=True` this isn't required. `decode` is also not a supported string method in python3.

Fixes:
- Address stack trace on Open Webui shutdown with Redis support enabled.

See #7964 for more details