### PR TITLE
fix: Handle no location permission

### DIFF
--- a/src/lib/components/chat/MessageInput/Commands/Prompts.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Prompts.svelte
@@ -74,7 +74,13 @@
 		}
 
 		if (command.content.includes('{{USER_LOCATION}}')) {
-			const location = await getUserPosition();
+			let location;
+			try {
+				location = await getUserPosition();
+			} catch (error) {
+				toast.error($i18n.t('Location access not allowed'));
+				location = 'LOCATION_UNKNOWN';
+			}
 			text = text.replaceAll('{{USER_LOCATION}}', String(location));
 		}
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -279,9 +279,9 @@ export const generateInitialsImage = (name) => {
 	const initials =
 		sanitizedName.length > 0
 			? sanitizedName[0] +
-				(sanitizedName.split(' ').length > 1
-					? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
-					: '')
+			(sanitizedName.split(' ').length > 1
+				? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
+				: '')
 			: '';
 
 	ctx.fillText(initials.toUpperCase(), canvas.width / 2, canvas.height / 2);
@@ -348,10 +348,10 @@ export const compareVersion = (latest, current) => {
 	return current === '0.0.0'
 		? false
 		: current.localeCompare(latest, undefined, {
-				numeric: true,
-				sensitivity: 'case',
-				caseFirst: 'upper'
-			}) < 0;
+			numeric: true,
+			sensitivity: 'case',
+			caseFirst: 'upper'
+		}) < 0;
 };
 
 export const findWordIndices = (text) => {
@@ -846,6 +846,9 @@ export const promptTemplate = (
 	if (user_location) {
 		// Replace {{USER_LOCATION}} in the template with the current location
 		template = template.replace('{{USER_LOCATION}}', user_location);
+	} else {
+		// Replace {{USER_LOCATION}} in the template with 'Unknown' if no location is provided
+		template = template.replace('{{USER_LOCATION}}', 'LOCATION_UNKNOWN');
 	}
 
 	return template;


### PR DESCRIPTION
# Changelog Entry

### Description

This PR contains a fix for when the user has not given Open-WebUI access to the users location. Instead of erroring out and refusing to send the message the variable {{USER_LOCATION}} is now replaced with LOCATION_UNKNOWN. Additionally when the user is using {{USER_LOCATION}} in a slash prompt, an error toast is displayed notifying the user that location data is not available.

### Fixed

- Fixes an issue where a prompt couldn't be sent if a location variable was present but location access was not allowed.
