### PR TITLE
feat: About and Releases in Help menu

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext, tick } from 'svelte';
 	import { toast } from 'svelte-sonner';
-	import { config, models, settings, user } from '$lib/stores';
+	import { config, models, settings, user, activeSettingsTabKey } from '$lib/stores';
 	import { updateUserSettings } from '$lib/apis/users';
 	import { getModels as _getModels } from '$lib/apis';
 	import { goto } from '$app/navigation';
@@ -372,10 +372,20 @@
 		}
 	};
 
+	$: if (show && $activeSettingsTabKey) {
+		const tabExists = searchData.find((tab) => tab.id === $activeSettingsTabKey);
+		if (tabExists) {
+			selectedTab = $activeSettingsTabKey;
+		}
+		activeSettingsTabKey.set(null);
+	}
+
 	$: if (show) {
 		addScrollListener();
 	} else {
 		removeScrollListener();
+		search = '';
+		visibleTabs = searchData.map((tab) => tab.id);
 	}
 </script>
 

--- a/src/lib/components/layout/Help/HelpMenu.svelte
+++ b/src/lib/components/layout/Help/HelpMenu.svelte
@@ -2,13 +2,15 @@
 	import { DropdownMenu } from 'bits-ui';
 	import { getContext } from 'svelte';
 
-	import { showSettings } from '$lib/stores';
+	import { showSettings, activeSettingsTabKey } from '$lib/stores';
 	import { flyAndScale } from '$lib/utils/transitions';
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import QuestionMarkCircle from '$lib/components/icons/QuestionMarkCircle.svelte';
-	import Lifebuoy from '$lib/components/icons/Lifebuoy.svelte';
 	import Keyboard from '$lib/components/icons/Keyboard.svelte';
+	import Map from '$lib/components/icons/Map.svelte';
+	import Info from '$lib/components/icons/Info.svelte';
+
 	const i18n = getContext('i18n');
 
 	export let showDocsHandler: Function;
@@ -34,26 +36,56 @@
 			align="end"
 			transition={flyAndScale}
 		>
+			<!-- About -->
 			<DropdownMenu.Item
-				class="flex gap-2 items-center px-3 py-2 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
-				id="chat-share-button"
+				class="flex gap-2 items-center px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+				id="menu-item-about"
+				on:click={() => {
+					activeSettingsTabKey.set('about');
+					showSettings.set(true);
+					onClose();
+				}}
+			>
+				<Info className="size-5" />
+				<div class="flex items-center">{$i18n.t('About')}</div>
+			</DropdownMenu.Item>
+
+			<!-- Documentation -->
+			<DropdownMenu.Item
+				class="flex gap-2 items-center px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+				id="menu-item-documentation"
 				on:click={() => {
 					window.open('https://docs.openwebui.com', '_blank');
+					onClose();
 				}}
 			>
 				<QuestionMarkCircle className="size-5" />
 				<div class="flex items-center">{$i18n.t('Documentation')}</div>
 			</DropdownMenu.Item>
 
+			<!-- Releases -->
 			<DropdownMenu.Item
-				class="flex gap-2 items-center px-3 py-2 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
-				id="chat-share-button"
+				class="flex gap-2 items-center px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+				id="menu-item-releases"
+				on:click={() => {
+					window.open('https://github.com/open-webui/open-webui/releases', '_blank');
+					onClose();
+				}}
+			>
+				<Map className="size-5" />
+				<div class="flex items-center">{$i18n.t('Releases')}</div>
+			</DropdownMenu.Item>
+
+			<!-- Keyboard Shortcuts -->
+			<DropdownMenu.Item
+				class="flex gap-2 items-center px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+				id="menu-item-keyboard-shortcuts"
 				on:click={() => {
 					showShortcutsHandler();
 				}}
 			>
 				<Keyboard className="size-5" />
-				<div class="flex items-center">{$i18n.t('Keyboard shortcuts')}</div>
+				<div class="flex items-center">{$i18n.t('Keyboard Shortcuts')}</div>
 			</DropdownMenu.Item>
 		</DropdownMenu.Content>
 	</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -66,6 +66,7 @@ export const settings: Writable<Settings> = writable({});
 
 export const showSidebar = writable(false);
 export const showSettings = writable(false);
+export const activeSettingsTabKey: Writable<string | null> = writable(null);
 export const showArchivedChats = writable(false);
 export const showChangelog = writable(false);
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- This pull request introduces the ability to directly open the "About" tab within the Settings Modal by clicking a new "About" link in the Help Menu. It also refactors the Help Menu by adding a "Releases" link and improving existing items. The active tab state for the Settings Modal is now managed globally using a new Svelte store.

### Added
- **Global State for Active Settings Tab**: Introduced a new Svelte writable store `activeSettingsTabKey` in `src/lib/stores/index.ts` to manage and reflect the currently active tab in the Settings Modal.
- **In `HelpMenu.svelte`**:
    - New "About" menu item in the Help menu:
        - Displays an "Info" icon.
        - When clicked, it sets `activeSettingsTabKey` to `'about'`, opens the Settings Modal to the `About` section, and then closes the Help Menu.
    - New "Releases" menu item in the Help menu:
        - Displays a "Map" icon
        - When clicked, it opens the Open WebUI GitHub releases page in a new tab and then closes the Help Menu.
    - Imported `Info` and `Map` icons for the new menu items.

### Changed
- **`SettingsModal.svelte`**:
    - Imports, subscribes to and updates the `activeSettingsTabKey` store.
    - When the modal becomes visible (e.g., `$show` is true), if `$activeSettingsTabKey` is set to a valid tab ID, the modal will display that specific tab.
    - When a tab is clicked within the modal, the `activeSettingsTabKey` store is updated to reflect the newly selected tab's ID.
    - The `activeSettingsTabKey` store is explicitly set to `null` during the initialization script of the `SettingsModal` component.
- **`HelpMenu.svelte`**:
    - Imports `showSettings` and `activeSettingsTabKey` stores to interact with the Settings Modal.
    - The existing "Documentation" menu item:
        - Now calls `onClose()` (to close the Help Menu dropdown) after opening the documentation link.
        - Its `id` attribute has been updated from `chat-share-button` to `menu-item-documentation` for clarity.
    - The existing "Keyboard Shortcuts" menu item:
        - Now calls `onClose()` (to close the Help Menu dropdown) after triggering the shortcuts display.
        - Its `id` attribute has been updated (likely from a duplicated `chat-share-button`) to `menu-item-keyboard-shortcuts`.
        - Text updated from `$i18n.t('Keyboard shortcuts')` to `$i18n.t('Keyboard Shortcuts')` (capitalization).

---

### Additional Information
- This change introduces a more user-friendly way to access application information and release notes.
- The global `activeSettingsTabKey` store provides a more robust way to control the Settings Modal's displayed tab from external components.

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/abccac9c-742b-4055-bb62-4e14224c019c)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
