### PR TITLE
fix: Align backend <source> tag indexing with frontend citation grouping

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -888,16 +888,20 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # If context is not empty, insert it into the messages
     if len(sources) > 0:
         context_string = ""
-        citated_file_idx = {}
-        for _, source in enumerate(sources, 1):
+        citation_idx = {}
+        for source in sources:
             if "document" in source:
                 for doc_context, doc_meta in zip(
                     source["document"], source["metadata"]
                 ):
-                    file_id = doc_meta.get("file_id")
-                    if file_id not in citated_file_idx:
-                        citated_file_idx[file_id] = len(citated_file_idx) + 1
-                    context_string += f'<source id="{citated_file_idx[file_id]}">{doc_context}</source>\n'
+                    citation_id = (
+                        doc_meta.get("source", None)
+                        or source.get("source", {}).get("id", None)
+                        or "N/A"
+                    )
+                    if citation_id not in citation_idx:
+                        citation_idx[citation_id] = len(citation_idx) + 1
+                    context_string += f'<source id="{citation_idx[citation_id]}">{doc_context}</source>\n'
 
         context_string = context_string.strip()
         prompt = get_last_user_message(form_data["messages"])

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -83,6 +83,7 @@
 			});
 			return acc;
 		}, []);
+		console.log('citations', citations);
 
 		showRelevance = calculateShowRelevance(citations);
 		showPercentage = shouldShowPercentage(citations);


### PR DESCRIPTION
### Related Issue and PR:

#12811 #12562

### Problem

The current backend logic for generating citation indexes within `<source>` tags in the context string, leads to inconsistencies with how the frontend groups and display citations:

1. **Web Search Results:** Web search results lack a `file_id` in their metadata. The original code used `file_id` as the key for indexing, causing all web results (where `file_id` is `None`) to map to the same index, even though they represent distinct sources. This directly causes issue #12811
2. **Frontend Grouping Mismatch:** Sources that the frontend treats as a single citation group (e.g., potentially multiple uploads of files with the same name, or multiple chunks from the same logical source) could be assigned different sequential indices by the backend based on their distinct `file_id`. This results in generated text like `[1][2][3]` where the frontend might only display clickable citations for `[1][2]`, leaving subsequent numbers as plain text because they refer to indices not uniquely represented in the frontend's grouped view.

### Root Cause

The backend used an internal identifier (`file_id`) to create unique sequential indices for *each document chunk*. However, the frontend aggregates citation sources based on a different logic: `metadata?.source ?? source?.source?.id ?? 'N/A'`. 

https://github.com/open-webui/open-webui/blob/c5636ff68c4e9ca095cd6458cc740f4a3aa53831/src/lib/components/chat/Messages/Citations.svelte#L47-L57

This mismatch causes the mapping between the backend-generated `<source id="...">` tags and the frontend's citation display to break.

### Solution

This PR modifies the backend context generation logic to use the **exact same identifier logic as the frontend** for creating the citation indices within the `<source>` tags.

Specifically, the identifier used to group sources and assign the `id` attribute in `<source id="{index}">` is now calculated using:
`doc_meta.get("source", None) or source.get("source", {}).get("id", None) or "N/A"`

This ensures that:
- Each unique logical citation source (as identified by the frontend logic) gets a single, consistent index number.
- Documents belonging to the same logical citation group (e.g., multiple web results grouped under one citation, or multiple chunks from the same file) will now correctly share the same `<source id="...">` index in the backend-generated context.
- The indices (`[1]`, `[2]`, etc.) referenced in the model's generation will directly correspond to the citation blocks rendered by the frontend.

This alignment will hopefully ensure citation references function correctly.