### PR TITLE
Fix JavaScript heap out of memory in Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm ci
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
-RUN npm run build
+RUN NODE_OPTIONS='--max-old-space-size=6144' npm run build
 
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base


### PR DESCRIPTION
## Problem
The current Dockerfile fails during frontend build with "JavaScript heap out of memory" error when Node.js runs out of heap memory during the Vite build process.

## Solution
Added `NODE_OPTIONS='--max-old-space-size=6144'` to the npm build command to allocate 6GB of heap memory for Node.js, resolving the memory allocation issue.

## Changes
- Modified `RUN npm run build` to `RUN NODE_OPTIONS='--max-old-space-size=6144' npm run build` in Dockerfile line ~39

## Testing
- ✅ Build completes successfully without memory errors
- ✅ No functional changes to application behavior
- ✅ Same approach successfully used in previous versions

## Impact
- Fixes build failures for users experiencing memory issues
- Enables successful Docker builds on systems with limited memory
- No breaking changes or performance impact on runtime