### PR TITLE
fix: remove inline md images before task execution

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -57,6 +57,7 @@ from open_webui.utils.task import (
     get_task_model_id,
     rag_template,
     tools_function_calling_generation_template,
+    filter_message_content_for_tasks,
 )
 from open_webui.utils.misc import (
     deep_update,
@@ -955,30 +956,7 @@ async def process_chat_response(
             # Remove details tags and files from the messages.
             # as get_message_list creates a new list, it does not affect
             # the original messages outside of this handler
-
-            messages = []
-            for message in message_list:
-                content = message.get("content", "")
-                if isinstance(content, list):
-                    for item in content:
-                        if item.get("type") == "text":
-                            content = item["text"]
-                            break
-
-                if isinstance(content, str):
-                    content = re.sub(
-                        r"<details\b[^>]*>.*?<\/details>",
-                        "",
-                        content,
-                        flags=re.S | re.I,
-                    ).strip()
-
-                messages.append(
-                    {
-                        "role": message["role"],
-                        "content": content,
-                    }
-                )
+            messages = filter_message_content_for_tasks(message_list)
 
             if tasks and messages:
                 if TASKS.TITLE_GENERATION in tasks:


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Follow-Up on https://github.com/open-webui/open-webui/issues/13834 to remove inline markdown images (base64, urls, ...) before sending the messages to the task models. This allows title/tag generation even when inline images are present.

### Changed

- Added another regex string for replacement before task execution
- Put content cleaning in separate method for less complexity in middleware method

---

### Additional Information

Tested the method with the following function

```python
import pytest

def test_filter_message_content_for_tasks():
    # Test case 1: Basic string content
    message_list = [
        {"role": "user", "content": "Hello, what's the task?"},
        {"role": "assistant", "content": "The task is to create a Python script."}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered == message_list  # Content should remain unchanged
    
    # Test case 2: Content with details tags
    message_list = [
        {"role": "user", "content": "Please help me with this.<details>Extra info</details>"},
        {"role": "assistant", "content": "<details type=\"reasoning\">Reasoning: I think this is the best approach.</details>My answer is 42."}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered[0]["content"] == "Please help me with this."
    assert filtered[1]["content"] == "My answer is 42."
    
    # Test case 3: Content with images
    message_list = [
        {"role": "user", "content": "Here's my diagram: ![diagram](https://example.com/image.png) What do you think?"},
        {"role": "assistant", "content": "![example](image.jpg) This looks good."}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered[0]["content"] == "Here's my diagram:  What do you think?", filtered[0]["content"]
    assert filtered[1]["content"] == "This looks good.", filtered[1]["content"]
    
    # Test case 4: Content as list with text items
    message_list = [
        {"role": "user", "content": [{"type": "text", "text": "Here's my question"}]},
        {"role": "assistant", "content": [{"type": "text", "text": "Here's my answer"}]}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered[0]["content"] == "Here's my question"
    assert filtered[1]["content"] == "Here's my answer"
    
    # Test case 5: Mixed content
    message_list = [
        {"role": "user", "content": "Query with <details>hidden details</details> and ![image](img.png)"},
        {"role": "assistant", "content": [{"type": "text", "text": "<details>Reasoning</details>Answer"}]}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered[0]["content"] == "Query with  and"
    assert filtered[1]["content"] == "Answer"

    # Test case 6: Content with base64 encoded images
    message_list = [
        {"role": "user", "content": "Here's my screenshot: ![image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==)"},
        {"role": "assistant", "content": "I see your \n![screenshot](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=) and it looks good."}
    ]
    filtered = filter_message_content_for_tasks(message_list)
    assert filtered[0]["content"] == "Here's my screenshot:", filtered[0]["content"]
    assert filtered[1]["content"] == "I see your \n and it looks good.", filtered[1]["content"]

print("Running tests...")
test_filter_message_content_for_tasks()
print("All tests passed!")
```

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
