### PR TITLE
fix: allow non-root jupyter base_url

### DIFF
--- a/backend/open_webui/utils/code_interpreter.py
+++ b/backend/open_webui/utils/code_interpreter.py
@@ -44,12 +44,14 @@ class JupyterCodeExecuter:
         :param password: Jupyter password (optional)
         :param timeout: WebSocket timeout in seconds (default: 60s)
         """
-        self.base_url = base_url.rstrip("/")
+        self.base_url = base_url
         self.code = code
         self.token = token
         self.password = password
         self.timeout = timeout
         self.kernel_id = ""
+        if self.base_url[-1] != '/':
+            self.base_url += '/'
         self.session = aiohttp.ClientSession(trust_env=True, base_url=self.base_url)
         self.params = {}
         self.result = ResultModel()
@@ -61,7 +63,7 @@ class JupyterCodeExecuter:
         if self.kernel_id:
             try:
                 async with self.session.delete(
-                    f"/api/kernels/{self.kernel_id}", params=self.params
+                    f"api/kernels/{self.kernel_id}", params=self.params
                 ) as response:
                     response.raise_for_status()
             except Exception as err:
@@ -81,7 +83,7 @@ class JupyterCodeExecuter:
     async def sign_in(self) -> None:
         # password authentication
         if self.password and not self.token:
-            async with self.session.get("/login") as response:
+            async with self.session.get("login") as response:
                 response.raise_for_status()
                 xsrf_token = response.cookies["_xsrf"].value
                 if not xsrf_token:
@@ -89,7 +91,7 @@ class JupyterCodeExecuter:
                 self.session.cookie_jar.update_cookies(response.cookies)
                 self.session.headers.update({"X-XSRFToken": xsrf_token})
             async with self.session.post(
-                "/login",
+                "login",
                 data={"_xsrf": xsrf_token, "password": self.password},
                 allow_redirects=False,
             ) as response:
@@ -102,16 +104,16 @@ class JupyterCodeExecuter:
 
     async def init_kernel(self) -> None:
         async with self.session.post(
-            url="/api/kernels", params=self.params
+            url="api/kernels", params=self.params
         ) as response:
             response.raise_for_status()
             kernel_data = await response.json()
             self.kernel_id = kernel_data["id"]
 
     def init_ws(self) -> (str, dict):
-        ws_base = self.base_url.replace("http", "ws")
+        ws_base = self.base_url.replace("http", "ws", 1)
         ws_params = "?" + "&".join([f"{key}={val}" for key, val in self.params.items()])
-        websocket_url = f"{ws_base}/api/kernels/{self.kernel_id}/channels{ws_params if len(ws_params) > 1 else ''}"
+        websocket_url = f"{ws_base}api/kernels/{self.kernel_id}/channels{ws_params if len(ws_params) > 1 else ''}"
         ws_headers = {}
         if self.password and not self.token:
             ws_headers = {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x ] **Description:** Provide a concise description of the changes made in this pull request.
- [x ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [n/a ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x ] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

The code_interpreter.py did not function correctly for Jupyter server instances running under an URL with a prefix. If for example the Jupyter server was available at `http://server.example.com/jupyter/` the `/jupyter/` part of the URL was ignored. This fixes this bug.

To test, launch:
`jupyter-lab --ServerApp.base_url=/jupyter/`

### Added



### Changed


### Deprecated


### Removed


### Fixed

code_interpreter.py: class JupyterCodeExecuter now stores the base_url WITH trailing slash (adding one if not provided), and then executes self.session.get/post WITHOUT leading slash. The init_ws function was also fixed to not mess up URLs that happen to contain the string "http".

### Security


### Breaking Changes


---

### Additional Information


### Screenshots or Videos


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
