### PR TITLE
fix: ollama tool call

### DIFF
--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -6,19 +6,18 @@ from open_webui.utils.misc import (
 )
 
 
-def convert_ollama_tool_call_to_openai(tool_calls: dict) -> dict:
+def convert_ollama_tool_call_to_openai(tool_calls: list) -> list:
     openai_tool_calls = []
     for tool_call in tool_calls:
+        function = tool_call.get("function", {})
         openai_tool_call = {
-            "index": tool_call.get("index", 0),
+            "index": tool_call.get("index", function.get("index", 0)),
             "id": tool_call.get("id", f"call_{str(uuid4())}"),
             "type": "function",
             "function": {
-                "name": tool_call.get("function", {}).get("name", ""),
-                "arguments": json.dumps(
-                    tool_call.get("function", {}).get("arguments", {})
-                ),
-            },
+                "name": function.get("name", ""),
+                "arguments": json.dumps(function.get("arguments", {}))
+            }
         }
         openai_tool_calls.append(openai_tool_call)
     return openai_tool_calls

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -16,8 +16,8 @@ def convert_ollama_tool_call_to_openai(tool_calls: list) -> list:
             "type": "function",
             "function": {
                 "name": function.get("name", ""),
-                "arguments": json.dumps(function.get("arguments", {}))
-            }
+                "arguments": json.dumps(function.get("arguments", {})),
+            },
         }
         openai_tool_calls.append(openai_tool_call)
     return openai_tool_calls


### PR DESCRIPTION
# Changelog Entry

### Description

Fixed the issue with multiple tool calls in Ollama. The `index` for Ollama's tool calls is located inside the `function` key. When using multiple tools, the code was unable to retrieve the correct `index`, instead using a default value of 0 for all tools, which led to errors. Previously, the code worked correctly when only a single tool was called because there was only one required `index`.
fix: #15546
fix: #15350

### Fixed

- Fixed the issue with multiple tool calls in Ollama

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
