### PR TITLE
feat: Replace folder chevrons with open/close folder icon + update folder double-click behavior

### DIFF
--- a/src/lib/components/icons/FolderIcon.svelte
+++ b/src/lib/components/icons/FolderIcon.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Folder from './Folder.svelte';
+	import FolderOpen from './FolderOpen.svelte';
+	export let open = false;
+	export let className = 'size-4';
+	export let strokeWidth = '1.5';
+</script>
+
+{#if open}
+	<FolderOpen {className} {strokeWidth} />
+{:else}
+	<Folder {className} {strokeWidth} />
+{/if}

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -25,11 +25,10 @@
 		updateChatFolderIdById
 	} from '$lib/apis/chats';
 
-	import ChevronDown from '../../icons/ChevronDown.svelte';
-	import ChevronRight from '../../icons/ChevronRight.svelte';
 	import Collapsible from '../../common/Collapsible.svelte';
 	import DragGhost from '$lib/components/common/DragGhost.svelte';
 
+	import FolderIcon from '$lib/components/icons/FolderIcon.svelte';
 	import FolderOpen from '$lib/components/icons/FolderOpen.svelte';
 	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
 
@@ -60,6 +59,27 @@
 	let dragged = false;
 
 	let name = '';
+
+	let timer = null;
+	const handleSingleClick = async () => {
+		await goto('/');
+		selectedFolder.set(folders[folderId]);
+	};
+	const clickHandler = (event) => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+			open = !open; // Revert the toggle from the first click
+			showFolderModal = true;
+			event.stopPropagation();
+			event.preventDefault();
+		} else {
+			timer = setTimeout(() => {
+				timer = null;
+				handleSingleClick();
+			}, 250);
+		}
+	};
 
 	const onDragOver = (e) => {
 		e.preventDefault();
@@ -430,21 +450,10 @@
 				folderId
 					? 'bg-gray-100 dark:bg-gray-900'
 					: ''}"
-				on:dblclick={() => {
-					renameHandler();
-				}}
-				on:click={async (e) => {
-					await goto('/');
-
-					selectedFolder.set(folders[folderId]);
-				}}
+				on:click={clickHandler}
 			>
 				<div class="text-gray-300 dark:text-gray-600">
-					{#if open}
-						<ChevronDown className=" size-3" strokeWidth="2.5" />
-					{:else}
-						<ChevronRight className=" size-3" strokeWidth="2.5" />
-					{/if}
+					<FolderIcon {open} className="size-3.5" strokeWidth="2" />
 				</div>
 
 				<div class="translate-y-[0.5px] flex-1 justify-start text-start line-clamp-1">

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -10,7 +10,7 @@
 
 	import { toast } from 'svelte-sonner';
 
-	import { chatId, selectedFolder } from '$lib/stores';
+	import { chatId, mobile, selectedFolder, showSidebar } from '$lib/stores';
 
 	import {
 		deleteFolderById,
@@ -64,6 +64,9 @@
 	const handleSingleClick = async () => {
 		await goto('/');
 		selectedFolder.set(folders[folderId]);
+		if ($mobile) {
+			showSidebar.set(!$showSidebar);
+		}
 	};
 	const clickHandler = (event) => {
 		if (timer) {
@@ -275,7 +278,7 @@
 
 	onDestroy(() => {
 		if (folderElement) {
-			folderElement.addEventListener('dragover', onDragOver);
+			folderElement.removeEventListener('dragover', onDragOver);
 			folderElement.removeEventListener('drop', onDrop);
 			folderElement.removeEventListener('dragleave', onDragLeave);
 
@@ -450,6 +453,9 @@
 				folderId
 					? 'bg-gray-100 dark:bg-gray-900'
 					: ''}"
+				on:dblclick={() => {
+					renameHandler();
+				}}
 				on:click={clickHandler}
 			>
 				<div class="text-gray-300 dark:text-gray-600">


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- Replaced the chevron icons for open/closed folders with a more elegant folder icon that animates between open and closed states.
- Changed the double-click behavior on a folder to open the edit modal instead of the inline text editor. This provides a more consistent and user-friendly way to edit folder names.

### Added
- Created a new `FolderIcon.svelte` component to encapsulate the open/closed logic for the folder icon.

### Changed
- Updated `RecursiveFolder.svelte` to use the new `FolderIcon.svelte `component instead of the previous chevron icons.
- Changed the `on:dblclick` event handler in `RecursiveFolder.svelte` to open the `FolderModal` instead of triggering the inline edit functionality.

### Removed
- Removed the direct usage of `ChevronDown.svelte` and `ChevronRight.svelte` from `RecursiveFolder.svelte`.

---

### Additional Information
- This change addresses a feature request I had on Discord to replace the folder chevrons with an animated folder icon for a more elegant user experience.
- This change makes folders more easily discernible in the UI and aligns the design choice to be more in tune with ChatGPT's chat sidebar. The necessary icon assets were already available in the codebase, which made for a straightforward implementation.
- The double-click behavior was updated to provide a more intuitive and consistent way to edit folder names, resolving an issue where the previous interaction was not user-friendly.

### Screenshots or Videos
Folders before:
<img width="257" height="409" alt="image" src="https://github.com/user-attachments/assets/3ac7c757-4cf6-4367-b84d-b54d4c206f6f" />

Folders after:
<img width="261" height="310" alt="image" src="https://github.com/user-attachments/assets/c4455ce8-05c5-4b2d-b46e-c13d8080ff26" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.