### PR TITLE
fix: ensure uvicorn uses correct Python environment (venv/pyenv) by invoking via python

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -65,4 +65,6 @@ if [ -n "$SPACE_ID" ]; then
   export WEBUI_URL=${SPACE_HOST}
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --workers "${UVICORN_WORKERS:-1}"
+PYTHON_CMD=$(command -v python3 || command -v python)
+
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec "$PYTHON_CMD" -m uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --workers "${UVICORN_WORKERS:-1}"


### PR DESCRIPTION
### Description:

This PR updates the application startup command to invoke `uvicorn` via the appropriate Python interpreter instead of calling `uvicorn` directly. This ensures the correct virtual environment (`venv`) or `pyenv`-managed Python version is used, avoiding accidental fallback to the system Python.

#### Changes:
- Replaced:
  ```bash
  exec uvicorn open_webui.main:app ...
  ```
  with:
  ```bash
  PYTHON_CMD=$(command -v python3 || command -v python)
  exec "$PYTHON_CMD" -m uvicorn open_webui.main:app ...
  ```

#### Motivation:
- Directly running `uvicorn` may use the system Python, ignoring the active virtual environment or `pyenv` configuration.
- This causes dependency mismatches or unexpected behavior in customized Python setups.
- Running `uvicorn` via `python -m` ensures it is invoked using the correct Python context.

#### Impact:
- Improves reliability across different environments (system Python, `venv`, `pyenv`).
- No functional changes to the app logic; only affects how it's launched.

#### Testing:
- Validated on:
  - `pyenv` environments
  - Virtual environments (`venv`)
  - Bare systems with only `python3` or `python`
- Confirmed that the correct interpreter and dependencies are used in all cases.

---