### PR TITLE
fix: Correct Citations for knowledge base models

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -904,7 +904,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     file_id = doc_meta.get('file_id')
                     if file_id not in citated_file_idx:
                         citated_file_idx[file_id] = len(citated_file_idx) + 1
-                    context_string += f"<source><source_id>{citated_file_idx[file_id]}</source_id><source_context>{doc_context}</source_context></source>\n"
+                    context_string += (
+                        f'<source id="{citated_file_idx[file_id]}">{doc_context}</source>\n'
+                    )
 
         context_string = context_string.strip()
         prompt = get_last_user_message(form_data["messages"])

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -897,12 +897,14 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # If context is not empty, insert it into the messages
     if len(sources) > 0:
         context_string = ""
-        for source_idx, source in enumerate(sources):
+        citated_file_idx = {}
+        for _, source in enumerate(sources, 1):
             if "document" in source:
-                for doc_idx, doc_context in enumerate(source["document"]):
-                    context_string += (
-                        f'<source id="{source_idx + 1}">{doc_context}</source>\n'
-                    )
+                for doc_context, doc_meta in zip(source["document"], source['metadata']):
+                    file_id = doc_meta.get('file_id')
+                    if file_id not in citated_file_idx:
+                        citated_file_idx[file_id] = len(citated_file_idx) + 1
+                    context_string += f"<source><source_id>{citated_file_idx[file_id]}</source_id><source_context>{doc_context}</source_context></source>\n"
 
         context_string = context_string.strip()
         prompt = get_last_user_message(form_data["messages"])


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

The RAG-pipeline was not citing correctly when using a model equipped with one or more knowledge bases. This small change corrects the citations by giving the model the actual document id of the chunk-context-source (instead of the knowledge base id). This works all the way through frontend citation parsing due to the consistent order of the source objects.

Cases citation might break: When the metadata.name is not unique within the sources (e.g. multiple files with the same ' name'). Then the deduplication step in citation rendering takes some sources out and the numbers are not aligned any more.

### Fixed

- Using the deduplicated document id when creating context for the LLM

### Manual tests:

- Using model with knowledge base
- Using model with > 1 knowledge bases
- Uploading 1 file directly in chat
- Uploading >1 files directly in chat

All manual tests used correct citations of the relevant source.

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

This has been topic of this discussion https://github.com/open-webui/open-webui/discussions/11599 but was not furtherly taken care of.

Additional discussion: https://github.com/open-webui/open-webui/discussions/10595

