### PR TITLE
pref/optimize_get_filtered_models prevent N+1 queries

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional
+from typing import Optional,List
 
 from open_webui.internal.db import Base, JSONField, get_db
 from open_webui.env import SRC_LOG_LEVELS
@@ -213,7 +213,12 @@ class ModelsTable:
                 return ModelModel.model_validate(model)
         except Exception:
             return None
-
+        
+    def get_models_by_ids(self, model_ids: List[str]) -> List[ModelModel]:
+        with get_db() as db:
+            models = db.query(Model).filter(Model.id.in_(model_ids)).all()
+            return [ModelModel.model_validate(model) for model in models]
+        
     def toggle_model_by_id(self, id: str) -> Optional[ModelModel]:
         with get_db() as db:
             try:


### PR DESCRIPTION
Refactor get_filtered_models to eliminate the N+1 query problem by batch-fetching all necessary model_info objects.

Description:
This pull request refactors the get_filtered_models function to optimize performance by eliminating the N+1 query problem. By batch-fetching all necessary model_info objects in a single database query and utilizing a lookup dictionary, the number of database queries is reduced from O(N) to O(1).

Changed:
Optimized: Modified get_filtered_models to batch-fetch model_info objects required for access checks, preventing individual queries within the loop.
Performance Improvement: Enhanced the efficiency and scalability of model filtering when processing multiple models.

Fixed:
Resolved: Fixed the N+1 query issue in get_filtered_models, reducing unnecessary database load and latency.

Benefits:
Performance: Significantly reduces database queries, improving response times.
Scalability: Better handles large lists of models without degrading performance.
Maintainability: Cleaner code with separation of data fetching and processing.