### PR TITLE
feat: add input validation for image size based on generation model type

### DIFF
--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -664,14 +664,40 @@
 					<div class=" mb-2.5 text-sm font-medium">{$i18n.t('Set Image Size')}</div>
 					<div class="flex w-full">
 						<div class="flex-1 mr-2">
-							<Tooltip content={$i18n.t('Enter Image Size (e.g. 512x512)')} placement="top-start">
-								<input
-									class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
-									placeholder={$i18n.t('Enter Image Size (e.g. 512x512)')}
-									bind:value={imageGenerationConfig.IMAGE_SIZE}
-									required
-								/>
-							</Tooltip>
+							{#if imageGenerationConfig?.MODEL?.toLowerCase().includes('dall-e-3')}
+								<Tooltip content={$i18n.t('Select DALL-E-3 image size')} placement="top-start">
+									<select
+										class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										bind:value={imageGenerationConfig.IMAGE_SIZE}
+										required
+									>
+										<option value="1024x1024">1024x1024</option>
+										<option value="1792x1024">1792x1024</option>
+										<option value="1024x1792">1024x1792</option>
+									</select>
+								</Tooltip>
+							{:else if imageGenerationConfig?.MODEL?.toLowerCase().includes('dall-e-2')}
+								<Tooltip content={$i18n.t('Select DALL-E-2 image size')} placement="top-start">
+									<select
+										class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										bind:value={imageGenerationConfig.IMAGE_SIZE}
+										required
+									>
+										<option value="256x256">256x256</option>
+										<option value="512x512">512x512</option>
+										<option value="1024x1024">1024x1024</option>
+									</select>
+								</Tooltip>
+							{:else}
+								<Tooltip content={$i18n.t('Enter Image Size (e.g. 512x512)')} placement="top-start">
+									<input
+										class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										placeholder={$i18n.t('Enter Image Size (e.g. 512x512)')}
+										bind:value={imageGenerationConfig.IMAGE_SIZE}
+										required
+									/>
+								</Tooltip>
+							{/if}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
# Pull Request

### Description
This pull request introduces input validation for the image size based on the selected model in the image generation configuration. It improves user experience by dynamically displaying appropriate options for DALL-E-2 and DALL-E-3 models, and allows manual input of custom image sizes if the model is not one of these.

### Added
- Conditional rendering of `<select>` and `<input>` elements for image size based on the selected model (DALL-E-2 or DALL-E-3).
- Tooltips to provide user guidance for selecting or entering image sizes.
![CleanShot 2025-02-28 at 16 04 18](https://github.com/user-attachments/assets/8f0cb8f4-1712-4555-abcf-c8323848214c)

### Changed
- Updated the component to include validation for the input field for image size.
- Improved user interface by offering specific size options for different models.

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- N/A

### Security
- N/A

### Breaking Changes
- **BREAKING CHANGE**: The input mechanism for image size has changed. Existing implementations that depend on the former input method may need to be updated.

---

### Additional Information
- This change aims to improve the usability of the image size selection process and reduce user errors when inputting image sizes. 
- Issues related to image size validation can be referenced in issue #<issue-number> (if applicable).

### Screenshots or Videos
- [Attach any relevant screenshots or videos demonstrating the changes]
