### PR TITLE
fix: make content parameter optional in OpenAI chat completion API endpoint

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1197,7 +1197,7 @@ class OpenAIChatMessageContent(BaseModel):
 
 class OpenAIChatMessage(BaseModel):
     role: str
-    content: Union[str, list[OpenAIChatMessageContent]]
+    content: Union[Optional[str], list[OpenAIChatMessageContent]]
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
# Changelog Entry

### Description

- Solves  #12441
- Improve compatibility of OpenAI chat completion endpoint with the corresponding endpoint in Ollama

### Changed

- `content` parameter in OpenAI chat completion endpoint is now optional.

