### PR TITLE
feat:Increase Node.js heap size to avoid memory allocation errors during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN npm ci
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
-RUN npm run build
+RUN NODE_OPTIONS=--max-old-space-size=4096 npm run build
 
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base


### PR DESCRIPTION
**DESCRIPTION** 

This pull request addresses an issue that may arise when building the project, especially for larger repositories or environments with higher memory usage during the build process. Specifically, the build process in Node.js might run out of memory, causing the compilation to fail, as seen in some cases where the project requires more heap space than the default allocation.

To resolve this, I've added the following environment **variable:**

`**NODE_OPTIONS=--max-old-space-size=4096**`

This adjustment increases the available heap size for the Node.js process, preventing the out-of-memory error `**(101.7 fatal error: ineffective mark-compacts near heap limit allocation failed - javascript heap out of memory)**` during the build process. It's a simple but effective way to ensure more stable builds, particularly for large projects or machines with limited available memory.

**Why this change is useful:**

Fixes build failures: In some environments, especially when dealing with larger or more complex projects, this change prevents memory-related build failures.
Minimal impact: This change only affects the build process and won't interfere with the runtime or production environment.
Widely applicable: Many developers may face similar memory issues when building large repositories, and this fix can be applied universally.
Considerations:

If your environment has limited resources (especially RAM), please note that this change may not be necessary and could be adjusted based on specific needs.
We recommend monitoring the build process after this change to ensure no further issues arise in other environments.
I believe this small but crucial adjustment will make the build process more resilient and should prevent the "out-of-memory" issue some users may face. I’m happy to discuss or modify the change further if needed.

Thanks for considering this improvement!