### PR TITLE
feat: allow string valves to include newlines

### DIFF
--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -80,10 +80,21 @@
 									/>
 								</div>
 							</div>
-						{:else}
+						{:else if (valvesSpec.properties[property]?.type ?? null) !== 'string'}
 							<input
 								class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100 dark:border-gray-850"
 								type="text"
+								placeholder={valvesSpec.properties[property].title}
+								bind:value={valves[property]}
+								autocomplete="off"
+								required
+								on:change={() => {
+									dispatch('change');
+								}}
+							/>
+						{:else}
+							<textarea
+								class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100 dark:border-gray-850"
 								placeholder={valvesSpec.properties[property].title}
 								bind:value={valves[property]}
 								autocomplete="off"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
      **Review comment**: The code could be slightly refactored to use conditionals to decrease code duplication, but conditional element types in jsx-style code are notoriously hard to parse, so a bit of duplication doesn't seem too terrible.
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title, using one of the following:
      **Comment:** Technically this could be a bug fix, depending on the intention for string valves in the first place.

# Changelog Entry

- 💬 **Allow newlines in string valves**: You can now put newlines in valves of type `string`.

### Description

This code conditionally renders the valve input as a `<textarea>` if the valve is of type string - this allows adding newlines to the string that gets saved to the backend.

---

### Additional Information

Relevant discussion post: #11646

### Screenshots or Videos

<img width="510" alt="Untitled" src="https://github.com/user-attachments/assets/f3172a79-0af3-4ae8-ab80-51d5037746c7" />
