### PR TITLE
fix: UVICORN_WORKERS __init__.py pass application as string

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -76,7 +76,7 @@ def serve(
     from open_webui.env import UVICORN_WORKERS  # Import the workers setting
 
     uvicorn.run(
-        open_webui.main.app,
+        "open_webui.main:app",
         host=host,
         port=port,
         forwarded_allow_ips="*",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

# Changelog Entry

### Description

- If UVICORN_WORKERS aren't used, Open WebUI works as intended.
- If UVICORN_WORKERS is set to a higher value than 1, Uvicorn will throw a warning, that the application must be passed as a string

### Changed

- Changed the application to be passed as a string

---

### Additional Information

- I also tested if Open WebUI still starts if **no workers are passed** (aka only 1 worker) and the application is passed as a string: yes Open WebUI still starts. So by changing this into a string will work for all cases (only 1 worker or multiple workers)

Tested on pip venv python3.11 + python 3.12

