### PR TITLE
fix: Docling - serialize picture description parameters

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -162,15 +162,15 @@ class DoclingLoader:
                     if picture_description_mode == "local" and self.params.get(
                         "picture_description_local", {}
                     ):
-                        params["picture_description_local"] = self.params.get(
-                            "picture_description_local", {}
+                        params["picture_description_local"] = json.dumps(
+                            self.params.get("picture_description_local", {})
                         )
 
                     elif picture_description_mode == "api" and self.params.get(
                         "picture_description_api", {}
                     ):
-                        params["picture_description_api"] = self.params.get(
-                            "picture_description_api", {}
+                        params["picture_description_api"] = json.dumps(
+                            self.params.get("picture_description_api", {})
                         )
 
                 if self.params.get("ocr_engine") and self.params.get("ocr_lang"):


### PR DESCRIPTION
### Description

Docling expects `picture_description_local` and `picture_description_api` keys values as JSON strings. This PR adresses that.

### Fixed

- serializes content of `picture_description_local` and `picture_description_api` before sending it into Docling

### Screenshots or Videos

The system now accepts Docling options objects like so:

![image](https://github.com/user-attachments/assets/fe830aa0-9e87-4483-b6cf-307fa90b900f)
![image](https://github.com/user-attachments/assets/ad7a0646-a0af-471e-a8b1-b566205acf6a)


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
