### PR TITLE
feat: sort archived chats

### DIFF
--- a/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
@@ -154,7 +154,7 @@
 												class="px-3 py-2 cursor-pointer select-none"
 												on:click={() => setSortKey('title')}
 											>
-												{$i18n.t('Name')}
+												{$i18n.t('Title')}
 												{#if sortKey === 'title'}
 													{sortOrder === 'asc' ? '▲' : '▼'}
 												{:else}

--- a/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
@@ -5,6 +5,7 @@
 	import dayjs from 'dayjs';
 	import { getContext, createEventDispatcher } from 'svelte';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
+	import XMark from '$lib/components/icons/XMark.svelte';
 
 	dayjs.extend(localizedFormat);
 
@@ -116,26 +117,38 @@
 
 		<div class="flex flex-col w-full px-5 pb-4 dark:text-gray-200">
 			<div class=" flex w-full mt-2 space-x-2">
-				<div class="flex flex-1">
-					<div class=" self-center ml-1 mr-3">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 20 20"
-							fill="currentColor"
-							class="w-4 h-4"
-						>
-							<path
-								fill-rule="evenodd"
-								d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-								clip-rule="evenodd"
-							/>
-						</svg>
-					</div>
+				<div class=" self-center ml-1 mr-3">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 20 20"
+						fill="currentColor"
+						class="w-4 h-4"
+					>
+						<path
+							fill-rule="evenodd"
+							d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+							clip-rule="evenodd"
+						/>
+					</svg>
+				</div>
+
+				<div class="flex flex-1 relative">
 					<input
 						class=" w-full text-sm pr-4 py-1 rounded-r-xl outline-hidden bg-transparent"
 						bind:value={searchValue}
 						placeholder={$i18n.t('Search Chats')}
 					/>
+
+					{#if searchValue}
+						<button
+							class="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-900 transition flex items-center justify-center"
+							on:click={() => {
+								searchValue = '';
+							}}
+						>
+							<XMark className="size-3" strokeWidth="2" />
+						</button>
+					{/if}
 				</div>
 			</div>
 			<hr class="border-gray-100 dark:border-gray-850 my-2" />

--- a/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte
@@ -29,6 +29,18 @@
 	let searchValue = '';
 	let showUnarchiveAllConfirmDialog = false;
 
+	let sortKey = 'created_at';
+	let sortOrder = 'desc';
+
+	function setSortKey(key) {
+		if (sortKey === key) {
+			sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortKey = key;
+			sortOrder = 'asc';
+		}
+	}
+
 	const unarchiveChatHandler = async (chatId) => {
 		const res = await archiveChatById(localStorage.token, chatId).catch((error) => {
 			toast.error(`${error}`);
@@ -137,17 +149,50 @@
 										class="text-xs text-gray-700 uppercase bg-transparent dark:text-gray-200 border-b-2 border-gray-50 dark:border-gray-850"
 									>
 										<tr>
-											<th scope="col" class="px-3 py-2"> {$i18n.t('Name')} </th>
-											<th scope="col" class="px-3 py-2 hidden md:flex">
+											<th
+												scope="col"
+												class="px-3 py-2 cursor-pointer select-none"
+												on:click={() => setSortKey('title')}
+											>
+												{$i18n.t('Name')}
+												{#if sortKey === 'title'}
+													{sortOrder === 'asc' ? '▲' : '▼'}
+												{:else}
+													<span class="invisible">▲</span>
+												{/if}
+											</th>
+											<th
+												scope="col"
+												class="px-3 py-2 hidden md:flex cursor-pointer select-none justify-end"
+												on:click={() => setSortKey('created_at')}
+											>
 												{$i18n.t('Created At')}
+												{#if sortKey === 'created_at'}
+													{sortOrder === 'asc' ? '▲' : '▼'}
+												{:else}
+													<span class="invisible">▲</span>
+												{/if}
 											</th>
 											<th scope="col" class="px-3 py-2 text-right" />
 										</tr>
 									</thead>
 									<tbody>
-										{#each chats.filter((c) => searchValue === '' || c.title
-													.toLowerCase()
-													.includes(searchValue.toLowerCase())) as chat, idx}
+										{#each chats
+											.filter((c) => searchValue === '' || c.title
+														.toLowerCase()
+														.includes(searchValue.toLowerCase()))
+											.sort((a, b) => {
+												const aValue = a[sortKey];
+												const bValue = b[sortKey];
+
+												if (aValue < bValue) {
+													return sortOrder === 'asc' ? -1 : 1;
+												}
+												if (aValue > bValue) {
+													return sortOrder === 'asc' ? 1 : -1;
+												}
+												return 0;
+											}) as chat, idx}
 											<tr
 												class="bg-transparent {idx !== chats.length - 1 &&
 													'border-b'} dark:bg-gray-900 border-gray-50 dark:border-gray-850 text-xs"
@@ -160,7 +205,7 @@
 													</a>
 												</td>
 
-												<td class=" px-3 py-1 hidden md:flex h-[2.5rem]">
+												<td class=" px-3 py-1 hidden md:flex h-[2.5rem] justify-end">
 													<div class="my-auto">
 														{dayjs(chat.created_at * 1000).format('LLL')}
 													</div>
@@ -231,7 +276,7 @@
 									showUnarchiveAllConfirmDialog = true;
 								}}
 							>
-								{$i18n.t('Unarchive All Archived Chats')}
+								{$i18n.t('Unarchive All')}
 							</button>
 
 							<button
@@ -240,7 +285,7 @@
 									exportChatsHandler();
 								}}
 							>
-								{$i18n.t('Export All Archived Chats')}
+								{$i18n.t('Export All')}
 							</button>
 						</div>
 					</div>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- Added sorting capabilities to the Archived Chats modal (`src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte`). This allows users to sort their archived conversations by "Name" (chat title) or "Created At", making it easier to navigate and find specific chats, especially for users with a large number of archived conversations. The sorting logic and UI pattern were adapted from the existing `UserChatsModal.svelte` component. (See `Screenshots` section)

### Added
- Added state variables (`sortKey`, `sortOrder`) to manage the current sorting criteria in the Archived Chats modal.
- Added a `setSortKey` function to toggle sorting direction and change the sort column on header clicks.

### Changed
- Modified the table headers for "Name" and "Created At" in the Archived Chats modal (`src/lib/components/layout/Sidebar/ArchivedChatsModal.svelte`) to be clickable.
- Implemented visual indicators (up/down arrows) in the table headers to show the current sort direction.
- Updated the chat list rendering logic in the Archived Chats modal to apply sorting based on the selected `sortKey` and `sortOrder` after filtering by the search input.
- Adapted the sorting implementation pattern from the `UserChatsModal.svelte` component.

### Additional Information
- The sorting functionality was directly ported from the `src/lib/components/admin/Users/UserList/UserChatsModal.svelte` component's implementation for the "Title" and "Updated at" columns.
- Removed `Archived Chats` from button names for a cleaner UI.

### Screenshots
**Before `Archived Chats modal` update:**
![image](https://github.com/user-attachments/assets/a315b5bd-0863-46e9-9f6d-7327c4ecb525)
**After `Archived Chats Modal` sort update:**
![image](https://github.com/user-attachments/assets/e139180d-9cfe-4286-8db6-c4f6eeba8d0e)


### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
