### PR TITLE
fix: OAuth authentication failure on second login due to stale session state

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -669,6 +669,7 @@ async def signup(request: Request, response: Response, form_data: SignupForm):
 @router.get("/signout")
 async def signout(request: Request, response: Response):
     response.delete_cookie("token")
+    response.delete_cookie("oui-session")
 
     if ENABLE_OAUTH_SIGNUP.value:
         oauth_id_token = request.cookies.get("oauth_id_token")


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry
### Description
- Fixes OAuth authentication failure on second login attempt by ensuring proper session cleanup during logout. This resolves the "mismatching_state: CSRF Warning!" error that prevented users from logging in again after logging out when using OAuth providers (Microsoft Entra ID, Google, GitHub, etc.).

### Added
- Session cookie deletion during logout to ensure clean OAuth state for subsequent login attempts

### Changed
- Modified the `/signout` endpoint to include deletion of the `oui-session` cookie alongside existing token cleanup

### Fixed
- OAuth login failing with "mismatching_state: CSRF Warning!" error on second login attempt
- Generic "The email or password provided is incorrect" error message shown in browser for OAuth-specific failures
- Stale OAuth state persisting across logout/login cycles in multi-worker Redis-backed deployments
- Session data not being properly cleared during logout when using OAuth authentication

### Security
- Improved OAuth CSRF protection by ensuring fresh state tokens for each authentication flow
- Eliminated potential session fixation vulnerabilities by properly clearing all session data on logout

### Breaking Changes
- None

---
### Additional Information
- **Root Cause**: The OAuth state token used for CSRF protection is stored in the session (via `authlib` and Starlette's SessionMiddleware). The session is tracked by the `oui-session` cookie, which was not being deleted during logout. This caused the old OAuth state to persist, leading to state mismatch errors on subsequent login attempts.

- **Impact**: This bug affected **ALL** OAuth providers (Microsoft, Google, GitHub, etc.) and was particularly problematic in production environments.

- **Testing Performed**: 
  - Verified the issue reproduces consistently before the fix
  - Confirmed successful login -> logout -> login (and a few more logout -> login's) flow after applying the fix
  - Tested with Microsoft Entra ID OAuth provider in multi-worker setup with Redis

- **Related Issues**:
  **- Fixes: https://github.com/open-webui/open-webui/issues/15104**

  - Related to: https://github.com/open-webui/open-webui/issues/13509
 
  - Relates to: https://github.com/open-webui/open-webui/discussions/15008
  - Relates to: https://github.com/open-webui/open-webui/discussions/15007
  - Relates to: https://github.com/open-webui/open-webui/issues/14540

- Before fix: OAuth login works first time, fails on second attempt with CSRF error in logs and generic error in UI
- After fix: OAuth login works consistently across multiple login/logout cycles

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.