### PR TITLE
wip: Optimize get_all_models 

### DIFF
--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -163,6 +163,17 @@ class FunctionsTable:
                 return FunctionModel.model_validate(function)
         except Exception:
             return None
+    
+    def get_functions_by_ids(self, ids: list[str]) -> list[FunctionModel]:
+        try:
+            with get_db() as db:
+                return [
+                    FunctionModel.model_validate(function)
+                    for function in db.query(Function).filter(Function.id.in_(ids)).all()
+                ]
+        except Exception as e:
+            log.exception(f"Error getting functions by ids {ids}: {e}")
+            return []
 
     def get_functions(self, active_only=False) -> list[FunctionModel]:
         with get_db() as db:

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -79,11 +79,9 @@ async def get_all_base_models(request: Request, user: UserModel = None):
 async def get_all_models(request, user: UserModel = None):
     models = await get_all_base_models(request, user=user)
 
-    # If there are no models, return an empty list
     if len(models) == 0:
         return []
 
-    # Add arena models
     if request.app.state.config.ENABLE_EVALUATION_ARENA_MODELS:
         arena_models = []
         if len(request.app.state.config.EVALUATION_ARENA_MODELS) > 0:
@@ -91,9 +89,7 @@ async def get_all_models(request, user: UserModel = None):
                 {
                     "id": model["id"],
                     "name": model["name"],
-                    "info": {
-                        "meta": model["meta"],
-                    },
+                    "info": {"meta": model["meta"]},
                     "object": "model",
                     "created": int(time.time()),
                     "owned_by": "arena",
@@ -102,118 +98,131 @@ async def get_all_models(request, user: UserModel = None):
                 for model in request.app.state.config.EVALUATION_ARENA_MODELS
             ]
         else:
-            # Add default arena model
             arena_models = [
                 {
                     "id": DEFAULT_ARENA_MODEL["id"],
                     "name": DEFAULT_ARENA_MODEL["name"],
-                    "info": {
-                        "meta": DEFAULT_ARENA_MODEL["meta"],
-                    },
+                    "info": {"meta": DEFAULT_ARENA_MODEL["meta"]},
                     "object": "model",
                     "created": int(time.time()),
                     "owned_by": "arena",
                     "arena": True,
                 }
             ]
-        models = models + arena_models
+        models.extend(arena_models)
 
-    global_action_ids = [
-        function.id for function in Functions.get_global_action_functions()
-    ]
-    enabled_action_ids = [
-        function.id
-        for function in Functions.get_functions_by_type("action", active_only=True)
-    ]
-
-    global_filter_ids = [
-        function.id for function in Functions.get_global_filter_functions()
-    ]
-    enabled_filter_ids = [
-        function.id
-        for function in Functions.get_functions_by_type("filter", active_only=True)
-    ]
+    global_action_ids = {function.id for function in Functions.get_global_action_functions()}
+    enabled_action_ids = {function.id for function in Functions.get_functions_by_type("action", active_only=True)}
+    global_filter_ids = {function.id for function in Functions.get_global_filter_functions()}
+    enabled_filter_ids = {function.id for function in Functions.get_functions_by_type("filter", active_only=True)}
 
     custom_models = Models.get_all_models()
-    for custom_model in custom_models:
-        if custom_model.base_model_id is None:
-            for model in models:
-                if custom_model.id == model["id"] or (
-                    model.get("owned_by") == "ollama"
-                    and custom_model.id
-                    == model["id"].split(":")[
-                        0
-                    ]  # Ollama may return model ids in different formats (e.g., 'llama3' vs. 'llama3:7b')
-                ):
-                    if custom_model.is_active:
-                        model["name"] = custom_model.name
-                        model["info"] = custom_model.model_dump()
+    active_custom_models = {model.id: model for model in custom_models if model.is_active}
+    inactive_custom_models = {model.id: model for model in custom_models if not model.is_active}
 
-                        # Set action_ids and filter_ids
-                        action_ids = []
-                        filter_ids = []
+    models_to_remove = []
+    models_dict = {model["id"]: model for model in models}
+    
+    for model_id, model in models_dict.items():
+        if model_id in inactive_custom_models and inactive_custom_models[model_id].base_model_id is None:
+            models_to_remove.append(model)
+        elif model_id in active_custom_models:
+            custom_model = active_custom_models[model_id]
+            if custom_model.base_model_id is None:
+                model["name"] = custom_model.name
+                model["info"] = custom_model.model_dump()
+                
+                action_ids = []
+                filter_ids = []
+                if "info" in model and "meta" in model["info"]:
+                    action_ids.extend(model["info"]["meta"].get("actionIds", []))
+                    filter_ids.extend(model["info"]["meta"].get("filterIds", []))
+                
+                model["action_ids"] = action_ids
+                model["filter_ids"] = filter_ids
 
-                        if "info" in model and "meta" in model["info"]:
-                            action_ids.extend(
-                                model["info"]["meta"].get("actionIds", [])
-                            )
-                            filter_ids.extend(
-                                model["info"]["meta"].get("filterIds", [])
-                            )
+    for model in models_to_remove:
+        models.remove(model)
 
-                        model["action_ids"] = action_ids
-                        model["filter_ids"] = filter_ids
-                    else:
-                        models.remove(model)
-
-        elif custom_model.is_active and (
-            custom_model.id not in [model["id"] for model in models]
-        ):
+    for custom_model in active_custom_models.values():
+        if custom_model.base_model_id is not None and custom_model.id not in models_dict:
             owned_by = "openai"
             pipe = None
-
-            action_ids = []
-            filter_ids = []
-
+            
             for model in models:
-                if (
-                    custom_model.base_model_id == model["id"]
-                    or custom_model.base_model_id == model["id"].split(":")[0]
-                ):
+                if (custom_model.base_model_id == model["id"] or 
+                    custom_model.base_model_id == model["id"].split(":")[0]):
                     owned_by = model.get("owned_by", "unknown owner")
                     if "pipe" in model:
                         pipe = model["pipe"]
                     break
 
+            action_ids = []
+            filter_ids = []
             if custom_model.meta:
                 meta = custom_model.meta.model_dump()
+                action_ids.extend(meta.get("actionIds", []))
+                filter_ids.extend(meta.get("filterIds", []))
 
-                if "actionIds" in meta:
-                    action_ids.extend(meta["actionIds"])
+            new_model = {
+                "id": custom_model.id,
+                "name": custom_model.name,
+                "object": "model",
+                "created": custom_model.created_at,
+                "owned_by": owned_by,
+                "info": custom_model.model_dump(),
+                "preset": True,
+                "action_ids": action_ids,
+                "filter_ids": filter_ids,
+            }
+            if pipe is not None:
+                new_model["pipe"] = pipe
+            
+            models.append(new_model)
 
-                if "filterIds" in meta:
-                    filter_ids.extend(meta["filterIds"])
+    all_action_ids = set()
+    all_filter_ids = set()
+    
+    for model in models:
+        model_action_ids = set(model.get("action_ids", []))
+        model_filter_ids = set(model.get("filter_ids", []))
+        
+        model_action_ids.update(global_action_ids)
+        model_filter_ids.update(global_filter_ids)
+        
+        model_action_ids.intersection_update(enabled_action_ids)
+        model_filter_ids.intersection_update(enabled_filter_ids)
+        
+        model["final_action_ids"] = model_action_ids
+        model["final_filter_ids"] = model_filter_ids
+        
+        all_action_ids.update(model_action_ids)
+        all_filter_ids.update(model_filter_ids)
 
-            models.append(
-                {
-                    "id": f"{custom_model.id}",
-                    "name": custom_model.name,
-                    "object": "model",
-                    "created": custom_model.created_at,
-                    "owned_by": owned_by,
-                    "info": custom_model.model_dump(),
-                    "preset": True,
-                    **({"pipe": pipe} if pipe is not None else {}),
-                    "action_ids": action_ids,
-                    "filter_ids": filter_ids,
-                }
-            )
+    action_functions_map = {}
+    filter_functions_map = {}
+    
+    if all_action_ids:
+        action_functions = Functions.get_functions_by_ids(list(all_action_ids))
+        action_functions_map = {func.id: func for func in action_functions if func is not None}
+    
+    if all_filter_ids:
+        filter_functions = Functions.get_functions_by_ids(list(all_filter_ids))
+        filter_functions_map = {func.id: func for func in filter_functions if func is not None}
 
-    # Process action_ids to get the actions
+    function_modules_cache = {}
+    all_function_ids = all_action_ids.union(all_filter_ids)
+    
+    for function_id in all_function_ids:
+        try:
+            function_module, _, _ = get_function_module_from_cache(request, function_id)
+            function_modules_cache[function_id] = function_module
+        except Exception as e:
+            log.warning(f"Failed to load function module {function_id}: {e}")
+            continue
+
     def get_action_items_from_module(function, module):
-        actions = []
         if hasattr(module, "actions"):
-            actions = module.actions
             return [
                 {
                     "id": f"{function.id}.{action['id']}",
@@ -226,7 +235,7 @@ async def get_all_models(request, user: UserModel = None):
                         or getattr(module, "icon", None),
                     ),
                 }
-                for action in actions
+                for action in module.actions
             ]
         else:
             return [
@@ -240,7 +249,6 @@ async def get_all_models(request, user: UserModel = None):
                 }
             ]
 
-    # Process filter_ids to get the filters
     def get_filter_items_from_module(function, module):
         return [
             {
@@ -253,50 +261,37 @@ async def get_all_models(request, user: UserModel = None):
             }
         ]
 
-    def get_function_module_by_id(function_id):
-        function_module, _, _ = get_function_module_from_cache(request, function_id)
-        return function_module
-
     for model in models:
-        action_ids = [
-            action_id
-            for action_id in list(set(model.pop("action_ids", []) + global_action_ids))
-            if action_id in enabled_action_ids
-        ]
-        filter_ids = [
-            filter_id
-            for filter_id in list(set(model.pop("filter_ids", []) + global_filter_ids))
-            if filter_id in enabled_filter_ids
-        ]
+        final_action_ids = model.pop("final_action_ids", set())
+        final_filter_ids = model.pop("final_filter_ids", set())
+        model.pop("action_ids", None)
+        model.pop("filter_ids", None)
 
         model["actions"] = []
-        for action_id in action_ids:
-            action_function = Functions.get_function_by_id(action_id)
-            if action_function is None:
-                raise Exception(f"Action not found: {action_id}")
-
-            function_module = get_function_module_by_id(action_id)
-            model["actions"].extend(
-                get_action_items_from_module(action_function, function_module)
-            )
+        for action_id in final_action_ids:
+            if action_id in action_functions_map and action_id in function_modules_cache:
+                action_function = action_functions_map[action_id]
+                function_module = function_modules_cache[action_id]
+                model["actions"].extend(
+                    get_action_items_from_module(action_function, function_module)
+                )
 
         model["filters"] = []
-        for filter_id in filter_ids:
-            filter_function = Functions.get_function_by_id(filter_id)
-            if filter_function is None:
-                raise Exception(f"Filter not found: {filter_id}")
-
-            function_module = get_function_module_by_id(filter_id)
-
-            if getattr(function_module, "toggle", None):
-                model["filters"].extend(
-                    get_filter_items_from_module(filter_function, function_module)
-                )
+        for filter_id in final_filter_ids:
+            if filter_id in filter_functions_map and filter_id in function_modules_cache:
+                filter_function = filter_functions_map[filter_id]
+                function_module = function_modules_cache[filter_id]
+                
+                if getattr(function_module, "toggle", None):
+                    model["filters"].extend(
+                        get_filter_items_from_module(filter_function, function_module)
+                    )
 
     log.debug(f"get_all_models() returned {len(models)} models")
 
     request.app.state.MODELS = {model["id"]: model for model in models}
     return models
+
 
 
 def check_model_access(user, model):


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Optimized the `get_all_models()` function to reduce run time from 1.5~ seconds to 0.54~ seconds (in my environment) for about a 60%~ speed improvement. 
- The 0.5~ seconds is mostly from the `get_all_base_models` method.

### Added

- `Functions.get_functions_by_ids()` to batch multiple function lookups by id
- Dictionary-based lookups for custom models and functions
- Error handling for function module loading

### Changed

- Replaced individual database calls with batch queries using `Functions.get_functions_by_ids()`
- Converted lists operations to sets for faster speed.
- Pre-calculate action/filter IDs and store temporarily to avoid redundant processing
- Restructured custom model processing logic to use dictionary lookups instead of nested loops
- Modified function module loading to use centralized caching mechanism
- Replaced list concatenation with `extend()` method for better memory efficiency

### Deprecated

- None

### Removed

- Redundant database queries within model processing loops
- Repeated function module loading operations
- Inefficient list management / concatenation

### Breaking Changes

- **NONE I FOUND** - All changes are just re-writes and optimizations of the original code, in theory the input -> output should be exactly the same. The function input parameters, and output structure remain unchanged.

---

### Additional Information

- ~~**This code likely works though I haven't thoroughly tested it.**~~
- Tested the code locally, works great and its consistently faster. Editing models, filters, functions and pipes work.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
