### PR TITLE
feature: Add Import/Export for Default Prompt Suggestions

### DIFF
--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -540,20 +540,20 @@
 										required
 									>
 										{#if banner.type == ''}
-											<option value="" selected disabled class="text-gray-900 dark:text-gray-100"
+											<option value="" selected disabled class="text-gray-900"
 												>{$i18n.t('Type')}</option
 											>
 										{/if}
-										<option value="info" class="text-gray-900 dark:text-gray-100"
+										<option value="info" class="text-gray-900"
 											>{$i18n.t('Info')}</option
 										>
-										<option value="warning" class="text-gray-900 dark:text-gray-100"
+										<option value="warning" class="text-gray-900"
 											>{$i18n.t('Warning')}</option
 										>
-										<option value="error" class="text-gray-900 dark:text-gray-100"
+										<option value="error" class="text-gray-900"
 											>{$i18n.t('Error')}</option
 										>
-										<option value="success" class="text-gray-900 dark:text-gray-100"
+										<option value="success" class="text-gray-900"
 											>{$i18n.t('Success')}</option
 										>
 									</select>

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -51,6 +51,8 @@
 	let banners: Banner[] = [];
 	let fileInput: HTMLInputElement;
 
+	const BANNER_CONTENT_MAX_LENGTH = 512; // Define the character limit
+
 	const updateInterfaceHandler = async () => {
 		try {
 			taskConfig = await updateTaskConfig(localStorage.token, taskConfig);
@@ -532,41 +534,47 @@
 						{#each banners as banner, bannerIdx (banner.id)}
 							<div class=" flex justify-between">
 								<div
-									class="flex flex-row flex-1 border rounded-xl border-gray-100 dark:border-gray-850"
+									class="flex flex-col flex-1 border rounded-xl border-gray-100 dark:border-gray-850"
 								>
-									<select
-										class="w-fit capitalize rounded-xl py-2 px-4 text-xs bg-transparent outline-hidden"
-										bind:value={banner.type}
-										required
-									>
-										{#if banner.type == ''}
-											<option value="" selected disabled class="text-gray-900"
-												>{$i18n.t('Type')}</option
-											>
-										{/if}
-										<option value="info" class="text-gray-900"
-											>{$i18n.t('Info')}</option
+									<div class="flex flex-row flex-1">
+										<select
+											class="w-fit capitalize rounded-tl-xl py-2 px-4 text-xs bg-transparent outline-hidden"
+											bind:value={banner.type}
+											required
 										>
-										<option value="warning" class="text-gray-900"
-											>{$i18n.t('Warning')}</option
-										>
-										<option value="error" class="text-gray-900"
-											>{$i18n.t('Error')}</option
-										>
-										<option value="success" class="text-gray-900"
-											>{$i18n.t('Success')}</option
-										>
-									</select>
-									<input
-										class="pr-5 py-1.5 text-xs w-full bg-transparent outline-hidden"
-										placeholder={$i18n.t('Content')}
-										bind:value={banner.content}
-									/>
-									<div class="relative top-1.5 -left-2">
-										<Tooltip content={$i18n.t('Dismissible')} className="flex h-fit items-center">
-											<Switch bind:state={banner.dismissible} />
-										</Tooltip>
+											{#if banner.type == ''}
+												<option value="" selected disabled class="text-gray-900"
+													>{$i18n.t('Type')}</option
+												>
+											{/if}
+											<option value="info" class="text-gray-900">{$i18n.t('Info')}</option>
+											<option value="warning" class="text-gray-900">{$i18n.t('Warning')}</option>
+											<option value="error" class="text-gray-900">{$i18n.t('Error')}</option>
+											<option value="success" class="text-gray-900">{$i18n.t('Success')}</option>
+										</select>
+										<input
+											class="pr-5 py-1.5 text-xs w-full bg-transparent outline-hidden border-l border-gray-100 dark:border-gray-850"
+											placeholder={$i18n.t('Content (Max {{maxLength}} chars)', {
+												maxLength: BANNER_CONTENT_MAX_LENGTH
+											})}
+											bind:value={banner.content}
+											maxlength={BANNER_CONTENT_MAX_LENGTH}
+										/>
+										<div class="relative top-1.5 right-2 flex items-center px-2">
+											<Tooltip content={$i18n.t('Dismissible')} className="flex h-fit items-center">
+												<Switch bind:state={banner.dismissible} />
+											</Tooltip>
+										</div>
 									</div>
+									{#if banner.content.length > BANNER_CONTENT_MAX_LENGTH * 0.8}
+										<div
+											class="text-xs px-4 pb-1 {banner.content.length > BANNER_CONTENT_MAX_LENGTH
+												? 'text-red-500'
+												: 'text-gray-500 dark:text-gray-400'}"
+										>
+											{banner.content.length}/{BANNER_CONTENT_MAX_LENGTH}
+										</div>
+									{/if}
 								</div>
 								<button
 									class="px-2"

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -59,7 +59,9 @@
 	};
 
 	$: if (suggestionPrompts) {
-		sortedPrompts = [...(suggestionPrompts ?? [])].sort(() => Math.random() - 0.5);
+		sortedPrompts = [...(suggestionPrompts ?? [])]
+			.map((p) => ({ ...p, clientId: p.id || crypto.randomUUID() })) // Add a clientId if no id
+			.sort(() => Math.random() - 0.5);
 		getFilteredPrompts(inputValue);
 	}
 </script>
@@ -81,7 +83,7 @@
 
 <div class="h-40 overflow-auto scrollbar-none {className} items-start">
 	{#if filteredPrompts.length > 0}
-		{#each filteredPrompts as prompt, idx (prompt.id || prompt.content)}
+		{#each filteredPrompts as prompt, idx (idx)}
 			<button
 				class="waterfall flex flex-col flex-1 shrink-0 w-full justify-between
 				       px-3 py-2 rounded-xl bg-transparent hover:bg-black/5


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** The prefix "feature" was used to categorize this pull request.

### Description

-   This pull request introduces the ability for administrators to import and export Default Prompt Suggestions using JSON files, simplifying bulk management. It significantly enhances the reliability of the Interface settings page (`src/lib/components/settings/Interface.svelte`) by adding comprehensive error handling for API calls and file operations, providing user feedback via toasts. Input validation has been added to prevent the creation of multiple empty banners or prompt suggestions, improving data integrity and user experience. Minor UI tweaks and code quality improvements (like explicit loop keying) are also included.

### Added

-   Import/Export functionality for Default Prompt Suggestions (JSON format).
-   Validation logic to prevent adding multiple empty banners or prompt suggestions.
-   Error handling using `try...catch` and `svelte-sonner` toasts for API calls (`updateInterfaceHandler`, `onMount`, `updateBanners`) and file import/export.
-   `PromptSuggestion` TypeScript type definition.
-   `required` attribute for prompt suggestion input fields.
-   `type="number"` and improved styling for the Autocomplete Max Length input.
-   `aria-label` for delete buttons for better accessibility.
-   Explicit keying (`(key)`) for all `#each` loops (models, banners, prompt suggestions).
-   Improved dark mode styling for banner type select options.

### Changed

-   Refactored `onMount` for more robust initial data loading and error handling.
-   Improved `promptSuggestions` initialization in `onMount` to guarantee correct data structure.
-   Refactored `updateInterfaceHandler` to validate `promptSuggestions` *before* API submission and update local state post-success.
-   Updated the UI layout for the Default Prompt Suggestions section to include Import/Export buttons.
-   Minor styling adjustments to buttons, notes, and inputs.

### Fixed

-   Potential application instability caused by unhandled errors during API calls or data initialization.
-   Risk of saving invalid data by adding pre-save validation for prompt suggestions.
-   Improved list rendering performance and stability with explicit `#each` loop keys.

---

### Additional Information

-   All changes are contained within `src/lib/components/settings/Interface.svelte`.
-   The JSON format for import/export is:
    ```json
    {
      "prompts": [
        {
          "title": "Example Title",
          "subtitle": "Optional Subtitle",
          "prompt": "The actual prompt content."
        }
      ]
    }
    ```
-   Error handling provides clearer feedback to the user if settings fail to load or save, or if file operations encounter issues.
-   This PR completes a longstanding feature request I've had that was converted into a discussion. https://github.com/open-webui/open-webui/issues/2933
### Screenshots or Videos

# `Before:`
![image](https://github.com/user-attachments/assets/c7115cc4-9e40-443b-88b4-323baa4293bb)

# `After:`
![image](https://github.com/user-attachments/assets/5ee17bae-2419-4a41-9e36-52c18781c120)


# `New Checks Added:`
![image](https://github.com/user-attachments/assets/75490888-cc01-456c-86e2-d1467e370dff)
![image](https://github.com/user-attachments/assets/b0318ab4-fc04-415a-ae7e-c2312c3246f3)
![image](https://github.com/user-attachments/assets/3ed6f4c7-e7cf-45bf-8692-49b36ab85bcb)
![image](https://github.com/user-attachments/assets/937991fe-6a5c-4a5b-9a91-30533f7777ec)

# `Banners character limit:`
Before:
![image](https://github.com/user-attachments/assets/7be4f43d-7605-484d-9cb3-7b6c74e47ae0)
After:
![image](https://github.com/user-attachments/assets/96e639c7-cf1d-4e87-8099-295335fc7683)