### PR TITLE
FIX: Add posthog lib forcing version to avoid opentelemetry issue

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,6 +51,7 @@ langchain-community==0.3.26
 
 fake-useragent==2.1.0
 chromadb==0.6.3
+posthog==5.4.0
 pymilvus==2.5.0
 qdrant-client==1.14.3
 opensearch-py==2.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ dependencies = [
 
     "moto[s3]>=5.0.26",
 
+    "posthog==5.4.0",
+
 ]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.13.0a1"


### PR DESCRIPTION
### Description

Add "posthog==5.4.0" lib to pyproject.toml & backend/requirements.txt to avoid chromadb issue for lib versions incompatibility with that lib (chromadb  requiere posthog>=2.4.0,<6.0.0 ) which produce error in opentelemetry.

issue: https://github.com/open-webui/open-webui/discussions/15624


### Added

Add "posthog==5.4.0" lib to pyproject.toml & backend/requirements.txt 
______
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.