### PR TITLE
FIX: STT default whisper trascription language

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -561,7 +561,12 @@ def transcription_handler(request, file_path, metadata):
             file_path,
             beam_size=5,
             vad_filter=request.app.state.config.WHISPER_VAD_FILTER,
-            language=metadata.get("language",None) if WHISPER_LANGUAGE=="" else WHISPER_LANGUAGE,
+            language=(
+                metadata.get("language", None)
+                if WHISPER_LANGUAGE == ""
+                else WHISPER_LANGUAGE
+            ),
+        )            
         )
         log.info(
             "Detected language '%s' with probability %f"

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -561,7 +561,7 @@ def transcription_handler(request, file_path, metadata):
             file_path,
             beam_size=5,
             vad_filter=request.app.state.config.WHISPER_VAD_FILTER,
-            language=metadata.get("language") or WHISPER_LANGUAGE,
+            language=metadata.get("language",None) if WHISPER_LANGUAGE=="" else WHISPER_LANGUAGE,
         )
         log.info(
             "Detected language '%s' with probability %f"

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -566,7 +566,6 @@ def transcription_handler(request, file_path, metadata):
                 if WHISPER_LANGUAGE == ""
                 else WHISPER_LANGUAGE
             ),
-        )            
         )
         log.info(
             "Detected language '%s' with probability %f"


### PR DESCRIPTION
### Description:
### FIX: STT default whisper trascription language

Fix the transcripcion language used by default whisper, setting as WHISPER_LANGUAGE if it is setted in env var, even if a language is detected in the file's metadata.
It is understood that if a language is set as an environment variable for transcriptions, this should be the preferred one and the one that should be used for that purpose.

It would be advisable to add this variable as configurable in UI

### Changed

- Logic for select transcription language

_____
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
