### PR TITLE
fix: support gpt-image-1 with correct parameter

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -501,9 +501,9 @@ async def image_generations(
                     else request.app.state.config.IMAGE_SIZE
                 ),
                 **(
-                    {"response_format": "b64_json"}
+                    {}
                     if "gpt-image-1" in request.app.state.config.IMAGE_GENERATION_MODEL
-                    else {}
+                    else {"response_format": "b64_json"}
                 ),
             }
 


### PR DESCRIPTION
# Pull Request Checklist

### [Discussion](https://github.com/open-webui/open-webui/discussions/13539) is here.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

As I described in this closed [pr](https://github.com/open-webui/open-webui/pull/13327). The gpt-image-1 model does not support the "response_format" parameter, which caused issues when generating images. And https://github.com/open-webui/open-webui/commit/6ae2d2c4eae0c6e67612a8226ea5f92ed019791f was incorrect. So I commit a little fix in this pr. 
#### The ERROR log:
```
> File "/app/backend/open_webui/utils/middleware.py", line 528, in chat_image_generation_handler
    images = await image_generations(
                   └ <function image_generations at 0x7fe5601d0ea0>

  File "/app/backend/open_webui/routers/images.py", line 680, in image_generations
    raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(error))
          │                                     │              │       └ "Unknown parameter: 'response_format'. (request id: 20250506095635818440966jr062kMG)"
          │                                     │              └ <function ERROR_MESSAGES.<lambda> at 0x7fe596d0fa60>
          │                                     └ <enum 'ERROR_MESSAGES'>
          └ <class 'fastapi.exceptions.HTTPException'>

fastapi.exceptions.HTTPException: 400: [ERROR: Unknown parameter: 'response_format'. (request id: 20250506095635818440966jr062kMG)]
```

### Added

None

### Changed

incorrect code:
```python
                **(
                     {"response_format": "b64_json"}
                     if "gpt-image-1" in request.app.state.config.IMAGE_GENERATION_MODEL
                     else {}
                 ),
```
correct code:
```python
                **(
                     {}
                     if "gpt-image-1" in request.app.state.config.IMAGE_GENERATION_MODEL
                     else {"response_format": "b64_json"}
                 ),
```

### Deprecated

None

### Removed

None

### Fixed

- Support gpt-image-1 with correct parameter

### Security

None

### Breaking Changes

- **BREAKING CHANGE**: None
---

### Additional Information

- None

### Screenshots or Videos
Before change
![image](https://github.com/user-attachments/assets/0d8f2e9c-7274-4b21-a793-3aee48adbb8c)
After change
![image](https://github.com/user-attachments/assets/18aad41c-8796-44a9-92bb-a7e00b199d6d)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
