### PR TITLE
feat: Improve folders to act like ChatGPT "projects"

### DIFF
--- a/backend/open_webui/migrations/versions/e7f8a9b2c5d1_add_system_prompt_to_folder.py
+++ b/backend/open_webui/migrations/versions/e7f8a9b2c5d1_add_system_prompt_to_folder.py
@@ -1,0 +1,22 @@
+"""Add system prompt to folder
+
+Revision ID: e7f8a9b2c5d1
+Revises: 9f0c9cd09105
+Create Date: 2025-06-21 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7f8a9b2c5d1'
+down_revision: Union[str, None] = '9f0c9cd09105'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column('folder', sa.Column('system_prompt', sa.Text(), nullable=True))
+
+def downgrade() -> None:
+    op.drop_column('folder', 'system_prompt')

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -66,6 +66,7 @@ class ChatModel(BaseModel):
 
 class ChatForm(BaseModel):
     chat: dict
+    folder_id: Optional[str] = None
 
 
 class ChatImportForm(ChatForm):
@@ -118,6 +119,7 @@ class ChatTable:
                         else "New Chat"
                     ),
                     "chat": form_data.chat,
+                    "folder_id": form_data.folder_id,
                     "created_at": int(time.time()),
                     "updated_at": int(time.time()),
                 }

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -105,33 +105,33 @@ async def get_folder_by_id(id: str, user=Depends(get_verified_user)):
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-
 ############################
-# Update Folder Name By Id
+# Update Folder Details By Id
 ############################
 
 
 @router.post("/{id}/update")
-async def update_folder_name_by_id(
+async def update_folder_by_id(
     id: str, form_data: FolderForm, user=Depends(get_verified_user)
 ):
     folder = Folders.get_folder_by_id_and_user_id(id, user.id)
     if folder:
-        existing_folder = Folders.get_folder_by_parent_id_and_user_id_and_name(
-            folder.parent_id, user.id, form_data.name
-        )
-        if existing_folder:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT("Folder already exists"),
-            )
-
         try:
-            folder = Folders.update_folder_name_by_id_and_user_id(
-                id, user.id, form_data.name
+            updated_folder = Folders.update_folder_details_by_id_and_user_id(
+                id=id,
+                user_id=user.id,
+                name=form_data.name,
+                system_prompt=form_data.system_prompt,
             )
-
-            return folder
+            if updated_folder:
+                return updated_folder
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=ERROR_MESSAGES.DEFAULT(
+                        "Could not update folder. It might be due to a name conflict or invalid data."
+                    ),
+                )
         except Exception as e:
             log.exception(e)
             log.error(f"Error updating folder: {id}")

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -4,6 +4,8 @@ import { getTimeRange } from '$lib/utils';
 export const createNewChat = async (token: string, chat: object) => {
 	let error = null;
 
+	const { folder_id, ...chatData } = chat as any;
+
 	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/new`, {
 		method: 'POST',
 		headers: {
@@ -12,7 +14,8 @@ export const createNewChat = async (token: string, chat: object) => {
 			authorization: `Bearer ${token}`
 		},
 		body: JSON.stringify({
-			chat: chat
+			chat: chatData,
+			...(folder_id && { folder_id: folder_id })
 		})
 	})
 		.then(async (res) => {

--- a/src/lib/apis/folders/index.ts
+++ b/src/lib/apis/folders/index.ts
@@ -92,7 +92,11 @@ export const getFolderById = async (token: string, id: string) => {
 	return res;
 };
 
-export const updateFolderNameById = async (token: string, id: string, name: string) => {
+export const updateFolderById = async (
+	token: string,
+	id: string,
+	folderData: { name: string; system_prompt?: string }
+) => {
 	let error = null;
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/folders/${id}/update`, {
@@ -102,9 +106,7 @@ export const updateFolderNameById = async (token: string, id: string, name: stri
 			'Content-Type': 'application/json',
 			authorization: `Bearer ${token}`
 		},
-		body: JSON.stringify({
-			name: name
-		})
+		body: JSON.stringify(folderData)
 	})
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();

--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -2,7 +2,9 @@
 	import { WEBUI_BASE_URL } from '$lib/constants';
 	import { marked } from 'marked';
 
-	import { config, user, models as _models, temporaryChatEnabled } from '$lib/stores';
+	import { config, user, models as _models, temporaryChatEnabled, pendingFolderId, pendingFolderName } from '$lib/stores';
+	import FolderOpen from '$lib/components/icons/FolderOpen.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
 	import { onMount, getContext } from 'svelte';
 
 	import { blur, fade } from 'svelte/transition';
@@ -76,6 +78,27 @@
 					<EyeSlash strokeWidth="2.5" className="size-5" />{$i18n.t('Temporary Chat')}
 				</div>
 			</Tooltip>
+		{/if}
+
+		{#if $pendingFolderName}
+		    <div class="mt-4 mb-4 px-4 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg max-w-xl">
+		        <div class="flex items-center gap-2 text-blue-700 dark:text-blue-300">
+		            <FolderOpen className="size-4" />
+		            <span class="text-sm font-medium">
+		                {$i18n.t('Next chat will be created in folder:')} 
+		                <strong>{$pendingFolderName}</strong>
+		            </span>
+		            <button 
+		                class="ml-auto text-blue-500 hover:text-blue-700"
+		                on:click={() => {
+		                    pendingFolderId.set(null);
+		                    pendingFolderName.set(null);
+		                }}
+		            >
+		                <XMark className="size-4" />
+		            </button>
+		        </div>
+		    </div>
 		{/if}
 
 		<div

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -7,7 +7,7 @@
 
 	const dispatch = createEventDispatcher();
 
-	import { config, user, models as _models, temporaryChatEnabled } from '$lib/stores';
+	import { config, user, models as _models, temporaryChatEnabled, pendingFolderId, pendingFolderName } from '$lib/stores';
 	import { sanitizeResponseContent, extractCurlyBraceWords } from '$lib/utils';
 	import { WEBUI_BASE_URL } from '$lib/constants';
 
@@ -15,6 +15,9 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import EyeSlash from '$lib/components/icons/EyeSlash.svelte';
 	import MessageInput from './MessageInput.svelte';
+
+	import FolderOpen from '$lib/components/icons/FolderOpen.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -101,6 +104,27 @@
 				<EyeSlash strokeWidth="2.5" className="size-5" />{$i18n.t('Temporary Chat')}
 			</div>
 		</Tooltip>
+	{/if}
+
+	{#if $pendingFolderName}
+	    <div class="mb-2 px-4 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg mx-auto max-w-xl">
+	        <div class="flex items-center gap-2 text-blue-700 dark:text-blue-300">
+	            <FolderOpen className="size-4" />
+	            <span class="text-sm font-medium">
+	                {$i18n.t('Next chat will be created in folder:')} 
+	                <strong>{$pendingFolderName}</strong>
+	            </span>
+	            <button 
+	                class="ml-auto text-blue-500 hover:text-blue-700"
+	                on:click={() => {
+	                    pendingFolderId.set(null);
+	                    pendingFolderName.set(null);
+	                }}
+	            >
+	                <XMark className="size-4" />
+	            </button>
+	        </div>
+	    </div>
 	{/if}
 
 	<div

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -176,8 +176,6 @@
 		if ($mobile) {
 			showSidebar.set(false);
 		}
-
-		toast.success($i18n.t('Folder selected for next chat'));
 	};
 
 	const initChannels = async () => {

--- a/src/lib/components/layout/Sidebar/Folders.svelte
+++ b/src/lib/components/layout/Sidebar/Folders.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import RecursiveFolder from './RecursiveFolder.svelte';
+	import EditFolderModal from './Folders/EditFolderModal.svelte';
+	import { updateFolderById } from '$lib/apis/folders';
 
 	const dispatch = createEventDispatcher();
-	import RecursiveFolder from './RecursiveFolder.svelte';
+	const i18n = getContext('i18n');
+
 	export let folders = {};
 
 	let folderList = [];
+
 	// Get the list of folders that have no parent, sorted by name alphabetically
 	$: folderList = Object.keys(folders)
 		.filter((key) => folders[key].parent_id === null)
@@ -15,7 +21,62 @@
 				sensitivity: 'base'
 			})
 		);
+
+	let showEditFolderModal = false;
+	let currentEditingFolder = null;
+
+	const handleEditFolderEvent = (event) => {
+		const folderToEdit = event.detail;
+		if (folderToEdit && folderToEdit.id) {
+			currentEditingFolder = { ...folderToEdit };
+			showEditFolderModal = true;
+		} else {
+			console.error('EditFolder event did not provide valid folder data:', event.detail);
+			toast.error($i18n.t('Failed to open edit dialog: Invalid folder data.'));
+		}
+	};
+
+	const handleSaveFolderEdit = async (event) => {
+		const { id, name, system_prompt } = event.detail;
+
+		try {
+			const updatedFolder = await updateFolderById(localStorage.token, id, {
+				name,
+				system_prompt
+			});
+
+			if (updatedFolder && updatedFolder.id) {
+				toast.success($i18n.t('Folder updated successfully'));
+				showEditFolderModal = false;
+				currentEditingFolder = null;
+				dispatch('update', updatedFolder);
+			} else {
+				const errorDetail = updatedFolder?.detail || $i18n.t('Unknown error');
+				toast.error(`${$i18n.t('Failed to update folder')}: ${errorDetail}`);
+			}
+		} catch (error) {
+			console.error('Failed to update folder:', error);
+			const errorDetail = error?.detail || error?.message || $i18n.t('Unknown error');
+			toast.error(`${$i18n.t('Failed to update folder')}: ${errorDetail}`);
+		}
+	};
+
+	const handleCreateChatInFolder = (event) => {
+	    dispatch('createChatInFolder', event.detail);
+	};
 </script>
+
+{#if showEditFolderModal && currentEditingFolder}
+	<EditFolderModal
+		bind:show={showEditFolderModal}
+		folder={currentEditingFolder}
+		on:saveFolder={handleSaveFolderEdit}
+		on:close={() => {
+			showEditFolderModal = false;
+			currentEditingFolder = null;
+		}}
+	/>
+{/if}
 
 {#each folderList as folderId (folderId)}
 	<RecursiveFolder
@@ -31,5 +92,7 @@
 		on:change={(e) => {
 			dispatch('change', e.detail);
 		}}
+		on:editFolder={handleEditFolderEvent}
+		on:createChatInFolder={handleCreateChatInFolder}
 	/>
 {/each}

--- a/src/lib/components/layout/Sidebar/Folders/EditFolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/EditFolderModal.svelte
@@ -95,7 +95,7 @@
 							id="systemPrompt"
 							bind:value={currentSystemPrompt}
 							placeholder={$i18n.t('Enter a system prompt for all chats in this folder...')}
-							className="w-full text-sm bg-transparent placeholder:text-gray-400 dark:placeholder:text-gray-600 outline-none border border-gray-300 dark:border-gray-700 rounded-lg p-2 focus:ring-1 focus:ring-blue-500 min-h-[120px] resize-y"
+							className="w-full text-sm bg-transparent placeholder:text-gray-400 dark:placeholder:text-gray-600 outline-none border border-gray-300 dark:border-gray-700 rounded-lg p-2 focus:ring-1 focus:ring-blue-500 min-h-[120px] max-h-[600px] overflow-y-auto resize-none"
 							rows={5}
 						/>
 					</div>

--- a/src/lib/components/layout/Sidebar/Folders/EditFolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/EditFolderModal.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import { createEventDispatcher, getContext } from 'svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import Textarea from '$lib/components/common/Textarea.svelte';
+	import { user } from '$lib/stores';
+	const dispatch = createEventDispatcher();
+	const i18n = getContext('i18n');
+	export let show = false;
+	export let folder = { id: '', name: '', system_prompt: '' };
+	let currentName = '';
+	let currentSystemPrompt = '';
+	let loading = false;
+	let initialized = false;
+	// Initialize values once when modal opens
+	$: if (show && folder && !initialized) {
+		currentName = folder.name || '';
+		currentSystemPrompt = folder.system_prompt || '';
+		initialized = true;
+	}
+	// Reset when modal closes
+	$: if (!show) {
+		initialized = false;
+		loading = false;
+	}
+	// Auto-focus name input when modal opens
+	$: if (show && initialized) {
+		setTimeout(() => {
+			document.getElementById('folderName')?.focus();
+		}, 150);
+	}
+	const handleSubmit = () => {
+		if (!currentName.trim()) return;
+		loading = true;
+		dispatch('saveFolder', {
+			id: folder.id,
+			name: currentName.trim(),
+			system_prompt: currentSystemPrompt.trim() || null
+		});
+	};
+	const handleClose = () => {
+		loading = false;
+		initialized = false;
+		dispatch('close');
+	};
+</script>
+
+<Modal bind:show on:close={handleClose} size="md">
+	<div>
+		<div class="flex justify-between items-center dark:text-gray-100 px-5 pt-4 pb-1.5">
+			<div class="text-lg font-medium self-center font-primary">
+				{$i18n.t('Edit Folder')}
+			</div>
+			<button
+				class="self-center p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full"
+				on:click={handleClose}
+				aria-label={$i18n.t('Close')}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 20 20"
+					fill="currentColor"
+					class="w-5 h-5"
+				>
+					<path
+						d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"
+					/>
+				</svg>
+			</button>
+		</div>
+		<form
+			class="flex flex-col w-full px-6 pb-6 md:space-y-5 dark:text-gray-200"
+			on:submit|preventDefault={handleSubmit}
+		>
+			<div class="px-1 space-y-4">
+				<div>
+					<label for="folderName" class="block mb-1 text-xs text-gray-500">
+						{$i18n.t('Folder Name')}
+					</label>
+					<input
+						id="folderName"
+						class="w-full text-sm bg-transparent placeholder:text-gray-400 dark:placeholder:text-gray-600 outline-none border border-gray-300 dark:border-gray-700 rounded-lg p-2 focus:ring-1 focus:ring-blue-500"
+						type="text"
+						bind:value={currentName}
+						placeholder={$i18n.t('Enter folder name')}
+						required
+					/>
+				</div>
+
+				{#if $user?.role === 'admin' || ($user?.permissions.chat?.system_prompt ?? true)}
+					<div>
+						<label for="systemPrompt" class="block mb-1 text-xs text-gray-500">
+							{$i18n.t('System Prompt (Optional)')}
+						</label>
+						<Textarea
+							id="systemPrompt"
+							bind:value={currentSystemPrompt}
+							placeholder={$i18n.t('Enter a system prompt for all chats in this folder...')}
+							className="w-full text-sm bg-transparent placeholder:text-gray-400 dark:placeholder:text-gray-600 outline-none border border-gray-300 dark:border-gray-700 rounded-lg p-2 focus:ring-1 focus:ring-blue-500 min-h-[120px] resize-y"
+							rows={5}
+						/>
+					</div>
+				{/if}
+			</div>
+			<div class="flex justify-end items-center pt-4 text-sm font-medium gap-2">
+				<button
+					type="button"
+					class="px-3.5 py-1.5 text-sm font-medium dark:bg-gray-700 dark:hover:bg-gray-600 bg-gray-100 hover:bg-gray-200 text-black dark:text-white transition rounded-full"
+					on:click={handleClose}
+				>
+					{$i18n.t('Cancel')}
+				</button>
+				<button
+					class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-800 text-white dark:bg-white dark:text-black dark:hover:bg-gray-200 transition rounded-full flex items-center"
+					type="submit"
+					disabled={loading}
+				>
+					{#if loading}
+						<div class="mr-2 self-center">
+							<svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+								<circle
+									cx="12"
+									cy="12"
+									r="10"
+									stroke="currentColor"
+									stroke-width="2"
+									fill="none"
+									stroke-linecap="round"
+									stroke-dasharray="32"
+									stroke-dashoffset="32"
+								/>
+							</svg>
+						</div>
+					{/if}
+					{$i18n.t('Save')}
+				</button>
+			</div>
+		</form>
+	</div>
+</Modal>

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -16,6 +16,7 @@
 
 	const handleMenuTrigger = (event) => {
 		event.stopPropagation();
+		show = !show;
 	};
 </script>
 

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -13,6 +13,10 @@
 	import Download from '$lib/components/icons/Download.svelte';
 
 	let show = false;
+
+	const handleMenuTrigger = (event) => {
+		event.stopPropagation();
+	};
 </script>
 
 <Dropdown
@@ -23,9 +27,11 @@
 		}
 	}}
 >
-	<Tooltip content={$i18n.t('More')}>
-		<slot />
-	</Tooltip>
+	<div on:click={handleMenuTrigger} on:pointerup={handleMenuTrigger}>
+		<Tooltip content={$i18n.t('More')}>
+			<slot />
+		</Tooltip>
+	</div>
 
 	<div slot="content">
 		<DropdownMenu.Content

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -13,11 +13,6 @@
 	import Download from '$lib/components/icons/Download.svelte';
 
 	let show = false;
-
-	const handleMenuTrigger = (event) => {
-		event.stopPropagation();
-		show = !show;
-	};
 </script>
 
 <Dropdown
@@ -28,11 +23,9 @@
 		}
 	}}
 >
-	<div on:click={handleMenuTrigger} on:pointerup={handleMenuTrigger}>
-		<Tooltip content={$i18n.t('More')}>
-			<slot />
-		</Tooltip>
-	</div>
+	<Tooltip content={$i18n.t('More')}>
+		<slot />
+	</Tooltip>
 
 	<div slot="content">
 		<DropdownMenu.Content

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -38,11 +38,11 @@
 			<DropdownMenu.Item
 				class="flex gap-2 items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
 				on:click={() => {
-					dispatch('rename');
+					dispatch('editFolder');
 				}}
 			>
 				<Pencil strokeWidth="2" />
-				<div class="flex items-center">{$i18n.t('Rename')}</div>
+				<div class="flex items-center">{$i18n.t('Edit Folder')}</div>
 			</DropdownMenu.Item>
 
 			<DropdownMenu.Item

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -47,6 +47,7 @@
 	export let parentDragged = false;
 
 	let folderElement;
+	let folderMenuShow = false;
 
 	let draggedOver = false;
 	let dragged = false;
@@ -373,7 +374,16 @@
 					    exportHandler();
 					}}
 				    >
-					<button class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto">
+					<button 
+						class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto"
+						on:click={(e) => {
+        						e.stopPropagation();
+        						folderMenuShow = !folderMenuShow;
+						}}
+						on:pointerup={(e) => {
+        						e.stopPropagation();
+						}}
+					>
 						<EllipsisHorizontal className="size-4" strokeWidth="2.5" />
 					</button>
 				    </FolderMenu>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -373,7 +373,15 @@
 					    exportHandler();
 					}}
 				    >
-					<button class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto" on:click={(e) => {}}>
+					<button 
+						class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto" 
+						on:click={(e) => {
+					        	e.stopPropagation();
+						}}
+						on:pointerup={(e) => {
+					        	e.stopPropagation();
+						}}
+					>
 					    <EllipsisHorizontal className="size-4" strokeWidth="2.5" />
 					</button>
 				    </FolderMenu>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -47,7 +47,6 @@
 	export let parentDragged = false;
 
 	let folderElement;
-	let folderMenuShow = false;
 
 	let draggedOver = false;
 	let dragged = false;

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -47,7 +47,6 @@
 	export let parentDragged = false;
 
 	let folderElement;
-	let folderMenuShow = false;
 
 	let draggedOver = false;
 	let dragged = false;
@@ -374,17 +373,8 @@
 					    exportHandler();
 					}}
 				    >
-					<button 
-						class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto"
-						on:click={(e) => {
-        						e.stopPropagation();
-        						folderMenuShow = !folderMenuShow;
-						}}
-						on:pointerup={(e) => {
-        						e.stopPropagation();
-						}}
-					>
-						<EllipsisHorizontal className="size-4" strokeWidth="2.5" />
+					<button class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto" on:click={(e) => {}}>
+					    <EllipsisHorizontal className="size-4" strokeWidth="2.5" />
 					</button>
 				    </FolderMenu>
 				</div>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -47,6 +47,7 @@
 	export let parentDragged = false;
 
 	let folderElement;
+	let folderMenuShow = false;
 
 	let draggedOver = false;
 	let dragged = false;
@@ -373,16 +374,8 @@
 					    exportHandler();
 					}}
 				    >
-					<button 
-						class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto" 
-						on:click={(e) => {
-					        	e.stopPropagation();
-						}}
-						on:pointerup={(e) => {
-					        	e.stopPropagation();
-						}}
-					>
-					    <EllipsisHorizontal className="size-4" strokeWidth="2.5" />
+					<button class="p-0.5 dark:hover:bg-gray-850 hover:bg-gray-200 rounded-lg touch-auto">
+						<EllipsisHorizontal className="size-4" strokeWidth="2.5" />
 					</button>
 				    </FolderMenu>
 				</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -46,6 +46,11 @@ export const TTSWorker = writable(null);
 export const chatId = writable('');
 export const chatTitle = writable('');
 
+export const refreshSidebar = writable(() => {});
+export const pendingFolderId = writable(null);
+export const pendingFolderName = writable(null);
+export const folders = writable({});
+
 export const channels = writable([]);
 export const chats = writable(null);
 export const pinnedChats = writable([]);


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry
### Description
This pull request introduces a **highly requested** evolution of the existing folder system, **transforming folders into powerful, project-like workspaces**. This work is a direct response to a significant number of community discussions and feature requests calling for project-based organization, custom instructions per folder, and more streamlined workflows, similar to features found in OpenAI ChatGPT's projects feature or in Claude's folders where you can also adjust them similarly.

**By enhancing folders with dedicated system prompts and improving the user experience for chat creation, this PR addresses the core feedback from a wide range of community discussions**. The community has clearly expressed a desire for more structured and contextualized chat management, and this implementation delivers a foundational and robust solution.

### Added
- **Folder-Specific System Prompts:** Folders can now have a dedicated System Prompt that is automatically prepended to every new chat created within them, enabling customized behavior on a per-folder basis. This system prompt is optional. You can still use folders as just folders.
- **"Edit Folder" Modal:** A new modal has been introduced to edit folder properties, allowing users to edit both the folder name and its system prompt from a single, unified interface.
- **Direct Chat Creation in Folders:** A new "plus" icon now appears when hovering over a folder in the sidebar, allowing users to create a new chat directly within that folder. This was never possible before. Before you'd have to create a new chat (outside a folder) and then move it into the folder. Now, this annoyance is gone and it's also important that it is gone, since you need to be able to make use of the new system prompt that is stored inside folders.
- **UI Notification Banner:** When a folder is selected for direct chat creation, a blue banner appears on the chat screen, notifying the user which folder the next chat will be created in.
- **Database Migration:** An Alembic migration has been added to introduce the `system_prompt` column to the `folder` table.

### Changed
- **Folder Renaming UX:** The previous inline folder renaming has been replaced by the more robust "Edit Folder" modal.
- **Default Folder Name:** The default name for new folders has been changed from "Untitled" to "📁 Untitled Folder" for better visual distinction.
__**Tim:**__ feel free to change this if you like, but during my heavy testing, i found this new name for newly created folders to be visually much better and more clearly differentiated from the rest of the UI and it allowed me to more quickly identify folders in the sidebar.
- **Sidebar State Management:** The frontend state management for the sidebar has been refactored to use global Svelte stores (`folders`, `refreshSidebar`) for consistent and reactive updates.
- **Folder Update API:** The backend endpoint `POST /api/folders/{id}/update` has been enhanced to accept both `name` and `system_prompt` fields.

### Deprecated
- **Inline Folder Renaming:** The UX pattern of double-clicking a folder to rename it inline has been deprecated in favor of the new "Edit Folder" modal.

### Removed
- The previous backend logic for updating only a folder's name has been removed and consolidated into the more comprehensive `update_folder_details_by_id_and_user_id` function.

### Security
- **System Prompt Permissions:** The new "Edit Folder" modal includes a permission check (`$user?.role === 'admin' || ($user?.permissions.chat?.system_prompt ?? true)`), ensuring that only authorized users can view or edit the system prompt field.

### Breaking Changes
- None.

---
### Additional Information

#### Community Context & Discussion References
**This work is a direct response to extensive community feedback.** The core improvements in this PR are directly linked to the following discussions and issues:

- **[#12620 - feat: Projects](https://github.com/open-webui/open-webui/discussions/12620)**
  - *Community Request:* Users asked for a "Projects" feature like OpenAI's, suggesting folder enhancements as a viable alternative.
  - *This PR's Solution:* We implement the core of that "Projects" concept by empowering folders with specific system prompts, turning them into distinct project workspaces.

- **[#14299 - enh: folders are like projects](https://github.com/open-webui/open-webui/discussions/14299)**
  - *Community Request:* Users provided detailed mockups and use-cases for enriching folders with custom instructions and a "start conversation in folder" UI button.
  - *This PR's Solution:* **We directly implement both key suggestions:** folder-specific system prompts via the "Edit Folder" modal and the new UI for creating chats directly inside folders.

- **[#13040 - Implement a "Project" feature](https://github.com/open-webui/open-webui/discussions/13040)**
  - *Community Request:* Users described the need for project-like features to better organize tasks, manage long-term goals, and structure conversations.
  - *This PR's Solution:* By allowing folders to have unique system prompts, we provide the foundational mechanism to achieve the structured, goal-oriented conversations that users described.

- **[#12597 - feat: Projects (Issue)](https://github.com/open-webui/open-webui/issues/12597)**
  - *Community Request:* This issue formally tracked the need for a project-like feature, with a key comment highlighting the value of **project-specific system prompts.**
  - *This PR's Solution:* We directly resolve this issue by adding the highly requested folder-specific system prompt capability, fulfilling the issue's primary goal.

- **[#15132 - Feature Request: System Prompt Profiles](https://github.com/open-webui/open-webui/discussions/15132)**
  - *Community Request:* Users requested reusable "System Prompt Profiles" to efficiently manage different contexts for their chats.
  - *This PR's Solution:* We introduce the first step towards this goal by enabling **system prompts to be scoped to a folder**, providing the powerful contextual benefit users were seeking. This could serve as a powerful alternative to "System Prompt Profiles" **since the Folders could now act as those requested Profiles!**

- **[#10562 - feat: Enhance Folder Management with "New Chat in Folder" and "Create Subfolder" Options](https://github.com/open-webui/open-webui/issues/10562)**
  - **Community Request:** "New Chat in Folder: This option would enable users to initiate a new chat directly within a selected folder, eliminating the need for manual drag-and-drop operations."
  - **This PR:** hits the nail in the head and implements this.

- https://github.com/open-webui/open-webui/issues/12084
- This feature request is related to https://github.com/open-webui/open-webui/issues/10562 and also asks for an ability to create new chats directly within a folder.

#### Technical Notes
A significant part of this effort involved refactoring the sidebar's state management. We moved the folder list from a local component variable into a global Svelte store (`$folders`). This was essential to fix reactivity bugs and allow components like `Chat.svelte` to trigger a sidebar refresh via a second global store, `$refreshSidebar`. This creates a robust, decoupled architecture that is easier to maintain and extend in the future.

### Screenshots or Videos

https://github.com/user-attachments/assets/8eef986d-8e51-492f-8a59-fd812a7edb6b

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.