### PR TITLE
chore: Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: '/backend'
+  - package-ecosystem: uv
+    directory: '/'
     schedule:
       interval: monthly
     target-branch: 'dev'
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    target-branch: 'dev'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       # Check for updates to GitHub Actions every week
       interval: monthly
+    target-branch: 'dev'


### PR DESCRIPTION
### Description

- Migrate package ecosystem to `uv` for python dependencies. See https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/
- Fix directory for python, it should be the directory where the uv.lock/pyproject.toml are, not the code.
- Add missing entry for `npm` dependencies.
- Add target-branch to `github-actions` tracker.

With these fixes you should see +10 new PR's get created with dependency updates since the current dependabot configuration was not working at all.