### PR TITLE
fix: Avoid secondary error when collection is empty in parallel hybrid search

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -320,11 +320,9 @@ def query_collection_with_hybrid_search(
             log.exception(f"Error when querying the collection with hybrid_search: {e}")
             return None, e
 
-    tasks = [
-        (collection_name, query)
-        for collection_name in collection_names
-        for query in queries
-    ]
+    # Prepare tasks for all collections and queries
+    # Avoid running any tasks for collections that failed to fetch data (have assigned None)
+    tasks = [(cn, q) for cn in collection_names if collection_results[cn] is not None for q in queries]
 
     with ThreadPoolExecutor() as executor:
         future_results = [executor.submit(process_query, cn, q) for cn, q in tasks]


### PR DESCRIPTION
# Checklist
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Do not perform a search task on empty collections (None), avoiding an additional error happening.

### Fixed

- Filterering tasks for parallel search if collection empty


### Additional Information
#### Error output before (2 errors)

Notice the: | ERROR    | open_webui.retrieval.utils:process_query:317 - **Error when querying the collection with hybrid_search: 'NoneType' object has no attribute 'documents' - {}**

```
open-webui        | 2025-04-05 08:40:28.463 | ERROR    | open_webui.retrieval.utils:query_collection_with_hybrid_search:299 - Failed to fetch collection 26268380-14ee-4c1a-bd25-c790c8fd3e16: Collection 26268380-14ee-4c1a-bd25-c790c8fd3e16 does not exist. - {}
open-webui        | Traceback (most recent call last):
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
open-webui        |     self._bootstrap_inner()
open-webui        |     │    └ <function Thread._bootstrap_inner at 0x7333099fc860>
open-webui        |     └ <Thread(ThreadPoolExecutor-5_0, started 126658898036416)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
open-webui        |     self.run()
open-webui        |     │    └ <function Thread.run at 0x7333099fc540>
open-webui        |     └ <Thread(ThreadPoolExecutor-5_0, started 126658898036416)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
open-webui        |     self._target(*self._args, **self._kwargs)
open-webui        |     │    │        │    │        │    └ {}
open-webui        |     │    │        │    │        └ <Thread(ThreadPoolExecutor-5_0, started 126658898036416)>
open-webui        |     │    │        │    └ (<weakref at 0x73321806e8e0; to 'ThreadPoolExecutor' at 0x73320b899990>, <_queue.SimpleQueue object at 0x73321812bab0>, None,...
open-webui        |     │    │        └ <Thread(ThreadPoolExecutor-5_0, started 126658898036416)>
open-webui        |     │    └ <function _worker at 0x733308ac99e0>
open-webui        |     └ <Thread(ThreadPoolExecutor-5_0, started 126658898036416)>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
open-webui        |     work_item.run()
open-webui        |     │         └ <function _WorkItem.run at 0x733308ac9b20>
open-webui        |     └ <concurrent.futures.thread._WorkItem object at 0x733218dcd510>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
open-webui        |     result = self.fn(*self.args, **self.kwargs)
open-webui        |              │    │   │    │       │    └ {}
open-webui        |              │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x733218dcd510>
open-webui        |              │    │   │    └ ()
open-webui        |              │    │   └ <concurrent.futures.thread._WorkItem object at 0x733218dcd510>
open-webui        |              │    └ <function chat_completion_files_handler.<locals>.<lambda> at 0x733218346160>
open-webui        |              └ <concurrent.futures.thread._WorkItem object at 0x733218dcd510>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/utils/middleware.py", line 594, in <lambda>
open-webui        |     lambda: get_sources_from_files(
open-webui        |             └ <function get_sources_from_files at 0x73328bd3c0e0>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 508, in get_sources_from_files
open-webui        |     context = query_collection_with_hybrid_search(
open-webui        |               └ <function query_collection_with_hybrid_search at 0x73328bd3c2c0>
open-webui        | 
open-webui        | > File "/app/backend/open_webui/retrieval/utils.py", line 295, in query_collection_with_hybrid_search
open-webui        |     collection_results[collection_name] = VECTOR_DB_CLIENT.get(
open-webui        |     │                  │                  │                └ <function ChromaClient.get at 0x733296197060>
open-webui        |     │                  │                  └ <open_webui.retrieval.vector.dbs.chroma.ChromaClient object at 0x7332961902d0>
open-webui        |     │                  └ '26268380-14ee-4c1a-bd25-c790c8fd3e16'
open-webui        |     └ {}
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/vector/dbs/chroma.py", line 121, in get
open-webui        |     collection = self.client.get_collection(name=collection_name)
open-webui        |                  │    │      │                   └ '26268380-14ee-4c1a-bd25-c790c8fd3e16'
open-webui        |                  │    │      └ <function Client.get_collection at 0x733296dd2de0>
open-webui        |                  │    └ <chromadb.api.client.Client object at 0x733296d22250>
open-webui        |                  └ <open_webui.retrieval.vector.dbs.chroma.ChromaClient object at 0x7332961902d0>
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/client.py", line 171, in get_collection
open-webui        |     model = self._server.get_collection(
open-webui        |             │    │       └ <function SegmentAPI.get_collection at 0x7332931a5580>
open-webui        |             │    └ <chromadb.api.segment.SegmentAPI object at 0x7332961838d0>
open-webui        |             └ <chromadb.api.client.Client object at 0x733296d22250>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/telemetry/opentelemetry/__init__.py", line 150, in wrapper
open-webui        |     return f(*args, **kwargs)
open-webui        |            │  │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │  └ (<chromadb.api.segment.SegmentAPI object at 0x7332961838d0>,)
open-webui        |            └ <function SegmentAPI.get_collection at 0x7332931a54e0>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/segment.py", line 103, in wrapper
open-webui        |     return self._rate_limit_enforcer.rate_limit(func)(*args, **kwargs)
open-webui        |            │    │                    │          │      │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │    │                    │          │      └ (<chromadb.api.segment.SegmentAPI object at 0x7332961838d0>,)
open-webui        |            │    │                    │          └ <function SegmentAPI.get_collection at 0x7332931a5440>
open-webui        |            │    │                    └ <function SimpleRateLimitEnforcer.rate_limit at 0x733292f1f880>
open-webui        |            │    └ <chromadb.rate_limit.simple_rate_limit.SimpleRateLimitEnforcer object at 0x733292f26150>
open-webui        |            └ <chromadb.api.segment.SegmentAPI object at 0x7332961838d0>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/rate_limit/simple_rate_limit/__init__.py", line 23, in wrapper
open-webui        |     return func(*args, **kwargs)
open-webui        |            │     │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │     └ (<chromadb.api.segment.SegmentAPI object at 0x7332961838d0>,)
open-webui        |            └ <function SegmentAPI.get_collection at 0x7332931a5440>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/segment.py", line 300, in get_collection
open-webui        |     raise InvalidCollectionException(f"Collection {name} does not exist.")
open-webui        |           └ <class 'chromadb.errors.InvalidCollectionException'>
open-webui        | 
open-webui        | chromadb.errors.InvalidCollectionException: Collection 26268380-14ee-4c1a-bd25-c790c8fd3e16 does not exist.
open-webui        | 2025-04-05 08:40:28.481 | INFO     | open_webui.retrieval.utils:query_collection_with_hybrid_search:302 - Starting hybrid search for 3 queries in 1 collections... - {}
open-webui        | 2025-04-05 08:40:28.482 | ERROR    | open_webui.retrieval.utils:process_query:317 - Error when querying the collection with hybrid_search: 'NoneType' object has no attribute 'documents' - {}
open-webui        | Traceback (most recent call last):
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
open-webui        |     self._bootstrap_inner()
open-webui        |     │    └ <function Thread._bootstrap_inner at 0x7333099fc860>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
open-webui        |     self.run()
open-webui        |     │    └ <function Thread.run at 0x7333099fc540>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
open-webui        |     self._target(*self._args, **self._kwargs)
open-webui        |     │    │        │    │        │    └ {}
open-webui        |     │    │        │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    │        │    └ (<weakref at 0x733213f560c0; to 'ThreadPoolExecutor' at 0x7332181b3890>, <_queue.SimpleQueue object at 0x733213f531f0>, None,...
open-webui        |     │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    └ <function _worker at 0x733308ac99e0>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
open-webui        |     work_item.run()
open-webui        |     │         └ <function _WorkItem.run at 0x733308ac9b20>
open-webui        |     └ <concurrent.futures.thread._WorkItem object at 0x733218d83950>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
open-webui        |     result = self.fn(*self.args, **self.kwargs)
open-webui        |              │    │   │    │       │    └ {}
open-webui        |              │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x733218d83950>
open-webui        |              │    │   │    └ ('26268380-14ee-4c1a-bd25-c790c8fd3e16', 'Was steht drin?')
open-webui        |              │    │   └ <concurrent.futures.thread._WorkItem object at 0x733218d83950>
open-webui        |              │    └ <function query_collection_with_hybrid_search.<locals>.process_query at 0x73321814d9e0>
open-webui        |              └ <concurrent.futures.thread._WorkItem object at 0x733218d83950>
open-webui        | 
open-webui        | > File "/app/backend/open_webui/retrieval/utils.py", line 305, in process_query
open-webui        |     result = query_doc_with_hybrid_search(
open-webui        |              └ <function query_doc_with_hybrid_search at 0x73328bd3ca40>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 171, in query_doc_with_hybrid_search
open-webui        |     raise e
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 120, in query_doc_with_hybrid_search
open-webui        |     texts=collection_result.documents[0],
open-webui        |           └ None
open-webui        | 
open-webui        | AttributeError: 'NoneType' object has no attribute 'documents'
open-webui        | 2025-04-05 08:40:28.483 | ERROR    | open_webui.retrieval.utils:process_query:317 - Error when querying the collection with hybrid_search: 'NoneType' object has no attribute 'documents' - {}
open-webui        | Traceback (most recent call last):
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
open-webui        |     self._bootstrap_inner()
open-webui        |     │    └ <function Thread._bootstrap_inner at 0x7333099fc860>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
open-webui        |     self.run()
open-webui        |     │    └ <function Thread.run at 0x7333099fc540>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
open-webui        |     self._target(*self._args, **self._kwargs)
open-webui        |     │    │        │    │        │    └ {}
open-webui        |     │    │        │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    │        │    └ (<weakref at 0x733213f560c0; to 'ThreadPoolExecutor' at 0x7332181b3890>, <_queue.SimpleQueue object at 0x733213f531f0>, None,...
open-webui        |     │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    └ <function _worker at 0x733308ac99e0>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
open-webui        |     work_item.run()
open-webui        |     │         └ <function _WorkItem.run at 0x733308ac9b20>
open-webui        |     └ <concurrent.futures.thread._WorkItem object at 0x7332180d0950>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
open-webui        |     result = self.fn(*self.args, **self.kwargs)
open-webui        |              │    │   │    │       │    └ {}
open-webui        |              │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x7332180d0950>
open-webui        |              │    │   │    └ ('26268380-14ee-4c1a-bd25-c790c8fd3e16', 'Aktuelle Informationen zu Was steht drin?')
open-webui        |              │    │   └ <concurrent.futures.thread._WorkItem object at 0x7332180d0950>
open-webui        |              │    └ <function query_collection_with_hybrid_search.<locals>.process_query at 0x73321814d9e0>
open-webui        |              └ <concurrent.futures.thread._WorkItem object at 0x7332180d0950>
open-webui        | 
open-webui        | > File "/app/backend/open_webui/retrieval/utils.py", line 305, in process_query
open-webui        |     result = query_doc_with_hybrid_search(
open-webui        |              └ <function query_doc_with_hybrid_search at 0x73328bd3ca40>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 171, in query_doc_with_hybrid_search
open-webui        |     raise e
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 120, in query_doc_with_hybrid_search
open-webui        |     texts=collection_result.documents[0],
open-webui        |           └ None
open-webui        | 
open-webui        | AttributeError: 'NoneType' object has no attribute 'documents'
open-webui        | 2025-04-05 08:40:28.484 | ERROR    | open_webui.retrieval.utils:process_query:317 - Error when querying the collection with hybrid_search: 'NoneType' object has no attribute 'documents' - {}
open-webui        | Traceback (most recent call last):
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
open-webui        |     self._bootstrap_inner()
open-webui        |     │    └ <function Thread._bootstrap_inner at 0x7333099fc860>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
open-webui        |     self.run()
open-webui        |     │    └ <function Thread.run at 0x7333099fc540>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
open-webui        |     self._target(*self._args, **self._kwargs)
open-webui        |     │    │        │    │        │    └ {}
open-webui        |     │    │        │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    │        │    └ (<weakref at 0x733213f560c0; to 'ThreadPoolExecutor' at 0x7332181b3890>, <_queue.SimpleQueue object at 0x733213f531f0>, None,...
open-webui        |     │    │        └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |     │    └ <function _worker at 0x733308ac99e0>
open-webui        |     └ <Thread(ThreadPoolExecutor-6_0, started 126658753332928)>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
open-webui        |     work_item.run()
open-webui        |     │         └ <function _WorkItem.run at 0x733308ac9b20>
open-webui        |     └ <concurrent.futures.thread._WorkItem object at 0x7332180d2b50>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
open-webui        |     result = self.fn(*self.args, **self.kwargs)
open-webui        |              │    │   │    │       │    └ {}
open-webui        |              │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x7332180d2b50>
open-webui        |              │    │   │    └ ('26268380-14ee-4c1a-bd25-c790c8fd3e16', 'Was steht drin? 2025')
open-webui        |              │    │   └ <concurrent.futures.thread._WorkItem object at 0x7332180d2b50>
open-webui        |              │    └ <function query_collection_with_hybrid_search.<locals>.process_query at 0x73321814d9e0>
open-webui        |              └ <concurrent.futures.thread._WorkItem object at 0x7332180d2b50>
open-webui        | 
open-webui        | > File "/app/backend/open_webui/retrieval/utils.py", line 305, in process_query
open-webui        |     result = query_doc_with_hybrid_search(
open-webui        |              └ <function query_doc_with_hybrid_search at 0x73328bd3ca40>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 171, in query_doc_with_hybrid_search
open-webui        |     raise e
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 120, in query_doc_with_hybrid_search
open-webui        |     texts=collection_result.documents[0],
open-webui        |           └ None
open-webui        | 
open-webui        | AttributeError: 'NoneType' object has no attribute 'documents'
```
#### Error output after PR (one error only, no data in collection)
```
open-webui        | 2025-04-05 08:45:42.437 | ERROR    | open_webui.retrieval.utils:query_collection_with_hybrid_search:299 - Failed to fetch collection 26268380-14ee-4c1a-bd25-c790c8fd3e16: Collection 26268380-14ee-4c1a-bd25-c790c8fd3e16 does not exist. - {}
open-webui        | Traceback (most recent call last):
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
open-webui        |     self._bootstrap_inner()
open-webui        |     │    └ <function Thread._bootstrap_inner at 0x76b1ca4a8860>
open-webui        |     └ <Thread(ThreadPoolExecutor-3_0, started 130500758865600)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
open-webui        |     self.run()
open-webui        |     │    └ <function Thread.run at 0x76b1ca4a8540>
open-webui        |     └ <Thread(ThreadPoolExecutor-3_0, started 130500758865600)>
open-webui        |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
open-webui        |     self._target(*self._args, **self._kwargs)
open-webui        |     │    │        │    │        │    └ {}
open-webui        |     │    │        │    │        └ <Thread(ThreadPoolExecutor-3_0, started 130500758865600)>
open-webui        |     │    │        │    └ (<weakref at 0x76b0d82d74c0; to 'ThreadPoolExecutor' at 0x76b150b69610>, <_queue.SimpleQueue object at 0x76b0d8d32fc0>, None,...
open-webui        |     │    │        └ <Thread(ThreadPoolExecutor-3_0, started 130500758865600)>
open-webui        |     │    └ <function _worker at 0x76b1c95759e0>
open-webui        |     └ <Thread(ThreadPoolExecutor-3_0, started 130500758865600)>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
open-webui        |     work_item.run()
open-webui        |     │         └ <function _WorkItem.run at 0x76b1c9575b20>
open-webui        |     └ <concurrent.futures.thread._WorkItem object at 0x76b0d8090b10>
open-webui        |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
open-webui        |     result = self.fn(*self.args, **self.kwargs)
open-webui        |              │    │   │    │       │    └ {}
open-webui        |              │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x76b0d8090b10>
open-webui        |              │    │   │    └ ()
open-webui        |              │    │   └ <concurrent.futures.thread._WorkItem object at 0x76b0d8090b10>
open-webui        |              │    └ <function chat_completion_files_handler.<locals>.<lambda> at 0x76b0d97a39c0>
open-webui        |              └ <concurrent.futures.thread._WorkItem object at 0x76b0d8090b10>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/utils/middleware.py", line 594, in <lambda>
open-webui        |     lambda: get_sources_from_files(
open-webui        |             └ <function get_sources_from_files at 0x76b1509080e0>
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/utils.py", line 505, in get_sources_from_files
open-webui        |     context = query_collection_with_hybrid_search(
open-webui        |               └ <function query_collection_with_hybrid_search at 0x76b1509082c0>
open-webui        | 
open-webui        | > File "/app/backend/open_webui/retrieval/utils.py", line 295, in query_collection_with_hybrid_search
open-webui        |     collection_results[collection_name] = VECTOR_DB_CLIENT.get(
open-webui        |     │                  │                  │                └ <function ChromaClient.get at 0x76b156cc7060>
open-webui        |     │                  │                  └ <open_webui.retrieval.vector.dbs.chroma.ChromaClient object at 0x76b156cf9750>
open-webui        |     │                  └ '26268380-14ee-4c1a-bd25-c790c8fd3e16'
open-webui        |     └ {}
open-webui        | 
open-webui        |   File "/app/backend/open_webui/retrieval/vector/dbs/chroma.py", line 121, in get
open-webui        |     collection = self.client.get_collection(name=collection_name)
open-webui        |                  │    │      │                   └ '26268380-14ee-4c1a-bd25-c790c8fd3e16'
open-webui        |                  │    │      └ <function Client.get_collection at 0x76b1578fede0>
open-webui        |                  │    └ <chromadb.api.client.Client object at 0x76b156d3dad0>
open-webui        |                  └ <open_webui.retrieval.vector.dbs.chroma.ChromaClient object at 0x76b156cf9750>
open-webui        | 
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/client.py", line 171, in get_collection
open-webui        |     model = self._server.get_collection(
open-webui        |             │    │       └ <function SegmentAPI.get_collection at 0x76b156bf1580>
open-webui        |             │    └ <chromadb.api.segment.SegmentAPI object at 0x76b156b075d0>
open-webui        |             └ <chromadb.api.client.Client object at 0x76b156d3dad0>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/telemetry/opentelemetry/__init__.py", line 150, in wrapper
open-webui        |     return f(*args, **kwargs)
open-webui        |            │  │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │  └ (<chromadb.api.segment.SegmentAPI object at 0x76b156b075d0>,)
open-webui        |            └ <function SegmentAPI.get_collection at 0x76b156bf14e0>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/segment.py", line 103, in wrapper
open-webui        |     return self._rate_limit_enforcer.rate_limit(func)(*args, **kwargs)
open-webui        |            │    │                    │          │      │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │    │                    │          │      └ (<chromadb.api.segment.SegmentAPI object at 0x76b156b075d0>,)
open-webui        |            │    │                    │          └ <function SegmentAPI.get_collection at 0x76b156bf1440>
open-webui        |            │    │                    └ <function SimpleRateLimitEnforcer.rate_limit at 0x76b153a4b880>
open-webui        |            │    └ <chromadb.rate_limit.simple_rate_limit.SimpleRateLimitEnforcer object at 0x76b156c2cd10>
open-webui        |            └ <chromadb.api.segment.SegmentAPI object at 0x76b156b075d0>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/rate_limit/simple_rate_limit/__init__.py", line 23, in wrapper
open-webui        |     return func(*args, **kwargs)
open-webui        |            │     │       └ {'name': '26268380-14ee-4c1a-bd25-c790c8fd3e16', 'tenant': 'default_tenant', 'database': 'default_database'}
open-webui        |            │     └ (<chromadb.api.segment.SegmentAPI object at 0x76b156b075d0>,)
open-webui        |            └ <function SegmentAPI.get_collection at 0x76b156bf1440>
open-webui        |   File "/usr/local/lib/python3.11/site-packages/chromadb/api/segment.py", line 300, in get_collection
open-webui        |     raise InvalidCollectionException(f"Collection {name} does not exist.")
open-webui        |           └ <class 'chromadb.errors.InvalidCollectionException'>
open-webui        | 
open-webui        | chromadb.errors.InvalidCollectionException: Collection 26268380-14ee-4c1a-bd25-c790c8fd3e16 does not exist.
```

