### PR TITLE
FIX #5682 dates not surviving importing

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -608,7 +608,7 @@ export const convertOpenAIChats = (_chats) => {
 				user_id: '',
 				title: convo['title'],
 				chat: chat,
-				timestamp: convo['timestamp']
+				timestamp: convo['create_time']
 			});
 		} else {
 			failed++;


### PR DESCRIPTION
FIXES #5682, FIXES #11773 Extremely simple fix: just replaced the frontend svelte code that does the importing. One of the keys were wrong, it was `convo['timestamp']` instead of `convo['create_time']`

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Fixed issue FIXES #5682, FIXES #11773 where chat dates were not being preserved during import due to incorrect property name.
- [x] **Changelog:** Added changelog entry below.
- [x] **Documentation:** No documentation updates needed for this fix.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Tested importing chats and verified dates are now preserved correctly.
- [x] **Code review:** Performed self-review, change is minimal and follows project standards.
- [x] **Prefix:** Using `fix` prefix as this resolves a bug.

# Changelog Entry

### Description

Fixed an issue where chat dates were not being preserved when importing conversations. The bug was caused by accessing the wrong property name (`timestamp` instead of `create_time`) when mapping the imported chat data.

### Fixed

- Chat dates now correctly persist when importing conversations by using the proper `create_time` property instead of `timestamp`

### Breaking Changes

None

---

### Additional Information

The fix addresses issue #5682 where imported chat dates were being lost. The root cause was that we were trying to access `convo['timestamp']` but the data actually uses `convo['create_time']` for the timestamp field. This small property name change ensures the dates are properly preserved during import.

The change is minimal and only affects the chat import functionality. No other parts of the codebase are impacted.
