### PR TITLE
fix: check for email claim before skipping userinfo endpoint

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -193,7 +193,7 @@ class OAuthManager:
             log.warning(f"OAuth callback error: {e}")
             raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
         user_data: UserInfo = token.get("userinfo")
-        if not user_data:
+        if not user_data or "email" not in user_data:
             user_data: UserInfo = await client.userinfo(token=token)
         if not user_data:
             log.warning(f"OAuth callback failed, user data is missing: {token}")


### PR DESCRIPTION
# Fixes #9452

## Description
Fixes an issue where OIDC authentication fails when the email claim is only available via the userinfo endpoint but not in the token's userinfo data. This affects OIDC providers (like Duke) that follow the pattern of providing complete user information through the userinfo endpoint rather than in the token response.

## Changelog

### Fixed
- OIDC authentication now properly fetches email claim from userinfo endpoint when not present in token data
- Prevents authentication failures with OIDC providers that separate token and userinfo responses

### Changed
- Modified the userinfo data fetch logic to check specifically for required email claim

## Implementation Details
The fix modifies the OIDC authentication flow to check not just for the presence of userinfo data in the token, but specifically for the required email claim. If the email claim is missing, it will make a call to the userinfo endpoint to fetch complete user data.

### Code Changes
In `/app/backend/open_webui/utils/oauth.py`:
```python
# Before
user_data: UserInfo = token.get("userinfo")
if not user_data:
    user_data: UserInfo = await client.userinfo(token=token)

# After
user_data: UserInfo = token.get("userinfo")
if not user_data or "email" not in user_data:
    user_data: UserInfo = await client.userinfo(token=token)