### PR TITLE
FIX: Show Content of Uploaded File in FileItemModal.svelte

### DIFF
--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -3,6 +3,7 @@
 	import { formatFileSize, getLineCount } from '$lib/utils';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import { getKnowledgeById } from '$lib/apis/knowledge';
+	import { getFileById } from '$lib/apis/files';
 
 	const i18n = getContext('i18n');
 
@@ -47,6 +48,22 @@
 
 			if (knowledge) {
 				item.files = knowledge.files || [];
+			}
+			loading = false;
+		}
+
+		if (item?.type === 'file') {
+			loading = true;
+
+			const file = await getFileById(localStorage.token, item.id).catch((e) => {
+				console.error('Error fetching File:', e);
+				return null;
+			});
+
+			if (file) {
+				item.file.data.content = file.data.content;
+			} else {
+				toast.error($i18n.t('No content found in file.'));
 			}
 			loading = false;
 		}


### PR DESCRIPTION
### FIX: Show Content of Uploaded File in FileItemModal.svelte

**Problem:** Content of uploaded files added to the message (e.g. text or xlsx) is not displayed in the FileItemModal, it simply appears as  "No Content". However, the embedded is successful and the content can be displayed simply by clicking the file link in the modal.

This feature was working propertly in v0.6.22 with the same FileItem & FileItemModal files, but not in the dev v.0.6.26

With this update, that repopulate item.file.data.content, the content is displayed correctly.


**Note**: This is a quick fix to fit the current structure, but I think try/catch clauses are needed here.

___
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
