### PR TITLE
feat: read max_tokens from model config with fallback to 1000 for title and tag generation

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -192,15 +192,19 @@ async def generate_title(
         },
     )
 
+    max_tokens = (
+        models[task_model_id].get("info", {}).get("params", {}).get("max_tokens", 1000)
+    )
+
     payload = {
         "model": task_model_id,
         "messages": [{"role": "user", "content": content}],
         "stream": False,
         **(
-            {"max_tokens": 1000}
+            {"max_tokens": max_tokens}
             if models[task_model_id].get("owned_by") == "ollama"
             else {
-                "max_completion_tokens": 1000,
+                "max_completion_tokens": max_tokens,
             }
         ),
         "metadata": {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

Improves title and tag generation by using the max_tokens value from the model configuration when available, with a fallback to the previous default of 1000.

### Description

This change is necessary for models like Gemini Pro that generate longer responses and require a higher token limit to successfully generate titles or tags.

### Breaking Changes

- **BREAKING CHANGE**: NONE
---

### Additional Information


The request looks more or less like that:

```
{
  "model": "gemini-2.5-pro-preview-05-06",
  "top_p": 1,
  "stream": false,
  "messages": [
    {
      "role": "system",
      "content": "...."
    },
    {
      "role": "user",
      "content": "### Task:\nGenerate a concise, 3-5 word title with an emoji summarizing the chat history.\n### Guidelines:\n- The title should clearly represent the main theme or subject of the conversation.\n- Use emojis that enhance understanding of the topic, but avoid quotation marks or special formatting.\n- Write the title in the chat's primary language; default to English if multilingual.\n- Prioritize accuracy over excessive creativity; keep it clear and simple.\n- Your entire response must consist solely of the JSON object, without any introductory or concluding text.\n- The output must be a single, raw JSON object, without any markdown code fences or other encapsulating text.\n- Ensure no conversational text, affirmations, or explanations precede or follow the raw JSON output, as this will cause direct parsing failure.\n### Output:\nJSON format: { \"title\": \"your concise title here\" }\n### Examples:\n- { \"title\": \"📉 Stock Market Trends\" },\n- { \"title\": \"🍪 Perfect Chocolate Chip Recipe\" },\n- { \"title\": \"Ev... (truncated 6758 chars)"
    }
  ],
  "max_tokens": 1000,
  "temperature": 0
}
```
The response:

```
{
  "id": "chatcmpl-7990e450-9693-4c1c-9ce0-45f96154e3df",
  "model": "gemini-2.5-pro-preview-05-06",
  "usage": {
    "total_tokens": 3832,
    "prompt_tokens": 2832,
    "completion_tokens": 1000,
    "prompt_tokens_details": {
      "audio_tokens": null,
      "cached_tokens": null
    },
    "completion_tokens_details": {
      "audio_tokens": null,
      "reasoning_tokens": 1000,
      "accepted_prediction_tokens": null,
      "rejected_prediction_tokens": null
    }
  },
  "object": "chat.completion",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": null,
        "tool_calls": null,
        "function_call": null
      },
      "finish_reason": "length"
    }
  ],
  "created": 1747595646,
  "system_fingerprint": null,
  "vertex_ai_safety_results": [],
  "vertex_ai_citation_metadata": [],
  "vertex_ai_grounding_metadata": []
}
```

Causing the followng exception:

```
2025-05-18 23:09:00.333 | ERROR    | asyncio.runners:run:118 - Task exception was never retrieved
future: <Task finished name='Task-516' coro=<process_chat_response.<locals>.post_response_handler() done, defined at /home/user/open-webui/backend/open_webui/utils/middleware.py:1227> exception=AttributeError("'NoneType' object has no attribute 'find'")> - {}
Traceback (most recent call last):

> File "/home/user/open-webui/backend/open_webui/utils/middleware.py", line 2269, in post_response_handler
    await background_tasks_handler()
          └ <function process_chat_response.<locals>.background_tasks_handler at 0x7feba4033380>

  File "/home/user/open-webui/backend/open_webui/utils/middleware.py", line 1007, in background_tasks_handler
    title_string.find("{") : title_string.rfind("}") + 1
    │                        └ None
    └ None

AttributeError: 'NoneType' object has no attribute 'find'
```
Reading the max_tokens from model (eg 16384), title and tags generation works fine!

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
