### PR TITLE
fix: improve model sorting by handling missing names

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1317,7 +1317,10 @@ async def get_models(
         model_order_dict = {model_id: i for i, model_id in enumerate(model_order_list)}
         # Sort models by order list priority, with fallback for those not in the list
         models.sort(
-            key=lambda x: (model_order_dict.get(x["id"], float("inf")), x["name"])
+            key=lambda x: (
+                model_order_dict.get(x.get("id"), float("inf")),
+                (x.get("name") or "").lower()
+            )
         )
 
     # Filter out models that the user does not have access to


### PR DESCRIPTION


* [x] **Target branch:** Verified that this pull request targets the `dev` branch.
* [x] **Description:** Provided a concise description of the changes made in this pull request.
* [x] **Changelog:** Added a changelog entry in Keep a Changelog format at the bottom of this PR description.
* [ ] **Documentation:** No documentation changes needed — behavior remains the same for users.
* [x] **Dependencies:** No new dependencies introduced.
* [x] **Testing:** Manually tested to confirm `/api/models` endpoint no longer fails when a model has no `name`.
* [x] **Code review:** Performed a self-review for coding standards and project style.
* [x] **Prefix:** `fix: Prevent /api/models from failing when models have missing names`

---

# Changelog Entry

### Description

* Fixes a bug in `/api/models` where the server returned a 500 error if any model in the list was missing a `name` field (or had it set to `null`).
* Implemented a safe sort key that falls back to an empty string for missing names, preventing `TypeError` comparisons between `None` and `str`.

### Added

* None

### Changed

* Updated sort key in `get_models()` to use `.get()` with a fallback when sorting by model name.

### Deprecated

* None

### Removed

* None

### Fixed

* **Fix:** Resolved `TypeError: '<' not supported between instances of 'NoneType' and 'str'` when sorting models in `/api/models`.

### Security

* No security changes.

### Breaking Changes

* None

---

### Additional Information

* This bug surfaced when a configured provider (e.g., OpenAI, Ollama) returned model entries with a missing or null `name` field.
* Instead of failing the entire endpoint, the fix ensures such entries are still included and safely sorted.
* Related logs:

  ```
  TypeError: '<' not supported between instances of 'NoneType' and 'str'
  ```

### Screenshots or Videos

*Not applicable – API behavior fix.*
