### PR TITLE
Add SSL Integration Comments and WebSocket Auto-Fix in start_windows.bat

### DIFF
--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -41,4 +41,5 @@ IF "%WEBUI_SECRET_KEY%%WEBUI_JWT_SECRET_KEY%" == " " (
 
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
-uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*'
+uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ws auto
+:: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "fnss.pem" --ws auto

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -42,4 +42,4 @@ IF "%WEBUI_SECRET_KEY%%WEBUI_JWT_SECRET_KEY%" == " " (
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
 uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ws auto
-:: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "fnss.pem" --ws auto
+:: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "cert.pem" --ws auto


### PR DESCRIPTION
 
This PR enhances the `start_windows.bat` script by:  

- Adding comments for **SSL integration**, making it easier for users to enable SSL when needed.  
- Including the `-ws auto` flag to address WebSocket-related issues, ensuring a smoother experience for users facing connection problems.  

These improvements make the script more user-friendly and help troubleshoot common setup challenges.  

---  

### **Changelog Entry**  

#### **Added**  
- Comments in `start_windows.bat` to guide users on enabling SSL integration.  
- The `-ws auto` flag to resolve WebSocket issues automatically.  

#### **Changed**  
- Updated `start_windows.bat` to include WebSocket handling improvements.  

#### **Deprecated**  
- N/A  

#### **Removed**  
- N/A  

#### **Fixed**  
- WebSocket connection issues by adding `-ws auto`.  

#### **Security**  
- N/A  

#### **Breaking Changes**  
- None  

---  

### **Additional Information**  
- These changes improve setup clarity and reduce troubleshooting effort for new users.  
- The WebSocket fix ensures smoother real-time interactions within the application.  

### **Screenshots or Videos**  
- N/A  