### PR TITLE
refac: improve chat performance for slow platform(#8538).

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1037,20 +1037,20 @@ JSON format: { "tags": ["tag1", "tag2", "tag3"] }
 ENABLE_TAGS_GENERATION = PersistentConfig(
     "ENABLE_TAGS_GENERATION",
     "task.tags.enable",
-    os.environ.get("ENABLE_TAGS_GENERATION", "True").lower() == "true",
+    os.environ.get("ENABLE_TAGS_GENERATION", "False").lower() == "true",
 )
 
 
 ENABLE_SEARCH_QUERY_GENERATION = PersistentConfig(
     "ENABLE_SEARCH_QUERY_GENERATION",
     "task.query.search.enable",
-    os.environ.get("ENABLE_SEARCH_QUERY_GENERATION", "True").lower() == "true",
+    os.environ.get("ENABLE_SEARCH_QUERY_GENERATION", "False").lower() == "true",
 )
 
 ENABLE_RETRIEVAL_QUERY_GENERATION = PersistentConfig(
     "ENABLE_RETRIEVAL_QUERY_GENERATION",
     "task.query.retrieval.enable",
-    os.environ.get("ENABLE_RETRIEVAL_QUERY_GENERATION", "True").lower() == "true",
+    os.environ.get("ENABLE_RETRIEVAL_QUERY_GENERATION", "False").lower() == "true",
 )
 
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions]
https://github.com/open-webui/open-webui/discussions/8538

### Description

For slow Laptop, currently  Open WebUI is very very slow. It's improve performance some by disable some LLM inference during tag, search, retrival query. If you accept this PR, it's good for a lot of beginner. But for more professional use, current configuration is better for accurate answer in chat.

Disable LLM utilization for:
* TAG GENERATION
* SEARCH QUERY GENERATION
* RETRIVAL QUERY GENERATION
