### PR TITLE
i18n(html): sync html language with i18n language

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 	import { createEventDispatcher, onMount, getContext } from 'svelte';
-	import { getLanguages } from '$lib/i18n';
+	import { changeAllLanguage, getLanguages } from '$lib/i18n';
 	const dispatch = createEventDispatcher();
 
 	import { models, settings, theme, user } from '$lib/stores';
@@ -198,7 +198,7 @@
 						bind:value={lang}
 						placeholder="Select a language"
 						on:change={(e) => {
-							$i18n.changeLanguage(lang);
+							changeAllLanguage(lang);
 						}}
 					>
 						{#each languages as language}

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,7 +1,8 @@
 import i18next from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import type { i18n as i18nType } from 'i18next';
+import type { i18n as i18nType, TFunction } from 'i18next';
+import {changeLanguage} from 'i18next'
 import { writable } from 'svelte/store';
 
 const createI18nStore = (i18n: i18nType) => {
@@ -70,6 +71,17 @@ export const initI18n = (defaultLocale: string | undefined) => {
 
 const i18n = createI18nStore(i18next);
 const isLoadingStore = createIsLoadingStore(i18next);
+
+export const changeHTMLLanguage = (lang: string) => {
+	document.documentElement.setAttribute('lang', lang);
+}
+
+export const changeAllLanguage = (lang: string) : Promise<TFunction> => {
+	// change html language
+	changeHTMLLanguage(lang);
+	// change i18n
+	return changeLanguage(lang);
+}
 
 export const getLanguages = async () => {
 	const languages = (await import(`./locales/languages.json`)).default;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,7 +40,7 @@
 	import 'tippy.js/dist/tippy.css';
 
 	import { WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
-	import i18n, { initI18n, getLanguages } from '$lib/i18n';
+	import i18n, { initI18n, getLanguages, changeAllLanguage, changeHTMLLanguage } from '$lib/i18n';
 	import { bestMatchingLanguage } from '$lib/utils';
 	import { getAllTags, getChatList } from '$lib/apis/chats';
 	import NotificationToast from '$lib/components/NotificationToast.svelte';
@@ -464,7 +464,9 @@
 		// so `/error` can show something that's not `undefined`.
 
 		initI18n();
-		if (!localStorage.locale) {
+		if (localStorage.locale) {
+			changeHTMLLanguage(localStorage.locale);
+		} else {
 			const languages = await getLanguages();
 			const browserLanguages = navigator.languages
 				? navigator.languages
@@ -472,7 +474,7 @@
 			const lang = backendConfig.default_locale
 				? backendConfig.default_locale
 				: bestMatchingLanguage(languages, browserLanguages, 'en-US');
-			$i18n.changeLanguage(lang);
+			changeAllLanguage(lang);
 		}
 
 		if (backendConfig) {


### PR DESCRIPTION
# Changelog Entry

### Added

- Improved Language Consistency: The HTML lang attribute now automatically synchronizes with the application's selected i18n language

---

### Screenshots or Videos

<img width="697" alt="image" src="https://github.com/user-attachments/assets/77e67972-d1a2-4cf5-8f57-eee994075aea" />

<img width="455" alt="image" src="https://github.com/user-attachments/assets/3527972d-6add-4f83-ab22-b8a97ad2fb2c" />

<img width="372" alt="image" src="https://github.com/user-attachments/assets/682ba7cb-df37-4976-b232-719d0be3b93b" />
