### PR TITLE
feat Make Google PSE search return more than 10 google search results

### DIFF
--- a/backend/open_webui/retrieval/web/google_pse.py
+++ b/backend/open_webui/retrieval/web/google_pse.py
@@ -8,7 +8,6 @@ from open_webui.env import SRC_LOG_LEVELS
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
 
-
 def search_google_pse(
     api_key: str,
     search_engine_id: str,
@@ -17,34 +16,51 @@ def search_google_pse(
     filter_list: Optional[list[str]] = None,
 ) -> list[SearchResult]:
     """Search using Google's Programmable Search Engine API and return the results as a list of SearchResult objects.
+    Handles pagination for counts greater than 10.
 
     Args:
         api_key (str): A Programmable Search Engine API key
         search_engine_id (str): A Programmable Search Engine ID
         query (str): The query to search for
+        count (int): The number of results to return (max 100, as PSE max results per query is 10 and max page is 10)
+        filter_list (Optional[list[str]], optional): A list of keywords to filter out from results. Defaults to None.
+
+    Returns:
+        list[SearchResult]: A list of SearchResult objects.
     """
     url = "https://www.googleapis.com/customsearch/v1"
-
     headers = {"Content-Type": "application/json"}
-    params = {
-        "cx": search_engine_id,
-        "q": query,
-        "key": api_key,
-        "num": count,
-    }
+    all_results = []
+    start_index = 1  # Google PSE start parameter is 1-based
 
-    response = requests.request("GET", url, headers=headers, params=params)
-    response.raise_for_status()
+    while count > 0:
+        num_results_this_page = min(count, 10)  # Google PSE max results per page is 10
+        params = {
+            "cx": search_engine_id,
+            "q": query,
+            "key": api_key,
+            "num": num_results_this_page,
+            "start": start_index,
+        }
+        response = requests.request("GET", url, headers=headers, params=params)
+        response.raise_for_status()
+        json_response = response.json()
+        results = json_response.get("items", [])
+        if results: # check if results are returned. If not, no more pages to fetch.
+            all_results.extend(results)
+            count -= len(results) # Decrement count by the number of results fetched in this page.
+            start_index += 10 # Increment start index for the next page
+        else:
+            break # No more results from Google PSE, break the loop
 
-    json_response = response.json()
-    results = json_response.get("items", [])
     if filter_list:
-        results = get_filtered_results(results, filter_list)
+        all_results = get_filtered_results(all_results, filter_list)
+
     return [
         SearchResult(
             link=result["link"],
             title=result.get("title"),
             snippet=result.get("snippet"),
         )
-        for result in results
+        for result in all_results
     ]


### PR DESCRIPTION
# Pull Request Checklist

The Google PSE search returns maximum 10 results through 1 query. The Google PSE api returns an error if num is set to a number larger than 10. We need to use the start parameter to send multiple queries to get more than 10 results from google PSE

[discussion](https://github.com/open-webui/open-webui/discussions/9836)

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation**: No need to update doc, this is an enhencement of previous feature.
- [ ] **Dependencies**: No new dependencies
- [x] **Testing: code is tested** Have you written and run sufficient tests for validating the changes?
- [x] **Code review**: code is reviewed (this is a small pr)
- [x] **Prefix**:  
 - **feat**: Introduces a new feature or enhancement to the codebase


# Changelog Entry
### Added
- **Pagination Support for `count > 10`:**
    - Implemented pagination logic to handle requests for more than 10 search results from Google Programmable Search Engine.
    - When `count` is greater than 10, the function now automatically makes multiple API calls using the `start` parameter to retrieve results in pages of 10.
    - This allows users to retrieve up to 100 search results (the maximum practical limit due to Google PSE's page limitations).

### Changed
- **`count` Parameter Behavior:**
    - Updated the function to correctly handle the `count` parameter for values greater than 10.
    - The function now iteratively fetches results until the desired `count` is reached or no more results are available from Google PSE.
    - Clarified in the function docstring that `count` can now exceed 10 and up to a practical maximum of 100, due to Google PSE limitations.

### Internal
- **Introduced `start_index` variable:**
    - Added a `start_index` variable to manage the `start` parameter for Google PSE API calls during pagination.
    - `start_index` is incremented by 10 in each iteration to fetch the next page of results.
- **Looping for Pagination:**
    - Implemented a `while count > 0` loop to handle pagination logic.
    - The loop continues making API requests until the requested `count` is fulfilled or Google PSE returns no more results.
- **Results Accumulation:**
    - Modified the function to accumulate results from each page into the `all_results` list before filtering and returning.
- **Added check for empty results:**
    - Included a check `if results:` to break the pagination loop when Google PSE returns an empty list of results, indicating no more pages are available.
   
