### PR TITLE
perf: optimize get_models

### DIFF
--- a/backend/open_webui/conftest.py
+++ b/backend/open_webui/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -5,7 +5,7 @@ from typing import Optional
 from open_webui.internal.db import Base, JSONField, get_db
 from open_webui.env import SRC_LOG_LEVELS
 
-from open_webui.models.users import Users, UserResponse
+from open_webui.models.users import Users, UserResponse, User
 
 
 from pydantic import BaseModel, ConfigDict
@@ -176,8 +176,7 @@ class ModelsTable:
     def get_models(self) -> list[ModelUserResponse]:
         with get_db() as db:
             models = []
-            for model in db.query(Model).filter(Model.base_model_id != None).all():
-                user = Users.get_user_by_id(model.user_id)
+            for model, user in db.query(Model, User).outerjoin(User, Model.user_id == User.id).filter(Model.base_model_id != None).all():
                 models.append(
                     ModelUserResponse.model_validate(
                         {

--- a/backend/open_webui/test/apps/webui/routers/test_models.py
+++ b/backend/open_webui/test/apps/webui/routers/test_models.py
@@ -19,7 +19,7 @@ class TestModels(AbstractPostgresTest):
 
         with mock_webui_user(id="2"):
             response = self.fast_api_client.post(
-                self.create_url("/add"),
+                self.create_url("/create"),
                 json={
                     "id": "my-model",
                     "base_model_id": "base-model-id",
@@ -51,7 +51,7 @@ class TestModels(AbstractPostgresTest):
 
         with mock_webui_user(id="2"):
             response = self.fast_api_client.delete(
-                self.create_url("/delete?id=my-model")
+                self.create_url("/model/delete?id=my-model")
             )
         assert response.status_code == 200
 

--- a/backend/open_webui/test/util/mock_user.py
+++ b/backend/open_webui/test/util/mock_user.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 @contextmanager
 def mock_webui_user(**kwargs):
-    from open_webui.routers.webui import app
+    from main import app
 
     with mock_user(app, **kwargs):
         yield


### PR DESCRIPTION
# Changelog Entry

### Description

This is to improve the performance of the DB query for the get_models() function. 

Given that we have N models, we can reduce the number of DB queries from 1 + N (for retrieving the users) to 1.

### Changed

- Refactored get_models() function
- Fixed models test