### PR TITLE
refac: improve prompt formatting for selected text in FloatingButtons

### DIFF
--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -44,7 +44,13 @@
 			toast.error('Model not selected');
 			return;
 		}
-		prompt = `${floatingInputValue}\n\`\`\`\n${selectedText}\n\`\`\``;
+		prompt = [
+			// Blockquote each line of the selected text
+			...selectedText.split('\n').map(line => `> ${line}`),
+			'',
+			// Then your question
+			floatingInputValue
+		].join('\n');
 		floatingInputValue = '';
 
 		responseContent = '';
@@ -121,8 +127,11 @@
 			toast.error('Model not selected');
 			return;
 		}
-		const explainText = $i18n.t('Explain this section to me in more detail');
-		prompt = `${explainText}\n\n\`\`\`\n${selectedText}\n\`\`\``;
+		const quotedText = selectedText
+			.split('\n')
+			.map(line => `> ${line}`)
+			.join('\n');
+		prompt = `${quotedText}\n\nExplain`;
 
 		responseContent = '';
 		const [res, controller] = await chatCompletion(localStorage.token, {


### PR DESCRIPTION
### Description

- Refactored prompt construction to improve readability and formatting for selected text. Replaced template literals with blockquote-style formatting (`>`) for better LLM input parsing. No functional logic changes - purely a formatting improvement. However, I've experienced quite a few cases now where the (old) logic actually confuses the LLM by having the quote after the Explain/Ask request.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

### Changelog Entry

#### Changed
- Refactored prompt generation in `FloatingButtons` to use blockquote-style (`>`) formatting per line of selected text.
- Moved selected text *before* the discussion prompt to improve clarity and reduce confusion for LLMs.
- Removed inline template literal usage in favor of `.join('\n')` based construction for better readability and maintainability.