### PR TITLE
fix: Prevent idle transactions with PGvector DB

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -421,10 +421,12 @@ class PgvectorClient(VectorDBBase):
                 documents[qid].append(row.text)
                 metadatas[qid].append(row.vmetadata)
 
+            self.session.rollback() # read-only transaction
             return SearchResult(
                 ids=ids, distances=distances, documents=documents, metadatas=metadatas
             )
         except Exception as e:
+            self.session.rollback()
             log.exception(f"Error during search: {e}")
             return None
 
@@ -477,12 +479,14 @@ class PgvectorClient(VectorDBBase):
             documents = [[result.text for result in results]]
             metadatas = [[result.vmetadata for result in results]]
 
+            self.session.rollback() # read-only transaction
             return GetResult(
                 ids=ids,
                 documents=documents,
                 metadatas=metadatas,
             )
         except Exception as e:
+            self.session.rollback()
             log.exception(f"Error during query: {e}")
             return None
 
@@ -523,8 +527,10 @@ class PgvectorClient(VectorDBBase):
                 documents = [[result.text for result in results]]
                 metadatas = [[result.vmetadata for result in results]]
 
+            self.session.rollback() # read-only transaction
             return GetResult(ids=ids, documents=documents, metadatas=metadatas)
         except Exception as e:
+            self.session.rollback()
             log.exception(f"Error during get: {e}")
             return None
 
@@ -592,8 +598,10 @@ class PgvectorClient(VectorDBBase):
                 .first()
                 is not None
             )
+            self.session.rollback() # read-only transaction
             return exists
         except Exception as e:
+            self.session.rollback()
             log.exception(f"Error checking collection existence: {e}")
             return False
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

The current implementation of PgvectorClient doesn't call commit() at the end of read-only methods (which of course seems intuitively correct), leaving `idle in transaction` transactions. The pg_stat-activity would look like so:

```
openwebui=# SELECT 
    pid, 
    usename, 
    application_name, 
    client_addr, 
    query_start, 
    state 
FROM 
    pg_stat_activity 
WHERE  
    query NOT LIKE '%pg_stat_activity%'
ORDER BY 
    query_start ASC;
  pid   |  usename   | application_name | client_addr |          query_start          |        state        
--------+------------+------------------+-------------+-------------------------------+---------------------
....
 329961 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:31:07.244193+02 | idle
 329954 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:32:59.133255+02 | idle in transaction
 329960 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:33:44.001915+02 | idle
 329551 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.736138+02 | idle
 329510 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.742168+02 | idle
 329405 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.904287+02 | idle
 329401 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.910246+02 | idle
 329503 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.942612+02 | idle
 329482 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.9471+02   | idle
 329523 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:38.951378+02 | idle
 329546 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:39.002317+02 | idle
 329572 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:39.008305+02 | idle
 329702 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:39.292772+02 | idle
 332930 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:39.378427+02 | idle in transaction
 332935 | openwebui  |                  | 1.2.3.4 | 2025-08-09 19:34:57.216976+02 | idle in transaction
....
 ```

Now, setting the parameter `idle_in_transaction_session_timeout` on the database, which would be best practice, would close these session, producing error messages at the minimum.

More concerning though, in certain scenarios you would find the following error:

`ERROR    | open_webui.retrieval.vector.dbs.pgvector:search:423 - Error during search: Can't reconnect until invalid transaction is rolled back.  Please rollback() fully before proceeding (Background on this error at: https://sqlalche.me/e/20/8s2b) - {}`

The present PR fixes both of these issues by explicitly "rolling back" the read-only transactions to close them, which appears to be the safest choice (without changing the whole implementation). Since the methods are meant to be read-only, there should be nothing to `rollback`. Of course there should be nothing to `commit` as well, but rolling back still appears the most robust choice. 

Tested and indeed prevents any idle in transaction without any issue.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
