### PR TITLE
Add Disable All toggle switch in Settings > Models

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -269,5 +269,15 @@ class ModelsTable:
         except Exception:
             return False
 
+    def toggle_all_models(self, enable: bool) -> bool:
+        try:
+            with get_db() as db:
+                db.query(Model).update({"is_active": enable})
+                db.commit()
+                return True
+        except Exception as e:
+            log.exception(f"Failed to toggle all models: {e}")
+            return False
+
 
 Models = ModelsTable()

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -201,3 +201,20 @@ async def delete_model_by_id(id: str, user=Depends(get_verified_user)):
 async def delete_all_models(user=Depends(get_admin_user)):
     result = Models.delete_all_models()
     return result
+
+
+############################
+# ToggleAllModels
+############################
+
+
+@router.post("/toggle_all", response_model=bool)
+async def toggle_all_models(enable: bool, user=Depends(get_admin_user)):
+    result = Models.toggle_all_models(enable)
+    if result:
+        return result
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT("Error toggling all models"),
+        )

--- a/src/lib/apis/models/index.ts
+++ b/src/lib/apis/models/index.ts
@@ -263,3 +263,33 @@ export const deleteAllModels = async (token: string) => {
 
 	return res;
 };
+
+export const toggleAllModels = async (token: string, enable: boolean) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/models/toggle_all`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ enable })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err;
+
+			console.log(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -12,7 +12,8 @@
 		deleteAllModels,
 		getBaseModels,
 		toggleModelById,
-		updateModelById
+		updateModelById,
+		toggleAllModels
 	} from '$lib/apis/models';
 
 	import { getModels } from '$lib/apis';
@@ -44,15 +45,12 @@
 	let showConfigModal = false;
 	let showManageModal = false;
 
+	let disableAllModels = false;
+
 	$: if (models) {
 		filteredModels = models
 			.filter((m) => searchValue === '' || m.name.toLowerCase().includes(searchValue.toLowerCase()))
 			.sort((a, b) => {
-				// // Check if either model is inactive and push them to the bottom
-				// if ((a.is_active ?? true) !== (b.is_active ?? true)) {
-				// 	return (b.is_active ?? true) - (a.is_active ?? true);
-				// }
-				// If both models' active states are the same, sort alphabetically
 				return a.name.localeCompare(b.name);
 			});
 	}
@@ -137,13 +135,23 @@
 			await toggleModelById(localStorage.token, model.id);
 		}
 
-		// await init();
+			_models.set(
+			await getModels(
+				localStorage.token,
+				$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
+			)
+		);
+	};
+
+	const toggleAllModelsHandler = async () => {
+		await toggleAllModels(localStorage.token, disableAllModels);
 		_models.set(
 			await getModels(
 				localStorage.token,
 				$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
 			)
 		);
+		await init();
 	};
 
 	onMount(async () => {
@@ -188,6 +196,19 @@
 							}}
 						>
 							<Cog6 />
+						</button>
+					</Tooltip>
+
+					<Tooltip content={$i18n.t('Disable All Models')}>
+						<button
+							class=" p-1 rounded-full flex gap-1 items-center"
+							type="button"
+							on:click={async () => {
+								disableAllModels = !disableAllModels;
+								await toggleAllModelsHandler();
+							}}
+						>
+							<Wrench />
 						</button>
 					</Tooltip>
 				</div>


### PR DESCRIPTION
Fixes #11175

Add a "Disable All" toggle switch in the "Settings > Models" section to disable/enable all models at once.

* **backend/open_webui/models/models.py**
  - Add a new method `toggle_all_models` to the `ModelsTable` class to handle disabling/enabling all models at once.

* **backend/open_webui/routers/models.py**
  - Add a new endpoint `/models/toggle_all` to handle the "Disable All" toggle request.
  - Implement the `toggle_all_models` method in the new endpoint to disable/enable all models at once.

* **src/lib/apis/models/index.ts**
  - Add a new function `toggleAllModels` to call the new endpoint for toggling all models.
  - Update the `toggleAllModels` function to handle the response from the new endpoint.

* **src/lib/components/admin/Settings/Models.svelte**
  - Add a "Disable All" toggle switch to the "Settings > Models" section to disable/enable all models at once.
  - Implement the `toggleAllModels` function to handle the "Disable All" toggle request.

