### PR TITLE
fix: remove hard-coded `marker` path from base url in datalab document loader

### DIFF
--- a/backend/open_webui/retrieval/loaders/datalab_marker.py
+++ b/backend/open_webui/retrieval/loaders/datalab_marker.py
@@ -64,7 +64,7 @@ class DatalabMarkerLoader:
         return mime_map.get(ext, "application/octet-stream")
 
     def check_marker_request_status(self, request_id: str) -> dict:
-        url = f"{self.api_base_url}/marker/{request_id}"
+        url = f"{self.api_base_url}/{request_id}"
         headers = {"X-Api-Key": self.api_key}
         try:
             response = requests.get(url, headers=headers)
@@ -111,7 +111,7 @@ class DatalabMarkerLoader:
             with open(self.file_path, "rb") as f:
                 files = {"file": (filename, f, mime_type)}
                 response = requests.post(
-                    f"{self.api_base_url}/marker",
+                    f"{self.api_base_url}",
                     data=form_data,
                     files=files,
                     headers=headers,

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -283,7 +283,7 @@ class Loader:
         ):
             api_base_url = self.kwargs.get("DATALAB_MARKER_API_BASE_URL", "")
             if not api_base_url or api_base_url.strip() == "":
-                api_base_url = "https://www.datalab.to/api/v1"
+                api_base_url = "https://www.datalab.to/api/v1/marker"
 
             loader = DatalabMarkerLoader(
                 file_path=file_path,


### PR DESCRIPTION
A `refac` after PR https://github.com/open-webui/open-webui/pull/15903 was merged inadvertently broke the marker API document loader by hardcoding `/marker` paths in `datalab_marker.py` while removing them from the default datalab API URL in `main.py`.

**Changes:** 

* Remove hardcoded `/marker` paths from `datalab_marker.py`
* Restore `/marker` to the default URL in `main.py`

This ensures the marker API works correctly whether using datalab's API or a custom marker server.

**Tested:**
 
* Patched the files & created a custom container at `docker.io/hisma/openwebui:dev`

Confirmed working with datalab marker API with patched files - 
```
2025-08-23T23:00:25.908705932Z 2025-08-23 23:00:25.908 | INFO     | open_webui.routers.files:upload_file_handler:159 - file.content_type: application/pdf
2025-08-23T23:00:25.926423859Z 2025-08-23 23:00:25.926 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.0.213:63343 - "POST /api/v1/files/ HTTP/1.1" 200
2025-08-23T23:00:25.942955076Z 2025-08-23 23:00:25.942 | INFO     | open_webui.retrieval.loaders.datalab_marker:load:106 - Datalab Marker POST request parameters: {'filename': '14190016-d5f5-4e6e-9c42-de96b98dbacc_81250143.pdf', 'mime_type': 'application/pdf', **{'use_llm': 'true', 'skip_cache': 'false', 'force_ocr': 'false', 'paginate': 'true', 'strip_existing_ocr': 'false', 'disable_image_extraction': 'true', 'format_lines': 'false', 'output_format': 'markdown', 'additional_config': '{"keep_pageheader_in_output": true, "keep_pagefooter_in_output": true}'}}
2025-08-23T23:00:25.949432861Z 2025-08-23 23:00:25.949 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.0.213:63343 - "GET /api/v1/files/14190016-d5f5-4e6e-9c42-de96b98dbacc/process/status?stream=true HTTP/1.1" 200
2025-08-23T23:00:46.207359551Z 2025-08-23 23:00:46.207 | INFO     | open_webui.retrieval.loaders.datalab_marker:load:177 - Marker processing completed successfully: {
2025-08-23T23:00:46.207400302Z   "status": "complete",
2025-08-23T23:00:46.207410773Z   "output_format": "markdown",
2025-08-23T23:00:46.207418593Z   "success": true,
2025-08-23T23:00:46.207425923Z   "error": "",
2025-08-23T23:00:46.207433153Z   "page_count": 1,
2025-08-23T23:00:46.207440653Z   "total_cost": null
2025-08-23T23:00:46.207478215Z }
2025-08-23T23:00:46.207845897Z 2025-08-23 23:00:46.207 | INFO     | open_webui.retrieval.loaders.datalab_marker:load:255 - Saved Marker output to: /app/backend/data/uploads/marker_output/14190016-d5f5-4e6e-9c42-de96b98dbacc_81250143.md
2025-08-23T23:00:46.234086277Z 2025-08-23 23:00:46.233 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1182 - save_docs_to_vector_db: document 81250143.pdf file-14190016-d5f5-4e6e-9c42-de96b98dbacc
2025-08-23T23:00:46.236616281Z 2025-08-23 23:00:46.236 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1208 - Using token text splitter: cl100k_base
2025-08-23T23:00:46.528894879Z 2025-08-23 23:00:46.528 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1182 - save_docs_to_vector_db: document 81250143.pdf 928f611c-b181-4a2c-8889-da6b15452df7
2025-08-23T23:00:46.530271935Z 2025-08-23 23:00:46.530 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1208 - Using token text splitter: cl100k_base
2025-08-23T23:00:47.395597619Z 2025-08-23 23:00:47.395 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1298 - adding to collection 928f611c-b181-4a2c-8889-da6b15452df7
2025-08-23T23:00:47.445963169Z 2025-08-23 23:00:47.445 | INFO     | open_webui.routers.retrieval:save_docs_to_vector_db:1298 - adding to collection file-14190016-d5f5-4e6e-9c42-de96b98dbacc
2025-08-23T23:00:48.326968716Z 2025-08-23 23:00:48.326 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.0.213:62442 - "GET /_app/version.json HTTP/1.1" 200
2025-08-23T23:00:52.231641802Z 2025-08-23 23:00:52.231 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.0.213:63343 - "POST /api/v1/knowledge/928f611c-b181-4a2c-8889-da6b15452df7/file/add HTTP/1.1" 200
```

file successfully uploaded to knowledgebase using datalab - 
<img width="3371" height="1461" alt="image" src="https://github.com/user-attachments/assets/fe41dec4-79dc-415e-ae2e-58f320d405de" />


@GeorgelPreput please test with your locally hosted server and confirm it works now.

 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
