### PR TITLE
i18n: Fix translation placeholder for SSO provider in Bahasa Indonesia

### DIFF
--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -249,7 +249,7 @@
 	"Content": "Konten",
 	"Content Extraction Engine": "",
 	"Continue Response": "Lanjutkan Tanggapan",
-	"Continue with {{provider}}": "Lanjutkan dengan {{penyedia}}",
+	"Continue with {{provider}}": "Lanjutkan dengan {{provider}}",
 	"Continue with Email": "",
 	"Continue with LDAP": "",
 	"Control how message text is split for TTS requests. 'Punctuation' splits into sentences, 'paragraphs' splits into paragraphs, and 'none' keeps the message as a single string.": "",


### PR DESCRIPTION
# Pull Request Checklist
### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Fixed incorrect placeholder in Bahasa Indonesia translation for SSO provider text.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
  (Not required for this text fix)
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
  (No new dependencies)
- [x] **Testing:** Manually tested by verifying SSO provider name display on the UI.
- [x] **Code review:** Self-reviewed the code.
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
This pull request fixes an error in the Bahasa Indonesia translation for the Single Sign-On (SSO) provider text. Previously, the `{{provider}}` placeholder was incorrectly translated to `{{penyedia}}`, which caused the SSO provider name not to display correctly. This fix ensures the `{{provider}}` placeholder remains intact and functional.

### Fixed
- Corrected the translation of `\"Continue with {{provider}}\"` from `\"Lanjutkan dengan {{penyedia}}\"` back to `\"Lanjutkan dengan {{provider}}\"` in the Bahasa Indonesia translation file.

---
### Additional Information
This error caused the SSO provider name to not appear in the login display.

### Screenshots or Videos
before
<img width="428" alt="image" src="https://github.com/user-attachments/assets/7576be19-7b83-4de8-8207-afbd43281719" />

after
<img width="430" alt="image" src="https://github.com/user-attachments/assets/6166b26d-8d37-4f0d-81c4-dc3c2ddab092" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.