### PR TITLE
**fix**: Fix build failure due to Node.js memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN npm ci
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
-RUN npm run build
+RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build
+
 
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base


### PR DESCRIPTION
This pull request fixes an issue that occurred when building the project locally, where the Node.js heap memory limit was exceeded, causing the build to fail with an "out of memory" error.

**Changes made:**

- Updated the Dockerfile to modify the `npm run build` command by setting `NODE_OPTIONS="--max-old-space-size=4096" `before running the build.

- This change increases the available memory during the build to 4GB, preventing allocation failures and fatal heap limit errors.

**Context**: Previously, running npm run build inside the Docker image resulted in fatal errors like:

`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

This fix ensures that the build process can successfully complete without running out of memory.

