### PR TITLE
Fix: Fix Image parameter for Automatic1111 `/generations` endpoint

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -623,7 +623,7 @@ async def image_generations(
             or request.app.state.config.IMAGE_GENERATION_ENGINE == ""
         ):
             if form_data.model:
-                set_image_model(form_data.model)
+                set_image_model(request, form_data.model)
 
             data = {
                 "prompt": form_data.prompt,


### PR DESCRIPTION
### Description

- When sending requests to the `/generations` endpoint for images with a `model` body parameter and the image generation engine is `Automatic1111` an error occurs since the `set_image_model` method is used wrong and missing the request parameter.

### Fixed

- `model` param errors when using `Automatic1111` in image generation API.
