### PR TITLE
Prevent SSRF and HTML injection

### DIFF
--- a/backend/open_webui/utils/pdf_generator.py
+++ b/backend/open_webui/utils/pdf_generator.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, Any, List
+from html import escape
 
 from markdown import markdown
 
@@ -10,7 +11,6 @@ from fpdf import FPDF
 
 from open_webui.env import STATIC_DIR, FONTS_DIR
 from open_webui.models.chats import ChatTitleMessagesForm
-
 
 class PDFGenerator:
     """
@@ -41,13 +41,13 @@ class PDFGenerator:
 
     def _build_html_message(self, message: Dict[str, Any]) -> str:
         """Build HTML for a single message."""
-        role = message.get("role", "user")
-        content = message.get("content", "")
+        role = escape(message.get("role", "user"))
+        content = escape(message.get("content", ""))
         timestamp = message.get("timestamp")
 
-        model = message.get("model") if role == "assistant" else ""
+        model = escape(message.get("model") if role == "assistant" else "")
 
-        date_str = self.format_timestamp(timestamp) if timestamp else ""
+        date_str = escape(self.format_timestamp(timestamp) if timestamp else "")
 
         # extends pymdownx extension to convert markdown to html.
         # - https://facelessuser.github.io/pymdown-extensions/usage_notes/
@@ -76,6 +76,7 @@ class PDFGenerator:
 
     def _generate_html_body(self) -> str:
         """Generate the full HTML body for the PDF."""
+        escaped_title = escape(self.form_data.title)
         return f"""
         <html>
             <head>
@@ -84,7 +85,7 @@ class PDFGenerator:
             <body>
             <div>
                 <div>
-                    <h2>{self.form_data.title}</h2>
+                    <h2>{escaped_title}</h2>
                     {self.messages_html}
                 </div>
             </div>


### PR DESCRIPTION
There is a vulnerability on the /api/v1/util/pdf endpoint via SSRF and HTML injection. This PR applies a patch such that contents in the request are escaped to html characters before rendeing the HTML service side.

@tjbck we have flagged this as a vulnerability which is of medium risk.