### PR TITLE
fix(auth): correctly use password hash when duplicate email records exist

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -129,12 +129,16 @@ class AuthsTable:
 
     def authenticate_user(self, email: str, password: str) -> Optional[UserModel]:
         log.info(f"authenticate_user: {email}")
+
+        user = Users.get_user_by_email(email)
+        if not user:
+            return None
+
         try:
             with get_db() as db:
-                auth = db.query(Auth).filter_by(email=email, active=True).first()
+                auth = db.query(Auth).filter_by(id=user.id, active=True).first()
                 if auth:
                     if verify_password(password, auth.password):
-                        user = Users.get_user_by_id(auth.id)
                         return user
                     else:
                         return None

--- a/backend/open_webui/retrieval/web/searchapi.py
+++ b/backend/open_webui/retrieval/web/searchapi.py
@@ -42,7 +42,9 @@ def search_searchapi(
         results = get_filtered_results(results, filter_list)
     return [
         SearchResult(
-            link=result["link"], title=result.get("title"), snippet=result.get("snippet")
+            link=result["link"],
+            title=result.get("title"),
+            snippet=result.get("snippet"),
         )
         for result in results[:count]
     ]

--- a/backend/open_webui/retrieval/web/serpapi.py
+++ b/backend/open_webui/retrieval/web/serpapi.py
@@ -42,7 +42,9 @@ def search_serpapi(
         results = get_filtered_results(results, filter_list)
     return [
         SearchResult(
-            link=result["link"], title=result.get("title"), snippet=result.get("snippet")
+            link=result["link"],
+            title=result.get("title"),
+            snippet=result.get("snippet"),
         )
         for result in results[:count]
     ]


### PR DESCRIPTION
# Changelog Entry

### Description

The Auth table may contain multiple records with the same email address, particularly if a user was deleted and then signed up again. This PR will use the user ID to select the specific Auth record, ensuring that we use the correct password hash.

### Fixed

- Fixed an invalid password hash use in auth

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
