### PR TITLE
fix: sanatizeResponseContent for stop token display

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -83,9 +83,9 @@ export const sanitizeResponseContent = (content: string) => {
 		.replace(/<\|[a-z]*$/, '')
 		.replace(/<\|[a-z]+\|$/, '')
 		.replace(/<$/, '')
-		.replaceAll(/<\|[a-z]+\|>/g, ' ')
 		.replaceAll('<', '&lt;')
 		.replaceAll('>', '&gt;')
+		.replaceAll(/<\|[a-z]+\|>/g, ' ')
 		.trim();
 };
 
@@ -361,9 +361,9 @@ export const generateInitialsImage = (name) => {
 	const initials =
 		sanitizedName.length > 0
 			? sanitizedName[0] +
-				(sanitizedName.split(' ').length > 1
-					? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
-					: '')
+			(sanitizedName.split(' ').length > 1
+				? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
+				: '')
 			: '';
 
 	ctx.fillText(initials.toUpperCase(), canvas.width / 2, canvas.height / 2);
@@ -514,10 +514,10 @@ export const compareVersion = (latest, current) => {
 	return current === '0.0.0'
 		? false
 		: current.localeCompare(latest, undefined, {
-				numeric: true,
-				sensitivity: 'case',
-				caseFirst: 'upper'
-			}) < 0;
+			numeric: true,
+			sensitivity: 'case',
+			caseFirst: 'upper'
+		}) < 0;
 };
 
 export const extractCurlyBraceWords = (text) => {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- Fixed an issue where specific model "stop" tokens (e.g., `<|system|>`, `<|user|>`) in model descriptions were not displayed correctly. Previously, these tokens were being inadvertently removed or corrupted by an overzealous sanitization rule, making model descriptions appear incomplete or malformed.

### Changed
- Updated the `sanitizeResponseContent` utility function (`src/lib/utils/index.ts`) to reorder string replacement operations. Specifically, the general HTML entity escaping for `<` and `>` characters is now performed *after* specific regex-based cleanups, ensuring that essential tokens are properly escaped for rendering rather than being removed or altered.

### Fixed
- Corrected the display of special tokens (e.g., `<|system|>`, `<|user|>`, `<|end|>`, `<|assistant|>`) within model descriptions in `ChatPlaceholder.svelte` and `Placeholder.svelte`, ensuring they are now rendered literally as intended.


---

### Additional Information
- The issue was traced to the `sanitizeResponseContent` function where a `replaceAll(/<\|[a-z]+\|>/g, ' ')` operation was occurring *before* the general HTML escaping for `<` and `>` characters. By moving this specific `replaceAll` operation to occur *after* the HTML escaping, the tokens are now correctly converted to their HTML entity equivalents (`<|token|>`) and displayed as plain text by the browser, rather than being replaced with a space.
  - Related files: `src/lib/utils/index.ts`, `src/lib/components/chat/ChatPlaceholder.svelte`, `src/lib/components/chat/Placeholder.svelte`

### Screenshots or Videos
## Before fix:
![image](https://github.com/user-attachments/assets/6c285258-7ee0-4b16-83cf-36823a064384)
![image](https://github.com/user-attachments/assets/5922b8b9-2b1f-4d29-94d5-dc90c11dfc02)
![image](https://github.com/user-attachments/assets/35b24b94-0870-4c49-99b7-2de99cd76a4f)
## After fix:
![image](https://github.com/user-attachments/assets/61896bf2-3778-4573-bfaa-ca34807209e4)
![image](https://github.com/user-attachments/assets/ee1f1f72-8c60-4a73-ad49-d57defa67ac3)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
