### PR TITLE
feat: Add Clear button to Functions and Models pages search bar

### DIFF
--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -32,6 +32,7 @@
 	import Search from '../icons/Search.svelte';
 	import Plus from '../icons/Plus.svelte';
 	import ChevronRight from '../icons/ChevronRight.svelte';
+	import XMark from '../icons/XMark.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -215,6 +216,19 @@
 				bind:value={query}
 				placeholder={$i18n.t('Search Functions')}
 			/>
+
+			{#if query}
+				<div class="self-center pl-1.5 translate-y-[0.5px] rounded-l-xl bg-transparent">
+					<button
+						class="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+						on:click={() => {
+							query = '';
+						}}
+					>
+						<XMark className="size-3" strokeWidth="2" />
+					</button>
+				</div>
+			{/if}
 		</div>
 
 		<div>

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -20,6 +20,7 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Switch from '$lib/components/common/Switch.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
 
 	import ModelEditor from '$lib/components/workspace/Models/ModelEditor.svelte';
 	import { toast } from 'svelte-sonner';
@@ -271,6 +272,18 @@
 						bind:value={searchValue}
 						placeholder={$i18n.t('Search Models')}
 					/>
+					{#if searchValue}
+						<div class="self-center pl-1.5 translate-y-[0.5px] rounded-l-xl bg-transparent">
+							<button
+								class="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+								on:click={() => {
+									searchValue = '';
+								}}
+							>
+								<XMark className="size-3" strokeWidth="2" />
+							</button>
+						</div>
+					{/if}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- This pull request introduces a user interface enhancement to search functionalities across different sections of the application. A clear button (an "X" icon) has been added to the search input fields in both the **Admin Settings > Models** section and the **Admin Panel > Functions** section. This button becomes visible when text is entered into the respective search fields, allowing users to quickly and easily clear their search queries and reset the displayed lists.

### Added

- **Clear Button for Model Search**: Added an "X" (clear) button next to the model search input field (`src/lib/components/admin/Models.svelte`).
    - The button is conditionally displayed only when there is text (`searchValue`) in the search input.
    - Clicking the button clears the `searchValue`, effectively resetting the model search filter.
- **Clear Button for Functions Search**: Added an "X" (clear) button next to the functions search input field (`src/lib/components/admin/Functions.svelte`).
    - The button is conditionally displayed only when there is text in the search input for functions.
    - Clicking the button clears the search query for functions, resetting the function list filter.
- **Icon Import**: Imported the `XMark.svelte` icon component for use in both clear buttons.

### Changed

- **Model Search UI**: Modified the layout of the model search input area in `src/lib/components/admin/Models.svelte` to accommodate the new clear button, ensuring it is visually integrated with the search field.
- **Functions Search UI**: Modified the layout of the functions search input area in `src/lib/components/admin/Functions.svelte` to accommodate the new clear button, ensuring visual consistency.

---

### Additional Information
- Related https://github.com/open-webui/open-webui/commit/aee9d05916f2011ba449e2d1d8ccebfc8a83e4a3

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
