### PR TITLE
Isolated fix to single section

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1980,27 +1980,37 @@ async def process_chat_response(
                     tools = metadata.get("tools", {})
 
                     results = []
+
                     for tool_call in response_tool_calls:
                         tool_call_id = tool_call.get("id", "")
                         tool_name = tool_call.get("function", {}).get("name", "")
+                        tool_call_args = tool_call.get("function", {}).get("arguments", "{}")
 
                         tool_function_params = {}
                         try:
                             # json.loads cannot be used because some models do not produce valid JSON
                             tool_function_params = ast.literal_eval(
-                                tool_call.get("function", {}).get("arguments", "{}")
+                                tool_call_args
                             )
                         except Exception as e:
                             log.debug(e)
                             # Fallback to JSON parsing
                             try:
                                 tool_function_params = json.loads(
-                                    tool_call.get("function", {}).get("arguments", "{}")
+                                    tool_call_args
                                 )
                             except Exception as e:
-                                log.debug(
-                                    f"Error parsing tool call arguments: {tool_call.get('function', {}).get('arguments', '{}')}"
+                                log.error(
+                                    f"Error parsing tool call arguments: {tool_call_args}"
                                 )
+
+                        # Mutate the original tool call response params as they are passed back to the passed
+                        # back to the LLM via the content blocks. If they are in a json block and are invalid json, 
+                        # this can cause downstream LLM integrations to fail (e.g. bedrock gateway) where response
+                        # params are not valid json.
+                        # Main case so far is no args = "" = invalid json.
+                        log.debug(f"Parsed args from {tool_call_args} to {tool_function_params}")
+                        tool_call.setdefault("function", {})["arguments"] = json.dumps(tool_function_params)
 
                         tool_result = None
 


### PR DESCRIPTION
This is a fix IF the fix for this issue even belongs in Open WebUI. I'm not sure of the actual best place this one should be fixed, so have raised a discussion for this issue here - https://github.com/open-webui/open-webui/discussions/14882. Discussion has diagrams and more details. 

I feel like the fix for this issue does belong in Open WebUI, but feel free to just close this PR if you think it actually belongs somewhere else (e.g. bedrock gateway). If it does belong here, but the late mutation is a bit ugly, I can move it up closer to the response stream receiving part.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes? 
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** fix: MCP Tools with Empty Arguments JSON Parsing Error

# Changelog Entry

### Description

- Fixed JSON parsing errors when MCP (Model Context Protocol) tools with no arguments are executed, preventing "Expecting value: line 1 column 1 (char 0)" errors
- Added NODE_OPTIONS build argument support to prevent frontend build memory allocation failures during Docker builds

### Changed
- Tool call argument processing in middleware to convert empty argument strings to valid JSON objects before tool execution
- Debug log to an actual error log.


### Fixed
- **MCP Tool Execution**: Fixed JSON parsing errors when MCP tools with no arguments are called, where empty argument strings `""` are now properly converted to valid JSON empty objects `"{}"`

### Security
- [None]

### Breaking Changes
- [None - changes are backward compatible]

### Screenshots or Videos
Screenshot shows a before after in a single chat of the error and then fixed
![image](https://github.com/user-attachments/assets/508a8b3f-e553-4f5e-9005-3704dd9583ae)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.