### PR TITLE
UPD: Enable ExceptionGroup catching in tasks.py & handler in main.py

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -578,17 +578,19 @@ async def lifespan(app: FastAPI):
 
     yield
 
-# In the lifespan shutdown  
-    if hasattr(app.state, "redis_task_command_listener"):  
-        try:  
-            app.state.redis_task_command_listener.cancel()  
-            await app.state.redis_task_command_listener  
-        except ExceptionGroup as eg:  
-            log.error(f"Multiple errors during listener shutdown: {len(eg.exceptions)} exceptions")  
-            for exc in eg.exceptions:  
-                log.error(f"Shutdown error: {type(exc).__name__}: {exc}")  
-        except asyncio.CancelledError:  
-            pass  # Expected during shutdown  
+    # In the lifespan shutdown
+    if hasattr(app.state, "redis_task_command_listener"):
+        try:
+            app.state.redis_task_command_listener.cancel()
+            await app.state.redis_task_command_listener
+        except ExceptionGroup as eg:
+            log.error(
+                f"Multiple errors during listener shutdown: {len(eg.exceptions)} exceptions"
+            )
+            for exc in eg.exceptions:
+                log.error(f"Shutdown error: {type(exc).__name__}: {exc}")
+        except asyncio.CancelledError:
+            pass  # Expected during shutdown
         except Exception as e:  
             log.error(f"Error during listener shutdown: {e}")
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -591,7 +591,7 @@ async def lifespan(app: FastAPI):
                 log.error(f"Shutdown error: {type(exc).__name__}: {exc}")
         except asyncio.CancelledError:
             pass  # Expected during shutdown
-        except Exception as e:  
+        except Exception as e:
             log.error(f"Error during listener shutdown: {e}")
 
 

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -43,7 +43,9 @@ async def redis_task_command_listener(app):
             try:
                 command = json.loads(message["data"])
             except json.JSONDecodeError as json_error:
-                log.warning(f"Invalid JSON in Redis message: {message['data'][:100]}... Error: {json_error}")
+                log.warning(
+                    f"Invalid JSON in Redis message: {message['data'][:100]}... Error: {json_error}"
+                )
                 continue
 
             if command.get("action") == "stop":
@@ -58,7 +60,9 @@ async def redis_task_command_listener(app):
                         log.error(f"Error cancelling task {task_id}: {cancel_error}")
         except ExceptionGroup as eg:
             # Handle multiple concurrent exceptions
-            log.error(f"Multiple errors in task command processing: {len(eg.exceptions)} exceptions")
+            log.error(
+                f"Multiple errors in task command processing: {len(eg.exceptions)} exceptions"
+            )
             for i, exc in enumerate(eg.exceptions):
                 log.error(f"  Exception {i+1}: {type(exc).__name__}: {exc}")
         except Exception as e:
@@ -127,7 +131,9 @@ async def cleanup_task(redis, task_id: str, id=None):
 
     # If multiple errors occurred, group them
     if len(cleanup_errors) > 1 and ExceptionGroup:
-        raise ExceptionGroup(f"Multiple cleanup errors for task {task_id}", cleanup_errors)
+        raise ExceptionGroup(
+            f"Multiple cleanup errors for task {task_id}", cleanup_errors
+        )
     elif cleanup_errors:
         raise cleanup_errors[0]
 

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -106,7 +106,7 @@ async def redis_send_command(redis: Redis, command: dict):
 
 async def cleanup_task(redis, task_id: str, id=None):
     """
-    Remove a completed or canceled task with proper exception handling.
+    Remove a completed or canceled task from the global `tasks` dictionary with proper exception handling.
     """
     cleanup_errors = []
 


### PR DESCRIPTION
Implementation of ExceptionGroup catching as commented in https://github.com/open-webui/open-webui/discussions/16732#discussioncomment-14155085

In some scenarios with concurrent tasks, for example when uploading files (e.g. issue https://github.com/open-webui/open-webui/discussions/16964), multiple tasks may fail simultaneously, resulting in "ExceptionGroup: Unhandled errors in a TaskGroup." errors.

To solve this it's necessary manage this faults as ExceptionGroup, and that is what this implementation does.

As also arised errors `ERROR | open_webui.tasks:redis_task_command_listener:55 - Error handling distributed task command: Expecting value: line 1 column 1 (char 0)` due to a Redis pub/sub message contains empty or invalid JSON data,  a check for this situation is implemented.

This errors are "dificult" to reproduce/verify, for this reason I also tested with a python script  that generate failed concurrent tasks: [test_exceptiongroup.py](https://github.com/user-attachments/files/21860833/test_exceptiongroup.py) (place&execute in backend dir)

I tested in diferent ways, uploading multiples files, running the script some times between other tasks,...
Now only appear a ` | WARNING  | open_webui.tasks:redis_task_command_listener:46 - Invalid JSON in Redis message: invalid_json... Error: Expecting value: line 1 column 1 (char 0)`

Changes:

in tasks.py
Added caching for multiple concurrent exceptions.
Modified:
- async def redis_task_command_listener
- async def cleanup_task

in main.py
Added caching for concurrent exceptions handler.
Modified:
- redis_task_command_listener

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

Regards
Ricardo