### PR TITLE
WIP: add periodic data cleanup task

### DIFF
--- a/backend/open_webui/data_cleanup_task.py
+++ b/backend/open_webui/data_cleanup_task.py
@@ -1,0 +1,243 @@
+import logging
+import os
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+import fcntl
+from pathlib import Path
+from typing import Iterator, Literal
+
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from open_webui.config import CACHE_DIR
+from open_webui.env import DATABASE_URL, SRC_LOG_LEVELS
+from open_webui.internal.db import get_db
+from open_webui.retrieval.vector.connector import VECTOR_DB_CLIENT
+from open_webui.storage.provider import Storage
+from sqlalchemy import text
+
+log = logging.getLogger(__name__)
+log.setLevel(SRC_LOG_LEVELS["DATA_CLEANUP"])
+
+DATA_CLEANUP_ENABLED = os.getenv("DATA_CLEANUP_ENABLED", "false").lower() == "true"
+if DATA_CLEANUP_ENABLED:
+    if "DATA_CLEANUP_MAX_CHAT_AGE_DAYS" not in os.environ:
+        raise ValueError(
+            "If DATA_CLEANUP_ENABLED is set, DATA_CLEANUP_MAX_CHAT_AGE_DAYS must be set"
+        )
+    DATA_CLEANUP_MAX_CHAT_AGE_DAYS = float(os.environ["DATA_CLEANUP_MAX_CHAT_AGE_DAYS"])
+
+    if "DATA_CLEANUP_MAX_CACHE_AGE_DAYS" not in os.environ:
+        raise ValueError(
+            "If DATA_CLEANUP_ENABLED is set, DATA_CLEANUP_MAX_CHAT_AGE_DAYS must be set"
+        )
+    DATA_CLEANUP_MAX_CACHE_AGE_DAYS = float(
+        os.environ["DATA_CLEANUP_MAX_CACHE_AGE_DAYS"]
+    )
+
+    if "DATA_CLEANUP_CRON_SCHEDULE" not in os.environ:
+        raise ValueError(
+            "If DATA_CLEANUP_ENABLED is set, DATA_CLEANUP_CRON_SCHEDULE must be set"
+        )
+    DATA_CLEANUP_CRON_SCHEDULE = os.environ["DATA_CLEANUP_CRON_SCHEDULE"]
+
+db_type: Literal["postgres", "sqlite"]
+if DATABASE_URL.startswith("postgres"):
+    db_type = "postgres"
+elif DATABASE_URL.startswith("sqlite"):
+    db_type = "sqlite"
+else:
+    raise ValueError(
+        "Only postgres and sqlite are supported by OpenWebUI"
+    )
+
+
+async def setup_data_cleanup_schedule() -> None:
+    """
+    Sets up a cron job to run data cleanup policy with apscheduler.
+    """
+    assert DATA_CLEANUP_ENABLED
+
+    log.info(
+        f"Data cleanup policy enabled. "
+        f"Chats older than {DATA_CLEANUP_MAX_CHAT_AGE_DAYS} days will be deleted. "
+        f"Cache files older than {DATA_CLEANUP_MAX_CACHE_AGE_DAYS} days will be deleted. "
+        f"Running on cron schedule '{DATA_CLEANUP_CRON_SCHEDULE}'"
+    )
+    scheduler = AsyncIOScheduler()
+    # use sqlalchemy job store to sync across multiple instances
+    scheduler.add_jobstore(
+        SQLAlchemyJobStore(DATABASE_URL, tablename="data_cleanup_tasks")
+    )
+    # keep only the jobs defined in this function
+    scheduler.remove_all_jobs()
+    scheduler.start()
+    scheduler.add_job(
+        cleanup_data,
+        CronTrigger.from_crontab(DATA_CLEANUP_CRON_SCHEDULE),
+        id="data_cleanup_task",
+        max_instances=1,
+        coalesce=True,
+        replace_existing=True,
+    )
+
+
+def cleanup_data() -> None:
+    """
+    Cleans up old chats and files from the database and storage.
+    """
+    with try_acquire_db_lock("data_cleanup_task") as acquired:
+        if acquired:
+            now = datetime.now()
+            log.info("Applying data cleanup policy")
+            delete_chats_and_uploads(
+                now - timedelta(days=DATA_CLEANUP_MAX_CHAT_AGE_DAYS)
+            )
+            delete_cache_files(now - timedelta(days=DATA_CLEANUP_MAX_CACHE_AGE_DAYS))
+
+
+@contextmanager
+def try_acquire_db_lock(id: str) -> Iterator[bool]:
+    """
+    Context manager which attempts to acquire a db lock with the given id.
+    Yields a boolean indicating whether the lock was acquired, or False if it was already held.
+
+    Needed to prevent multiple instances of the data cleanup task from running at the same time when horizontally scaling.
+    This functionality is inbuilt in apscheduler v4.x, but it is still in alpha (after 3 years ;_;)
+    """
+    log.debug(f"Acquiring '{id}' db lock")
+    lock_provider = (
+        _try_acquire_db_lock_postgres(id)
+        if DATABASE_URL.startswith("postgres")
+        else _try_acquire_file_lock(id)
+    )
+    with lock_provider as acquired:
+        if acquired:
+            log.debug(f"Acquired '{id}' db lock")
+        else:
+            log.debug(f"'{id}' db lock already held by another process")
+
+        yield acquired
+
+        if acquired:
+            log.debug(f"Releasing '{id}' db lock")
+            # lock released on session close
+
+
+@contextmanager
+def _try_acquire_db_lock_postgres(id: str) -> Iterator[bool]:
+    with get_db() as db:
+        acquired = db.execute(
+            text(f"SELECT pg_try_advisory_lock(hashtext('{id}'))")
+        ).scalar_one()
+        assert isinstance(acquired, bool)
+        yield acquired
+
+
+@contextmanager
+def _try_acquire_file_lock(id: str) -> Iterator[bool]:
+    # SQLite only supports single node, so we can use a file lock
+    lock_path = f"/tmp/{id}.lock"
+    with open(lock_path, "w") as lock_file:
+        try:
+            # Try to acquire the lock
+            fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            yield True
+        except BlockingIOError:
+            yield False
+
+
+def delete_chats_and_uploads(cutoff: datetime) -> None:
+
+    chats_sql = f"select *, updated_at < {int(cutoff.timestamp())} as expired from chat"
+
+    json_array_elements = "json_each" if db_type == "sqlite" else "json_array_elements"
+
+    chat_file_jsons_sql = f"""
+        with chats as ({chats_sql})
+        select value, chats.expired as expired
+        from chats, {json_array_elements}(chat -> 'files')
+        -- only use 'status' = 'uploaded' files to prevent deleting knowledge base collections
+        where value->>'status' = 'uploaded'
+    """
+
+    expired_files_sql = f"""
+        with chat_file_jsons as ({chat_file_jsons_sql})
+        select * from file
+        join chat_file_jsons on file.id = chat_file_jsons.value->>'id'
+        where chat_file_jsons.expired
+    """
+
+    with get_db() as db:
+        
+        expired_chat_file_paths = db.execute(text(f"""
+            with expired_files as ({expired_files_sql})
+            select path from expired_files
+        """))
+
+        for [path] in expired_chat_file_paths:
+            log.debug(f"- Deleting file {path} from storage")
+            # WARNING: this could fail without exception (but with printed note) if the file is not found in storage
+            Storage.delete_file(path)
+
+        # delete expired chat files from the db
+        n_files_deleted = db.execute(text(f"""
+            with expired_files as ({expired_files_sql})
+            delete from file
+            where id in (select id from expired_files)
+        """)).rowcount # type: ignore
+        assert isinstance(n_files_deleted, int)
+        log.info(f"Deleted {n_files_deleted} file rows from the db")
+        
+        # delete the expired chat files from the db
+        expired_collection_names = db.execute(text(f"""
+            with chat_file_jsons as ({chat_file_jsons_sql})
+            select distinct value->>'collection_name' from chat_file_jsons a
+            where a.expired and not exists (
+                select 1 from chat_file_jsons b
+                where a.value->>'collection_name' = b.value->>'collection_name'
+                and not b.expired
+            )
+        """))
+
+        for [collection_name] in expired_collection_names:
+            log.debug(f"- Deleting expired collection {collection_name} from vector db")
+            VECTOR_DB_CLIENT.delete_collection(collection_name)
+
+        # delete the expired chats from the db
+        n_chats_deleted = db.execute(text(f"""
+            with chats as ({chats_sql})
+            delete from chat
+            where id in (select id from chats where expired)
+        """)).rowcount # type: ignore
+        assert isinstance(n_chats_deleted, int)
+        log.info(f"Deleted {n_chats_deleted} chat rows from the db")
+
+        db.commit()
+
+
+def delete_cache_files(cutoff: datetime) -> None:
+    """
+    Deletes files older than cutoff from /app/data/cache/[audio|image]/**
+    """
+    FOLDERS_TO_CLEAN = ["audio", "image"]
+
+    cache_paths = [
+        fp
+        for folder in FOLDERS_TO_CLEAN
+        for fp in Path(CACHE_DIR).glob(f"{folder}/**/*")
+        if fp.is_file()
+    ]
+    log.info(f"Found {len(cache_paths)} total cache files in {CACHE_DIR}")
+    log.debug(f"Cache files created before {cutoff} will be deleted")
+    min_ctime = cutoff.timestamp()
+
+    c = 0
+    for fp in cache_paths:
+        ctime = fp.stat().st_ctime
+        log.debug(f"- {fp}: {ctime}")
+        if ctime < min_ctime:
+            fp.unlink()
+            c += 1
+
+    log.info(f"Deleted {c} cache files")

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -92,6 +92,7 @@ log_sources = [
     "WEBHOOK",
     "SOCKET",
     "OAUTH",
+    "DATA_CLEANUP",
 ]
 
 SRC_LOG_LEVELS = {}

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -51,7 +51,7 @@ class JSONField(types.TypeDecorator):
 # Workaround to handle the peewee migration
 # This is required to ensure the peewee migration is handled before the alembic migration
 def handle_peewee_migration(DATABASE_URL):
-    # db = None
+    db = None
     try:
         # Replace the postgresql:// with postgres:// to handle the peewee migration
         db = register_connection(DATABASE_URL.replace("postgresql://", "postgres://"))
@@ -65,11 +65,11 @@ def handle_peewee_migration(DATABASE_URL):
         raise
     finally:
         # Properly closing the database connection
-        if db and not db.is_closed():
-            db.close()
-
-        # Assert if db connection has been closed
-        assert db.is_closed(), "Database connection is still open."
+        if db:
+            if not db.is_closed():
+                db.close()
+            # Assert if db connection has been closed
+            assert db.is_closed(), "Database connection is still open."
 
 
 handle_peewee_migration(DATABASE_URL)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -361,6 +361,7 @@ from open_webui.env import (
     ENABLE_OTEL,
     EXTERNAL_PWA_MANIFEST_URL,
 )
+from open_webui.data_cleanup_task import DATA_CLEANUP_ENABLED, setup_data_cleanup_schedule
 
 
 from open_webui.utils.models import (
@@ -455,6 +456,9 @@ async def lifespan(app: FastAPI):
     if pool_size and pool_size > 0:
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = pool_size
+
+    if DATA_CLEANUP_ENABLED:
+        await setup_data_cleanup_schedule()
 
     asyncio.create_task(periodic_usage_pool_cleanup())
 

--- a/backend/open_webui/test/apps/webui/routers/test_auths.py
+++ b/backend/open_webui/test/apps/webui/routers/test_auths.py
@@ -1,5 +1,5 @@
-from test.util.abstract_integration_test import AbstractPostgresTest
-from test.util.mock_user import mock_webui_user
+from open_webui.test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.test.util.mock_user import mock_webui_user
 
 
 class TestAuths(AbstractPostgresTest):

--- a/backend/open_webui/test/apps/webui/routers/test_chats.py
+++ b/backend/open_webui/test/apps/webui/routers/test_chats.py
@@ -1,7 +1,7 @@
 import uuid
 
-from test.util.abstract_integration_test import AbstractPostgresTest
-from test.util.mock_user import mock_webui_user
+from open_webui.test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.test.util.mock_user import mock_webui_user
 
 
 class TestChats(AbstractPostgresTest):

--- a/backend/open_webui/test/apps/webui/routers/test_models.py
+++ b/backend/open_webui/test/apps/webui/routers/test_models.py
@@ -1,5 +1,5 @@
-from test.util.abstract_integration_test import AbstractPostgresTest
-from test.util.mock_user import mock_webui_user
+from open_webui.test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.test.util.mock_user import mock_webui_user
 
 
 class TestModels(AbstractPostgresTest):

--- a/backend/open_webui/test/apps/webui/routers/test_prompts.py
+++ b/backend/open_webui/test/apps/webui/routers/test_prompts.py
@@ -1,5 +1,5 @@
-from test.util.abstract_integration_test import AbstractPostgresTest
-from test.util.mock_user import mock_webui_user
+from open_webui.test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.test.util.mock_user import mock_webui_user
 
 
 class TestPrompts(AbstractPostgresTest):

--- a/backend/open_webui/test/apps/webui/routers/test_users.py
+++ b/backend/open_webui/test/apps/webui/routers/test_users.py
@@ -1,5 +1,5 @@
-from test.util.abstract_integration_test import AbstractPostgresTest
-from test.util.mock_user import mock_webui_user
+from open_webui.test.util.abstract_integration_test import AbstractPostgresTest
+from open_webui.test.util.mock_user import mock_webui_user
 
 
 def _get_user_by_id(data, param):

--- a/backend/open_webui/test/test_data_cleanup_task.py
+++ b/backend/open_webui/test/test_data_cleanup_task.py
@@ -1,0 +1,182 @@
+from datetime import datetime
+import time
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+from open_webui.test.util.abstract_integration_test import AbstractDBTest, AbstractPostgresTest, AbstractSQLiteTest
+from open_webui.test.util.mock_user import mock_webui_user
+from pydantic import BaseModel
+
+class DataCleanupTaskUnitTestMixin(AbstractDBTest):
+    "tests individual functions of the data cleanup task, with any DB backend"
+
+    def test_try_acquire_db_lock_exclusive(self):
+        """
+        Test that the try_acquire_db_lock method works as expected.
+        Ideally this would be tested across multiple processes, but this is fine for now.
+        """
+        from open_webui.data_cleanup_task import try_acquire_db_lock
+        with (
+            try_acquire_db_lock("test") as acquired_a,
+            try_acquire_db_lock("test") as acquired_b
+        ):
+            assert acquired_a != acquired_b # xor
+    
+    def test_delete_cache_files(self):
+        from open_webui.data_cleanup_task import CACHE_DIR, delete_cache_files
+        def dummy_paths(cache_paths: list[str]) -> list[Path]:
+            fps = [Path(CACHE_DIR) / path for path in cache_paths]
+            for fp in fps:
+                fp.parent.mkdir(parents=True, exist_ok=True)
+                fp.touch()
+            return fps
+        
+        before_cutoff = dummy_paths(["audio/dummy_before.wav", "image/dummy_before.png"])
+        cutoff = datetime.now()
+        after_cutoff = dummy_paths(["audio/dummy_after.wav", "image/dummy_after.png"])
+        
+        delete_cache_files(cutoff)
+        
+        # Check that the older files were deleted
+        for dummy_fp in before_cutoff:
+            assert not dummy_fp.exists()
+        # and the newer ones were not
+        for dummy_fp in after_cutoff:
+            assert dummy_fp.exists()
+    
+    def test_delete_chats_and_uploads(self):
+        from open_webui.data_cleanup_task import delete_chats_and_uploads, VECTOR_DB_CLIENT
+        from open_webui.models.chats import Chats
+        from open_webui.models.files import Files
+
+        # a url file that's shared between all chats
+        shared_web_url = "https://google.com/robots.txt?type=shared"
+        # a url file that's only shared between expired chats
+        before_cutoff_shared_web_url = "https://google.com/robots.txt?type=shared_by_expiring"
+        # a url file that's only shared between non-expired chats
+        after_cutoff_shared_web_url = "https://google.com/robots.txt?type=shared_by_non_expiring"
+
+        with mock_webui_user():
+            shared_web_file_1 = self._process_web(shared_web_url)
+            before_cutoff_shared_web_file_1 = self._process_web(before_cutoff_shared_web_url)
+            before_cutoff_uploaded_file_1 = self._upload_file("dummy1.txt", b"dummy content")
+            before_cutoff_uploaded_file_1_path = Path(Files.get_file_by_id(before_cutoff_uploaded_file_1.id).path) # type: ignore
+            before_cutoff_chat_1_id = self._create_chat_with_files([shared_web_file_1, before_cutoff_shared_web_file_1, before_cutoff_uploaded_file_1])
+
+            shared_web_file_2 = self._process_web(shared_web_url)
+            before_cutoff_shared_web_file_2 = self._process_web(before_cutoff_shared_web_url)
+            before_cutoff_uploaded_file_2 = self._upload_file("dummy2.txt", b"dummy content")
+            before_cutoff_uploaded_file_2_path = Path(Files.get_file_by_id(before_cutoff_uploaded_file_2.id).path) # type: ignore
+            before_cutoff_chat_2_id = self._create_chat_with_files([shared_web_file_2, before_cutoff_shared_web_file_2, before_cutoff_uploaded_file_2])
+        
+            time.sleep(1) # ensure that the cutoff is different from chat.created_at (timestamp has seconds granularity)
+            cutoff = datetime.now()
+
+            shared_web_file_3 = self._process_web(shared_web_url)
+            after_cutoff_shared_web_file_1 = self._process_web(after_cutoff_shared_web_url)
+            after_cutoff_uploaded_file_1 = self._upload_file("dummy3.txt", b"dummy content")
+            after_cutoff_uploaded_file_1_path = Path(Files.get_file_by_id(after_cutoff_uploaded_file_1.id).path) # type: ignore
+            after_cutoff_chat_1_id = self._create_chat_with_files([shared_web_file_3, after_cutoff_shared_web_file_1, after_cutoff_uploaded_file_1])
+
+            after_cutoff_shared_web_file_2 = self._process_web(after_cutoff_shared_web_url)
+            after_cutoff_uploaded_file_2 = self._upload_file("dummy4.txt", b"dummy content")
+            after_cutoff_uploaded_file_2_path = Path(Files.get_file_by_id(after_cutoff_uploaded_file_2.id).path) # type: ignore
+            after_cutoff_chat_2_id = self._create_chat_with_files([after_cutoff_shared_web_file_2, after_cutoff_uploaded_file_2])
+         
+        delete_chats_and_uploads(cutoff)
+
+        # validate that all shared web files share the same collection name
+        assert shared_web_file_1.collection_name == shared_web_file_2.collection_name == shared_web_file_3.collection_name
+        assert before_cutoff_shared_web_file_1.collection_name == before_cutoff_shared_web_file_2.collection_name
+        assert after_cutoff_shared_web_file_1.collection_name == after_cutoff_shared_web_file_2.collection_name
+
+        # validate shared web files are deleted ONLYif they are not shared with any non-expired chats
+        assert VECTOR_DB_CLIENT.has_collection(shared_web_file_1.collection_name)
+        assert not VECTOR_DB_CLIENT.has_collection(before_cutoff_shared_web_file_1.collection_name)
+        assert VECTOR_DB_CLIENT.has_collection(after_cutoff_shared_web_file_1.collection_name)
+
+        # validate expected assets of before_cutoff_chat_1 are deleted
+        assert not Chats.get_chat_by_id(before_cutoff_chat_1_id)
+        assert not Files.get_file_by_id(before_cutoff_uploaded_file_1.id)
+        assert not VECTOR_DB_CLIENT.has_collection(before_cutoff_shared_web_file_1.collection_name)
+        assert not before_cutoff_uploaded_file_1_path.exists()
+
+        # validate expected assets of before_cutoff_chat_2 are deleted
+        assert not Chats.get_chat_by_id(before_cutoff_chat_2_id)
+        assert not Files.get_file_by_id(before_cutoff_uploaded_file_2.id)
+        assert not VECTOR_DB_CLIENT.has_collection(before_cutoff_shared_web_file_2.collection_name)
+        assert not before_cutoff_uploaded_file_2_path.exists()
+
+        # validate expected assets of after_cutoff_chat_1 are not deleted
+        assert Chats.get_chat_by_id(after_cutoff_chat_1_id)
+        assert Files.get_file_by_id(after_cutoff_uploaded_file_1.id)
+        assert VECTOR_DB_CLIENT.has_collection(after_cutoff_shared_web_file_1.collection_name)
+        assert after_cutoff_uploaded_file_1_path.exists()
+
+        # validate expected assets of after_cutoff_chat_2 are not deleted
+        assert Chats.get_chat_by_id(after_cutoff_chat_2_id)
+        assert Files.get_file_by_id(after_cutoff_uploaded_file_2.id)
+        assert VECTOR_DB_CLIENT.has_collection(after_cutoff_shared_web_file_2.collection_name)
+        assert after_cutoff_uploaded_file_2_path.exists()
+
+
+    def _upload_file(self, file_name: str, file_content: bytes) -> "ChatFileUploaded":
+        """
+        Helper function for POST /api/v1/files/
+        """
+        response = self.fast_api_client.post(
+            "/api/v1/files/",
+            files={"file": (file_name, file_content)}
+        )
+        response.raise_for_status()
+        data = response.json()
+        return ChatFileUploaded(
+            id=data["id"],
+            collection_name=data["meta"]["collection_name"],
+        )
+
+    def _process_web(self, url: str) -> "ChatFile":
+        from open_webui.routers.retrieval import ProcessUrlForm
+        """
+        Helper function for POST /api/v1/retrieval/process/web/
+        """
+        response = self.fast_api_client.post(
+            "/api/v1/retrieval/process/web",
+            json=ProcessUrlForm(url=url).model_dump()
+        )
+        response.raise_for_status()
+        return ChatFile(
+            collection_name=response.json()["collection_name"],
+        )
+
+    def _create_chat_with_files(self, files: list["ChatFile | ChatFileUploaded"]) -> str:
+        """
+        Helper function for POST /api/v1/chats/new
+        Returns the chat ID.
+        """
+        from open_webui.models.chats import ChatForm
+
+        response = self.fast_api_client.post(
+            "/api/v1/chats/new",
+            json=ChatForm(chat={
+                "files": [file.model_dump() for file in files],
+            }).model_dump(),
+        )
+        response.raise_for_status()
+        return response.json()["id"]
+
+
+
+class TestDataCleanupTaskUnitTestPostgres(DataCleanupTaskUnitTestMixin, AbstractPostgresTest):
+    ...
+
+class TestDataCleanupTaskUnitTestSQLite(DataCleanupTaskUnitTestMixin, AbstractSQLiteTest):
+    ...
+
+class ChatFile(BaseModel):
+    status: Literal["uploaded"] = "uploaded"
+    collection_name: str
+
+
+class ChatFileUploaded(ChatFile):
+    id: str

--- a/backend/open_webui/test/util/abstract_integration_test.py
+++ b/backend/open_webui/test/util/abstract_integration_test.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def get_fast_api_client():
-    from main import app
+    from open_webui.main import app
 
     with TestClient(app) as c:
         return c

--- a/backend/open_webui/test/util/mock_user.py
+++ b/backend/open_webui/test/util/mock_user.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 @contextmanager
 def mock_webui_user(**kwargs):
-    from open_webui.routers.webui import app
+    from open_webui.main import app
 
     with mock_user(app, **kwargs):
         yield


### PR DESCRIPTION
Adds periodic `apscheduler` job for implementing data retention policy by deleting expired db chat table rows, associated records, and cache files. Only supports `sqlite` and `postgres` databases.

Discussion: https://github.com/open-webui/open-webui/discussions/7465

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests for validating the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To cleary categorize this pull request, prefix the pull request title, using one of the following

# Changelog Entry

### Description

- Add periodic data cleanup task to periodically delete old db chat table rows, associated records, and cache files. 

### Added

- **Periodic Data Cleanup Task**, configurable through environment variables:
  - `DATA_CLEANUP_ENABLED (bool, default False)`: Whether to enable the data cleanup policy.
  - `DATA_CLEANUP_MAX_CHAT_AGE_DAYS (float)`: Sets the threshold for max chat age in days after which chats are deleted from DB, and uploaded files removed. Required if `DATA_CLEANUP_ENABLED`.
  - `DATA_CLEANUP_MAX_CACHE_AGE_DAYS (float)`: Sets the threshold for max cache file age after which files are deleted (from the /app/data/cache/[audio|image] folders). Required if `DATA_CLEANUP_ENABLED`.
  - `DATA_CLEANUP_CRON_SCHEDULE (str)`: Crontab schedule for the cleanup job eg: "0 * * * *" (the top of every hour). Required if `DATA_CLEANUP_ENABLED`.
  - `DATA_CLEANUP_LOG_LEVEL (str, default "INFO")`: Sets the log level for the data_cleanup_policy module. EG: `"DEBUG" | "INFO"` etc

