### PR TITLE
Updated middleware.py to add OpenRouter compatibility

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1560,7 +1560,7 @@ async def process_chat_response(
 
                                     value = delta.get("content")
 
-                                    reasoning_content = delta.get("reasoning_content")
+                                    reasoning_content = delta.get("reasoning_content") or delta.get("reasoning")
                                     if reasoning_content:
                                         if (
                                             not content_blocks


### PR DESCRIPTION
### Description

- Added OpenRouter "reasoning" field compatibility. Previously, only "reasoning_content" field was being checked, so OpenRouter requests on reasoning models did not output the thinking process in the UI as "reasoning_content" is not part of the object, but "reasoning" is

### Changed

- Conditional assignment to check and use either "reasoning_content" or "reasoning" field value

---

### Additional Information

- [LiteLLM](https://docs.litellm.ai/docs/reasoning_content) uses "reasoning_content" field, which is the only one being used on OpenWebUI, however, other providers like [OpenRouter](https://openrouter.ai/docs/use-cases/reasoning-tokens) use "reasoning"