### PR TITLE
fix: issue: Using an external tool server causes the response to be unable to stop #15695 

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -226,6 +226,9 @@ async def chat_completion_tools_handler(
                         tool_function = tool["callable"]
                         tool_result = await tool_function(**tool_function_params)
 
+                except asyncio.CancelledError:
+                    log.debug(f"Tool execution cancelled for: {tool_function_name}")
+                    raise
                 except Exception as e:
                     tool_result = str(e)
 
@@ -2191,6 +2194,9 @@ async def process_chat_response(
                                         **tool_function_params
                                     )
 
+                            except asyncio.CancelledError:
+                                log.debug(f"Tool execution cancelled for: {tool_name}")
+                                raise
                             except Exception as e:
                                 tool_result = str(e)
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -226,9 +226,6 @@ async def chat_completion_tools_handler(
                         tool_function = tool["callable"]
                         tool_result = await tool_function(**tool_function_params)
 
-                except asyncio.CancelledError:
-                    log.debug(f"Tool execution cancelled for: {tool_function_name}")
-                    raise
                 except Exception as e:
                     tool_result = str(e)
 
@@ -2194,9 +2191,6 @@ async def process_chat_response(
                                         **tool_function_params
                                     )
 
-                            except asyncio.CancelledError:
-                                log.debug(f"Tool execution cancelled for: {tool_name}")
-                                raise
                             except Exception as e:
                                 tool_result = str(e)
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -446,9 +446,11 @@ async def get_tool_server_data(token: str, url: str) -> Dict[str, Any]:
         headers["Authorization"] = f"Bearer {token}"
 
     error = None
+    session = None
     try:
         timeout = aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA)
-        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+        session = aiohttp.ClientSession(timeout=timeout, trust_env=True)
+        try:
             async with session.get(
                 url, headers=headers, ssl=AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL
             ) as response:
@@ -462,6 +464,13 @@ async def get_tool_server_data(token: str, url: str) -> Dict[str, Any]:
                     res = yaml.safe_load(text_content)
                 else:
                     res = await response.json()
+        finally:
+            if session and not session.closed:
+                await session.close()
+                
+    except asyncio.CancelledError:
+        log.debug(f"Tool server data fetch cancelled for URL: {url}")
+        raise
     except Exception as err:
         log.exception(f"Could not fetch tool server spec from {url}")
         if isinstance(err, dict) and "detail" in err:
@@ -469,6 +478,13 @@ async def get_tool_server_data(token: str, url: str) -> Dict[str, Any]:
         else:
             error = str(err)
         raise Exception(error)
+    finally:
+        # Additional cleanup to handle any remaining session
+        if session and not session.closed:
+            try:
+                await session.close()
+            except Exception as cleanup_error:
+                log.debug(f"Error during session cleanup: {cleanup_error}")
 
     data = {
         "openapi": res,
@@ -551,6 +567,7 @@ async def execute_tool_server(
     token: str, url: str, name: str, params: Dict[str, Any], server_data: Dict[str, Any]
 ) -> Any:
     error = None
+    session = None
     try:
         openapi = server_data.get("openapi", {})
         paths = openapi.get("paths", {})
@@ -614,7 +631,9 @@ async def execute_tool_server(
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        async with aiohttp.ClientSession(trust_env=True) as session:
+        # Create session explicitly to ensure proper cleanup on cancellation
+        session = aiohttp.ClientSession(trust_env=True)
+        try:
             request_method = getattr(session, http_method.lower())
 
             if http_method in ["post", "put", "patch"]:
@@ -638,8 +657,22 @@ async def execute_tool_server(
                         text = await response.text()
                         raise Exception(f"HTTP error {response.status}: {text}")
                     return await response.json()
+        finally:
+            # Ensure session is closed even on cancellation
+            if session and not session.closed:
+                await session.close()
 
+    except asyncio.CancelledError:
+        log.debug(f"Tool execution cancelled for operation: {name}")
+        raise
     except Exception as err:
         error = str(err)
         log.exception(f"API Request Error: {error}")
         return {"error": error}
+    finally:
+        # Additional cleanup to handle any remaining session
+        if session and not session.closed:
+            try:
+                await session.close()
+            except Exception as cleanup_error:
+                log.debug(f"Error during session cleanup: {cleanup_error}")


### PR DESCRIPTION
Before submitting, make sure you've checked the following:

 Target branch: Please verify that the pull request targets the dev branch.
 Description: Provide a concise description of the changes made in this pull request.
 Changelog: Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
 Documentation: Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
 Dependencies: Are there any new dependencies? Have you updated the dependency versions in the documentation?
 Testing: Have you written and run sufficient tests to validate the changes?
 Code review: Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
 Prefix: To clearly categorize this pull request, prefix the pull request title using one of the following: fix (Bug fix or error correction)
Problem
When users clicked the stop button during tool execution in chat completions, the backend would log "Unclosed client session" and "Unclosed connector" warnings. This issue only occurred when tools were involved in the generation process.

Root Cause
The problem was in the execute_tool_server() and get_tool_server_data() functions in /backend/open_webui/utils/tools.py. These functions used the async with aiohttp.ClientSession() pattern, but when tasks containing these functions were cancelled via the stop button, the session cleanup might not complete properly during cancellation.

Solution
Modified both functions to ensure proper session cleanup even when tasks are cancelled by implementing manual session management with explicit cleanup in try/finally blocks and dedicated asyncio.CancelledError handlers.

Changelog Entry
Description
Fixed unclosed aiohttp client sessions when stopping tool tasks, eliminating resource leaks and "Unclosed client session" warnings that occurred when users cancelled tool execution mid-process.

Added
Explicit asyncio.CancelledError handling in tool server functions
Informative logging when tool operations are cancelled
Changed
Modified execute_tool_server() to use manual session management with defensive cleanup
Modified get_tool_server_data() to use manual session management with defensive cleanup
Replaced async with aiohttp.ClientSession() pattern with explicit session creation and cleanup
Fixed
Resource leak: Unclosed aiohttp client sessions when tasks are cancelled
Warning messages: "Unclosed client session" and "Unclosed connector" errors in logs
Session cleanup: Proper session closure during task cancellation scenarios
Additional Information
This fix ensures HTTP sessions are properly closed in all scenarios: normal completion, error conditions, and task cancellation
No breaking changes - all existing tool execution behavior is preserved
Affects only the backend tool execution infrastructure
Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.