### PR TITLE
Fix: Remove own vector collection from knowledges

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -490,7 +490,7 @@ def get_sources_from_files(
                 if file.get("legacy"):
                     collection_names = file.get("collection_names", [])
                 else:
-                    file_ids = file.get("data", []).get("file_ids", [])
+                    file_ids = (file.get("data") or {}).get("file_ids", [])
                     file_ids = [f"file-{file_id}" for file_id in file_ids]
                     collection_names.extend(file_ids)
             elif file.get("collection_name"):

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -490,7 +490,9 @@ def get_sources_from_files(
                 if file.get("legacy"):
                     collection_names = file.get("collection_names", [])
                 else:
-                    collection_names.append(file["id"])
+                    file_ids = file.get("data", []).get("file_ids", [])
+                    file_ids = [f"file-{file_id}" for file_id in file_ids]
+                    collection_names.extend(file_ids)
             elif file.get("collection_name"):
                 collection_names.append(file["collection_name"])
             elif file.get("id"):

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -494,7 +494,7 @@ def remove_file_from_knowledge_by_id(
     for knowledge_ in knowledges:
         if knowledge_.id == knowledge.id:
             continue  # skip the own knowledge base
-        files_ids = (knowledge_.data or {}).get("files_ids", [])
+        files_ids = (knowledge_.data or {}).get("file_ids", [])
         if form_data.file_id in files_ids:
             file_in_other_knowledges = True
             break
@@ -601,13 +601,13 @@ async def delete_knowledge_by_id(id: str, user=Depends(get_verified_user)):
                 Models.update_model_by_id(model.id, model_form)
 
     # Find files in other knowledges
-    if current_files_ids := set((knowledge.data or {}).get("files_ids", [])):
+    if current_files_ids := set((knowledge.data or {}).get("file_ids", [])):
         knowledges = Knowledges.get_knowledge_bases()
         other_file_ids = set()
         for knowledge_ in knowledges:
             if knowledge_.id == knowledge.id:
                 continue  # skip the current knowledge
-            other_file_ids.update(set((knowledge_.data or {}).get("files_ids", [])))
+            other_file_ids.update(set((knowledge_.data or {}).get("file_ids", [])))
 
         # Delete only the files which are not present in other knowledges
         files_ids_to_delete = current_files_ids.difference(other_file_ids)
@@ -656,13 +656,13 @@ async def reset_knowledge_by_id(id: str, user=Depends(get_verified_user)):
         )
 
     # Find files in other knowledges
-    if current_files_ids := set((knowledge.data or {}).get("files_ids", [])):
+    if current_files_ids := set((knowledge.data or {}).get("file_ids", [])):
         knowledges = Knowledges.get_knowledge_bases()
         other_file_ids = set()
         for knowledge_ in knowledges:
             if knowledge_.id == knowledge.id:
                 continue  # skip the current knowledge
-            other_file_ids.update(set((knowledge_.data or {}).get("files_ids", [])))
+            other_file_ids.update(set((knowledge_.data or {}).get("file_ids", [])))
 
         # Delete only the files which are not present in other knowledges
         files_ids_to_delete = current_files_ids.difference(other_file_ids)

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -354,19 +354,6 @@ def add_file_to_knowledge_by_id(
             detail=ERROR_MESSAGES.FILE_NOT_PROCESSED,
         )
 
-    # Add content to the vector database
-    try:
-        process_file(
-            request,
-            ProcessFileForm(file_id=form_data.file_id, collection_name=id),
-            user=user,
-        )
-    except Exception as e:
-        log.debug(e)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        )
 
     if knowledge:
         data = knowledge.data or {}

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -358,8 +358,10 @@ def add_file_to_knowledge_by_id(
     if knowledge:
         data = knowledge.data or {}
         file_ids = data.get("file_ids", [])
+        files = Files.get_files_by_ids(file_ids)
+        file_hashes = {file.hash for file in files if file.hash}
 
-        if form_data.file_id not in file_ids:
+        if (form_data.file_id not in file_ids) and (file.hash not in file_hashes):
             file_ids.append(form_data.file_id)
             data["file_ids"] = file_ids
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Removed the file processing step from "adding file to knowledge" as it led to a second entry in the vector db 
- Removed knowledges own vector collection

### Changed

- Knowledges now have no own vector "collection"

### Fixed

- Removed doubled file processing when added file to knowledge

---

### Additional Information

- **Before the fix** the process of "adding a file to a knowledge through the UI" was as followed:
file upload -> add to knowledge
#### file upload:
- file is uploaded into the "uploads" directory
- file is added to the "file" table in the `webui.db` database
- **file content is chunked and added to the vector_db with the collection name "file-{id}"**

#### add to knowledge
- file is checked if it is in `file` table of `webui.db`
- **file content is chunked and added to the vector db with the collection name "{knowledge-id}" (added to all other vectors in this collection)**
- file id is added to the knowledge entry

The problem is marked in bold. The file is added two times to the vector db, and the first vector entry "file-{id}" is never used again because each knowledge manages its own vector data on top of each file and the vector data of "{knowledge-id}" is used. This leads to bloat in the vector db and orphaned collections. This PR fixes that as the knowledge now uses the correct "file-{id}" vector entries that are created at file upload.

Two potentially negative points arise from that:
- Befor the PR, there was one (huge) call to the vector db, as the vector knowledge entry held every document in one collection. This is now split into a "retrieve-and-rerank" step for each file, which could be a bit slower
- If you now try to add an unprocessed file to the knowledge, the adding fails. Before that, the knowledge processed the file itself anyway. I see this as an absolute corner case, as one has to explicitly call the file upload API endpoint with "process=False" and I don't see the point in adding unprocessed files. The case that the file is not found in the `file` table is already covered.

Edit: I've so far reworked the knowledges handling of vector collections. The logic is that only files should have an entry in the vector db, and knowledges should only be a collection of files (not vector "collection" here). If a file is added to multiple knowledges with the API, a knowledge checks if that file is used in any other knowledge on deletion  (in the UI, each upload is a separate file with its own UUID, so this is already a corner case).