### PR TITLE
fix: Web RAG empty content

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1557,19 +1557,24 @@ async def process_web_search(
             collection_names = []
             for doc_idx, doc in enumerate(docs):
                 if doc and doc.page_content:
-                    collection_name = f"web-search-{calculate_sha256_string(form_data.query + '-' + urls[doc_idx])}"[
-                        :63
-                    ]
+                    try:
+                        collection_name = f"web-search-{calculate_sha256_string(form_data.query + '-' + urls[doc_idx])}"[
+                            :63
+                        ]
 
-                    collection_names.append(collection_name)
-                    await run_in_threadpool(
-                        save_docs_to_vector_db,
-                        request,
-                        [doc],
-                        collection_name,
-                        overwrite=True,
-                        user=user,
-                    )
+                        collection_names.append(collection_name)
+                        await run_in_threadpool(
+                            save_docs_to_vector_db,
+                            request,
+                            [doc],
+                            collection_name,
+                            overwrite=True,
+                            user=user,
+                        )
+                    except Exception as e:
+                        log.error(
+                            f"Failed to save document {urls[doc_idx]}: {e}"
+                        )
 
             return {
                 "status": True,


### PR DESCRIPTION
### Related Issue and Commit
#12832 70718dda90af07370414dea28f9a93058623a33b

### Problem Description
After web pages are loaded, the backend proceeds to `save_doc_to_vector_db`. However, if one of the documents has an empty `page_content`, the `save_docs_to_vector_db` operation fails, subsequently causing the entire web search to fail. Commit 70718dda90af07370414dea28f9a93058623a33b partially addresses this issue by adding a check for empty `doc.page_content`.

However, there are cases where `doc.page_content` contains **only whitespace**, which also causes the `save_docs_to_vector_db` process to fail. This happens because `save_docs_to_vector_db` performs preprocessing on the `page_content`, including cleaning and splitting, which cannot handle whitespace-only content.

https://github.com/open-webui/open-webui/blob/70718dda90af07370414dea28f9a93058623a33b/backend/open_webui/routers/retrieval.py#L862-L863

### Proposed Solution
To ensure the web search process remains robust, we can wrap the `save_docs_to_vector_db` process in a try-catch block. This will handle potential errors gracefully, preventing them from failing the entire web search.
