### PR TITLE
fix: url value when response contains url tag

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -517,7 +517,7 @@ async def image_generations(
             images = []
 
             for image in res["data"]:
-                if image_url := image.get("url",None):
+                if image_url := image.get("url", None):
                     image_data, content_type = load_url_image_data(image_url, headers)
                 else:
                     image_data, content_type = load_b64_image_data(image["b64_json"])

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -517,9 +517,9 @@ async def image_generations(
             images = []
 
             for image in res["data"]:
-                if "url" in image:
+                if image_url := image.get("url",None):
                     image_data, content_type = load_url_image_data(
-                        image["url"], headers
+                        image_url, headers
                     )
                 else:
                     image_data, content_type = load_b64_image_data(image["b64_json"])

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -518,9 +518,7 @@ async def image_generations(
 
             for image in res["data"]:
                 if image_url := image.get("url",None):
-                    image_data, content_type = load_url_image_data(
-                        image_url, headers
-                    )
+                    image_data, content_type = load_url_image_data(image_url, headers)
                 else:
                     image_data, content_type = load_b64_image_data(image["b64_json"])
 


### PR DESCRIPTION
When the response contains b64_json, the "url" tag still exists but comes as null, the logic is to resolve this point where it contains the url tag, but empty, thus directing to b64_json

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests for validating the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- observing the response, url comes as null, when the b64_json is filled, this PR addresses this correction.

### Changed

- backend/open_webui/routers/images.py