### PR TITLE
feat: Add CTRL+C Rich Text toggle in settings

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -390,21 +390,6 @@
 		console.log('mounted');
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('chat-events', chatEventHandler);
-
-		const handleCopy = (event: ClipboardEvent) => {
-			if (!get(settings).richTextCopy) {
-				const selection = window.getSelection();
-				if (selection) {
-					// Prevent the browser's default copy behavior which is rich text.
-					event.preventDefault();
-					const text = selection.toString();
-					if (event.clipboardData) {
-						event.clipboardData.setData('text/plain', text);
-					}
-				}
-			}
-			// If settings.richTextCopy is true, the default behavior (rich text) will be used.
-		};
 		document.addEventListener('copy', handleCopy);
 
 		if (!$chatId) {
@@ -1227,6 +1212,23 @@
 		console.log(data);
 		if (autoScroll) {
 			scrollToBottom();
+		}
+	};
+
+	const handleCopy = (event: ClipboardEvent) => {
+		if (!$settings.richTextCopy) {
+			console.log('Copying text as plain text');
+			const selection = window.getSelection();
+			if (selection) {
+				// Prevent the browser's default rich text copy behavior.
+				event.preventDefault();
+				const text = selection.toString();
+				if (event.clipboardData) {
+					event.clipboardData.setData('text/plain', text);
+				}
+			}
+		} else {
+			console.log('Copying text as rich text');
 		}
 	};
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -391,6 +391,22 @@
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('chat-events', chatEventHandler);
 
+		const handleCopy = (event: ClipboardEvent) => {
+			if (!get(settings).richTextCopy) {
+				const selection = window.getSelection();
+				if (selection) {
+					// Prevent the browser's default copy behavior which is rich text.
+					event.preventDefault();
+					const text = selection.toString();
+					if (event.clipboardData) {
+						event.clipboardData.setData('text/plain', text);
+					}
+				}
+			}
+			// If settings.richTextCopy is true, the default behavior (rich text) will be used.
+		};
+		document.addEventListener('copy', handleCopy);
+
 		if (!$chatId) {
 			chatIdUnsubscriber = chatId.subscribe(async (value) => {
 				if (!value) {
@@ -449,6 +465,7 @@
 	onDestroy(() => {
 		chatIdUnsubscriber?.();
 		window.removeEventListener('message', onMessageHandler);
+		document.removeEventListener('copy', handleCopy);
 		$socket?.off('chat-events', chatEventHandler);
 	});
 

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -31,6 +31,7 @@
 	let defaultModelId = '';
 	let showUsername = false;
 	let richTextInput = true;
+	let richTextCopy = true;
 	let largeTextAsFile = false;
 	let notificationSound = true;
 
@@ -157,6 +158,11 @@
 	const toggleRichTextInput = async () => {
 		richTextInput = !richTextInput;
 		saveSettings({ richTextInput });
+	};
+
+	const toggleRichTextCopy = async () => {
+		richTextCopy = !richTextCopy;
+		saveSettings({ richTextCopy });
 	};
 
 	const toggleLargeTextAsFile = async () => {
@@ -533,6 +539,28 @@
 						type="button"
 					>
 						{#if richTextInput === true}
+							<span class="ml-2 self-center">{$i18n.t('On')}</span>
+						{:else}
+							<span class="ml-2 self-center">{$i18n.t('Off')}</span>
+						{/if}
+					</button>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div class=" self-center text-xs">
+						{$i18n.t('CTRL+C Rich Text')}
+					</div>
+
+					<button
+						class="p-1 px-3 text-xs flex rounded transition"
+						on:click={() => {
+							toggleRichTextCopy();
+						}}
+						type="button"
+					>
+						{#if richTextCopy === true}
 							<span class="ml-2 self-center">{$i18n.t('On')}</span>
 						{:else}
 							<span class="ml-2 self-center">{$i18n.t('Off')}</span>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -225,6 +225,7 @@
 		voiceInterruption = $settings.voiceInterruption ?? false;
 
 		richTextInput = $settings.richTextInput ?? true;
+		richTextCopy = $settings.richTextCopy ?? true;
 		largeTextAsFile = $settings.largeTextAsFile ?? false;
 
 		landingPageMode = $settings.landingPageMode ?? '';


### PR DESCRIPTION
# Changelog Entry

### Description

- Added a toggle option in the settings to allow users to choose between copying rich text or unformatted text when using CTRL+C in OpenWebUI. This addresses the issue where copying to Google Sheets clears formatting due to rich text.

### Added

- Added a new setting `richTextCopy` to toggle between copying rich text and unformatted text. This only affects CTRL+C.
- Added a new UI element in the settings interface to control the `richTextCopy` option.

### Changed

- Modified the `Chat.svelte` component to handle the copy event based on the `richTextCopy` setting.

### Fixed

- Fixed the issue where copying to Google Sheets clears formatting by providing an option to copy unformatted text.

### Security

- No security-related changes were made.

### Breaking Changes

- None. This change is backward compatible and does not affect existing functionality.

---

### Additional Information

- This change addresses the feature request described in issue #10126
- The new setting allows users to choose their preferred copy behavior using CTRL+C, while leaving the copy button behaviour.

### Screenshots or Videos

https://github.com/user-attachments/assets/4a66b664-98c7-4310-a9c1-353a0fa9c21a