### PR TITLE
chore: Bump Python Docker image to python3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV APP_BUILD_HASH=${BUILD_HASH}
 RUN npm run build
 
 ######## WebUI backend ########
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.12-slim-bookworm AS base
 
 # Use args
 ARG USE_CUDA


### PR DESCRIPTION
### Description

- Bump base image for Python from `3.11`  to ` 3.12`.

Fixes #12284 