### PR TITLE
fix: fix hybrid search

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -937,7 +937,6 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
 
 app.state.RERANKING_FUNCTION = get_reranking_function(
     app.state.config.RAG_RERANKING_ENGINE,
-    app.state.config.RAG_RERANKING_MODEL,
     reranking_function=app.state.rf,
 )
 

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -445,7 +445,7 @@ def get_embedding_function(
         raise ValueError(f"Unknown embedding engine: {embedding_engine}")
 
 
-def get_reranking_function(reranking_engine, reranking_model, reranking_function):
+def get_reranking_function(reranking_engine, reranking_function):
     if reranking_function is None:
         return None
     if reranking_engine == "external":

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2049,11 +2049,13 @@ def query_doc_handler(
                 ),
                 k=form_data.k if form_data.k else request.app.state.config.TOP_K,
                 reranking_function=(
-                    lambda sentences: (
-                        request.app.state.RERANKING_FUNCTION(sentences, user=user)
-                        if request.app.state.RERANKING_FUNCTION
-                        else None
+                    (
+                        lambda sentences: request.app.state.RERANKING_FUNCTION(
+                            sentences, user=user
+                        )
                     )
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
                 ),
                 k_reranker=form_data.k_reranker
                 or request.app.state.config.TOP_K_RERANKER,
@@ -2111,8 +2113,14 @@ def query_collection_handler(
                     query, prefix=prefix, user=user
                 ),
                 k=form_data.k if form_data.k else request.app.state.config.TOP_K,
-                reranking_function=lambda sentences: request.app.state.RERANKING_FUNCTION(
-                    sentences, user=user
+                reranking_function=(
+                    (
+                        lambda sentences: request.app.state.RERANKING_FUNCTION(
+                            sentences, user=user
+                        )
+                    )
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
                 ),
                 k_reranker=form_data.k_reranker
                 or request.app.state.config.TOP_K_RERANKER,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -828,7 +828,6 @@ async def update_rag_config(
 
             request.app.state.RERANKING_FUNCTION = get_reranking_function(
                 request.app.state.config.RAG_RERANKING_ENGINE,
-                request.app.state.config.RAG_RERANKING_MODEL,
                 request.app.state.rf,
             )
         except Exception as e:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -653,13 +653,13 @@ async def chat_completion_files_handler(
                         ),
                         k=request.app.state.config.TOP_K,
                         reranking_function=(
-                            lambda sentences: (
-                                request.app.state.RERANKING_FUNCTION(
+                            (
+                                lambda sentences: request.app.state.RERANKING_FUNCTION(
                                     sentences, user=user
                                 )
-                                if request.app.state.RERANKING_FUNCTION
-                                else None
                             )
+                            if request.app.state.RERANKING_FUNCTION
+                            else None
                         ),
                         k_reranker=request.app.state.config.TOP_K_RERANKER,
                         r=request.app.state.config.RELEVANCE_THRESHOLD,


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes the bug of https://github.com/open-webui/open-webui/issues/15734

This error happens when hybrid search is on:
```
File "/home/vscode/.vscode-server/extensions/ms-python.debugpy-2025.10.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydev_bundle/pydev_monkey.py", line 1131, in __call__
    ret = self.original_func(*self.args, **self.kwargs)
          │    │              │    │       │    └ {}
          │    │              │    │       └ <_pydev_bundle.pydev_monkey._NewThreadStartupWithTrace object at 0x7b1e70f37b90>
          │    │              │    └ ()
          │    │              └ <_pydev_bundle.pydev_monkey._NewThreadStartupWithTrace object at 0x7b1e70f37b90>
          │    └ <bound method Thread._bootstrap of <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>>
          └ <_pydev_bundle.pydev_monkey._NewThreadStartupWithTrace object at 0x7b1e70f37b90>

  File "/usr/local/lib/python3.11/threading.py", line 1002, in _bootstrap
    self._bootstrap_inner()
    │    └ <function Thread._bootstrap_inner at 0x7b1fcc189e40>
    └ <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>
  File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
    │    └ <function Thread.run at 0x7b1fcc189b20>
    └ <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>
  File "/usr/local/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
    │    │        │    │        │    └ {}
    │    │        │    │        └ <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>
    │    │        │    └ (<weakref at 0x7b1e70e865c0; to 'ThreadPoolExecutor' at 0x7b1fcc21bdd0>, <_queue.SimpleQueue object at 0x7b1e70e02a70>, None,...
    │    │        └ <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>
    │    └ <function _worker at 0x7b1fb3ef6700>
    └ <Thread(ThreadPoolExecutor-4_1, started 135369852974784)>
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 83, in _worker
    work_item.run()
    │         └ <function _WorkItem.run at 0x7b1fb3ef68e0>
    └ <concurrent.futures.thread._WorkItem object at 0x7b1e70e2f190>
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             │    │   │    │       │    └ {}
             │    │   │    │       └ <concurrent.futures.thread._WorkItem object at 0x7b1e70e2f190>
             │    │   │    └ ('7ab9dc6b-dec5-4967-8156-0ac6cbe03882', 'latest Lenovo laptops 2025')
             │    │   └ <concurrent.futures.thread._WorkItem object at 0x7b1e70e2f190>
             │    └ <function query_collection_with_hybrid_search.<locals>.process_query at 0x7b1e70e168e0>
             └ <concurrent.futures.thread._WorkItem object at 0x7b1e70e2f190>

> File "/workspaces/open-webui-mirror/backend/open_webui/retrieval/utils.py", line 358, in process_query
    result = query_doc_with_hybrid_search(
             └ <function query_doc_with_hybrid_search at 0x7b1eb9930f40>

  File "/workspaces/open-webui-mirror/backend/open_webui/retrieval/utils.py", line 192, in query_doc_with_hybrid_search
    raise e

  File "/workspaces/open-webui-mirror/backend/open_webui/retrieval/utils.py", line 165, in query_doc_with_hybrid_search
    result = compression_retriever.invoke(query)
             │                     │      └ 'latest Lenovo laptops 2025'
             │                     └ <function BaseRetriever.invoke at 0x7b1eb9adcf40>
             └ ContextualCompressionRetriever(base_compressor=RerankCompressor(embedding_function=<function chat_completion_files_handler.<l...

  File "/home/vscode/.local/lib/python3.11/site-packages/langchain_core/retrievers.py", line 259, in invoke
    result = self._get_relevant_documents(
             │    └ <function ContextualCompressionRetriever._get_relevant_documents at 0x7b1eb9adc900>
             └ ContextualCompressionRetriever(base_compressor=RerankCompressor(embedding_function=<function chat_completion_files_handler.<l...
  File "/home/vscode/.local/lib/python3.11/site-packages/langchain/retrievers/contextual_compression.py", line 44, in _get_relevant_documents
    compressed_docs = self.base_compressor.compress_documents(
                      │    │               └ <function RerankCompressor.compress_documents at 0x7b1eb98f2c00>
                      │    └ RerankCompressor(embedding_function=<function chat_completion_files_handler.<locals>.<lambda>.<locals>.<lambda> at 0x7b1e70f2...
                      └ ContextualCompressionRetriever(base_compressor=RerankCompressor(embedding_function=<function chat_completion_files_handler.<l...

  File "/workspaces/open-webui-mirror/backend/open_webui/retrieval/utils.py", line 956, in compress_documents
    zip(documents, scores.tolist() if not isinstance(scores, list) else scores)
        │          │                                 │                  └ None
        │          │                                 └ None
        │          └ None
        └ [Document(metadata={'created_by': '38686f35-715d-4c52-b1b6-d0ff691d6965', 'creationdate': '', 'creator': 'Lenovo', 'embedding...
```

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
