### PR TITLE
Accessibility settings modal general tab

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -232,7 +232,7 @@
 	};
 </script>
 
-<div class="flex flex-col h-full justify-between text-sm">
+<section class="flex flex-col h-full justify-between text-sm">
 	<div class="  overflow-y-scroll max-h-[28rem] lg:max-h-full">
 		<div class="">
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</div>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -235,7 +235,7 @@
 <section class="flex flex-col h-full justify-between text-sm">
 	<div class="  overflow-y-scroll max-h-[28rem] lg:max-h-full">
 		<div class="">
-			<div class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</div>
+			<h2 class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</h2>
 
 			<div class="flex w-full justify-between">
 				<label for="theme-select" class=" self-center text-xs font-medium">{$i18n.t('Theme')}</label>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -245,7 +245,6 @@
 						id="theme-select"
 						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 						bind:value={selectedTheme}
-						placeholder="Select a theme"
 						on:change={() => themeChangeHandler(selectedTheme)}
 					>
 						<option value="system">⚙️ {$i18n.t('System')}</option>
@@ -268,7 +267,6 @@
 						id="language-select"
 						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 						bind:value={lang}
-						placeholder="Select a language"
 						on:change={(e) => {
 							changeLanguage(lang);
 						}}

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -233,15 +233,16 @@
 </script>
 
 <section class="flex flex-col h-full justify-between text-sm">
-	<div class="  overflow-y-scroll max-h-[28rem] lg:max-h-full">
+	<div class="overflow-y-scroll max-h-[28rem] lg:max-h-full">
 		<div class="">
 			<h2 class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</h2>
 
 			<div class="flex w-full justify-between">
-				<label for="theme-select" class=" self-center text-xs font-medium">{$i18n.t('Theme')}</label>
+				<label for="theme-select" class=" self-center text-xs font-medium">{$i18n.t('Theme')}</label
+				>
 				<div class="flex items-center relative">
 					<select
-					id="theme-select"
+						id="theme-select"
 						class=" dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
 						bind:value={selectedTheme}
 						placeholder="Select a theme"
@@ -258,12 +259,14 @@
 				</div>
 			</div>
 
-			<div class=" flex w-full justify-between">
-				<label for="language-select" class=" self-center text-xs font-medium">{$i18n.t('Language')}</label>
+			<div class="flex w-full justify-between">
+				<label for="language-select" class=" self-center text-xs font-medium"
+					>{$i18n.t('Language')}</label
+				>
 				<div class="flex items-center relative">
 					<select
-					id="language-select"
-						class=" dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
+						id="language-select"
+						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
 						bind:value={lang}
 						placeholder="Select a language"
 						on:change={(e) => {
@@ -290,15 +293,19 @@
 			{/if}
 
 			<div>
-				<div class=" py-0.5 flex w-full justify-between">
-					<div class=" self-center text-xs font-medium">{$i18n.t('Notifications')}</div>
-
+				<div class="py-0.5 flex w-full justify-between">
+					<label class="self-center text-xs font-medium" id="notification-label">
+						{$i18n.t('Notifications')}
+					</label>
 					<button
 						class="p-1 px-3 text-xs flex rounded-sm transition"
+						type="button"
+						role="switch"
+						aria-checked={notificationEnabled}
+						aria-labelledby="notification-label"
 						on:click={() => {
 							toggleNotification();
 						}}
-						type="button"
 					>
 						{#if notificationEnabled === true}
 							<span class="ml-2 self-center">{$i18n.t('On')}</span>
@@ -314,7 +321,9 @@
 			<hr class="border-gray-50 dark:border-gray-850 my-3" />
 
 			<div>
-				<label for="enter-system-prompt" class=" my-2.5 text-sm font-medium">{$i18n.t('System Prompt')}</label>
+				<label for="enter-system-prompt" class=" my-2.5 text-sm font-medium"
+					>{$i18n.t('System Prompt')}</label
+				>
 				<Textarea
 					bind:value={system}
 					className="w-full text-sm bg-white dark:text-gray-300 dark:bg-gray-900 outline-hidden resize-none"

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -238,9 +238,10 @@
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</div>
 
 			<div class="flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Theme')}</div>
+				<label for="theme-select" class=" self-center text-xs font-medium">{$i18n.t('Theme')}</label>
 				<div class="flex items-center relative">
 					<select
+					id="theme-select"
 						class=" dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
 						bind:value={selectedTheme}
 						placeholder="Select a theme"
@@ -258,9 +259,10 @@
 			</div>
 
 			<div class=" flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Language')}</div>
+				<label for="language-select" class=" self-center text-xs font-medium">{$i18n.t('Language')}</label>
 				<div class="flex items-center relative">
 					<select
+					id="language-select"
 						class=" dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
 						bind:value={lang}
 						placeholder="Select a language"
@@ -312,11 +314,12 @@
 			<hr class="border-gray-50 dark:border-gray-850 my-3" />
 
 			<div>
-				<div class=" my-2.5 text-sm font-medium">{$i18n.t('System Prompt')}</div>
+				<label for="enter-system-prompt" class=" my-2.5 text-sm font-medium">{$i18n.t('System Prompt')}</label>
 				<Textarea
 					bind:value={system}
 					className="w-full text-sm bg-white dark:text-gray-300 dark:bg-gray-900 outline-hidden resize-none"
 					rows="4"
+					id="enter-system-prompt"
 					placeholder={$i18n.t('Enter system prompt here')}
 				/>
 			</div>
@@ -421,4 +424,4 @@
 			{$i18n.t('Save')}
 		</button>
 	</div>
-</div>
+</section>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -243,7 +243,7 @@
 				<div class="flex items-center relative">
 					<select
 						id="theme-select"
-						class=" dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
+						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 						bind:value={selectedTheme}
 						placeholder="Select a theme"
 						on:change={() => themeChangeHandler(selectedTheme)}
@@ -266,7 +266,7 @@
 				<div class="flex items-center relative">
 					<select
 						id="language-select"
-						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right"
+						class="dark:bg-gray-900 w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent outline-hidden text-right focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 						bind:value={lang}
 						placeholder="Select a language"
 						on:change={(e) => {

--- a/src/lib/components/common/Textarea.svelte
+++ b/src/lib/components/common/Textarea.svelte
@@ -2,6 +2,7 @@
 	import { onMount, tick } from 'svelte';
 
 	export let value = '';
+	export let id = '';
 	export let placeholder = '';
 	export let rows = 1;
 	export let minSize = null;
@@ -42,6 +43,7 @@
 	bind:value
 	{placeholder}
 	class={className}
+	{id}
 	style="field-sizing: content;"
 	{rows}
 	{required}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Accessibility in the **general tab** in the **settings modal**. 

* Replaced non-semantic `<div` elements with `<label>` elements for `<select>` inputs to ensure proper form labeling.
* Wrapped related content in a `<section>` and added a `<h2>` heading to improve screen reader navigation.
* Updated the notifications on/off button to be accessible by  assistive technology by adding `role="switch"` and managing state with the `aria-checked` attribute.
* Removed the `placeholder` attribute from `<select>`, as it is not valid or supported for this element.
* Make focus visible on `<select`

These changes enhance usability and accessibility, especially for users relying on assistive technologies.

### Added

- [List any new features, functionalities, or additions]

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- [List any fixes, corrections, or bug fixes]

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
