### PR TITLE
FIX: Error on Ollama Connections Prefixing

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -349,7 +349,7 @@ async def get_all_models(request: Request, user: UserModel = None):
 
                 if prefix_id:
                     for model in response.get("models", []):
-                        model["model"] = f"{prefix_id}.{model['model']}"
+                        model["name"] = f"{prefix_id}.{model['model']}"
 
                 if tags:
                     for model in response.get("models", []):


### PR DESCRIPTION
After review address by PR https://github.com/open-webui/open-webui/pull/12823

I detected an error on prefixing code,

As it is, what is prefixed in function is modelID not model name, that cause an incorrect access to model  and a incomplete model name showed on list.

AS i commented on referenced PR:
I was testing and I think that the problem is on:
https://github.com/open-webui/open-webui/blob/aca37f592d0dedea2529fcb4304e4ff39e0c1219/backend/open_webui/routers/ollama.py#L352

**It add prefix to model ID, not to model name, causing that prefixed name isn't showed and a wrong sent if used this list.**

The correct have to be:

```
model["name"] = f"{prefix_id}.{model['model']}"
```

...................................................

test It with 2 ollamas connections, one on server and second in other computer prefixed as "hp" with just one model ("qwen2:0.5b")

as it is, we have this output:
(2 ollama connections, idx=0 & idx=1, prefixed 1 as 'hp')

```
16:21:44.556 | INFO     | open_webui.routers.ollama:get_all_models:306 - idx:0 url:http://127.0.0.1:11434 - {}
16:21:44.557 | INFO     | open_webui.routers.ollama:get_all_models:320 - api_config: {'enable': True, 'tags': [], 'prefix_id': '', 'model_ids': [], 'key': ''} - {}
16:21:44.558 | INFO     | open_webui.routers.ollama:get_all_models:306 - idx:1 url:http://192.168.1.20:11434 - {}
16:21:44.559 | INFO     | open_webui.routers.ollama:get_all_models:320 - api_config: {'enable': True, 'tags': [], 'prefix_id': 'hp', 'model_ids': [], 'key': 'ollama'} - {}
ollama[501618]: 16:21:44 | 200 |   11.031368ms |       127.0.0.1 | GET      "/api/tags"
16:21:44.575 | INFO     | open_webui.routers.ollama:get_all_models:336 - idx:0 response:{'models': [{'name': 'cogito:14b', 'model': 'cogito:14b', 'modified_at': '2025-04-09T04:55:20.969488279+02:00', 'size': 8985291236, 'digest': 'd0cac86a23474d1ed5c455a667879c8fbaf160440f7433e738eab814ae3316e0', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '14.8B', 'quantization_level': 'Q4_K_M'}}, {'name': 'cogito:8b', 'model': 'cogito:8b', 'modified_at': '2025-04-09T01:01:45.229132397+02:00', 'size': 4920747948, 'digest': '75b508ddece134205c621b91237310024ca983027fb7f724c2032d106419bd1b', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_K_M'}}, {'name': 'minicpm-v:latest', 'model': 'minicpm-v:latest', 'modified_at': '2025-03-16T13:12:54.021115592+01:00', 'size': 5473838466, 'digest': 'c92bfad0120556eda311984f1ac2f0d0a589b8d68c4053c13486b526276aa205', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2', 'clip'], 'parameter_size': '7.6B', 'quantization_level': 'Q4_0'}}, {'name': 'gemma3:4b', 'model': 'gemma3:4b', 'modified_at': '2025-03-14T03:48:53.277178929+01:00', 'size': 3338801718, 'digest': 'c0494fe00251c4fc844e6a1801f9cbd26c37441d034af3cb9284402f7e91989d', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'gemma3', 'families': ['gemma3'], 'parameter_size': '4.3B', 'quantization_level': 'Q4_K_M'}}, {'name': 'gemma3:12b', 'model': 'gemma3:12b', 'modified_at': '2025-03-13T00:01:43.501312653+01:00', 'size': 8149190199, 'digest': '6fd036cefda5093cc827b6c16be5e447f23857d4a472ce0bdba0720573d4dcd9', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'gemma3', 'families': ['gemma3'], 'parameter_size': '12.2B', 'quantization_level': 'Q4_K_M'}}, {'name': 'phi4-mini:latest', 'model': 'phi4-mini:latest', 'modified_at': '2025-03-12T08:37:57.465072423+01:00', 'size': 2491876774, 'digest': '78fad5d182a7c33065e153a5f8ba210754207ba9d91973f57dffa7f487363753', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'phi3', 'families': ['phi3'], 'parameter_size': '3.8B', 'quantization_level': 'Q4_K_M'}}, {'name': 'granite3.2-vision:latest', 'model': 'granite3.2-vision:latest', 'modified_at': '2025-03-12T03:13:55.713192088+01:00', 'size': 2437852465, 'digest': '3be41a661804ad72cd08269816c5a145f1df6479ad07e2b3a7e29dba575d2669', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'granite', 'families': ['granite', 'clip'], 'parameter_size': '2.5B', 'quantization_level': 'Q4_K_M'}}, {'name': 'MFDoom/deepseek-r1-tool-calling:8b', 'model': 'MFDoom/deepseek-r1-tool-calling:8b', 'modified_at': '2025-03-11T00:47:28.013071303+01:00', 'size': 4920739742, 'digest': '3aa3d24e7e624d24402e00afb506d42c9cc3cc86f8df8cd8f937fb474205bbb8', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_K_M'}}, {'name': 'lucianotonet/llamaclaude:latest', 'model': 'lucianotonet/llamaclaude:latest', 'modified_at': '2025-03-11T00:43:16.610052227+01:00', 'size': 4661228600, 'digest': 'e262810ccf99b418664ebcc14f3fc29cccc3726ec98f3cbb334bbcb260e4d794', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_0'}}, {'name': 'llama3-groq-tool-use:latest', 'model': 'llama3-groq-tool-use:latest', 'modified_at': '2025-03-10T11:52:14.799652476+01:00', 'size': 4661257688, 'digest': '36211dad2b153f09fe2b0c5f3e4e82ee83d27db68e3a00006cd934dfdc5057a4', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_0'}}, {'name': 'llama3.2-vision:latest', 'model': 'llama3.2-vision:latest', 'modified_at': '2025-02-23T03:19:27.420317782+01:00', 'size': 7901829417, 'digest': '085a1fdae525a3804ac95416b38498099c241defd0f1efc71dcca7f63190ba3d', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'mllama', 'families': ['mllama', 'mllama'], 'parameter_size': '9.8B', 'quantization_level': 'Q4_K_M'}}, {'name': 'deepseek-r1:8b', 'model': 'deepseek-r1:8b', 'modified_at': '2025-02-19T19:38:27.024615596+01:00', 'size': 4920738407, 'digest': '28f8fd6cdc677661426adab9338ce3c013d7e69a5bea9e704b364171a5d61a10', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_K_M'}}, {'name': 'tazarov/all-minilm-l6-v2-f32:latest', 'model': 'tazarov/all-minilm-l6-v2-f32:latest', 'modified_at': '2025-02-19T13:09:51.591407169+01:00', 'size': 91017428, 'digest': '5828eca1915b4fe9cbc0cbb8f6215507801d5bee135ba3ac226f98e3bd123d31', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'bert', 'families': ['bert'], 'parameter_size': '23M', 'quantization_level': 'F32'}}, {'name': 'deepscaler:latest', 'model': 'deepscaler:latest', 'modified_at': '2025-02-15T00:46:07.436185065+01:00', 'size': 3560419491, 'digest': '0031bcf7459f9405e9ae68b522c3fb791ad64814eff25dbec007435d837977e6', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '1.8B', 'quantization_level': 'F16'}}, {'name': 'codegemma:2b', 'model': 'codegemma:2b', 'modified_at': '2025-01-10T15:06:47.756343233+01:00', 'size': 1551198417, 'digest': '926331004170f1c177e6185e8c7e6339bcc701cbda124ed4b235246191f38bff', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'gemma', 'families': ['gemma'], 'parameter_size': '3B', 'quantization_level': 'Q4_0'}}, {'name': 'granite-code:latest', 'model': 'granite-code:latest', 'modified_at': '2025-01-10T14:47:09.894318698+01:00', 'size': 1997354777, 'digest': 'becc94fe18760be2de6f1c8b0a5ce3656bcf1f3a6b8a2e48519098fa214a149b', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '3.5B', 'quantization_level': 'Q4_0'}}, {'name': 'all-minilm:latest', 'model': 'all-minilm:latest', 'modified_at': '2025-01-07T20:00:46.114354536+01:00', 'size': 45960996, 'digest': '1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'bert', 'families': ['bert'], 'parameter_size': '23M', 'quantization_level': 'F16'}}, {'name': 'moondream:latest', 'model': 'moondream:latest', 'modified_at': '2025-01-06T11:52:35.155708798+01:00', 'size': 1738451197, 'digest': '55fc3abd386771e5b5d1bbcc732f3c3f4df6e9f9f08f1131f9cc27ba2d1eec5b', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'phi2', 'families': ['phi2', 'clip'], 'parameter_size': '1B', 'quantization_level': 'Q4_0'}}, {'name': 'granite3.1-moe:3b', 'model': 'granite3.1-moe:3b', 'modified_at': '2025-01-04T17:49:50.503374845+01:00', 'size': 2016901724, 'digest': 'df6f6578dba8595a1d834879f9ade35413748595139c5b6554cd264078f02c58', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'granitemoe', 'families': ['granitemoe'], 'parameter_size': '3.3B', 'quantization_level': 'Q4_K_M'}}, {'name': 'llama3.2:latest', 'model': 'llama3.2:latest', 'modified_at': '2025-01-04T17:32:17.035276811+01:00', 'size': 2019393189, 'digest': 'a80c4f17acd55265feec403c7aef86be0c25983ab279d83f3bcd3abbcb5b8b72', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '3.2B', 'quantization_level': 'Q4_K_M'}}, {'name': 'smollm2:1.7b', 'model': 'smollm2:1.7b', 'modified_at': '2025-01-04T16:45:35.984016148+01:00', 'size': 1820428533, 'digest': 'cef4a1e09247f018ca0c482ad4c2ce1474aba5e87f245dacf97f07948d05d8b4', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '1.7B', 'quantization_level': 'Q8_0'}}, {'name': 'jina/jina-embeddings-v2-base-es:latest', 'model': 'jina/jina-embeddings-v2-base-es:latest', 'modified_at': '2025-01-04T15:53:44.368726585+01:00', 'size': 323014832, 'digest': '30eb9bfe76bc36e6630a1ac9f8586af8c4a672e3d9302cf191ce02a9e989546d', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'jina-bert-v2', 'families': ['jina-bert-v2'], 'parameter_size': '160.26M', 'quantization_level': 'F16'}}, {'name': 'openchat:latest', 'model': 'openchat:latest', 'modified_at': '2025-01-02T20:50:55.20462837+01:00', 'size': 4109876386, 'digest': '537a4e03b649d93bf57381199a85f412bfc35912e46db197407740230968e71f', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '7B', 'quantization_level': 'Q4_0'}}, {'name': 'llama3.1:latest', 'model': 'llama3.1:latest', 'modified_at': '2024-09-21T16:56:59.262273695+02:00', 'size': 4661230766, 'digest': '42182419e9508c30c4b1fe55015f06b65f4ca4b9e28a744be55008d21998a093', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '8.0B', 'quantization_level': 'Q4_0'}}, {'name': 'nemotron-mini:latest', 'model': 'nemotron-mini:latest', 'modified_at': '2024-09-21T14:11:59.360352421+02:00', 'size': 2697402546, 'digest': 'ed76ab18784f5a01c9ec5b3c250e964d4f9c7a983e59ba041bb995f0fe2e8fb3', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'nemotron', 'families': ['nemotron'], 'parameter_size': '4.2B', 'quantization_level': 'Q4_K_M'}}, {'name': 'qwen2.5:latest', 'model': 'qwen2.5:latest', 'modified_at': '2024-09-21T13:45:12.903202926+02:00', 'size': 4683087332, 'digest': '845dbda0ea48ed749caafd9e6037047aa19acfcfd82e704d7ca97d631a0b697e', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '7.6B', 'quantization_level': 'Q4_K_M'}}, {'name': 'qwen2.5:3b', 'model': 'qwen2.5:3b', 'modified_at': '2024-09-21T13:02:16.810963198+02:00', 'size': 1929912432, 'digest': '357c53fb659c5076de1d65ccb0b397446227b71a42be9d1603d46168015c9e4b', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '3.1B', 'quantization_level': 'Q4_K_M'}}, {'name': 'qwen2.5:0.5b', 'model': 'qwen2.5:0.5b', 'modified_at': '2024-09-21T12:51:06.665900835+02:00', 'size': 397821319, 'digest': 'a8b0c51577010a279d933d14c2a8ab4b268079d44c5c8830c0a93900f1827c67', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '494.03M', 'quantization_level': 'Q4_K_M'}}, {'name': 'qwen2.5:1.5b', 'model': 'qwen2.5:1.5b', 'modified_at': '2024-09-21T12:43:57.42486089+02:00', 'size': 986061892, 'digest': '65ec06548149b04c096a120e4a6da9d4017ea809c91734ea5631e89f96ddc57b', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '1.5B', 'quantization_level': 'Q4_K_M'}}, {'name': 'bge-m3:latest', 'model': 'bge-m3:latest', 'modified_at': '2024-09-21T12:35:19.432812687+02:00', 'size': 1157672605, 'digest': '7907646426070047a77226ac3e684fbbe8410524f7b4a74d02837e43f2146bab', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'bert', 'families': ['bert'], 'parameter_size': '566.70M', 'quantization_level': 'F16'}}, {'name': 'codegeex4:latest', 'model': 'codegeex4:latest', 'modified_at': '2024-09-21T12:15:29.910701991+02:00', 'size': 5455323291, 'digest': '867b8e81d03898ac2289d809edb718d67a6d706d6a644bb1a922ee1607c7e5ed', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'chatglm', 'families': ['chatglm'], 'parameter_size': '9.4B', 'quantization_level': 'Q4_0'}}, {'name': 'qwen2.5-coder:latest', 'model': 'qwen2.5-coder:latest', 'modified_at': '2024-09-21T11:34:38.235473841+02:00', 'size': 4683087590, 'digest': '87098ba7390d43e0f8d615776bc7c4372c9e568c436bc1933f93832f9cf09b84', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '7.6B', 'quantization_level': 'Q4_K_M'}}, {'name': 'stablelm2:latest', 'model': 'stablelm2:latest', 'modified_at': '2024-09-21T10:57:47.315268095+02:00', 'size': 982790462, 'digest': '714a6116cffa8b415b52c62a7a2d09ba6227ed733baa0025c937a36aee5504f3', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'stablelm', 'families': ['stablelm'], 'parameter_size': '2B', 'quantization_level': 'Q4_0'}}, {'name': 'llava-phi3:latest', 'model': 'llava-phi3:latest', 'modified_at': '2024-09-21T09:14:43.196692608+02:00', 'size': 2926568956, 'digest': 'c7edd7b8759394f9995a9394b97a29aeff7ee9c921054a210347326287d300f2', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama', 'clip'], 'parameter_size': '4B', 'quantization_level': 'Q4_K_M'}}, {'name': 'mathstral:latest', 'model': 'mathstral:latest', 'modified_at': '2024-09-21T05:21:02.63338787+02:00', 'size': 4113300723, 'digest': '4ee7052be55a6db85ac0739b7c5b4c219e97a6b27f9976518f404d3ded1b0704', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '7.2B', 'quantization_level': 'Q4_0'}}, {'name': 'reader-lm:latest', 'model': 'reader-lm:latest', 'modified_at': '2024-09-21T04:51:34.310223312+02:00', 'size': 934966934, 'digest': '33da2b9e0afe889906c8cd52bd8957e5bd56747b6b7787206f170bbd5184092a', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '1.5B', 'quantization_level': 'Q4_0'}}, {'name': 'nuextract:latest', 'model': 'nuextract:latest', 'modified_at': '2024-09-21T04:45:08.238187384+02:00', 'size': 2176188345, 'digest': '233ce1dee972b5f9fe5a874e8f6d14da3d8429a672ee7f0c364df38aa322d229', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'phi3', 'families': ['phi3'], 'parameter_size': '3.8B', 'quantization_level': 'Q4_0'}}, {'name': 'smollm:latest', 'model': 'smollm:latest', 'modified_at': '2024-09-21T04:21:10.359053577+02:00', 'size': 990741362, 'digest': '95f6557a0f0f1e1d08ba0d426e50de0927dd2b0861a384b193802c551b298c28', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'llama', 'families': ['llama'], 'parameter_size': '1.7B', 'quantization_level': 'Q4_0'}}, {'name': 'phi3.5:latest', 'model': 'phi3.5:latest', 'modified_at': '2024-09-21T04:03:09.008952948+02:00', 'size': 2176178843, 'digest': '61819fb370a3c1a9be6694869331e5f85f867a079e9271d66cb223acb81d04ba', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'phi3', 'families': ['phi3'], 'parameter_size': '3.8B', 'quantization_level': 'Q4_0'}}, {'name': 'gemma2:2b', 'model': 'gemma2:2b', 'modified_at': '2024-09-19T22:36:39.433089677+02:00', 'size': 1629518495, 'digest': '8ccf136fdd5298f3ffe2d69862750ea7fb56555fa4d5b18c04e3fa4d82ee09d7', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'gemma2', 'families': ['gemma2'], 'parameter_size': '2.6B', 'quantization_level': 'Q4_0'}}]} - {}
16:21:44.576 | INFO     | open_webui.routers.ollama:get_all_models:336 - idx:1 response:{'models': [{'name': 'qwen2:0.5b', 'model': 'qwen2:0.5b', 'modified_at': '2024-06-11T13:54:32.569547159+02:00', 'size': 352164041, 'digest': '6f48b936a09f7743c7dd30e72fdb14cba296bc5861902e4d0c387e8fb5050b39', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '494.03M', 'quantization_level': 'Q4_0'}}]} - {}
16:21:44.577 | INFO     | open_webui.routers.ollama:get_all_models:360 - model:{**'name': 'qwen2:0.5b', 'model': 'hp.qwen2:0.5b'**, 'modified_at': '2024-06-11T13:54:32.569547159+02:00', 'size': 352164041, 'digest': '6f48b936a09f7743c7dd30e72fdb14cba296bc5861902e4d0c387e8fb5050b39', 'details': {'parent_model': '', 'format': 'gguf', 'family': 'qwen2', 'families': ['qwen2'], 'parameter_size': '494.03M', 'quantization_level': 'Q4_0'}} - {}
16:21:44.577 | DEBUG    | aiocache.base:set:280 - SET open_webui.routers.ollamaget_all_models(<starlette.requests.Request object at 0x7516f2b9e300>,)[('user', UserModel(id='4ed44e79-97d7-4152-bf26-694cece387df', name='ricardo', email='rgaricano@gmail.com', role='admin', profile_image_url='/user.png', last_active_at=1744640504, updated_at=1744129456, created_at=1744129456, api_key=None, settings=UserSettings(ui={'version': '0.6.4', 'params': {}, 'backgroundImageUrl': 'data:image/jpeg;base64,/9j/...2Q==', 'models': ['cogito:14b'], 'imageCompressionSize': {'width': '', 'height': ''}, 'notifications': {'webhook_url': ''}, 'title': {'auto': False}, 'autoTags': False}), info=None, oauth_sub=None))] 1 (0.0000)s - {}
16:21:44.592 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 79.116.30.143:0 - "GET /api/models/base HTTP/1.1" 200 - {}
```

Remark:
```
open_webui.routers.ollama:get_all_models:336 - idx:1 response:{'models': [{'name': 'qwen2:0.5b', 'model': 'qwen2:0.5b'
```
after prefixed:
```
open_webui.routers.ollama:get_all_models:360 - model:{**'name': 'qwen2:0.5b', 'model': 'hp.qwen2:0.5b'**,
```

After fixing we have the correct output after prefixed:
```
open_webui.routers.ollama:get_all_models:360 - model:{'name': 'hp.qwen2:0.5b', 'model': 'qwen2:0.5b',
```

and in screen, before:
![openwebui_ollama_fix](https://github.com/user-attachments/assets/5b9d6b65-44ff-47b5-a1c2-2eaf618be697)

now appear name and modelID correctly:

![openwebui_ollama_fix1](https://github.com/user-attachments/assets/90036e69-c622-499c-9edd-f4af4f5c70e2)

And successfull response throght /ollama/api/embed API call

![openwebui_ollama_fix2](https://github.com/user-attachments/assets/c188af7f-6121-4991-9102-862d00336584)
cafba7286
