### PR TITLE
feat: Bypass file creation with CTRL + SHIFT + V

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -146,6 +146,27 @@
 							</div>
 						</div>
 					</div>
+
+					<div class="w-full flex justify-between items-center">
+						<div class=" text-sm">{$i18n.t('Paste as plaintext')}</div>
+						<div class="flex space-x-1 text-xs">
+							<div
+								class=" h-fit py-1 px-2 flex items-center justify-center rounded-sm border border-black/10 capitalize text-gray-600 dark:border-white/10 dark:text-gray-300"
+							>
+								Ctrl/⌘
+							</div>
+							<div
+								class=" h-fit py-1 px-2 flex items-center justify-center rounded-sm border border-black/10 capitalize text-gray-600 dark:border-white/10 dark:text-gray-300"
+							>
+								Shift
+							</div>
+							<div
+								class=" h-fit py-1 px-2 flex items-center justify-center rounded-sm border border-black/10 capitalize text-gray-600 dark:border-white/10 dark:text-gray-300"
+							>
+								V
+							</div>
+						</div>
+					</div>
 				</div>
 
 				<div class="flex flex-col space-y-3 w-full self-start">

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -126,6 +126,12 @@
 		editor.commands.setContent(content);
 	};
 
+	export const insertPlainText = (textToInsert: string) => {
+		if (editor) {
+			editor.chain().focus().insertContent(textToInsert).run();
+		}
+	};
+
 	const selectTemplate = () => {
 		if (value !== '') {
 			// After updating the state, try to find and select the next template
@@ -355,22 +361,14 @@
 							const hasImageItem = Array.from(event.clipboardData.items).some((item) =>
 								item.type.startsWith('image/')
 							);
-							if (hasImageFile) {
-								// If there's an image, dispatch the event to the parent
-								eventDispatch('paste', { event });
-								event.preventDefault();
-								return true;
-							}
 
-							if (hasImageItem) {
+							if (hasImageFile || hasImageItem) {
 								// If there's an image item, dispatch the event to the parent
 								eventDispatch('paste', { event });
 								event.preventDefault();
 								return true;
 							}
 						}
-
-						// For all other cases (text, formatted text, etc.), let ProseMirror handle it
 						view.dispatch(view.state.tr.scrollIntoView()); // Move viewport to the cursor after pasting
 						return false;
 					}

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -363,7 +363,7 @@
 							);
 
 							if (hasImageFile || hasImageItem) {
-								// If there's an image item, dispatch the event to the parent
+								// If there's an image or image item, dispatch the event to the parent
 								eventDispatch('paste', { event });
 								event.preventDefault();
 								return true;


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? *(Assuming no for this change, but double-check if any internal docs on shortcuts/paste handling exist).*
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes? *(Manual testing confirmed functionality).*
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

Related issue/discussion: https://github.com/open-webui/open-webui/issues/13577

---

# Changelog Entry

### Description

- This pull request enhances the "paste large text as file" feature. Users can now bypass the file creation and paste text directly using `CTRL+SHIFT+V` (or `CMD+SHIFT+V`), if the "paste large text as file" setting is enabled. This provides more flexibility when pasting large content. The implementation involves tracking modifier key states globally within `MessageInput.svelte` to reliably detect the bypass shortcut, as direct event properties from the rich text editor's paste event were found to be inconsistent. An `insertPlainText` function was added to `RichTextInput.svelte` to allow `MessageInput.svelte` to programmatically insert text when the bypass is triggered. Additionally, a new entry for this shortcut has been added to the Keyboard Shortcuts modal. A minor refactor in `RichTextInput.svelte` combined image paste detection logic.
- Related issue / Feature request: https://github.com/open-webui/open-webui/issues/13577

### Added
- Functionality to bypass "paste large text as file" by using `CTRL+SHIFT+V` (or `CMD+SHIFT+V`) to paste as plain text.
- Global modifier key state tracking (`isShiftPressed`, `isCtrlMetaPressed`) in `MessageInput.svelte` for robust shortcut detection.
- Exported `insertPlainText` method in `RichTextInput.svelte` to enable programmatic text insertion by its parent.
- Keyboard shortcut entry in `ShortcutsModal.svelte` for "Paste as plaintext" (`Ctrl/⌘ + Shift + V`).

### Changed
- Modified `on:paste` handler in `MessageInput.svelte` for `RichTextInput` to use globally tracked modifier key states for bypass detection and to call `RichTextInput.insertPlainText()` when bypassed.
- Simplified `paste` handler in `RichTextInput.svelte` to always dispatch to `MessageInput.svelte` for long text when `largeTextAsFile` is enabled, delegating bypass logic to the parent.
- Refactored image paste detection in `RichTextInput.svelte` to a single conditional block for `hasImageFile || hasImageItem`.
  - **I did not want to create a new PR just for this small refac, please forgive me.**

---

### Additional Information
- The primary challenge was the unreliable reporting of modifier key states in the `paste` event object emitted by the `RichTextInput` component (Tiptap/ProseMirror). The solution involves `MessageInput.svelte` listening to global `keydown` and `keyup` events to maintain an accurate state of modifier keys, which is then consulted when a paste event is received from `RichTextInput`.
- The translation key for the new shortcut in `ShortcutsModal.svelte` is `'Paste as plaintext'`. This will need to be added to localization files.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.