### PR TITLE
feat: Expose chat_id as a header on ENABLE_FORWARD_USER_INFO_HEADERS for OpenAI chat completion endpoint

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -822,6 +822,7 @@ async def generate_chat_completion(
                 "X-OpenWebUI-User-Id": user.id,
                 "X-OpenWebUI-User-Email": user.email,
                 "X-OpenWebUI-User-Role": user.role,
+                "X-OpenWebUI-Chat-Id": metadata.get("chat_id", "") if metadata else "",
             }
             if ENABLE_FORWARD_USER_INFO_HEADERS
             else {}
@@ -917,6 +918,7 @@ async def embeddings(request: Request, form_data: dict, user):
     # Find correct backend url/key based on model
     await get_all_models(request, user=user)
     model_id = form_data.get("model")
+
     models = request.app.state.OPENAI_MODELS
     if model_id in models:
         idx = models[model_id]["urlIdx"]


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Expose chat_id on ENABLE_FORWARD_USER_INFO_HEADERS for OpenAI chat completion endpoint as X-OpenWebUI-Chat-Id

### Added

- Adds a new field in headers sent by the OpenAI router that exposes the current chat_id from form_data["metadata"]

---

### Additional Information

- Issue: #15739

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.



---

A few notes : I wonder if it would be better to expose it with a new environment variable, what do you think? Also, where else can we expose chat_id, except the OpenAI chat completions?