### PR TITLE
add customizer

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -84,4 +84,4 @@ sed -i "s|WEBUI_NAME = os.environ.get.*|WEBUI_NAME = os.environ.get(\"WEBUI_NAME
 sed -i "s|WEBUI_FAVICON_URL = .*|WEBUI_FAVICON_URL = \"$BASE_URL/favicon.png\"|" "$ENV_PY"
 sed -i '/if WEBUI_NAME != .*Open WebUI/,/WEBUI_NAME += .*Open WebUI/d' "$ENV_PY"
 
-echo -e "\n🎉 DONE — '$NEW_NAME' is now rocking with **favicon-dark.png** included across backend and root static dirs!"
+echo -e "\n🎉 DONE — '$NEW_NAME'"

--- a/customize.sh
+++ b/customize.sh
@@ -27,6 +27,7 @@ fi
 echo -e "\n🔍 Checking assets at $BASE_URL..."
 declare -A ASSETS=(
   ["favicon.png"]="500x500"
+  ["favicon-dark.png"]="500x500"
   ["logo.png"]="500x500"
   ["web-app-manifest-512x512.png"]="512x512"
   ["web-app-manifest-192x192.png"]="192x192"
@@ -68,8 +69,6 @@ for file in "${!ASSETS[@]}"; do
 done
 
 # 5️⃣ Update root-level static directories
-#    - ./static/favicon.png
-#    - everything in ./static/static/
 ROOT_STATIC1="./static"
 ROOT_STATIC2="./static/static"
 mkdir -p "$ROOT_STATIC1" "$ROOT_STATIC2"
@@ -85,4 +84,4 @@ sed -i "s|WEBUI_NAME = os.environ.get.*|WEBUI_NAME = os.environ.get(\"WEBUI_NAME
 sed -i "s|WEBUI_FAVICON_URL = .*|WEBUI_FAVICON_URL = \"$BASE_URL/favicon.png\"|" "$ENV_PY"
 sed -i '/if WEBUI_NAME != .*Open WebUI/,/WEBUI_NAME += .*Open WebUI/d' "$ENV_PY"
 
-echo -e "\n🎉 DONE — '$NEW_NAME' is now baked into your local Open WebUI clone, and all icons in backend/open_webui/static, ./static/favicon.png, and ./static/static/* are replaced!"
+echo -e "\n🎉 DONE — '$NEW_NAME' is now rocking with **favicon-dark.png** included across backend and root static dirs!"

--- a/customize.sh
+++ b/customize.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+echo "🔥 FixCraft AI WebUI Customizer — Launching..."
+echo "Dranding Customizer By F1xGOD"
+echo ""
+# 1️⃣ Ask for local repo path
+read -p "👉 Path to your local open-webui directory (default: current dir): " OPENWEBUI_DIR
+OPENWEBUI_DIR=${OPENWEBUI_DIR:-.}
+
+if [[ ! -d "$OPENWEBUI_DIR" ]]; then
+  echo "❌ Directory '$OPENWEBUI_DIR' not found! Exiting."
+  exit 1
+fi
+
+cd "$OPENWEBUI_DIR"
+echo "🚀 Operating in: $(pwd)"
+
+# 2️⃣ Get new name & asset URL
+read -p "👉 New WebUI name (default: FixCraft AI): " NEW_NAME
+NEW_NAME=${NEW_NAME:-FixCraft AI}
+
+read -p "👉 Base URL for assets (e.g. https://www.fixcraft.org): " BASE_URL
+if [[ -z "$BASE_URL" ]]; then
+  echo "❌ No URL given. Exiting."
+  exit 1
+fi
+
+echo -e "\n🔍 Checking assets at $BASE_URL..."
+declare -A ASSETS=(
+  ["favicon.png"]="500x500"
+  ["logo.png"]="500x500"
+  ["web-app-manifest-512x512.png"]="512x512"
+  ["web-app-manifest-192x192.png"]="192x192"
+  ["favicon-96x96.png"]="96x96"
+  ["apple-touch-icon.png"]="180x180"
+  ["favicon.svg"]="vector"
+  ["favicon.ico"]="16x16/32x32"
+  ["splash.png"]="any"
+  ["splash-dark.png"]="any"
+)
+
+MISSING=()
+for file in "${!ASSETS[@]}"; do
+  if ! curl -sSf "$BASE_URL/$file" -o /dev/null; then
+    echo "❌ Missing: $file (should be ${ASSETS[$file]})"
+    MISSING+=("$file (${ASSETS[$file]})")
+  else
+    echo "✅ Found:   $file (${ASSETS[$file]})"
+  fi
+done
+
+if (( ${#MISSING[@]} > 0 )); then
+  echo -e "\n🚨 NOT ALL ASSETS INSTALLED! Fix these before running again."
+  for m in "${MISSING[@]}"; do echo "   • $m"; done
+  exit 1
+fi
+
+echo -e "\n✅ All assets present. Starting customization..."
+
+# 3️⃣ Branding in HTML
+sed -i "s/Open WebUI/$NEW_NAME/g" ./src/app.html
+
+# 4️⃣ Download assets
+STATIC_DIR="./backend/open_webui/static"
+mkdir -p "$STATIC_DIR"
+for file in "${!ASSETS[@]}"; do
+  echo "⬇️  Downloading $file..."
+  curl -sSf "$BASE_URL/$file" -o "$STATIC_DIR/$file"
+done
+
+# Copy favicon.png also to root static (legacy)
+cp "$STATIC_DIR/favicon.png" "$STATIC_DIR/../favicon.png"
+
+# 5️⃣ Patch env.py
+ENV_PY="./backend/open_webui/env.py"
+sed -i "s|WEBUI_NAME = os.environ.get.*|WEBUI_NAME = os.environ.get(\"WEBUI_NAME\", \"$NEW_NAME\")|" "$ENV_PY"
+sed -i "s|WEBUI_FAVICON_URL = .*|WEBUI_FAVICON_URL = \"$BASE_URL/favicon.png\"|" "$ENV_PY"
+sed -i '/if WEBUI_NAME != .*Open WebUI/,/WEBUI_NAME += .*Open WebUI/d' "$ENV_PY"
+
+echo -e "\n🎉 DONE — '$NEW_NAME' is now baked into your local Open WebUI clone!"
+

--- a/customize.sh
+++ b/customize.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "🔥 FixCraft AI WebUI Customizer — Launching..."
-echo "Dranding Customizer By F1xGOD"
+echo "🔥 Open WebUI Customizer — Launching..."
+echo "Branding Customizer By F1xGOD"
 echo ""
 # 1️⃣ Ask for local repo path
 read -p "👉 Path to your local open-webui directory (default: current dir): " OPENWEBUI_DIR
@@ -12,14 +12,12 @@ if [[ ! -d "$OPENWEBUI_DIR" ]]; then
   echo "❌ Directory '$OPENWEBUI_DIR' not found! Exiting."
   exit 1
 fi
-
 cd "$OPENWEBUI_DIR"
 echo "🚀 Operating in: $(pwd)"
 
 # 2️⃣ Get new name & asset URL
 read -p "👉 New WebUI name (default: FixCraft AI): " NEW_NAME
 NEW_NAME=${NEW_NAME:-FixCraft AI}
-
 read -p "👉 Base URL for assets (e.g. https://www.fixcraft.org): " BASE_URL
 if [[ -z "$BASE_URL" ]]; then
   echo "❌ No URL given. Exiting."
@@ -61,22 +59,30 @@ echo -e "\n✅ All assets present. Starting customization..."
 # 3️⃣ Branding in HTML
 sed -i "s/Open WebUI/$NEW_NAME/g" ./src/app.html
 
-# 4️⃣ Download assets
+# 4️⃣ Download into backend static
 STATIC_DIR="./backend/open_webui/static"
 mkdir -p "$STATIC_DIR"
 for file in "${!ASSETS[@]}"; do
-  echo "⬇️  Downloading $file..."
+  echo "⬇️  Downloading $file to backend static..."
   curl -sSf "$BASE_URL/$file" -o "$STATIC_DIR/$file"
 done
 
-# Copy favicon.png also to root static (legacy)
-cp "$STATIC_DIR/favicon.png" "$STATIC_DIR/../favicon.png"
+# 5️⃣ Update root-level static directories
+#    - ./static/favicon.png
+#    - everything in ./static/static/
+ROOT_STATIC1="./static"
+ROOT_STATIC2="./static/static"
+mkdir -p "$ROOT_STATIC1" "$ROOT_STATIC2"
+for file in "${!ASSETS[@]}"; do
+  echo "📂 Copying $file to $ROOT_STATIC1 and $ROOT_STATIC2..."
+  cp "$STATIC_DIR/$file" "$ROOT_STATIC1/$file"
+  cp "$STATIC_DIR/$file" "$ROOT_STATIC2/$file"
+done
 
-# 5️⃣ Patch env.py
+# 6️⃣ Patch env.py
 ENV_PY="./backend/open_webui/env.py"
 sed -i "s|WEBUI_NAME = os.environ.get.*|WEBUI_NAME = os.environ.get(\"WEBUI_NAME\", \"$NEW_NAME\")|" "$ENV_PY"
 sed -i "s|WEBUI_FAVICON_URL = .*|WEBUI_FAVICON_URL = \"$BASE_URL/favicon.png\"|" "$ENV_PY"
 sed -i '/if WEBUI_NAME != .*Open WebUI/,/WEBUI_NAME += .*Open WebUI/d' "$ENV_PY"
 
-echo -e "\n🎉 DONE — '$NEW_NAME' is now baked into your local Open WebUI clone!"
-
+echo -e "\n🎉 DONE — '$NEW_NAME' is now baked into your local Open WebUI clone, and all icons in backend/open_webui/static, ./static/favicon.png, and ./static/static/* are replaced!"


### PR DESCRIPTION
# Pull Request Checklist

**Title:**  
`feat: add customize.sh for interactive branding & asset verification`

---

**Description:**  
This PR introduces a new `customize.sh` script that lets users dynamically rebrand Open WebUI in-place. It:

- Prompts for the local repo path (defaults to current directory)  
- Asks for a new UI name and base URL for hosted assets  
- Verifies each required asset (favicon, logo, manifests, touch icons, splash images, etc.) with size hints—exits early on any 404  
- Replaces all “Open WebUI” references in `src/app.html` with the custom name  
- Downloads assets into `backend/open_webui/static` (and copies the favicon for legacy support)  
- Patches `env.py` to set `WEBUI_NAME` and `WEBUI_FAVICON_URL` and removes the old conditional block

---

## Checklist

- [ ] **Target branch:** `main`  maybe dev if you dont want it to go to main
- [ ] **Description:** Concise summary above  
- [ ] **Changelog:** Added entry below  
- [ ] **Documentation:** _(no docs changes needed—script is self-contained)_  
- [ ] **Dependencies:** _(none)_  
- [ ] **Testing:** Manual testing of all prompts & asset checks  
- [ ] **Code review:** I have self-reviewed for coding style & bash best practices  
- [ ] **Prefix:** `feat`

---

## Changelog

### Description
Adds an interactive `customize.sh` helper script so contributors can rebrand Open WebUI without cloning or manual edits.

### Added
- `customize.sh` under project root  
- Interactive prompts for:  
  - Local repo directory  
  - New WebUI name (default: FixCraft AI)  
  - Base URL for assets  
- Automated checks for all required assets, with helpful size hints  
- Bash logic to patch HTML, download files, and update `env.py`

### Removed
- Nothing

### Breaking Changes
**None** — script is opt-in and does not alter code unless explicitly run

---

### Additional Information
- Tested on Bash 5.2 / Debian 12
- No external dependencies beyond `curl`, `sed`, and standard UNIX tools  
- Closes issue #15494

---

### Contributor License Agreement  
By submitting this pull request, I confirm I have read and agree to the [CLA](/CONTRIBUTOR_LICENSE_AGREEMENT).
