### PR TITLE
Fix double‐slash (//auth) in OAuth callback redirect

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -537,7 +537,7 @@ class OAuthManager:
             )
         # Redirect back to the frontend with the JWT token
 
-        redirect_base_url = request.app.state.config.WEBUI_URL or request.base_url
+        redirect_base_url = str(request.app.state.config.WEBUI_URL or request.base_url)
         if isinstance(redirect_base_url, str) and redirect_base_url.endswith("/"):
             redirect_base_url = redirect_base_url[:-1]
         redirect_url = f"{redirect_base_url}/auth#token={jwt_token}"


### PR DESCRIPTION
#### Summary
Convert the value used to build the OAuth callback redirect URL to a plain string so that a trailing slash can be trimmed correctly. This prevents the generated redirect from containing two slashes (e.g. `https://host//auth`) which breaks login when Azure AD / Microsoft OAuth is used.

#### Background
`backend/open_webui/utils/oauth.py` constructs the post-login redirect like this:

```python
redirect_base_url = request.app.state.config.WEBUI_URL or request.base_url
if isinstance(redirect_base_url, str) and redirect_base_url.endswith('/'):
    redirect_base_url = redirect_base_url[:-1]
redirect_url = f"{redirect_base_url}/auth#token={jwt_token}"
```

`request.base_url` is a `starlette.datastructures.URL` object, not a `str`. When `WEBUI_URL` is unset and the code falls back to `request.base_url`, the `isinstance(..., str)` check fails, so the trailing slash is **not** removed. After implicit string conversion we end up with `...//auth`.

# Changelog Entry
- fix: double‐slash (//auth) in OAuth callback redirect


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
