### PR TITLE
fix: handle escaped characters in DATABASE_URL username

### DIFF
--- a/backend/open_webui/internal/wrappers.py
+++ b/backend/open_webui/internal/wrappers.py
@@ -43,7 +43,7 @@ class ReconnectingPostgresqlDatabase(CustomReconnectMixin, PostgresqlDatabase):
 
 
 def register_connection(db_url):
-    db = connect(db_url, unquote_password=True)
+    db = connect(db_url, unquote_user=True, unquote_password=True)
     if isinstance(db, PostgresqlDatabase):
         # Enable autoconnect for SQLite databases, managed by Peewee
         db.autoconnect = True
@@ -51,7 +51,7 @@ def register_connection(db_url):
         log.info("Connected to PostgreSQL database")
 
         # Get the connection details
-        connection = parse(db_url, unquote_password=True)
+        connection = parse(db_url, unquote_user=True, unquote_password=True)
 
         # Use our custom database class that supports reconnection
         db = ReconnectingPostgresqlDatabase(**connection)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ aiofiles
 
 sqlalchemy==2.0.38
 alembic==1.14.0
-peewee==3.17.9
+peewee==3.18.1
 peewee-migrate==1.12.2
 psycopg2-binary==2.9.9
 pgvector==0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 
     "sqlalchemy==2.0.38",
     "alembic==1.14.0",
-    "peewee==3.17.9",
+    "peewee==3.18.1",
     "peewee-migrate==1.12.2",
     "psycopg2-binary==2.9.9",
     "pgvector==0.4.0",


### PR DESCRIPTION
# Changelog Entry

### Description

- When specifying an external database using the DATABASE_URL, the username might contain an escaped @ sign (`%40`), just like the password might contain escaped special characters. OpenWebUI should properly decode this URL and unescape the `%40` back into `@` before sending the username to the database.  The call to the Peewee library unescapes the password, but not the username.  SqlAlchemy handles it for both username and password.
- This PR updates the call to Peewee, instructing it to unescape special characters in the username.  This feature was recently added to Peewee.

### Fixed

- Proper handling of escaped special characters in the username part of the DATABASE_URL

---

### Additional Information

- Fixes #12145 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
