### PR TITLE
fix(windows): set SelectorEventLoopPolicy to resolve aiodns error

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -322,6 +322,9 @@ from open_webui.utils.security_headers import SecurityHeadersMiddleware
 
 from open_webui.tasks import stop_task, list_tasks  # Import from tasks.py
 
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 if SAFE_MODE:
     print("SAFE MODE ENABLED")
     Functions.deactivate_all_functions()


### PR DESCRIPTION
# Pull Request Checklist

### Created issue under the discussion tab as required for pull requests: (https://github.com/open-webui/open-webui/discussions/10813)

**Before submitting, checked:**
- [x] **Target branch:** `dev`
- [x] **Description:** Add WindowsSelectorEventLoopPolicy to resolve aiodns error
- [x] **Changelog:** Added entry below
- [x] **Documentation:** N/A (code-only fix)
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Confirmed working on Windows 11 23H2 + Python 3.11
- [x] **Code review:** Self-reviewed for style/standards

**PR Title:**  
`fix(windows): Set WindowsSelectorEventLoopPolicy to resolve aiodns error`

---

# Changelog Entry

### Description  
Resolved Windows-specific async I/O error affecting DNS resolution in aiodns.

### Added  
- None

### Changed  
- None

### Deprecated  
- None

### Removed  
- None

### Fixed  
- Added Windows event loop policy configuration to `main.py` to enable SelectorEventLoop usage

### Security  
- None

### Breaking Changes  
- **None** - Behavior remains identical on non-Windows systems

---

### Additional Information  
**References:**  
- Fixes Windows users experiencing:  
  > ERROR [open_webui.routers.openai] aiodns needs SelectorEventLoop on Windows  
- Follows recommendation from aiodns Issue #86 ([saghul/aiodns#86](https://github.com/saghul/aiodns/issues/86))  
- Validated on Windows 10 with 64-bit Python 3.11  

### Screenshots or Videos  
_N/A - Backend configuration change_
