### PR TITLE
feat: inject user context (name and email) into prompt generation templates

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1471,6 +1471,10 @@ AUTOCOMPLETE_GENERATION_PROMPT_TEMPLATE = PersistentConfig(
 DEFAULT_AUTOCOMPLETE_GENERATION_PROMPT_TEMPLATE = """### Task:
 You are an autocompletion system. Continue the text in `<text>` based on the **completion type** in `<type>` and the given language.  
 
+### **User Data**:
+User Name: {{USER_NAME}}
+User Email: {{USER_EMAIL}}
+
 ### **Instructions**:
 1. Analyze `<text>` for context and meaning.  
 2. Use `<type>` to guide your output:  
@@ -1518,6 +1522,9 @@ TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE = PersistentConfig(
 
 
 DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE = """Available Tools: {{TOOLS}}
+
+User Name: {{USER_NAME}}
+User Email: {{USER_EMAIL}}
 
 Your task is to choose and return the correct tool(s) from the list of available tools based on the query. Follow these guidelines:
 
@@ -2028,6 +2035,10 @@ CHUNK_OVERLAP = PersistentConfig(
 
 DEFAULT_RAG_TEMPLATE = """### Task:
 Respond to the user query using the provided context, incorporating inline citations in the format [id] **only when the <source> tag includes an explicit id attribute** (e.g., <source id="1">).
+
+### User Data:
+User Name: {{USER_NAME}}
+User Email: {{USER_EMAIL}}
 
 ### Guidelines:
 - If you don't know the answer, clearly state that.

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -192,6 +192,7 @@ async def generate_title(
         {
             "name": user.name,
             "location": user.info.get("location") if user.info else None,
+            "email": user.email,
         },
     )
 
@@ -274,7 +275,7 @@ async def generate_chat_tags(
         template = DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE
 
     content = tags_generation_template(
-        template, form_data["messages"], {"name": user.name}
+        template, form_data["messages"], {"name": user.name, "email": user.email}
     )
 
     payload = {
@@ -346,6 +347,7 @@ async def generate_image_prompt(
         form_data["messages"],
         user={
             "name": user.name,
+            "email": user.email,
         },
     )
 
@@ -429,7 +431,7 @@ async def generate_queries(
         template = DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE
 
     content = query_generation_template(
-        template, form_data["messages"], {"name": user.name}
+        template, form_data["messages"], {"name": user.name, "email": user.email}
     )
 
     payload = {
@@ -516,7 +518,7 @@ async def generate_autocompletion(
         template = DEFAULT_AUTOCOMPLETE_GENERATION_PROMPT_TEMPLATE
 
     content = autocomplete_generation_template(
-        template, prompt, messages, type, {"name": user.name}
+        template, prompt, messages, type, {"name": user.name, "email": user.email}
     )
 
     payload = {
@@ -585,6 +587,7 @@ async def generate_emoji(
         {
             "name": user.name,
             "location": user.info.get("location") if user.info else None,
+            "email": user.email
         },
     )
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -155,7 +155,7 @@ async def chat_completion_tools_handler(
         template = DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE
 
     tools_function_calling_prompt = tools_function_calling_generation_template(
-        template, tools_specs
+        template, tools_specs, user
     )
     payload = get_tools_function_calling_payload(
         body["messages"], task_model_id, tools_function_calling_prompt

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -26,6 +26,7 @@ def apply_model_system_prompt_to_body(
         template_params = {
             "user_name": user.name,
             "user_location": user.info.get("location") if user.info else None,
+            "user_email": user.email
         }
     else:
         template_params = {}

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -39,7 +39,7 @@ def prompt_variables_template(template: str, variables: dict[str, str]) -> str:
 
 
 def prompt_template(
-    template: str, user_name: Optional[str] = None, user_location: Optional[str] = None
+    template: str, user_name: Optional[str] = None, user_location: Optional[str] = None, user_email: Optional[str] = None
 ) -> str:
     # Get the current date
     current_date = datetime.now()
@@ -69,6 +69,13 @@ def prompt_template(
     else:
         # Replace {{USER_LOCATION}} in the template with "Unknown"
         template = template.replace("{{USER_LOCATION}}", "Unknown")
+
+    if user_email:
+        # Replace {{USER_EMAIL}} in the template with the current email
+        template = template.replace("{{USER_EMAIL}}", user_email)
+    else:
+        # Replace {{USER_EMAIL}} in the template with "Unknown"
+        template = template.replace("{{USER_EMAIL}}", "Unknown")
 
     return template
 
@@ -198,7 +205,7 @@ def title_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -217,7 +224,7 @@ def tags_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -235,7 +242,7 @@ def image_prompt_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -250,7 +257,7 @@ def emoji_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -273,7 +280,7 @@ def autocomplete_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -291,7 +298,7 @@ def query_generation_template(
     template = prompt_template(
         template,
         **(
-            {"user_name": user.get("name"), "user_location": user.get("location")}
+            {"user_name": user.get("name"), "user_location": user.get("location"), "user_email": user.get("email")}
             if user
             else {}
         ),
@@ -336,6 +343,12 @@ def moa_response_generation_template(
     return template
 
 
-def tools_function_calling_generation_template(template: str, tools_specs: str) -> str:
+def tools_function_calling_generation_template(template: str, tools_specs: str, user: Optional[dict] = None) -> str:
     template = template.replace("{{TOOLS}}", tools_specs)
+    if user:
+        template = template.replace("{{USER_NAME}}", user.name)
+        template = template.replace("{{USER_EMAIL}}", user.email)
+    else:
+        template = template.replace("{{USER_NAME}}", "Unknown")
+        template = template.replace("{{USER_EMAIL}}", "Unknown")    
     return template


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

- This pull request introduces the injection of user context (name and email) into all relevant prompt generation templates.
This allows external tools like MCP to perform user-specific permission validation or prompt customization.
It ensures backward compatibility by defaulting missing values to "Unknown".

### Added

- Support for user.name and user.email placeholders in:
  - tools_function_calling_generation_template
  - All other prompt generation templates in utils/task.py

### Changed

- Prompt templates now include user-specific context where applicable.

---

### Additional Information

This change was motivated by the need to securely handle user-specific operations through MCP by providing essential user identifiers like email.

> **Note:**  
> To ensure that these user details (`name` and `email`) are **always available** in the prompt context, it is necessary to **include them explicitly in the model's system prompt**.
![image](https://github.com/user-attachments/assets/7bc614e5-c942-4d54-9b47-2b029fce4a80)

Related to discussion: [13608](https://github.com/open-webui/open-webui/discussions/13608)

### Screenshots or Videos

Before:
![Screenshot_4](https://github.com/user-attachments/assets/76354978-9fe4-405d-8ed7-2dc387b82605)

After:
![Novo Projeto (1)](https://github.com/user-attachments/assets/3dffb173-1165-485e-9d44-bc46c7cd8864)

MCP:
![Novo Projeto](https://github.com/user-attachments/assets/2b83f350-a4fd-411a-8b07-0ea909099fcc)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
