### PR TITLE
feat: cache tool servers in redis when available

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -232,7 +232,7 @@ async def generate_function_chat_completion(
         "__metadata__": metadata,
         "__request__": request,
     }
-    extra_params["__tools__"] = get_tools(
+    extra_params["__tools__"] = await get_tools(
         request,
         tool_ids,
         user,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -120,8 +120,6 @@ from open_webui.config import (
     ENABLE_BASE_MODELS_CACHE,
     # Thread pool size for FastAPI/AnyIO
     THREAD_POOL_SIZE,
-    # Tool Server Configs
-    TOOL_SERVER_CONNECTIONS,
     # Code Execution
     ENABLE_CODE_EXECUTION,
     CODE_EXECUTION_ENGINE,
@@ -630,7 +628,6 @@ app.state.OPENAI_MODELS = {}
 #
 ########################################
 
-app.state.config.TOOL_SERVER_CONNECTIONS = TOOL_SERVER_CONNECTIONS
 app.state.TOOL_SERVERS = []
 
 ########################################

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -120,6 +120,8 @@ from open_webui.config import (
     ENABLE_BASE_MODELS_CACHE,
     # Thread pool size for FastAPI/AnyIO
     THREAD_POOL_SIZE,
+    # Tool Server Configs
+    TOOL_SERVER_CONNECTIONS,
     # Code Execution
     ENABLE_CODE_EXECUTION,
     CODE_EXECUTION_ENGINE,
@@ -628,6 +630,7 @@ app.state.OPENAI_MODELS = {}
 #
 ########################################
 
+app.state.config.TOOL_SERVER_CONNECTIONS = TOOL_SERVER_CONNECTIONS
 app.state.TOOL_SERVERS = []
 
 ########################################

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -875,7 +875,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     tools_dict = {}
 
     if tool_ids:
-        tools_dict = get_tools(
+        tools_dict = await get_tools(
             request,
             tool_ids,
             user,

--- a/backend/open_webui/utils/tools_cache.py
+++ b/backend/open_webui/utils/tools_cache.py
@@ -46,7 +46,13 @@ async def get_cached_tool_servers(request: Request):
 
     # Check in-memory cache
     if request.app.state.TOOL_SERVERS:
-        return request.app.state.TOOL_SERVERS
+        # Check if all tool servers have the required _raw property. This is for backwards compatibility. before
+        # we added the ability to cache tool servers in Redis. TODO: remove this some time in the future (added Jul 2025)
+        if all(hasattr(server, "_raw") for server in request.app.state.TOOL_SERVERS):
+            return request.app.state.TOOL_SERVERS
+        else:
+            log.debug("Tool servers cache missing _raw property, invalidating")
+            request.app.state.TOOL_SERVERS = []
 
     # Check if the tool server connections have been initialized by an environment variable
     if request.app.state.config.TOOL_SERVER_CONNECTIONS:

--- a/backend/open_webui/utils/tools_cache.py
+++ b/backend/open_webui/utils/tools_cache.py
@@ -48,7 +48,13 @@ async def get_cached_tool_servers(request: Request):
     if request.app.state.TOOL_SERVERS:
         return request.app.state.TOOL_SERVERS
 
-    log.debug("No cached tool servers found")
+    # Check if the tool server connections have been initialized by an environment variable
+    if request.app.state.config.TOOL_SERVER_CONNECTIONS:
+        return await set_and_cache_tool_servers(
+            request, request.app.state.config.TOOL_SERVER_CONNECTIONS
+        )
+
+    log.debug("No cached tool servers or tool server connections found")
     return []
 
 

--- a/backend/open_webui/utils/tools_cache.py
+++ b/backend/open_webui/utils/tools_cache.py
@@ -1,0 +1,79 @@
+import json
+import logging
+
+from fastapi import Request
+
+from open_webui.utils.tools import get_tool_servers_data
+
+log = logging.getLogger(__name__)
+
+
+REDIS_TOOL_SERVERS_KEY = "open-webui:tool_servers"
+
+
+async def invalidate_tool_servers_cache(request: Request):
+    """
+    Invalidate tool servers cache in both Redis and memory.
+    """
+    request.app.state.TOOL_SERVERS = []
+
+    # Clear Redis cache if available
+    if hasattr(request.app.state, "redis") and request.app.state.redis is not None:
+        try:
+            await request.app.state.redis.delete(REDIS_TOOL_SERVERS_KEY)
+            log.debug("Invalidated tool servers cache in Redis")
+        except Exception as e:
+            log.warning(f"Failed to invalidate tool servers cache in Redis: {e}")
+
+
+async def get_cached_tool_servers(request: Request):
+    """
+    Get tool servers from Redis cache if available, otherwise from memory.
+    Returns empty list if no cached data is found.
+    """
+    if hasattr(request.app.state, "redis") and request.app.state.redis is not None:
+        try:
+            cached_data = await request.app.state.redis.get(REDIS_TOOL_SERVERS_KEY)
+            if cached_data:
+                tool_servers = json.loads(cached_data)
+                log.debug(
+                    "Retrieved tool servers from Redis cache:"
+                    f" {len(tool_servers)} servers"
+                )
+                return tool_servers
+        except Exception as e:
+            log.warning(f"Failed to retrieve tool servers from Redis: {e}")
+
+    # Check in-memory cache
+    if request.app.state.TOOL_SERVERS:
+        return request.app.state.TOOL_SERVERS
+
+    log.debug("No cached tool servers found")
+    return []
+
+
+async def set_and_cache_tool_servers(request: Request, connections: list):
+    """
+    Set tool server connections and immediately fetch and cache the tool servers.
+    This replaces the need to store connections in app.state.config.
+    """
+    await invalidate_tool_servers_cache(request)
+
+    tool_servers = await get_tool_servers_data(connections)
+
+    request.app.state.TOOL_SERVERS = tool_servers
+
+    # Cache in Redis if available
+    if hasattr(request.app.state, "redis") and request.app.state.redis is not None:
+        try:
+            await request.app.state.redis.set(
+                REDIS_TOOL_SERVERS_KEY,
+                json.dumps(tool_servers),
+                ex=300,  # 5 minutes TTL
+            )
+            log.debug(f"Cached tool servers in Redis: {len(tool_servers)} servers")
+        except Exception as e:
+            log.warning(f"Failed to cache tool servers in Redis: {e}")
+
+    log.info(f"Fetched and cached {len(tool_servers)} tool servers")
+    return tool_servers

--- a/backend/open_webui/utils/tools_cache.py
+++ b/backend/open_webui/utils/tools_cache.py
@@ -3,8 +3,6 @@ import logging
 
 from fastapi import Request
 
-from open_webui.utils.tools import get_tool_servers_data
-
 log = logging.getLogger(__name__)
 
 
@@ -69,6 +67,9 @@ async def set_and_cache_tool_servers(request: Request, connections: list):
     Set tool server connections and immediately fetch and cache the tool servers.
     This replaces the need to store connections in app.state.config.
     """
+    # Dynamic import to avoid circular import
+    from open_webui.utils.tools import get_tool_servers_data
+
     await invalidate_tool_servers_cache(request)
 
     tool_servers = await get_tool_servers_data(connections)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

Implements Redis-based caching for Tool Servers to support multi-pod backend deployments. Previously, tool servers were cached in memory per pod, causing inconsistencies when multiple backend pods were running. This enhancement stores tool servers in Redis for shared access across all pods, with fallback to memory cache when Redis is unavailable.

We don't really need to keep the TOOL_SERVERS_CONNECTION in memory. We can derive the information from `tool_servers`.

### Added

- **Redis-based tool server caching system** (`open_webui/utils/tools_cache.py`)
  - `get_cached_tool_servers()`: Retrieves tool servers from Redis → memory cache
  - `set_and_cache_tool_servers()`: Immediately fetches and caches tool servers when configuration is set  
  - `invalidate_tool_servers_cache()`: Clears both Redis and memory cache
- **Self-contained tool server data** with `access_control` and `__raw` properties
- **cahcing invalidation** when tool server configuration is updated

### Changed

- **Tool server configuration flow** now immediately fetches and caches servers instead of storing connections
- **Tool server data structure** enhanced with `access_control` property and `__raw` original connection data
- **Tools router** simplified to only read from cache, eliminating runtime config dependencies
- **Configuration endpoints** now retrieve connections from cached tool servers' `__raw` property
- **Configuration flow change**: Tool servers are now cached immediately when configuration is set, rather than on-demand

### Removed

- **Dependency on `request.app.state.config.TOOL_SERVER_CONNECTIONS`** for runtime tool server access
- **Import of `TOOL_SERVER_CONNECTIONS`** from main.py
- **Complex conditional logic** in cache retrieval functions

### Fixed

- **Multi-pod tool server inconsistency** - tool servers now shared via Redis cache across all backend pods
- **Tool server updates not propagating** between pods in multi-instance deployments

### Breaking Changesn/a


---

### Additional Information

**Technical Implementation:**
- **Redis Key**: `open-webui:tool_servers` with 5-minute TTL
- **Fallback Strategy**: Redis → Memory → Empty list (no more on-demand fetching)
- **Data Structure**: Tool servers now include `access_control` and `__raw` (original connection) properties
- **Multi-pod Safe**: All pods share the same Redis cache for consistent tool server state

**Migration Path:**
- Existing deployments will automatically migrate to the new caching system
- Single-pod deployments continue to work with memory fallback
- Multi-pod deployments now properly share tool server state via Redis

**Files Modified:**
- `open_webui/utils/tools_cache.py` - New Redis caching module  
- `open_webui/utils/tools.py` - Enhanced tool server data structure
- `open_webui/routers/configs.py` - Updated configuration endpoints
- `open_webui/routers/tools.py` - Simplified cache-only access + refresh endpoint
- `open_webui/main.py` - Removed TOOL_SERVER_CONNECTIONS dependency

**Testing Recommendations:**
- Verify tool server functionality with Redis enabled/disabled
- Test multi-pod deployment tool server consistency
- Validate cache refresh endpoint functionality
- Confirm existing tool server configurations continue working

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.