### PR TITLE
feat: Batched response streaming

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1406,6 +1406,7 @@ async def chat_completion(
             "filter_ids": form_data.pop("filter_ids", []),
             "tool_ids": form_data.get("tool_ids", None),
             "tool_servers": form_data.pop("tool_servers", None),
+            "stream_batch_size": form_data.pop("stream_batch_size", None),
             "files": form_data.get("files", None),
             "features": form_data.get("features", {}),
             "variables": form_data.get("variables", {}),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -684,7 +684,7 @@ def apply_params_to_form_data(form_data, model):
 
     open_webui_params = {
         "stream_response": bool,
-	"streaming_batch_size": int,
+        "streaming_batch_size": int,
         "function_calling": str,
         "system": str,
     }
@@ -1817,7 +1817,7 @@ async def process_chat_response(
 
                     response_tool_calls = []
                     delta_count = 0
-                    delta_batch_size = max(1, form_data.get("stream_batch_size", 1))
+                    delta_batch_size = max(1, form_data.get("metadata", {}).get("stream_batch_size", 1))
 
                     async for line in response.body_iterator:
                         line = line.decode("utf-8") if isinstance(line, bytes) else line

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1817,7 +1817,7 @@ async def process_chat_response(
 
                     response_tool_calls = []
                     delta_count = 0
-                    delta_batch_size = max(1, form_data.get("metadata", {}).get("stream_batch_size", 1))
+                    delta_batch_size = max(1, int(form_data.get("metadata", {}).get("stream_batch_size") or 1))
 
                     async for line in response.body_iterator:
                         line = line.decode("utf-8") if isinstance(line, bytes) else line

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -684,6 +684,7 @@ def apply_params_to_form_data(form_data, model):
 
     open_webui_params = {
         "stream_response": bool,
+	"streaming_batch_size": int,
         "function_calling": str,
         "system": str,
     }
@@ -1816,7 +1817,7 @@ async def process_chat_response(
 
                     response_tool_calls = []
                     delta_count = 0
-                    BATCH_SIZE = 3
+                    delta_batch_size = max(1, form_data.get("stream_batch_size", 1))
 
                     async for line in response.body_iterator:
                         line = line.decode("utf-8") if isinstance(line, bytes) else line
@@ -2067,7 +2068,7 @@ async def process_chat_response(
 
                                 if delta:
                                     delta_count += 1
-                                    if delta_count >= BATCH_SIZE:
+                                    if delta_count >= delta_batch_size:
                                         await event_emitter(
                                             {
                                                 "type": "chat:completion",

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -69,6 +69,7 @@ def remove_open_webui_params(params: dict) -> dict:
     """
     open_webui_params = {
         "stream_response": bool,
+	"streaming_batch_size": int,
         "function_calling": str,
         "system": str,
     }

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -69,7 +69,7 @@ def remove_open_webui_params(params: dict) -> dict:
     """
     open_webui_params = {
         "stream_response": bool,
-	"streaming_batch_size": int,
+        "streaming_batch_size": int,
         "function_calling": str,
         "system": str,
     }

--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -121,7 +121,7 @@ async function* streamLargeDeltasAsRandomChunks(
 		}
 
 		let content = textStreamUpdate.value;
-		if (content.length < 5) {
+		if (content.length < 3) {
 			yield { done: false, value: content };
 			continue;
 		}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1634,11 +1634,12 @@
 			params?.stream_response ??
 			true;
 
-		const stream_batch_size =
-			model?.info?.params?.streaming_batch_size ??
-			$settings?.params?.streaming_batch_size ??
-			params?.streaming_batch_size ??
-			1;
+		const stream_batch_size = Math.max(
+			model?.info?.params?.streaming_batch_size ?? 0,
+			$settings?.params?.streaming_batch_size ?? 0,
+			params?.streaming_batch_size ?? 0,
+			1
+			);
 
 		let messages = [
 			params?.system || $settings.system

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1694,7 +1694,6 @@
 			localStorage.token,
 			{
 				stream: stream,
-				stream_batch_size: stream_batch_size,
 				model: model.id,
 				messages: messages,
 				params: {
@@ -1748,6 +1747,7 @@
 				session_id: $socket?.id,
 				chat_id: $chatId,
 				id: responseMessageId,
+				stream_batch_size: stream_batch_size,
 
 				background_tasks: {
 					...(!$temporaryChatEnabled &&

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1634,6 +1634,12 @@
 			params?.stream_response ??
 			true;
 
+		const stream_batch_size =
+			model?.info?.params?.streaming_batch_size ??
+			$settings?.params?.streaming_batch_size ??
+			params?.streaming_batch_size ??
+			1;
+
 		let messages = [
 			params?.system || $settings.system
 				? {
@@ -1687,6 +1693,7 @@
 			localStorage.token,
 			{
 				stream: stream,
+				stream_batch_size: stream_batch_size,
 				model: model.id,
 				messages: messages,
 				params: {

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -89,61 +89,59 @@
 		</Tooltip>
 	</div>
 
-	{#if admin}
-		<div class=" py-0.5 w-full justify-between">
-			<Tooltip
-				content={$i18n.t(
-					'Sets the number of tokens to batch before emitting events while streaming. Higher values reduce CPU usage of server, client and Redis, but may lead to choppy streaming.'
-				)}
-				placement="top-start"
-				className="inline-tooltip"
-			>
-				<div class="flex w-full justify-between">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Streaming Batch Size')}
-					</div>
-					<button
-						class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
-						type="button"
-						on:click={() => {
-							params.streaming_batch_size = (params?.streaming_batch_size ?? null) === null ? 1 : null;
-						}}
-					>
-						{#if (params?.streaming_batch_size ?? null) === null}
-							<span class="ml-2 self-center"> {$i18n.t('Default')} </span>
-						{:else}
-							<span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
-						{/if}
-					</button>
+	<div class=" py-0.5 w-full justify-between">
+		<Tooltip
+			content={$i18n.t(
+				'Sets the number of tokens to batch before emitting events while streaming. Higher values improve performance, but may lead to choppy streaming.'
+			)}
+			placement="top-start"
+			className="inline-tooltip"
+		>
+			<div class="flex w-full justify-between">
+				<div class=" self-center text-xs font-medium">
+					{$i18n.t('Streaming Batch Size')}
 				</div>
-			</Tooltip>
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
+					type="button"
+					on:click={() => {
+						params.streaming_batch_size = (params?.streaming_batch_size ?? null) === null ? 1 : null;
+					}}
+				>
+					{#if (params?.streaming_batch_size ?? null) === null}
+						<span class="ml-2 self-center"> {$i18n.t('Default')} </span>
+					{:else}
+						<span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
+					{/if}
+				</button>
+			</div>
+		</Tooltip>
 
-			{#if (params?.streaming_batch_size ?? null) !== null}
-				<div class="flex mt-0.5 space-x-2">
-					<div class=" flex-1">
-						<input
-							id="steps-range"
-							type="range"
-							min="1"
-							max="100"
-							step="1"
-							bind:value={params.streaming_batch_size}
-							class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
-						/>
-					</div>
-					<div>
-						<input
-							bind:value={params.streaming_batch_size}
-							type="number"
-							class=" bg-transparent text-center w-14"
-							min="1"
-							step="1"
-						/>
-					</div>
+		{#if (params?.streaming_batch_size ?? null) !== null}
+			<div class="flex mt-0.5 space-x-2">
+				<div class=" flex-1">
+					<input
+						id="steps-range"
+						type="range"
+						min="1"
+						max="100"
+						step="1"
+						bind:value={params.streaming_batch_size}
+						class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+					/>
 				</div>
-			{/if}
-		</div>
-	{/if}
+				<div>
+					<input
+						bind:value={params.streaming_batch_size}
+						type="number"
+						class=" bg-transparent text-center w-14"
+						min="1"
+						step="1"
+					/>
+				</div>
+			</div>
+		{/if}
+	</div>
 
 	<div>
 		<Tooltip

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -15,6 +15,7 @@
 	const defaultParams = {
 		// Advanced
 		stream_response: null, // Set stream responses for this model individually
+		streaming_batch_size: null,
 		function_calling: null,
 		seed: null,
 		stop: null,
@@ -87,6 +88,62 @@
 			</div>
 		</Tooltip>
 	</div>
+
+	{#if admin}
+		<div class=" py-0.5 w-full justify-between">
+			<Tooltip
+				content={$i18n.t(
+					'Sets the number of tokens to batch before emitting events while streaming. Higher values reduce CPU usage of server, client and Redis, but may lead to choppy streaming.'
+				)}
+				placement="top-start"
+				className="inline-tooltip"
+			>
+				<div class="flex w-full justify-between">
+					<div class=" self-center text-xs font-medium">
+						{$i18n.t('Streaming Batch Size')}
+					</div>
+					<button
+						class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
+						type="button"
+						on:click={() => {
+							params.streaming_batch_size = (params?.streaming_batch_size ?? null) === null ? 1 : null;
+						}}
+					>
+						{#if (params?.streaming_batch_size ?? null) === null}
+							<span class="ml-2 self-center"> {$i18n.t('Default')} </span>
+						{:else}
+							<span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
+						{/if}
+					</button>
+				</div>
+			</Tooltip>
+
+			{#if (params?.streaming_batch_size ?? null) !== null}
+				<div class="flex mt-0.5 space-x-2">
+					<div class=" flex-1">
+						<input
+							id="steps-range"
+							type="range"
+							min="1"
+							max="100"
+							step="1"
+							bind:value={params.streaming_batch_size}
+							class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+						/>
+					</div>
+					<div>
+						<input
+							bind:value={params.streaming_batch_size}
+							type="number"
+							class=" bg-transparent text-center w-14"
+							min="1"
+							step="1"
+						/>
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
 
 	<div>
 		<Tooltip

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -42,6 +42,7 @@
 	let params = {
 		// Advanced
 		stream_response: null,
+		streaming_batch_size: null,
 		function_calling: null,
 		seed: null,
 		temperature: null,
@@ -71,6 +72,7 @@
 			system: system !== '' ? system : undefined,
 			params: {
 				stream_response: params.stream_response !== null ? params.stream_response : undefined,
+				streaming_batch_size: params.streaming_batch_size !== null ? params.streaming_batch_size : undefined,
 				function_calling: params.function_calling !== null ? params.function_calling : undefined,
 				seed: (params.seed !== null ? params.seed : undefined) ?? undefined,
 				stop: params.stop ? params.stop.split(',').filter((e) => e) : undefined,


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Currently, streaming high token/s via Open WebUI leads to *very* high CPU usage on the server, the Redis and also the client. In the worst case, the pubsub messages aren't consumed fast enough back from Redis, leading to a quickly growing output buffer on the Redis server and ultimately a **terminated** Redis connection. It is possible to make your deployment **unusable** by streaming enough fast responses.

In the following part of the result of profiling using cProfile during streaming of a response:

```
>>> p.sort_stats(pstats.SortKey.CUMULATIVE).print_stats()
Tue Aug  5 22:24:25 2025   profiling_results.prof

         29276198 function calls (28451782 primitive calls) in 42.148 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   131723    0.307    0.000   21.347    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_server.py:129(emit)
   131723    0.294    0.000   20.924    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_pubsub_manager.py:40(emit)
   204781    0.316    0.000   11.431    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/retry.py:58(call_with_retry)
   125999    0.251    0.000   10.747    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_redis_manager.py:73(_publish)
    68688    0.317    0.000    9.869    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_pubsub_manager.py:138(_handle_emit)
   126004    0.477    0.000    9.838    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/client.py:667(execute_command)
    68688    0.589    0.000    9.485    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_manager.py:13(emit)
    15837    0.496    0.000    8.688    0.001 /usr/local/lib/python3.11/site-packages/socketio/async_pubsub_manager.py:197(_thread)
   204797    0.425    0.000    7.624    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/connection.py:567(read_response)
    78801    0.112    0.000    7.074    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_redis_manager.py:112(_listen)
   204797    0.360    0.000    7.046    0.000 /usr/local/lib/python3.11/site-packages/redis/_parsers/resp2.py:74(read_response)
    78798    0.084    0.000    6.961    0.000 /usr/local/lib/python3.11/site-packages/socketio/async_redis_manager.py:91(_redis_listen_with_retries)
    78801    0.202    0.000    6.877    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/client.py:1094(listen)
    11193    0.015    0.000    6.791    0.001 /app/backend/open_webui/utils/middleware.py:1407(response_handler)
    11184    0.281    0.000    6.701    0.001 /app/backend/open_webui/utils/middleware.py:1801(stream_body_handler)
395774/204797    1.047    0.000    6.540    0.000 /usr/local/lib/python3.11/site-packages/redis/_parsers/resp2.py:87(_read_response)
    78802    0.259    0.000    6.234    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/client.py:969(parse_response)
    62965    0.332    0.000    5.972    0.000 /usr/local/lib/python3.11/site-packages/socketio/packet.py:45(encode)
    78804    0.120    0.000    5.917    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/client.py:956(_execute)
    63030    0.257    0.000    5.659    0.000 /usr/local/lib/python3.11/json/__init__.py:183(dumps)
   125930    0.232    0.000    5.337    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/client.py:647(_send_command_parse_response)
    63030    0.214    0.000    5.308    0.000 /usr/local/lib/python3.11/json/encoder.py:183(encode)
    63030    5.052    0.000    5.052    0.000 /usr/local/lib/python3.11/json/encoder.py:205(iterencode)
    65045    0.194    0.000    3.970    0.000 /usr/local/lib/python3.11/site-packages/redis/_parsers/resp2.py:123(<listcomp>)
   391627    1.126    0.000    3.786    0.000 /usr/local/lib/python3.11/site-packages/redis/_parsers/base.py:273(_readline)
    11448    0.113    0.000    3.625    0.000 /app/backend/open_webui/socket/main.py:633(__event_emitter__)
    63051    0.249    0.000    2.742    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/connection.py:1131(get_connection)
     5731    0.061    0.000    2.742    0.000 /usr/local/lib/python3.11/site-packages/engineio/async_socket.py:198(writer)
    63012    0.175    0.000    2.630    0.000 /usr/local/lib/python3.11/site-packages/redis/asyncio/connection.py:552(send_command)
     5724    0.012    0.000    2.575    0.000 /app/backend/open_webui/socket/utils.py:74(get)
     5729    0.036    0.000    2.566    0.000 /app/backend/open_webui/socket/utils.py:48(__getitem__)
```

Obviously, most time is spent somehow related to SocketIO/Redis and streaming in the middleware.

One way to reduce the problem is introduced in this PR: The possibility to batch multiple tokens together before emission during streaming. This reduces proportionally to the batch size the number of events emitted, the number of pubsub messages and the amount of data processed by the client, improving performance in all components.

Because the optimal batch size for a still visually fluid streaming depends on the generated token/s of the given model, the setting is introduced as "Advanced parameter", configurable for each model individually, but also per user as setting or in chat controls. The **highest** value will take precedence, such that the admin maintains control of the minimal acceptable batch size. The default batch size remains at 1, i.e. no batching.

The fluidity of the streaming is maintained for considerable batch sizes, depending on generation speed, by the fluid streaming mechanism in the frontend code. The minimal threshold for it to apply is reduced from 5 to 3 deltas.

**As a result, just setting a batch size of 3 reduces CPU usage on the server by about 50%, with minimal loss in fluidity for decent token generation rates.**

### Added

- Delta batching for response streaming
- Configurable batch size per model, user, chat

### Changed

- Tweaked threshold for fluid streaming mechanism in frontend

### Screenshots or Videos


https://github.com/user-attachments/assets/842fcac2-8128-4384-ac1b-d38b4ccea084

https://github.com/user-attachments/assets/7a361676-922f-4642-9ab2-b59f8b6ff57d

<img width="1207" height="363" alt="Screenshot From 2025-08-06 14-52-55" src="https://github.com/user-attachments/assets/0cc69a50-5644-4cdd-bdba-587f3103e02d" />

### Additional notes

An argument could be made that the term "buffer" should be used instead of "batch", affecting the variable names used. Please let me know if you prefer to call it buffer.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
