### PR TITLE
fix: `max_results` in Tavily search handler

### DIFF
--- a/backend/open_webui/retrieval/web/tavily.py
+++ b/backend/open_webui/retrieval/web/tavily.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import requests
-from open_webui.retrieval.web.main import SearchResult
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
@@ -21,18 +21,25 @@ def search_tavily(
     Args:
         api_key (str): A Tavily Search API key
         query (str): The query to search for
+        count (int): The maximum number of results to return
 
     Returns:
         list[SearchResult]: A list of search results
     """
     url = "https://api.tavily.com/search"
-    data = {"query": query, "api_key": api_key}
-    response = requests.post(url, json=data)
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    data = {"query": query, "max_results": count}
+    response = requests.post(url, headers=headers, json=data)
     response.raise_for_status()
 
     json_response = response.json()
 
-    raw_search_results = json_response.get("results", [])
+    results = json_response.get("results", [])
+    if filter_list:
+        results = get_filtered_results(results, filter_list)
 
     return [
         SearchResult(
@@ -40,5 +47,5 @@ def search_tavily(
             title=result.get("title", ""),
             snippet=result.get("content"),
         )
-        for result in raw_search_results[:count]
+        for result in results
     ]


### PR DESCRIPTION
# Changelog Entry

### Description

Related: #13075 
Fixed some small bugs when calling Tavily search API.

1. API Key Handling
    - Previously, the API key was passed in the request body, which is not documented in Tavily's [official API reference](https://docs.tavily.com/documentation/api-reference/endpoint/search).
    - Updated to pass the `api_key` in the `Authorization` header, following the recommended practice.
2. `max_results` Parameter
    - The Tavily API natively supports `max_results` (default: 5) parameter, facing issues when `count` is greater than 5.
    - Pass the `count` parameter as `max_results` to get the correct number of search results.
3. Domain Filter Fix
    - The Tavily search handler previously ignored the domain filter list.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.