### PR TITLE
fix(deps): upgrade pydantic from v2.9.2 to v2.10.3+ in requirements.txt and pyproject.toml

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.115.7
 uvicorn[standard]==0.30.6
-pydantic==2.9.2
+pydantic==2.10.6
 python-multipart==0.0.18
 
 python-socketio==5.11.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "fastapi==0.115.7",
     "uvicorn[standard]==0.30.6",
-    "pydantic==2.9.2",
+    "pydantic==2.10.6",
     "python-multipart==0.0.18",
 
     "python-socketio==5.11.3",


### PR DESCRIPTION
fix(deps): upgrade pydantic from v2.9.2 to v2.10.3+ in requirements.txt and pyproject.toml

- Resolve firecrawl-py dependency conflict between firecrawl-py(>=2.10.3) and pinned pydantic(2.9.2)
- Ensure compatibility with other Python packages by aligning pydantic versions

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
In Pull Request #10341, the introduction of firecrawl-py==1.12.0 creates a dependency conflict with the existing pinned version of pydantic==2.9.2.
This PR resolves dependency conflicts between firecrawl-py and pinned pydantic versions by:

- Upgrading pydantic from v2.9.2 to v2.10.3+
- Aligning version constraints in both requirements.txt and pyproject.toml
- Ensuring compatibility with firecrawl-py's requirement (pydantic>=2.10.3)

### Changed

- `backend/requirements.txt `
- `pyproject.toml`

### Error MSG

``` text
=> ERROR [base  9/13] RUN pip3 install uv &&     if [ "false" = "true" ]; then     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir &&     uv pip install --system -r requirements.tx  44.7s
------
 > [base  9/13] RUN pip3 install uv &&     if [ "false" = "true" ]; then     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir &&     uv pip install --system -r requirements.txt --no-cache-dir &&     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" &&     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])";     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])";     else     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir &&     uv pip install --system -r requirements.txt --no-cache-dir &&     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" &&     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])";     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])";     fi;     chown -R 0:0 /app/backend/data/:
2.167 Collecting uv
2.354   Downloading uv-0.6.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2.408 Downloading uv-0.6.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.3 MB)
3.284    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.3/16.3 MB 20.9 MB/s eta 0:00:00
3.366 Installing collected packages: uv
3.592 Successfully installed uv-0.6.1
3.592 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
3.831 
3.831 [notice] A new release of pip is available: 24.0 -> 25.0.1
3.831 [notice] To update, run: pip install --upgrade pip
4.187 Looking in indexes: https://download.pytorch.org/whl/cpu
5.459 Collecting torch
5.499   Downloading https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl.metadata (26 kB)
6.206 Collecting torchvision
6.243   Downloading https://download.pytorch.org/whl/cpu/torchvision-0.21.0%2Bcpu-cp311-cp311-linux_x86_64.whl.metadata (6.1 kB)
6.738 Collecting torchaudio
6.775   Downloading https://download.pytorch.org/whl/cpu/torchaudio-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl.metadata (6.6 kB)
7.037 Collecting filelock (from torch)
7.074   Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl.metadata (2.8 kB)
7.331 Collecting typing-extensions>=4.10.0 (from torch)
7.368   Downloading https://download.pytorch.org/whl/typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
8.037 Collecting networkx (from torch)
8.074   Downloading https://download.pytorch.org/whl/networkx-3.3-py3-none-any.whl.metadata (5.1 kB)
8.715 Collecting jinja2 (from torch)
8.751   Downloading https://download.pytorch.org/whl/Jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
9.384 Collecting fsspec (from torch)
9.422   Downloading https://download.pytorch.org/whl/fsspec-2024.6.1-py3-none-any.whl.metadata (11 kB)
10.07 Collecting sympy==1.13.1 (from torch)
10.11   Downloading https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl (6.2 MB)
10.42      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.2/6.2 MB 19.9 MB/s eta 0:00:00
11.11 Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch)
11.15   Downloading https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
11.16      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 536.2/536.2 kB 42.0 MB/s eta 0:00:00
11.43 Collecting numpy (from torchvision)
11.46   Downloading https://download.pytorch.org/whl/numpy-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
11.47      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.9/60.9 kB 243.0 MB/s eta 0:00:00
12.32 Collecting pillow!=8.3.*,>=5.3.0 (from torchvision)
12.36   Downloading https://download.pytorch.org/whl/pillow-11.0.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.1 kB)
12.68 Collecting MarkupSafe>=2.0 (from jinja2->torch)
12.72   Downloading https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
12.84 Downloading https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl (178.7 MB)
20.31    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.7/178.7 MB 24.1 MB/s eta 0:00:00
20.35 Downloading https://download.pytorch.org/whl/cpu/torchvision-0.21.0%2Bcpu-cp311-cp311-linux_x86_64.whl (1.8 MB)
20.42    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 26.7 MB/s eta 0:00:00
20.45 Downloading https://download.pytorch.org/whl/cpu/torchaudio-2.6.0%2Bcpu-cp311-cp311-linux_x86_64.whl (1.7 MB)
20.52    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 27.2 MB/s eta 0:00:00
20.56 Downloading https://download.pytorch.org/whl/pillow-11.0.0-cp311-cp311-manylinux_2_28_x86_64.whl (4.4 MB)
20.73    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.4/4.4 MB 25.3 MB/s eta 0:00:00
20.77 Downloading https://download.pytorch.org/whl/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
20.81 Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
20.84 Downloading https://download.pytorch.org/whl/fsspec-2024.6.1-py3-none-any.whl (177 kB)
20.85    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 177.6/177.6 kB 34.9 MB/s eta 0:00:00
20.89 Downloading https://download.pytorch.org/whl/Jinja2-3.1.4-py3-none-any.whl (133 kB)
20.89    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.3/133.3 kB 43.3 MB/s eta 0:00:00
20.93 Downloading https://download.pytorch.org/whl/networkx-3.3-py3-none-any.whl (1.7 MB)
20.99    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 27.9 MB/s eta 0:00:00
21.03 Downloading https://download.pytorch.org/whl/numpy-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.3 MB)
21.96    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.3/16.3 MB 24.0 MB/s eta 0:00:00
22.83 Installing collected packages: mpmath, typing-extensions, sympy, pillow, numpy, networkx, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision, torchaudio
40.44 Successfully installed MarkupSafe-2.1.5 filelock-3.13.1 fsspec-2024.6.1 jinja2-3.1.4 mpmath-1.3.0 networkx-3.3 numpy-2.1.2 pillow-11.0.0 sympy-1.13.1 torch-2.6.0+cpu torchaudio-2.6.0+cpu torchvision-0.21.0+cpu typing-extensions-4.12.2
40.44 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
41.13 Using Python 3.11.11 environment at: /usr/local
43.75   × No solution found when resolving dependencies:
43.75   ╰─▶ Because firecrawl-py==1.12.0 depends on pydantic>=2.10.3 and you
43.75       require pydantic==2.9.2, we can conclude that your requirements and
43.75       firecrawl-py==1.12.0 are incompatible.
43.75       And because you require firecrawl-py==1.12.0, we can conclude that your
43.75       requirements are unsatisfiable.
43.82 Traceback (most recent call last):
43.82   File "<string>", line 1, in <module>
43.82 ModuleNotFoundError: No module named 'tiktoken'
43.82 chown: cannot access '/app/backend/data/': No such file or directory
------
Dockerfile:135
--------------------
 134 |     
 135 | >>> RUN pip3 install uv && \
 136 | >>>     if [ "$USE_CUDA" = "true" ]; then \
 137 | >>>     # If you use CUDA the whisper and embedding model will be downloaded on first use
 138 | >>>     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/$USE_CUDA_DOCKER_VER --no-cache-dir && \
 139 | >>>     uv pip install --system -r requirements.txt --no-cache-dir && \
 140 | >>>     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
 141 | >>>     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
 142 | >>>     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
 143 | >>>     else \
 144 | >>>     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir && \
 145 | >>>     uv pip install --system -r requirements.txt --no-cache-dir && \
 146 | >>>     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')" && \
 147 | >>>     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
 148 | >>>     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
 149 | >>>     fi; \
 150 | >>>     chown -R $UID:$GID /app/backend/data/
 151 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pip3 install uv &&     if [ \"$USE_CUDA\" = \"true\" ]; then     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/$USE_CUDA_DOCKER_VER --no-cache-dir &&     uv pip install --system -r requirements.txt --no-cache-dir &&     python -c \"import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')\" &&     python -c \"import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])\";     python -c \"import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])\";     else     pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir &&     uv pip install --system -r requirements.txt --no-cache-dir &&     python -c \"import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cpu')\" &&     python -c \"import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])\";     python -c \"import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])\";     fi;     chown -R $UID:$GID /app/backend/data/" did not complete successfully: exit code: 
```