### PR TITLE
FIX- RTL text orientation in Messages, and LTR allways for CodeBlock

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -37,7 +37,7 @@
 	export let code = '';
 	export let attributes = {};
 
-	export let className = 'my-2';
+	export let className = 'my-2 !text-left !direction-ltr';
 	export let editorClassName = '';
 	export let stickyButtonsClassName = 'top-0';
 

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -639,7 +639,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-full markdown-prose {$settings.chatDirection === 'RTL' ? 'text-right' : ''}">
 					<div>
 						{#if (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length > 0}
 							{@const status = (

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -639,7 +639,12 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose {$settings.chatDirection === 'RTL' ? 'text-right' : ''}">
+				<div
+					class="chat-{message.role} w-full min-w-full markdown-prose {$settings.chatDirection ===
+					'RTL'
+						? 'text-right'
+						: ''}"
+				>
 					<div>
 						{#if (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length > 0}
 							{@const status = (

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -329,7 +329,7 @@
 								? `max-w-[90%] px-5 py-2  bg-gray-50 dark:bg-gray-850 ${
 										message.files ? 'rounded-tr-lg' : ''
 									}`
-								: ' w-full'}"
+								: ' w-full'} {$settings.chatDirection === 'RTL' ? 'text-right' : ''}"
 						>
 							{#if message.content}
 								<Markdown id={`${chatId}-${message.id}`} content={message.content} {topPadding} />


### PR DESCRIPTION
### FIX for RTL text orientation
Issue: https://github.com/open-webui/open-webui/discussions/16827

Added alignament condition  in User Message & Response depending of the User Settings.
Added LTR alignament for Code Block.

![openwebui_RTL0](https://github.com/user-attachments/assets/85f88a8f-0aa2-4e13-aa54-ceadd5ab5098)
![openwebui_RTL1](https://github.com/user-attachments/assets/c54cbe88-b216-4607-83c1-ad7a364b6763)

____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
