### PR TITLE
feat: show all knowledge collections

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -5,6 +5,7 @@
 	import FileItem from '$lib/components/common/FileItem.svelte';
 
 	export let selectedFileId = null;
+	export let dismissible = false;
 	export let files = [];
 
 	export let small = false;
@@ -24,7 +25,7 @@
 				type="file"
 				size={file?.size ?? file?.meta?.size ?? ''}
 				loading={file.status === 'uploading'}
-				dismissible
+				dismissible={dismissible}
 				on:click={() => {
 					if (file.status === 'uploading') {
 						return;

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -396,7 +396,7 @@
 	"Done": "Erledigt",
 	"Download": "Exportieren",
 	"Download as SVG": "Exportieren als SVG",
-	"Download canceled": "Exportierung abgebrochen",
+	"Download canceled": "Export abgebrochen",
 	"Download Database": "Datenbank exportieren",
 	"Drag and drop a file to upload or select a file to view": "Ziehen Sie eine Datei zum Hochladen oder wählen Sie eine Datei zum Anzeigen aus",
 	"Select a file to view": "Wählen Sie eine Datei zum Anzeigen aus",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Exportierung abgebrochen",
 	"Download Database": "Datenbank exportieren",
 	"Drag and drop a file to upload or select a file to view": "Ziehen Sie eine Datei zum Hochladen oder wählen Sie eine Datei zum Anzeigen aus",
+	"Select a file to view": "Wählen Sie eine Datei zum Anzeigen aus",
 	"Draw": "Zeichnen",
 	"Drop any files here to upload": "Dateien hierher ziehen, um sie hochzuladen",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "z. B. '30s','10m'. Gültige Zeiteinheiten sind 's', 'm', 'h'.",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Descarga cancelada",
 	"Download Database": "Descargar Base de Datos",
 	"Drag and drop a file to upload or select a file to view": "Arrastra y suelta un archivo para subirlo o selecciona uno para verlo",
+	"Select a file to view": "Selecciona un archivo para ver",
 	"Draw": "Dibujar",
 	"Drop any files here to upload": "Arrastra aquí los archivos a subir.",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "p.ej. '30s','10m'. Unidades de tiempo válidas son 's', 'm', 'h'.",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Téléchargement annulé",
 	"Download Database": "Télécharger la base de données",
 	"Drag and drop a file to upload or select a file to view": "Glissez et déposez un fichier pour le téléverser ou sélectionnez un fichier à visualiser",
+	"Select a file to view": "Sélectionnez un fichier à visualiser",
 	"Draw": "Match nul",
 	"Drop any files here to upload": "Déposez des fichiers ici pour les téléverser",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "par ex. '30s', '10 min'. Les unités de temps valides sont 's', 'm', 'h'.",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Téléchargement annulé",
 	"Download Database": "Télécharger la base de données",
 	"Drag and drop a file to upload or select a file to view": "Glissez et déposez un fichier pour le téléverser ou sélectionnez un fichier à visualiser",
+	"Select a file to view": "Sélectionnez un fichier à visualiser",
 	"Draw": "Match nul",
 	"Drop any files here to upload": "Déposez des fichiers ici pour les téléverser",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "par ex. '30s', '10 min'. Les unités de temps valides sont 's', 'm', 'h'.",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Scaricamento annullato",
 	"Download Database": "Scarica database",
 	"Drag and drop a file to upload or select a file to view": "Trascina e rilascia un file per caricarlo o seleziona un file da visualizzare",
+	"Select a file to view": "Seleziona un file da visualizzare",
 	"Draw": "Disegna",
 	"Drop any files here to upload": "Rilascia qui i file per caricarli",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "ad esempio '30s','10m'. Le unità di tempo valide sono 's', 'm', 'h'.",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -399,6 +399,7 @@
 	"Download canceled": "Download geannuleerd",
 	"Download Database": "Download database",
 	"Drag and drop a file to upload or select a file to view": "Sleep een bestand om te uploaden of selecteer een bestand om te bekijken",
+	"Select a file to view": "Selecteer een bestand om te bekijken",
 	"Draw": "Teken",
 	"Drop any files here to upload": "",
 	"e.g. '30s','10m'. Valid time units are 's', 'm', 'h'.": "bijv. '30s', '10m'. Geldige tijdseenheden zijn 's', 'm', 'h'.",

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -57,6 +57,7 @@ export const models: Writable<Model[]> = writable([]);
 
 export const prompts: Writable<null | Prompt[]> = writable(null);
 export const knowledge: Writable<null | Document[]> = writable(null);
+export const knowledgeList: Writable<null | Document[]> = writable(null);
 export const tools = writable(null);
 export const functions = writable(null);
 

--- a/src/routes/(app)/workspace/knowledge/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/+page.svelte
@@ -1,14 +1,15 @@
 <script>
 	import { onMount } from 'svelte';
-	import { knowledge } from '$lib/stores';
+	import { knowledge, knowledgeList } from '$lib/stores';
 
-	import { getKnowledgeBases } from '$lib/apis/knowledge';
+	import { getKnowledgeBases, getKnowledgeBaseList } from '$lib/apis/knowledge';
 	import Knowledge from '$lib/components/workspace/Knowledge.svelte';
 
 	onMount(async () => {
 		await Promise.all([
 			(async () => {
 				knowledge.set(await getKnowledgeBases(localStorage.token));
+				knowledgeList.set(await getKnowledgeBaseList(localStorage.token));
 			})()
 		]);
 	});


### PR DESCRIPTION
Discussion: https://github.com/open-webui/open-webui/discussions/15315

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Added support for displaying all knowledge collections, including public ones that users have read-only access to, while maintaining proper write access controls for editing and management operations.

### Added

- New `knowledgeList` store to track all available knowledge collections
- "Public" badge for knowledge collections that users can view but not edit
- Read-only mode for knowledge base content when users lack write access
- `checkWriteAccess` function to determine user permissions for knowledge collections
- New translation key `"Select a file to view"` across all supported locales

### Changed

- Knowledge listing now shows both owned and publicly accessible collections
- File upload and editing interfaces are conditionally disabled based on write access
- Knowledge base editor switches to read-only mode for public collections
- Access control button is only shown for collections with write access
- File item components now accept a `dismissible` parameter to control delete functionality
- Drag and drop functionality is only enabled for collections with write access

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- Proper access control implementation ensures users cannot modify knowledge collections they don't own
- Read-only mode prevents unauthorized editing of public knowledge bases

### Breaking Changes

- None

---

### Additional Information

- This change enhances the knowledge management system by allowing users to discover and access public knowledge collections while maintaining security boundaries
- The implementation preserves the existing user experience for owned collections while adding clear visual indicators for public access
- All UI elements that require write permissions are appropriately disabled or hidden when viewing public collections

### Screenshots or Videos

- "Public" Badge for read-only collections 
<img width="878" height="338" alt="image" src="https://github.com/user-attachments/assets/e15fef56-01b6-472e-9a9b-66a2c8205e92" />
- Edit / Delete UI elements are hidden for read-only collections
<img width="1224" height="253" alt="image" src="https://github.com/user-attachments/assets/9ead977c-d08a-4eec-ba75-ee7eb175a48b" />
- File contents of read-only collections are rendered as plain text instead of interactive editor
<img width="1219" height="576" alt="image" src="https://github.com/user-attachments/assets/ca69f881-260c-454b-96aa-0d13262558e1" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.