### PR TITLE
fix: Rag dedupe (again)

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -179,17 +179,17 @@ def merge_and_sort_query_results(
     combined_distances = []
     combined_documents = []
     combined_metadatas = []
-    combined_ids = []
+    combined_hashes = []
 
     for data in query_results:
         combined_distances.extend(data["distances"][0])
         combined_documents.extend(data["documents"][0])
         combined_metadatas.extend(data["metadatas"][0])
-        # DISTINCT(chunk_id,file_id) - in case if id (chunk_ids) become ordinals
-        combined_ids.extend([id + meta["file_id"] for id, meta in zip(data["ids"][0], data["metadatas"][0])])
+        hashes = [hash((doc, meta.get("hash"),)) for doc, meta in zip(data["documents"][0], data["metadatas"][0])]
+        combined_hashes.extend(hashes)
 
     # Create a list of tuples (distance, document, metadata, ids)
-    combined = list(zip(combined_distances, combined_documents, combined_metadatas, combined_ids))
+    combined = list(zip(combined_distances, combined_documents, combined_metadatas, combined_hashes))
 
     # Sort the list based on distances
     combined.sort(key=lambda x: x[0], reverse=reverse)
@@ -200,15 +200,15 @@ def merge_and_sort_query_results(
     # Otherwise we don't have anything :-(
     if combined:
         # Unzip the sorted list
-        all_distances, all_documents, all_metadatas, all_ids = zip(*combined)
-        seen_ids = set()
+        all_distances, all_documents, all_metadatas, all_hashes = zip(*combined)
+        seen_hashes = set()
         # Slicing the lists to include only k elements
-        for index, id in enumerate(all_ids):
-            if id not in seen_ids:
+        for index, id in enumerate(all_hashes):
+            if id not in seen_hashes:
                 sorted_distances.append(all_distances[index])
                 sorted_documents.append(all_documents[index])
                 sorted_metadatas.append(all_metadatas[index])
-                seen_ids.add(id)
+                seen_hashes.add(id)
                 if len(sorted_distances) >= k:
                     break
 

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -173,7 +173,7 @@ def merge_get_results(get_results: list[dict]) -> dict:
 
 
 def merge_and_sort_query_results(
-        query_results: list[dict], k: int, reverse: bool = False
+    query_results: list[dict], k: int, reverse: bool = False
 ) -> list[dict]:
     # Initialize lists to store combined data
     combined_distances = []
@@ -185,11 +185,21 @@ def merge_and_sort_query_results(
         combined_distances.extend(data["distances"][0])
         combined_documents.extend(data["documents"][0])
         combined_metadatas.extend(data["metadatas"][0])
-        hashes = [hash((doc, meta.get("hash"),)) for doc, meta in zip(data["documents"][0], data["metadatas"][0])]
+        hashes = [
+            hash(
+                (
+                    doc,
+                    meta.get("hash"),
+                )
+            )
+            for doc, meta in zip(data["documents"][0], data["metadatas"][0])
+        ]
         combined_hashes.extend(hashes)
 
     # Create a list of tuples (distance, document, metadata, ids)
-    combined = list(zip(combined_distances, combined_documents, combined_metadatas, combined_hashes))
+    combined = list(
+        zip(combined_distances, combined_documents, combined_metadatas, combined_hashes)
+    )
 
     # Sort the list based on distances
     combined.sort(key=lambda x: x[0], reverse=reverse)

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -173,37 +173,44 @@ def merge_get_results(get_results: list[dict]) -> dict:
 
 
 def merge_and_sort_query_results(
-    query_results: list[dict], k: int, reverse: bool = False
+        query_results: list[dict], k: int, reverse: bool = False
 ) -> list[dict]:
     # Initialize lists to store combined data
     combined_distances = []
     combined_documents = []
     combined_metadatas = []
+    combined_ids = []
 
     for data in query_results:
         combined_distances.extend(data["distances"][0])
         combined_documents.extend(data["documents"][0])
         combined_metadatas.extend(data["metadatas"][0])
+        # DISTINCT(chunk_id,file_id) - in case if id (chunk_ids) become ordinals
+        combined_ids.extend([id + meta["file_id"] for id, meta in zip(data["ids"][0], data["metadatas"][0])])
 
-    # Create a list of tuples (distance, document, metadata)
-    combined = list(zip(combined_distances, combined_documents, combined_metadatas))
+    # Create a list of tuples (distance, document, metadata, ids)
+    combined = list(zip(combined_distances, combined_documents, combined_metadatas, combined_ids))
 
     # Sort the list based on distances
     combined.sort(key=lambda x: x[0], reverse=reverse)
 
-    # We don't have anything :-(
-    if not combined:
-        sorted_distances = []
-        sorted_documents = []
-        sorted_metadatas = []
-    else:
+    sorted_distances = []
+    sorted_documents = []
+    sorted_metadatas = []
+    # Otherwise we don't have anything :-(
+    if combined:
         # Unzip the sorted list
-        sorted_distances, sorted_documents, sorted_metadatas = zip(*combined)
-
+        all_distances, all_documents, all_metadatas, all_ids = zip(*combined)
+        seen_ids = set()
         # Slicing the lists to include only k elements
-        sorted_distances = list(sorted_distances)[:k]
-        sorted_documents = list(sorted_documents)[:k]
-        sorted_metadatas = list(sorted_metadatas)[:k]
+        for index, id in enumerate(all_ids):
+            if id not in seen_ids:
+                sorted_distances.append(all_distances[index])
+                sorted_documents.append(all_documents[index])
+                sorted_metadatas.append(all_metadatas[index])
+                seen_ids.add(id)
+                if len(sorted_distances) >= k:
+                    break
 
     # Create the output dictionary
     result = {


### PR DESCRIPTION
# RAG: result duplicates

Discussed: https://github.com/open-webui/open-webui/discussions/10188

Previous attempt #10272 and the failure #10428 
This time I use a document hash and metadata hash (but optional) for deduplication.

# Changelog Entry

### Description

- fixes wasting RAG context by result duplicates

### Fixed

- removes result duplicates
