### PR TITLE
Fix: retrieving the compose running status code

### DIFF
--- a/run-compose.sh
+++ b/run-compose.sh
@@ -236,9 +236,11 @@ if [[ $choice == "" || $choice == "y" ]]; then
     # Wait for the command to finish
     wait $PID
 
+    run_compose_status=$?
+
     echo
     # Check exit status
-    if [ $? -eq 0 ]; then
+    if [ $run_compose_status -eq 0 ]; then
         echo -e "${GREEN}${BOLD}Compose project started successfully.${NC}"
     else
         echo -e "${RED}${BOLD}There was an error starting the compose project.${NC}"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Change the approach about retrieving the run compose status code after running the `$DEFAULT_COMPOSE_COMMAND` command has been done.

### Added

- After running and wait `$DEFAULT_COMPOSE_COMMAND`, it should store the status code variable.

### Changed

- Add the `run_compose_status` variable to store the `$DEFAULT_COMPOSE_COMMAND` command running status.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Addressing the issue about retrieving the incorrect `$DEFAULT_COMPOSE_COMMAND` command running status code.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- N/A

### Screenshots or Videos

- N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.