### PR TITLE
feat: Add password visibility toggle to password fields with SensitiveInput.svelte component

### DIFF
--- a/src/lib/components/admin/Users/UserList/AddUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/AddUserModal.svelte
@@ -10,6 +10,7 @@
 	import Modal from '$lib/components/common/Modal.svelte';
 	import { generateInitialsImage } from '$lib/utils';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -224,12 +225,13 @@
 								<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Password')}</div>
 
 								<div class="flex-1">
-									<input
+									<SensitiveInput
 										class="w-full text-sm bg-transparent disabled:text-gray-500 dark:disabled:text-gray-500 outline-hidden"
 										type="password"
 										bind:value={_user.password}
 										placeholder={$i18n.t('Enter Your Password')}
 										autocomplete="off"
+										required
 									/>
 								</div>
 							</div>

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -9,6 +9,7 @@
 	import Modal from '$lib/components/common/Modal.svelte';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -139,12 +140,13 @@
 								<div class=" mb-1 text-xs text-gray-500">{$i18n.t('New Password')}</div>
 
 								<div class="flex-1">
-									<input
+									<SensitiveInput
 										class="w-full text-sm bg-transparent outline-hidden"
 										type="password"
 										placeholder={$i18n.t('Enter New Password')}
 										bind:value={_user.password}
 										autocomplete="new-password"
+										required
 									/>
 								</div>
 							</div>

--- a/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
+++ b/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
@@ -2,6 +2,7 @@
 	import { getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { updateUserPassword } from '$lib/apis/auths';
+	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -59,8 +60,8 @@
 				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Current Password')}</div>
 
 				<div class="flex-1">
-					<input
-						class="w-full bg-transparent dark:text-gray-300 outline-hidden placeholder:opacity-30"
+					<SensitiveInput
+						class="w-full bg-transparent text-sm dark:text-gray-300 outline-hidden placeholder:opacity-30"
 						type="password"
 						bind:value={currentPassword}
 						placeholder={$i18n.t('Enter your current password')}
@@ -74,7 +75,7 @@
 				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('New Password')}</div>
 
 				<div class="flex-1">
-					<input
+					<SensitiveInput
 						class="w-full bg-transparent text-sm dark:text-gray-300 outline-hidden placeholder:opacity-30"
 						type="password"
 						bind:value={newPassword}
@@ -89,7 +90,7 @@
 				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Confirm Password')}</div>
 
 				<div class="flex-1">
-					<input
+					<SensitiveInput
 						class="w-full bg-transparent text-sm dark:text-gray-300 outline-hidden placeholder:opacity-30"
 						type="password"
 						bind:value={newPasswordConfirm}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -18,6 +18,7 @@
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import OnBoarding from '$lib/components/OnBoarding.svelte';
+	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -306,7 +307,7 @@
 											<label for="password" class="text-sm font-medium text-left mb-1 block"
 												>{$i18n.t('Password')}</label
 											>
-											<input
+											<SensitiveInput
 												bind:value={password}
 												type="password"
 												id="password"
@@ -325,7 +326,7 @@
 													class="text-sm font-medium text-left mb-1 block"
 													>{$i18n.t('Confirm Password')}</label
 												>
-												<input
+												<SensitiveInput
 													bind:value={confirmPassword}
 													type="password"
 													id="confirm-password"


### PR DESCRIPTION
# Pull Request Checklist
### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- Replaced standard HTML `<input>` elements with the `SensitiveInput` component for improved security and consistent handling of sensitive data, specifically for password fields. This also involved updating related imports and adjusting props.

### Added
- Added `import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';` in multiple files.

### Changed
- Replaced `<input>` tags with `<SensitiveInput>` component in:
    - `src/lib/components/admin/Users/UserList/AddUserModal.svelte`
    - `src/lib/components/admin/Users/UserList/EditUserModal.svelte`
    - `src/lib/components/chat/Settings/Account/UpdatePassword.svelte`
    - `src/routes/auth/+page.svelte` (Login & Registration form inputs)

### Removed
- Removed several `<input>` elements.

### Fixed
- Improved handling of sensitive input fields by using a dedicated component.

### Security
- Enhanced security for password input fields by using `SensitiveInput` component.

### Breaking Changes
- **BREAKING CHANGE**: Direct usage of `<input>` for password fields has been replaced with `SensitiveInput`. Components that directly interacted with the previous `<input>` structure for passwords may need adjustments if not updated. I've tested my changes in this PR though and they generally look good and just work.

### Additional Information
- This pull request fulfills a long standing feature request by an Open WebUI Discord server member. It also compliments the [`Confirm Password on Signup` commit](https://github.com/open-webui/open-webui/commit/b510f21a5b4b4f2039ac5c157dd27ac12ed185db).
<img width="1375" height="112" alt="image" src="https://github.com/user-attachments/assets/970d50cc-8f06-4c1b-91c8-ab22b3c8aa32" />

### Screenshots or Videos
- `src/lib/components/admin/Users/UserList/AddUserModal.svelte`
<img width="508" height="411" alt="image" src="https://github.com/user-attachments/assets/00941c5b-d001-462f-b2a9-e3ad3494f7d0" />

- `src/lib/components/admin/Users/UserList/EditUserModal.svelte`
<img width="508" height="411" alt="image" src="https://github.com/user-attachments/assets/0891c34b-f0a8-4abf-8c9d-8b81e6bb8e2e" />

- `src/lib/components/chat/Settings/Account/UpdatePassword.svelte`
<img width="927" height="608" alt="image" src="https://github.com/user-attachments/assets/cabeeb07-4716-433c-a289-a82d38cbd2f5" />

- `src/routes/auth/+page.svelte` (Login & Registration form inputs)
<img width="927" height="608" alt="image" src="https://github.com/user-attachments/assets/81873269-2591-4965-92e0-2328a5b104b6" />
<img width="927" height="608" alt="image" src="https://github.com/user-attachments/assets/b1b2b24d-3f75-4c1f-acda-03ce25d92b46" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.