### PR TITLE
fix: Resolve AttributeError for TikaLoader by passing kwargs

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -85,10 +85,11 @@ known_source_ext = [
 
 
 class TikaLoader:
-    def __init__(self, url, file_path, mime_type=None):
+    def __init__(self, url, file_path, mime_type=None, loader_kwargs=None):
         self.url = url
         self.file_path = file_path
         self.mime_type = mime_type
+        self.kwargs = loader_kwargs if loader_kwargs is not None else {}
 
     def load(self) -> list[Document]:
         with open(self.file_path, "rb") as f:
@@ -213,6 +214,7 @@ class Loader:
                     url=self.kwargs.get("TIKA_SERVER_URL"),
                     file_path=file_path,
                     mime_type=file_content_type,
+                    loader_kwargs=self.kwargs,
                 )
         elif self.engine == "docling" and self.kwargs.get("DOCLING_SERVER_URL"):
             if self._is_text_file(file_ext, file_content_type):


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes an AttributeError: 'TikaLoader' object has no attribute 'kwargs' that occurred during file processing when Tika is selected as the document engine. This error prevented configurations like PDF_EXTRACT_IMAGES from being correctly applied. The root cause was that the necessary keyword arguments (kwargs) containing these configurations were not being passed from the main Loader class to the TikaLoader instance during initialization. This PR ensures these arguments are correctly propagated.

### Added

N/A

### Changed

Modified Loader._get_loader method in backend/open_webui/retrieval/loaders/main.py to pass the self.kwargs dictionary to the TikaLoader constructor.

Modified TikaLoader.__init__ method in backend/open_webui/retrieval/loaders/main.py to accept an optional loader_kwargs argument and store it as self.kwargs, initializing to an empty dict if not provided.

### Deprecated

N/A

### Removed

N/A

### Fixed

Resolved AttributeError: 'TikaLoader' object has no attribute 'kwargs' when using Tika for document parsing, allowing configurations like PDF_EXTRACT_IMAGES to function correctly.


### Security

N/A

### Breaking Changes

N/A

---

### Additional Information

This fix directly addresses the traceback reported where TikaLoader.load() attempted to access self.kwargs.get("PDF_EXTRACT_IMAGES") but self.kwargs did not exist on the object instance.

Manual testing confirmed that file uploads using the Tika engine now complete successfully without the AttributeError after applying these changes.

Although the template suggests opening a discussion first, this PR directly addresses a specific AttributeError identified from error logs and aims to restore previously working functionality.


### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
