### PR TITLE
feat: populate default prompt templates

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -17,6 +17,14 @@ from open_webui.utils.task import (
     emoji_generation_template,
     moa_response_generation_template,
 )
+from open_webui.config import (
+    DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
+)
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.constants import TASKS
 
@@ -68,7 +76,17 @@ async def get_task_config(request: Request, user=Depends(get_verified_user)):
         "ENABLE_RETRIEVAL_QUERY_GENERATION": request.app.state.config.ENABLE_RETRIEVAL_QUERY_GENERATION,
         "QUERY_GENERATION_PROMPT_TEMPLATE": request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE,
         "TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE": request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
+        # Effective prompt templates (config value or default)
+        "_defaults": {
+            "TITLE_GENERATION_PROMPT_TEMPLATE": request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE if request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE != "" else DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE,
+            "FOLLOW_UP_GENERATION_PROMPT_TEMPLATE": request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE if request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE != "" else DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE,
+            "TAGS_GENERATION_PROMPT_TEMPLATE": request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE if request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE != "" else DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE,
+            "QUERY_GENERATION_PROMPT_TEMPLATE": request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE if request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE.strip() != "" else DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE,
+            "IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE": request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE if request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE != "" else DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE,
+            "TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE": request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE if request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE != "" else DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
+        }
     }
+
 
 
 class TaskConfigForm(BaseModel):

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -88,7 +88,6 @@ async def get_task_config(request: Request, user=Depends(get_verified_user)):
     }
 
 
-
 class TaskConfigForm(BaseModel):
     TASK_MODEL: Optional[str]
     TASK_MODEL_EXTERNAL: Optional[str]

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -516,6 +516,7 @@ export const getTaskConfig = async (token: string = '') => {
 	return res;
 };
 
+
 export const updateTaskConfig = async (token: string, config: object) => {
 	let error = null;
 

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -516,7 +516,6 @@ export const getTaskConfig = async (token: string = '') => {
 	return res;
 };
 
-
 export const updateTaskConfig = async (token: string, config: object) => {
 	let error = null;
 

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -26,6 +26,16 @@
 
 	const i18n = getContext('i18n');
 
+	// Dynamic default prompt templates fetched from backend
+	let defaultPrompts = {
+		TITLE_GENERATION_PROMPT_TEMPLATE: '',
+		FOLLOW_UP_GENERATION_PROMPT_TEMPLATE: '',
+		TAGS_GENERATION_PROMPT_TEMPLATE: '',
+		QUERY_GENERATION_PROMPT_TEMPLATE: '',
+		IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE: '',
+		TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE: ''
+	};
+
 	let taskConfig = {
 		TASK_MODEL: '',
 		TASK_MODEL_EXTERNAL: '',
@@ -59,7 +69,29 @@
 
 	onMount(async () => {
 		await init();
-		taskConfig = await getTaskConfig(localStorage.token);
+		const taskConfigResponse = await getTaskConfig(localStorage.token);
+		taskConfig = taskConfigResponse;
+		defaultPrompts = taskConfigResponse._defaults || {};
+
+		// If any prompt template is empty, set it to the default value
+		if (!taskConfig.TITLE_GENERATION_PROMPT_TEMPLATE) {
+			taskConfig.TITLE_GENERATION_PROMPT_TEMPLATE = defaultPrompts.TITLE_GENERATION_PROMPT_TEMPLATE || '';
+		}
+		if (!taskConfig.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE) {
+			taskConfig.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE = defaultPrompts.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE || '';
+		}
+		if (!taskConfig.TAGS_GENERATION_PROMPT_TEMPLATE) {
+			taskConfig.TAGS_GENERATION_PROMPT_TEMPLATE = defaultPrompts.TAGS_GENERATION_PROMPT_TEMPLATE || '';
+		}
+		if (!taskConfig.QUERY_GENERATION_PROMPT_TEMPLATE) {
+			taskConfig.QUERY_GENERATION_PROMPT_TEMPLATE = defaultPrompts.QUERY_GENERATION_PROMPT_TEMPLATE || '';
+		}
+		if (!taskConfig.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE) {
+			taskConfig.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE = defaultPrompts.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE || '';
+		}
+		if (!taskConfig.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE) {
+			taskConfig.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE = defaultPrompts.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE || '';
+		}
 
 		promptSuggestions = $config?.default_prompt_suggestions ?? [];
 		banners = await getBanners(localStorage.token);
@@ -229,9 +261,7 @@
 						>
 							<Textarea
 								bind:value={taskConfig.TITLE_GENERATION_PROMPT_TEMPLATE}
-								placeholder={$i18n.t(
-									'Leave empty to use the default prompt, or enter a custom prompt'
-								)}
+								placeholder={defaultPrompts.TITLE_GENERATION_PROMPT_TEMPLATE}
 							/>
 						</Tooltip>
 					</div>
@@ -255,9 +285,7 @@
 						>
 							<Textarea
 								bind:value={taskConfig.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE}
-								placeholder={$i18n.t(
-									'Leave empty to use the default prompt, or enter a custom prompt'
-								)}
+								placeholder={defaultPrompts.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE}
 							/>
 						</Tooltip>
 					</div>
@@ -281,9 +309,7 @@
 						>
 							<Textarea
 								bind:value={taskConfig.TAGS_GENERATION_PROMPT_TEMPLATE}
-								placeholder={$i18n.t(
-									'Leave empty to use the default prompt, or enter a custom prompt'
-								)}
+								placeholder={defaultPrompts.TAGS_GENERATION_PROMPT_TEMPLATE}
 							/>
 						</Tooltip>
 					</div>
@@ -314,9 +340,7 @@
 					>
 						<Textarea
 							bind:value={taskConfig.QUERY_GENERATION_PROMPT_TEMPLATE}
-							placeholder={$i18n.t(
-								'Leave empty to use the default prompt, or enter a custom prompt'
-							)}
+							placeholder={defaultPrompts.QUERY_GENERATION_PROMPT_TEMPLATE}
 						/>
 					</Tooltip>
 				</div>
@@ -359,9 +383,7 @@
 					>
 						<Textarea
 							bind:value={taskConfig.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE}
-							placeholder={$i18n.t(
-								'Leave empty to use the default prompt, or enter a custom prompt'
-							)}
+							placeholder={defaultPrompts.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE}
 						/>
 					</Tooltip>
 				</div>
@@ -375,9 +397,7 @@
 					>
 						<Textarea
 							bind:value={taskConfig.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE}
-							placeholder={$i18n.t(
-								'Leave empty to use the default prompt, or enter a custom prompt'
-							)}
+							placeholder={defaultPrompts.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE}
 						/>
 					</Tooltip>
 				</div>

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -261,7 +261,9 @@
 						>
 							<Textarea
 								bind:value={taskConfig.TITLE_GENERATION_PROMPT_TEMPLATE}
-								placeholder={defaultPrompts.TITLE_GENERATION_PROMPT_TEMPLATE}
+								placeholder={$i18n.t(
+									'Leave empty to use the default prompt, or enter a custom prompt'
+								)}
 							/>
 						</Tooltip>
 					</div>
@@ -285,7 +287,9 @@
 						>
 							<Textarea
 								bind:value={taskConfig.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE}
-								placeholder={defaultPrompts.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE}
+								placeholder={$i18n.t(
+									'Leave empty to use the default prompt, or enter a custom prompt'
+								)}
 							/>
 						</Tooltip>
 					</div>
@@ -309,7 +313,9 @@
 						>
 							<Textarea
 								bind:value={taskConfig.TAGS_GENERATION_PROMPT_TEMPLATE}
-								placeholder={defaultPrompts.TAGS_GENERATION_PROMPT_TEMPLATE}
+								placeholder={$i18n.t(
+									'Leave empty to use the default prompt, or enter a custom prompt'
+								)}
 							/>
 						</Tooltip>
 					</div>
@@ -340,7 +346,9 @@
 					>
 						<Textarea
 							bind:value={taskConfig.QUERY_GENERATION_PROMPT_TEMPLATE}
-							placeholder={defaultPrompts.QUERY_GENERATION_PROMPT_TEMPLATE}
+							placeholder={$i18n.t(
+								'Leave empty to use the default prompt, or enter a custom prompt'
+							)}
 						/>
 					</Tooltip>
 				</div>
@@ -383,7 +391,9 @@
 					>
 						<Textarea
 							bind:value={taskConfig.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE}
-							placeholder={defaultPrompts.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE}
+							placeholder={$i18n.t(
+								'Leave empty to use the default prompt, or enter a custom prompt'
+							)}
 						/>
 					</Tooltip>
 				</div>
@@ -397,7 +407,9 @@
 					>
 						<Textarea
 							bind:value={taskConfig.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE}
-							placeholder={defaultPrompts.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE}
+							placeholder={$i18n.t(
+								'Leave empty to use the default prompt, or enter a custom prompt'
+							)}
 						/>
 					</Tooltip>
 				</div>

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -69,9 +69,8 @@
 
 	onMount(async () => {
 		await init();
-		const taskConfigResponse = await getTaskConfig(localStorage.token);
-		taskConfig = taskConfigResponse;
-		defaultPrompts = taskConfigResponse._defaults || {};
+		taskConfig = await getTaskConfig(localStorage.token);
+		defaultPrompts = taskConfig._defaults || {};
 
 		// If any prompt template is empty, set it to the default value
 		if (!taskConfig.TITLE_GENERATION_PROMPT_TEMPLATE) {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? not needed
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? no
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

I wanted to add a /no_think to the title prompt for my local Qwen model, ended up having to look through the codebase to find the original prompt. Prompts now get prefilled in the Admin settings with the default prompt, or whatever you put in there.

### Changed

1. Adds a _defaults section to the task config API by importing the DEFAULT_*_PROMPT_TEMPLATE constants in tasks.py and returning them in the API response so the frontend can access the actual default prompt text.
2. Improves the frontend admin interface by automatically populating empty prompt template fields with the actual default text values instead of leaving them blank, making it easier for admins to see and modify the default prompts.

### Screenshots or Videos

<img width="1435" height="861" alt="image" src="https://github.com/user-attachments/assets/afe80b93-193a-41b7-ba4c-87ba23f6c746" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
