### PR TITLE
Fix "Cannot read properties of undefined (reading 'startsWith')"

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/Source.svelte
+++ b/src/lib/components/chat/Messages/Markdown/Source.svelte
@@ -2,7 +2,7 @@
 	export let token;
 	export let onClick: Function = () => {};
 
-	let attributes: Record<string, string> = {};
+	let attributes: Record<string, string | undefined> = {};
 
 	function extractAttributes(input: string): Record<string, string> {
 		const regex = /(\w+)="([^"]*)"/g;
@@ -42,6 +42,6 @@
 	}}
 >
 	<span class="line-clamp-1">
-		{formattedTitle(attributes.title)}
+		{attributes.title ? formattedTitle(attributes.title) : ''}
 	</span>
 </button>


### PR DESCRIPTION
I don't know the root cause of why `title` isn't available here, but it's crashing the UI because the types are wrong.

Looks like this was introduced in bbda717b69cd26f7a3cb1c87a383e0d5d522a30c

![image](https://github.com/user-attachments/assets/5a25e871-8751-4106-a7b5-541446281fcd)

![image](https://github.com/user-attachments/assets/e963762e-8a28-4bd9-a427-798137de689a)
