### PR TITLE
fix: typing error in replace_messages_variable func args

### DIFF
--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -104,7 +104,7 @@ def replace_prompt_variable(template: str, prompt: str) -> str:
 
 
 def replace_messages_variable(
-    template: str, messages: Optional[list[str]] = None
+    template: str, messages: Optional[list[dict]] = None
 ) -> str:
     def replacement_function(match):
         full_match = match.group(0)


### PR DESCRIPTION
# Changelog Entry

### Description

- The typing hint for `messgaes` args in `replace_messages_variable` is `str`. But it actually should be a `dict`.


### Fixed

- Modify `messages` typing to `dict`.

