### PR TITLE
feat: Add OpenAI-Compliant /v1/embeddings Endpoints

### DIFF
--- a/backend/open_webui/models/embeddings.py
+++ b/backend/open_webui/models/embeddings.py
@@ -1,0 +1,25 @@
+# backend/open_webui/models/embeddings.py
+from typing import Union, List, Optional
+from pydantic import BaseModel, Field
+
+class OpenAIEmbeddingRequest(BaseModel):
+    input: Union[str, List[str]]
+    model: str
+    encoding_format: Optional[str] = Field("float", pattern="^(float|base64)$")
+    dimensions: Optional[int] = None
+    user: Optional[str] = None
+
+class EmbeddingObject(BaseModel):
+    object: str = "embedding"
+    embedding: Union[List[float], str] # List of floats or base64 string
+    index: int
+
+class UsageObject(BaseModel):
+    prompt_tokens: int
+    total_tokens: int
+
+class OpenAIEmbeddingResponse(BaseModel):
+    object: str = "list"
+    data: List[EmbeddingObject]
+    model: str # The model ID used for the embedding
+    usage: UsageObject

--- a/backend/open_webui/routers/local.py
+++ b/backend/open_webui/routers/local.py
@@ -1,0 +1,99 @@
+# backend/open_webui/routers/local.py
+import logging
+import base64
+import struct
+import numpy as np
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from open_webui.models.embeddings import OpenAIEmbeddingRequest, OpenAIEmbeddingResponse, EmbeddingObject, UsageObject
+from open_webui.utils.auth import get_verified_user, UserModel
+from open_webui.config import RAG_EMBEDDING_MODEL_AUTO_UPDATE # PersistentConfig
+from open_webui.env import DEVICE_TYPE, RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE # PersistentConfig
+from open_webui.retrieval.utils import get_model_path
+
+log = logging.getLogger(__name__)
+router = APIRouter()
+loaded_local_models = {}
+
+def get_sentence_transformer_model_internal(model_id: str): # Renamed to avoid conflict
+    if model_id not in loaded_local_models:
+        try:
+            from sentence_transformers import SentenceTransformer
+            log.info(f"Loading local SentenceTransformer model: {model_id}")
+            resolved_model_path = get_model_path(model_id, RAG_EMBEDDING_MODEL_AUTO_UPDATE.value)
+            loaded_local_models[model_id] = SentenceTransformer(
+                resolved_model_path,
+                device=DEVICE_TYPE.value, # Access PersistentConfig via .value
+                trust_remote_code=RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE.value # Access PersistentConfig via .value
+            )
+            log.info(f"Successfully loaded local model: {model_id} from {resolved_model_path}")
+        except Exception as e:
+            log.exception(f"Failed to load local ST model {model_id}: {e}")
+            raise RuntimeError(f"Could not load local model '{model_id}'. Error: {e}")
+    return loaded_local_models[model_id]
+
+async def generate_local_embeddings_v1(
+    request_obj: Request, # Kept for consistency, may not be used if request_data has all info
+    request_data: OpenAIEmbeddingRequest,
+    user: UserModel # Kept for consistency
+) -> OpenAIEmbeddingResponse:
+    log.info(f"Local v1 embeddings request for model '{request_data.model}'")
+    model_id_to_load = request_data.model
+
+    try:
+        model = get_sentence_transformer_model_internal(model_id_to_load)
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+    inputs_to_embed = [request_data.input] if isinstance(request_data.input, str) else request_data.input
+    if not inputs_to_embed:
+        raise HTTPException(status_code=400, detail="Input list/string cannot be empty.")
+
+    try:
+        # type: ignore
+        raw_embeddings_np = model.encode(inputs_to_embed, convert_to_tensor=False) 
+        # Ensure raw_embeddings is List[List[float]]
+        if isinstance(raw_embeddings_np, np.ndarray):
+            if raw_embeddings_np.ndim == 1: # Single embedding case
+                 raw_embeddings = [raw_embeddings_np.tolist()]
+            else: # Batch embedding case
+                 raw_embeddings = [arr.tolist() for arr in raw_embeddings_np]
+        elif isinstance(raw_embeddings_np, list) and all(isinstance(arr, np.ndarray) for arr in raw_embeddings_np):
+            raw_embeddings = [arr.tolist() for arr in raw_embeddings_np]
+        else:
+            log.error(f"Unexpected embedding output format from model {model_id_to_load}: {type(raw_embeddings_np)}")
+            raise HTTPException(status_code=500, detail=f"Embedding generation failed due to unexpected output format.")
+
+    except Exception as e:
+        log.exception(f"Error during local model encoding for {model_id_to_load}: {e}")
+        raise HTTPException(status_code=500, detail=f"Embedding generation failed. Error: {e}")
+
+    output_embeddings_data: List[EmbeddingObject] = []
+    prompt_tokens_total = 0 # Placeholder, or use tiktoken
+
+    for index, vector in enumerate(raw_embeddings):
+        embedding_vector = vector
+        if request_data.encoding_format == "base64":
+            byte_array = bytearray()
+            for val in embedding_vector:
+                byte_array.extend(struct.pack('f', val))
+            embedding_vector = base64.b64encode(byte_array).decode('utf-8')
+        
+        output_embeddings_data.append(EmbeddingObject(embedding=embedding_vector, index=index))
+        # Optional: Calculate prompt_tokens_total
+
+    return OpenAIEmbeddingResponse(
+        data=output_embeddings_data,
+        model=request_data.model,
+        usage=UsageObject(prompt_tokens=prompt_tokens_total, total_tokens=prompt_tokens_total)
+    )
+
+@router.post("/v1/embeddings", response_model=OpenAIEmbeddingResponse)
+async def local_v1_embeddings_direct_endpoint( # Renamed for clarity
+    request_data: OpenAIEmbeddingRequest,
+    request: Request, # FastAPI Request object
+    user=Depends(get_verified_user)
+):
+    return await generate_local_embeddings_v1(request, request_data, user) 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:**  This PR introduces new OpenAI-compliant /v1/embeddings API endpoints for both OpenAI-compatible services (via /openai/v1/embeddings) and Ollama backends (via /ollama/v1/embeddings). It includes shared Pydantic schemas for consistent request/response structures and a utility for token estimation.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** API documentation is managed by FastAPI /docs page.
- [x] **Dependencies:** No new dependencies added.
- [X] **Testing:** I used curl commands to verify new endpoints work as expected without breaking older existing embedding endpoints. See the [gist](https://gist.github.com/pranitl/0284c121e0b580b6e095a4a25f570f0b) for the various commands. 
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This pull request introduces standardized, OpenAI-compliant embedding generation capabilities through new API endpoints. It adds `POST /openai/v1/embeddings` to interface with various configured OpenAI-compatible services and `POST /ollama/v1/embeddings` to provide an OpenAI-compliant interface for Ollama's embedding models. This enhancement aims to provide a consistent API for embedding generation, regardless of the backend service.

The implementation includes:

  - Shared Pydantic models (`OpenAIEmbeddingsRequest`, `OpenAIEmbeddingsResponse`, etc.) in `backend/open_webui/models/openai_schemas.py` for consistent OpenAI-compliant request/response handling across the new endpoints.
  - A token estimation utility (`estimate_embedding_tokens`) in `backend/open_webui/utils/misc.py` for use by the Ollama endpoint to populate usage statistics.
  - The `/ollama/v1/embeddings` endpoint performs translation of OpenAI-formatted requests to Ollama's native embedding request format and translates Ollama's responses back to the OpenAI schema.
  - The `/openai/v1/embeddings` endpoint routes requests to the appropriate configured OpenAI-compatible backend (e.g., official OpenAI, Azure OpenAI, other generic providers).

### Added

 - New API endpoint `POST /openai/v1/embeddings` in `backend/open_webui/routers/openai.py` for generating embeddings using configured OpenAI-compatible services.
  - New API endpoint `POST /ollama/v1/embeddings` in `backend/open_webui/routers/ollama.py` for generating embeddings via Ollama, using an OpenAI-compliant interface.
  - New shared Pydantic models for OpenAI embedding schemas (`OpenAIEmbeddingsRequest`, `OpenAIEmbeddingData`, `OpenAIUsage`, `OpenAIEmbeddingsResponse`) in `backend/open_webui/models/openai_schemas.py`.
  - New utility function `estimate_embedding_tokens` in `backend/open_webui/utils/misc.py` to help estimate token counts for embedding inputs, primarily for Ollama.
  - New helper function `_generate_ollama_embeddings_native` (or similar) within `backend/open_webui/routers/ollama.py` to centralize Ollama's native embedding call logic.)*

### Changed

- Refactored existing Ollama native embedding logic within `backend/open_webui/routers/ollama.py` to utilize a new internal helper function. This improves code structure and reusability for calls to Ollama's `/api/embed` or `/api/embeddings`.)*
  - Utilizes existing model configuration mechanisms to fetch API keys, base URLs, and other parameters for OpenAI-compatible embedding models.

### Deprecated

- No functionality is deprecated by this PR. (Note: `/ollama/api/embed` is already marked as deprecated in the codebase prior to this work).

### Removed

- No functionality or files are removed by this PR.

### Fixed

- N/A (This PR is primarily a new feature).

### Security

- New endpoints adhere to existing authentication and authorization mechanisms within Open WebUI. User context is utilized for requests.

### Breaking Changes

- No breaking changes are introduced. Existing Ollama embedding endpoints (`/ollama/api/embed` and `/ollama/api/embeddings`) remain functional and unaffected.

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- N/A (Backend API changes). `curl` commands for testing have been successfully executed against a local development instance.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
