### PR TITLE
fix: resolve placeholder not updating in sequential __event_call__ prompts (#14927)

### DIFF
--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -27,8 +27,13 @@
 
 	let modalElement = null;
 	let mounted = false;
+	let internalInputValue = '';
 
 	let focusTrap: FocusTrap.FocusTrap | null = null;
+
+	$: if (show) {
+		internalInputValue = inputValue || '';
+	}
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Escape') {
@@ -45,7 +50,7 @@
 	const confirmHandler = async () => {
 		show = false;
 		await onConfirm();
-		dispatch('confirm', inputValue);
+		dispatch('confirm', internalInputValue);
 	};
 
 	onMount(() => {
@@ -119,7 +124,7 @@
 
 						{#if input}
 							<textarea
-								bind:value={inputValue}
+								bind:value={internalInputValue}
 								placeholder={inputPlaceholder ? inputPlaceholder : $i18n.t('Enter your message')}
 								class="w-full mt-2 rounded-lg px-4 py-2 text-sm dark:text-gray-300 dark:bg-gray-900 outline-hidden resize-none"
 								rows="3"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- In Svelte, the parent (Chat.svelte) passed a prop (`inputValue`) to the child (ConfirmDialog.svelte), but the child used `bind:value` for two-way binding. This caused the child's input to directly mutate the parent's state.
- The child component now uses an internal state (`internalInputValue`) for the textarea binding, separate from the prop.
- The internal state is initialized from the prop when the dialog opens, and only sent to the parent via event on confirmation.

### Added

- None

### Changed

- ConfirmDialog.svelte: Separated prop (`inputValue`) and internal state (`internalInputValue`), updated binding logic.

### Deprecated

- None

### Removed

- None

### Fixed

- Fixed a bug where the parent's state was unintentionally changed by the child due to two-way binding (#14927).

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- Related issue: #14927

### Screenshots or Videos

- (N/A)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

