### PR TITLE
feat: add OAuth configuration warning for missing OPENID_PROVIDER_URL

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -680,6 +680,19 @@ def load_oauth_providers():
             "register": oidc_oauth_register,
         }
 
+    configured_providers = []
+    if GOOGLE_CLIENT_ID.value:
+        configured_providers.append("Google")
+    if MICROSOFT_CLIENT_ID.value:
+        configured_providers.append("Microsoft") 
+    if GITHUB_CLIENT_ID.value:
+        configured_providers.append("GitHub")
+    
+    if configured_providers and not OPENID_PROVIDER_URL.value:
+        provider_list = ", ".join(configured_providers)
+        log.warning(f"⚠️  OAuth providers configured ({provider_list}) but OPENID_PROVIDER_URL not set - logout will not work!")
+        log.warning(f"Set OPENID_PROVIDER_URL to your OAuth provider's OpenID Connect discovery endpoint to fix logout functionality.")
+
 
 load_oauth_providers()
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [[Open WebUI Docs](https://github.com/open-webui/docs)](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase


# Changelog Entry
### Description
Adds a startup warning when OAuth providers (Google, Microsoft, or GitHub) are configured but the required `OPENID_PROVIDER_URL` environment variable is not set. This helps administrators identify incomplete OAuth configurations that would result in non-functional logout functionality.

### Added
- Configuration validation warning in `load_oauth_providers()` function
- Clear messaging indicating which OAuth providers are configured and the missing requirement
- Helpful guidance on setting the correct `OPENID_PROVIDER_URL` value

### Changed
- Enhanced `load_oauth_providers()` function to include configuration validation

### Deprecated
- None

### Removed
- None

### Fixed
- Improved user experience by proactively identifying incomplete OAuth configurations
- Prevents silent OAuth logout failures due to missing configuration

### Security
- None

### Breaking Changes
- None

---
### Additional Information
This change addresses a common configuration issue where users set up OAuth providers (Google, Microsoft, GitHub) but forget to configure the required `OPENID_PROVIDER_URL` environment variable, resulting in OAuth logout not working properly. The warning appears during application startup and provides clear guidance on how to fix the configuration.

- **No new dependencies** - Uses existing logging infrastructure
- **Minimal code impact** - Only adds ~10 lines at the end of existing function
- **Non-breaking** - Pure addition that doesn't change existing behavior
- **Related to discussion in issue #15007 and #15999** regarding OAuth logout functionality

**The warning only appears when:**
1. One or more OAuth providers are configured (have client ID/secret)
2. `OPENID_PROVIDER_URL` is not set
3. During application startup when `load_oauth_providers()` is called


### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [[Contributor License Agreement (CLA)](https://claude.ai/CONTRIBUTOR_LICENSE_AGREEMENT)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.