### PR TITLE
fix: Chat page fails to load on undefined message

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1225,6 +1225,9 @@ export const createMessagesList = (history, messageId) => {
 	}
 
 	const message = history.messages[messageId];
+	if (message === undefined) {
+		return [];
+	}
 	if (message?.parentId) {
 		return [...createMessagesList(history, message.parentId), message];
 	} else {


### PR DESCRIPTION
### Fixes an edge case where a malformed Chat history Message causes the Chat page load to fail.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request.

# Changelog Entry

### Fixed

- Fixed an edge case which caused the Chat page load to fail.

---

### Additional Information

In some specific cirumstances, when messages or chat history is malformed, the retrieved `message` object can be `undefined`.
When this happens, the current code just returns it as `[message]`.

This then causes an error when executing [line 121 from /src/routes/s/[id]/+page.svelte](https://github.com/open-webui/open-webui/blob/ba0088f39b7a093920b142a5172554686f24df60/src/routes/s/%5Bid%5D/%2Bpage.svelte#L120):
```javascript
history.messages[messages.at(-1).id].done = true;
```
because this line is trying to access an attribute that might not be available.

I have not looked into why the `message` object can be `undefined` though. That would be worth looking into.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
