### PR TITLE
fix(katex): Allow CJK characters adjacent to math delimiters

### DIFF
--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -11,7 +11,8 @@ const DELIMITER_LIST = [
 ];
 
 // Defines characters that are allowed to immediately precede or follow a math delimiter.
-const ALLOWED_SURROUNDING_CHARS = '\\s?。，!-\\/:-@\\[-`{-~\\p{Script=Han}';
+const ALLOWED_SURROUNDING_CHARS =
+	'\\s?。，、；!-\\/:-@\\[-`{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
 
 // const DELIMITER_LIST = [
 //     { left: '$$', right: '$$', display: false },

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -10,6 +10,9 @@ const DELIMITER_LIST = [
 	{ left: '\\begin{equation}', right: '\\end{equation}', display: true }
 ];
 
+// Defines characters that are allowed to immediately precede or follow a math delimiter.
+const ALLOWED_SURROUNDING_CHARS = '\\s?。，!-\\/:-@\\[-`{-~\\p{Script=Han}';
+
 // const DELIMITER_LIST = [
 //     { left: '$$', right: '$$', display: false },
 //     { left: '$', right: '$', display: false },
@@ -44,10 +47,13 @@ function generateRegexRules(delimiters) {
 
 	// Math formulas can end in special characters
 	const inlineRule = new RegExp(
-		`^(${inlinePatterns.join('|')})(?=[\\s?。，!-\/:-@[-\`{-~]|$)`,
+		`^(${inlinePatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`,
 		'u'
 	);
-	const blockRule = new RegExp(`^(${blockPatterns.join('|')})(?=[\\s?。，!-\/:-@[-\`{-~]|$)`, 'u');
+	const blockRule = new RegExp(
+		`^(${blockPatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`,
+		'u'
+	);
 
 	return { inlineRule, blockRule };
 }
@@ -91,7 +97,9 @@ function katexStart(src, displayMode: boolean) {
 
 		// Check if the delimiter is preceded by a special character.
 		// If it does, then it's potentially a math formula.
-		const f = index === 0 || indexSrc.charAt(index - 1).match(/[\s?。，!-\/:-@[-`{-~]/);
+		const f =
+			index === 0 ||
+			indexSrc.charAt(index - 1).match(new RegExp(`[${ALLOWED_SURROUNDING_CHARS}]`, 'u'));
 		if (f) {
 			const possibleKatex = indexSrc.substring(index);
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

The current regex patterns reject math delimiters (`$...$`, etc.) when they appear directly against Chinese characters (e.g., `$A$等于$B$`). This is particularly problematic because that many LLMs naturally output math expressions adjacent to Chinese text **without spacing** (e.g., `这里，$A$是一个矩阵，$E$是单位矩阵`, more examples discussed in #13487). However, our katex validation rules require **special characters/whitespace around delimiters**, causing Chinese+math combinations failed to render.

(Notably, in native [`marked-katex-extension`](https://www.npmjs.com/package/marked-katex-extension), this case is correctly handled.)

![owui](https://github.com/user-attachments/assets/a6754ce0-e2ba-468b-bf89-cd8e5796885a)

### Changed

- Introduced `ALLOWED_SURROUNDING_CHARS` constant
- Added Unicode `\p{Script=Han}` support, updated the parsing logic in lookahead checks  (`$x$中文`) and preceding checks (`中文$x$`)
- Maintained all existing punctuation/whitespace rules

### Testings

![chinese](https://github.com/user-attachments/assets/98704a12-b4ec-49e6-a4aa-f7d2b77ad424)

![japanese](https://github.com/user-attachments/assets/d02c96f5-7d55-428e-a1b7-cf986700d3a3)

![korean](https://github.com/user-attachments/assets/4771589c-a92c-4e0f-b6f0-60fdff772e8e)

I've also conducted some regression tests, and they all passed.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
