### PR TITLE
Patch security risk with public /cache endpoint

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -37,7 +37,7 @@ from fastapi import (
 from fastapi.openapi.docs import get_swagger_ui_html
 
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from starlette_compress import CompressMiddleware
@@ -1628,7 +1628,19 @@ async def healthcheck_with_db():
 
 
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
-app.mount("/cache", StaticFiles(directory=CACHE_DIR), name="cache")
+
+@app.get("/cache/{path:path}")
+async def serve_cache_file(
+    path: str,
+    user=Depends(get_verified_user),
+):
+    file_path = os.path.abspath(os.path.join(CACHE_DIR, user.id, path))
+    # prevent path traversal
+    if not file_path.startswith(os.path.abspath(CACHE_DIR)):
+        raise HTTPException(status_code=404, detail="File not found")
+    if not os.path.isfile(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path)
 
 
 def swagger_ui_html(*args, **kwargs):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2219,13 +2219,14 @@ async def process_chat_response(
 
                                                 # ensure the path exists
                                                 os.makedirs(
-                                                    os.path.join(CACHE_DIR, "images"),
+                                                    os.path.join(CACHE_DIR, user.id, "images"),
                                                     exist_ok=True,
                                                 )
 
                                                 image_path = os.path.join(
                                                     CACHE_DIR,
-                                                    f"images/{id}.png",
+                                                    user.id,
+                                                    f"images/{id}",
                                                 )
 
                                                 with open(image_path, "wb") as f:
@@ -2236,7 +2237,7 @@ async def process_chat_response(
                                                     )
 
                                                 stdoutLines[idx] = (
-                                                    f"![Output Image {idx}](/cache/images/{id}.png)"
+                                                    f"![Output Image {idx}](/cache/images/{id})"
                                                 )
 
                                         output["stdout"] = "\n".join(stdoutLines)
@@ -2251,12 +2252,13 @@ async def process_chat_response(
 
                                                 # ensure the path exists
                                                 os.makedirs(
-                                                    os.path.join(CACHE_DIR, "images"),
+                                                    os.path.join(CACHE_DIR, user.id, "images"),
                                                     exist_ok=True,
                                                 )
 
                                                 image_path = os.path.join(
                                                     CACHE_DIR,
+                                                    user.id,
                                                     f"images/{id}.png",
                                                 )
 
@@ -2268,7 +2270,7 @@ async def process_chat_response(
                                                     )
 
                                                 resultLines[idx] = (
-                                                    f"![Output Image {idx}](/cache/images/{id}.png)"
+                                                    f"![Output Image {idx}](/cache/images/{id})"
                                                 )
 
                                         output["result"] = "\n".join(resultLines)


### PR DESCRIPTION
The `/cache` endpoint is unprotected and any file that is created in that directory will automatically be available without any auth. 
This PR adds protection over this endpoint to be available only to users of the app but also to only the user specific that created the image. 

In addition it is recommended to remove the extension of the file being written as load balancer and similar systems could activate cache  if the extension is kept  as it is identified as a file, and if cache is activated then it defeats the purpose of authentication as it will serve the file directly without triggering the logic of the endpoint. 
For now the only place I see it being used is for the images, which I already patched in this PR.

I tested but Please test from your side. 