### PR TITLE
fix: restore compatibility for older o1 models (o1-mini, o1-preview)

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -84,9 +84,15 @@ def openai_o1_o3_handler(payload):
         payload["max_completion_tokens"] = payload["max_tokens"]
         del payload["max_tokens"]
 
-    # Fix: o1 and o3 do not support the "system" parameter. Modify "system" to "developer"
+    # Fix: o1 and o3 do not support the "system" role directly.
+    # For older models like "o1-mini" or "o1-preview", use role "user".
+    # For newer o1/o3 models, replace "system" with "developer".
     if payload["messages"][0]["role"] == "system":
-        payload["messages"][0]["role"] = "developer"
+        model_lower = payload["model"].lower()
+        if model_lower.startswith("o1-mini") or model_lower.startswith("o1-preview"):
+            payload["messages"][0]["role"] = "user"
+        else:
+            payload["messages"][0]["role"] = "developer"
 
     return payload
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] **Target branch:** This pull request targets the `dev` branch.  
- [x] **Description:** See the “Description” section below.  
- [x] **Changelog:** Added a changelog entry following [Keep a Changelog](https://keepachangelog.com/).  
- [x] **Documentation:** No additional documentation changes needed.  
- [x] **Dependencies:** No new dependencies introduced.  
- [ ] **Testing:** Basic tests performed locally; changes do not affect existing tests negatively.  
- [x] **Code review:** Self-review performed; code adheres to project coding standards.  
- [x] **Prefix:** Using the “fix” prefix because this pull request addresses a bug/compatibility issue.  

---

# Changelog Entry

### Description

In [PR #10617](https://github.com/open-webui/open-webui/pull/10617), we replaced the `system` role with the `developer` role for newer o1/o3 models. However, older models like `o1-mini` and `o1-preview` do not support the `developer` role. This pull request restores compatibility for those legacy models by remapping `system` → `user` specifically for `o1-mini` and `o1-preview`.

### Added
- N/A

### Changed
- The role mapping logic to correctly handle older o1 models by setting `system` → `user` instead of `developer`.

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Compatibility for older o1 models (`o1-mini`, `o1-preview`) that do not support the `developer` role.

### Security
- N/A

### Breaking Changes
- None

---

### Additional Information
- N/A

### Screenshots or Videos
- N/A