### PR TITLE
fix: Add `text-sm` class to the code editor div to reduce font size.

### DIFF
--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -232,4 +232,4 @@
 	});
 </script>
 
-<div id="code-textarea-{id}" class="h-full w-full" />
+<div id="code-textarea-{id}" class="h-full w-full text-sm" />


### PR DESCRIPTION
### Description

- Default font size is 1rem (16px) what yields very large text in monospace. Code blocks should have 14 px (0.875 rem).

Fixes #12693

### Added

- Added class name `text-sm`

### Screenshots or Videos

Second code block has class name applied:

![image](https://github.com/user-attachments/assets/63426fa0-6697-4f9c-9664-547dedd84386)

