### PR TITLE
Fix OIDC logout via end session endpoint

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -539,10 +539,10 @@ async def signout(request: Request, response: Response):
                             logout_url = openid_data.get("end_session_endpoint")
                             if logout_url:
                                 response.delete_cookie("oauth_id_token")
-                                return RedirectResponse(
-                                    headers=response.headers,
-                                    url=f"{logout_url}?id_token_hint={oauth_id_token}",
-                                )
+                                return {
+                                    "status": True,
+                                    "end_session_endpoint": f"{logout_url}?id_token_hint={oauth_id_token}"
+                                }
                         else:
                             raise HTTPException(
                                 status_code=resp.status,

--- a/src/lib/apis/auths/index.spec.ts
+++ b/src/lib/apis/auths/index.spec.ts
@@ -2,7 +2,6 @@ import { describe, beforeEach, expect, it, vi } from 'vitest';
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { userSignOut } from '$lib/apis/auths';
 
-
 const mocks = vi.hoisted(() => {
 	return {
 		fetch: vi.fn(),
@@ -32,12 +31,12 @@ describe('userSignOut()', () => {
 		);
 	});
 
-	it('should not throw on OK response', async () => {
+	it('should return the OK response', async () => {
 		mocks.fetch.mockImplementation(() => {
 			return new Response('{ "status": true }', { status: 200 });
 		});
 
-		await expect(userSignOut()).resolves.toBe(undefined);
+		await expect(userSignOut()).resolves.toEqual({ "status": true });
 	});
 
 	describe("failed", () => {

--- a/src/lib/apis/auths/index.spec.ts
+++ b/src/lib/apis/auths/index.spec.ts
@@ -1,0 +1,68 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+import { userSignOut } from '$lib/apis/auths';
+
+
+const mocks = vi.hoisted(() => {
+	return {
+		fetch: vi.fn(),
+	};
+});
+
+vi.stubGlobal('fetch', mocks.fetch);
+
+describe('userSignOut()', () => {
+	beforeEach(() => {
+		mocks.fetch.mockImplementation(() => {
+			return new Response('', { status: 500 });
+		});
+	});
+
+	it('should GET /auths/signout and include credentials', async () => {
+		try {
+			await userSignOut();
+		} catch { /* expected */ }
+
+		expect(fetch).toHaveBeenCalledWith(
+			`${WEBUI_API_BASE_URL}/auths/signout`,
+			{
+				method: 'GET',
+				credentials: 'include',
+			},
+		);
+	});
+
+	it('should not throw on OK response', async () => {
+		mocks.fetch.mockImplementation(() => {
+			return new Response('{ "status": true }', { status: 200 });
+		});
+
+		await expect(userSignOut()).resolves.toBe(undefined);
+	});
+
+	describe("failed", () => {
+		it('should throw generic error', async () => {
+			mocks.fetch.mockImplementation(() => {
+				return new Response('', { status: 404, statusText: 'not found' });
+			});
+
+			await expect(userSignOut()).rejects.toThrowError('Request failed with no details: 404 not found');
+		});
+
+		it('should throw error containing detail', async () => {
+			mocks.fetch.mockImplementation(() => {
+				return new Response('{ "detail": "something wrong" }', { status: 500, headers: { 'Content-Type': 'application/json' } });
+			});
+
+			await expect(userSignOut()).rejects.toThrowError('something wrong');
+		});
+
+		it('should throw generic error with missing detail', async () => {
+			mocks.fetch.mockImplementation(() => {
+				return new Response('{ }', { status: 500, statusText: 'server error', headers: { 'Content-Type': 'application/json' } });
+			});
+
+			await expect(userSignOut()).rejects.toThrowError('Request failed with no details: 500 server error');
+		});
+	});
+});

--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -339,6 +339,8 @@ export const userSignOut = async () => {
 
 		throw new Error(detail ?? `Request failed with no details: ${res.status} ${res.statusText}`);
 	}
+
+	return await res.json();
 };
 
 export const addUser = async (

--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -325,27 +325,19 @@ export const userSignUp = async (
 };
 
 export const userSignOut = async () => {
-	let error = null;
-
 	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/signout`, {
 		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json'
-		},
 		credentials: 'include'
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res;
-		})
-		.catch((err) => {
-			console.log(err);
-			error = err.detail;
-			return null;
-		});
+	});
 
-	if (error) {
-		throw error;
+	if (!res.ok) {
+		let detail;
+
+		try {
+			detail = (await res.json())?.detail;
+		} catch (e) { /* don't try to recover if server errors are no JSON */ }
+
+		throw new Error(detail ?? `Request failed with no details: ${res.status} ${res.statusText}`);
 	}
 };
 

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import { DropdownMenu } from 'bits-ui';
 	import { createEventDispatcher, getContext, onMount } from 'svelte';
-
 	import { flyAndScale } from '$lib/utils/transitions';
 	import { goto } from '$app/navigation';
 	import ArchiveBox from '$lib/components/icons/ArchiveBox.svelte';
 	import { showSettings, activeUserIds, USAGE_POOL, mobile, showSidebar, user } from '$lib/stores';
 	import { fade, slide } from 'svelte/transition';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import { userSignOut } from '$lib/apis/auths';
+	import { signout } from '$lib/services/auths';
 
 	const i18n = getContext('i18n');
 
@@ -155,15 +154,7 @@
 
 			<button
 				class="flex rounded-md py-2 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
-				on:click={async () => {
-					await userSignOut();
-					user.set(null);
-
-					localStorage.removeItem('token');
-					location.href = '/auth';
-
-					show = false;
-				}}
+				on:click={() => { signout(); show = false; }}
 			>
 				<div class=" self-center mr-3">
 					<svg

--- a/src/lib/services/auths.spec.ts
+++ b/src/lib/services/auths.spec.ts
@@ -1,0 +1,156 @@
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { get, writable } from 'svelte/store';
+import { signout } from '$lib/services/auths';
+
+const mocks = vi.hoisted(() => {
+	return {
+		userSignOut: vi.fn(),
+	};
+});
+
+vi.mock('$lib/apis/auths', () => {
+	return {
+		userSignOut: mocks.userSignOut,
+	};
+});
+
+vi.mock('$lib/stores', () => {
+	mocks.config = writable({ });
+	mocks.user = writable({ });
+
+	return {
+		config: mocks.config,
+		user: mocks.user,
+	};
+});
+
+vi.stubGlobal('location', {
+	href: 'unset',
+});
+
+vi.stubGlobal('localStorage', {
+	removeItem: vi.fn(),
+});
+
+describe('signout()', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		mocks.config.set({
+			oauth: {
+				providers: {
+					oidc: 'Test',
+				},
+			},
+		});
+		mocks.user.set({ });
+		location.href = 'unset';
+		mocks.userSignOut.mockImplementation(() => ({ status: true }));
+	});
+
+	it('should call api.userSignOut()', async () => {
+		mocks.config.set({ /* No oauth configured */ });
+
+		signout();
+		await expect(mocks.userSignOut).toHaveBeenCalled();
+	});
+
+	it('should re-throw', async () => {
+		mocks.userSignOut.mockImplementation(() => { throw new Error('some error'); });
+		await expect(signout()).rejects.toThrowError('some error');
+	});
+
+	it('should throw if signout was not successful', async () => {
+		mocks.config.set({ /* No oauth configured */ });
+
+		mocks.userSignOut.mockImplementation(() => ({ status: false }));
+		await expect(signout()).rejects.toThrowError('Signout was not successful');
+	});
+
+	describe("signout successful", () => {
+		describe('no end_session_endpoint', () => {
+			beforeEach(() => {
+				mocks.config.set({ /* No oauth configured */ });
+
+				mocks.userSignOut.mockImplementation(() => ({ status: true }));
+			});
+
+			it('should set location to /auth', async () => {
+				await signout();
+				expect(location.href).toBe('/auth');
+			});
+
+			it('should remove token from localStorage', async () => {
+				await signout();
+				expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+			});
+
+			it('should unset the user', async () => {
+				await signout();
+				expect(get(mocks.user)).toEqual(null);
+			});
+		});
+
+		describe('has no end_session_endpoint with OIDC configured', () => {
+			beforeEach(() => {
+				mocks.config.set({
+					oauth: {
+						providers: {
+							oidc: 'Test',
+						},
+					},
+				});
+
+				// end_session_endpoint missing
+				mocks.userSignOut.mockImplementation(() => ({ status: true }));
+			});
+
+			it('should remove token from localStorage', async () => {
+				await expect(signout()).rejects.toThrowError('OIDC configured but no end_session_endpoint sent');
+
+				expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+			});
+
+			it('should unset the user', async () => {
+				await expect(signout()).rejects.toThrowError('OIDC configured but no end_session_endpoint sent');
+
+				expect(get(mocks.user)).toEqual(null);
+			});
+
+			it('should throw if no end_session_endpoint was sent', async () => {
+				await expect(signout()).rejects.toThrowError('OIDC configured but no end_session_endpoint sent');
+			});
+		});
+
+		describe('has end_session_endpoint', () => {
+			const endpoint = 'https://acmeauth.com/logout';
+
+			beforeEach(() => {
+				mocks.config.set({
+					oauth: {
+						providers: {
+							oidc: 'Test',
+						},
+					},
+				});
+
+				mocks.userSignOut.mockImplementation(() => ({ status: true, end_session_endpoint: endpoint }));
+			});
+
+			it('should set location to /auth', async () => {
+				await signout();
+				expect(location.href).toBe(endpoint);
+			});
+
+			it('should remove token from localStorage', async () => {
+				await signout();
+				expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+			});
+
+			it('should unset the user', async () => {
+				await signout();
+				expect(get(mocks.user)).toEqual(null);
+			});
+		});
+	});
+});

--- a/src/lib/services/auths.ts
+++ b/src/lib/services/auths.ts
@@ -1,0 +1,22 @@
+import { get } from 'svelte/store';
+import { config, user } from '$lib/stores';
+import { userSignOut } from '$lib/apis/auths';
+
+export async function signout(response) {
+	const signoutResponse = await userSignOut();
+
+	if (!signoutResponse?.status) {
+		throw new Error('Signout was not successful');
+	}
+
+	user.set(null);
+	localStorage.removeItem('token');
+
+	if (get(config)?.oauth?.providers?.oidc && !signoutResponse?.end_session_endpoint) {
+		throw new Error('OIDC configured but no end_session_endpoint sent');
+	}
+
+	const postSignoutLocation = signoutResponse?.end_session_endpoint ?? '/auth';
+
+	location.href = postSignoutLocation;
+};


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? _(none)_
- [x] ~**Testing:** Have you written and run sufficient tests to validate the changes?~ _(test infrastructure is broken)_ _(manual testing done)_
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

When OIDC is configured, the session in Open WebUI is invalidated and the user must be redirected to the Auth server's end_session_endpoint to invalidate the session there.

With the previous implementation, the end_session_endpoint was sent as a redirect to the client.

However, since the request is made as Fetch request it has to obey CORS rules.

This would require the Auth server to set Access-Control-Allow-Origin, which is not sensible. If this header is not set, the request would fail, thus the logout would not be completed at the Auth server.


### Fixed

- For OIDC authentication: logout fixed to properly call `end_session_endpoint` (before this fix the endpoint was not called due to a CORS error)


### Screenshots or Videos

#### Broken

https://github.com/user-attachments/assets/f8493fd1-a464-445a-87f9-f7c97399a140

#### Fixed

https://github.com/user-attachments/assets/fec16ed3-a826-4b83-b7b5-aee1b5fd0329



