### PR TITLE
Fix: Hold shift key for quickly archiving / deleting chats in custom folders

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -50,6 +50,8 @@
 
 	let name = '';
 
+	let shiftKey = false;
+
 	const onDragOver = (e) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -57,6 +59,18 @@
 			return;
 		}
 		draggedOver = true;
+	};
+
+	const onKeyDown = (e) => {
+		if (e.key === 'Shift') {
+			shiftKey = true;
+		}
+	};
+
+	const onKeyUp = (e) => {
+		if (e.key === 'Shift') {
+			shiftKey = false;
+		}
 	};
 
 	const onDrop = async (e) => {
@@ -215,6 +229,9 @@
 			// Event listener for when dragging ends
 			folderElement.addEventListener('dragend', onDragEnd);
 		}
+
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
 
 		if (folders[folderId]?.new) {
 			delete folders[folderId].new;
@@ -495,6 +512,7 @@
 							<ChatItem
 								id={chat.id}
 								title={chat.title}
+								{shiftKey}
 								on:change={(e) => {
 									dispatch('change', e.detail);
 								}}


### PR DESCRIPTION
# Changelog Entry

### Description
Current behaviour: When users hold shift key and hover to a chat item, the item will show the Archive button and Delete button for quick action. It works for chats inside the pin folder and the root directory. However, this does not work for chats inside custom folders

### Fixed
Updated `RecursiveFolder.svelte` to resolve this issue.

### Screenshots or Videos
![image](https://github.com/user-attachments/assets/93fc2f7b-293c-4da1-97c7-5f45470f409e)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
