### PR TITLE
FEAT: simplify OAuth signout to avoid forcing external provider logout

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -674,39 +674,7 @@ async def signout(request: Request, response: Response):
     if ENABLE_OAUTH_SIGNUP.value:
         oauth_id_token = request.cookies.get("oauth_id_token")
         if oauth_id_token:
-            try:
-                async with ClientSession(trust_env=True) as session:
-                    async with session.get(OPENID_PROVIDER_URL.value) as resp:
-                        if resp.status == 200:
-                            openid_data = await resp.json()
-                            logout_url = openid_data.get("end_session_endpoint")
-                            if logout_url:
-                                response.delete_cookie("oauth_id_token")
-
-                                return JSONResponse(
-                                    status_code=200,
-                                    content={
-                                        "status": True,
-                                        "redirect_url": f"{logout_url}?id_token_hint={oauth_id_token}"
-                                        + (
-                                            f"&post_logout_redirect_uri={WEBUI_AUTH_SIGNOUT_REDIRECT_URL}"
-                                            if WEBUI_AUTH_SIGNOUT_REDIRECT_URL
-                                            else ""
-                                        ),
-                                    },
-                                    headers=response.headers,
-                                )
-                        else:
-                            raise HTTPException(
-                                status_code=resp.status,
-                                detail="Failed to fetch OpenID configuration",
-                            )
-            except Exception as e:
-                log.error(f"OpenID signout error: {str(e)}")
-                raise HTTPException(
-                    status_code=500,
-                    detail="Failed to sign out from the OpenID provider.",
-                )
+            response.delete_cookie("oauth_id_token")
 
     if WEBUI_AUTH_SIGNOUT_REDIRECT_URL:
         return JSONResponse(


### PR DESCRIPTION
Improve user experience by removing forced external OAuth provider logout during signout

Remove OpenID provider logout redirect that forced users out of their external accounts
Keep local session cleanup (delete token, oui-session, and oauth_id_token cookies)
Preserve existing WEBUI_AUTH_SIGNOUT_REDIRECT_URL redirect functionality
Eliminate unnecessary HTTP requests to external OAuth providers during signout
Allow users to quickly re-authenticate without re-entering provider credentials
This change provides a more user-friendly signout experience by only logging users out of the application while maintaining their external OAuth sessions for seamless re-authentication.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Simplified OAuth signout process to improve user experience by removing forced external provider logout while maintaining local session cleanup and redirect functionality

### Added

N/A

### Changed

Modified signout endpoint to only clear local application cookies (token, oui-session, oauth_id_token) without redirecting to external OAuth provider logout endpoints
Streamlined signout flow to reduce unnecessary HTTP requests to external providers
Maintained existing WEBUI_AUTH_SIGNOUT_REDIRECT_URL redirect functionality for custom post-signout redirects

### Deprecated

N/A

### Removed

Removed OpenID Connect end_session_endpoint redirect logic that forced users to log out of their external OAuth accounts
Removed complex error handling for external OAuth provider communication during signout
Removed aiohttp ClientSession usage and OpenID provider configuration fetching during signout

### Fixed

Fixed user experience issue where signing out of the application would also force logout from external OAuth accounts
Fixed unnecessary network requests to external OAuth providers during application signout

### Security

Maintained proper local session cleanup by ensuring all authentication cookies are properly deleted
Preserved security by clearing oauth_id_token to prevent token reuse

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

N/A

### Additional Information

This change affects all OAuth/OpenID Connect providers configured in the system
Users will now have a smoother experience when signing out and back in, as they won't need to re-authenticate with their external provider unless their external session has expired
The change reduces network latency during signout by eliminating external API calls
Local application security is maintained through proper cookie cleanup

### Screenshots or Videos

N/A (Backend authentication flow change)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
