### PR TITLE
fix: do not allow uninstalling open-webui to install a tool + uv faster than pip

### DIFF
--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -171,7 +171,13 @@ def install_frontmatter_requirements(requirements):
             req_list = [req.strip() for req in requirements.split(",")]
             for req in req_list:
                 log.info(f"Installing requirement: {req}")
-                subprocess.check_call([sys.executable, "-m", "pip", "install", req])
+                subprocess.check_call([
+                    sys.executable, "-m", "uv", "pip",
+                    "install",
+                    "--overrides", "/app/backend/requirements.txt",
+                    req,
+                    "--system"
+                ])
         except Exception as e:
             log.error(f"Error installing package: {req}")
             raise e


### PR DESCRIPTION
- **feat: Implement Document Intelligence as Content Extraction Engine**
- **Update catalan translation.json**
- **Fix on ollama to openai conversion - stream can return a single message with content**
- **Update zh-CN translation**
- **refac**
- **i18n: Update Chinese Translation**
- **feat/async-pipes**
- **fix:Quick selection tool lost**
- **Update audio.py to fetch custom URL voices and models**
- **Update audio.py**
- **Support thinking tags used by Openthinker**
- **Added support for stop parameter**
- **refac**
- **refac**
- **fix: model import**
- **Fix: Ensure `user_oauth_groups` defaults to an empty list to prevent TypeError**
- **feat: added Trust Proxy Environment switch in Web Search admin settings tab.**
- **refac: code block image styling**
- **Update payload.py**
- **refac**
- **refac**
- **refac**
- **refac**
- **fix: do not allow uninstalling open-webui to install a tool + uv faster than pip**

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

1. In the current state, pip was used to install requirements from tools. This is problematic because pip is slow and because open-webui is completely unresponsive when the command is being run. uv is way faster than pip so this is an improvement but making the dependency installation without hanging is out of scope of this PR.
2. Doing `pip install something` can totally break the dependencies needed by openwebui and I ran into several catastrophic failures because of this. I looked up online and both pip and uv seem to support specifying constraints during an install. Hence doing `(uv) pip install --overrides /app/backend/requirements.txt [the new dependencies]` seems to be safer.


### Changed

- Faster and safer dependency installation for tools

### Fixed

- No longer possible t uninstall open-webui or its dependencies by mistake when installing tools.

### Security

- Made it a bit harder to uninstall open-webui and its dependencies at tool installation.

---

### Additional Information

Note: it is still possible to wreak havoc the env by modifying the /app/backend/requirements.txt file in the tool directly, but at least we can't uninstall open-webui *by mistake*.