### PR TITLE
fix: Include usage in chatCompleted handler for pipeline outlet functions

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -836,6 +836,7 @@
 				content: m.content,
 				info: m.info ? m.info : undefined,
 				timestamp: m.timestamp,
+				...(m.usage ? { usage: m.usage } : {}),
 				...(m.sources ? { sources: m.sources } : {})
 			})),
 			model_item: $models.find((m) => m.id === modelId),


### PR DESCRIPTION
# Changelog Entry

### Description

- This includes usage data if it exists in the chatCompleted handler which allows it to be processed in the filter pipeline outlet. I'm assuming this was functional at one point because pipelines, such as the [Langfuse filter pipeline](https://github.com/open-webui/pipelines/blob/main/examples/filters/langfuse_filter_pipeline.py) seem to assume it will be available but usage would never be passed to the outlet as code is currently. The langfuse filter is looking for info but this doesn't seem consistent with OpenAI so I left it as usage.

### Fixed

- This includes usage data if it exists in the chatCompleted handler which allows it to be processed in filter pipeline outlet functions.

