### PR TITLE
fix: Chat rename not updating inside folders

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -83,6 +83,8 @@
 			currentChatPage.set(1);
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 			await pinnedChats.set(await getPinnedChatList(localStorage.token));
+
+			dispatch('change');
 		}
 	};
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed an issue where renaming a chat inside a folder didn’t update the UI immediately, even though the database was updated. This now works consistently for chats inside and outside folders.

### Added

- Added a `dispatch('change')` call in `ChatItem.svelte` to notify parent components of title updates.

### Changed

- Modified the `editChatTitle` function in `ChatItem.svelte` to propagate changes to folder components.

### Deprecated

- None

### Removed

- None

### Fixed

- Fixed chat title updates not refreshing inside folders on the UI.

### Security

- None

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

- This change ensures that renaming a chat triggers a UI refresh for all components, including folders, by dispatching a `change` event to parent components.
- Tested locally with a sample `webui.db` file, confirming that folder chats now update correctly.

### Screenshots or Videos


