### PR TITLE
fix: replace "system" with "developer" for o1 and o3 models

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -84,9 +84,9 @@ def openai_o1_o3_handler(payload):
         payload["max_completion_tokens"] = payload["max_tokens"]
         del payload["max_tokens"]
 
-    # Fix: O1 does not support the "system" parameter, Modify "system" to "user"
+    # Fix: o1 and o3 do not support the "system" parameter. Modify "system" to "developer"
     if payload["messages"][0]["role"] == "system":
-        payload["messages"][0]["role"] = "user"
+        payload["messages"][0]["role"] = "developer"
 
     return payload
 


### PR DESCRIPTION
### Description

This implementation corrects the temporary fix in the codebase. Initially, the "o" series models only supported the "user" role. However, they recently introduced support for the "developer" role, which is equivalent to the "system" role.

### Fixed
- Fixed role mapping: changed `"system"` to `"developer"` for o1 and o3 models.

### Changelog Entry
- Fixed: Updated OpenAI o1 and o3 role handling by replacing "system" with "developer".

### Additional Information
- No new dependencies were introduced.
- No breaking changes expected.