### PR TITLE
chore: Improve config.json migration

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import base64
 
 from datetime import datetime
 from pathlib import Path
@@ -20,6 +21,8 @@ from open_webui.env import (
     OFFLINE_MODE,
     OPEN_WEBUI_DIR,
     WEBUI_AUTH,
+    WEBUI_FAVICON_URL,
+    WEBUI_NAME,
     log,
 )
 from open_webui.internal.db import Base, get_db

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import shutil
-import base64
 
 from datetime import datetime
 from pathlib import Path
@@ -21,8 +20,6 @@ from open_webui.env import (
     OFFLINE_MODE,
     OPEN_WEBUI_DIR,
     WEBUI_AUTH,
-    WEBUI_FAVICON_URL,
-    WEBUI_NAME,
     log,
 )
 from open_webui.internal.db import Base, get_db

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -72,11 +72,6 @@ class Config(Base):
     updated_at = Column(DateTime, nullable=True, onupdate=func.now())
 
 
-def load_json_config():
-    with open(f"{DATA_DIR}/config.json", "r") as file:
-        return json.load(file)
-
-
 def save_to_db(data):
     with get_db() as db:
         existing_config = db.query(Config).first()
@@ -96,11 +91,19 @@ def reset_config():
         db.commit()
 
 
-# When initializing, check if config.json exists and migrate it to the database
-if os.path.exists(f"{DATA_DIR}/config.json"):
-    data = load_json_config()
-    save_to_db(data)
-    os.rename(f"{DATA_DIR}/config.json", f"{DATA_DIR}/old_config.json")
+def attempt_migrate_config():
+    """Attempt to migrate config.json to the database"""
+    try:
+        with open(DATA_DIR / "config.json", "r") as file:
+            data = json.load(file)
+        save_to_db(data)
+        os.rename(DATA_DIR / "config.json", DATA_DIR / "old_config.json")
+    except FileNotFoundError:
+        pass
+
+
+attempt_migrate_config()
+
 
 DEFAULT_CONFIG = {
     "version": 0,


### PR DESCRIPTION
# Description

Fixed a Time-of-Check Time-of-Use (TOCTOU) bug by handling exceptions instead of checking for a file existing beforehand. While this is extremely unlikely to occur naturally we should fix it anyway.

`load_json_config` was only being used by the migration, so we can remove it.

We previously saved the loaded config in the `data` variable. This has a global scope and would not get removed by the gc. We can fix this by moving the migration into its own function.

## Future

We should probably add a comment on how long of a migration period we want to have. This project moves very fast and the migration started 7 months ago already.