### PR TITLE
feat(api): Expose Retrieved RAG Chunks and Sources in Chat Completion API Response

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1127,7 +1127,7 @@ async def chat_completion(
         request.state.metadata = metadata
         form_data["metadata"] = metadata
 
-        form_data, metadata, events = await process_chat_payload(
+        form_data, metadata, events, context_chunks_with_source = await process_chat_payload(
             request, form_data, user, metadata, model
         )
 
@@ -1150,6 +1150,9 @@ async def chat_completion(
 
     try:
         response = await chat_completion_handler(request, form_data, user)
+
+        if isinstance(response, dict):
+            response["context_chunks_with_source"] = context_chunks_with_source
 
         return await process_chat_response(
             request, response, form_data, user, metadata, model, events, tasks

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -929,6 +929,13 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 form_data["messages"],
             )
 
+    context_chunks_with_source = [
+        {"source": meta.get("name"), "chunk": doc}
+        for source in sources
+        if "document" in source
+        for doc, meta in zip(source["document"], source["metadata"])
+    ]
+
     # If there are citations, add them to the data_items
     sources = [source for source in sources if source.get("source", {}).get("name", "")]
 
@@ -948,7 +955,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             }
         )
 
-    return form_data, metadata, events
+    return form_data, metadata, events, context_chunks_with_source
 
 
 async def process_chat_response(


### PR DESCRIPTION
**Feature: Expose RAG Context and Sources via /api/chat/completions**

This PR introduces support for exposing the context and source chunks used in the RAG (Retrieval-Augmented Generation) process through the existing /api/chat/completions endpoint.

🔍 **Motivation:**

Currently, the RAG context used during the generation is not exposed, which limits:
Debugging and validation of the chunks retrieved by the retriever.
Monitoring of relevance and document retrieval performance.
I previously opened a discussion on this topic: [#13304](https://github.com/open-webui/open-webui/discussions/13304)

🛠 **Implementation:**

This PR adds the following fields to the API response:
context_chunks_with_source: a list of the retrieved chunks and the corresponding file names used during the RAG step.
This makes it possible to externally inspect and evaluate the retrieval process without modifying the backend logic.