### PR TITLE
fix: ollama backend native tool calling

### DIFF
--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -124,7 +124,7 @@ def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
         tool_call_id = message.get("tool_call_id", None)
 
         # Check if the content is a string (just a simple message)
-        if isinstance(content, str):
+        if isinstance(content, str) and not tool_calls:
             # If the content is a string, it's pure text
             new_message["content"] = content
 


### PR DESCRIPTION
Fixes ollama native tool calling because native tool calling content will be str '', and tool call processing will be completely ignored.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Fix ollama backend native tool calling
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

# Changelog Entry

### Description

- Added tool_calls check in convert_messages_openai_to_ollama, so data sent to ollama contains proper tool_calls properties, not just {'role':'assistant', 'content':''} if you uses native tool calling.

### Changed

- Added tool_calls check in convert_messages_openai_to_ollama

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]
