### PR TITLE
**FIX** Update Knowledge ReIndexing to continue upon missing\corrupt collections

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -178,10 +178,26 @@ async def reindex_knowledge_files(request: Request, user=Depends(get_verified_us
 
     log.info(f"Starting reindexing for {len(knowledge_bases)} knowledge bases")
 
-    for knowledge_base in knowledge_bases:
-        try:
-            files = Files.get_files_by_ids(knowledge_base.data.get("file_ids", []))
+    deleted_knowledge_bases = []
 
+    for knowledge_base in knowledge_bases:
+        # -- Robust error handling for missing or invalid data
+        if not knowledge_base.data or not isinstance(knowledge_base.data, dict):
+            log.warning(
+                f"Knowledge base {knowledge_base.id} has no data or invalid data ({knowledge_base.data!r}). Deleting."
+            )
+            try:
+                Knowledges.delete_knowledge_by_id(id=knowledge_base.id)
+                deleted_knowledge_bases.append(knowledge_base.id)
+            except Exception as e:
+                log.error(
+                    f"Failed to delete invalid knowledge base {knowledge_base.id}: {e}"
+                )
+            continue
+
+        try:
+            file_ids = knowledge_base.data.get("file_ids", [])
+            files = Files.get_files_by_ids(file_ids)
             try:
                 if VECTOR_DB_CLIENT.has_collection(collection_name=knowledge_base.id):
                     VECTOR_DB_CLIENT.delete_collection(
@@ -189,10 +205,7 @@ async def reindex_knowledge_files(request: Request, user=Depends(get_verified_us
                     )
             except Exception as e:
                 log.error(f"Error deleting collection {knowledge_base.id}: {str(e)}")
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"Error deleting vector DB collection",
-                )
+                continue  # Skip, don't raise
 
             failed_files = []
             for file in files:
@@ -213,10 +226,8 @@ async def reindex_knowledge_files(request: Request, user=Depends(get_verified_us
 
         except Exception as e:
             log.error(f"Error processing knowledge base {knowledge_base.id}: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Error processing knowledge base",
-            )
+            # Don't raise, just continue
+            continue
 
         if failed_files:
             log.warning(
@@ -225,7 +236,9 @@ async def reindex_knowledge_files(request: Request, user=Depends(get_verified_us
             for failed in failed_files:
                 log.warning(f"File ID: {failed['file_id']}, Error: {failed['error']}")
 
-    log.info("Reindexing completed successfully")
+    log.info(
+        f"Reindexing completed. Deleted {len(deleted_knowledge_bases)} invalid knowledge bases: {deleted_knowledge_bases}"
+    )
     return True
 
 


### PR DESCRIPTION
Improve Error Handling ReIndexing Knowledge Database
The new Reindexing feature is gold, however it would not run on my instance due to corrupt\missing collections, so I had to make some small changes.  It is unlikely I will need this again due to new maintenance, however may help others.
Some of the exception handling was modified, so potentially may not agree with the team.  However others may seek to re-use these changes.

Description:
Minor changes to knowledge.py to include more robust handling of corrupt or missing collections.

No additional documentation\dependencies.
Further testing is encouraged, as only tested on two instances.

# Changelog Entry

### Changed
-- Improved resiliency during ReIndexing to handle and clean-up missing collections.
-- Allow the Indexing to continue in the event of exceptions with individual collections

### Description
- Modification to knowledge.py during reindexing of knowledge
- If there is a missing or invalid collection, delete it and log.
- Don't raise an exception when deleting a collection, allowing re-indexing to continue

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.