### PR TITLE
**fix** Fix title generation JSON enforcement changes

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -167,13 +167,11 @@ async def generate_title(
     # Remove reasoning details from the messages
     for message in messages:
         message["content"] = re.sub(
-            r"<details\s+type=\"reasoning\"[^>]*>.*?<\/details>",
+            r'<details\s+type="reasoning".*?>.*?</details>',
             "",
             message["content"],
-            flags=re.S,
+            flags=re.DOTALL,
         ).strip()
-
-    print(messages)
 
     content = title_generation_template(
         template,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -909,7 +909,7 @@ async def process_chat_response(
                                     "title", "New Chat"
                                 )
                             except Exception as e:
-                                pass
+                                title = None
 
                             if not title:
                                 title = messages[0].get("content", "New Chat")


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title, using one of the following:

# Changelog Entry

### Description

Fix bug where task would crash if it generated a summary without strict JSON format.
However, this only mitigates the root issue: see **Additional Information**.

### Added

### Changed

- Refactored regex for stripping thoughts before title generation (to be more readable)

### Deprecated

### Removed

### Fixed

- Fix bug where task would crash if it generated a summary without strict JSON format

### Security

- Fix bug where task would crash if it generated a summary without strict JSON format

### Breaking Changes

---

### Additional Information

The cause of the new issue is due to the new change to enforce a strict JSON response when generating titles.
This fix only prevents the generation task from crashing. It simply ignores the bad response and falls back to the chat history.

### Screenshots or Videos
## Example of query failure
This is an easy way to get title generation to fail:
![Screenshot 2025-01-30 085816](https://github.com/user-attachments/assets/263a822c-8e5b-402b-8371-2932210d2186)
Which produces the fallback title:
![Screenshot 2025-01-30 085822](https://github.com/user-attachments/assets/fc6bcea8-662c-4a7a-9637-4912540739d6)
(Note: The issue is with the title generation response, not directly the initial response above.)

Also, I've seen it fail even with more unrelated prompts like topics about medicine, science, or history. With many models, sometimes the model disobeys and uses Markdown instead of JSON. An example was `**Title:** 💊 Health and Medicine`

For further context, earlier I suggested having an explicit setting for chain of thought models (see the closed PR https://github.com/open-webui/open-webui/pull/9088), but it was not preferred.