### PR TITLE
feat: support gpt-image-1

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -500,7 +500,11 @@ async def image_generations(
                     if form_data.size
                     else request.app.state.config.IMAGE_SIZE
                 ),
-                "response_format": "b64_json",
+                "response_format": (
+                    ""
+                    if "gpt-image-1" in request.app.state.config.IMAGE_GENERATION_MODEL
+                    else "b64_json"
+                )
             }
 
             # Use asyncio.to_thread for the requests.post call


### PR DESCRIPTION
### Description:

This update fixes an incompatibility between open-webui and the gpt-image-1 image generation model. The gpt-image-1 model does not support the "response_format" parameter, which caused issues when generating images.

### Changes:

Replaced:
```python
"response_format": "b64_json",
```
with:
```python
"response_format": (
    ""
    if "gpt-image-1" in request.app.state.config.IMAGE_GENERATION_MODEL
    else "b64_json"
)
```
This ensures that an empty string is passed for the "response_format" parameter when using the gpt-image-1 model, and "b64_json" is used otherwise.

### Impact:
Open-webui will now correctly format requests to the server, allowing for successful image generation without triggering exceptions.

### Validated on:
* Virtual environments (venv)
* Bare systems with only python3 or python
* Docker environments.
Confirmed that the correct interpreter and dependencies are used in all cases.