### PR TITLE
Feat(main): Use the environment variable PORT/HOST to dynamically print UI URL

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -471,6 +471,9 @@ print(
 v{VERSION} - building the best AI user interface.
 {f"Commit: {WEBUI_BUILD_HASH}" if WEBUI_BUILD_HASH != "dev-build" else ""}
 https://github.com/open-webui/open-webui
+
+Default link to open Webui: http://localhost:8080
+To stop the server, press Ctrl+C
 """
 )
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -457,6 +457,9 @@ class SPAStaticFiles(StaticFiles):
             else:
                 raise ex
 
+import os  # Ensure the environment variable is set
+PORT = os.getenv("PORT", "8080")
+DISPLAY_HOST = os.getenv("HOST", "localhost")
 
 print(
     rf"""
@@ -472,8 +475,9 @@ v{VERSION} - building the best AI user interface.
 {f"Commit: {WEBUI_BUILD_HASH}" if WEBUI_BUILD_HASH != "dev-build" else ""}
 https://github.com/open-webui/open-webui
 
-Default link to open Webui: http://localhost:8080
+Open Webui in http://{DISPLAY_HOST}:{PORT}
 To stop the server, press Ctrl+C
+
 """
 )
 


### PR DESCRIPTION
### Description


- Modify the print(...) at the top level of backend/open_webui/main.py, to dynamically concatenate through the environment variables PORT (default 8080) and HOST (default localhost).

• This way, whether the user is using bash backend/start.sh, open-webui serve --port xxx, or directly uvicorn open_webui.main:app --port xxx, as long as PORT or/and HOST are exported to the environment variables, the access address prompt in the terminal will be consistent with the actual listening port.

### Added

- Modified backend/open_webui/main.py,  changed to use the PORT and DISPLAY_HOST dynamically read from the above text.

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- [List any fixes, corrections, or bug fixes]

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]
- 
<img width="825" alt="SCR-20250604-rsoa" src="https://github.com/user-attachments/assets/6b2e59aa-1342-47a9-858f-37cada0db05d" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
