### PR TITLE
feat: Add Clear Search button to workspace pages

### DIFF
--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -105,6 +105,29 @@
 					bind:value={query}
 					placeholder={$i18n.t('Search Knowledge')}
 				/>
+				{#if query}
+					<Tooltip content={$i18n.t('Clear search')} placement="top">
+						<button
+							on:click={() => {
+								query = '';
+							}}
+							class="ml-1 p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
+							aria-label={$i18n.t('Clear search')}
+							type="button"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="2"
+								stroke="currentColor"
+								class="w-4 h-4"
+							>
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</Tooltip>
+				{/if}
 			</div>
 
 			<div>

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -229,6 +229,29 @@
 					bind:value={searchValue}
 					placeholder={$i18n.t('Search Models')}
 				/>
+				{#if searchValue}
+					<Tooltip content={$i18n.t('Clear search')} placement="top">
+						<button
+							on:click={() => {
+								searchValue = '';
+							}}
+							class="ml-1 p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
+							aria-label={$i18n.t('Clear search')}
+							type="button"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="2"
+								stroke="currentColor"
+								class="w-4 h-4"
+							>
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</Tooltip>
+				{/if}
 			</div>
 
 			<div>

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -126,6 +126,32 @@
 					bind:value={query}
 					placeholder={$i18n.t('Search Prompts')}
 				/>
+				{#if query}
+					<Tooltip content={$i18n.t('Clear search')} placement="top">
+						<button
+							on:click={() => {
+								query = '';
+								// currentPage = 1; // Assuming currentPage logic might be needed if pagination exists.
+								// In this simplified version, currentPage is not defined, so we'll omit it.
+								// If you re-introduce pagination, you'll want to reset it here.
+							}}
+							class="ml-1 p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
+							aria-label={$i18n.t('Clear search')}
+							type="button"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="2"
+								stroke="currentColor"
+								class="w-4 h-4"
+							>
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</Tooltip>
+				{/if}
 			</div>
 
 			<div>

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -190,6 +190,29 @@
 					bind:value={query}
 					placeholder={$i18n.t('Search Tools')}
 				/>
+				{#if query}
+					<Tooltip content={$i18n.t('Clear search')} placement="top">
+						<button
+							on:click={() => {
+								query = '';
+							}}
+							class="ml-1 p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
+							aria-label={$i18n.t('Clear search')}
+							type="button"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="2"
+								stroke="currentColor"
+								class="w-4 h-4"
+							>
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					</Tooltip>
+				{/if}
 			</div>
 
 			<div>


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

---

# Description
This pull request introduces a 'Clear Search' (X) button to the search input fields on the Prompts, Models, Knowledge, and Tools pages within the workspace. This button enhances user experience by providing a quick and consistent way to clear search queries. The button appears dynamically when text is entered into the search field and includes a helpful tooltip.

---

# Changelog Entry

- Implemented a 'Clear Search' button for search bars on the Prompts, Models, Knowledge, and Tools pages to improve usability. The button appears when input is detected and allows for quick clearing of the search query.

### Added
- A 'Clear Search' (X) button component with a tooltip has been added to the search input fields on the following workspace pages:
    - `src/lib/components/workspace/Prompts.svelte`
    - `src/lib/components/workspace/Models.svelte`
    - `src/lib/components/workspace/Knowledge.svelte`
    - `src/lib/components/workspace/Tools.svelte`
- The button's `on:click` event clears the respective search query variable (e.g., `query` or `searchValue`).
```
				{#if query} {/* or searchValue depending on the file */}
					<Tooltip content={$i18n.t('Clear search')} placement="top">
						<button
							on:click={() => {
								// query = ''; // Example, actual variable might differ
								// searchValue = ''; // Example for Models.svelte
							}}
							class="ml-1 p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
							aria-label={$i18n.t('Clear search')}
							type="button"
						>
							<svg
								xmlns="http://www.w3.org/2000/svg"
								fill="none"
								viewBox="0 0 24 24"
								stroke-width="2"
								stroke="currentColor"
								class="w-4 h-4"
							>
								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
							</svg>
						</button>
					</Tooltip>
				{/if}
```

---

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/7a353d2e-99ff-4d3e-806d-2a7ba8cc2660)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
