### PR TITLE
feat: UVICORN_WORKERS variable and docs

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -73,8 +73,15 @@ def serve(
             os.environ["LD_LIBRARY_PATH"] = ":".join(LD_LIBRARY_PATH)
 
     import open_webui.main  # we need set environment variables before importing main
+    from open_webui.env import UVICORN_WORKERS  # Import the workers setting
 
-    uvicorn.run(open_webui.main.app, host=host, port=port, forwarded_allow_ips="*")
+    uvicorn.run(
+        open_webui.main.app, 
+        host=host, 
+        port=port, 
+        forwarded_allow_ips="*",
+        workers=UVICORN_WORKERS
+    )
 
 
 @app.command()

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -327,6 +327,19 @@ REDIS_SENTINEL_HOSTS = os.environ.get("REDIS_SENTINEL_HOSTS", "")
 REDIS_SENTINEL_PORT = os.environ.get("REDIS_SENTINEL_PORT", "26379")
 
 ####################################
+# UVICORN WORKERS
+####################################
+
+UVICORN_WORKERS = os.environ.get("UVICORN_WORKERS", "1")
+try:
+    UVICORN_WORKERS = int(UVICORN_WORKERS)
+    if UVICORN_WORKERS < 1:
+        UVICORN_WORKERS = 1
+except ValueError:
+    UVICORN_WORKERS = 1
+    log.info(f"Invalid UVICORN_WORKERS value, defaulting to {UVICORN_WORKERS}")
+
+####################################
 # WEBUI_AUTH (Required for security)
 ####################################
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -330,6 +330,7 @@ REDIS_SENTINEL_PORT = os.environ.get("REDIS_SENTINEL_PORT", "26379")
 # UVICORN WORKERS
 ####################################
 
+# Number of uvicorn worker processes for handling requests
 UVICORN_WORKERS = os.environ.get("UVICORN_WORKERS", "1")
 try:
     UVICORN_WORKERS = int(UVICORN_WORKERS)

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -65,4 +65,4 @@ if [ -n "$SPACE_ID" ]; then
   export WEBUI_URL=${SPACE_HOST}
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --workers "${UVICORN_WORKERS:-1}"

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -41,5 +41,6 @@ IF "%WEBUI_SECRET_KEY%%WEBUI_JWT_SECRET_KEY%" == " " (
 
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
-uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ws auto
+IF "%UVICORN_WORKERS%"=="" SET UVICORN_WORKERS=1
+uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --workers %UVICORN_WORKERS% --ws auto
 :: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "cert.pem" --ws auto


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

This PR adds support for running OpenWebUI with multiple Uvicorn worker processes via a new environment variable UVICORN_WORKERS. This enhancement improves scalability and performance on multi-core systems by allowing the application to handle more concurrent requests.

**Why it is needed**

- As discussed in [the discussion](https://github.com/open-webui/open-webui/discussions/9032), the only other way to use multiple uvicorn workers is by manually editing the respective files (in the venv or in the docker) and this is NOT recommended for obvious reasons.
  - Furthermore, **any edits and modifications to these files will be gone by the next time you update** your open-webui (files get overwritten by new update).
- Finally, using WEB_CONCURRENCY (the variable used by uvicorn) does not work by our tests (see disc.), because OpenWebUI is calling uvicorn directly in the \_\_init\_\_.py file -> variable needs to be passed directly, instead.

So, a proper solution is needed.

Documentation: https://github.com/open-webui/docs/pull/482

### Solves

Solves this issue https://github.com/open-webui/open-webui/issues/12286 
Solves this discussion https://github.com/open-webui/open-webui/discussions/12362
Solves this discussion https://github.com/open-webui/open-webui/discussions/9032

### Relates to

Related to:
https://github.com/open-webui/open-webui/issues/10365#issuecomment-2784050405

### Added

Added new environment variable UVICORN_WORKERS to control the number of Uvicorn worker processes
Added worker parameter to all server startup methods (start.sh, windows-start.bat, init.py)
Added validation and normalization of the worker count (ensuring it's at least 1 and defaults to 1)

### Changed

Modified the serve() command in init.py to use the configured number of workers
Modified the dev() command to conditionally use multiple workers only when hot-reload is disabled
Updated bash and batch scripts to respect the UVICORN_WORKERS environment variable

### Additional Information

The default value is 1 worker, if environment variable is not specified.
If a kubernetes/k8s/helm multi-node (multi pod) cluster is being used, it is advised to NOT change the UVICORN_WORKERS variable, i.e. leave it at it's default value, which is 1.
A pod should only run one uvicorn worker at a time.

Works with all startup methods: pip install startup (open-webui serve), bash script (start.sh), and Windows script (windows-start.bat)

### Screenshots or Videos

N/A (Server-side enhancement with no visual changes)