### PR TITLE
fix: audio api endpoint filetype check

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -625,7 +625,9 @@ def transcription(
 ):
     log.info(f"file.content_type: {file.content_type}")
 
-    if file.content_type not in ["audio/mpeg", "audio/wav", "audio/ogg", "audio/x-m4a"]:
+    supported_filetypes = ("audio/mpeg", "audio/wav", "audio/ogg", "audio/x-m4a")
+
+    if not file.content_type.startswith(supported_filetypes):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.FILE_NOT_SUPPORTED,


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

Fixes #11426 

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?

Not applicable.

- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? **Not Applicable**

Not applicable.

- [X] **Testing:** Have you written and run sufficient tests for validating the changes?

Preexisting tests against `/api/audio` endpoints, if any, still apply.

- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]

See #11426 for more context. A more technical rationale for the changes follow.

RFC2046 allows the Content-Type field to have additional parameters after the main type/subtype information (Section 1).

Following RFC4281, many applications put codec information inside parameters in the Content-Type. This is especially common for formats that support many codecs, such as Ogg (RFC5334, Section 4).

The `/api/audio/transcriptions` endpoint is currently rejecting files that contain parameters in the Content-Type field with a bad request error.

This commit changes the current check in order to accept any Content-Type field that begins with a supported type/subtype as listed in the `supported_filetypes` tuple.

Since Content-Type here is provided by the user, I believe this check is meant to prevent honest mistakes, like posting a PDF to an audio processing endpoint, not as a security measure against possibly malicious use. Therefore, I think it's OK not to validate the rest of the field.

### Fixed

- **🎤 Audio API Issue**: Fixed an issue where the audio API endpoint was throwing an error for some files with a valid content-type.