### PR TITLE
[improvement] default permission for new groups is false for enforce …

### DIFF
--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -64,7 +64,7 @@
 			delete: true,
 			edit: true,
 			temporary: true,
-			temporary_enforced: true
+			temporary_enforced: false
 		},
 		features: {
 			web_search: true,

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -25,7 +25,7 @@
 			edit: true,
 			file_upload: true,
 			temporary: true,
-			temporary_enforced: true
+			temporary_enforced: false
 		},
 		features: {
 			web_search: true,


### PR DESCRIPTION
currently in the Groups.svelte and Permissions.svelte the value is "true"; so if a admin creates a new group, the temporary chat is set to true by default, i guess most of the users need this permission set to false