### PR TITLE
fix: API Key Endpoint Restrictions for Dynamic Paths

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -182,7 +182,11 @@ def get_current_user(
                 ).split(",")
             ]
 
-            if request.url.path not in allowed_paths:
+            # Check if the request path matches any allowed endpoint.
+            if not any(
+                request.url.path == allowed or request.url.path.startswith(allowed + "/")
+                for allowed in allowed_paths
+            ):
                 raise HTTPException(
                     status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.API_KEY_NOT_ALLOWED
                 )


### PR DESCRIPTION
### Description

- This pull request addresses an issue where API key authentication was failing for endpoints with dynamic path segments. Previously, the allowed endpoint configuration was based on strict string equality, which meant that if an allowed endpoint was set to `GET /api/v1/files`, any request to a dynamic endpoint like `GET /api/v1/files/{id}` would not match and would be incorrectly rejected.

### Fixed / Changed

- Enhanced Path Matching: Updated the endpoint check logic to iterate over all allowed endpoints using any().
- Support for Dynamic Routes: The updated logic now checks if the request path either exactly matches an allowed endpoint or starts with the allowed endpoint followed by a /. This ensures that endpoints such as /api/v1/files/123 correctly pass the check when /api/v1/files is allowed.

### Reasoning:

- We ran into this issue after using the `ENABLE_API_KEY_ENDPOINT_RESTRICTIONS` feature. We added `/api/v1/files`, and `/api/v1/files/` to the allowed list, but users couldn't call any of the dynamic routes like `/api/v1/files/{id}`.