### PR TITLE
fix: Add global model store and sync selected model across components

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -20,6 +20,7 @@
 		config,
 		type Model,
 		models,
+		model,
 		tags as allTags,
 		settings,
 		showSidebar,
@@ -119,6 +120,11 @@
 	let atSelectedModel: Model | undefined;
 	let selectedModelIds = [];
 	$: selectedModelIds = atSelectedModel !== undefined ? [atSelectedModel.id] : selectedModels;
+
+	// Sync the first selected model with the global model store
+	$: if (selectedModels.length > 0 && selectedModels[0] !== '') {
+		model.set(selectedModels[0]);
+	}
 
 	let selectedToolIds = [];
 	let selectedFilterIds = [];

--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -10,7 +10,8 @@
 		settings,
 		showArtifacts,
 		showControls,
-		showOverview
+		showOverview,
+		model as selectedModel
 	} from '$lib/stores';
 	import FloatingButtons from '../ContentRenderer/FloatingButtons.svelte';
 	import { createMessagesList } from '$lib/utils';
@@ -192,7 +193,7 @@
 	<FloatingButtons
 		bind:this={floatingButtonsElement}
 		{id}
-		model={model?.id}
+		model={$selectedModel}
 		messages={createMessagesList(history, id)}
 		onAdd={({ modelId, parentId, messages }) => {
 			console.log(modelId, parentId, messages);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -52,6 +52,7 @@ export const pinnedChats = writable([]);
 export const tags = writable([]);
 
 export const models: Writable<Model[]> = writable([]);
+export const model = writable('');
 
 export const prompts: Writable<null | Prompt[]> = writable(null);
 export const knowledge: Writable<null | Document[]> = writable(null);


### PR DESCRIPTION
Fixes a bug where the "Explain" and "Ask" features used the model that generated the message, instead of the currently selected model.

### Description

- Fixes model selection for "Explain" and "Ask" quick actions to always use the currently selected model.

### Changed

- FloatingButtons and ContentRenderer now use the global selected model.

### Fixed

- "Explain" and "Ask" now use the currently selected model, not the message's original model.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
