### PR TITLE
fix: properly handle full URLs in form_data.path

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -7,7 +7,11 @@ from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.config import get_config, save_config
 from open_webui.config import BannerModel
 
-from open_webui.utils.tools import get_tool_server_data, get_tool_servers_data
+from open_webui.utils.tools import (
+    get_tool_server_data,
+    get_tool_servers_data,
+    build_tool_server_url,
+)
 
 
 router = APIRouter()
@@ -135,7 +139,7 @@ async def verify_tool_servers_config(
         elif form_data.auth_type == "session":
             token = request.state.token.credentials
 
-        url = f"{form_data.url}/{form_data.path}"
+        url = build_tool_server_url(form_data.url, form_data.path)
         return await get_tool_server_data(token, url)
     except Exception as e:
         raise HTTPException(

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -489,15 +489,7 @@ async def get_tool_servers_data(
         if server.get("config", {}).get("enable"):
             # Path (to OpenAPI spec URL) can be either a full URL or a path to append to the base URL
             openapi_path = server.get("path", "openapi.json")
-            if "://" in openapi_path:
-                # If it contains "://", it's a full URL
-                full_url = openapi_path
-            else:
-                if not openapi_path.startswith("/"):
-                    # Ensure the path starts with a slash
-                    openapi_path = f"/{openapi_path}"
-
-                full_url = f"{server.get('url')}{openapi_path}"
+            full_url = build_tool_server_url(server.get("url"), openapi_path)
 
             info = server.get("info", {})
 
@@ -643,3 +635,16 @@ async def execute_tool_server(
         error = str(err)
         log.exception(f"API Request Error: {error}")
         return {"error": error}
+
+
+def build_tool_server_url(url: Optional[str], path: str) -> str:
+    """
+    Build the full URL for a tool server, given a base url and a path.
+    """
+    if "://" in path:
+        # If it contains "://", it's a full URL
+        return path
+    if not path.startswith("/"):
+        # Ensure the path starts with a slash
+        path = f"/{path}"
+    return f"{url}{path}"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** Provided a concise description of the changes made in this pull request.
- [x] **Changelog:** A changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Documentation will be updated as needed in [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources.
- [ ] **Dependencies:** No new dependencies introduced.
- [x] **Testing:** Sufficient tests have been written and run to validate the changes.
- [x] **Code review:** Self-review has been performed for adherence to coding standards.
- [x] **Prefix:** The pull request title is prefixed as follows: **fix**: Properly handle full URLs in form_data.path and tool server paths

# Changelog Entry

### Description

- This pull request fixes a bug in URL construction logic. When `form_data.path` contains a full URL (i.e., it includes '://'), the backend now uses this value directly instead of concatenating it with `form_data.url`. This ensures valid URL usage for both relative and absolute paths.

### Added

- None.

### Changed

- In `backend/open_webui/routers/configs.py`, updated URL construction logic to check for and use full URLs in `form_data.path`.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed an issue where a full URL in `form_data.path` would be incorrectly concatenated with `form_data.url`, resulting in an invalid URL.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Related commit: 2c7ccc69fe614b65bb584b53b89c3eee2eac894b

### Screenshots or Videos

- N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.