### PR TITLE
[FIX] Incorrect Aria Label Text for Model Names

### DIFF
--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <button
-	aria-label="model-item"
+	aria-label="{item.value}"
 	class="flex group/item w-full text-left font-medium line-clamp-1 select-none items-center rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-hidden transition-all duration-75 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg cursor-pointer data-highlighted:bg-muted {index ===
 	selectedModelIdx
 		? 'bg-gray-100 dark:bg-gray-800 group-hover:bg-transparent'


### PR DESCRIPTION

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]

There is a long-standing issue on the chat window where a hard-coded string is used in the aria labels of all models. The issue has been mentioned in the accessibility tracking issue, but hasn't been addressed for months. There is no prefix for A11Y fixes.

### Fixed

- [List any fixes, corrections, or bug fixes]

Proposed fix with the correct item.

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

The issue is mentioned in one of the first comments here: https://github.com/open-webui/open-webui/issues/2790 from september last year.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
