### PR TITLE
i18n: DE Translation - fixed too long word

### DIFF
--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -587,7 +587,7 @@
 	"Install from Github URL": "Installiere von der Github-URL",
 	"Instant Auto-Send After Voice Transcription": "Spracherkennung direkt absenden",
 	"Integration": "",
-	"Interface": "Benutzeroberfläche",
+	"Interface": "Oberfläche",
 	"Invalid file format.": "Ungültiges Dateiformat.",
 	"Invalid Tag": "Ungültiger Tag",
 	"is typing...": "schreibt ...",


### PR DESCRIPTION
# Pull Request Checklist

### Based on [Discussion #11994](https://github.com/open-webui/open-webui/discussions/11994)

## Description
Hi, I would like to change a too long DE translation by changing word (translated to en) "userinterface" to "interface". See screenshot, tested on Chrome, Win 11:

![image](https://github.com/user-attachments/assets/116e9f47-f1ce-42e2-9729-ccbaa413926e)


