### PR TITLE
chore: Only run GitHub workflows when needed

### DIFF
--- a/.github/workflows/format-backend.yaml
+++ b/.github/workflows/format-backend.yaml
@@ -5,10 +5,18 @@ on:
     branches:
       - main
       - dev
+    paths:
+      - 'backend/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - main
       - dev
+    paths:
+      - 'backend/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:
@@ -17,7 +25,9 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version:
+          - 3.11.x
+          - 3.12.x
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '${{ matrix.python-version }}'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/format-build-frontend.yaml
+++ b/.github/workflows/format-build-frontend.yaml
@@ -5,10 +5,18 @@ on:
     branches:
       - main
       - dev
+    paths-ignore:
+      - 'backend/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   pull_request:
     branches:
       - main
       - dev
+    paths-ignore:
+      - 'backend/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
 
 jobs:
   build:
@@ -21,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Or specify any other version you want to use
+          node-version: '22'
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
### Description

- Currently workflows are run all the time, they should only run when needed.
- The backend workflow will only run when changes to `backend/`, `pyproject.toml` and `uv.lock` files are made.
- The frontend workflow will run when changes are *not* related to `Python`.
- Added `python3.12` to workflow