### PR TITLE
Fix - Restore Claude Code Router compatibility ('list' object has no attribute 'replace')

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -450,6 +450,7 @@ from open_webui.utils.chat import (
 )
 from open_webui.utils.embeddings import generate_embeddings
 from open_webui.utils.middleware import process_chat_payload, process_chat_response
+from open_webui.utils.payload import normalize_chat_payload
 from open_webui.utils.access_control import has_access
 
 from open_webui.utils.auth import (
@@ -1400,6 +1401,13 @@ async def chat_completion(
 ):
     if not request.app.state.MODELS:
         await get_all_models(request, user=user)
+
+    form_data, has_non_text = normalize_chat_payload(form_data)
+    if has_non_text:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="message.content contains non text parts for example images not supported by this endpoint. Send text only content or use a multimodal capable route.",
+        )
 
     model_id = form_data.get("model", None)
     model_item = form_data.pop("model_item", {})


### PR DESCRIPTION
Background / Problem:

Since Open WebUI v0.6.23, the OpenAI-compatible chat endpoints began assuming message.content and system are strings during preprocessing.

Claude Code Router (CCR) (and other Anthropic-style clients) legitimately send arrays of parts for messages[i].content (and sometimes system), e.g.:

 {"role":"user","content":[{"type":"text","text":"Say OK"}]}

Open Web UI v0.6.22 tolerated this; v0.6.23 crashes with:

 {"detail":"'list' object has no attribute 'replace'"}

because string ops (e.g., .replace, .strip) are applied to a list.

Goal: Make /api/chat/completions and /api/v1/chat/completions robust to string or array content for:

    messages[i].content
    top-level system (when provided)
    messages[i].role == "system" messages

This is achieved by normalizing chat payload content.

Open web ui v0.6.23 example (the regression which breaks claude code router usage):

igorhvr:open-webui/ $ curl -s -X POST http://localhost:8000/api/v1/chat/completions \
 -H "Authorization: Bearer sk-ELIDED" -H "Content-Type: application/json" \
 -d '{"model":"ollama.gemma3:27b","messages":[
       {"role":"system","content":[{"type":"text","text":"You are helpful."}]},
       {"role":"user","content":[{"type":"text","text":"Say OK"}]}
     ]}'

{"detail":"'list' object has no attribute 'replace'"}%

Open web ui v0.6.22 example:
igorhvr:open-webui/ $ curl -s -X POST http://localhost:3000/api/v1/chat/completions \
 -H "Authorization: Bearer sk-ELIDED" -H "Content-Type: application/json" \
 -d '{"model":"ollama.gemma3:27b","messages":[
       {"role":"system","content":[{"type":"text","text":"You are helpful."}]},
       {"role":"user","content":[{"type":"text","text":"Say OK"}]}
     ]}'

{"id":"gemma3:27b-3809e0c6-bbc5-4666-b75a-342b04209700","created":1755855779,"model":"gemma3:27b","choices":[{"index":0,"logprobs":null,"finish_reason":"stop","message":{"role":"assistant","content":"OK.\n\n\n\nIs there anything I can help you with? 😊\n\n\n\n"}}],"object":"chat.completion","usage":{"response_token/s":2.43,"prompt_token/s":6.36,"total_duration":14312802695,"load_duration":4936762602,"prompt_eval_count":20,"prompt_tokens":20,"prompt_eval_duration":3143677971,"eval_count":15,"completion_tokens":15,"eval_duration":6171468695,"approximate_total":"0h0m14s","total_tokens":35,"completion_tokens_details":{"reasoning_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}%

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
Re: I tried to document the exact details in the pull request. Please let me know if this still necessary.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- 
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
 This was NOT yet tested.

- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.