### PR TITLE
Fixed crash on incorrect models endpoint issue

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -362,7 +362,7 @@ async def get_all_models_responses(request: Request, user: UserModel) -> list:
             tags = api_config.get("tags", [])
 
             for model in (
-                response if isinstance(response, list) else response.get("data", [])
+                response if isinstance(response, list) else (response.get("data") or [] if isinstance(response, dict) else [])
             ):
                 if prefix_id:
                     model["id"] = (


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed crash when an incorrect external endpoint is configured (or endpoint is down) when listing models

### Fixed

- Closes #16663 Incorrect external endpoint setting causes openwebui to hang without displaying settings panel

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
