### PR TITLE
WIP Return 404 for non html files

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -330,7 +330,13 @@ class SPAStaticFiles(StaticFiles):
             return await super().get_response(path, scope)
         except (HTTPException, StarletteHTTPException) as ex:
             if ex.status_code == 404:
-                return await super().get_response("index.html", scope)
+                if path.endswith(".html"):
+                    response = await super().get_response("index.html", scope)
+                    response.status_code = 200
+                    return response
+                else:
+                    # Return 404 for non-HTML files
+                    raise ex
             else:
                 raise ex
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -330,13 +330,11 @@ class SPAStaticFiles(StaticFiles):
             return await super().get_response(path, scope)
         except (HTTPException, StarletteHTTPException) as ex:
             if ex.status_code == 404:
-                if path.endswith(".html"):
-                    response = await super().get_response("index.html", scope)
-                    response.status_code = 200
-                    return response
-                else:
-                    # Return 404 for non-HTML files
+                if path.endswith(".js"):
+                    # Return 404 for javascript files
                     raise ex
+                else:
+                    return await super().get_response("index.html", scope)
             else:
                 raise ex
 


### PR DESCRIPTION
At the moment, if a path does not exist in the application it returns the index.html file with a 200 response. This is common practice for SPAs to have a nice user experience and not reload the page when the user is navigating over the application. 

This can create a problem though if the same response is given for other type of files other than HTML, for example .js files in particulat.
A case if that when using caching either in the browser, the load balancer or an enterprise application like Akamai it can disrupt the cache behaviour. For example, on every build the js files are generated with a different name but some cache might have the endpoint call cached together with the JS files that it should serve, but these files might not exist anymore since the name changed, but the response stills gives 200, telling the client system that everything is OK while it is not. In this specific case the file requested will be a javacscript file but the response is an html file and since it return 200 it can trigger mimetype mismatched as it would be expecting a response mimetype text/javascript but it gets a text/html. 

This fix makes sure the 200 and index.html response is given by default but only for javascript files it returns a 404.