### PR TITLE
Rereank model loading error. but cannot get detailed information, and adds catch logic printing

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -150,8 +150,8 @@ def get_rf(
                     device=DEVICE_TYPE,
                     trust_remote_code=RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
                 )
-            except:
-                log.error("CrossEncoder error")
+            except Exception as e:
+                log.error(f"CrossEncoder error: {e}")
                 raise Exception(ERROR_MESSAGES.DEFAULT("CrossEncoder error"))
     return rf
 


### PR DESCRIPTION
 
tip rerank error info 

# Pull Request Checklist
backend/open_webui/routers/retrieval.py:get_rf



**Before submitting, make sure you've checked the following:**
    
- [ x ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
 
- [ X ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
 

# Changelog Entry

### Description

- Rereank model loading error. but cannot get detailed information, and adds catch logic printing
 

### Fixed

- "name 'init_empty_weights' is not defined" need have both bitsandbytes and accelerate installed.
 

 
 
