### PR TITLE
fix: Update Ollama option handling in payload.py's convert_payload_openai_to_ollama

### DIFF
--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -190,10 +190,6 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
     elif "max_tokens" in openai_payload:
         ollama_options["num_predict"] = openai_payload["max_tokens"]
 
-    # Handle frequency / presence_penalty, which needs renaming and checking
-    if "frequency_penalty" in openai_payload:
-        ollama_options["repeat_penalty"] = openai_payload["frequency_penalty"]
-
     # Add options to payload if any have been set
     if ollama_options:
         ollama_payload["options"] = ollama_options

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -194,10 +194,6 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
     if "frequency_penalty" in openai_payload:
         ollama_options["repeat_penalty"] = openai_payload["frequency_penalty"]
 
-    if "presence_penalty" in openai_payload and "penalty" not in ollama_options:
-        # We are assuming presence penalty uses a similar concept in Ollama, which needs custom handling if exists.
-        ollama_options["new_topic_penalty"] = openai_payload["presence_penalty"]
-
     # Add options to payload if any have been set
     if ollama_options:
         ollama_payload["options"] = ollama_options

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -179,11 +179,6 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
         ollama_payload["options"] = openai_payload["options"]
         ollama_options = openai_payload["options"]
 
-    # Handle parameters which map directly
-    for param in ["temperature", "top_p", "seed"]:
-        if param in openai_payload:
-            ollama_options[param] = openai_payload[param]
-
     # Mapping OpenAI's `max_tokens` -> Ollama's `num_predict`
     if "max_tokens" in openai_payload:
         ollama_options["num_predict"] = openai_payload["max_tokens"]

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -182,7 +182,12 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
         # Re-Mapping OpenAI's `max_tokens` -> Ollama's `num_predict`
         if "max_tokens" in ollama_options:
             ollama_options["num_predict"] = ollama_options["max_tokens"] 
-            del ollama_options["max_tokens"] # To prevent Ollama warning of invalid option provided        
+            del ollama_options["max_tokens"] # To prevent Ollama warning of invalid option provided
+
+        # Ollama lacks a "system" prompt option. It has to be provided as a direct parameter, so we copy it down.
+        if "system" in ollama_options:
+            ollama_payload["system"] = ollama_options["system"] 
+            del ollama_options["system"] # To prevent Ollama warning of invalid option provided
 
     # Add options to payload if any have been set
     if ollama_options:

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -185,9 +185,7 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
             ollama_options[param] = openai_payload[param]
 
     # Mapping OpenAI's `max_tokens` -> Ollama's `num_predict`
-    if "max_completion_tokens" in openai_payload:
-        ollama_options["num_predict"] = openai_payload["max_completion_tokens"]
-    elif "max_tokens" in openai_payload:
+    if "max_tokens" in openai_payload:
         ollama_options["num_predict"] = openai_payload["max_tokens"]
 
     # Add options to payload if any have been set

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -178,10 +178,11 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
     if openai_payload.get("options"):
         ollama_payload["options"] = openai_payload["options"]
         ollama_options = openai_payload["options"]
-
-    # Mapping OpenAI's `max_tokens` -> Ollama's `num_predict`
-    if "max_tokens" in openai_payload:
-        ollama_options["num_predict"] = openai_payload["max_tokens"]
+        
+        # Re-Mapping OpenAI's `max_tokens` -> Ollama's `num_predict`
+        if "max_tokens" in ollama_options:
+            ollama_options["num_predict"] = ollama_options["max_tokens"] 
+            del ollama_options["max_tokens"] # To prevent Ollama warning of invalid option provided        
 
     # Add options to payload if any have been set
     if ollama_options:

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -173,8 +173,6 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
         ollama_payload["format"] = openai_payload["format"]
 
     # If there are advanced parameters in the payload, format them in Ollama's options field
-    ollama_options = {}
-
     if openai_payload.get("options"):
         ollama_payload["options"] = openai_payload["options"]
         ollama_options = openai_payload["options"]
@@ -188,10 +186,6 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
         if "system" in ollama_options:
             ollama_payload["system"] = ollama_options["system"] 
             del ollama_options["system"] # To prevent Ollama warning of invalid option provided
-
-    # Add options to payload if any have been set
-    if ollama_options:
-        ollama_payload["options"] = ollama_options
 
     if "metadata" in openai_payload:
         ollama_payload["metadata"] = openai_payload["metadata"]


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests for validating the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- This is part 1 of 2 of recreating PR #10015 more atomicly.
- The goal is to update Payload.py's convert_payload_openai_to_ollama to better handle options for Ollama, particularly num_predict which currently does not work if the user sets it via personal or chat-specific advanced parameters.
- For most of these changes, the issue was that the parameters/options were being looked for in openai_payload, but they were actually present in openai_payload['options'], causing them to not be found.
- Each commit is very atomic with notes, please let me know if this was *too* granular.

### Removed

- Removed the mapping of presence_penalty to new_topic_penalty. new_topic_penalty is not a valid Ollama parameter, and Ollama supports presence_penalty natively. Presence_penalty is being added to Open WebUI in PR #10016. 
- Removed the mapping of frequency_penalty to repeat_penalty. Repeat_penalty is a valid Ollama parameter, but Ollama also supports frequence_penalty natively. Repeat_penalty is being added to Open WebUI  in PR #10016, allowing Ollama users to choose which method they prefer.
- Remove mapping of max_completion_tokens to num_predict. The UI never sends max_completion_tokens. It is only used for OpenAI models o1 and o3, and OpenAI.py and Tasks.py populate it from max_tokens.
- Remove mapping of temperature, seed and top_p from payload to options. These options are found in the options dictionary already, and are not in the base payload.
- Removed an empty ollama options dictionary that was not used.

### Fixed

- Fixed mapping of max_tokens to num_predict. The issue was that max_tokens was being looked for in openai_payload, but was present in openai_payload['options'] instead. After remapping, we delete max_tokens to stop Ollama from throwing a warning for invalid options.
- Fixed passing "system" prompt to Ollama. The system prompt is present in openai_payload['options'], but Ollama does not accept it as an option. It must be part of the payload. After copying it to the payload, we delete it from the options to prevent Ollama throwing a warning for invalid options.

---

### Additional Information

- Originally submitted as PR #10015 but broken up to be more atomic.
- Originally opened as a discussion as #9770.