### PR TITLE
fix(openwebui-litellm): Fix missing userId in custom callback integration

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1544,6 +1544,7 @@
 		const res = await generateOpenAIChatCompletion(
 			localStorage.token,
 			{
+				user: $user?.id,
 				stream: stream,
 				model: model.id,
 				messages: messages,

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -86,6 +86,7 @@
 		const [res, controller] = await chatCompletion(
 			localStorage.token,
 			{
+				user: $user?.id,
 				model: model.id,
 				stream: true,
 				messages: [

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -43,6 +43,7 @@
 		const [res, controller] = await chatCompletion(
 			localStorage.token,
 			{
+				user: $user?.id,
 				model: model.id,
 				stream: true,
 				messages: [


### PR DESCRIPTION
This PR solves the issue with OpenWebUI integration where the userId comes as None in the Litellm custom callback system. Specifically, when monitoring async_log_success_event callbacks,  this change helps to track user-specific chat activities.

# Changelog Entry

### Description
Fix userId being reported as None in Litellm callbacks by properly passing user ID in OpenAI chat completions. This resolves issues with user-specific chat activity tracking and observability metrics.

### Added
- User ID parameter in chat completion requests


### Changed
- Modified generateOpenAIChatCompletion() to include user ID
- Modified chatCompletion() to include user ID

### Fixed
- Fixed userId being None in async_log_success_event callbacks
- Resolved user tracking issues in chat activities

Related Discussions:
- #11752 (Original issue discussion)
- #5627 (Similar issue reference)

Impact:
- Enables user-specific chat analytics
- Facilitates usage pattern analysis by user