### PR TITLE
fix: add GPT-5 support to Azure OpenAI SDK parameter handling

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -709,7 +709,7 @@ def convert_to_azure_payload(url, payload: dict, api_version: str):
     allowed_params = get_azure_allowed_params(api_version)
 
     # Special handling for o-series models
-    if model.startswith("o") and model.endswith("-mini"):
+    if (model.startswith("o") and model.endswith("-mini")) or model.startswith("gpt-5"):
         # Convert max_tokens to max_completion_tokens for o-series models
         if "max_tokens" in payload:
             payload["max_completion_tokens"] = payload["max_tokens"]


### PR DESCRIPTION
Description:
  ## Summary
  - Ensure proper parameter mapping for GPT-5 models alongside existing
  o-series models

  ## Changes Made
  - Updated `convert_to_azure_payload` function in
  `backend/open_webui/routers/openai.py`
  - Extended condition to include GPT-5 models when converting `max_tokens` to
  `max_completion_tokens`

  ## Background
  GPT-5 models, like o-series models, require the `max_completion_tokens`
  parameter instead of `max_tokens` when using the Azure OpenAI API. This
  change ensures consistent behavior across both model families.