### PR TITLE
Fix merge_ollama_models_lists

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -329,6 +329,7 @@ def merge_ollama_models_lists(model_lists):
     for idx, model_list in enumerate(model_lists):
         if model_list is not None:
             for model in model_list:
+                if model.get("model") == None: continue
                 id = model["model"]
                 if id not in merged_models:
                     model["urls"] = [idx]


### PR DESCRIPTION
Fixes: 

> 2025-08-24 03:04:28.058 | Exception in ASGI application
> 2025-08-24 03:04:28.058 |   + Exception Group Traceback (most recent call last):
> 2025-08-24 03:04:28.058 |   |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
> 2025-08-24 03:04:28.058 |   |     yield
> 2025-08-24 03:04:28.058 |   |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
> 2025-08-24 03:04:28.058 |   |     async with anyio.create_task_group() as task_group:
> 2025-08-24 03:04:28.058 |   |   File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
> 2025-08-24 03:04:28.058 |   |     raise BaseExceptionGroup(
> 2025-08-24 03:04:28.058 |   | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
> 2025-08-24 03:04:28.058 |   +-+---------------- 1 ----------------
> 2025-08-24 03:04:28.058 |     | Traceback (most recent call last):
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
> 2025-08-24 03:04:28.058 |     |     result = await app(  # type: ignore[func-returns-value]
> 2025-08-24 03:04:28.058 |     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
> 2025-08-24 03:04:28.058 |     |     return await self.app(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
> 2025-08-24 03:04:28.058 |     |     await super().__call__(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 112, in __call__
> 2025-08-24 03:04:28.058 |     |     await self.middleware_stack(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive, _send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 85, in __call__
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
> 2025-08-24 03:04:28.058 |     |     with recv_stream, send_stream, collapse_excgroups():
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
> 2025-08-24 03:04:28.058 |     |     self.gen.throw(typ, value, traceback)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
> 2025-08-24 03:04:28.058 |     |     response = await self.dispatch_func(request, call_next)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/main.py", line 1186, in inspect_websocket
> 2025-08-24 03:04:28.058 |     |     return await call_next(request)
> 2025-08-24 03:04:28.058 |     |            ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
> 2025-08-24 03:04:28.058 |     |     raise app_exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive_or_disconnect, send_no_error)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
> 2025-08-24 03:04:28.058 |     |     with recv_stream, send_stream, collapse_excgroups():
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
> 2025-08-24 03:04:28.058 |     |     self.gen.throw(typ, value, traceback)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
> 2025-08-24 03:04:28.058 |     |     response = await self.dispatch_func(request, call_next)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/main.py", line 1165, in check_url
> 2025-08-24 03:04:28.058 |     |     response = await call_next(request)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
> 2025-08-24 03:04:28.058 |     |     raise app_exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive_or_disconnect, send_no_error)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
> 2025-08-24 03:04:28.058 |     |     with recv_stream, send_stream, collapse_excgroups():
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
> 2025-08-24 03:04:28.058 |     |     self.gen.throw(typ, value, traceback)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
> 2025-08-24 03:04:28.058 |     |     response = await self.dispatch_func(request, call_next)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/main.py", line 1151, in commit_session_after_request
> 2025-08-24 03:04:28.058 |     |     response = await call_next(request)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
> 2025-08-24 03:04:28.058 |     |     raise app_exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive_or_disconnect, send_no_error)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
> 2025-08-24 03:04:28.058 |     |     with recv_stream, send_stream, collapse_excgroups():
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
> 2025-08-24 03:04:28.058 |     |     self.gen.throw(typ, value, traceback)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
> 2025-08-24 03:04:28.058 |     |     response = await self.dispatch_func(request, call_next)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/utils/security_headers.py", line 11, in dispatch
> 2025-08-24 03:04:28.058 |     |     response = await call_next(request)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
> 2025-08-24 03:04:28.058 |     |     raise app_exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive_or_disconnect, send_no_error)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
> 2025-08-24 03:04:28.058 |     |     with recv_stream, send_stream, collapse_excgroups():
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
> 2025-08-24 03:04:28.058 |     |     self.gen.throw(typ, value, traceback)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
> 2025-08-24 03:04:28.058 |     |     response = await self.dispatch_func(request, call_next)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/main.py", line 1137, in dispatch
> 2025-08-24 03:04:28.058 |     |     response = await call_next(request)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
> 2025-08-24 03:04:28.058 |     |     raise app_exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive_or_disconnect, send_no_error)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette_compress/__init__.py", line 92, in __call__
> 2025-08-24 03:04:28.058 |     |     return await self._zstd(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette_compress/_zstd_legacy.py", line 100, in __call__
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive, wrapper)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
> 2025-08-24 03:04:28.058 |     |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
> 2025-08-24 03:04:28.058 |     |     await app(scope, receive, sender)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
> 2025-08-24 03:04:28.058 |     |     await self.middleware_stack(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
> 2025-08-24 03:04:28.058 |     |     await route.handle(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
> 2025-08-24 03:04:28.058 |     |     await self.app(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
> 2025-08-24 03:04:28.058 |     |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
> 2025-08-24 03:04:28.058 |     |     raise exc
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
> 2025-08-24 03:04:28.058 |     |     await app(scope, receive, sender)
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
> 2025-08-24 03:04:28.058 |     |     response = await f(request)
> 2025-08-24 03:04:28.058 |     |                ^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
> 2025-08-24 03:04:28.058 |     |     raw_response = await run_endpoint_function(
> 2025-08-24 03:04:28.058 |     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
> 2025-08-24 03:04:28.058 |     |     return await dependant.call(**values)
> 2025-08-24 03:04:28.058 |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/main.py", line 1291, in get_models
> 2025-08-24 03:04:28.058 |     |     all_models = await get_all_models(request, refresh=refresh, user=user)
> 2025-08-24 03:04:28.058 |     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/utils/models.py", line 87, in get_all_models
> 2025-08-24 03:04:28.058 |     |     base_models = await get_all_base_models(request, user=user)
> 2025-08-24 03:04:28.058 |     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/utils/models.py", line 72, in get_all_base_models
> 2025-08-24 03:04:28.058 |     |     openai_models, ollama_models, function_models = await asyncio.gather(
> 2025-08-24 03:04:28.058 |     |                                                     ^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/utils/models.py", line 38, in fetch_ollama_models
> 2025-08-24 03:04:28.058 |     |     raw_ollama_models = await ollama.get_all_models(request, user=user)
> 2025-08-24 03:04:28.058 |     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/aiocache/decorators.py", line 109, in wrapper
> 2025-08-24 03:04:28.058 |     |     return await self.decorator(f, *args, **kwargs)
> 2025-08-24 03:04:28.058 |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/usr/local/lib/python3.11/site-packages/aiocache/decorators.py", line 124, in decorator
> 2025-08-24 03:04:28.058 |     |     result = await f(*args, **kwargs)
> 2025-08-24 03:04:28.058 |     |              ^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/routers/ollama.py", line 407, in get_all_models
> 2025-08-24 03:04:28.058 |     |     "models": merge_ollama_models_lists(
> 2025-08-24 03:04:28.058 |     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
> 2025-08-24 03:04:28.058 |     |   File "/app/backend/open_webui/routers/ollama.py", line 332, in merge_ollama_models_lists
> 2025-08-24 03:04:28.058 |     |     id = model["model"]
> 2025-08-24 03:04:28.058 |     |          ~~~~~^^^^^^^^^
> 2025-08-24 03:04:28.058 |     | KeyError: 'model'
> 2025-08-24 03:04:28.058 |     +------------------------------------