### PR TITLE
enh: Improve visibility of overflow / hidden tools when more than 3 are present

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -102,7 +102,7 @@
 			transition={flyAndScale}
 		>
 			{#if Object.keys(tools).length > 0}
-				<div class="  max-h-28 overflow-y-auto scrollbar-hidden">
+				<div class="max-h-28 overflow-y-auto scrollbar-thin">
 					{#each Object.keys(tools) as toolId}
 						<button
 							class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
@@ -141,6 +141,17 @@
 						</button>
 					{/each}
 				</div>
+<button
+						class="flex w-full justify-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800"
+						on:click={() => {
+							const element = document.querySelector('.max-h-28');
+							if (element) {
+								element.classList.remove('max-h-28');
+							}
+						}}
+					>
+						^
+					</button>
 
 				<hr class="border-black/5 dark:border-white/5 my-1" />
 			{/if}

--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -33,6 +33,7 @@
 
 	let tools = {};
 	let show = false;
+	let showAllTools = false;
 
 	$: if (show) {
 		init();
@@ -102,7 +103,7 @@
 			transition={flyAndScale}
 		>
 			{#if Object.keys(tools).length > 0}
-				<div class="max-h-28 overflow-y-auto scrollbar-thin">
+				<div class="{showAllTools ? '' : 'max-h-28'} overflow-y-auto scrollbar-thin">
 					{#each Object.keys(tools) as toolId}
 						<button
 							class="flex w-full justify-between gap-2 items-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl"
@@ -141,18 +142,25 @@
 						</button>
 					{/each}
 				</div>
-<button
-						class="flex w-full justify-center px-3 py-2 text-sm font-medium cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800"
+					<button
+						class="flex w-full justify-center items-center text-sm font-medium cursor-pointer rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800"
 						on:click={() => {
-							const element = document.querySelector('.max-h-28');
-							if (element) {
-								element.classList.remove('max-h-28');
-							}
+							showAllTools = !showAllTools;
 						}}
+						title={showAllTools ? $i18n.t('Show Less') : $i18n.t('Show All')}
 					>
-						^
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke-width="2.5"
+							stroke="currentColor"
+							class="size-3 transition-transform duration-200 {showAllTools ? 'rotate-180' : ''} text-gray-300 dark:text-gray-600"
+						>
+							<path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"
+							></path>
+						</svg>
 					</button>
-
 				<hr class="border-black/5 dark:border-white/5 my-1" />
 			{/if}
 

--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -142,6 +142,7 @@
 						</button>
 					{/each}
 				</div>
+					{#if Object.keys(tools).length > 3}
 					<button
 						class="flex w-full justify-center items-center text-sm font-medium cursor-pointer rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800"
 						on:click={() => {
@@ -161,6 +162,7 @@
 							></path>
 						</svg>
 					</button>
+					{/if}
 				<hr class="border-black/5 dark:border-white/5 my-1" />
 			{/if}
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Discussions thread:
https://github.com/open-webui/open-webui/discussions/13702

- Enhanced the tool menu in the chat input ([`src/lib/components/chat/MessageInput/InputMenu.svelte`](src/lib/components/chat/MessageInput/InputMenu.svelte:0)) to improve discoverability of tools when more than three are present. Previously, overflow was hidden without a consistently visible scrollbar, making it difficult for users to find additional tools without specific mouse/trackpad actions. This change introduces a persistent scrollbar for overflow and a toggle to show all tools.

### Added

- A persistently visible scrollbar (using `scrollbar-thin` class) to the tools list container within [`src/lib/components/chat/MessageInput/InputMenu.svelte`](src/lib/components/chat/MessageInput/InputMenu.svelte:106) when its content overflows.
- A toggle button (chevron SVG icon) below the tools list in [`src/lib/components/chat/MessageInput/InputMenu.svelte`](src/lib/components/chat/MessageInput/InputMenu.svelte:145) to expand or collapse the list, allowing users to view all available tools or a compact list (max 3 visible by default).

### Changed

- The tools list container `div` in [`src/lib/components/chat/MessageInput/InputMenu.svelte`](src/lib/components/chat/MessageInput/InputMenu.svelte:106) now dynamically applies or removes the `max-h-28` class based on the `showAllTools` state variable, controlled by the new toggle button.
- The toggle button uses the same SVG chevron icon that chat collapse on the sidebar uses and rotates 180 degrees to visually indicate the expanded or collapsed state.
- The SVG icon for the toggle button in [`src/lib/components/chat/MessageInput/InputMenu.svelte`](src/lib/components/chat/MessageInput/InputMenu.svelte:158) is styled with `text-gray-300 dark:text-gray-600` to match the chat collapse. 

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Improved usability for discovering tools in the input menu when the number of tools exceeds the default visible limit.
- Addressed the issue where users without a scroll wheel/trackpad might struggle to reveal overflowing tools.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- These changes aim to directly address user feedback regarding the difficulty of finding tools when the list overflows. The solution provides both a visual cue (scrollbar) and an explicit control (toggle button) for managing the display of tools.
- No new dependencies were added.
- No documentation changes are required for this UI enhancement.
https://github.com/open-webui/open-webui/discussions/13702

### Screenshots or Videos

When more than 3 tools present:
**Usage video:**
https://github.com/user-attachments/assets/cae67e1f-3c3b-490e-ace2-15e1b8000194
Screenshot:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/c5982417-bf63-4fdb-ba61-6c351083b08f" />

When 3 or fewer (retains original):
<img width="929" alt="image" src="https://github.com/user-attachments/assets/71a21e54-8f50-45af-90e8-10df23ef0cd1" />



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.