### PR TITLE
i18n: Update ko-KR (Korean) translation.json

### DIFF
--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -128,7 +128,7 @@
 	"Available list": "가능한 목록",
 	"Available Tools": "",
 	"available!": "사용 가능!",
-	"Awful": "끔찍함",
+	"Awful": "형편없음",
 	"Azure AI Speech": "Azure AI 음성",
 	"Azure Region": "Azure 지역",
 	"Back": "뒤로가기",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** See below
- [x] **Changelog:** Yes
- [x] **Code review:**  I did a self-review based on other existing keys in the same file.
- [x] **Prefix:** yes, used i18n

# Changelog Entry

### Description

In the Korean translation file, I noticed that the word "끔찍함", used to represent the lower bound of a rating scale (opposite of "fantastic"), felt overly emotional and somewhat informal for the context in which it's being used.

To improve clarity and maintain a more neutral and professional tone, I replaced "끔찍함" with "형편없음", which still conveys a strong negative sentiment but in a more appropriate and formal manner.

This small adjustment helps ensure consistency in tone across the UI and aligns better with other descriptors used in the same file. No functional changes were made, only the label string was updated.