### PR TITLE
Feat: optional update toast as environment variable

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -460,3 +460,8 @@ OTEL_TRACES_SAMPLER = os.environ.get(
 
 PIP_OPTIONS = os.getenv("PIP_OPTIONS", "").split()
 PIP_PACKAGE_INDEX_OPTIONS = os.getenv("PIP_PACKAGE_INDEX_OPTIONS", "").split()
+
+
+ENABLE_UPDATE_NOTIFICATION = (
+    os.environ.get("ENABLE_UPDATE_NOTIFICATION", "True").lower() == "true"
+)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -318,6 +318,7 @@ from open_webui.env import (
     AUDIT_EXCLUDED_PATHS,
     AUDIT_LOG_LEVEL,
     CHANGELOG,
+    ENABLE_UPDATE_NOTIFICATION,
     REDIS_URL,
     REDIS_SENTINEL_HOSTS,
     REDIS_SENTINEL_PORT,
@@ -1222,6 +1223,7 @@ async def get_app_config(request: Request):
             "enable_signup": app.state.config.ENABLE_SIGNUP,
             "enable_login_form": app.state.config.ENABLE_LOGIN_FORM,
             "enable_websocket": ENABLE_WEBSOCKET_SUPPORT,
+            "enable_update_notification": ENABLE_UPDATE_NOTIFICATION,
             **(
                 {
                     "enable_direct_connections": app.state.config.ENABLE_DIRECT_CONNECTIONS,

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -443,25 +443,27 @@
 
 			{#if $user.role === 'admin'}
 				<div>
-					<div class=" py-0.5 flex w-full justify-between">
-						<div class=" self-center text-xs">
-							{$i18n.t('Toast notifications for new updates')}
-						</div>
+					{#if $config?.features.enable_update_notification}
+						<div class=" py-0.5 flex w-full justify-between">
+							<div class=" self-center text-xs">
+								{$i18n.t('Toast notifications for new updates')}
+							</div>
 
-						<button
-							class="p-1 px-3 text-xs flex rounded-sm transition"
-							on:click={() => {
-								toggleShowUpdateToast();
-							}}
-							type="button"
-						>
-							{#if showUpdateToast === true}
-								<span class="ml-2 self-center">{$i18n.t('On')}</span>
-							{:else}
-								<span class="ml-2 self-center">{$i18n.t('Off')}</span>
-							{/if}
-						</button>
-					</div>
+							<button
+								class="p-1 px-3 text-xs flex rounded-sm transition"
+								on:click={() => {
+									toggleShowUpdateToast();
+								}}
+								type="button"
+							>
+								{#if showUpdateToast === true}
+									<span class="ml-2 self-center">{$i18n.t('On')}</span>
+								{:else}
+									<span class="ml-2 self-center">{$i18n.t('Off')}</span>
+								{/if}
+							</button>
+						</div>
+					{/if}
 				</div>
 
 				<div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -213,6 +213,7 @@ type Config = {
 		enable_admin_chat_access: boolean;
 		enable_community_sharing: boolean;
 		enable_autocomplete_generation: boolean;
+		enable_update_notification: boolean;
 	};
 	oauth: {
 		providers: {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -238,7 +238,7 @@
 <SettingsModal bind:show={$showSettings} />
 <ChangelogModal bind:show={$showChangelog} />
 
-{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
+{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true) && ($config?.features.enable_update_notification ?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>
 		<UpdateInfoToast
 			{version}


### PR DESCRIPTION
# Changelog Entry

### Description

These changes add a feature flag `ENABLE_UPDATE_NOTIFICATION` to disable the update toast notification. Deployments may choose not to upgrade if their infrastructure is not ready to handle it, with that in mind it is not always possible for the OI admin to update, given these external factors. The update sometimes might not be up to the OI admin.

### Added

- `ENABLE_UPDATE_NOTIFICATION` environment variable to disable the update notification through the global configs. Default `True`.
- Changes in the UI to only show the 'Show "What's New" modal on login' setting interface option when the mentioned environment variable is truthy. 

### Changed

- Conditional rule to render the toast in the frontend. 
