### PR TITLE
feat: Optionally hide private workspace items from admins

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1216,6 +1216,10 @@ ENABLE_ADMIN_CHAT_ACCESS = (
     os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "True").lower() == "true"
 )
 
+ENABLE_ADMIN_WORKSPACE_ACCESS = (
+    os.environ.get("ENABLE_ADMIN_WORKSPACE_ACCESS", "True").lower() == "true"
+)
+
 ENABLE_COMMUNITY_SHARING = PersistentConfig(
     "ENABLE_COMMUNITY_SHARING",
     "ui.enable_community_sharing",

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -106,10 +106,8 @@ async def get_knowledge_list(user=Depends(get_verified_user)):
         all_knowledge_bases = Knowledges.get_knowledge_bases()
         filtered_knowledge_bases = []
         for kb in all_knowledge_bases:
-            is_private_other_user = (
-                kb.access_control == {} and kb.user_id != user.id
-            )
-            if not is_private_other_user and (
+            # If admin owns it, it's public, or admin has specific write access (group/direct)
+            if (
                 kb.user_id == user.id
                 or kb.access_control is None
                 or has_access(user.id, "write", kb.access_control)

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -105,7 +105,7 @@ async def get_knowledge(user=Depends(get_verified_user)):
 async def get_knowledge_list(user=Depends(get_verified_user)):
     knowledge_bases = []
 
-    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS.value:
+    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
         all_knowledge_bases = Knowledges.get_knowledge_bases()
         filtered_knowledge_bases = []
         for kb in all_knowledge_bases:

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -43,7 +43,7 @@ router = APIRouter()
 async def get_knowledge(user=Depends(get_verified_user)):
     knowledge_bases = []
 
-    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS.value:
+    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
         all_knowledge_bases = Knowledges.get_knowledge_bases()
         filtered_knowledge_bases = []
         for kb in all_knowledge_bases:

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -26,7 +26,7 @@ router = APIRouter()
 
 @router.get("/", response_model=list[ModelUserResponse])
 async def get_models(id: Optional[str] = None, user=Depends(get_verified_user)):
-    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS.value:
+    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
         all_models = Models.get_models()
         filtered_models = []
         for model in all_models:

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -30,12 +30,7 @@ async def get_models(id: Optional[str] = None, user=Depends(get_verified_user)):
         all_models = Models.get_models()
         filtered_models = []
         for model in all_models:
-            # Check if the model is private and belongs to another user
-            is_private_other_user = (
-                model.access_control == {} and model.user_id != user.id
-            )
-
-            if not is_private_other_user and (
+            if (
                 model.user_id == user.id
                 or model.access_control is None
                 or has_access(user.id, "read", model.access_control)

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -25,12 +25,7 @@ async def get_prompts(user=Depends(get_verified_user)):
         all_prompts = Prompts.get_prompts()
         filtered_prompts = []
         for prompt in all_prompts:
-            # Check if the prompt is private and belongs to another user
-            is_private_other_user = (
-                prompt.access_control == {} and prompt.user_id != user.id
-            )
-
-            if not is_private_other_user and (
+            if (
                 prompt.user_id == user.id
                 or prompt.access_control is None
                 or has_access(user.id, "read", prompt.access_control)
@@ -51,12 +46,7 @@ async def get_prompt_list(user=Depends(get_verified_user)):
         all_prompts = Prompts.get_prompts()
         filtered_prompts = []
         for prompt in all_prompts:
-            # Check if the prompt is private and belongs to another user
-            is_private_other_user = (
-                prompt.access_control == {} and prompt.user_id != user.id
-            )
-
-            if not is_private_other_user and (
+            if (
                 prompt.user_id == user.id
                 or prompt.access_control is None
                 or has_access(user.id, "write", prompt.access_control)

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 @router.get("/", response_model=list[PromptModel])
 async def get_prompts(user=Depends(get_verified_user)):
-    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS.value:
+    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
         all_prompts = Prompts.get_prompts()
         filtered_prompts = []
         for prompt in all_prompts:
@@ -47,7 +47,7 @@ async def get_prompts(user=Depends(get_verified_user)):
 
 @router.get("/list", response_model=list[PromptUserResponse])
 async def get_prompt_list(user=Depends(get_verified_user)):
-    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS.value:
+    if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
         all_prompts = Prompts.get_prompts()
         filtered_prompts = []
         for prompt in all_prompts:

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -72,18 +72,15 @@ async def get_tools(request: Request, user=Depends(get_verified_user)):
 
     # Apply admin workspace access control first to DB tools
     if user.role == "admin" and not ENABLE_ADMIN_WORKSPACE_ACCESS:
-        db_tools = Tools.get_tools()
-        filtered_db_tools = []
-        for tool in db_tools:
-            is_private_other_user = (
-                tool.access_control == {} and tool.user_id != user.id
-            )
-            if not is_private_other_user and (
-                tool.user_id == user.id
-                or tool.access_control is None
-                or has_access(user.id, "read", tool.access_control)
-            ):
-                filtered_db_tools.append(tool)
+    db_tools_from_db = Tools.get_tools() # Renamed to avoid confusion
+    filtered_db_tools = []
+    for tool in db_tools_from_db: # Iterate over DB tools
+        if (
+            tool.user_id == user.id
+            or tool.access_control is None
+            or has_access(user.id, "read", tool.access_control)
+        ):
+            filtered_db_tools.append(tool)
         tools = filtered_db_tools
     else:
         # Original logic for fetching DB tools if not admin or flag is true
@@ -171,13 +168,10 @@ async def get_tool_list(user=Depends(get_verified_user)):
         all_tools = Tools.get_tools()
         filtered_tools = []
         for tool in all_tools:
-            is_private_other_user = (
-                tool.access_control == {} and tool.user_id != user.id
-            )
-            if not is_private_other_user and (
+            if (
                 tool.user_id == user.id
                 or tool.access_control is None
-                or has_access(user.id, "write", tool.access_control) # "write" for this list
+                or has_access(user.id, "write", tool.access_control) # "write"
             ):
                 filtered_tools.append(tool)
         return filtered_tools


### PR DESCRIPTION
# Pull Request Checklist

### Related issue:

https://github.com/open-webui/open-webui/discussions/14083

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? https://github.com/open-webui/docs/pull/560
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

- Prev.: If a user created a private item in a workspace section (private prompt, private tool, private knowledgebase, private model), then any admin would always see all items, even if set to private and not shared with any group.
  - This would lead to clutterered UI, obstruct the admin's ability to manage workspaces properly in larger instances
  - Admin does not need to see private user's items - the introduction of a feature to hide private objects would lead to more privacy for users
    - Users would potentially expect private items to be somewhat private

Fixes: https://github.com/open-webui/open-webui/discussions/14083

### Added

- Added a new env var to optionally hide all workspace items that are "private" from all admins.

### Changed

- If the env var is not set, current behaviour does not change.

### Security

- Optional privacy improvements for users.

---

### Additional Information

- Behaviour of prompts/knowledge/etc. that is shared WITH A GROUP does not change
  - Admins are, by default, member of all groups. So if a user creates a prompt and shares it with a group, the admins will see that workspace item.
  - Only if the workspace item was created with "private" permissions and the env var is set, will it be hidden from admins.

Related docs PR: https://github.com/open-webui/docs/pull/560

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
