### PR TITLE
Fix: some FileItemModal.svelte strings to i18n

### DIFF
--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -133,9 +133,9 @@
 							>
 								<div class="flex items-center gap-1.5 text-xs">
 									{#if enableFullContent}
-										Using Entire Document
+										$i18n.t('Using Entire Document')
 									{:else}
-										Using Focused Retrieval
+										$i18n.t(`Using Focused Retrieval')
 									{/if}
 									<Switch
 										bind:state={enableFullContent}

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1396,6 +1396,8 @@
 	"User Webhooks": "",
 	"Username": "",
 	"Users": "",
+	"Using Entire Document": "",
+	"Using Focused Retrieval": "",
 	"Using the default arena model with all models. Click the plus button to add custom models.": "",
 	"Utilize": "",
 	"Valid time units:": "",


### PR DESCRIPTION
### Description
#### Fix "Using Entire Document" and "Using Focused Retrieval" FileItemModal.svelte strings, to i18n to address issue https://github.com/open-webui/open-webui/issues/15728

### Added
 - i18n function for strings
 - strings in en-US locales
_____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
