### PR TITLE
Fix- Missed deps in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"@tiptap/extensions": "^3.0.7",
 		"@tiptap/pm": "^3.0.7",
 		"@tiptap/starter-kit": "^3.0.7",
+		"@tiptap/suggestion": "^3.0.9",
 		"@xyflow/svelte": "^0.1.19",
 		"async": "^3.2.5",
 		"bits-ui": "^0.21.15",
@@ -137,6 +138,7 @@
 		"uuid": "^9.0.1",
 		"vite-plugin-static-copy": "^2.2.0",
 		"y-prosemirror": "^1.3.7",
+		"y-protocols":"^1.0.6",
 		"yaml": "^2.7.1",
 		"yjs": "^13.6.27"
 	},


### PR DESCRIPTION
Fix for errors when building due to a missed dependency and module.

Added missed dependency:  "@tiptap/suggestion": "^3.0.9",
and module: "y-protocols":"^1.0.6",



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
