### PR TITLE
fix: failure to bind metadata variable on insert for PGVECTOR_PGCRYPTO feature returning syntax error

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -203,6 +203,8 @@ class PgvectorClient(VectorDBBase):
                 for item in items:
                     vector = self.adjust_vector_length(item["vector"])
                     # Use raw SQL for BYTEA/pgcrypto
+                    # Ensure metadata is converted to its JSON text representation
+                    json_metadata = json.dumps(item["metadata"])
                     self.session.execute(
                         text(
                             """
@@ -211,7 +213,7 @@ class PgvectorClient(VectorDBBase):
                             VALUES (
                                 :id, :vector, :collection_name,
                                 pgp_sym_encrypt(:text, :key),
-                                pgp_sym_encrypt(:metadata::text, :key)
+                                pgp_sym_encrypt(:metadata_text, :key)
                             )
                             ON CONFLICT (id) DO NOTHING
                         """
@@ -221,7 +223,7 @@ class PgvectorClient(VectorDBBase):
                             "vector": vector,
                             "collection_name": collection_name,
                             "text": item["text"],
-                            "metadata": json.dumps(item["metadata"]),
+                            "metadata_text": json_metadata,
                             "key": PGVECTOR_PGCRYPTO_KEY,
                         },
                     )
@@ -255,6 +257,7 @@ class PgvectorClient(VectorDBBase):
             if PGVECTOR_PGCRYPTO:
                 for item in items:
                     vector = self.adjust_vector_length(item["vector"])
+                    json_metadata = json.dumps(item["metadata"])
                     self.session.execute(
                         text(
                             """
@@ -263,7 +266,7 @@ class PgvectorClient(VectorDBBase):
                             VALUES (
                                 :id, :vector, :collection_name,
                                 pgp_sym_encrypt(:text, :key),
-                                pgp_sym_encrypt(:metadata::text, :key)
+                                pgp_sym_encrypt(:metadata_text, :key)
                             )
                             ON CONFLICT (id) DO UPDATE SET
                               vector = EXCLUDED.vector,
@@ -277,7 +280,7 @@ class PgvectorClient(VectorDBBase):
                             "vector": vector,
                             "collection_name": collection_name,
                             "text": item["text"],
-                            "metadata": json.dumps(item["metadata"]),
+                            "metadata_text": json_metadata,
                             "key": PGVECTOR_PGCRYPTO_KEY,
                         },
                     )


### PR DESCRIPTION
with CLA this time

In testing of the experimental PGVECTOR_PGCRYPTO feature we found that it failed to process/upload any documents due to a syntax error raised from failure to bind the metadata variable in the form "pgp_sym_encrypt(:metadata::text, :key)" this proposed fix (potentially just removing ::text might also work) explicitly serialises the json as a text variable and ensures that sqlalchemy correctly treats it as text and binds it correctly. Tested in Openwebui version v0.6.18 using Postgres 17.4

3 changes were made to the insert / upsert functions:

Added json_metadata = json.dumps(item["metadata"]) as seperate line
updated reference where this field is passed into sqlalchemy to "metadata_text": json_metadata,
and updated the pgp_sym_encrypt(:metadata_text, :key) line accordingly in the insert and upsert functions
We have then validated upload was successful for the document_chunk table with text, vmetadata fields defined as bytea fields and validated document retrieval and image summary of pdf works as expected using docling and the image summary api functionality.

Fixed
Corrected PGVECTOR_PGCRYPTO implementation to remove syntax error relating to metadata field

Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreements (CLA)](https://github.com/CONTRIBUTOR_LICENSE_AGREEMENT) and [Open WebUI specific Contributor License Agreements](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.