### PR TITLE
Update jina_search.py

### DIFF
--- a/backend/open_webui/retrieval/web/jina_search.py
+++ b/backend/open_webui/retrieval/web/jina_search.py
@@ -20,14 +20,26 @@ def search_jina(api_key: str, query: str, count: int) -> list[SearchResult]:
         list[SearchResult]: A list of search results
     """
     jina_search_endpoint = "https://s.jina.ai/"
-    headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
-    url = str(URL(jina_search_endpoint + query))
-    response = requests.get(url, headers=headers)
+
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": api_key,
+        "X-Retain-Images": "none"
+    }
+
+    payload = {
+        "q": query,
+        "count": count if count <= 10 else 10
+    }
+
+    url = str(URL(jina_search_endpoint))
+    response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()
     data = response.json()
 
     results = []
-    for result in data["data"][:count]:
+    for result in data["data"]:
         results.append(
             SearchResult(
                 link=result["url"],


### PR DESCRIPTION
### Description

Updated Jina's search function in order to use POST and make use of the result count passed by the user, as well as adding a header to not return the images possibly found on the search reducing token usage.

### Added

- `"Content-Type": "application/json"` header
- `"X-Retain-Images": "none"` header
- Added a `payload `variable containing the query and result count (capped at 10)

### Changed

- Replaced GET request by a POST request

### Removed

- `[:count]` cap on the `data["data"]` loop because we are already asking Jina to return the result count specified by the user

---

### Additional Information

- Jina supports a max of 10 result count