### PR TITLE
Update: Show/Hide File Upload Button w/Permission

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -44,6 +44,10 @@
 		$config?.features?.enable_web_search &&
 		($user.role === 'admin' || $user?.permissions?.features?.web_search);
 
+	let canUploadFiles = false;
+
+	$: canUploadFiles = $user.role === 'admin' || $user?.permissions?.chat?.file_upload;
+
 	$: if (show) {
 		init();
 	}
@@ -176,7 +180,8 @@
 					<div class=" line-clamp-1">{$i18n.t('Capture')}</div>
 				</DropdownMenu.Item>
 			{/if}
-
+			
+			{#if canUploadFiles}
 			<DropdownMenu.Item
 				class="flex gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
 				on:click={() => {
@@ -186,6 +191,7 @@
 				<DocumentArrowUpSolid />
 				<div class="line-clamp-1">{$i18n.t('Upload Files')}</div>
 			</DropdownMenu.Item>
+			{/if}
 
 			{#if $config?.features?.enable_google_drive_integration}
 				<DropdownMenu.Item


### PR DESCRIPTION
https://github.com/open-webui/open-webui/issues/8881#issuecomment-2613151026

# Changelog Entry

### Description

This pull request adds show/hide functionality to the "Upload Files" button based on user permissions. This ensures that the button is only visible to users with the appropriate File Upload permissions or admin privileges.

### Added

- New logic to InputMenu.svelte to conditionally display the "Upload Files" button based on the user's permissions.
- A reactive variable canUploadFiles in the frontend code, which determines the visibility of the upload functionality.

### Changed

- Refactored existing code to include permission-based checks for the "Upload Files" feature.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- None. This change is backward-compatible.

---

### Additional Information

- This change aligns with the RBAC system introduced in Open WebUI, extending its functionality to manage access to the "Upload Files" feature.
