### PR TITLE
fix: add `(Clone)` to title and `-clone` to id when cloning a workspace prompt

### DIFF
--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -13,6 +13,7 @@
 	export let onSubmit: Function;
 	export let edit = false;
 	export let prompt = null;
+	export let clone = false;
 
 	const i18n = getContext('i18n');
 
@@ -66,10 +67,18 @@
 
 	onMount(async () => {
 		if (prompt) {
-			title = prompt.title;
-			await tick();
-
-			command = prompt.command.at(0) === '/' ? prompt.command.slice(1) : prompt.command;
+			if (clone) {
+				title = `${prompt.title} (Clone)`;
+				const baseCommand = prompt.command.startsWith('/')
+					? prompt.command.substring(1)
+					: prompt.command;
+				command = slugify(`${baseCommand} clone`);
+				hasManualEdit = true;
+			} else {
+				title = prompt.title;
+				command = prompt.command.at(0) === '/' ? prompt.command.slice(1) : prompt.command;
+				hasManualEdit = true;
+			}
 			content = prompt.content;
 
 			accessControl = prompt?.access_control === undefined ? {} : prompt?.access_control;

--- a/src/routes/(app)/workspace/prompts/create/+page.svelte
+++ b/src/routes/(app)/workspace/prompts/create/+page.svelte
@@ -9,14 +9,22 @@
 	import { createNewPrompt, getPrompts } from '$lib/apis/prompts';
 	import PromptEditor from '$lib/components/workspace/Prompts/PromptEditor.svelte';
 
-	let prompt = null;
+	let prompt: {
+		title: string;
+		command: string;
+		content: string;
+		access_control: any | null;
+	} | null = null;
+
+	let clone = false;
+
 	const onSubmit = async (_prompt) => {
-		const prompt = await createNewPrompt(localStorage.token, _prompt).catch((error) => {
+		const res = await createNewPrompt(localStorage.token, _prompt).catch((error) => {
 			toast.error(`${error}`);
 			return null;
 		});
 
-		if (prompt) {
+		if (res) {
 			toast.success($i18n.t('Prompt created successfully'));
 
 			await prompts.set(await getPrompts(localStorage.token));
@@ -33,8 +41,9 @@
 			)
 				return;
 			const _prompt = JSON.parse(event.data);
-			console.log(_prompt);
+			console.log('Received prompt via window message:', _prompt);
 
+			clone = true;
 			prompt = {
 				title: _prompt.title,
 				command: _prompt.command,
@@ -49,18 +58,21 @@
 
 		if (sessionStorage.prompt) {
 			const _prompt = JSON.parse(sessionStorage.prompt);
+			sessionStorage.removeItem('prompt');
 
+			console.log('Received prompt via sessionStorage:', _prompt);
+
+			clone = true;
 			prompt = {
 				title: _prompt.title,
 				command: _prompt.command,
 				content: _prompt.content,
 				access_control: null
 			};
-			sessionStorage.removeItem('prompt');
 		}
 	});
 </script>
 
 {#key prompt}
-	<PromptEditor {prompt} {onSubmit} />
+	<PromptEditor {prompt} {onSubmit} {clone} />
 {/key}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- This pull request refines and aligns the existing prompt cloning functionality within the `PromptEditor` to provide a more consistent and user-friendly experience, similar to cloning features found in other workspace pages.
- When a prompt is loaded for creation (e.g., from an external source or session storage) and intended as a clone, its title will now be automatically appended with `(Clone)`, and its command will be modified (e.g., `/original-command-clone`) to suggest a unique new command. This streamlines the duplication process and reduces manual input for the user.

### Added
- A new `clone` boolean prop has been added to `PromptEditor.svelte` to explicitly control the cloning behavior when loading prompts.
- New logic within `PromptEditor.svelte` to automatically adjust the `title` and `command` of a prompt when the `clone` prop is `true`, including appending `(Clone)` to the title and slugifying a new command from the base command, ensuring uniqueness for cloned prompts.

### Changed
- `src/lib/components/workspace/Prompts/PromptEditor.svelte`:
    - The prompt initialization logic for `title` and `command` has been updated to leverage the new `clone` prop.
    - The `hasManualEdit` flag is now consistently set to `true` upon prompt initialization, regardless of whether it's a clone or a new prompt.
- `src/routes/(app)/workspace/prompts/create/+page.svelte`:
    - The `PromptEditor` component now correctly receives and utilizes the new `clone` prop.
    - Logic was added to set `clone = true` when a prompt is received via `window.opener` messages or `sessionStorage`, ensuring these imported prompts are treated as clones with the new naming conventions.
    - The `prompt` variable in the `onSubmit` function was renamed to `res` for better clarity.
    - The `sessionStorage.removeItem('prompt');` call was repositioned for logical flow.
    - Type annotation for the `prompt` variable was added for improved code clarity and type safety.

---

### Additional Information
- This enhancement standardizes the "clone" experience for prompts, aligning it with similar functionalities across the application.
- The automatic naming and command adjustment for cloned prompts significantly reduces friction for users who frequently duplicate prompts for minor variations.
- The explicit `clone` prop in `PromptEditor` provides clearer control over when these cloning-specific adjustments should be applied.

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/d25b2a18-3816-4eb3-8927-caa546c410ff)
![image](https://github.com/user-attachments/assets/f6bcfce5-5c90-4bc6-9cb6-f9d8b8c5e7b7)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
