### PR TITLE
Feat: Add Support for Images in Prompt Suggestions

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -206,6 +206,7 @@ async def set_models_config(
 class PromptSuggestion(BaseModel):
     title: list[str]
     content: str
+    imageUrl: str = ""
 
 
 class SetDefaultSuggestionsForm(BaseModel):

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -15,6 +15,7 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Switch from '$lib/components/common/Switch.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import Image from '$lib/components/common/Image.svelte';
 
 	const dispatch = createEventDispatcher();
 
@@ -427,15 +428,25 @@
 												bind:value={prompt.title[1]}
 											/>
 										</div>
+										<div class="flex w-full">
+											<textarea
+												class="px-3 py-1.5 w-full text-xs bg-transparent outline-hidden border-r border-gray-100 dark:border-gray-850 resize-none"
+												placeholder={$i18n.t(
+													'Prompt (e.g. Tell me a fun fact about the Roman Empire)'
+												)}
+												rows="3"
+												bind:value={prompt.content}
+											/>
 
-										<textarea
-											class="px-3 py-1.5 text-xs w-full bg-transparent outline-hidden border-r border-gray-100 dark:border-gray-850 resize-none"
-											placeholder={$i18n.t(
-												'Prompt (e.g. Tell me a fun fact about the Roman Empire)'
-											)}
-											rows="3"
-											bind:value={prompt.content}
-										/>
+											{#if prompt.imageUrl && prompt.image !== ''}
+												<Image
+													src={prompt.imageUrl}
+													alt="suggestion"
+													className="outline-hidden focus:outline-hidden"
+													imageClassName="min-w-14 size-14 rounded-xl object-cover"
+												/>
+											{/if}
+										</div>
 									</div>
 
 									<button

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2015,6 +2015,7 @@
 									bind:history
 									bind:autoScroll
 									bind:prompt
+									bind:files
 									{selectedModels}
 									{atSelectedModel}
 									{sendPrompt}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -30,6 +30,7 @@
 	export let user = $_user;
 
 	export let prompt;
+	export let files = [];
 	export let history = {};
 	export let selectedModels;
 	export let atSelectedModel;
@@ -394,15 +395,22 @@
 			modelIds={selectedModels}
 			{atSelectedModel}
 			submitPrompt={async (p) => {
-				let text = p;
+				const {content, imageUrl} = p;
+				let text = content;
 
-				if (p.includes('{{CLIPBOARD}}')) {
+				if (content.includes('{{CLIPBOARD}}')) {
 					const clipboardText = await navigator.clipboard.readText().catch((err) => {
 						toast.error($i18n.t('Failed to read clipboard contents'));
 						return '{{CLIPBOARD}}';
 					});
 
-					text = p.replaceAll('{{CLIPBOARD}}', clipboardText);
+					text = content.replaceAll('{{CLIPBOARD}}', clipboardText);
+
+					console.log('Clipboard text:', clipboardText, text);
+				}
+				
+				if (imageUrl !== "") {
+					files = [{ type: 'image', url: imageUrl }]
 				}
 
 				prompt = text;

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -43,17 +43,22 @@
 	let models = [];
 
 	const selectSuggestionPrompt = async (p) => {
-		let text = p;
+		const {content, imageUrl} = p;
+		let text = content;
 
-		if (p.includes('{{CLIPBOARD}}')) {
+		if (content.includes('{{CLIPBOARD}}')) {
 			const clipboardText = await navigator.clipboard.readText().catch((err) => {
 				toast.error($i18n.t('Failed to read clipboard contents'));
 				return '{{CLIPBOARD}}';
 			});
 
-			text = p.replaceAll('{{CLIPBOARD}}', clipboardText);
+			text = content.replaceAll('{{CLIPBOARD}}', clipboardText);
 
 			console.log('Clipboard text:', clipboardText, text);
+		}
+		
+		if (imageUrl !== "") {
+			files = [{ type: 'image', url: imageUrl }]
 		}
 
 		prompt = text;

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -5,6 +5,8 @@
 	import { WEBUI_NAME } from '$lib/stores';
 	import { WEBUI_VERSION } from '$lib/constants';
 
+	import Image from '../common/Image.svelte';
+
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
 
@@ -83,11 +85,11 @@
 	{#if filteredPrompts.length > 0}
 		{#each filteredPrompts as prompt, idx (prompt.id || prompt.content)}
 			<button
-				class="waterfall flex flex-col flex-1 shrink-0 w-full justify-between
-				       px-3 py-2 rounded-xl bg-transparent hover:bg-black/5
+				class="waterfall flex flex-row flex-1 shrink-0 w-full justify-between
+				       pl-3 pr-2 py-2 rounded-xl bg-transparent hover:bg-black/5
 				       dark:hover:bg-white/5 transition group"
 				style="animation-delay: {idx * 60}ms"
-				on:click={() => dispatch('select', prompt.content)}
+				on:click={() => dispatch('select', {content: prompt.content, imageUrl: prompt.imageUrl})}
 			>
 				<div class="flex flex-col text-left">
 					{#if prompt.title && prompt.title[0] !== ''}
@@ -108,6 +110,14 @@
 						<div class="text-xs text-gray-500 font-normal line-clamp-1">{$i18n.t('Prompt')}</div>
 					{/if}
 				</div>
+				{#if prompt.imageUrl && prompt.imageUrl !== ''}
+					<Image
+						src={prompt.imageUrl}
+						alt="input"
+						className="outline-hidden focus:outline-hidden pointer-events-none"
+						imageClassName=" size-10 rounded-lg object-cover"
+					/>
+				{/if}
 			</button>
 		{/each}
 	{/if}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -10,6 +10,7 @@
 	import ActionsSelector from '$lib/components/workspace/Models/ActionsSelector.svelte';
 	import Capabilities from '$lib/components/workspace/Models/Capabilities.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import Image from '$lib/components/common/Image.svelte';
 	import { getTools } from '$lib/apis/tools';
 	import { getFunctions } from '$lib/apis/functions';
 	import { getKnowledgeBases } from '$lib/apis/knowledge';
@@ -656,6 +657,17 @@
 												placeholder={$i18n.t('Write a prompt suggestion (e.g. Who are you?)')}
 												bind:value={prompt.content}
 											/>
+
+											{#if prompt.imageUrl && prompt.image !== ''}
+												<Image
+													src={prompt.imageUrl}
+													alt="suggestion"
+													className="outline-hidden focus:outline-hidden"
+													imageClassName="min-w-10 size-10 rounded-xl object-cover"
+												/>
+											{/if}
+
+											<!-- TODO: Add way to upload an image (maybe files) -->
 
 											<button
 												class="px-2"


### PR DESCRIPTION
### First-time contributor: #12126

# Checklist
- [x] **Target branch**
- [x] **Description**
- [x] **Changelog:**
- [x] **Documentation:** Currently there is no documentation for Prompt Suggestions or the `/suggestions` endpoint. I can add both if needed.
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually tested, using the `/suggestions` endpoint and import functions in the models settings to add an base64 image to the prompt.
- [x] **Code review**
- [x] **Prefix**

# Changelog Entry

### Description
This PR adds support for images in promp suggestions.

### Added

- Added the Image component to `Suggestions.svelte`, `Interface.svelte` and `ModelEditor.svelte`
- Added a binding for files to `Messages.svelte` to make it possible to add the image to the message input
- imageUrl as additional optional argument for the `/suggestions` endpoint in `config.py`

---

### Additional Information

- At this point adding an image can only be done by using endpoints or importing a JSON file in the models admin settings.
- Uploading a image in a way similar to the chat would be better, but I didn't see a way to do that without copying the upload 
functionality of the chat, or creating a new component that handles uploads.


### Screenshots or Videos

![image](https://github.com/user-attachments/assets/132e8365-1618-43a2-b875-f6708d044216)
