### PR TITLE
feat: Advanced search filters (before/after date based search, multiple tags)

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -186,11 +186,6 @@ async def search_user_chats(
         )
     ]
 
-    # Re-evaluate tag deletion logic.
-    # This logic was originally tied to text-based tag search.
-    # If 'tags' list is provided explicitly, this might not be the desired behavior,
-    # or it should only apply if 'text' contained the tag and not the 'tags' param.
-    # For now, keeping it similar but checking if text is the source of the tag.
     if text:
         words = text.strip().split(" ")
         if page == 1 and len(words) == 1 and words[0].startswith("tag:"):

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -245,12 +245,31 @@ export const getAllChats = async (token: string) => {
 	return res;
 };
 
-export const getChatListBySearchText = async (token: string, text: string, page: number = 1) => {
+export const getChatListBySearchText = async (
+	token: string,
+	searchParamsObj: {
+		text: string;
+		tags?: string[];
+		before?: string;
+		after?: string;
+	},
+	page: number = 1
+) => {
 	let error = null;
 
 	const searchParams = new URLSearchParams();
-	searchParams.append('text', text);
+	searchParams.append('text', searchParamsObj.text);
 	searchParams.append('page', `${page}`);
+
+	if (searchParamsObj.tags && searchParamsObj.tags.length > 0) {
+		searchParams.append('tags', searchParamsObj.tags.join(','));
+	}
+	if (searchParamsObj.before) {
+		searchParams.append('before_date', searchParamsObj.before);
+	}
+	if (searchParamsObj.after) {
+		searchParams.append('after_date', searchParamsObj.after);
+	}
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/search?${searchParams.toString()}`, {
 		method: 'GET',

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -100,9 +100,6 @@
 		page += 1;
 
 		let newChatList = [];
-		// parsedQuery should already be set by searchHandler or a previous loadMoreChats
-		// No need to parse again unless query string itself could change independently,
-		// but it's bound to SearchInput, which triggers searchHandler on input.
 
 		if (query.trim()) {
 			newChatList = await getChatListBySearchText(localStorage.token, parsedQuery, page);
@@ -119,15 +116,6 @@
 
 		chatListLoading = false;
 	};
-
-	// Remove init and onMount, searchHandler is called on input
-	// const init = () => {
-	// 	searchHandler();
-	// };
-
-	// onMount(() => {
-	// 	init();
-	// });
 </script>
 
 <Modal size="md" bind:show>


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch. (Assuming `dev` based on common practice)
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? (No documentation changes were made by me)
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? (No new dependencies were added)
- [x] **Testing:** Have you written and run sufficient tests to validate the changes? (Manual testing was performed by you throughout the process)
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards? (Yes, to the best of my ability)
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

---

# Changelog Entry

### Description

This pull request enhances the chat search functionality in Open WebUI by
- adding support for multiple tag searches and
- filtering by chat update recency using `before:YYYY-MM-DD` and `after:YYYY-MM-DD` parameters.

The implementation spans frontend UI components, API communication layers, and backend database query logic. Several minor bug fixes identified during development were also addressed.

### Added

- **Advanced Search Parameters:**
    - You can now filter chats by their last update time using `before:YYYY-MM-DD` and `after:YYYY-MM-DD` syntax.
    - Multiple `tag:<tag_id>` parameters can now be used simultaneously to find chats matching all specified tags.
    - Multiple different search parameters can now be combined (i.e. combining `tag:` with `before:` like so: `tag:general before:2025-06-11`)
- **Frontend UI for New Filters:**
    - `SearchInput.svelte` now suggests `before:` and `after:` parameters with descriptions.
    - `SearchModal.svelte` parses these new parameters from the query string.
- **Backend Support for New Filters:**
    - API endpoint (`/api/v1/chats/search`) updated to accept `tags`, `before_date`, and `after_date` query parameters.
    - Database query logic in `models/chats.py` updated to filter chats based on `updated_at` timestamps and multiple tags.

### Changed

- **Search Query Parsing (Frontend):**
    - `SearchModal.svelte`'s `parseSearchQuery` function updated to extract structured search terms (text, tags, before date, after date) from your input string.
    - (Note: Attempts to handle optional spaces like `before: YYYY-MM-DD` were reverted to maintain stability, so no space is currently supported after the colon).
- **API Layer (`apis/chats/index.ts`):**
    - `getChatListBySearchText` now sends a structured object containing parsed search parameters to the backend.
- **Backend Router (`routers/chats.py`):**
    - `search_user_chats` endpoint signature changed to accept distinct query parameters for text, tags, before date, and after date.
- **Backend Model (`models/chats.py`):**
    - `get_chats_by_user_id_and_search_text` method signature changed to accept distinct search parameters.
    - Logic for tag filtering now uses the explicit list of tags.
    - Date filtering implemented by converting date strings to UTC timestamps and comparing against the `updated_at` field. `before:DATE` includes `DATE` (until 23:59:59 UTC), and `after:DATE` includes `DATE` (from 00:00:00 UTC).

---

### Additional Information

- The development process involved iterative testing and feedback
- The `before:DATE` and `after:DATE` filters operate on the chat's `updated_at` timestamp. (This is the most logical approach in my opinion and is also logical from the added descriptive text for the two new parameters)

### Screenshots or Videos

![image](https://github.com/user-attachments/assets/b2e99b0a-1187-45b0-8415-2c8257f9c1c3)

![image](https://github.com/user-attachments/assets/9fec17e5-7729-4e1b-b1eb-afd52afaa3d5)
(this is correct because the cutoff for the dates is always at midnight - searching "before:2025-06-11" would yield all chats updated BEFORE 2025-06-11 at 23:59 for example, and searching for "after:2025-06-11" will yield all chats updated AFTER 2025-06-11 00:01 for example)

![image](https://github.com/user-attachments/assets/94be279e-c6a8-4572-9f6e-9c81ae51af3d)
Combining different search parameters for a more detailed search!

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
