### PR TITLE
fix: Optional content from files routes

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -51,7 +51,9 @@ class QdrantClient:
         self.client.create_collection(
             collection_name=collection_name_with_prefix,
             vectors_config=models.VectorParams(
-                size=dimension, distance=models.Distance.COSINE, on_disk=self.QDRANT_ON_DISK
+                size=dimension,
+                distance=models.Distance.COSINE,
+                on_disk=self.QDRANT_ON_DISK,
             ),
         )
 

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -173,7 +173,8 @@ async def list_files(user=Depends(get_verified_user), content: bool = Query(True
 
     if not content:
         for file in files:
-            del file.data["content"]
+            if "content" in file.data:
+                del file.data["content"]
 
     return files
 
@@ -214,7 +215,8 @@ async def search_files(
 
     if not content:
         for file in matching_files:
-            del file.data["content"]
+            if "content" in file.data:
+                del file.data["content"]
 
     return matching_files
 


### PR DESCRIPTION
### Description

- Check if "content" is present in `File.data` before removing key.

Fixes #12893