### PR TITLE
Fix: CSV loader encoding issue using autodetect_encoding=True

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -228,7 +228,7 @@ class Loader:
                     file_path, extract_images=self.kwargs.get("PDF_EXTRACT_IMAGES")
                 )
             elif file_ext == "csv":
-                loader = CSVLoader(file_path)
+                loader = CSVLoader(file_path, autodetect_encoding=True)
             elif file_ext == "rst":
                 loader = UnstructuredRSTLoader(file_path, mode="elements")
             elif file_ext == "xml":


### PR DESCRIPTION
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** Fixes a bug in knowledge file loading where CSV files with non-UTF-8 encodings would fail.
- [x] **Changelog:** Added a `Fixed` entry following Keep a Changelog format.
- [x] **Testing:** Manually tested with multiple CSV encodings.
- [x] **Code review:** Self-reviewed for correctness and style.
- [x] **Prefix:** `fix`

---

# Changelog Entry

### Description

Fixes an encoding-related bug that prevented some CSV files from loading into the knowledge base. This change enables automatic encoding detection by passing `autodetect_encoding=True` to the `CSVLoader`.

### Fixed

- CSVLoader now detects encoding automatically to support non-UTF-8 CSV files.

---

### Screenshots or Videos

![image](https://github.com/user-attachments/assets/07f2785a-71a1-4118-95a9-c0cbd4b2672e)

---