### PR TITLE
PR-FIX: Download PDF generator with MD

### DIFF
--- a/backend/open_webui/utils/pdf_generator.py
+++ b/backend/open_webui/utils/pdf_generator.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+pefrom datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, Any, List
@@ -42,8 +42,8 @@ class PDFGenerator:
 
     def _build_html_message(self, message: Dict[str, Any]) -> str:
         """Build HTML for a single message."""
-        role = markdown(message.get("role", "user"))
-        content = escape(message.get("content", ""))
+        role = escape(message.get("role", "user"))
+        content = markdown(message.get("content", ""))
         timestamp = message.get("timestamp")
 
         model = escape(message.get("model") if role == "assistant" else "")

--- a/backend/open_webui/utils/pdf_generator.py
+++ b/backend/open_webui/utils/pdf_generator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, Any, List
 from html import escape
 
-from markdown import markdown
+from mistletoe import markdown
 
 import site
 from fpdf import FPDF
@@ -42,7 +42,7 @@ class PDFGenerator:
 
     def _build_html_message(self, message: Dict[str, Any]) -> str:
         """Build HTML for a single message."""
-        role = escape(message.get("role", "user"))
+        role = markdown(message.get("role", "user"))
         content = escape(message.get("content", ""))
         timestamp = message.get("timestamp")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -66,7 +66,7 @@ docx2txt==0.8
 python-pptx==1.0.0
 unstructured==0.16.17
 nltk==3.9.1
-Markdown==3.7
+mistletoe
 pypandoc==1.13
 pandas==2.2.3
 openpyxl==3.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "python-pptx==1.0.0",
     "unstructured==0.16.17",
     "nltk==3.9.1",
-    "Markdown==3.7",
+    "mistletoe==3.7",
     "pypandoc==1.13",
     "pandas==2.2.3",
     "openpyxl==3.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "python-pptx==1.0.0",
     "unstructured==0.16.17",
     "nltk==3.9.1",
-    "mistletoe==3.7",
+    "mistletoe",
     "pypandoc==1.13",
     "pandas==2.2.3",
     "openpyxl==3.1.5",


### PR DESCRIPTION
## FIX: Download PDF generator with MD
---

Replace markdown lib by fpdf2 recommended lib mistletoe (https://github.com/miyuchina/mistletoe) for convert MD to html and render to PDF improving view.

This commit replace markdown lib, does the same job and improve conversion to hml.
I tested I didn't find any incompatibility with previous uses of markdown here or in other places.
(mistletoe lib is MIT licence)

https://github.com/open-webui/open-webui/discussions/11840
![openwebui-pdf-mark](https://github.com/user-attachments/assets/02a79d28-4a0f-41b3-9041-f645319a42cb)