### PR TITLE
Bug fix, configurable default if using oauth via the `DEFAULT_USER_ROLE` env variable

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -82,9 +82,8 @@ class OAuthManager:
             oauth_allowed_roles = auth_manager_config.OAUTH_ALLOWED_ROLES
             oauth_admin_roles = auth_manager_config.OAUTH_ADMIN_ROLES
             oauth_roles = None
-            role = (
-                auth_manager_config.DEFAULT_USER_ROLE
-            )  # Default/fallback role if no matching roles are found
+            # Default/fallback role if no matching roles are found
+            role = auth_manager_config.DEFAULT_USER_ROLE
 
             # Next block extracts the roles from the user data, accepting nested claims of any depth
             if oauth_claim and oauth_allowed_roles and oauth_admin_roles:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -82,7 +82,9 @@ class OAuthManager:
             oauth_allowed_roles = auth_manager_config.OAUTH_ALLOWED_ROLES
             oauth_admin_roles = auth_manager_config.OAUTH_ADMIN_ROLES
             oauth_roles = None
-            role = "pending"  # Default/fallback role if no matching roles are found
+            role = (
+                auth_manager_config.DEFAULT_USER_ROLE
+            )  # Default/fallback role if no matching roles are found
 
             # Next block extracts the roles from the user data, accepting nested claims of any depth
             if oauth_claim and oauth_allowed_roles and oauth_admin_roles:


### PR DESCRIPTION
TBh I think this is a straight forward one @tjbck 

For some reason currently the default role behaviour is different if using the OAuth roles. This PR addresses that, it changes the hardcoded default role for the one available for the user to set via environment variables. If the user does not set the default role via the environment variables then it will default to the same behaviour as before.