### PR TITLE
**fix**: do_picture_description feature when using Docling as an external document parser

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -297,7 +297,7 @@ class Loader:
                         "picture_description_local": (
                             '{\n'
                             '    "repo_id": "HuggingFaceTB/SmolVLM-256M-Instruct",\n'
-                            '    "prompt": "Describe the image in detail, including objects, actions, and connections. Use a descriptive and informative style."\n'
+                            '    "prompt": "Analyze the image and provide a comprehensive, detailed description. Identify all visible objects, their attributes, actions taking place, spatial relationships, and any contextual or inferred connections. Use clear, structured, and informative language suitable for downstream retrieval or knowledge extraction tasks."\n'
                             '}'
                         )
                     },

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -293,14 +293,8 @@ class Loader:
                         "ocr_lang": self.kwargs.get("DOCLING_OCR_LANG"),
                         "do_picture_description": self.kwargs.get(
                             "DOCLING_DO_PICTURE_DESCRIPTION"
-                        ),
-                        "picture_description_local": (
-                            '{\n'
-                            '    "repo_id": "HuggingFaceTB/SmolVLM-256M-Instruct",\n'
-                            '    "prompt": "Analyze the image and provide a comprehensive, detailed description. Identify all visible objects, their attributes, actions taking place, spatial relationships, and any contextual or inferred connections. Use clear, structured, and informative language suitable for downstream retrieval or knowledge extraction tasks."\n'
-                            '}'
                         )
-                    },
+                    }
                 )
         elif (
             self.engine == "document_intelligence"

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -294,6 +294,12 @@ class Loader:
                         "do_picture_classification": self.kwargs.get(
                             "DOCLING_DO_PICTURE_DESCRIPTION"
                         ),
+                        "picture_description_local": (
+                            '{\n'
+                            '    "repo_id": "HuggingFaceTB/SmolVLM-256M-Instruct",\n'
+                            '    "prompt": "Describe the image in detail, including objects, actions, and connections. Use a descriptive and informative style."\n'
+                            '}'
+                        )
                     },
                 )
         elif (

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -148,13 +148,13 @@ class DoclingLoader:
 
             params = {
                 "image_export_mode": "placeholder",
-                "table_mode": "accurate",
+                "table_mode": "accurate"
             }
 
             if self.params:
-                if self.params.get("do_picture_classification"):
-                    params["do_picture_classification"] = self.params.get(
-                        "do_picture_classification"
+                if self.params.get("do_picture_description"):
+                    params["do_picture_description"] = self.params.get(
+                        "do_picture_description"
                     )
 
                 if self.params.get("ocr_engine") and self.params.get("ocr_lang"):
@@ -291,7 +291,7 @@ class Loader:
                     params={
                         "ocr_engine": self.kwargs.get("DOCLING_OCR_ENGINE"),
                         "ocr_lang": self.kwargs.get("DOCLING_OCR_LANG"),
-                        "do_picture_classification": self.kwargs.get(
+                        "do_picture_description": self.kwargs.get(
                             "DOCLING_DO_PICTURE_DESCRIPTION"
                         ),
                         "picture_description_local": (


### PR DESCRIPTION
# Changelog Entry

### Description

`do_picture_description` feature of Docling was implemented, but not working properly

### Added

so far, I have added only an hard-coded defaults for Docling's prefered VLM "HuggingFaceTB/SmolVLM-256M-Instruct" including a prompt to extract the information.

### Changed

There were mismatch between `do_picture_classification` and `do_picture_description`. Fixed.

### Deprecated

none

### Removed

none

### Fixed

There were mismatch between `do_picture_classification` and `do_picture_description`. Fixed.


### Breaking Changes

none

---

### Additional Information

In next iteration, I should make (at least) the model and the prompt configurable. There is also Docling's feature to use remote API for picture descriptions. That should be added too.

### Screenshots or Videos

Input:
![one](https://github.com/user-attachments/assets/e9bf5788-7158-4669-822f-cc1239428a41)

Output:
![2](https://github.com/user-attachments/assets/dbd48bcd-4307-4dfa-8c44-e5d1ef35a86c)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
