### PR TITLE
fix: textarea auto-resize in playground UX

### DIFF
--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -44,6 +44,17 @@
 	let message = '';
 
 	let messages = [];
+	let chatTextareaHeight = '3rem';
+
+	$: if (showSystem) {
+		setTimeout(() => {
+			const textarea = document.getElementById('system-textarea');
+			if (textarea) {
+				textarea.style.height = 'auto';
+				textarea.style.height = textarea.scrollHeight + 'px';
+			}
+		}, 50);
+	}
 
 	const scrollToBottom = () => {
 		const element = messagesContainerElement;
@@ -148,12 +159,19 @@
 
 	const addHandler = async () => {
 		if (message) {
-			messages.push({
-				role: role,
-				content: message
-			});
+			messages.push({ role, content: message });
 			messages = messages;
 			message = '';
+
+			// Reset textarea height using the ID
+			const textarea = document.getElementById('message-input');
+			if (textarea) {
+				requestAnimationFrame(() => {
+					textarea.style.height = '3rem';
+					textarea.dispatchEvent(new Event('input'));
+				});
+			}
+
 			await tick();
 			scrollToBottom();
 		}
@@ -232,6 +250,15 @@
 					bind:open={showSystem}
 					buttonClassName="w-full rounded-lg text-sm border border-gray-50 dark:border-gray-850 w-full py-1 px-1.5"
 					grow={true}
+					on:expand={() => {
+						setTimeout(() => {
+							const textarea = document.getElementById('system-textarea');
+							if (textarea) {
+								textarea.style.height = 'auto';
+								textarea.style.height = textarea.scrollHeight + 'px';
+							}
+						}, 0);
+					}}
 				>
 					<div class="flex gap-2 justify-between items-center">
 						<div class=" flex-shrink-0 font-medium ml-1.5">
@@ -245,7 +272,18 @@
 						{/if}
 
 						<div class="flex-shrink-0">
-							<button class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg">
+							<button
+								class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg"
+								on:click={() => {
+									setTimeout(() => {
+										const textarea = document.getElementById('system-textarea');
+										if (textarea) {
+											textarea.style.height = 'auto';
+											textarea.style.height = textarea.scrollHeight + 'px';
+										}
+									}, 50); // increased timeout to ensure content is visible
+								}}
+							>
 								{#if showSystem}
 									<ChevronUp className="size-3.5" />
 								{:else}
@@ -259,10 +297,20 @@
 						<div class="pt-1 px-1.5">
 							<textarea
 								id="system-textarea"
-								class="w-full h-full bg-transparent resize-none outline-none text-sm"
+								class="w-full h-full bg-transparent resize-y outline-none text-sm"
 								bind:value={system}
 								placeholder={$i18n.t("You're a helpful assistant.")}
 								rows="4"
+								on:input={(e) => {
+									e.target.style.height = 'auto';
+									e.target.style.height = e.target.scrollHeight + 'px';
+								}}
+								on:paste={(e) => {
+									setTimeout(() => {
+										e.target.style.height = 'auto';
+										e.target.style.height = e.target.scrollHeight + 'px';
+									}, 0);
+								}}
 							/>
 						</div>
 					</div>
@@ -301,8 +349,9 @@
 						<!-- $i18n.t('a user') -->
 						<!-- $i18n.t('an assistant') -->
 						<textarea
+							id="message-input"
 							bind:value={message}
-							class=" w-full h-full bg-transparent resize-none outline-none text-sm"
+							class="w-full h-full bg-transparent resize-y outline-none text-sm"
 							placeholder={$i18n.t(`Enter {{role}} message here`, {
 								role: role === 'user' ? $i18n.t('a user') : $i18n.t('an assistant')
 							})}

--- a/src/lib/components/playground/Chat/Messages.svelte
+++ b/src/lib/components/playground/Chat/Messages.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
-	import { onMount, getContext } from 'svelte';
+	import { onMount, afterUpdate, getContext } from 'svelte';
 
 	const i18n = getContext('i18n');
 
 	export let messages = [];
-	let textAreaElement: HTMLTextAreaElement;
-	onMount(() => {
+
+	const adjustTextareaHeight = (textarea: HTMLTextAreaElement) => {
+		if (textarea) {
+			textarea.style.height = 'auto';
+			textarea.style.height = textarea.scrollHeight + 'px';
+		}
+	};
+
+	afterUpdate(() => {
 		messages.forEach((message, idx) => {
-			textAreaElement.style.height = '';
-			textAreaElement.style.height = textAreaElement.scrollHeight + 'px';
+			const textarea = document.getElementById(`${message.role}-${idx}-textarea`);
+			adjustTextareaHeight(textarea as HTMLTextAreaElement);
 		});
 	});
 </script>
@@ -25,33 +32,21 @@
 			</div>
 
 			<div class="flex-1">
-				<!-- $i18n.t('a user') -->
-				<!-- $i18n.t('an assistant') -->
 				<textarea
 					id="{message.role}-{idx}-textarea"
-					bind:this={textAreaElement}
-					class="w-full bg-transparent outline-none rounded-lg p-2 text-sm resize-none overflow-hidden"
-					placeholder={$i18n.t(`Enter {{role}} message here`, {
+					class="w-full bg-transparent outline-none rounded-lg p-2 text-sm resize-y overflow-hidden"
+					placeholder={$i18n.t(`Enter assistant message here`, {
 						role: message.role === 'user' ? $i18n.t('a user') : $i18n.t('an assistant')
 					})}
 					rows="1"
-					on:input={(e) => {
-						textAreaElement.style.height = '';
-						textAreaElement.style.height = textAreaElement.scrollHeight + 'px';
-					}}
-					on:focus={(e) => {
-						textAreaElement.style.height = '';
-						textAreaElement.style.height = textAreaElement.scrollHeight + 'px';
-
-						// e.target.style.height = Math.min(e.target.scrollHeight, 200) + 'px';
-					}}
+					on:input={(e) => adjustTextareaHeight(e.target)}
 					bind:value={message.content}
 				/>
 			</div>
 
-			<div class=" pt-1">
+			<div class="pt-1">
 				<button
-					class=" group-hover:text-gray-500 dark:text-gray-900 dark:hover:text-gray-300 transition"
+					class="group-hover:text-gray-500 dark:text-gray-900 dark:hover:text-gray-300 transition"
 					on:click={() => {
 						messages = messages.filter((message, messageIdx) => messageIdx !== idx);
 					}}


### PR DESCRIPTION
# Changelog Entry
updates to:
/src/lib/component/playground/Chat/Messages.svelte
/src/lib/component/playground/Chat.svelte

### Description

- Implements proper height management for system instructions
- Improves message textarea resize behavior in chat history
- Adds afterUpdate lifecycle hook for consistent textarea sizing
- Refactors height adjustment logic for better maintainability


This PR addresses issues with textarea height management in the playground interface:
- System instructions now maintain proper height after collapse/expand
- Chat messages properly resize on content updates
- Message history maintains correct height for each entry

Testing:
- Tested with various content lengths
- Verified collapse/expand behavior
- Confirmed proper height reset after content changes


### Added
No new files added

### Changed
Changes to class of textarea, added handlers for paste, and updated addHandler in Chat.svelte

### Deprecated
None

### Removed
None

### Fixed

### Security

### Breaking Changes