### PR TITLE
fix: include items property in OpenAPI array parameters for OpenAI function calling

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -399,10 +399,16 @@ def convert_openapi_to_tool_payload(openapi_spec):
                         description += (
                             f". Possible values: {', '.join(param_schema.get('enum'))}"
                         )
-                    tool["parameters"]["properties"][param_name] = {
+                    param_property = {
                         "type": param_schema.get("type"),
                         "description": description,
                     }
+                    
+                    # Include items property for array types (required by OpenAI)
+                    if param_schema.get("type") == "array" and "items" in param_schema:
+                        param_property["items"] = param_schema["items"]
+                    
+                    tool["parameters"]["properties"][param_name] = param_property
                     if param.get("required"):
                         tool["parameters"]["required"].append(param_name)
 


### PR DESCRIPTION
## Summary

  Fixes OpenAPI array parameter conversion for OpenAI function calling by ensuring the 'items' property is
  included in generated function schemas.

  ## Problem
  - OpenAPI specs with array query parameters were generating invalid OpenAI function schemas
  - Missing 'items' property caused OpenAI to return 400 Bad Request: 'array schema missing items'
  - Issue affected tool servers using array parameters like tags filtering

  ## Solution
  - Modified `convert_openapi_to_tool_payload()` in `backend/open_webui/utils/tools.py`
  - Added logic to copy 'items' property for array-type parameters
  - Ensures generated schemas are valid for OpenAI function calling

  ## Test Plan
  - [x] Tested with exact example from issue #14115
  - [x] Verified generated schema now includes required 'items' property
  - [x] Syntax validation passed

  Fixes #14115
