### PR TITLE
UPD: requirements.txt adding httpx & optionals

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ async-timeout
 aiocache
 aiofiles
 starlette-compress==1.6.0
+httpx[socks,http2,zstd,cli,brotli]==0.28.1
 
 sqlalchemy==2.0.38
 alembic==1.14.0


### PR DESCRIPTION
## Update to solve issue https://github.com/open-webui/open-webui/issues/15683

### Update requirements.txt to add httpx and optional support for:

 - h2 - HTTP/2 support. (Optional, with httpx[http2]) socksio - SOCKS proxy support. (Optional, with httpx[socks])
 - rich - Rich terminal support. (Optional, with httpx[cli])
 - click - Command line client support. (Optional, with httpx[cli])
 -  brotli or brotlicffi - Decoding for "brotli" compressed responses. (Optional, with httpx[brotli])
 -  zstandard - Decoding for "zstd" compressed responses. (Optional, with httpx[zstd]) 

Added lib:
httpx[socks,http2,zstd,cli,brotli]==0.28.1
_____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
