### PR TITLE
**fix** Use WEBUI_URL from config instead of request.base_url

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -536,5 +536,5 @@ class OAuthManager:
                 secure=WEBUI_AUTH_COOKIE_SECURE,
             )
         # Redirect back to the frontend with the JWT token
-        redirect_url = f"{request.base_url}auth#token={jwt_token}"
+        redirect_url = f"{request.app.state.config.WEBUI_URL}auth#token={jwt_token}"
         return RedirectResponse(url=redirect_url, headers=response.headers)


### PR DESCRIPTION
The usage of `request.base_url` can result in a redirect to an internal, non-routable address if Open WebUI is behind a reverse proxy.

The `WEBUI_URL` setting says that it was added for search but based on the description it seems like a logical choice to use here as well.

This has been tested in an environment where Open WebUI is behind a reverse proxy (Envoy) and Open WebUI is on an internal network. After SSO login the redirect successfully goes to `<WEBUI_URL>auth#token={jwt_token}` where `WEBUI_URL` is like `https://public.domain/`

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Use `WEBUI_URL` value instead of `request.base_url` for redirect after successful SSO login

### Changed

- Use `WEBUI_URL` value instead of `request.base_url` for redirect after successful SSO login

### Breaking Changes

- **BREAKING CHANGE**: Users that depended on `request.base_url` and otherwise didn't set `WEBUI_URL` may have their redirect on successful SSO login broken.

---

### Additional Information

- The usage of `request.base_url` can result in a redirect to an internal, non-routable address if Open WebUI is behind a reverse proxy. This change allows the redirect URL after successful URL to be adminstrator-settable.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
