### PR TITLE
fix env.var based on documentation

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2376,6 +2376,7 @@ LDAP_SEARCH_FILTERS = PersistentConfig(
     "LDAP_SEARCH_FILTER",
     "ldap.server.search_filter",
     os.environ.get("LDAP_SEARCH_FILTER", ""),
+    os.environ.get("LDAP_SEARCH_FILTERS", ""),
 )
 
 LDAP_USE_TLS = PersistentConfig(


### PR DESCRIPTION
currently the documentation says, that the env var for LDAP_SEARCH_FILTERS is like this, but the implementation says LDAP_SEARCH_FILTER to be compatible with current implementation and doc we need to add this here.
