### PR TITLE
[PERF] Proper default pooling settings

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -272,15 +272,13 @@ if "postgres://" in DATABASE_URL:
 
 DATABASE_SCHEMA = os.environ.get("DATABASE_SCHEMA", None)
 
-DATABASE_POOL_SIZE = os.environ.get("DATABASE_POOL_SIZE", 0)
+DATABASE_POOL_SIZE = os.environ.get("DATABASE_POOL_SIZE", None)
 
-if DATABASE_POOL_SIZE == "":
-    DATABASE_POOL_SIZE = 0
-else:
+if DATABASE_POOL_SIZE != None:
     try:
         DATABASE_POOL_SIZE = int(DATABASE_POOL_SIZE)
     except Exception:
-        DATABASE_POOL_SIZE = 0
+        DATABASE_POOL_SIZE = None
 
 DATABASE_POOL_MAX_OVERFLOW = os.environ.get("DATABASE_POOL_MAX_OVERFLOW", 0)
 

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -94,9 +94,13 @@ else:
             pool_pre_ping=True,
             poolclass=QueuePool,
         )
-    else:
+    elif DATABASE_POOL_SIZE == 0:
         engine = create_engine(
             SQLALCHEMY_DATABASE_URL, pool_pre_ping=True, poolclass=NullPool
+        )
+    else:
+        engine = create_engine(
+            SQLALCHEMY_DATABASE_URL, pool_pre_ping=True
         )
 
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?

https://github.com/open-webui/docs/pull/592

- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

Changed default pooling to let SQLAlchemy figure out optimal pooling strategy in case DATABASE_POOL_SIZE is not set.

### Description

See discussion in https://github.com/open-webui/open-webui/pull/15175

This PR defaults the database pooling setting to "automatic" instead of NullPool for a better out-of-the-box experience, minimizing user frustration with slow API responses when using any db that is not SQLite.

Why?

It seems that some users, especially those using non-local databases, see slow response times from the API. One reason is that DATABASE_POOL_SIZE must be manually set to something that is appropriate for the anticipated workload. However, defaulting DATABASE_POOL_SIZE to 0 currently disables pooling (NullPool) and introduces an unnecessary bottleneck.

This change will:

- default SQLAlchemy to chose the proper default pooling setting automatically, in case DATABASE_POOL_SIZE is not set
- maintains that DATABASE_POOL_SIZE = 0 will turn off pooling by setting NullPool

I argue that this change provides a much better out-of-the-box experience. While users are still encouraged to configure the database pool size based on their specific needs and expected workload to handle concurrent requests efficiently, defaulting to "auto" removes a harmful and unnecessary performance bottleneck for all users, particularly those connecting to remote databases, where a default of NullPool is nonsense.

### Changed

- default pooling setting for db connections


### Additional Information

See discussion in https://github.com/open-webui/open-webui/pull/15175
https://docs-sqlalchemy.readthedocs.io/ko/latest/core/pooling.html


### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
