### PR TITLE
Exlude images from embeddings

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -81,7 +81,7 @@ def upload_file(
                     ProcessFileForm(file_id=id, content=result.get("text", "")),
                     user=user,
                 )
-            else:
+            elif file.content_type not in ["image/png", "image/jpeg", "image/gif"]:
                 process_file(request, ProcessFileForm(file_id=id), user=user)
 
             file_item = Files.get_file_by_id(id=id)


### PR DESCRIPTION
Generated mages are now treated with the same flow as normal files, which allows to back them out via the DB process. 
Unfortunately during the upload_file function it does the DB backup but also the embedding of files. Since images do not contain any text and there are no parsers defined for images, the process fails then trying to embed them. 

This PR adds a filter to check if the uploaded files are images, and if they are do not try to calculate embeddings.


