### PR TITLE
Avoid calling generate_queries when ENABLE_SEARCH_QUERY_GENERATION is false instead of raising a 400 status

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1312,7 +1312,7 @@ def process_web_search(
     request: Request, form_data: SearchForm, user=Depends(get_verified_user)
 ):
     try:
-        logging.info(
+        log.info(
             f"trying to web search with {request.app.state.config.RAG_WEB_SEARCH_ENGINE, form_data.query}"
         )
         web_results = search_web(
@@ -1326,6 +1326,8 @@ def process_web_search(
             detail=ERROR_MESSAGES.WEB_SEARCH_ERROR(e),
         )
 
+    n_results = len(web_results)
+    log.info(f"Found {n_results} web search results")
     log.debug(f"web_results: {web_results}")
 
     try:


### PR DESCRIPTION
# Changelog Entry

### Description

- Avoid calling generate_queries when ENABLE_SEARCH_QUERY_GENERATION is
false instead of raising a 400 status

### Changed

- Changed middleware.py in order to honour ENABLE_SEARCH_QUERY_GENERATION when set to false and fixed some typo error in retreival.py using logging.info instead of log.info

### Fixed

- Honour ENABLE_SEARCH_QUERY_GENERATION and if set to false return the prompt as a search query

### Additional Information

It would probably nice to have two additional properties: 

- CONCATENATE_SEARCH_QUERY_GENERATION which would join all user input in a single query
- USE_FIRST_MESSAGE_AS_SEARCH_QUERY so that the search query sticks to original prompt and not subsequent prompts that might have lost context

Let me know if these make sense in order to implement them!
