### PR TITLE
fix: update title generation prompt to ignore <think> tags

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1101,6 +1101,7 @@ Generate a concise, 3-5 word title with an emoji summarizing the chat history.
 - Use emojis that enhance understanding of the topic, but avoid quotation marks or special formatting.
 - Write the title in the chat's primary language; default to English if multilingual.
 - Prioritize accuracy over excessive creativity; keep it clear and simple.
+- Ignore any content enclosed within <think> tags when analyzing the chat history.
 ### Output:
 JSON format: { "title": "your concise title here" }
 ### Examples:


### PR DESCRIPTION
**Pull Request Title:** `fix: update title generation prompt to ignore <think> tags`

# Pull Request Checklist

- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Updated the title generation prompt to explicitly instruct the model to ignore content enclosed within `<think>` tags.
- [x] **Changelog:** Added a changelog entry.
- [x] **Documentation:** No major documentation updates required.
- [x] **Dependencies:** No new dependencies introduced.
- [x] **Testing:** Verified prompt effectiveness to ensure `<think>` content is ignored.
- [x] **Code review:** Performed self-review to ensure correctness and clarity.
- [x] **Prefix:** `docs` (since this is a prompt update and not a functional code change).

---

# Changelog Entry

### Description

- Improved the prompt for generating conversation titles by adding a guideline that explicitly instructs models to ignore `<think>`-enclosed content, ensuring better compatibility with models that use CoT reasoning.

### Added

- A new guideline in the title generation prompt to ignore `<think>` tags.

### Changed

- Refined the prompt structure for clarity and consistency.

### Fixed

- Prevented the model from incorporating `<think>` content into generated titles.

---

### Additional Information

- This update ensures better handling of `<think>`-formatted content, preventing unintended influences on the title generation process.
- No breaking changes or modifications to core functionalities.

---

### Screenshots or Videos

N/A (text-based update).
