### PR TITLE
Fix middleware.py missing prefix on embedding function

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -596,8 +596,8 @@ async def chat_completion_files_handler(
                         request=request,
                         files=files,
                         queries=queries,
-                        embedding_function=lambda query: request.app.state.EMBEDDING_FUNCTION(
-                            query, user=user
+                        embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                            query, prefix=prefix, user=user
                         ),
                         k=request.app.state.config.TOP_K,
                         reranking_function=request.app.state.rf,


### PR DESCRIPTION
Missing prefix after commit https://github.com/open-webui/open-webui/commit/433b5bddc159f50d8e2183f18050481ac49e8cce
