### PR TITLE
perf: Concurrent processing for web search queries

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -366,21 +366,17 @@ async def chat_web_search_handler(
         }
     )
 
-    web_search_tasks = [
-        asyncio.create_task(
+    gathered_results = await asyncio.gather(
+        *(
             process_web_search(
                 request,
-                SearchForm(
-                    **{
-                        "query": searchQuery,
-                    }
-                ),
+                SearchForm(**{"query": searchQuery}),
                 user=user,
             )
-        )
-        for searchQuery in queries
-    ]
-    gathered_results = await asyncio.gather(*web_search_tasks, return_exceptions=True)
+            for searchQuery in queries
+        ),
+        return_exceptions=True,
+    )
 
     for searchQuery, results in zip(queries, gathered_results):
         try:

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -683,6 +683,8 @@
 													{$i18n.t('No search query generated')}
 												{:else if status?.description === 'Generating search query'}
 													{$i18n.t('Generating search query')}
+												{:else if status?.description === 'Searching the web'}
+													{$i18n.t('Searching the web')}
 												{:else}
 													{status?.description}
 												{/if}


### PR DESCRIPTION
### Problem Description

This PR addresses the same issue as #13045 -- improving the performance of multiple web search queries -- but with a simpler and cleaner approach.

Currently, the `async process_web_search` handler processes queries **sequentially**, performing searches and loading pages one at a time. This creates a bottleneck when multiple queries are generated, significantly slowing down overall performance.

### Solution

Since `process_web_search` is an **I/O-intensive** operation, we can easily optimize it by parallelizing the execution using `asyncio` tasks and `asyncio.gather`. This allows multiple search queries to run concurrently, effectively reducing latency.

### Breaking Change

Previously, the backend emitted individual events (e.g., `"Searching {{searchQuery}}"`) for each query. Due to parallel processing, this is no longer feasible. Instead, we now emit a single event (`"Searching the web"`), aligning with common practices in other LLM web UIs.

### Testing

| Test Case | Sequential | Parallel | Speedup |
|-----------------------|------------|----------|---------|
| “what is open webui”, “how to install open webui”, “how to install open webui with docker”(max_results=5) | 20.01 (5.40+9.25+5.36) | 7.99 | 2.5x |
| “what is lorem”, “example website”, “vue vs svelte”(max_results=5) | 20.96 (7.80+5.34+7.81) | 7.58 | 2.8x |
| "svelte", "vue", "react", "angular", "nextjs", "nuxtjs", "jquery", "qwik", "astro"(max_results=1) | 18.36 | 3.11 | 5.9x |
| “melbourne”, “sydney”, “canberra”(max_results=5) | 35.01 (12.26+11.71+11.03) | 13.96 | 2.5x |

In typical cases, parallel execution introduces minimal overhead, with total latency approaching the lower-bound duration of the slowest single query.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.