### PR TITLE
FIX: User WorkSpace Create Tool Error

### DIFF
--- a/backend/open_webui/routers/utils.py
+++ b/backend/open_webui/routers/utils.py
@@ -33,7 +33,7 @@ class CodeForm(BaseModel):
 
 
 @router.post("/code/format")
-async def format_code(form_data: CodeForm, user=Depends(get_admin_user)):
+async def format_code(form_data: CodeForm, user=Depends(get_verified_user)):
     try:
         formatted_code = black.format_str(form_data.code, mode=black.Mode())
         return {"code": formatted_code}

--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -178,7 +178,7 @@ print(black.format_str("""${code.replace(/\\/g, '\\\\').replace(/`/g, '\\`').rep
 	export const formatPythonCodeHandler = async () => {
 		if (codeEditor) {
 			const res = await (
-				$user?.role === 'admin'
+				($user?.role === 'admin' || $user?.permissions?.features?.code_interpreter)
 					? formatPythonCode(localStorage.token, _value)
 					: formatPythonCodePyodide(_value)
 			).catch((error) => {


### PR DESCRIPTION
### Description

### FIX: User WorkSpace Create Tool Error

- When Creating new tool in user workspace arise an error due to lack of permission when code is formatted.
- It solve https://github.com/open-webui/open-webui/issues/16037

### Changed

- _backend/open_webui/routers/utils.py_
Permission changed to allow verified users to format code; there are more specific permission checks later, in formatPythonCodeHandler.

- _src/lib/components/common/CodeEditor.svelte_
Added permission for the user with code_interpreter permission.
The tools permission could also be used, but I assume the code_interpreter permission is more appropriate for that role; if the user doesn't have code_interpreter permission, they shouldn't have to format the code either.
However, I'm not sure; both permissions could also be used.


### Security

- **REQUIRES REVIEW ON APPLIED PERMISSION.**
__________
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
