### PR TITLE
[EASY] Set default picture to user.png

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -274,7 +274,7 @@ class OAuthManager:
                         log.error(
                             f"Error downloading profile image '{picture_url}': {e}"
                         )
-                        picture_url = ""
+                        picture_url = "/user.png"
                 if not picture_url:
                     picture_url = "/user.png"
 


### PR DESCRIPTION
If the user's picture cannot be retrieve via the URL provided by OAUTH then it is set to en empty string instead to the default `user.png` picture. This PR addresses that.