### PR TITLE
fix: mismatch between TOOL_SERVERS / TOOL_SERVER_CONNECTIONS indexing

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -45,7 +45,7 @@ async def get_tools(request: Request, user=Depends(get_verified_user)):
         )
 
     tools = Tools.get_tools()
-    for idx, server in enumerate(request.app.state.TOOL_SERVERS):
+    for server in request.app.state.TOOL_SERVERS:
         tools.append(
             ToolUserResponse(
                 **{
@@ -60,7 +60,7 @@ async def get_tools(request: Request, user=Depends(get_verified_user)):
                         .get("description", ""),
                     },
                     "access_control": request.app.state.config.TOOL_SERVER_CONNECTIONS[
-                        idx
+                        server["idx"]
                     ]
                     .get("config", {})
                     .get("access_control", None),

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -55,7 +55,12 @@ def get_tools(
                 tool_server_connection = (
                     request.app.state.config.TOOL_SERVER_CONNECTIONS[server_idx]
                 )
-                tool_server_data = request.app.state.TOOL_SERVERS[server_idx]
+                tool_server_data = None
+                for server in request.app.state.TOOL_SERVERS:
+                    if server["idx"] == server_idx:
+                        tool_server_data = server
+                        break
+                assert tool_server_data is not None
                 specs = tool_server_data.get("specs", [])
 
                 for spec in specs:


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- When global tool servers are disabled, some pieces of code don't work correctly. Using the tool in a chat can fail and the access control for tools might be wrong.

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fix issue with wrong behavior with disabled global tool servers.

### Security

### Breaking Changes

---

### Additional Information

When a tool server is disabled, the lists `TOOL_SERVERS` and `TOOL_SERVER_CONNECTIONS` have different indexes. This is not accounted for correctly everywhere.
This causes several problems. One of them is that the user gets an error message in chat when there are two tool servers, the first one is disabled, and the second one is being used in chat.

An alternative solution would be to convert `TOOL_SERVERS` to a dict with the server index as key. Not sure which solution you prefer.

### Screenshots or Videos
