### PR TITLE
DOC: Extend Audio MIME Type Setting Explanation

### DIFF
--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -200,7 +200,7 @@
 								<input
 									class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
 									bind:value={STT_SUPPORTED_CONTENT_TYPES}
-									placeholder={$i18n.t('e.g., audio/wav,audio/mpeg (leave blank for defaults)')}
+									placeholder={$i18n.t('e.g., audio/wav,audio/mpeg,video/* (leave blank for defaults, * for all)')}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
## DOC: Extend Audio MIME Type Setting Explanation

### Description

Add explanation in audio settings labeling  to add multiple mime types :

_'e.g., audio/wav,audio/mpeg,video/* (leave blank for defaults, * for all)'_


____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
