### PR TITLE
Use DB for generated images

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -56,11 +56,11 @@ def upload_file(
                     "id": id,
                     "filename": name,
                     "path": file_path,
-                    "data": file_metadata,
                     "meta": {
                         "name": name,
                         "content_type": file.content_type,
                         "size": len(contents),
+                        "data": file_metadata,
                     },
                 }
             ),

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -3,30 +3,22 @@ import os
 import uuid
 from pathlib import Path
 from typing import Optional
-from pydantic import BaseModel
-import mimetypes
 from urllib.parse import quote
 
-from open_webui.storage.provider import Storage
-
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from fastapi.responses import FileResponse, StreamingResponse
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 from open_webui.models.files import (
     FileForm,
     FileModel,
     FileModelResponse,
     Files,
 )
-from open_webui.routers.retrieval import process_file, ProcessFileForm
-
-from open_webui.config import UPLOAD_DIR
-from open_webui.env import SRC_LOG_LEVELS
-from open_webui.constants import ERROR_MESSAGES
-
-
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status, Request
-from fastapi.responses import FileResponse, StreamingResponse
-
-
+from open_webui.routers.retrieval import ProcessFileForm, process_file
+from open_webui.storage.provider import Storage
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])
@@ -41,7 +33,10 @@ router = APIRouter()
 
 @router.post("/", response_model=FileModelResponse)
 def upload_file(
-    request: Request, file: UploadFile = File(...), user=Depends(get_verified_user)
+    request: Request,
+    file: UploadFile = File(...),
+    user=Depends(get_verified_user),
+    file_metadata: dict = {},
 ):
     log.info(f"file.content_type: {file.content_type}")
     try:
@@ -61,6 +56,7 @@ def upload_file(
                     "id": id,
                     "filename": name,
                     "path": file_path,
+                    "data": file_metadata,
                     "meta": {
                         "name": name,
                         "content_type": file.content_type,
@@ -126,7 +122,7 @@ async def delete_all_files(user=Depends(get_admin_user)):
             Storage.delete_all_files()
         except Exception as e:
             log.exception(e)
-            log.error(f"Error deleting files")
+            log.error("Error deleting files")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT("Error deleting files"),
@@ -248,7 +244,7 @@ async def get_file_content_by_id(id: str, user=Depends(get_verified_user)):
                 )
         except Exception as e:
             log.exception(e)
-            log.error(f"Error getting file content")
+            log.error("Error getting file content")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
@@ -279,7 +275,7 @@ async def get_html_file_content_by_id(id: str, user=Depends(get_verified_user)):
                 )
         except Exception as e:
             log.exception(e)
-            log.error(f"Error getting file content")
+            log.error("Error getting file content")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT("Error getting file content"),
@@ -355,7 +351,7 @@ async def delete_file_by_id(id: str, user=Depends(get_verified_user)):
                 Storage.delete_file(file.path)
             except Exception as e:
                 log.exception(e)
-                log.error(f"Error deleting files")
+                log.error("Error deleting files")
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=ERROR_MESSAGES.DEFAULT("Error deleting files"),

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -3,6 +3,7 @@ import base64
 import io
 import json
 import logging
+import mimetypes
 import re
 from pathlib import Path
 from typing import Optional
@@ -411,15 +412,16 @@ def load_url_image_data(url, headers=None):
 
 
 def upload_image(request, data, image_data, content_type, user):
+    image_format = mimetypes.guess_extension(content_type)
     file = UploadFile(
         file=io.BytesIO(image_data),
-        filename="image",  # will be converted to a unique ID on upload_file
+        filename=f"generated{image_format}",  # will be converted to a unique ID on upload_file
         headers={
             "content-type": content_type,
         },
     )
     file_item = upload_file(request, file, user)
-    file_body_path = IMAGE_CACHE_DIR.joinpath(f"{file_item.id}.json")
+    file_body_path = IMAGE_CACHE_DIR.joinpath(f"{file_item.filename}.json")
 
     with open(file_body_path, "w") as f:
         json.dump(data, f)

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -7,26 +7,21 @@ import re
 import uuid
 from pathlib import Path
 from typing import Optional
+import io
 
 import requests
-
-
-from fastapi import Depends, FastAPI, HTTPException, Request, APIRouter
-from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-
-
+from fastapi import APIRouter, Depends, UploadFile, HTTPException, Request
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
-from open_webui.env import ENV, SRC_LOG_LEVELS, ENABLE_FORWARD_USER_INFO_HEADERS
-
+from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
+from open_webui.routers.files import upload_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.images.comfyui import (
     ComfyUIGenerateImageForm,
     ComfyUIWorkflow,
     comfyui_generate_image,
 )
-
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["IMAGES"])
@@ -39,7 +34,7 @@ router = APIRouter()
 
 
 @router.get("/config")
-async def get_config(request: Request, user=Depends(get_admin_user)):
+async def get_def(request: Request, user=Depends(get_admin_user)):
     return {
         "enabled": request.app.state.config.ENABLE_IMAGE_GENERATION,
         "engine": request.app.state.config.IMAGE_GENERATION_ENGINE,
@@ -271,7 +266,6 @@ async def get_image_config(request: Request, user=Depends(get_admin_user)):
 async def update_image_config(
     request: Request, form_data: ImageConfigForm, user=Depends(get_admin_user)
 ):
-
     set_image_model(request, form_data.MODEL)
 
     pattern = r"^\d+x\d+$"
@@ -383,35 +377,18 @@ class GenerateImageForm(BaseModel):
     negative_prompt: Optional[str] = None
 
 
-def save_b64_image(b64_str):
+def load_b64_image_data(b64_str):
     try:
-        image_id = str(uuid.uuid4())
-
         if "," in b64_str:
             header, encoded = b64_str.split(",", 1)
             mime_type = header.split(";")[0]
-
             img_data = base64.b64decode(encoded)
-            image_format = mimetypes.guess_extension(mime_type)
-
-            image_filename = f"{image_id}{image_format}"
-            file_path = IMAGE_CACHE_DIR / f"{image_filename}"
-            with open(file_path, "wb") as f:
-                f.write(img_data)
-            return image_filename
         else:
-            image_filename = f"{image_id}.png"
-            file_path = IMAGE_CACHE_DIR.joinpath(image_filename)
-
+            mime_type = "image/png"
             img_data = base64.b64decode(b64_str)
-
-            # Write the image data to a file
-            with open(file_path, "wb") as f:
-                f.write(img_data)
-            return image_filename
-
+        return img_data, mime_type
     except Exception as e:
-        log.exception(f"Error saving image: {e}")
+        log.exception(f"Error loading image data: {e}")
         return None
 
 
@@ -500,13 +477,17 @@ async def image_generations(
             images = []
 
             for image in res["data"]:
-                image_filename = save_b64_image(image["b64_json"])
-                images.append({"url": f"/cache/image/generations/{image_filename}"})
-                file_body_path = IMAGE_CACHE_DIR.joinpath(f"{image_filename}.json")
-
-                with open(file_body_path, "w") as f:
-                    json.dump(data, f)
-
+                image_data, content_type = load_b64_image_data(image["b64_json"])
+                file = UploadFile(
+                    file=io.BytesIO(image_data),
+                    filename="image",  # will be converted to a unique ID on upload_file
+                    headers={
+                        "content-type": content_type,
+                    },
+                )
+                file_item = upload_file(request, file, user)
+                url = request.app.url_path_for("get_file_content_by_id", id=file_item.id)
+                images.append({"url": url})
             return images
 
         elif request.app.state.config.IMAGE_GENERATION_ENGINE == "comfyui":

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -411,7 +411,7 @@ def load_url_image_data(url, headers=None):
         return None
 
 
-def upload_image(request, data, image_data, content_type, user):
+def upload_image(request, image_metadata, image_data, content_type, user):
     image_format = mimetypes.guess_extension(content_type)
     file = UploadFile(
         file=io.BytesIO(image_data),
@@ -420,12 +420,7 @@ def upload_image(request, data, image_data, content_type, user):
             "content-type": content_type,
         },
     )
-    file_item = upload_file(request, file, user)
-    file_body_path = IMAGE_CACHE_DIR.joinpath(f"{file_item.filename}.json")
-
-    with open(file_body_path, "w") as f:
-        json.dump(data, f)
-
+    file_item = upload_file(request, file, user, file_metadata=image_metadata)
     url = request.app.url_path_for("get_file_content_by_id", id=file_item.id)
     return url
 

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -34,7 +34,7 @@ router = APIRouter()
 
 
 @router.get("/config")
-async def get_def(request: Request, user=Depends(get_admin_user)):
+async def get_config(request: Request, user=Depends(get_admin_user)):
     return {
         "enabled": request.app.state.config.ENABLE_IMAGE_GENERATION,
         "engine": request.app.state.config.IMAGE_GENERATION_ENGINE,
@@ -456,7 +456,7 @@ async def image_generations(
                 requests.post,
                 url=f"{request.app.state.config.IMAGES_OPENAI_API_BASE_URL}/images/generations",
                 json=data,
-                headers=headers,
+                headers=headers,    
             )
 
             r.raise_for_status()

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -3,9 +3,7 @@ import base64
 import io
 import json
 import logging
-import mimetypes
 import re
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -456,7 +454,7 @@ async def image_generations(
                 requests.post,
                 url=f"{request.app.state.config.IMAGES_OPENAI_API_BASE_URL}/images/generations",
                 json=data,
-                headers=headers,    
+                headers=headers,
             )
 
             r.raise_for_status()


### PR DESCRIPTION
At the moment images generated have several issues:
- they are not managed by any external source
- their behaviour is different from other uploaded files
- there is no auth checks for users and images are just passed to the src if the img tag from the cache dir so they are basically public
- If multiple replicas since the logic depends on having them on disk it will fail to load since the image might have been written in a different replica when created.

This change makes the images to be treated exactly in the same way as upload files and backed up by the same mechanism. 
All the logic is pushed to the already proven 'files.py' logic. With this change all the problems mentioned above should be solved.

I tested using dall-e-3 openai model.

related to:  #5109 and #8186

cc @jk-f5 