### PR TITLE
fix: Implement outstanding REDIS_KEY_PREFIX declarations

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -25,6 +25,7 @@ from open_webui.env import (
     WEBSOCKET_REDIS_LOCK_TIMEOUT,
     WEBSOCKET_SENTINEL_PORT,
     WEBSOCKET_SENTINEL_HOSTS,
+    REDIS_KEY_PREFIX,
 )
 from open_webui.utils.auth import decode_token
 from open_webui.socket.utils import RedisDict, RedisLock, YdocManager
@@ -92,17 +93,17 @@ if WEBSOCKET_MANAGER == "redis":
         WEBSOCKET_SENTINEL_HOSTS, WEBSOCKET_SENTINEL_PORT
     )
     SESSION_POOL = RedisDict(
-        "open-webui:session_pool",
+        f"{REDIS_KEY_PREFIX}:session_pool",
         redis_url=WEBSOCKET_REDIS_URL,
         redis_sentinels=redis_sentinels,
     )
     USER_POOL = RedisDict(
-        "open-webui:user_pool",
+        f"{REDIS_KEY_PREFIX}:user_pool",
         redis_url=WEBSOCKET_REDIS_URL,
         redis_sentinels=redis_sentinels,
     )
     USAGE_POOL = RedisDict(
-        "open-webui:usage_pool",
+        f"{REDIS_KEY_PREFIX}:usage_pool",
         redis_url=WEBSOCKET_REDIS_URL,
         redis_sentinels=redis_sentinels,
     )
@@ -126,7 +127,7 @@ else:
 
 YDOC_MANAGER = YdocManager(
     redis=REDIS,
-    redis_key_prefix="open-webui:ydoc:documents",
+    redis_key_prefix=f"{REDIS_KEY_PREFIX}:ydoc:documents",
 )
 
 

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from open_webui.utils.redis import get_redis_connection
+from open_webui.env import REDIS_KEY_PREFIX
 from typing import Optional, List, Tuple
 import pycrdt as Y
 
@@ -97,7 +98,7 @@ class YdocManager:
     def __init__(
         self,
         redis=None,
-        redis_key_prefix: str = "open-webui:ydoc:documents",
+        redis_key_prefix: str = f"{REDIS_KEY_PREFIX}:ydoc:documents",
     ):
         self._updates = {}
         self._users = {}

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -8,7 +8,7 @@ from redis.asyncio import Redis
 from fastapi import Request
 from typing import Dict, List, Optional
 
-from open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS, REDIS_KEY_PREFIX
 
 
 log = logging.getLogger(__name__)
@@ -19,9 +19,9 @@ tasks: Dict[str, asyncio.Task] = {}
 item_tasks = {}
 
 
-REDIS_TASKS_KEY = "open-webui:tasks"
-REDIS_ITEM_TASKS_KEY = "open-webui:tasks:item"
-REDIS_PUBSUB_CHANNEL = "open-webui:tasks:commands"
+REDIS_TASKS_KEY = f"{REDIS_KEY_PREFIX}:tasks"
+REDIS_ITEM_TASKS_KEY = f"{REDIS_KEY_PREFIX}:tasks:item"
+REDIS_PUBSUB_CHANNEL = f"{REDIS_KEY_PREFIX}:tasks:commands"
 
 
 async def redis_task_command_listener(app):


### PR DESCRIPTION
Ref: https://github.com/open-webui/open-webui/discussions/15834

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction ✓
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed hardcoded Redis key prefixes in tasks and socket modules to properly respect the REDIS_KEY_PREFIX environment variable, ensuring consistent key namespacing for Redis cluster-mode compatibility

### Added

- N/A

### Changed

- Updated `backend/open_webui/tasks.py` to use `REDIS_KEY_PREFIX` environment variable instead of hardcoded "open-webui" prefix
- Updated `backend/open_webui/socket/main.py` to use `REDIS_KEY_PREFIX` environment variable for session pool, user pool, usage pool, and YdocManager keys
- Updated `backend/open_webui/socket/utils.py` YdocManager class default parameter to use `REDIS_KEY_PREFIX` environment variable

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed hardcoded Redis key prefixes that were not respecting the REDIS_KEY_PREFIX environment variable
- Resolved Redis cluster-mode compatibility issues by ensuring all Redis keys use the configurable prefix
- Fixed inconsistent key namespacing between different modules

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- This fix ensures that all Redis operations in the tasks and socket modules now properly respect the `REDIS_KEY_PREFIX` environment variable
- The changes maintain backward compatibility as the default value remains "open-webui"
- This allows multiple Open WebUI instances to share a Redis cluster with isolated key namespaces
- Files modified:
  - `backend/open_webui/tasks.py`: Updated Redis key constants to use environment variable
  - `backend/open_webui/socket/main.py`: Updated RedisDict and YdocManager instantiations to use environment variable
  - `backend/open_webui/socket/utils.py`: Updated YdocManager class constructor default parameter

### Screenshots or Videos

- N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.