### PR TITLE
fix: Forward response headers

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -12,7 +12,7 @@ import requests
 
 from fastapi import Depends, FastAPI, HTTPException, Request, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
@@ -859,13 +859,22 @@ async def generate_chat_completion(
             )
         else:
             try:
-                response = await r.json()
+                response_content = await r.json()
+                content = json.dumps(response_content)
+                media_type = "application/json"
             except Exception as e:
                 log.error(e)
-                response = await r.text()
-
+                content = await r.text()
+                media_type = "text/plain"
+            
             r.raise_for_status()
-            return response
+            
+            return Response(
+                content=content,
+                status_code=r.status,
+                headers=dict(r.headers),
+                media_type=media_type
+            )
     except Exception as e:
         log.exception(e)
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1309,7 +1309,7 @@ async def process_chat_response(
                         media_type=response.media_type,
                     )
                 else:
-                    return json.dumps(merged_data)
+                    return merged_data
 
             return response
         else:
@@ -1333,7 +1333,7 @@ async def process_chat_response(
                         media_type=response.media_type,
                     )
                 else:
-                    return json.dumps(merged_data)
+                    return merged_data
 
             return response
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1216,9 +1216,11 @@ async def process_chat_response(
 
     # Non-streaming response
     if not isinstance(response, StreamingResponse):
+        response_data = json.loads(response.body.decode())
+
         if event_emitter:
-            if "error" in response:
-                error = response["error"].get("detail", response["error"])
+            if "error" in response_data:
+                error = response_data["error"].get("detail", response_data["error"])
                 Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata["chat_id"],
                     metadata["message_id"],
@@ -1226,31 +1228,25 @@ async def process_chat_response(
                         "error": {"content": error},
                     },
                 )
-
-            if "selected_model_id" in response:
+            if "selected_model_id" in response_data:
                 Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata["chat_id"],
                     metadata["message_id"],
                     {
-                        "selectedModelId": response["selected_model_id"],
+                        "selectedModelId": response_data["selected_model_id"],
                     },
                 )
-
-            choices = response.get("choices", [])
+            choices = response_data.get("choices", [])
             if choices and choices[0].get("message", {}).get("content"):
-                content = response["choices"][0]["message"]["content"]
-
+                content = response_data["choices"][0]["message"]["content"]
                 if content:
-
                     await event_emitter(
                         {
                             "type": "chat:completion",
-                            "data": response,
+                            "data": response_data,
                         }
                     )
-
                     title = Chats.get_chat_title_by_id(metadata["chat_id"])
-
                     await event_emitter(
                         {
                             "type": "chat:completion",
@@ -1261,7 +1257,6 @@ async def process_chat_response(
                             },
                         }
                     )
-
                     # Save message in the database
                     Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata["chat_id"],
@@ -1271,7 +1266,6 @@ async def process_chat_response(
                             "content": content,
                         },
                     )
-
                     # Send a webhook notification if the user is not active
                     if not get_active_status_by_user_id(user.id):
                         webhook_url = Users.get_user_webhook_url_by_id(user.id)
@@ -1287,10 +1281,9 @@ async def process_chat_response(
                                     "url": f"{request.app.state.config.WEBUI_URL}/c/{metadata['chat_id']}",
                                 },
                             )
-
                     await background_tasks_handler()
 
-            if events and isinstance(events, list) and isinstance(response, dict):
+            if events and isinstance(events, list):
                 extra_response = {}
                 for event in events:
                     if isinstance(event, dict):
@@ -1298,14 +1291,23 @@ async def process_chat_response(
                     else:
                         extra_response[event] = True
 
-                response = {
+                # Merge the extra response
+                merged_data = {
                     **extra_response,
-                    **response,
+                    **response_data,
                 }
+
+                # Return a new Response object with the merged data
+                return Response(
+                    content=json.dumps(merged_data),
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                    media_type=response.media_type,
+                )
 
             return response
         else:
-            if events and isinstance(events, list) and isinstance(response, dict):
+            if events and isinstance(events, list):
                 extra_response = {}
                 for event in events:
                     if isinstance(event, dict):
@@ -1313,10 +1315,17 @@ async def process_chat_response(
                     else:
                         extra_response[event] = True
 
-                response = {
+                merged_data = {
                     **extra_response,
-                    **response,
+                    **response_data,
                 }
+
+                return Response(
+                    content=json.dumps(merged_data),
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                    media_type=response.media_type,
+                )
 
             return response
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -372,6 +372,9 @@ async def chat_web_search_handler(
             user,
         )
 
+        if res and isinstance(res, Response):
+            res = res.body.decode()
+
         response = res["choices"][0]["message"]["content"]
 
         try:
@@ -528,6 +531,9 @@ async def chat_image_generation_handler(
                 user,
             )
 
+            if res and isinstance(res, Response):
+                res = res.body.decode()
+
             response = res["choices"][0]["message"]["content"]
 
             try:
@@ -618,6 +624,10 @@ async def chat_completion_files_handler(
                 },
                 user,
             )
+
+            if queries_response and isinstance(queries_response, Response):
+                queries_response = queries_response.body.decode()
+
             queries_response = queries_response["choices"][0]["message"]["content"]
 
             try:
@@ -1059,6 +1069,9 @@ async def process_chat_response(
                         user,
                     )
 
+                    if res and isinstance(res, Response):
+                        res = json.loads(res.body.decode())
+
                     if res and isinstance(res, dict):
                         if len(res.get("choices", [])) == 1:
                             follow_ups_string = (
@@ -1114,6 +1127,9 @@ async def process_chat_response(
                             },
                             user,
                         )
+
+                        if res and isinstance(res, Response):
+                            res = json.loads(res.body.decode())
 
                         if res and isinstance(res, dict):
                             if len(res.get("choices", [])) == 1:
@@ -1171,6 +1187,9 @@ async def process_chat_response(
                         },
                         user,
                     )
+
+                    if res and isinstance(res, Response):
+                        res = json.loads(res.body.decode())
 
                     if res and isinstance(res, dict):
                         if len(res.get("choices", [])) == 1:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1216,7 +1216,10 @@ async def process_chat_response(
 
     # Non-streaming response
     if not isinstance(response, StreamingResponse):
-        response_data = json.loads(response.body.decode())
+        if isinstance(response, Response):
+            response_data = json.loads(response.body.decode())
+        else:
+            response_data = response
 
         if event_emitter:
             if "error" in response_data:
@@ -1297,13 +1300,16 @@ async def process_chat_response(
                     **response_data,
                 }
 
-                # Return a new Response object with the merged data
-                return Response(
-                    content=json.dumps(merged_data),
-                    status_code=response.status_code,
-                    headers=dict(response.headers),
-                    media_type=response.media_type,
-                )
+                if isinstance(response, Response):
+                    # Return a new Response object with the merged data
+                    return Response(
+                        content=json.dumps(merged_data),
+                        status_code=response.status_code,
+                        headers=dict(response.headers),
+                        media_type=response.media_type,
+                    )
+                else:
+                    return json.dumps(merged_data)
 
             return response
         else:
@@ -1319,13 +1325,15 @@ async def process_chat_response(
                     **extra_response,
                     **response_data,
                 }
-
-                return Response(
-                    content=json.dumps(merged_data),
-                    status_code=response.status_code,
-                    headers=dict(response.headers),
-                    media_type=response.media_type,
-                )
+                if isinstance(response, Response):
+                    return Response(
+                        content=json.dumps(merged_data),
+                        status_code=response.status_code,
+                        headers=dict(response.headers),
+                        media_type=response.media_type,
+                    )
+                else:
+                    return json.dumps(merged_data)
 
             return response
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -98,7 +98,6 @@ langfuse==2.44.0
 youtube-transcript-api==1.1.0
 pytube==15.0.0
 
-extract_msg
 pydub
 duckduckgo-search==8.0.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ dependencies = [
     "youtube-transcript-api==1.1.0",
     "pytube==15.0.0",
 
-    "extract_msg",
     "pydub",
     "duckduckgo-search==8.0.2",
 


### PR DESCRIPTION
# Changelog Entry

### Description

- Instead of only returning the payload of the response, we make sure that a proper `Response` object is constructed that includes the upstream API's response headers. 

### Added

- Response headers are preserved for non-streaming chat completion requests.

### Changed

- Changed the response construction for non-streaming requests

### Fixed

- Fixes issue #15411

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
