### PR TITLE
Feat: Add YouTube embed support using VIDEO_YOUTUBE_ID token

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
@@ -28,6 +28,8 @@
 			{@html html}
 		{:else if token.text.includes(`<iframe src="${WEBUI_BASE_URL}/api/v1/files/`)}
 			{@html `${token.text}`}
+		{:else if token.text.includes(`<iframe ytEmbed`)}
+			{@html `${token.text.replace(`<iframe ytEmbed`, `<iframe`)}`}
 		{:else if token.text.includes(`<source_id`)}
 			<Source {id} {token} onClick={onSourceClick} />
 		{:else}

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -274,6 +274,8 @@
 			{@html `${token.text}`}
 		{:else if token.text.includes(`<source_id`)}
 			<Source {id} {token} onClick={onSourceClick} />
+		{:else if token.text.includes(`<iframe ytEmbed`)}
+			{@html `${token.text.replace(`<iframe ytEmbed`, `<iframe`)}`}
 		{:else}
 			{token.text}
 		{/if}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -30,6 +30,14 @@ export const replaceTokens = (content, sourceIds, char, user) => {
 		{ regex: /{{char}}/gi, replacement: char },
 		{ regex: /{{user}}/gi, replacement: user },
 		{
+			regex: /{{(VIDEO_YOUTUBE_ID_[^\s{}]+)}}/gi,
+			replacement: (_, fullMatch) => {
+				const ytId = fullMatch.replace("VIDEO_YOUTUBE_ID_", ""); // Extract only the ID
+				const videoUrl = `https://www.youtube.com/embed/${ytId}`;
+				return `<iframe ytEmbed src="${videoUrl}" width="100%" height="500" frameborder="0" allowfullscreen></iframe>`;
+			}
+		},
+		{
 			regex: /{{VIDEO_FILE_ID_([a-f0-9-]+)}}/gi,
 			replacement: (_, fileId) =>
 				`<video src="${WEBUI_BASE_URL}/api/v1/files/${fileId}/content" controls></video>`


### PR DESCRIPTION
- [x] Target branch: `dev`
- [x] Description: Enables dynamic embedding of YouTube videos in chat markdown.
- [x] Changelog: Included
- [x] Testing: Manually tested with embedded tokens in messages
- [x] Code review: Self-reviewed
- [x] Prefix: feat

---

# Changelog Entry

### Added

- Markdown parser replaces `{{VIDEO_YOUTUBE_ID_XXXX}}` with `<iframe>` YouTube embeds.

---

### Additional Info

This makes embedding YouTube videos via token simple and safe, preserving formatting while enhancing interactivity.

![image](https://github.com/user-attachments/assets/55c77aef-ae89-46fe-a1a2-08e4874bc1b9)
