### PR TITLE
feat: Add "Allow Continue Response", "Allow Response Rating", and "Allow Response Regeneration" permissions

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1212,6 +1212,10 @@ USER_PERMISSIONS_CHAT_EDIT = (
     os.environ.get("USER_PERMISSIONS_CHAT_EDIT", "True").lower() == "true"
 )
 
+USER_PERMISSIONS_CHAT_CONTINUATION = (
+    os.environ.get("USER_PERMISSIONS_CHAT_CONTINUATION", "True").lower() == "true"
+)
+
 USER_PERMISSIONS_CHAT_SHARE = (
     os.environ.get("USER_PERMISSIONS_CHAT_SHARE", "True").lower() == "true"
 )
@@ -1292,6 +1296,7 @@ DEFAULT_USER_PERMISSIONS = {
         "delete": USER_PERMISSIONS_CHAT_DELETE,
         "edit": USER_PERMISSIONS_CHAT_EDIT,
         "share": USER_PERMISSIONS_CHAT_SHARE,
+        "continuation": USER_PERMISSIONS_CHAT_CONTINUATION,
         "export": USER_PERMISSIONS_CHAT_EXPORT,
         "stt": USER_PERMISSIONS_CHAT_STT,
         "tts": USER_PERMISSIONS_CHAT_TTS,

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1216,6 +1216,10 @@ USER_PERMISSIONS_CHAT_CONTINUATION = (
     os.environ.get("USER_PERMISSIONS_CHAT_CONTINUATION", "True").lower() == "true"
 )
 
+USER_PERMISSIONS_CHAT_REGENERATION = (
+    os.environ.get("USER_PERMISSIONS_CHAT_REGENERATION", "True").lower() == "true"
+)
+
 USER_PERMISSIONS_CHAT_SHARE = (
     os.environ.get("USER_PERMISSIONS_CHAT_SHARE", "True").lower() == "true"
 )
@@ -1299,8 +1303,9 @@ DEFAULT_USER_PERMISSIONS = {
         "file_upload": USER_PERMISSIONS_CHAT_FILE_UPLOAD,
         "delete": USER_PERMISSIONS_CHAT_DELETE,
         "edit": USER_PERMISSIONS_CHAT_EDIT,
-        "share": USER_PERMISSIONS_CHAT_SHARE,
         "continuation": USER_PERMISSIONS_CHAT_CONTINUATION,
+        "regeneration": USER_PERMISSIONS_CHAT_REGENERATION,
+        "share": USER_PERMISSIONS_CHAT_SHARE,
         "export": USER_PERMISSIONS_CHAT_EXPORT,
         "rating": USER_PERMISSIONS_CHAT_RATING,
         "stt": USER_PERMISSIONS_CHAT_STT,

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1224,6 +1224,10 @@ USER_PERMISSIONS_CHAT_EXPORT = (
     os.environ.get("USER_PERMISSIONS_CHAT_EXPORT", "True").lower() == "true"
 )
 
+USER_PERMISSIONS_CHAT_RATING = (
+    os.environ.get("USER_PERMISSIONS_CHAT_RATING", "True").lower() == "true"
+)
+
 USER_PERMISSIONS_CHAT_STT = (
     os.environ.get("USER_PERMISSIONS_CHAT_STT", "True").lower() == "true"
 )
@@ -1298,6 +1302,7 @@ DEFAULT_USER_PERMISSIONS = {
         "share": USER_PERMISSIONS_CHAT_SHARE,
         "continuation": USER_PERMISSIONS_CHAT_CONTINUATION,
         "export": USER_PERMISSIONS_CHAT_EXPORT,
+        "rating": USER_PERMISSIONS_CHAT_RATING,
         "stt": USER_PERMISSIONS_CHAT_STT,
         "tts": USER_PERMISSIONS_CHAT_TTS,
         "call": USER_PERMISSIONS_CHAT_CALL,

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -147,6 +147,7 @@ class ChatPermissions(BaseModel):
     file_upload: bool = True
     delete: bool = True
     edit: bool = True
+    continuation: bool = True
     share: bool = True
     export: bool = True
     stt: bool = True

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -150,6 +150,7 @@ class ChatPermissions(BaseModel):
     continuation: bool = True
     share: bool = True
     export: bool = True
+    rating: bool = True
     stt: bool = True
     tts: bool = True
     call: bool = True

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -148,6 +148,7 @@ class ChatPermissions(BaseModel):
     delete: bool = True
     edit: bool = True
     continuation: bool = True
+    regeneration: bool = True
     share: bool = True
     export: bool = True
     rating: bool = True

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -75,6 +75,7 @@
 			continuation: true,
 			share: true,
 			export: true,
+			rating: true,
 			stt: true,
 			tts: true,
 			call: true,

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -72,6 +72,7 @@
 			file_upload: true,
 			delete: true,
 			edit: true,
+			continuation: true,
 			share: true,
 			export: true,
 			stt: true,

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -73,6 +73,7 @@
 			delete: true,
 			edit: true,
 			continuation: true,
+			regeneration: true,
 			share: true,
 			export: true,
 			rating: true,

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -57,6 +57,7 @@
 			continuation: true,
 			share: true,
 			export: true,
+			rating: true,
 			stt: true,
 			tts: true,
 			call: true,

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -55,6 +55,7 @@
 			delete: true,
 			edit: true,
 			continuation: true,
+			regeneration: true,
 			share: true,
 			export: true,
 			rating: true,

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -54,6 +54,7 @@
 			file_upload: true,
 			delete: true,
 			edit: true,
+			continuation: true,
 			share: true,
 			export: true,
 			stt: true,

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -30,6 +30,7 @@
 			continuation: true,
 			share: true,
 			export: true,
+			rating: true,
 			stt: true,
 			tts: true,
 			call: true,
@@ -307,6 +308,14 @@
 			</div>
 
 			<Switch bind:state={permissions.chat.edit} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Allow Response Rating')}
+			</div>
+
+			<Switch bind:state={permissions.chat.rating} />
 		</div>
 
 		<div class="  flex w-full justify-between my-2 pr-2">

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -27,6 +27,7 @@
 			file_upload: true,
 			delete: true,
 			edit: true,
+			continuation: true,
 			share: true,
 			export: true,
 			stt: true,
@@ -306,6 +307,14 @@
 			</div>
 
 			<Switch bind:state={permissions.chat.edit} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Allow Continue Response')}
+			</div>
+
+			<Switch bind:state={permissions.chat.continuation} />
 		</div>
 
 		<div class="  flex w-full justify-between my-2 pr-2">

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -28,6 +28,7 @@
 			delete: true,
 			edit: true,
 			continuation: true,
+			regeneration: true,
 			share: true,
 			export: true,
 			rating: true,
@@ -308,6 +309,14 @@
 			</div>
 
 			<Switch bind:state={permissions.chat.edit} />
+		</div>
+
+		<div class="  flex w-full justify-between my-2 pr-2">
+			<div class=" self-center text-xs font-medium">
+				{$i18n.t('Allow Response Regeneration')}
+			</div>
+
+			<Switch bind:state={permissions.chat.regeneration} />
 		</div>
 
 		<div class="  flex w-full justify-between my-2 pr-2">

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1222,7 +1222,7 @@
 								{/if}
 
 								{#if !readOnly}
-									{#if !$temporaryChatEnabled && ($config?.features.enable_message_rating ?? true)}
+									{#if !$temporaryChatEnabled && ($config?.features.enable_message_rating ?? true) && ($user?.role === 'admin' || ($user?.permissions?.chat?.rating ?? true))}
 										<Tooltip content={$i18n.t('Good Response')} placement="bottom">
 											<button
 												aria-label={$i18n.t('Good Response')}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1337,79 +1337,11 @@
 										</Tooltip>
 									{/if}
 
-									{#if $settings?.regenerateMenu ?? true}
-										<button
-											type="button"
-											class="hidden regenerate-response-button"
-											on:click={() => {
-												showRateComment = false;
-												regenerateResponse(message);
-
-												(model?.actions ?? []).forEach((action) => {
-													dispatch('action', {
-														id: action.id,
-														event: {
-															id: 'regenerate-response',
-															data: {
-																messageId: message.id
-															}
-														}
-													});
-												});
-											}}
-										/>
-
-										<RegenerateMenu
-											onRegenerate={(prompt = null) => {
-												showRateComment = false;
-												regenerateResponse(message, prompt);
-
-												(model?.actions ?? []).forEach((action) => {
-													dispatch('action', {
-														id: action.id,
-														event: {
-															id: 'regenerate-response',
-															data: {
-																messageId: message.id
-															}
-														}
-													});
-												});
-											}}
-										>
-											<Tooltip content={$i18n.t('Regenerate')} placement="bottom">
-												<div
-													aria-label={$i18n.t('Regenerate')}
-													class="{isLastMessage
-														? 'visible'
-														: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
-												>
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														fill="none"
-														viewBox="0 0 24 24"
-														stroke-width="2.3"
-														aria-hidden="true"
-														stroke="currentColor"
-														class="w-4 h-4"
-													>
-														<path
-															stroke-linecap="round"
-															stroke-linejoin="round"
-															d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
-														/>
-													</svg>
-												</div>
-											</Tooltip>
-										</RegenerateMenu>
-									{:else}
-										<Tooltip content={$i18n.t('Regenerate')} placement="bottom">
+									{#if ($user?.role === 'admin' || ($user?.permissions?.chat?.regeneration ?? false))}
+										{#if $settings?.regenerateMenu ?? true}
 											<button
 												type="button"
-												aria-label={$i18n.t('Regenerate')}
-												class="{isLastMessage
-													? 'visible'
-													: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition regenerate-response-button"
+												class="hidden regenerate-response-button"
 												on:click={() => {
 													showRateComment = false;
 													regenerateResponse(message);
@@ -1426,24 +1358,94 @@
 														});
 													});
 												}}
+											/>
+
+											<RegenerateMenu
+												onRegenerate={(prompt = null) => {
+													showRateComment = false;
+													regenerateResponse(message, prompt);
+
+													(model?.actions ?? []).forEach((action) => {
+														dispatch('action', {
+															id: action.id,
+															event: {
+																id: 'regenerate-response',
+																data: {
+																	messageId: message.id
+																}
+															}
+														});
+													});
+												}}
 											>
-												<svg
-													xmlns="http://www.w3.org/2000/svg"
-													fill="none"
-													viewBox="0 0 24 24"
-													stroke-width="2.3"
-													aria-hidden="true"
-													stroke="currentColor"
-													class="w-4 h-4"
+												<Tooltip content={$i18n.t('Regenerate')} placement="bottom">
+													<div
+														aria-label={$i18n.t('Regenerate')}
+														class="{isLastMessage
+															? 'visible'
+															: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
+													>
+														<svg
+															xmlns="http://www.w3.org/2000/svg"
+															fill="none"
+															viewBox="0 0 24 24"
+															stroke-width="2.3"
+															aria-hidden="true"
+															stroke="currentColor"
+															class="w-4 h-4"
+														>
+															<path
+																stroke-linecap="round"
+																stroke-linejoin="round"
+																d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+															/>
+														</svg>
+													</div>
+												</Tooltip>
+											</RegenerateMenu>
+										{:else}
+											<Tooltip content={$i18n.t('Regenerate')} placement="bottom">
+												<button
+													type="button"
+													aria-label={$i18n.t('Regenerate')}
+													class="{isLastMessage
+														? 'visible'
+														: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition regenerate-response-button"
+													on:click={() => {
+														showRateComment = false;
+														regenerateResponse(message);
+
+														(model?.actions ?? []).forEach((action) => {
+															dispatch('action', {
+																id: action.id,
+																event: {
+																	id: 'regenerate-response',
+																	data: {
+																		messageId: message.id
+																	}
+																}
+															});
+														});
+													}}
 												>
-													<path
-														stroke-linecap="round"
-														stroke-linejoin="round"
-														d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
-													/>
-												</svg>
-											</button>
-										</Tooltip>
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke-width="2.3"
+														aria-hidden="true"
+														stroke="currentColor"
+														class="w-4 h-4"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+														/>
+													</svg>
+												</button>
+											</Tooltip>
+										{/if}
 									{/if}
 
 									{#if siblings.length > 1}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1300,7 +1300,7 @@
 										</Tooltip>
 									{/if}
 
-									{#if isLastMessage}
+									{#if isLastMessage && ($user?.role === 'admin' || ($user?.permissions?.chat?.continuation ?? true))}
 										<Tooltip content={$i18n.t('Continue Response')} placement="bottom">
 											<button
 												aria-label={$i18n.t('Continue Response')}

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -735,24 +735,26 @@
 				</div>
 			</div>
 
-			<div>
-				<div class=" py-0.5 flex w-full justify-between">
-					<div id="regenerate-menu-label" class=" self-center text-xs">
-						{$i18n.t('Regenerate Menu')}
-					</div>
+			{#if $user?.role === 'admin' || ($user?.permissions?.chat?.regeneration ?? true)}
+				<div>
+					<div class=" py-0.5 flex w-full justify-between">
+						<div id="regenerate-menu-label" class=" self-center text-xs">
+							{$i18n.t('Regenerate Menu')}
+						</div>
 
-					<div class="flex items-center gap-2 p-1">
-						<Switch
-							ariaLabelledbyId="regenerate-menu-label"
-							tooltip={true}
-							bind:state={regenerateMenu}
-							on:change={() => {
-								saveSettings({ regenerateMenu });
-							}}
-						/>
+						<div class="flex items-center gap-2 p-1">
+							<Switch
+								ariaLabelledbyId="regenerate-menu-label"
+								tooltip={true}
+								bind:state={regenerateMenu}
+								on:change={() => {
+									saveSettings({ regenerateMenu });
+								}}
+							/>
+						</div>
 					</div>
 				</div>
-			</div>
+			{/if}
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- This pull request introduces a new permission setting to control the visibility of the "Continue Response" button for LLM responses in a chat. This feature enhances security by allowing administrators to prevent potential system prompt leakage that can occur when users continue generating a model's response.

### Added
- **New Permission Toggle**: Added an "`Allow Continue Response`" (AKA "chat continuation") toggle in the admin panel for both group permissions and default user permissions.
- **Environment Variable**: Introduced the `USER_PERMISSIONS_CHAT_CONTINUATION` environment variable to configure the default state of this permission.

### Changed
- **ResponseMessage.svelte**: The "`Continue Response`" button is now conditionally rendered based on the `allow_chat_continuation permission` of the logged-in user.
- **Permissions.svelte**: Updated to include the new "`Allow Continue Response`" toggle switch.
- **EditGroupModal.svelte** & **Groups.svelte**: Updated to recognize and manage the new `continuation` permission flag.
- **users.py**: The `ChatPermissions` model was updated to include the `continuation: bool` field.
- **config.py**: The `DEFAULT_USER_PERMISSIONS` dictionary and related environment variable handling were updated to include the new permission.

### Security
- **System Prompt Protection**: This change helps mitigate system prompt leakage by giving administrators the ability to disable response continuation, a potential vector for such leaks.
<img width="1911" height="642" alt="image" src="https://github.com/user-attachments/assets/83387ffe-9048-44d0-9daf-647404f4148c" />

---

### Additional Information
- This feature was implemented to address the inherent risk of system prompt disclosure through user manipulation of model response generation. By providing granular control over the "Continue" button, administrators can better safeguard the integrity of their system prompts.

### Screenshots or Videos

### New `Allow Response Rating` permission toggle

<img width="700" height="503" alt="image" src="https://github.com/user-attachments/assets/86fe73cb-fc91-4514-8083-dc11d3f67792" />

### `Allow Response Rating` permission toggle `Enabled`
<img width="259" height="77" alt="image" src="https://github.com/user-attachments/assets/9b095dc5-900e-49bd-ab61-c72751cac405" />

### `Allow Response Rating` permission toggle `Disabled`
<img width="258" height="52" alt="image" src="https://github.com/user-attachments/assets/f8860744-7c3b-427b-8889-85edcc26012b" />

### New `Allow Continue Response` permission toggle

<img width="697" height="499" alt="image" src="https://github.com/user-attachments/assets/5cb893f9-e442-4e7d-a64e-3c438c1cb277" />

### `Allow Continue Response` permission toggle `Enabled`

<img width="336" height="79" alt="image" src="https://github.com/user-attachments/assets/d577b733-0623-4700-9bbb-0cbf71833c0e" />

### `Allow Continue Response` permission toggle `Disabled`

<img width="321" height="66" alt="image" src="https://github.com/user-attachments/assets/31b5bf25-4114-4558-a0b7-7ec4e6ab3c80" />

### New `Allow Response Regeneration` permission toggle
<img width="700" height="503" alt="image" src="https://github.com/user-attachments/assets/2baa0cdd-3860-41bb-b43c-34697b75480b" />

### `Allow Response Regeneration` permission toggle `Enabled`
<img width="261" height="72" alt="image" src="https://github.com/user-attachments/assets/fb374464-40be-47f2-9862-47671614d76f" />

### `Allow Response Regeneration` permission toggle `Disabled`
<img width="259" height="53" alt="image" src="https://github.com/user-attachments/assets/f88b3bd0-cd14-490f-80a4-c056ccca10c6" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.