### PR TITLE
fix: Fixing exception with missing None check in access_control.py

### DIFF
--- a/backend/open_webui/utils/access_control.py
+++ b/backend/open_webui/utils/access_control.py
@@ -96,7 +96,7 @@ def has_permission(
     user_groups = Groups.get_groups_by_member_id(user_id)
 
     for group in user_groups:
-        group_permissions = group.permissions
+        group_permissions = group.permissions or {}
         if get_permission(group_permissions, permission_hierarchy):
             return True
 


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed an exception that occurs when no groups have permission objects.

### Fixed

- Missing None check regarding group permissions

---

### Additional Information

This was the exception:
```
File "/home/webui/.local/lib/python3.11/site-packages/open_webui/routers/knowledge.py", line 145, in create_new_knowledge       
  if user.role != "admin" and not has_permission(
                                  ^^^^^^^^^^^^^^^
File "/home/webui/.local/lib/python3.11/site-packages/open_webui/utils/access_control.py", line 100, in has_permission
  if get_permission(group_permissions, permission_hierarchy):
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/webui/.local/lib/python3.11/site-packages/open_webui/utils/access_control.py", line 87, in get_permission
  if key not in permissions:
     ^^^^^^^^^^^^^^^^^^^^^^
```

The root cause was that sometimes groups don't have permissions, causing get_permissions() to fail.
The fix is to use the same pattern as combine_permissions() within the same file.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
