### PR TITLE
[improvement] insert temporary-chat=false logic & remove console.log()

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -195,13 +195,16 @@
 				showChangelog.set($settings?.version !== $config.version);
 			}
 
-			if ($page.url.searchParams.get('temporary-chat') === 'true') {
+			// check if searchParam is set, if yes & user is allowed to use param, then param > permission
+			// If "temporary-chat=true" is set in the URL, always enable temporary chat
+			const searchParam = $page.url.searchParams.get('temporary-chat');
+			if (searchParam === 'true') {
 				temporaryChatEnabled.set(true);
-			}
-
-			console.log($user.permissions);
-
-			if ($user?.permissions?.chat?.temporary_enforced) {
+			// If "temporary-chat=false" is set in the URL, always disable temporary chat
+			} else if (searchParam === 'false') {
+				temporaryChatEnabled.set(false);
+			// If "temporary-chat" is not set in the URL, check if user has permission to use temporary chat
+			} else if ($user?.permissions?.chat?.temporary_enforced) {
 				temporaryChatEnabled.set(true);
 			}
 


### PR DESCRIPTION
Improved Temporary Chat Behavior
**Current Behavior:**
- If the URL parameter temporary-chat is set to "true", temporary chat is enabled.
- If no URL parameter is set, the system checks for the user's permission.
- If the permission exists, the user has no option to disable temporary chat.

**Improvement:**
- Now, the user can explicitly set the URL parameter to "false" to disable temporary chat.
- This gives users more control, as the logic now follows:
- URL parameter > Permission

This change ensures that users can override enforced permissions via the URL parameter if needed. 🚀

Maybe this is needed? If not, just close it. When I thought about implementing this feature, I thought this logic would be nice for the user.