### PR TITLE
fix: error message propagation from filter-pipeline

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -90,8 +90,8 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
                     headers=headers,
                     json=request_data,
                 ) as response:
-                    response.raise_for_status()
                     payload = await response.json()
+                    response.raise_for_status()
             except aiohttp.ClientResponseError as e:
                 res = (
                     await response.json()
@@ -139,8 +139,8 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
                     headers=headers,
                     json=request_data,
                 ) as response:
-                    response.raise_for_status()
                     payload = await response.json()
+                    response.raise_for_status()
             except aiohttp.ClientResponseError as e:
                 try:
                     res = (


### PR DESCRIPTION
# Changelog Entry
Fix error message propagation from filter-pipeline

### Description

Error message returned from filter-pipeline was not being shown on UI. It always showed "Connection closed".
With this fix it will show the error message on the UI from the filter-pipeline properly.

### Screenshots or Videos

- Before
![image](https://github.com/user-attachments/assets/f4ffc924-8660-4d47-bdaf-5a3b0c4f3587)

- After
For filter https://github.com/open-webui/pipelines/blob/main/examples/filters/rate_limit_filter_pipeline.py
![image](https://github.com/user-attachments/assets/e44e0bc6-7752-4652-944f-d1ab88c1ed01)
