### PR TITLE
feat: Show generated sub-queries along sources in citation for RAG and web-search

### DIFF
--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -84,6 +84,31 @@
 			<div
 				class="flex flex-col w-full dark:text-gray-200 overflow-y-scroll max-h-[22rem] scrollbar-hidden"
 			>
+				{#if mergedDocuments.some(doc => doc.metadata?.retrieval_queries)}
+					{@const firstDocWithQueries = mergedDocuments.find(doc => doc.metadata?.retrieval_queries)}
+					{#if firstDocWithQueries}
+						<div class="text-sm font-medium dark:text-gray-300 mb-1">
+							{$i18n.t('Retrieval Queries')}
+						</div>
+						<div class="bg-gray-50 dark:bg-gray-800 p-3 rounded-md mb-3">
+							{#if Array.isArray(firstDocWithQueries.metadata.retrieval_queries)}
+								<ul class="text-sm text-gray-600 dark:text-gray-400 list-disc pl-5 space-y-1">
+									{#each firstDocWithQueries.metadata.retrieval_queries as query, i}
+										<li>
+											<span class="font-medium text-gray-700 dark:text-gray-300">#{i+1}:</span> {query}
+										</li>
+									{/each}
+								</ul>
+							{:else}
+								<div class="text-sm text-gray-600 dark:text-gray-400 p-1">
+									{firstDocWithQueries.metadata.retrieval_queries}
+								</div>
+							{/if}
+						</div>
+						<hr class="border-gray-100 dark:border-gray-850 my-3" />
+					{/if}
+				{/if}
+
 				{#each mergedDocuments as document, documentIdx}
 					<div class="flex flex-col w-full">
 						<div class="text-sm font-medium dark:text-gray-300">
@@ -117,6 +142,13 @@
 									{/if}
 								</div>
 							</Tooltip>
+							
+							{#if document.metadata?.parameters}
+								<div class="text-sm font-medium dark:text-gray-300 mt-2">
+									{$i18n.t('Parameters')}
+								</div>
+								<pre class="text-sm dark:text-gray-400 bg-gray-50 dark:bg-gray-800 p-2 rounded-md">{JSON.stringify(document.metadata.parameters, null, 2)}</pre>
+							{/if}
 							{#if showRelevance}
 								<div class="text-sm font-medium dark:text-gray-300 mt-2">
 									{$i18n.t('Relevance')}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

At present, when user asks a question against a knowledge collection, QUERY_GENERATION_PROMPT_TEMPLATE may be used to break down the question and then search in the collection. The user cannot see what queries were made to the knowledge base. This makes it difficult to understand why a source was fetched, cannot know what/how many queries the original question was broken into, cannot see impact of template change on queries easily.

Showing the actual queries sent to knowledge collection will help solve these.

The change made in PR works for web-search too.

## Added

- Show generated sub-queries along sources in citation for RAG and web-search

It shows users what queries were actually sent to database for RAG. It is solves the problems mentioned above, makes the system "look smart" and improves transparency with the user.

---

### Screenshots or Videos

Query: Does jupiter has highest no of moons?
Citation:
![image](https://github.com/user-attachments/assets/f86ce61d-c738-4637-a94e-e5f2f0918251)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.