### PR TITLE
fix: eliminate “no running event loop” errors during shutdown

### DIFF
--- a/backend/open_webui/test/util/test_task_cleanup.py
+++ b/backend/open_webui/test/util/test_task_cleanup.py
@@ -1,0 +1,68 @@
+# Tests validating the shutdown-safe scheduling helper
+
+import asyncio
+import logging
+import sys
+
+import pytest
+
+from open_webui import tasks as tasks_module
+
+
+# ---------------------------------------------------------------------------
+# 1. Normal loop – coroutine should be scheduled & executed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_create_task_active_loop():
+    flag = asyncio.Event()
+
+    async def setter():  # pragma: no cover
+        flag.set()
+
+    scheduler = getattr(tasks_module, "_safe_create_task", asyncio.create_task)
+    scheduler(setter())
+    await asyncio.sleep(0)
+    assert flag.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 2. Closed loop – scheduling must not raise RuntimeError (regression case)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_scheduling_on_closed_loop(caplog):
+    caplog.set_level(logging.ERROR)
+
+    # Capture unraisable exceptions that asyncio reports for closed-loop errors
+    captured: list[str] = []
+
+    def _hook(urex):
+        captured.append(str(urex.exc_value))
+
+    has_get = hasattr(sys, "get_unraisablehook")
+    if has_get:
+        old_hook = sys.get_unraisablehook()
+        sys.set_unraisablehook(_hook)
+    else:
+        old_hook = sys.unraisablehook
+        sys.unraisablehook = _hook
+
+    try:
+        # Close the current loop to mimic application shutdown
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.close()
+
+        # Patched code uses _safe_create_task, legacy code falls back to asyncio.create_task
+        scheduler = getattr(tasks_module, "_safe_create_task", asyncio.create_task)
+        scheduler(tasks_module.cleanup_task(None, "dummy"))
+    finally:
+        if has_get:
+            sys.set_unraisablehook(old_hook)
+        else:
+            sys.unraisablehook = old_hook
+
+    assert not captured  # no RuntimeError surfaced
+    assert not caplog.records  # nothing logged either


### PR DESCRIPTION

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

https://github.com/open-webui/open-webui/issues/15979

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
Redis Sentinel fail-over made our background tasks run slightly longer; if the server received SIGTERM during that window, the event loop was closed while `create_task`’s `done_callback` still tried to schedule `cleanup_task`.  The result was noisy tracebacks:

This PR hardens the scheduling helper so the callback simply skips work
when the loop is absent or closed—no more shutdown errors.

### Added
- Regression tests (`test_task_cleanup.py`) covering:
  * normal loop → coroutine scheduled
  * closed loop → scheduling silently skipped (was RuntimeError)

### Changed
- `_safe_create_task` now:
  ```python
  try:
      loop = asyncio.get_running_loop()
  except RuntimeError:
      return
  if not loop.is_closed():
      loop.create_task(coro)
  ```
- `create_task`’s callback uses the helper instead of raw
  `asyncio.create_task`.

### Deprecated
- None

### Removed
- None

### Fixed
- RuntimeError (“no running event loop”) emitted during graceful shutdown.

### Security
- N/A

### Breaking Changes
- **None**

---

### Additional Information
- Verified new tests fail on previous commit and pass after the fix.
- No API surface or dependency changes.


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
