### PR TITLE
feat: support Seed-OSS-36B thinking tags

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1822,6 +1822,7 @@ async def process_chat_response(
                 ("<Thought>", "</Thought>"),
                 ("<|begin_of_thought|>", "<|end_of_thought|>"),
                 ("◁think▷", "◁/think▷"),
+                ("<seed:think>", "</seed:think>"),
             ]
 
             code_interpreter_tags = [("<code_interpreter>", "</code_interpreter>")]


### PR DESCRIPTION
# Changelog Entry

### Description

- Include the reasoning tags needed to parse ByteDance's [Seed-OSS-36B-Instruct](https://huggingface.co/ByteDance-Seed/Seed-OSS-36B-Instruct) reasoning outputs

### Added

- Add `("<seed:think>", "</seed:think>"),` to the `reasoning_tags` list in `middleware.py`

---

### Testing

- I ran the model locally and after the change the thinking tags were correctly handled in the frontend

### Additional Information

- I hope this is atomic enough to not warrant a discussion post 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
