### PR TITLE
feat/fix: Use ENABLE_ADMIN_CHAT_ACCESS as a default for ENABLE_ADMIN_EXPORT

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1349,14 +1349,18 @@ WEBHOOK_URL = PersistentConfig(
     "WEBHOOK_URL", "webhook_url", os.environ.get("WEBHOOK_URL", "")
 )
 
-ENABLE_ADMIN_EXPORT = os.environ.get("ENABLE_ADMIN_EXPORT", "True").lower() == "true"
-
 ENABLE_ADMIN_WORKSPACE_CONTENT_ACCESS = (
     os.environ.get("ENABLE_ADMIN_WORKSPACE_CONTENT_ACCESS", "True").lower() == "true"
 )
 
 ENABLE_ADMIN_CHAT_ACCESS = (
     os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "True").lower() == "true"
+)
+
+ENABLE_ADMIN_EXPORT = (
+    os.environ.get("ENABLE_ADMIN_EXPORT",
+        os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "True")
+    ).lower() == "true"
 )
 
 ENABLE_COMMUNITY_SHARING = PersistentConfig(


### PR DESCRIPTION
This still retains the ability to manually configure ENABLE_ADMIN_EXPORT, but defaults its value to the value of ENABLE_ADMIN_CHAT_ACCESS if set, as the export contains the chats.

This is a followup to the discussion in #16625 where I found it highly unintuitive that disabling admin chat access, still retains his ability to regain that access by exporting all chats.

Looking at the code, there are examples like

```python
if PGVECTOR_PGCRYPTO and not PGVECTOR_PGCRYPTO_KEY:
    raise ValueError(
        "PGVECTOR_PGCRYPTO is enabled but PGVECTOR_PGCRYPTO_KEY is not set. Please provide a valid key."
    )
```

and

```python
if OLLAMA_BASE_URL == "" and OLLAMA_API_BASE_URL != "":
    OLLAMA_BASE_URL = (
        OLLAMA_API_BASE_URL[:-4]
        if OLLAMA_API_BASE_URL.endswith("/api")
        else OLLAMA_API_BASE_URL
    )
```

So dependant environment variables are not a new thing, which is why I hope you can accept this pull request.

# TODO

- [ ] [update Documentation](https://docs.openwebui.com/getting-started/env-configuration/#enable_admin_export) once we know this pull request has a chance to get merged

# Changelog Entry

### Description

- The environment variable `ENABLE_ADMIN_EXPORT`, now defaults to the value of `ENABLE_ADMIN_CHAT_ACCESS`, as the export contains the chats of all users.

### Changed

- If you have set `ENABLE_ADMIN_CHAT_ACCESS` to `false` but have not set `ENABLE_ADMIN_EXPORT`, it will now also be set to false and the respective controls in the admin interface will be hidden.

### Security

- This might fix a security violation where you wanted your admins to not be able to read user chats, but they still where able to via the export.

---

### Additional Information

- This was first reported by @dwt in #16625

### Screenshots or Videos

- 
<img width="1492" height="534" alt="image" src="https://github.com/user-attachments/assets/ca703263-3020-46bd-8731-520dd13fc7c5" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
