### PR TITLE
fix: regression for "open in new tab"

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -107,39 +107,41 @@
 			</button>
 
 			{#if role === 'admin'}
-				<button
-					class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+				<a
+					href="/playground"
+					class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition select-none"
 					on:click={() => {
-						goto('/playground');
 						show = false;
-
 						if ($mobile) {
 							showSidebar.set(false);
 						}
 					}}
+					rel="noopener noreferrer"
+					draggable="false"
 				>
 					<div class=" self-center mr-3">
 						<Code className="size-5" strokeWidth="1.5" />
 					</div>
 					<div class=" self-center truncate">{$i18n.t('Playground')}</div>
-				</button>
+				</a>
 
-				<button
-					class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+				<a
+					href="/admin"
+					class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition select-none"
 					on:click={() => {
-						goto('/admin');
 						show = false;
-
 						if ($mobile) {
 							showSidebar.set(false);
 						}
 					}}
+					rel="noopener noreferrer"
+					draggable="false"
 				>
 					<div class=" self-center mr-3">
 						<UserGroup className="w-5 h-5" strokeWidth="1.5" />
 					</div>
 					<div class=" self-center truncate">{$i18n.t('Admin Panel')}</div>
-				</button>
+				</a>
 			{/if}
 
 			{#if help}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- Improved user experience in the `UserMenu.svelte` component by allowing "Playground" and "Admin Panel" options to be opened in a new tab via right-click, while also preventing them from being unintentionally dragged or highlighting text upon click-and-drag.

### Added
- `href` attributes to the "Playground" (`/playground`) and "Admin Panel" (`/admin`) menu items, enabling standard browser link behavior (e.g., "Open in New Tab").
- `rel="noopener noreferrer"` attribute to these links for security best practices when opening new tabs.
- `draggable="false"` attribute to these links to prevent them from being draggable.
- `select-none` Tailwind CSS class to these links to prevent text highlighting on click-and-drag.

### Changed
- Converted "Playground" and "Admin Panel" menu items from `<button>` elements to `<a>` elements.

### Fixed
- Open in New Tab not being an option for `Playground` and `Admin Panel` in UserMenu.svelte.

### Security
- Added `rel="noopener noreferrer"` for improved security when opening new tabs.

---

### Additional Information
- This change provides more flexible interaction with key navigation links within the user menu, aligning them with common web patterns for opening pages in new tabs.
- This PR fixes a mistake I made in https://github.com/open-webui/open-webui/pull/14982

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
