### PR TITLE
fix: re-enable tools in native function calls after first invocation

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1608,6 +1608,7 @@ async def process_chat_response(
                             {
                                 "model": model_id,
                                 "stream": True,
+                                "tools" : form_data["tools"] ,
                                 "messages": [
                                     *form_data["messages"],
                                     {

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1608,7 +1608,7 @@ async def process_chat_response(
                             {
                                 "model": model_id,
                                 "stream": True,
-                                "tools" : form_data["tools"] ,
+                                "tools": form_data["tools"],
                                 "messages": [
                                     *form_data["messages"],
                                     {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:

# Changelog Entry

### Description

When native tool call is enabled, the first call to the completions endpoint contains the "tools" property, but that's not true for the next invocations. This limits native function calling usefulness, and some providers like anthropic endpoint even rejects those invocations.

```
{"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"{\\"type\\":\\"error\\",\\"error\\":{\\"type\\":\\"invalid_request_error\\",\\"message\\":\\"Requests which include `tool_use` or `tool_result` blocks must define tools.\\"}}","provider_name":"Anthropic"}},"user_id":"user_2jKp3JNlDXqIQgKa69AfEc5AZhq"}
```
After the one line change, llm are able to 

This has been commented in this closed pull request:

https://github.com/open-webui/open-webui/pull/7021