### PR TITLE
fix: prevent showing disabled setting-tabs to user

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -295,16 +295,43 @@
 	];
 
 	let search = '';
-	let visibleTabs = searchData.map((tab) => tab.id);
+	let visibleTabs = searchData
+		.filter(tab => {
+			// Filter based on permissions
+			if (tab.id === 'connections' && !($user?.role === 'admin' || ($user?.role === 'user' && $config?.features?.enable_direct_connections))) {
+				return false;
+			}
+			if (tab.id === 'tools' && !($user?.role === 'admin' || ($user?.role === 'user' && $user?.permissions?.features?.direct_tool_servers))) {
+				return false;
+			}
+			if (tab.id === 'admin' && $user?.role !== 'admin') {
+				return false;
+			}
+			return true;
+		})
+		.map((tab) => tab.id);
 	let searchDebounceTimeout;
 
 	const searchSettings = (query: string): string[] => {
 		const lowerCaseQuery = query.toLowerCase().trim();
 		return searchData
 			.filter(
-				(tab) =>
-					tab.title.toLowerCase().includes(lowerCaseQuery) ||
-					tab.keywords.some((keyword) => keyword.includes(lowerCaseQuery))
+				(tab) => {
+					// First check if the tab should be visible based on permissions
+					if (tab.id === 'connections' && !($user?.role === 'admin' || ($user?.role === 'user' && $config?.features?.enable_direct_connections))) {
+						return false;
+					}
+					if (tab.id === 'tools' && !($user?.role === 'admin' || ($user?.role === 'user' && $user?.permissions?.features?.direct_tool_servers))) {
+						return false;
+					}
+					if (tab.id === 'admin' && $user?.role !== 'admin') {
+						return false;
+					}
+					
+					// Then check if it matches the search query
+					return tab.title.toLowerCase().includes(lowerCaseQuery) ||
+						tab.keywords.some((keyword) => keyword.includes(lowerCaseQuery));
+				}
 			)
 			.map((tab) => tab.id);
 	};


### PR DESCRIPTION
### Fixed
If some settings are disabled, eg direct connections, direct tool servers, then they should not be visible to the user role, either directly or through searching the setting-tabs.

### Screenshots
"Manage Direct Connections" is not visible to user role
![image](https://github.com/user-attachments/assets/a2acff88-e35e-4506-a129-94c9e10098de)

But still they can search for it and see it. Same goes for "Manage Tool Servers".
![Screenshot_20250504_110122](https://github.com/user-attachments/assets/c60a0c90-06ad-495d-8820-bd1250bd0928)



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [CONTRIBUTOR_LICENSE_AGREEMENT](CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.