### PR TITLE
Add Audio HTML token support

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/HTMLToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/HTMLToken.svelte
@@ -38,6 +38,20 @@
 		{:else}
 			{token.text}
 		{/if}
+	{:else if html && html.includes('<audio')}
+		{@const audio = html.match(/<audio[^>]*>([\s\S]*?)<\/audio>/)}
+		{@const audioSrc = audio && audio[1]}
+		{#if audioSrc}
+			<!-- svelte-ignore a11y-media-has-caption -->
+			<audio
+				class="w-full my-2"
+				src={audioSrc.replaceAll('&amp;', '&')}
+				title="Audio player"
+				controls
+			></audio>
+		{:else}
+			{token.text}
+		{/if}
 	{:else if token.text && token.text.match(/<iframe\s+[^>]*src="https:\/\/www\.youtube\.com\/embed\/([a-zA-Z0-9_-]{11})(?:\?[^"]*)?"[^>]*><\/iframe>/)}
 		{@const match = token.text.match(
 			/<iframe\s+[^>]*src="https:\/\/www\.youtube\.com\/embed\/([a-zA-Z0-9_-]{11})(?:\?[^"]*)?"[^>]*><\/iframe>/


### PR DESCRIPTION
# Changelog Entry

### Description

This pull request introduces support for rendering HTML `<audio>` tags within the chat interface. Similar to how `<video>` tags are handled, this change allows users to embed and play audio content directly in their conversations. The implementation parses the `src` attribute from the `<audio>` tag and uses a standard HTML5 audio player for playback.

Sample audio: https://samplelib.com/lib/preview/mp3/sample-12s.mp3

### Added

- Rendering of audio tags in response

### Screenshots or Videos

![afbeelding](https://github.com/user-attachments/assets/f24af91b-69d7-4f1a-aa33-a1e8519652da)
![afbeelding](https://github.com/user-attachments/assets/8c1afc0c-d4c4-4f3d-940e-26d8e0ccd565)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
