### PR TITLE
Avoid calling generate_queries when ENABLE_SEARCH_QUERY_GENERATION is false

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1312,7 +1312,7 @@ def process_web_search(
     request: Request, form_data: SearchForm, user=Depends(get_verified_user)
 ):
     try:
-        logging.info(
+        log.info(
             f"trying to web search with {request.app.state.config.RAG_WEB_SEARCH_ENGINE, form_data.query}"
         )
         web_results = search_web(
@@ -1325,7 +1325,9 @@ def process_web_search(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.WEB_SEARCH_ERROR(e),
         )
-
+    
+    n_results = len(web_results)
+    log.info(f"Retreived {n_results} from web search")
     log.debug(f"web_results: {web_results}")
 
     try:


### PR DESCRIPTION
# Changelog Entry

### Description

- Currently, even if ENABLE_SEARCH_QUERY_GENERATION  generate_queries is called and returns a 400 error. This pull request avoids generating the query from the start and returns the user input

### Added

- Honor ENABLE_SEARCH_QUERY_GENERATION parameter

### Changed

- Changed middleware.py so that it doesn't call generate_queries and fixed a typo when logging web search and added a message stating the number of returned results
