### PR TITLE
add retrieval model optimizations

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -115,6 +115,7 @@ def get_ef(
             ef = SentenceTransformer(
                 get_model_path(embedding_model, auto_update),
                 device=DEVICE_TYPE,
+                model_kwargs={"torch_dtype": "float16"},
                 trust_remote_code=RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
             )
         except Exception as e:
@@ -148,6 +149,7 @@ def get_rf(
                 rf = sentence_transformers.CrossEncoder(
                     get_model_path(reranking_model, auto_update),
                     device=DEVICE_TYPE,
+                    automodel_args={"torch_dtype": "float16"},
                     trust_remote_code=RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
                 )
             except Exception as e:


### PR DESCRIPTION
Added retrieval model optimizations. `torch.cuda.empty_cache()` clears up any unnecessary memory occupied by pytorch after inference is complete. Models are loaded in FP16 because that's usually good enough but saves ram by 2x. 