### PR TITLE
fix: Improve automatic cleanup of code_interpreter formatting

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1188,6 +1188,23 @@ async def process_chat_response(
                         output = block.get("output", None)
                         lang = attributes.get("lang", "")
 
+                        # Separate content from ending whitespace but preserve it
+                        original_whitespace = ''
+                        content_stripped = content.rstrip()
+                        if len(content) > len(content_stripped):
+                            original_whitespace = content[len(content_stripped):]
+
+                        # Count the number of backticks to identify if we are in an opening code block
+                        backtick_segments = content_stripped.split('```')
+                        # Odd number of ``` segments -> the last backticks are closing a block
+                        # Even number -> the last backticks are opening a new block
+                        if len(backtick_segments) > 1 and len(backtick_segments) % 2 == 0:
+                            # The trailing backticks are opening a new block, they need to be removed or it will break the code interpreter markdown
+                            content = content_stripped.rstrip('`').rstrip() + original_whitespace
+                        else:
+                            # The trailing backticks are closing a block (or there are no backticks), so it won't cause issues
+                            content = content_stripped + original_whitespace
+
                         if output:
                             output = html.escape(json.dumps(output))
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- When Code Interpreter is activated, sometimes the LLM prefixes its call to <code_interpreter> with an opening code block (triple back ticks). This is not how it is supposed to work, as it will cause breakage in the visual markdown rendering of the Code Interpreter block. When the LLM makes this kind of mistake, we can automatically correct it by removing any OPENING code blocks. Note that we know it is an OPENING block by counting the sets of back ticks.

### Added

- None

### Changed

- None

### Deprecated

- None

### Removed

- None

### Fixed

- Improve reliability of Code Interpreter visual format rendering by removing invalid opening back ticks before each Code Interpreter block

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- None

### Screenshots or Videos

**Before:**
![image](https://github.com/user-attachments/assets/785c01c5-58ed-485f-9365-10de3d5cda0c)
![image](https://github.com/user-attachments/assets/146c0e9c-0d3d-4bc8-80b8-63ba9144bdba)


**After:**
![image](https://github.com/user-attachments/assets/7ca338e0-ad46-43a0-a438-33f4fa267d3a)
![image](https://github.com/user-attachments/assets/d94bafe4-a477-4387-9767-4b83acb0bec8)


