### PR TITLE
fix: FireCrawlLoader default mode to scrape

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -170,7 +170,7 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         continue_on_failure: bool = True,
         api_key: Optional[str] = None,
         api_url: Optional[str] = None,
-        mode: Literal["crawl", "scrape", "map"] = "crawl",
+        mode: Literal["crawl", "scrape", "map"] = "scrape",
         proxy: Optional[Dict[str, str]] = None,
         params: Optional[Dict] = None,
     ):


### PR DESCRIPTION
Hi, after 09874ab83dcf7c39babde9e5142b4caf9b2c9193, the FireCrawlLoader's source URLs are now correctly handled!

However, there’s still a small point to address. I strongly recommend changing FireCrawlLoader's default mode to `'scrape'`. The `'scrape'` mode focuses on fetching a single URL, which is consistent with the behavior of other web loaders. In contrast, selecting `'crawl'` mode—particularly when using a **self-hosted** Firecrawl instance—can result in Firecrawl recursively fetching all linked pages from the given URL, leading to unacceptably long processing times for just one webpage.