### PR TITLE
Changed `answerCount` to `count` param in bing.py

### DIFF
--- a/backend/open_webui/retrieval/web/bing.py
+++ b/backend/open_webui/retrieval/web/bing.py
@@ -23,7 +23,7 @@ def search_bing(
     filter_list: Optional[list[str]] = None,
 ) -> list[SearchResult]:
     mkt = locale
-    params = {"q": query, "mkt": mkt, "answerCount": count}
+    params = {"q": query, "mkt": mkt, "count": count}
     headers = {"Ocp-Apim-Subscription-Key": subscription_key}
 
     try:


### PR DESCRIPTION
### Description

- answerCount does not actually reduce the pages that are searched by OpenWebUI. Setting this to "count" makes sure that the "Search Result Count" is honored. Tested on my own deployment of Open WebUI.

### Changed

- Changed `answerCount` to `count` param in bing.py

### Fixed

-  "Search Result Count" is now honored for Bing search provider

See Bing API docs: https://learn.microsoft.com/en-us/bing/search-apis/bing-web-search/reference/query-parameters