### PR TITLE
feat: Enhance YouTube Transcription Loader for multi-language support

### DIFF
--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -83,7 +83,7 @@ class YoutubeLoader:
                 'Could not import "youtube_transcript_api" Python package. '
                 "Please install it with `pip install youtube-transcript-api`."
             )
-    
+
         if self.proxy_url:
             youtube_proxies = {
                 "http": self.proxy_url,
@@ -93,7 +93,7 @@ class YoutubeLoader:
             log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
         else:
             youtube_proxies = None
-    
+        
         try:
             transcript_list = YouTubeTranscriptApi.list_transcripts(
                 self.video_id, proxies=youtube_proxies
@@ -101,11 +101,11 @@ class YoutubeLoader:
         except Exception as e:
             log.exception("Loading YouTube transcript failed")
             return []
-
+        
         # Make a copy of the language list to avoid modifying the original
         languages_to_try = list(self.language)
         
-        # Add English as fallback, if not already in the list
+        # Add English as fallback if not already in the list
         if "en" not in languages_to_try:
             log.debug("Adding English as fallback language")
             languages_to_try.append("en")
@@ -129,8 +129,8 @@ class YoutubeLoader:
             except Exception as e:
                 log.info(f"Error finding transcript for language '{lang}'")
                 raise e
-        
+
         # If we get here, all languages failed
         languages_tried = ", ".join(languages_to_try)
-        log.warning(f"No transcript found for any of the specified languages: {languages_tried}")
-        raise NoTranscriptFound(f"No transcript found for any supported language. Add additional supported languages and verify whether the video has any transcripts.")
+        log.warning(f"No transcript found for any of the specified languages: {languages_tried}. Verify if the video has transcripts, add more languages if needed.")
+        raise NoTranscriptFound(f"No transcript found for any supported language. Verify if the video has transcripts, add more languages if needed.")

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -64,7 +64,7 @@ class YoutubeLoader:
         self._metadata = {"source": video_id}
         self.language = language
         self.proxy_url = proxy_url
-        # If language is string, convert to list
+        # Ensure language is a list
         if isinstance(language, str):
             self.language = [language]
         else:

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -88,8 +88,7 @@ class YoutubeLoader:
                 "http": self.proxy_url,
                 "https": self.proxy_url,
             }
-            # Don't log complete URL because it might contain secrets
-            log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
+            log.debug(f"Using proxy URL: {self.proxy_url}...")
         else:
             youtube_proxies = None
     
@@ -105,9 +104,8 @@ class YoutubeLoader:
         last_exception = None
         for lang in self.language:
             try:
-                log.debug(f"Attempting to find transcript for language '{lang}'")
                 transcript = transcript_list.find_transcript([lang])
-                log.info(f"Found transcript for language '{lang}'")
+                log.debug(f"Found transcript for language '{lang}'")
                 
                 transcript_pieces: List[Dict[str, Any]] = transcript.fetch()
                 transcript_text = " ".join(
@@ -127,10 +125,8 @@ class YoutubeLoader:
                 raise e
     
         # If all specified languages fail, raise the last exception
-        # This maintains compatibility with the error handling in the rest of the application
         if last_exception:
             log.warning(f"No transcript found for any of the specified languages: {', '.join(self.language)}")
             raise last_exception
         
-        # This should never happen (we'd have raised an exception above)
         return []

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -68,7 +68,7 @@ class YoutubeLoader:
         if isinstance(language, str):
             self.language = [language]
         else:
-            self.language = list(language)  # Make a copy to avoid modifying the original
+            self.language = list(language)
         
         # Add English as fallback if not already in the list
         if "en" not in self.language:

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -70,67 +70,67 @@ class YoutubeLoader:
             self.language = language
 
     def load(self) -> List[Document]:
-    """Load YouTube transcripts into `Document` objects."""
-    try:
-        from youtube_transcript_api import (
-            NoTranscriptFound,
-            TranscriptsDisabled,
-            YouTubeTranscriptApi,
-        )
-    except ImportError:
-        raise ImportError(
-            'Could not import "youtube_transcript_api" Python package. '
-            "Please install it with `pip install youtube-transcript-api`."
-        )
-
-    if self.proxy_url:
-        youtube_proxies = {
-            "http": self.proxy_url,
-            "https": self.proxy_url,
-        }
-        # Don't log complete URL because it might contain secrets
-        log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
-    else:
-        youtube_proxies = None
-
-    try:
-        transcript_list = YouTubeTranscriptApi.list_transcripts(
-            self.video_id, proxies=youtube_proxies
-        )
-    except Exception as e:
-        log.exception("Loading YouTube transcript failed")
-        return []
-
-    # Try each language in order of priority
-    last_exception = None
-    for lang in self.language:
+        """Load YouTube transcripts into `Document` objects."""
         try:
-            log.debug(f"Attempting to find transcript for language '{lang}'")
-            transcript = transcript_list.find_transcript([lang])
-            log.info(f"Found transcript for language '{lang}'")
-            
-            transcript_pieces: List[Dict[str, Any]] = transcript.fetch()
-            transcript_text = " ".join(
-                map(
-                    lambda transcript_piece: transcript_piece.text.strip(" "),
-                    transcript_pieces,
-                )
+            from youtube_transcript_api import (
+                NoTranscriptFound,
+                TranscriptsDisabled,
+                YouTubeTranscriptApi,
             )
-            return [Document(page_content=transcript_text, metadata=self._metadata)]
-        except NoTranscriptFound as e:
-            log.debug(f"No transcript found for language '{lang}'")
-            last_exception = e
-            continue
-        except Exception as e:
-            # If we hit any other type of exception, log it and re-raise
-            log.exception(f"Error finding transcript for language '{lang}'")
-            raise e
-
-    # If all specified languages fail, raise the last exception
-    # This maintains compatibility with the error handling in the rest of the application
-    if last_exception:
-        log.warning(f"No transcript found for any of the specified languages: {', '.join(self.language)}")
-        raise last_exception
+        except ImportError:
+            raise ImportError(
+                'Could not import "youtube_transcript_api" Python package. '
+                "Please install it with `pip install youtube-transcript-api`."
+            )
     
-    # This should never happen (we'd have raised an exception above)
-    return []
+        if self.proxy_url:
+            youtube_proxies = {
+                "http": self.proxy_url,
+                "https": self.proxy_url,
+            }
+            # Don't log complete URL because it might contain secrets
+            log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
+        else:
+            youtube_proxies = None
+    
+        try:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(
+                self.video_id, proxies=youtube_proxies
+            )
+        except Exception as e:
+            log.exception("Loading YouTube transcript failed")
+            return []
+    
+        # Try each language in order of priority
+        last_exception = None
+        for lang in self.language:
+            try:
+                log.debug(f"Attempting to find transcript for language '{lang}'")
+                transcript = transcript_list.find_transcript([lang])
+                log.info(f"Found transcript for language '{lang}'")
+                
+                transcript_pieces: List[Dict[str, Any]] = transcript.fetch()
+                transcript_text = " ".join(
+                    map(
+                        lambda transcript_piece: transcript_piece.text.strip(" "),
+                        transcript_pieces,
+                    )
+                )
+                return [Document(page_content=transcript_text, metadata=self._metadata)]
+            except NoTranscriptFound as e:
+                log.debug(f"No transcript found for language '{lang}'")
+                last_exception = e
+                continue
+            except Exception as e:
+                # If we hit any other type of exception, log it and re-raise
+                log.exception(f"Error finding transcript for language '{lang}'")
+                raise e
+    
+        # If all specified languages fail, raise the last exception
+        # This maintains compatibility with the error handling in the rest of the application
+        if last_exception:
+            log.warning(f"No transcript found for any of the specified languages: {', '.join(self.language)}")
+            raise last_exception
+        
+        # This should never happen (we'd have raised an exception above)
+        return []

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -64,6 +64,7 @@ class YoutubeLoader:
         self._metadata = {"source": video_id}
         self.language = language
         self.proxy_url = proxy_url
+        # If language is string, convert to list
         if isinstance(language, str):
             self.language = [language]
         else:
@@ -100,7 +101,7 @@ class YoutubeLoader:
         except Exception as e:
             log.exception("Loading YouTube transcript failed")
             return []
-    
+
         # Make a copy of the language list to avoid modifying the original
         languages_to_try = list(self.language)
         
@@ -129,7 +130,7 @@ class YoutubeLoader:
                 log.info(f"Error finding transcript for language '{lang}'")
                 raise e
         
-        # If we get here, all languages failed including the English fallback
+        # If we get here, all languages failed
         languages_tried = ", ".join(languages_to_try)
         log.warning(f"No transcript found for any of the specified languages: {languages_tried}")
-        raise NoTranscriptFound(f"No transcript found for any supported language")
+        raise NoTranscriptFound(f"No transcript found for any supported language. Add additional supported languages and verify whether the video has any transcripts.")

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -118,8 +118,7 @@ class YoutubeLoader:
                 log.debug(f"No transcript found for language '{lang}'")
                 continue
             except Exception as e:
-                # If we hit any other type of exception, log it and re-raise
-                log.exception(f"Error finding transcript for language '{lang}'")
+                log.warning(f"Error finding transcript for language '{lang}'")
                 raise e
     
         # If all specified languages fail, fall back to English (unless English was already tried)
@@ -141,7 +140,7 @@ class YoutubeLoader:
                 log.exception("Error finding English transcript fallback")
                 raise e
         
-        # If we get here, all languages failed including the English fallback
+        # All languages failed
         languages_tried = ", ".join(self.language)
         if "en" not in self.language:
             languages_tried += ", en (fallback)"

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -88,8 +88,7 @@ class YoutubeLoader:
                 "http": self.proxy_url,
                 "https": self.proxy_url,
             }
-            # Don't log complete URL because it might contain secrets
-            log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
+            log.debug(f"Using proxy URL: {self.proxy_url}...")
         else:
             youtube_proxies = None
     

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -118,7 +118,7 @@ class YoutubeLoader:
                 log.debug(f"No transcript found for language '{lang}'")
                 continue
             except Exception as e:
-                log.warning(f"Error finding transcript for language '{lang}'")
+                log.info(f"Error finding transcript for language '{lang}'")
                 raise e
     
         # If all specified languages fail, fall back to English (unless English was already tried)

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -128,5 +128,5 @@ class YoutubeLoader:
     
         # If we get here, all languages failed
         languages_tried = ", ".join(self.language)
-        log.warning(f"No transcript found for any of the specified languages: {languages_tried}")
-        raise NoTranscriptFound(f"No transcript found for any supported language")
+        log.warning(f"No transcript found for any of the specified languages: {languages_tried}. Verify if the video has transcripts, add more languages if needed.")
+        raise NoTranscriptFound(f"No transcript found for any supported language. Verify if the video has transcripts, add more languages if needed.")

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -88,7 +88,8 @@ class YoutubeLoader:
                 "http": self.proxy_url,
                 "https": self.proxy_url,
             }
-            log.debug(f"Using proxy URL: {self.proxy_url}...")
+            # Don't log complete URL because it might contain secrets
+            log.debug(f"Using proxy URL: {self.proxy_url[:14]}...")
         else:
             youtube_proxies = None
     


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [[Open WebUI Docs](https://github.com/open-webui/docs)](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry
### Description
Enhanced YouTube transcript loader to properly handle multiple language fallbacks. Previously, if a transcript wasn't available in the configured language, it would only fall back to English. Now, multiple languages can be specified in priority order, and the system will try each language in sequence before eventually falling back to English.

This is a nifty feature, as in some usecases, trying to work with videos in different languages will result in an unexpected error just because there was no transcription in e.g. `de` and `en`.

With this change, you can now create a custom priority list, e.g. `es,de,en` which will ensure different transcription languages will be (attempted to) fetched.

The behaviour of defaulting to English if any languages in the list were unsuccessful to be fetched **remained unchanged**. So a list of `es,de` will have the same result as `es,de,en`. 

### Added
- Support for multiple language fallbacks when fetching YouTube transcriptions

### Changed
- Modified the `load()` method in `YoutubeLoader` class to attempt to fetch transcripts in each configured language in priority order
- Updated documentation for `YOUTUBE_LOADER_LANGUAGE` config option to clarify the new behavior: https://github.com/open-webui/docs/pull/528

### Fixed
- Fixed issue #13309 and #1960 where YouTube transcription would fail if not available in the primary language, even if it was available in another supported language

### Additional Information
- This enhancement makes it easier to work with multilingual YouTube content by allowing admins to configure a priority list of languages to try when fetching transcriptions.
- The change is fully backward compatible with existing configurations, as single language settings continue to work as before.
- References:
  - Issue #13309: https://github.com/open-webui/open-webui/issues/13309
  - Issue #1960: https://github.com/open-webui/open-webui/issues/1960

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree tothe [Contributor License Agreement (CLA)](https://github.com/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.