### PR TITLE
feat - human-in-loop self-prompting via filters

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -849,6 +849,8 @@
 			return null;
 		});
 
+		console.log('chatCompletedHandler', res);
+
 		if (res !== null && res.messages) {
 			// Update chat history with the new messages
 			for (const message of res.messages) {
@@ -862,6 +864,11 @@
 						...message
 					};
 				}
+			}
+
+			if (res.prompt) {
+				// Set the prompt for the next response from that supplied.
+				await setPrompt(res.prompt);
 			}
 		}
 
@@ -1626,6 +1633,13 @@
 
 		await tick();
 		scrollToBottom();
+	};
+
+	const setPrompt = async (newPrompt) => {
+		// Set prompt for the next response. Note: this only sets the prompt; it does not submit it, thereby keeping the human in the loop.
+		console.log('setPrompt', newPrompt);
+		prompt = newPrompt;
+		await tick();
 	};
 
 	const handleOpenAIError = async (error, responseMessage) => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]

Certain broader AI/LLM functions require the ability for an LLM to self-prompt, that is, provide itself with a subsequent prompt in order to direct its subsequent responses. As a first step, and to aid safety and security, this should retain the human-in-the-loop such that the human operator may review and approve of the prompt, rather than have it automatically submitted.

Open-WebUI already has the ability, via `Outlet` `Filters`, to programatically extract content from an LLM's response; what is missing is the ability to feed any extracted material back via the (next) prompt. This PR adds this capability.

### Added

- [List any new features, functionalities, or additions]

This changeset adds a single new frontend function to ease programmatic setting of the (next) prompt, i.e., prefilling the prompt text input. If a "chat completed" payload contains an optional `prompt` field, this function is called to prefill the prompt with the payload-supplied value.

### Changed

- [List any changes, updates, refactorings, or optimizations]

N/A

### Deprecated

- [List any deprecated functionality or features that have been removed]

N/A

### Removed

- [List any removed features, files, or functionalities]

N/A

### Fixed

- [List any fixes, corrections, or bug fixes]

N/A

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

N/A

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

N/A

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

A minimal `Filter` to prefill the prompt is as follows:

```python
from pydantic import BaseModel
from typing import Optional

class Filter:
    class Valves(BaseModel):
        pass

    class UserValves(BaseModel):
        pass

    def __init__(self):
        self.valves = self.Valves()
        pass

    def outlet(self, body: dict, __user__: Optional[dict] = None) -> dict:
        body["prompt"] = "This is the next prompt."
        return body
```

This simply provides a fixed value ("This is the next prompt.") to be the next prompt, but illustrates the mechanism by which an `Outlet` `Filter` may provide a prompt. Additional processing/logic would allow arbitrary prompts to be provided, typically as a result of processing the LLM response.

See also https://github.com/open-webui/open-webui/discussions/11041.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

N/A