### PR TITLE
 **fix** improve stack trace of duckduckgo exception

### DIFF
--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -28,7 +28,7 @@ def search_duckduckgo(
         # Use the ddgs.text() method to perform the search
         try:
             search_results = ddgs.text(
-                query, safesearch="moderate", max_results=count, backend="api"
+                query, safesearch="moderate", max_results=count, backend="lite"
             )
         except RatelimitException as e:
             log.error(f"RatelimitException: {e}")

--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from duckduckgo_search import DDGS
+from duckduckgo_search.exceptions import RatelimitException
 from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
@@ -22,16 +23,15 @@ def search_duckduckgo(
         list[SearchResult]: A list of search results
     """
     # Use the DDGS context manager to create a DDGS object
+    search_results = []
     with DDGS() as ddgs:
         # Use the ddgs.text() method to perform the search
-        ddgs_gen = ddgs.text(
-            query, safesearch="moderate", max_results=count, backend="api"
-        )
-        # Check if there are search results
-        if ddgs_gen:
-            # Convert the search results into a list
-            search_results = [r for r in ddgs_gen]
-
+        try:
+            search_results = ddgs.text(
+                query, safesearch="moderate", max_results=count, backend="api"
+            )
+        except RatelimitException as e:
+            log.error(f"RatelimitException: {e}")
     if filter_list:
         search_results = get_filtered_results(search_results, filter_list)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -98,7 +98,7 @@ pytube==15.0.0
 
 extract_msg
 pydub
-duckduckgo-search~=7.3.2
+duckduckgo-search~=7.5.5
 
 ## Google Drive
 google-api-python-client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
 
     "extract_msg",
     "pydub",
-    "duckduckgo-search~=7.3.2",
+    "duckduckgo-search~=7.5.5",
 
     "google-api-python-client",
     "google-auth-httplib2",


### PR DESCRIPTION

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

# Changelog Entry

### Description

On ratelimiting, it is not easily shown what goes wrong, as one receives the full stack trace as seen here:
https://github.com/open-webui/open-webui/discussions/11503

This should be improved by catching the RatelimitException and only logging an error for this.
We could improve this as well by suggesting to reduce the concurrent requests..?

### Fixed

Further fixes include

* fix `search_results` might being out of scope
* ddgs.text does already always return a list
* move from deprecated "api" backend to lite (see https://github.com/deedy5/duckduckgo_search/commit/3ee8e08b1c8efc9b7356f406db299f1114dc4860 )