### PR TITLE
fix: The value of the 'Access-Control-Allow-Origin' header in the res…

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1255,7 +1255,7 @@ def validate_cors_origin(origin):
 # To test CORS_ALLOW_ORIGIN locally, you can set something like
 # CORS_ALLOW_ORIGIN=http://localhost:5173;http://localhost:8080
 # in your .env file depending on your frontend port, 5173 in this case.
-CORS_ALLOW_ORIGIN = os.environ.get("CORS_ALLOW_ORIGIN", "*").split(";")
+CORS_ALLOW_ORIGIN = os.environ.get("CORS_ALLOW_ORIGIN", "*;http://localhost:5173;http://localhost:8080").split(";")
 
 if "*" in CORS_ALLOW_ORIGIN:
     log.warning(


### PR DESCRIPTION
fix: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.

# Changelog Entry

### Description

When the user does not configure anything, the default CORS configuration on the backend is "`*`", and the frontend's credentials mode is set to 'include'. 

This leads to a CORS issue: `The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'`. 

As a result, first-time users encounter difficulties in normal usage on their localhost.

To resolve this, I have added http://localhost:5173;http://localhost:8080 to the default `CORS_ALLOW_ORIGIN`.

### Fixed

- The `The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'` issue, when the user does not configure anything.



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.