### PR TITLE
Fix: Robust Handling of LDAP Email Attribute Types

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -237,6 +237,8 @@ async def ldap_auth(request: Request, response: Response, form_data: LdapForm):
             email = email.lower()
         elif isinstance(email, list):
             email = email[0].lower()
+        else:
+            email = str(email).lower()
 
         cn = str(entry["cn"])
         user_dn = entry.entry_dn


### PR DESCRIPTION
Previously, the code only handled str and list types for the LDAP email attribute. This caused login failures when the attribute was returned as a different type (e.g., a custom LDAP object).

Old code fails with:
```
email = entry["mail"]
# email = Attribute("mail", ["user@example.com"]) → not str or list
email.lower()  # ❌ Attribute has no .lower()
```
New code fixes this:
```
email = entry["mail"].value
if not email:
    raise HTTPException(...)
elif isinstance(email, str):
    email = email.lower()
elif isinstance(email, list):
    email = email[0].lower()
else:
    email = str(email).lower()  # ✅ Fallback for unknown types
```
This makes login more robust across different LDAP setups and prevents edge case failures.