### PR TITLE
fix: Turn off richTextInput by default

### DIFF
--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -34,7 +34,7 @@
 
 	let detectArtifacts = true;
 
-	let richTextInput = true;
+	let richTextInput = false;
 	let promptAutocomplete = false;
 
 	let largeTextAsFile = false;
@@ -283,7 +283,7 @@
 		showEmojiInCall = $settings.showEmojiInCall ?? false;
 		voiceInterruption = $settings.voiceInterruption ?? false;
 
-		richTextInput = $settings.richTextInput ?? true;
+		richTextInput = $settings.richTextInput ?? false;
 		promptAutocomplete = $settings.promptAutocomplete ?? false;
 		largeTextAsFile = $settings.largeTextAsFile ?? false;
 		copyFormatted = $settings.copyFormatted ?? false;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

# Changelog Entry

### Description

Rich text input, in it's current form, can be faulty. It can break prompt templates, pasted Code or other formatted text by removing empty lines and line breaks.

This PR proposes to change the default behavior of rich text input to false.

### Changed

- Default setting in the Interface Settings is turned to "false" for rich text input.

---

### Additional Information

- I will try to examine the rich text input in the future, to try and improve it. For now, this PR is meant to, by default, disable rich text input, such that it does not cause any more problems with workflows until rich text input is fixed in a future PR.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.