### PR TITLE
fix: Handle JSONResponse objects in middleware to prevent TypeError

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1254,7 +1254,7 @@ async def process_chat_response(
     # Non-streaming response
     if not isinstance(response, StreamingResponse):
         if event_emitter:
-            if "error" in response:
+            if isinstance(response, dict) and "error" in response:
                 error = response["error"].get("detail", response["error"])
                 Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata["chat_id"],
@@ -1264,7 +1264,7 @@ async def process_chat_response(
                     },
                 )
 
-            if "selected_model_id" in response:
+            if isinstance(response, dict) and "selected_model_id" in response:
                 Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata["chat_id"],
                     metadata["message_id"],
@@ -1273,7 +1273,7 @@ async def process_chat_response(
                     },
                 )
 
-            choices = response.get("choices", [])
+            choices = response.get("choices", []) if isinstance(response, dict) else []
             if choices and choices[0].get("message", {}).get("content"):
                 content = response["choices"][0]["message"]["content"]
 


### PR DESCRIPTION
Fixes #16452

## Problem
The middleware was attempting to use the 'in' operator and .get() method directly on JSONResponse objects, causing TypeErrors when the API returned error responses.

## Solution
Added isinstance(response, dict) checks before using 'in' operator and calling .get() method to ensure operations are only performed on dictionary objects.

## Changes
- Modified process_chat_response() function in backend/open_webui/utils/middleware.py
- Added defensive programming to handle both dict and JSONResponse objects

## Testing
- Tested with OpenAI API error responses
- Confirmed proper error handling without system crashes
- Verified normal operation with successful responses