### PR TITLE
feat: separate otel metrics configuration

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -643,11 +643,18 @@ AUDIT_EXCLUDED_PATHS = [path.lstrip("/") for path in AUDIT_EXCLUDED_PATHS]
 
 ENABLE_OTEL = os.environ.get("ENABLE_OTEL", "False").lower() == "true"
 ENABLE_OTEL_METRICS = os.environ.get("ENABLE_OTEL_METRICS", "False").lower() == "true"
+
 OTEL_EXPORTER_OTLP_ENDPOINT = os.environ.get(
     "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"
 )
+OTEL_METRICS_EXPORTER_OTLP_ENDPOINT = os.environ.get(
+    "OTEL_METRICS_EXPORTER_OTLP_ENDPOINT", OTEL_EXPORTER_OTLP_ENDPOINT
+)
 OTEL_EXPORTER_OTLP_INSECURE = (
     os.environ.get("OTEL_EXPORTER_OTLP_INSECURE", "False").lower() == "true"
+)
+OTEL_METRICS_EXPORTER_OTLP_INSECURE = (
+    os.environ.get("OTEL_METRICS_EXPORTER_OTLP_INSECURE", "False").lower() == "true"
 )
 OTEL_SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "open-webui")
 OTEL_RESOURCE_ATTRIBUTES = os.environ.get(
@@ -659,9 +666,19 @@ OTEL_TRACES_SAMPLER = os.environ.get(
 OTEL_BASIC_AUTH_USERNAME = os.environ.get("OTEL_BASIC_AUTH_USERNAME", "")
 OTEL_BASIC_AUTH_PASSWORD = os.environ.get("OTEL_BASIC_AUTH_PASSWORD", "")
 
+OTEL_METRICS_BASIC_AUTH_USERNAME = os.environ.get(
+    "OTEL_METRICS_BASIC_AUTH_USERNAME", OTEL_BASIC_AUTH_USERNAME
+)
+OTEL_METRICS_BASIC_AUTH_PASSWORD = os.environ.get(
+    "OTEL_METRICS_BASIC_AUTH_PASSWORD", OTEL_BASIC_AUTH_PASSWORD
+)
 
 OTEL_OTLP_SPAN_EXPORTER = os.environ.get(
     "OTEL_OTLP_SPAN_EXPORTER", "grpc"
+).lower()  # grpc or http
+
+OTEL_METRICS_OTLP_SPAN_EXPORTER = os.environ.get(
+    "OTEL_METRICS_OTLP_SPAN_EXPORTER", OTEL_OTLP_SPAN_EXPORTER
 ).lower()  # grpc or http
 
 

--- a/backend/open_webui/utils/telemetry/metrics.py
+++ b/backend/open_webui/utils/telemetry/metrics.py
@@ -19,37 +19,69 @@ from __future__ import annotations
 
 import time
 from typing import Dict, List, Sequence, Any
+from base64 import b64encode
 
 from fastapi import FastAPI, Request
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
     OTLPMetricExporter,
 )
+
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter as OTLPHttpMetricExporter,
+)
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.view import View
 from opentelemetry.sdk.metrics.export import (
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.resources import Resource
 
-from open_webui.env import OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT
-
+from open_webui.env import (
+    OTEL_SERVICE_NAME,
+    OTEL_METRICS_EXPORTER_OTLP_ENDPOINT,
+    OTEL_METRICS_BASIC_AUTH_USERNAME,
+    OTEL_METRICS_BASIC_AUTH_PASSWORD,
+    OTEL_METRICS_OTLP_SPAN_EXPORTER,
+    OTEL_METRICS_EXPORTER_OTLP_INSECURE,
+)
 from open_webui.socket.main import get_active_user_ids
 from open_webui.models.users import Users
 
 _EXPORT_INTERVAL_MILLIS = 10_000  # 10 seconds
 
 
-def _build_meter_provider() -> MeterProvider:
+def _build_meter_provider(resource: Resource) -> MeterProvider:
     """Return a configured MeterProvider."""
+    headers = []
+    if OTEL_METRICS_BASIC_AUTH_USERNAME and OTEL_METRICS_BASIC_AUTH_PASSWORD:
+        auth_string = (
+            f"{OTEL_METRICS_BASIC_AUTH_USERNAME}:{OTEL_METRICS_BASIC_AUTH_PASSWORD}"
+        )
+        auth_header = b64encode(auth_string.encode()).decode()
+        headers = [("authorization", f"Basic {auth_header}")]
 
     # Periodic reader pushes metrics over OTLP/gRPC to collector
-    readers: List[PeriodicExportingMetricReader] = [
-        PeriodicExportingMetricReader(
-            OTLPMetricExporter(endpoint=OTEL_EXPORTER_OTLP_ENDPOINT),
-            export_interval_millis=_EXPORT_INTERVAL_MILLIS,
-        )
-    ]
+    if OTEL_METRICS_OTLP_SPAN_EXPORTER == "http":
+        readers: List[PeriodicExportingMetricReader] = [
+            PeriodicExportingMetricReader(
+                OTLPHttpMetricExporter(
+                    endpoint=OTEL_METRICS_EXPORTER_OTLP_ENDPOINT, headers=headers
+                ),
+                export_interval_millis=_EXPORT_INTERVAL_MILLIS,
+            )
+        ]
+    else:
+        readers: List[PeriodicExportingMetricReader] = [
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(
+                    endpoint=OTEL_METRICS_EXPORTER_OTLP_ENDPOINT,
+                    insecure=OTEL_METRICS_EXPORTER_OTLP_INSECURE,
+                    headers=headers,
+                ),
+                export_interval_millis=_EXPORT_INTERVAL_MILLIS,
+            )
+        ]
 
     # Optional view to limit cardinality: drop user-agent etc.
     views: List[View] = [
@@ -70,17 +102,17 @@ def _build_meter_provider() -> MeterProvider:
     ]
 
     provider = MeterProvider(
-        resource=Resource.create({SERVICE_NAME: OTEL_SERVICE_NAME}),
+        resource=resource,
         metric_readers=list(readers),
         views=views,
     )
     return provider
 
 
-def setup_metrics(app: FastAPI) -> None:
+def setup_metrics(app: FastAPI, resource: Resource) -> None:
     """Attach OTel metrics middleware to *app* and initialise provider."""
 
-    metrics.set_meter_provider(_build_meter_provider())
+    metrics.set_meter_provider(_build_meter_provider(resource))
     meter = metrics.get_meter(__name__)
 
     # Instruments

--- a/backend/open_webui/utils/telemetry/setup.py
+++ b/backend/open_webui/utils/telemetry/setup.py
@@ -26,11 +26,8 @@ from open_webui.env import (
 
 def setup(app: FastAPI, db_engine: Engine):
     # set up trace
-    trace.set_tracer_provider(
-        TracerProvider(
-            resource=Resource.create(attributes={SERVICE_NAME: OTEL_SERVICE_NAME})
-        )
-    )
+    resource = Resource.create(attributes={SERVICE_NAME: OTEL_SERVICE_NAME})
+    trace.set_tracer_provider(TracerProvider(resource=resource))
 
     # Add basic auth header only if both username and password are not empty
     headers = []
@@ -56,4 +53,4 @@ def setup(app: FastAPI, db_engine: Engine):
 
     # set up metrics only if enabled
     if ENABLE_OTEL_METRICS:
-        setup_metrics(app)
+        setup_metrics(app, resource)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR adds couple of configuration specific for open telemetry metrics configuration in order to distinguish them from the general otel configuration. This is handy especially in cases where separate endpoint for traces and metrics are used. One example is if lgtm stack is used, and the span exporter is http, where the endpoint for traces is `http://grafana:4318/v1/traces` and the metrics endpoint is `http://grafana:4318/v1/metrics`.
Also, this PR adds http metrics exporter (alongside with the existing grpc one), and handles metrics exporter authentication.
This should also resolve #16183.

### Added

**New configuration/environment variables**:
- `OTEL_METRICS_EXPORTER_OTLP_ENDPOINT` - otel metrics exporter endpoint, defaults to the `OTEL_EXPORTER_OTLP_ENDPOINT` one if not specified
- `OTEL_METRICS_BASIC_AUTH_USERNAME` and `OTEL_METRICS_BASIC_AUTH_PASSWORD` - basic credentials for authentication handling in metrics endpoint. Defaults to the traces credentials.
- `OTEL_METRICS_OTLP_SPAN_EXPORTER` - the span method for the metrics exporter (http/grpc). Defaults to the traces span exporter method
- `OTEL_METRICS_EXPORTER_OTLP_INSECURE` - whether the exporter should be insecure or not. Defaults to `False` like the traces one.

### Changed

Moved `resource` definition to the otel `setup.py` to avoid code duplication.
 
### Fixed

- Metrics exporter worked only in grpc mode, not in http
- Users couldn't separate endpoints for metrics and traces
- Users couldn't use authentication on metrics

---

### Additional Information

If this PR is approved I will create a docs PR.


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
