### PR TITLE
feat: send user's local date to openai compatible APIs

### DIFF
--- a/src/lib/apis/openai/index.ts
+++ b/src/lib/apis/openai/index.ts
@@ -1,4 +1,5 @@
 import { OPENAI_API_BASE_URL, WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
+import { getCurrentDateTime } from '$lib/utils';
 
 export const getOpenAIConfig = async (token: string = '') => {
 	let error = null;
@@ -364,6 +365,16 @@ export const generateOpenAIChatCompletion = async (
 	url: string = `${WEBUI_BASE_URL}/api`
 ) => {
 	let error = null;
+
+	const dateTime = getCurrentDateTime();
+	const bodyWithUserData = {
+		...body,
+		user_data: {
+			...(body as any).user_data,
+			date_time: dateTime
+		}
+	};
+	body = bodyWithUserData;
 
 	const res = await fetch(`${url}/chat/completions`, {
 		method: 'POST',

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1000,7 +1000,10 @@ export const bestMatchingLanguage = (supportedLanguages, preferredLanguages, def
 // Get the date in the format YYYY-MM-DD
 export const getFormattedDate = () => {
 	const date = new Date();
-	return date.toISOString().split('T')[0];
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
 };
 
 // Get the time in the format HH:MM:SS


### PR DESCRIPTION
Building on #10041 - this sends the user's local date for better servicing time sensitive prompts like "what's the weather?" or "what's going on in the world today?" or "when are the suns playing next?" etc...  I didn't put it in a header like the other user data since it comes from the frontend. Since all frontend derived data is sent in the payload, I included it there instead.