### PR TITLE
Enhance OpenAI TTS Voice Parameter Handling

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -264,7 +264,21 @@ async def speech(request: Request, user=Depends(get_verified_user)):
 
     if request.app.state.config.TTS_ENGINE == "openai":
         payload["model"] = request.app.state.config.TTS_MODEL
-
+        
+        # Handle voice parameter - support both string and JSON object formats
+        voice_setting = request.app.state.config.TTS_VOICE
+        if voice_setting:
+            try:
+                # Try to parse as JSON dict
+                voice_dict = json.loads(voice_setting)
+                if isinstance(voice_dict, dict):
+                    payload["voice"] = voice_dict
+                else:
+                    payload["voice"] = voice_setting
+            except (json.JSONDecodeError, TypeError):
+                # Not valid JSON, use as string
+                payload["voice"] = voice_setting
+        
         try:
             timeout = aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
             async with aiohttp.ClientSession(


### PR DESCRIPTION
This pull request introduces support for both string and JSON object formats for the voice parameter in the OpenAI TTS implementation.
Previously, the system only accepted a simple string for the voice setting, which limited compatibility with services requiring more complex configurations, such as Vertex AI TTS using the LiteLLM proxy.
With this update, the code now attempts to parse the TTS_VOICE configuration value. If it can be successfully parsed as a JSON object, it will be used as such; otherwise, the original string value will be utilized.
