### PR TITLE
UPD: "duckduckgo" MetaSearch - set concurrent requests

### DIFF
--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -5,6 +5,7 @@ from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from ddgs import DDGS
 from ddgs.exceptions import RatelimitException
 from open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import WEB_SEARCH_CONCURRENT_REQUESTS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
@@ -26,6 +27,7 @@ def search_duckduckgo(
     search_results = []
     with DDGS() as ddgs:
         # Use the ddgs.text() method to perform the search
+        ddgs.threads=WEB_SEARCH_CONCURRENT_REQUESTS
         try:
             search_results = ddgs.text(
                 query, safesearch="moderate", max_results=count, backend="lite"


### PR DESCRIPTION
## **UPDATE** for Distributed Global Search MetaSearch (DuckDuckGo)
- Fix https://github.com/open-webui/open-webui/issues/16630

- Forward the [WEB_SEARCH_CONCURRENT_REQUEST configuration variable](https://github.com/rgaricano/open-webui/blob/main/backend/open_webui/config.py#L2601) to the ddgs search requests function and assign this variable to the [ddgs.theads parameter](https://github.com/deedy5/ddgs/blob/main/ddgs/ddgs.py#L34).

### Aclarations

_About WEB_SEARCH_CONCURRENT_REQUEST env var:_
This variable is treated internally as requests_per_second and is used to calculate parallel requests, threads, or times in some methods/search engines.
The library works in parallel, adjusting concurrent requests based on `max_results`.
Here, it is assigned as its name suggests: number of concurrent/parallel searches (theads). 

_About name:_
Clarification on the name, as there are some issues and ongoing discussions about this "confusion."
The library we're using, **ddgs** (duckduckgo_search v0.0.3), started as a simple call to a default DuckDuckGo URL, but over the years, categorized search functions, greater parameterization, and more search engines have been added. **It's now a metasearch engine** (ddgs v9.5.4).
In recent versions of Open-WebUI, it has been updated, but without using the new features or limiting the search options, and with the default options, which results in it generating searches in several search engines, not just DuckDuckGo.

This isn't a bad or negative thing; it's another option and a good alternative to use as the default metasearch engine, but it needs work to take advantage of the features and add valves/configuration panel.

But it would be advisable to change the name or configurate it for use only duckduckgo search to avoid confusion.

_About Engines:_
(Right now, Open-WebUI only use text(query, safesearch="moderate", max_results=count, backend="lite") function for searches)
| DDGS function | Available backends |
| --------------|:-------------------|
| **text()**        | `bing`, `brave`, `duckduckgo`, `google`, `mojeek`, `mullvad_brave`, `mullvad_google`, `yandex`, `yahoo`, `wikipedia`|
| images()      | `duckduckgo` |
| videos()      | `duckduckgo` |
| news()        | `duckduckgo`, `yahoo` |
| books()       | `annasarchive` |

For Reference: [DDGS library](https://github.com/deedy5/ddgs)

---
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
