### PR TITLE
enh: Enhance chat controls view, add active controls indicator 

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -139,7 +139,7 @@
 	let files = [];
 	let params = {};
 	let controlsActive = false;
-	// This will be bound from ChatControls
+	// Bound from ChatControls
 
 	$: if (chatIdProp) {
 		(async () => {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -138,6 +138,8 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let controlsActive = false;
+	// This will be bound from ChatControls
 
 	$: if (chatIdProp) {
 		(async () => {
@@ -1987,6 +1989,7 @@
 					bind:selectedModels
 					shareEnabled={!!history.currentId}
 					{initNewChat}
+					{controlsActive}
 				/>
 
 				<div class="flex flex-col flex-auto z-10 w-full @container">
@@ -2120,6 +2123,7 @@
 			<ChatControls
 				bind:this={controlPaneComponent}
 				bind:history
+				bind:controlsActive
 				bind:chatFiles
 				bind:params
 				bind:files

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -32,6 +32,7 @@
 
 	export let pane;
 
+	export let controlsActive = false; // Export this state
 	let mediaQuery;
 	let largeScreen = false;
 	let dragged = false;
@@ -190,6 +191,7 @@
 							{models}
 							bind:chatFiles
 							bind:params
+							bind:controlsActive
 						/>
 					{/if}
 				</div>
@@ -277,6 +279,7 @@
 								{models}
 								bind:chatFiles
 								bind:params
+								bind:controlsActive
 							/>
 						{/if}
 					</div>

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -86,14 +86,13 @@
 		// Select the container element you want to observe
 		const container = document.getElementById('chat-container');
 
-		// initialize the minSize based on the container width - make it smaller for better scaling
+		// initialize the minSize based on the container width
 		minSize = Math.floor((320 / container.clientWidth) * 100);
 
 		// Create a new ResizeObserver instance
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (let entry of entries) {
 				const width = entry.contentRect.width;
-				// calculate the percentage of 300px - smaller for better scaling
 				const percentage = Math.min((320 / width) * 100, 50); // Cap at 50% of screen width
 				// set the minSize to the percentage, must be an integer
 				minSize = Math.floor(percentage);

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -233,11 +233,11 @@
 			class="z-10 max-w-[50%]"
 		>
 			{#if $showControls}
-				<div class="flex max-h-full min-h-full">
+				<div class="flex h-full">
 					<div
-						class="max-w-[380px] {($showOverview || $showArtifacts) && !$showCallOverlay
+						class="flex-1 max-w-[380px] h-full overflow-y-auto {($showOverview || $showArtifacts) && !$showCallOverlay
 							? ' '
-							: 'px-3 py-3 bg-white dark:shadow-lg dark:bg-gray-850 border border-gray-100 dark:border-gray-850'} z-40 pointer-events-auto overflow-y-auto scrollbar-hidden h-full"
+							: 'px-3 py-3 bg-white dark:shadow-lg dark:bg-gray-850 border border-gray-100 dark:border-gray-850'} z-40 pointer-events-auto scrollbar-hidden"
 					>
 						{#if $showCallOverlay}
 							<div class="w-full h-full flex justify-center">

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -230,12 +230,12 @@
 				showControls.set(false);
 			}}
 			collapsible={true}
-			class="z-10 max-w-[50%]"
+			class="z-10 max-w-[25%]"
 		>
 			{#if $showControls}
 				<div class="flex h-full">
 					<div
-						class="flex-1 max-w-[380px] h-full overflow-y-auto {($showOverview || $showArtifacts) && !$showCallOverlay
+						class="flex-1 {($showOverview || $showArtifacts) && !$showCallOverlay
 							? ' '
 							: 'px-3 py-3 bg-white dark:shadow-lg dark:bg-gray-850 border border-gray-100 dark:border-gray-850'} z-40 pointer-events-auto scrollbar-hidden"
 					>

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -85,21 +85,26 @@
 		// Select the container element you want to observe
 		const container = document.getElementById('chat-container');
 
-		// initialize the minSize based on the container width
-		minSize = Math.floor((350 / container.clientWidth) * 100);
+		// initialize the minSize based on the container width - make it smaller for better scaling
+		minSize = Math.floor((320 / container.clientWidth) * 100);
 
 		// Create a new ResizeObserver instance
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (let entry of entries) {
 				const width = entry.contentRect.width;
-				// calculate the percentage of 200px
-				const percentage = (350 / width) * 100;
+				// calculate the percentage of 300px - smaller for better scaling
+				const percentage = Math.min((320 / width) * 100, 50); // Cap at 50% of screen width
 				// set the minSize to the percentage, must be an integer
 				minSize = Math.floor(percentage);
 
 				if ($showControls) {
-					if (pane && pane.isExpanded() && pane.getSize() < minSize) {
-						pane.resize(minSize);
+					if (pane && pane.isExpanded()) {
+						// If current size is larger than 50% of window, reduce it
+						if (pane.getSize() > 50) {
+							pane.resize(50);
+						} else if (pane.getSize() < minSize) {
+							pane.resize(minSize);
+						}
 					}
 				}
 			}
@@ -146,8 +151,8 @@
 			>
 				<div
 					class=" {$showCallOverlay || $showOverview || $showArtifacts
-						? ' h-screen  w-full'
-						: 'px-6 py-4'} h-full"
+						? ' h-screen w-full'
+						: ''} h-full"
 				>
 					{#if $showCallOverlay}
 						<div
@@ -223,14 +228,14 @@
 				showControls.set(false);
 			}}
 			collapsible={true}
-			class=" z-10 "
+			class="z-10 max-w-[50%]"
 		>
 			{#if $showControls}
 				<div class="flex max-h-full min-h-full">
 					<div
-						class="w-full {($showOverview || $showArtifacts) && !$showCallOverlay
+						class="max-w-[380px] {($showOverview || $showArtifacts) && !$showCallOverlay
 							? ' '
-							: 'px-4 py-4 bg-white dark:shadow-lg dark:bg-gray-850  border border-gray-100 dark:border-gray-850'} z-40 pointer-events-auto overflow-y-auto scrollbar-hidden"
+							: 'px-3 py-3 bg-white dark:shadow-lg dark:bg-gray-850 border border-gray-100 dark:border-gray-850'} z-40 pointer-events-auto overflow-y-auto scrollbar-hidden h-full"
 					>
 						{#if $showCallOverlay}
 							<div class="w-full h-full flex justify-center">

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
 	const dispatch = createEventDispatcher();
-	const i18n = getContext('i18n');
+	const i18n = getContext<{ t: (key: string) => string }>('i18n');
 
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import AdvancedParams from '../Settings/Advanced/AdvancedParams.svelte';
@@ -10,9 +11,53 @@
 	import Collapsible from '$lib/components/common/Collapsible.svelte';
 
 	import { user } from '$lib/stores';
-	export let models = [];
-	export let chatFiles = [];
-	export let params = {};
+	
+	interface ChatFile {
+		name: string;
+		type: string;
+		size?: number;
+		url?: string;
+	}
+
+	interface ChatParams {
+		system: string;
+		stream_response: null;
+		function_calling: null;
+		seed: null;
+		stop: null;
+		temperature: null;
+		reasoning_effort: null;
+		logit_bias: null;
+		frequency_penalty: null;
+		repeat_last_n: null;
+		mirostat: null;
+		mirostat_eta: null;
+		mirostat_tau: null;
+		top_k: null;
+		top_p: null;
+		min_p: null;
+		tfs_z: null;
+		num_ctx: null;
+		num_batch: null;
+		num_keep: null;
+		max_tokens: null;
+		use_mmap: null;
+		use_mlock: null;
+		num_thread: null;
+		num_gpu: null;
+		template: null;
+	}
+
+	export let models: any[] = [];
+	export let chatFiles: ChatFile[] = [];
+	export let params: Partial<ChatParams> = {};
+
+	// Initialize params with default values if not set
+	$: {
+		if (params && Object.keys(params).length === 0) {
+			params = { ...DEFAULT_PARAMS };
+		}
+	}
 
 	let showValves = false;
 
@@ -47,7 +92,7 @@
 	};
 
 	// Reactive variable to track if any control differs from default
-	let controlsActive = false;
+	export let controlsActive = false; // Export the variable
 
 	$: {
 		controlsActive = false; // Reset before checking
@@ -81,10 +126,10 @@
 			</h2>
 			{#if controlsActive}
 				<span
-					class="ml-2 px-1.5 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 text-xs font-medium rounded-full inline-flex items-center gap-1 transition-all duration-200"
+					class="ml-2 px-1.5 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 text-xs font-small rounded-full inline-flex items-center gap-1 transition-all duration-200"
 				>
 					<span class="inline-block text-xs">✓</span>
-					<span>{$i18n.t('Custom Settings Applied')}</span>
+					<span>{$i18n.t('Changes Active')}</span>
 				</span>
 			{/if}
 		</div>

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -114,7 +114,7 @@
 </script>
 
 <div
-	class="bg-white dark:bg-gray-850 rounded-lg shadow-sm border border-gray-100 dark:border-gray-800 flex flex-col max-w-[380px]"
+	class="bg-white dark:bg-gray-850 rounded-lg shadow-sm border border-gray-100 dark:border-gray-800 flex flex-col h-full"
 >
 	<!-- Header -->
 	<div

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -15,13 +15,82 @@
 	export let params = {};
 
 	let showValves = false;
+
+	// Define default parameters to compare against
+	const DEFAULT_PARAMS = {
+		system: '',
+		stream_response: null,
+		function_calling: null,
+		seed: null,
+		stop: null,
+		temperature: null,
+		reasoning_effort: null,
+		logit_bias: null,
+		frequency_penalty: null,
+		repeat_last_n: null,
+		mirostat: null,
+		mirostat_eta: null,
+		mirostat_tau: null,
+		top_k: null,
+		top_p: null,
+		min_p: null,
+		tfs_z: null,
+		num_ctx: null,
+		num_batch: null,
+		num_keep: null,
+		max_tokens: null,
+		use_mmap: null,
+		use_mlock: null,
+		num_thread: null,
+		num_gpu: null,
+		template: null
+	};
+
+	// Reactive variable to track if any control differs from default
+	let controlsActive = false;
+
+	$: {
+		controlsActive = false; // Reset before checking
+		if (params) {
+			// Check system prompt
+			if (params.system !== DEFAULT_PARAMS.system) {
+				controlsActive = true;
+			}
+
+			// Check advanced params (excluding system)
+			for (const key in DEFAULT_PARAMS) {
+				if (key !== 'system' && params.hasOwnProperty(key) && params[key] !== DEFAULT_PARAMS[key]) {
+					controlsActive = true;
+					break; // Exit loop early if any difference is found
+				}
+			}
+		}
+	}
 </script>
 
-<div class=" dark:text-white">
-	<div class=" flex items-center justify-between dark:text-gray-100 mb-2">
-		<div class=" text-lg font-medium self-center font-primary">{$i18n.t('Chat Controls')}</div>
+<div
+	class="bg-white dark:bg-gray-850 rounded-lg shadow-sm border border-gray-100 dark:border-gray-800 flex flex-col max-w-[380px]"
+>
+	<!-- Header -->
+	<div
+		class="flex items-center justify-between px-2.5 py-2 border-b border-gray-100 dark:border-gray-700/50"
+	>
+		<div class="flex items-center">
+			<h2 class="text-base font-medium text-gray-900 dark:text-gray-100">
+				{$i18n.t('Chat Controls')}
+			</h2>
+			{#if controlsActive}
+				<span
+					class="ml-2 px-1.5 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 text-xs font-medium rounded-full inline-flex items-center gap-1 transition-all duration-200"
+				>
+					<span class="inline-block text-xs">✓</span>
+					<span>{$i18n.t('Custom Settings Applied')}</span>
+				</span>
+			{/if}
+		</div>
+
 		<button
-			class="self-center"
+			class="text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full p-1 transition-colors duration-200"
 			on:click={() => {
 				dispatch('close');
 			}}
@@ -30,10 +99,11 @@
 		</button>
 	</div>
 
-	<div class=" dark:text-gray-200 text-sm font-primary py-0.5 px-0.5">
+	<!-- Content -->
+	<div class="p-2 space-y-2.5 overflow-y-auto flex-1">
 		{#if chatFiles.length > 0}
-			<Collapsible title={$i18n.t('Files')} open={true} buttonClassName="w-full">
-				<div class="flex flex-col gap-1 mt-1.5" slot="content">
+			<Collapsible title={$i18n.t('Files')} open={true} buttonClassName="w-full rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 px-2 transition-colors duration-150">
+				<div class="flex flex-col gap-1 pt-1.5" slot="content">
 					{#each chatFiles as file, fileIdx}
 						<FileItem
 							className="w-full"
@@ -58,33 +128,33 @@
 				</div>
 			</Collapsible>
 
-			<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
+			<hr class="my-3 border-gray-100 dark:border-gray-700/50" />
 		{/if}
 
-		<Collapsible bind:open={showValves} title={$i18n.t('Valves')} buttonClassName="w-full">
-			<div class="text-sm" slot="content">
+		<Collapsible bind:open={showValves} title={$i18n.t('Valves')} buttonClassName="w-full text-sm rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 px-2 transition-colors duration-150">
+			<div class="text-sm pt-1.5" slot="content">
 				<Valves show={showValves} />
 			</div>
 		</Collapsible>
 
 		{#if $user?.role === 'admin' || $user?.permissions.chat?.controls}
-			<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
+			<hr class="my-3 border-gray-100 dark:border-gray-700/50" />
 
-			<Collapsible title={$i18n.t('System Prompt')} open={true} buttonClassName="w-full">
-				<div class="" slot="content">
+			<Collapsible title={$i18n.t('System Prompt')} open={true} buttonClassName="w-full text-sm rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 px-2 transition-colors duration-150">
+				<div class="pt-1.5" slot="content">
 					<textarea
 						bind:value={params.system}
-						class="w-full text-xs py-1.5 bg-transparent outline-hidden resize-none"
-						rows="4"
+						class="w-full text-sm p-2 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-blue-500 dark:focus:border-blue-400 outline-none resize-none transition-all duration-200 placeholder-gray-400 dark:placeholder-gray-500 hover:border-gray-300 dark:hover:border-gray-600"
+						rows="3"
 						placeholder={$i18n.t('Enter system prompt')}
 					/>
 				</div>
 			</Collapsible>
 
-			<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
+			<hr class="my-3 border-gray-100 dark:border-gray-700/50" />
 
-			<Collapsible title={$i18n.t('Advanced Params')} open={true} buttonClassName="w-full">
-				<div class="text-sm mt-1.5" slot="content">
+			<Collapsible title={$i18n.t('Advanced Params')} open={true} buttonClassName="w-full text-sm rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 px-2 transition-colors duration-150">
+				<div class="text-sm pt-1.5" slot="content">
 					<div>
 						<AdvancedParams admin={$user?.role === 'admin'} bind:params />
 					</div>

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -40,6 +40,7 @@
 	export let history;
 	export let selectedModels;
 	export let showModelSelector = true;
+	export let controlsActive = false;
 
 	let showShareChatModal = false;
 	let showDownloadChatModal = false;
@@ -129,7 +130,10 @@
 							}}
 							aria-label="Controls"
 						>
-							<div class=" m-auto self-center">
+							<div class="relative m-auto self-center">
+								{#if controlsActive}
+									<div class="absolute -top-0.5 -right-0.5 size-2 bg-blue-500 rounded-full" />
+								{/if}
 								<AdjustmentsHorizontal className=" size-5" strokeWidth="0.5" />
 							</div>
 						</button>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verified that this PR is opened against the `dev` branch.
- [x] **Description:** Concisely summarised the changes made (see below).
- [x] **Changelog:** Confirmed the **Changelog Entry** section follows [Keep a Changelog](https://keepachangelog.com/).
- [x] **Documentation:** Updated [Open WebUI Docs](https://github.com/open-webui/docs) where required.
- [x] **Dependencies:** Confirmed no new runtime dependencies; docs remain accurate.
- [x] **Testing:** Added/adjusted tests to cover new functionality and executed them.
- [x] **Code review:** Performed self‑review for style, lint, and project guidelines.
- [x] **Prefix:** Chosen appropriate PR title prefix.

---

# Changelog Entry

### Description

Thought you might like this one, just a little quality of life PR - it introduces a **visual indicator for active chat controls**, improved responsive behaviour for the controls pane, and a UI refresh for Chat Controls to better match the rest of the UI. I had some folks asking me the other day about the controls because they wanted to set a system prompt for that chat and I realized it doesn't look or feel like most of the rest of the app, and changes are largely hidden once you hide it away and you may forget entirely that you've got custom settings active. Introduced a nice little visual indicator so that folks get immediate feedback when any non‑default parameter or system prompt is set, reducing accidental mis‑configuration.

### Added

- **`controlsActive` reactive flag**  
  - Propagated from `Controls.svelte` → `ChatControls.svelte` → `Chat.svelte` → `Navbar.svelte`.
  - Blue “unread‑style” dot on the Adjustments icon and a badge labelled **“✓ Changes Active”** in the pane header when custom parameters are detected.
- **`ChatFile` & `ChatParams` TypeScript interfaces** for stronger typing.
- **Default‑params comparison logic** to detect deviations from baseline settings.
- **25 % max‑width cap** on the resizable Controls pane to prevent it occupying excessive space on large screens, works better across all browsers and sizes than its predecessor. 

### Changed

- **Pane resize algorithm**
  - Base reference width reduced to **320 px** (from 350 px).
  - Size capped at **≤ 50 %** of window width for better UX.
- **UI/UX polish**
  - Consistent padding, rounded corners, and dark‑mode border colours.
  - Cleaner textarea styles with focus rings.
  - Collapsible section buttons receive subtle hover backgrounds.
- **Navbar indicator** now wraps icon in `relative` container to host the blue dot.

### Deprecated

- _None_

### Removed

- _None_

### Fixed

- Prevent oversized Controls pane on ultra‑wide monitors.
- Minor sizing glitches when toggling between Overview/Artifacts/Call overlays.

### Security

- _N/A_

### Breaking Changes

- _None_ – existing APIs remain intact; new prop `controlsActive` is optional with sensible default.

---

### Additional Information

_No additional information._

### Screenshots or Videos

https://github.com/user-attachments/assets/7e32cb16-17e2-42ee-a563-b0fad53bf0b9

<img width="418" alt="image" src="https://github.com/user-attachments/assets/1b5223c5-f88b-48c5-bfa3-831a5bc5cdfd" />

<img width="100" alt="image" src="https://github.com/user-attachments/assets/5001de3d-9fb8-432b-b2e3-f95662940bbd" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
