### PR TITLE
fix: return local time from `getFormattedDate` and `getCurrentDateTime`

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1001,6 +1001,10 @@ export const bestMatchingLanguage = (supportedLanguages, preferredLanguages, def
 export const getFormattedDate = () => {
 	const date = new Date();
 	return date.toISOString().split('T')[0];
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
 };
 
 // Get the time in the format HH:MM:SS


### PR DESCRIPTION
Currently `getFormattedDate` returns UTC and `getCurrentDateTime` returns a mix of local and UTC. This currently only affects prompt templates, but I have another change to send this to openai backends to better serve users by knowing their time.