### PR TITLE
fix: Resolve small bugs on updated web/rag settings

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -621,8 +621,8 @@ async def update_rag_config(
 
     # Integration settings
     request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION = (
-        form_data.enable_google_drive_integration
-        if form_data.enable_google_drive_integration is not None
+        form_data.ENABLE_GOOGLE_DRIVE_INTEGRATION
+        if form_data.ENABLE_GOOGLE_DRIVE_INTEGRATION is not None
         else request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION
     )
     request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION = (
@@ -706,7 +706,7 @@ async def update_rag_config(
         request.app.state.config.YOUTUBE_LOADER_PROXY_URL = (
             form_data.web.YOUTUBE_LOADER_PROXY_URL
         )
-        request.app.state.config.YOUTUBE_LOADER_TRANSLATION = (
+        request.app.state.YOUTUBE_LOADER_TRANSLATION = (
             form_data.web.YOUTUBE_LOADER_TRANSLATION
         )
 

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -71,8 +71,7 @@
 
 			// Convert array back to comma-separated string for display
 			if (webConfig?.WEB_SEARCH_DOMAIN_FILTER_LIST) {
-				webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST =
-					webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
+				webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
 			}
 
 			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -46,11 +46,21 @@
 			webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = [];
 		}
 
+		// Convert Youtube loader language string to array before sending
+		if (webConfig.YOUTUBE_LOADER_LANGUAGE) {
+			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.split(',')
+				.map((lang) => lang.trim())
+				.filter((lang) => lang.length > 0);
+		} else {
+			webConfig.YOUTUBE_LOADER_LANGUAGE = [];
+		}
+
 		const res = await updateRAGConfig(localStorage.token, {
 			web: webConfig
 		});
 
-		webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(', ');
+		webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
+		webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
 	};
 
 	onMount(async () => {
@@ -62,7 +72,7 @@
 			// Convert array back to comma-separated string for display
 			if (webConfig?.WEB_SEARCH_DOMAIN_FILTER_LIST) {
 				webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST =
-					webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(', ');
+					webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
 			}
 
 			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
@@ -524,7 +534,6 @@
 								class="dark:bg-gray-900 w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
 								bind:value={webConfig.WEB_LOADER_ENGINE}
 								placeholder={$i18n.t('Select a engine')}
-								required
 							>
 								<option value="">{$i18n.t('Default')}</option>
 								{#each webLoaderEngines as engine}


### PR DESCRIPTION
This PR addresses minor issues identified after recent updates to the web search / rag configuration settings.

**Backend (`routers/retrieval.py`):**

1. Renamed `form_data.enable_google_drive_integration` to `form_data.ENABLE_GOOGLE_DRIVE_INTEGRATION`.
    - The corresponding field in `ConfigForm` was updated to uppercase, but the retrieval router was still using the lowercase version. (Potential 500 error)
2. Updated write operation from `request.app.state.config.YOUTUBE_LOADER_TRANSLATION` to `request.app.state.YOUTUBE_LOADER_TRANSLATION`.
    - This specific configuration value appears to be managed directly on the `app.state` object rather than within the nested `config` attribute. (Potential 500 error)

**Frontend (`WebSearch.svelte`):**

1. Removed the `required` attribute from the web loader selector input.
    - With `required`, users could not submit the form if the default value ("safe_web") was intended.
2. Convert `webConfig.YOUTUBE_LOADER_LANGUAGE` to a list data type before submitting the form update.
    - The backend API endpoint expects this configuration value to be a `list[str]`, similar to domain filter list. (Potential 4xx error)
3. (I suggest) Modified the display join logic from `webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(', ')` to `.join(',')`.
    - Aligns with the format shown in the input's placeholder text (no space after comma).
    - When user triggers the config update, the handler processes it into a list, and upon data binding, the Svelte component would likely display it *without* the space; After that if extra space is introduced, it will make the format change unexpectedly for the user post-submission.