### PR TITLE
FIX: Correction of mimetypes string

### DIFF
--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -201,7 +201,7 @@
 									class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
 									bind:value={STT_SUPPORTED_CONTENT_TYPES}
 									placeholder={$i18n.t(
-										'e.g., audio/wav,audio/mpeg,video/* (leave blank for defaults, * for all)'
+										'e.g., audio/wav,audio/mpeg,video/* (leave blank for defaults)'
 									)}
 								/>
 							</div>


### PR DESCRIPTION
Reversion of PR https://github.com/open-webui/open-webui/pull/15655

### Description

Removed " _`, * for all)`_ " from mimetype help string.

If mimetypes is set as * any uploaded file is tried to transcribe.

My apologies, I added this change because of a comment I took as proven, I'll be more careful with these little things!
______
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
