### PR TITLE
**fix** ChatMessage validator: content can be null when using tools

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -26,7 +26,7 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, validator
 from starlette.background import BackgroundTask
 
 
@@ -936,9 +936,18 @@ async def generate_completion(
 
 class ChatMessage(BaseModel):
     role: str
-    content: str
+    content: Optional[str] = None
     tool_calls: Optional[list[dict]] = None
     images: Optional[list[str]] = None
+
+    @validator("content", pre=True)
+    @classmethod
+    def check_at_least_one_field(cls, field_value, values, **kwargs):
+        # Raise an error if both 'content' and 'tool_calls' are None
+        if field_value is None and ("tool_calls" not in values or values["tool_calls"] is None):
+            raise ValueError("At least one of 'content' or 'tool_calls' must be provided")
+
+        return field_value
 
 
 class GenerateChatCompletionForm(BaseModel):


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed the ChatMessage validation: content can be null when using tools, for example, this should be a valid accepted message  call (the third message has no content)
```json
"messages": [
	{
		"content": "You are a helpful assistant", 
		"role": "system"
	}, {
		"content": "It feels so cold today in NY.", 
		"role": "user"
	}, {
		"role": "assistant", 
		"tool_calls": [
			{
				"type": "function", 
				"id": "call_1f82a3f7-7fe3-45a9-9de7-e03949b83563", 
				"function": {
					"name": "weather", 
					"arguments": "{\"city\": \"New York\"}"
				}
			}
		]
	}, {
		"content": "The weather in New York is 37 degrees.", 
		"role": "tool", 
		"tool_call_id": "call_1f82a3f7-7fe3-45a9-9de7-e03949b83563"
	}
]
```

### Fixed

- ChatMessage validator should handle message with null content when tool calls are present

---

### Additional Information

All the changes are tested and validated using this notebook file.
https://gist.github.com/Seniorsimo/214e39d7da6a72bff98f265a39c2fa14

Tested the varius intagration using:

OpenAI vs Open WebUI (gpt-3.5-turbo)
Ollama vs Open WebUI (qwen2.5:14b)
