### PR TITLE
fix: duplicate rendering of reasoning tags

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1263,7 +1263,10 @@ async def process_chat_response(
                 if content_blocks[-1]["type"] == "text":
                     for start_tag, end_tag in tags:
                         # Match start tag e.g., <tag> or <tag attr="value">
-                        start_tag_pattern = rf"<{re.escape(start_tag)}(\s.*?)?>"
+                        if content_type != "reasoning":
+                            start_tag_pattern = rf"<{re.escape(start_tag)}(\s.*?)?>"
+                        else:
+                            start_tag_pattern = rf"^\s*<{re.escape(start_tag)}(\s.*?)?>"
                         match = re.search(start_tag_pattern, content)
                         if match:
                             attr_content = (


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

This PR fixes an issue where the `<think>` tag appearing anywhere in the model output (including within code blocks or in plain text mentions) would incorrectly trigger the rendering logic for reasoning content. However, Chain-of-Thought (CoT) models only perform the reasoning step once at the beginning of the generation process.

To address this, the regular expression used to detect reasoning content has been updated to specifically match the `<think>` tag appearing at the *beginning* of the output string. This ensures that only the initial reasoning step is rendered as intended and prevents incorrect rendering when `<think>` appears elsewhere in the text.

fix #11659 discussion

### Fixed

- reasoning tag over-rendering

