### PR TITLE
notes: prevent title caret jump by ignoring socket title updates while input focused

### DIFF
--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -827,7 +827,8 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 			note.data.files = files;
 		}
 
-		if (_note.title && _note.title) {
+		// Avoid overwriting the local title while the user is actively editing it
+		if (_note.title !== undefined && !titleInputFocused && _note.title !== note.title) {
 			note.title = _note.title;
 		}
 


### PR DESCRIPTION
Problem
When editing a note title, characters could be deleted and the cursor would jump unexpectedly. This happened because real-time “note-events” (socket) updates were overwriting the local input value while the user was actively typing, resetting the input and caret.

Fix
In src/lib/components/notes/NoteEditor.svelte, guard applying server-driven title updates while the title input is focused:
•  Only update note.title from socket if the input is not focused and the incoming title differs.

Why this helps
This avoids mid-typing overwrites that caused the caret to move and occasional character loss while preserving real-time updates when the user isn’t editing.