### PR TITLE
 **fix** - Bug in the /ollama/api/embed API with models lacking tags (and with prefixes).

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -873,7 +873,7 @@ async def embed(
         prefix_ids = [config.get('prefix_id') for config in configs.values() if config.get('prefix_id')]
         prefix_id = None
         for prefix in prefix_ids:
-            if model.startswith(prefix):
+            if model.startswith(f"{prefix}."):
                 prefix_id = prefix
                 break
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [] **Testing:** Have you written and run sufficient tests to validate the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

https://github.com/open-webui/open-webui/issues/12821

The ollama/api/embed API is failing because the model is considered invalid, as it cannot pass the currently imposed filters (even though it is functioning correctly in Ollama).

I’ve implemented a fix to support models with the server prefix (in my case, called “core”). This is because you can have multiple Ollama instances, and from what I understood during debugging, they could potentially all be used.
Therefore, it seemed correct that the model should be written as $PREFIX.$MODEL:$TAG, and that OpenWebUI should remove the $PREFIX (which is transparent to Ollama) before sending the request.

### Fixed

- POST /ollama/api/embed

---

### Additional Information
old (No tested variation worked.):
```
curl -X POST -H "Authorization: Bearer sk-XXXX"  https://<HOSTNAME>/ollama/api/embed  -H "Content-Type: application/json" -d '{ 
  "model": "core.nomic-embed-text", 
  "input": "Open WebUI is great!"
}'
{"detail":"Model 'core.nomic-embed-text' was not found"}
```
```
curl -X POST -H "Authorization: Bearer sk-XXXX"  https://<HOSTNAME>/ollama/api/embed  -H "Content-Type: application/json" -d '{ 
  "model": "nomic-embed-text", 
  "input": "Open WebUI is great!"
}'
{"detail":"Model 'nomic-embed-text' was not found"}
```
```
curl -X POST -H "Authorization: Bearer sk-XXXX"  https://<HOSTNAME>/ollama/api/embed  -H "Content-Type: application/json" -d '{ 
  "model": "nomic-embed-text:latest", 
  "input": "Open WebUI is great!"
}'
{"detail":"Model 'nomic-embed-text:latest' was not found"}
```
After fix (as espected):
```
{"model":"nomic-embed-text","embeddings":[[-0.056914695,0.055697914,-0.1549053,-0.026616162,0.010132302,-0.03156889,0.00016965349,-0.012336917,0.0021112112,-0.07384131,0.019110769,0.048019346,0.041930925,0.027216388,-0.016383044,0.009003179,0.018780736,-0.067011006,-0.019285623,0.013756446,-0.01285572,-0.07379771,-0.012819334,0.019181537,0.114253506,0.0057112966,0.04088333,0.03268042,-0.024382962,0.0585762,0.008934068,-0.049994517,0.051116314,0.05507051,0.003221777,0.01893821,-0.0118947355,0.0014483614,-0.0123463,0.05618913,0.029865736,0.029030195,0.026760288,0.013840339,0.10947936,-0.048409175,-0.031754445,-0.022992881,0.045067705,-0.057429984,-0.024520898,-0.013584407,-0.021527236,-0.053985447,0.053814285,-0.027198708,-0.008185125,0.036539022,0.0070639458,0.034402207,0.08216921,0.04927452,0.012235585,0.021080568,0.03712948,0.014681297,0.0018030705,0.031872086,0.03923008,-0.02753878,0.0064302958,0.041984323,-0.010618592,-0.042572115,-0.023071619,-0.031168649,-0.026930487,-0.09808477,-0.04119539,-0.03582752,0.024026835,-0.0137784835,0.03558127,-0.017903682,0.07147222,-0.089647256,0.03510574,0.07465515,......],"total_duration":816400613,"load_duration":589051063,"prompt_eval_count":6}
```

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]
