### PR TITLE
Handle info dictionary in opeanapi data when it does not exist

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -528,6 +528,9 @@ async def get_tool_servers_data(
         openapi_data = response.get("openapi", {})
 
         if info and isinstance(openapi_data, dict):
+            if "info" not in openapi_data:
+                openapi_data["info"] = {}
+
             if "name" in info:
                 openapi_data["info"]["title"] = info.get("name", "Tool Server")
 


### PR DESCRIPTION
For registering tool server sometimes there is not `info` section for setting `title` and `description` which case `internal server error` with the following exception:

```
open-webui-6b8789fd86-2rwhg open-webui     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
open-webui-6b8789fd86-2rwhg open-webui     |     raw_response = await run_endpoint_function(
open-webui-6b8789fd86-2rwhg open-webui     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui-6b8789fd86-2rwhg open-webui     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
open-webui-6b8789fd86-2rwhg open-webui     |     return await dependant.call(**values)
open-webui-6b8789fd86-2rwhg open-webui     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui-6b8789fd86-2rwhg open-webui     |   File "/app/backend/open_webui/routers/configs.py", line 114, in set_tool2025-08-02T01:46:18.201693099Z _servers_config
open-webui-6b8789fd86-2rwhg open-webui     |     request.app.state.TOOL_SERVERS = await get_tool_servers_data(
open-webui-6b8789fd86-2rwhg open-webui     |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui-6b8789fd86-2rwhg open-webui     |   File "/app/backend/open_webui/utils/tools.py", line 532, in get_tool_servers_data
open-webui-6b8789fd86-2rwhg open-webui     |     openapi_data["info"]["title"] = info.get("name", "Tool Server")
open-webui-6b8789fd86-2rwhg open-webui     |     ~~~~~~~~~~~~^^^^^^^^
open-webui-6b8789fd86-2rwhg open-webui     | KeyError: 'info'
```

The change is going to fix this by passing an empty dictionary for `info` when it does not exist.