### PR TITLE
fix: don't prematurely close regular reasoning blocks after tool calls

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2033,8 +2033,10 @@ async def process_chat_response(
                                         }
 
                                     if value:
+                                        # close reasoning block if tool call inside reasoning
                                         if (
-                                            content_blocks
+                                            delta_tool_calls
+                                            and content_blocks
                                             and content_blocks[-1]["type"]
                                             == "reasoning"
                                             and content_blocks[-1]


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description


[2e36540023a3baf4a323d9b9a401a1689b8da012 ](https://github.com/open-webui/open-webui/commit/2e36540023a3baf4a323d9b9a401a1689b8da012) introduced handling of tool calls inside reasoning blocks (fixing https://github.com/open-webui/open-webui/issues/16305 ), by prematurely closing reasoning blocks. However, the mechanism would also apply when subsequent reasoning blocks would follow regular tool calls (i.e. outside reasoning blocks), effectively leaving only the first token of the reasoning block inside the reasoning block and rendering the rest as regular text.

Example:
<img width="946" height="401" alt="Screenshot From 2025-08-17 16-06-50" src="https://github.com/user-attachments/assets/00c04f48-555e-4256-977e-b5d4066e085a" />
... more reasoning content would follow including the final `</think>` tag, all rendered as regular text.

The present PR makes sure the premature closure is only activated when there is delta_tool_call.

**IMPORTANT**: I have NO way to test if https://github.com/open-webui/open-webui/issues/16305 remains fixed! **Please verify**. What I *can* confirm is that the issue shown in the screenshot is fixed.

### Fixed

- Processing of reasoning blocks after tool calls

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
