### PR TITLE
perf: Prevent model list API call from blocking UI

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -397,6 +397,10 @@
 		console.log('mounted');
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('chat-events', chatEventHandler);
+		models.subscribe(async () => {
+			await tick();
+			await initNewChat();
+		});
 
 		if (!$chatId) {
 			chatIdUnsubscriber = chatId.subscribe(async (value) => {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -95,12 +95,12 @@
 				settings.set(localStorageSettings);
 			}
 
-			models.set(
-				await getModels(
-					localStorage.token,
-					$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
-				)
-			);
+			getModels(
+				localStorage.token,
+				$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
+			).then((res) => {
+				models.set(res);
+			});
 
 			banners.set(await getBanners(localStorage.token));
 			tools.set(await getTools(localStorage.token));


### PR DESCRIPTION
# Changelog Entry

### Description

The API call to `/api/models` can take a long time. the ui waits until the api call promise is resolved before continuing any other ui state change or conducting any other api call. user sees a blank screen until the request has completed. This PR allows for the models list api call to run without blocking the UI.

This delay can become large if there are many model api urls, or if the servers are offline/are responding slowly.

### Changed

- set `models` store asynchronously to prevent UI blocking
- `src/lib/components/chat/Chat.svelte` onMount subscribes to `models` and runs the `initNewChat` function when `models` changes, ensuring the UI is hydrated with the new data.

---

### Additional Information

tested by adding an artificial delay to the endpoint `/api/models` in `backend/open_webui/main.py`: 
```python
@app.get("/api/models")
async def get_models(request: Request, user=Depends(get_verified_user)):
    import asyncio 
    await asyncio.sleep(10)
    ...
```

#### before: 

this video demonstrates the blank UI while the call to `/api/models` completes

https://github.com/user-attachments/assets/a26ad416-38c0-4606-91b9-5108185b1bd3


#### after: 

when the api call is done without blocking, the user gets a quick load, and is able to interact with the ui while the request completes in the background. 

https://github.com/user-attachments/assets/1b03d5df-4593-4ba1-81e8-b0e33f0e942f

#### user navigates during model load functions as intended.

the initNewChat function is not called if the user navigates. The model list is still refreshed once it becomes available.

https://github.com/user-attachments/assets/b509e839-bd7a-44a8-9b78-86dbd2885367


