### PR TITLE
fix: prevent hidden models from being selected as default model

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -58,7 +58,21 @@
 	let tags = [];
 
 	let selectedModel = '';
-	$: selectedModel = items.find((item) => item.value === value) ?? '';
+	$: {
+			const foundModel = items.find((item) => item.value === value);
+			if (foundModel && !(foundModel.model?.info?.meta?.hidden ?? false)) {
+				selectedModel = foundModel;
+			} else {
+				// hidden model or cannot find model
+				const firstVisibleModel = items.find(item => !(item.model?.info?.meta?.hidden ?? false));
+				if (firstVisibleModel) {
+					value = firstVisibleModel.value; // update
+					selectedModel = firstVisibleModel;
+				} else {
+					selectedModel = '';
+				}
+			}
+		}
 
 	let searchValue = '';
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

I opened [Discussions #14004](https://github.com/open-webui/open-webui/discussions/14004) to describe the issue and proposed solution.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** verify 'dev' branch
- [x] **Description:** see below
- [x] **Changelog:** see below
- [x] **Documentation:** n/a
- [x] **Dependencies:** none
- [x] **Testing:** yes
- [x] **Code review:** yes
- [x] **Prefix:** 
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

1. Problem
When a model is marked Hide Model in Admin Panel, it disappears from the picker but is still auto-selected as the default when starting a new chat.

2. Steps to reproduce

- Go to Admin Panel → Settings → Models.

- Select Model A and Click "more" button and the "Hide Model" button to toggle.

- Click “New Chat” → Model A appears as the selected model.

3. Expected behaviour
A hidden model should not be chosen as the default. The first visible model (or a user-defined default) should be used instead.

Note: The model should still be available for title-generation and tag-generation tasks under user permissions, but modifications are required to prevent users from initiating direct chat with it.

### Changed
- `src/lib/components/chat/ModelSelector/Selector.svelte`: replaced the simple reactive assignment of `selectedModel` with logic that skips hidden models and, if the current value points to a hidden or missing model, updates `value` (and `selectedModel`) to the first visible model or clears it when none are available.

### Fixed
- Prevented hidden models from remaining selected as the default when opening a new chat, so users will now fall back to the first non-hidden model.

---

### Screenshots or Videos

Public Model: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano
Hide Model: gpt-4.1-nano

Admin Panel
<img width="1247" alt="1" src="https://github.com/user-attachments/assets/5b481359-28c4-429b-80de-1c492b514017" />

User Accessed View
<img width="670" alt="2" src="https://github.com/user-attachments/assets/a5e2ab6d-0dc8-42ca-8584-11c8ce7742ff" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
