### PR TITLE
fix: urlIdx type conversion in pipeline filters

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -68,15 +68,9 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
 
     async with aiohttp.ClientSession(trust_env=True) as session:
         for filter in sorted_filters:
-            urlIdx = filter.get("urlIdx")
-            if urlIdx is None:
-                continue
-            
-            # Convert urlIdx to integer to avoid TypeError with string indices
             try:
-                urlIdx = int(urlIdx)
-            except (ValueError, TypeError):
-                log.error(f"Invalid urlIdx value: {urlIdx}")
+                urlIdx = int(filter.get("urlIdx"))
+            except (ValueError, TypeError, AttributeError):
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
@@ -124,15 +118,9 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
 
     async with aiohttp.ClientSession(trust_env=True) as session:
         for filter in sorted_filters:
-            urlIdx = filter.get("urlIdx")
-            if urlIdx is None:
-                continue
-            
-            # Convert urlIdx to integer to avoid TypeError with string indices
             try:
-                urlIdx = int(urlIdx)
-            except (ValueError, TypeError):
-                log.error(f"Invalid urlIdx value: {urlIdx}")
+                urlIdx = int(filter.get("urlIdx"))
+            except (ValueError, TypeError, AttributeError):
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -71,6 +71,13 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
             urlIdx = filter.get("urlIdx")
             if urlIdx is None:
                 continue
+            
+            # Convert urlIdx to integer to avoid TypeError with string indices
+            try:
+                urlIdx = int(urlIdx)
+            except (ValueError, TypeError):
+                log.error(f"Invalid urlIdx value: {urlIdx}")
+                continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
             key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
@@ -119,6 +126,13 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
         for filter in sorted_filters:
             urlIdx = filter.get("urlIdx")
             if urlIdx is None:
+                continue
+            
+            # Convert urlIdx to integer to avoid TypeError with string indices
+            try:
+                urlIdx = int(urlIdx)
+            except (ValueError, TypeError):
+                log.error(f"Invalid urlIdx value: {urlIdx}")
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]


### PR DESCRIPTION
Fix urlIdx type conversion in pipeline filters

This PR fixes the type error issue reported in open-webui/pipelines#511 by improving the urlIdx type handling in both inlet and outlet filters.

Changes:
- Simplified urlIdx type conversion in process_pipeline_inlet_filter and process_pipeline_outlet_filter

Testing:
- Built and tested locally with Docker (OpenWebUI v0.6.9)
- Verified pipeline filters work correctly with integer urlIdx values
- Confirmed the fix resolves the TypeError reported in the issue

Fixes open-webui/pipelines#511