### PR TITLE
feat: Add support for configuring FastAPI/AnyIO Thread Pool

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1204,7 +1204,7 @@ ENABLE_USER_WEBHOOKS = PersistentConfig(
 )
 
 # FastAPI / AnyIO settings
-THREAD_POOL_SIZE = int(os.getenv("THREAD_POOL_SIZE", "64"))
+THREAD_POOL_SIZE = int(os.getenv("THREAD_POOL_SIZE", "0"))
 
 
 def validate_cors_origins(origins):

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1203,6 +1203,9 @@ ENABLE_USER_WEBHOOKS = PersistentConfig(
     os.environ.get("ENABLE_USER_WEBHOOKS", "True").lower() == "true",
 )
 
+# FastAPI / AnyIO settings
+THREAD_POOL_SIZE = int(os.getenv("THREAD_POOL_SIZE", "64"))
+
 
 def validate_cors_origins(origins):
     for origin in origins:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -11,8 +11,7 @@ import random
 
 from contextlib import asynccontextmanager
 from urllib.parse import urlencode, parse_qs, urlparse
-import anyio
-import anyio.to_thread
+from anyio import to_thread
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -440,7 +439,7 @@ async def lifespan(app: FastAPI):
 
     pool_size = THREAD_POOL_SIZE
     if pool_size and pool_size > 0:
-        anyio.to_thread.current_default_thread_limiter().total_tokens = pool_size
+        to_thread.current_default_thread_limiter().total_tokens = pool_size
 
     asyncio.create_task(periodic_usage_pool_cleanup())
     yield

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -11,13 +11,13 @@ import random
 
 from contextlib import asynccontextmanager
 from urllib.parse import urlencode, parse_qs, urlparse
-from anyio import to_thread
 from pydantic import BaseModel
 from sqlalchemy import text
 
 from typing import Optional
 from aiocache import cached
 import aiohttp
+import anyio.to_thread
 import requests
 
 
@@ -439,7 +439,8 @@ async def lifespan(app: FastAPI):
 
     pool_size = THREAD_POOL_SIZE
     if pool_size and pool_size > 0:
-        to_thread.current_default_thread_limiter().total_tokens = pool_size
+        limiter = anyio.to_thread.current_default_thread_limiter()
+        limiter.total_tokens = pool_size
 
     asyncio.create_task(periodic_usage_pool_cleanup())
     yield

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -11,6 +11,8 @@ import random
 
 from contextlib import asynccontextmanager
 from urllib.parse import urlencode, parse_qs, urlparse
+import anyio
+import anyio.to_thread
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -106,6 +108,8 @@ from open_webui.config import (
     OPENAI_API_CONFIGS,
     # Direct Connections
     ENABLE_DIRECT_CONNECTIONS,
+    # Thread pool size for FastAPI/AnyIO
+    THREAD_POOL_SIZE,
     # Tool Server Configs
     TOOL_SERVER_CONNECTIONS,
     # Code Execution
@@ -433,6 +437,10 @@ async def lifespan(app: FastAPI):
 
     if LICENSE_KEY:
         get_license_data(app, LICENSE_KEY)
+
+    pool_size = THREAD_POOL_SIZE
+    if pool_size and pool_size > 0:
+        anyio.to_thread.current_default_thread_limiter().total_tokens = pool_size
 
     asyncio.create_task(periodic_usage_pool_cleanup())
     yield

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -742,5 +742,6 @@ def add_files_to_knowledge_batch(
         )
 
     return KnowledgeFilesResponse(
-        **knowledge.model_dump(), files=Files.get_file_metadatas_by_ids(existing_file_ids)
+        **knowledge.model_dump(),
+        files=Files.get_file_metadatas_by_ids(existing_file_ids),
     )

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -298,8 +298,10 @@ async def update_user_by_id(
             )
     except Exception as e:
         log.error(f"Error checking primary admin status: {e}")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not verify primary admin status.")
-
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not verify primary admin status.",
+        )
 
     user = Users.get_user_by_id(user_id)
 
@@ -341,7 +343,6 @@ async def update_user_by_id(
     )
 
 
-
 ############################
 # DeleteUserById
 ############################
@@ -359,7 +360,10 @@ async def delete_user_by_id(user_id: str, user=Depends(get_admin_user)):
             )
     except Exception as e:
         log.error(f"Error checking primary admin status: {e}")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not verify primary admin status.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not verify primary admin status.",
+        )
 
     if user.id != user_id:
         result = Auths.delete_auth_by_id(user_id)


### PR DESCRIPTION
### Description

- FastAPI uses AnyIO which by default has a limit of `40` threads for the whole application. These threads are used by any non-async or threaded function. This PR adds support for configuring this value via `ENV`, ~it also bumps the default value to 64 threads.~
- This should help the server from getting blocked when handling web-searches or any other `non-async` calls.

Implementation Source: https://github.com/Kludex/fastapi-tips#2-be-careful-with-non-async-functions
AnyIO Docs: https://www.starlette.io/threadpool/#concurrency-limitations

Related: https://github.com/open-webui/open-webui/pull/12958


