### PR TITLE
feat: Add option to disable OAuth profile pictures

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -331,6 +331,12 @@ JWT_EXPIRES_IN = PersistentConfig(
 # OAuth config
 ####################################
 
+OAUTH_USE_PICTURE_CLAIM = PersistentConfig(
+    "OAUTH_USE_PICTURE_CLAIM",
+    "oauth.oidc.use_picture_claim",
+    os.environ.get("OAUTH_USE_PICTURE_CLAIM", "True").lower() == "true",
+)
+
 ENABLE_OAUTH_SIGNUP = PersistentConfig(
     "ENABLE_OAUTH_SIGNUP",
     "oauth.enable_signup",


### PR DESCRIPTION
### Pull Request Description
This PR adds a new configuration option OAUTH_USE_PICTURE_CLAIM that allows administrators to toggle whether OAuth profile pictures are used or if the default user.png avatar is used instead. This addresses issue #12325, providing a simple way to disable the use of profile pictures from OAuth providers.

### Changelog Entry
**Description**
Added a new environment variable and configuration option to control whether profile pictures from OAuth providers are used or if the default avatar is used instead. This provides administrators with greater control over user avatars in their Open WebUI deployment.
Added

Added OAUTH_USE_PICTURE_CLAIM environment variable and corresponding PersistentConfig entry
Added conditional logic in oauth.py to respect this setting when processing user profile pictures

**Changed**

Modified the OAuth authentication flow to check the new configuration option before attempting to fetch and process profile pictures

**Fixed**

Fixes #12325: Added option to turn off the use of profile pictures from OAuth claims

### Additional Information
This change is minimal and focused on providing administrators with greater control over avatar usage. The default setting is True, which maintains backward compatibility with existing behavior.

Tested on a docker, expected functionality for True, False, and not specified values.
(this is my first time doing a PR, hopefully this is ok)