### PR TITLE
fix: 'Feedback Details' modal opening on 'More' button click

### DIFF
--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -307,6 +307,14 @@
 					<tr
 						class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-850/50 transition"
 						on:click={() => openFeedbackModal(feedback)}
+						role="button"
+						tabindex="0"
+						on:keydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								openFeedbackModal(feedback);
+							}
+						}}
 					>
 						<td class=" py-0.5 text-right font-semibold">
 							<div class="flex justify-center">
@@ -370,17 +378,30 @@
 						</td>
 
 						<td class=" px-3 py-1 text-right font-semibold">
-							<FeedbackMenu
-								on:delete={(e) => {
-									deleteFeedbackHandler(feedback.id);
+							<div
+								on:click|stopPropagation
+								role="button"
+								tabindex="0"
+								on:keydown={(e) => {
+									if (e.key === 'Enter' || e.key === ' ') {
+										e.preventDefault();
+										e.currentTarget.querySelector('button')?.click();
+									}
 								}}
 							>
-								<button
-									class="self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
+								<FeedbackMenu
+									on:delete={(e) => {
+										deleteFeedbackHandler(feedback.id);
+									}}
 								>
-									<EllipsisHorizontal />
-								</button>
-							</FeedbackMenu>
+									<button
+										class="self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
+										type="button"
+									>
+										<EllipsisHorizontal />
+									</button>
+								</FeedbackMenu>
+							</div>
 						</td>
 					</tr>
 				{/each}


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- Improve accessibility (a11y) for the feedback history table, enhancing keyboard navigation and interaction. These changes allow users to more easily open feedback details and access feedback menu options using only a keyboard.

### Added

- `role="button"` and `tabindex="0"` attributes to feedback table rows to enable keyboard navigation and activation.
- `on:keydown` event handlers to feedback table rows to open the feedback modal when `Enter` or `Space` keys are pressed.
- A wrapping `div` element around the `FeedbackMenu` component, including `on:click|stopPropagation`, `role="button"`, `tabindex="0"`, and `on:keydown` to ensure the menu button is independently accessible by keyboard and prevents unwanted event bubbling to the parent row.

### Changed
- Modified `<tr>` elements within the feedback table to be keyboard-navigable and activatable, improving the user experience for keyboard-only users.
- Adjusted the structure around the feedback menu button to enhance its individual accessibility and prevent its click/activation from triggering the row's click event.
- Added `type="button"` to the button element within the `FeedbackMenu` to ensure correct semantic behavior.

### Fixed
- Addressed accessibility issues by providing keyboard support for interacting with feedback table rows and their associated menu buttons.

---

### Additional Information
- These modifications align with Web Content Accessibility Guidelines (WCAG) to provide a more inclusive and usable interface for all users, including those who rely on keyboard navigation.

### Screenshots or Videos
**Before:**
![image](https://github.com/user-attachments/assets/8e619b88-9dfd-4579-9f1e-baf4ff0cf315)
**After:**
![image](https://github.com/user-attachments/assets/a3971cd5-2a34-4bef-96b8-ea8267e29359)
![image](https://github.com/user-attachments/assets/c9f1dd02-a015-46b8-9598-d6622a2941c5)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
