### PR TITLE
fix: disabled overscroll for iOS frontend

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -167,6 +167,7 @@
 <style type="text/css" nonce="">
 	html {
 		overflow-y: hidden !important;
+		overscroll-behavior-y: none;
 	}
 
 	#splash-screen {


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed overscroll issue on Apple mobile devices. Now PWA feels more like app, less like website.

### Fixed

- disabled overscroll which appeared on iOS devices

---

### Additional Information

- Discussion: https://github.com/open-webui/open-webui/discussions/16649
- Tested manually by scrolling different views on iOS Safari, iOS Orion, macOS Orion, Android Chrome

### Screenshots or Videos

- [before](https://github.com/user-attachments/assets/7c09507d-8b9f-4c6c-a01f-9a042ef90e88) – scrolling over `fixed` or `sticky` elements made whole page scroll
- [after](https://github.com/user-attachments/assets/0ac348b0-c965-4fbf-9b66-b6df5fc155d0) – scrolling over fixed elements doesn't make whole page scroll

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
