### PR TITLE
perf: Asynchronous `process_chat_payload` in chat completion

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1188,9 +1188,7 @@ async def chat_completion(
                 await event_emitter(
                     {
                         "type": "task-cancelled",
-                        "data": {
-                            "error": str(e),
-                        },
+                        "data": {"error": str(e)},
                     }
                 )
             raise HTTPException(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2240,7 +2240,9 @@ async def process_chat_response(
                 await background_tasks_handler()
             except asyncio.CancelledError:
                 log.warning("Task was cancelled!")
-                await event_emitter({"type": "task-cancelled"})
+                await event_emitter(
+                    {"type": "task-cancelled", "data": {"error": "Task was cancelled."}}
+                )
 
                 if not ENABLE_REALTIME_CHAT_SAVE:
                     # Save message in the database

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2255,11 +2255,7 @@ async def process_chat_response(
             if response.background is not None:
                 await response.background()
 
-        # background_tasks.add_task(post_response_handler, response, events)
-        task_id, _ = create_task(
-            post_response_handler(response, events), id=metadata["chat_id"]
-        )
-        return {"status": True, "task_id": task_id}
+        return await post_response_handler(response, events)
 
     else:
         # Fallback to the original response

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2241,7 +2241,7 @@ async def process_chat_response(
             except asyncio.CancelledError:
                 log.warning("Task was cancelled!")
                 await event_emitter(
-                    {"type": "task-cancelled", "data": {"error": "Task was cancelled."}}
+                    {"type": "task-cancelled", "data": {"error": ""}},
                 )
 
                 if not ENABLE_REALTIME_CHAT_SAVE:

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -350,6 +350,14 @@
 					eventConfirmationMessage = data.message;
 					eventConfirmationInputPlaceholder = data.placeholder;
 					eventConfirmationInputValue = data?.value ?? '';
+				} else if (type === 'task-cancelled') {
+					const taskCancelledError = data?.error ?? '';
+					if (taskCancelledError) {
+						toast.error(taskCancelledError);
+						message.error = { content: taskCancelledError };
+					}
+					message.done = true;
+					taskIds = null;
 				} else {
 					console.log('Unknown message type', data);
 				}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -357,7 +357,12 @@
 						message.error = { content: taskCancelledError };
 					}
 					message.done = true;
-					taskIds = null;
+					const taskRes = await getTaskIdsByChatId(localStorage.token, $chatId).catch((error) => {
+						return null;
+					});
+					if (taskRes) {
+						taskIds = taskRes.task_ids;
+					}
 				} else {
 					console.log('Unknown message type', data);
 				}


### PR DESCRIPTION
### Problem Description

The complete problem description is detailed in #13027.

For short, when using the `/api/chat/completions` endpoint asynchronously (typically from browser Web UI), the server should return a `task_id` immediately so the UI can track process and allow early cancellation.

However, if features like Web Search or Tools are enabled, the server waits for this preprocessing (`process_chat_payload`) to finish **before** returning `task_id`, leading two main issues:

1. **Delayed Cancellation**: Users cannot stop the request during the long preprocessing phase because UI doesn't have the `task_id` yet.
2. **Network Timeouts**: Long wait of this endpoint increase the chance of requests failing due to network timeouts, _commonly_ when using reverse proxies or intranet penetrations.

![Image](https://github.com/user-attachments/assets/e89c46a1-b4d5-428e-9f78-6009369a5d6a)

### Solution

This PR changes the behavior for asynchronous requests:

1. Check if the request is async (`event_emitter` and `event_caller` exists) at the very beginning of the chat completion handler.
2. If it *is* an async request:
    - Immediately create a background task that handle *both* `process_chat_payload` and `process_chat_response`
    - Return the `task_id` to the client right away.
3. If it *is not* a streaming request:
    - Keep the original behavior: process everything synchronously and return the StreamingResponse

![image](https://github.com/user-attachments/assets/6145000a-f01e-41bf-816f-da1c753588c1)

### Error handling

I extended the previously unhandled `task-cancelled` event. This event can be triggered by either `asyncio.CancelledError`, or when the `process_chat_payload_and_response` is running as a background job.

Formerly, when errors are encountered during `process_chat_payload` or `chat_completion_handler`, the `/api/chat/completions` endpoint would directly return the error message. Now that all the jobs are processed as a backend task, we must use WebSocket events to tell the browser about error details.

When the browser receives the `task-cancelled` event, it will mark `currentMessage.done = true` and re-fetch current taskIds, to ensure that the messages and the stop button behaves properly. This ensures the exact same user experience as the previous error handling logic, and robust error handling when chatting with multiple models.

### Additional Messages

I've tried my best to keep the original structure of codebase, make minimal changes, and ensure backward-compatibility.

### Tests

For sync requests, I used `curl` to test the chat completion endpoints, and they are behaving the same as original version:

```bash
curl -X POST "http://localhost:8080/api/chat/completions" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <my_token>" \
    -d '{
             "model": "deepseek-v3",
             "messages": [{
                   "role": "user",
                   "content": "hi"
              }],
              "stream": true
        }'
```

```bash
curl -X POST "http://localhost:8080/api/chat/completions" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <my_token>" \
    -d '{
             "model": "deepseek-v3",
             "messages": [{
                   "role": "user",
                   "content": "hi"
              }],
              "stream": false
        }'
```

For async requests, I tested the endpoint via browser Web UI. The endpoint returns with `task_id` very quickly and *before* the web search process ended. Upon receiving `task_id`, I am able to cancel the generation task at any time.

Error handling:
- [x] Error in `process_chat_payload` phase
- [x] Error in `process_chat_response` phase
- [x] `task-cancelled` error when user early stop a request
- [x] Stop button behavior when chatting with multiple models

![image](https://github.com/user-attachments/assets/533f77bf-0e5b-44c1-bb51-0b40a1f83c40)


More test cases / discussions are welcomed!

