### PR TITLE
fix: Add support for Azure US Government cloud endpoints

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -35,7 +35,7 @@
 	let connectionType = 'external';
 	let azure = false;
 	$: azure =
-		(url.includes('azure.') || url.includes('cognitive.microsoft.com')) && !direct ? true : false;
+		(url.includes('azure.') || url.includes('cognitive.microsoft.com') || url.includes('azure.us')) && !direct ? true : false;
 
 	let prefixId = '';
 	let enable = true;


### PR DESCRIPTION
# Pull Request Checklist
### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources? No update neede as this is a fix
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? - No New Dependencies
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry
### Description
- Fixed Azure URL detection to include Azure US Government cloud endpoints (*.azure.us domains), enabling automatic Azure mode detection for government cloud deployments

### Added
- 

### Changed
- Updated Azure detection logic in AddConnectionModal.svelte to include azure.us alongside existing azure.com and cognitive.microsoft.com patterns

### Deprecated
- 

### Removed
- 

### Fixed
- Azure URL validation now properly recognizes Azure US Government cloud endpoints (*.azure.us)

### Security
- 

### Breaking Changes
- 

---
### Additional Information
- Azure US Government cloud uses *.azure.us domains instead of standard *.azure.com domains
- Without this fix, users had to manually configure Azure settings even when using valid Azure Government endpoints
- This change ensures the UI automatically switches to Azure mode for both commercial and government Azure clouds

### Screenshots or Videos
- 

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
