### PR TITLE
chore: Dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: monthly
     target-branch: 'dev'
 
+  - package-ecosystem: pip
+    directory: '/backend'
+    schedule:
+      interval: monthly
+    target-branch: 'dev'
+
   - package-ecosystem: npm
     directory: '/'
     schedule:


### PR DESCRIPTION
### Description

- Re-added `pip` tracker for `backend/requirements.txt`  since that file is separate from the main `pyproject.toml`.

Related to #12515 