### PR TITLE
FIX: hybrid param in query collection not handled

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -124,20 +124,20 @@ def query_doc_with_hybrid_search(
     hybrid_bm25_weight: float,
 ) -> dict:
     try:
-        if not collection_result.documents[0]:  
+        if not collection_result.documents[0]:
             log.info(
                 f"Collection {collection_name} is empty, falling back to vector search only"
-            )  
-            # Use only vector search when no documents are available  
-            vector_search_retriever = VectorSearchRetriever(  
-                collection_name=collection_name,  
-                embedding_function=embedding_function,  
-                top_k=k,  
-            )  
-            ensemble_retriever = EnsembleRetriever(  
-                retrievers=[vector_search_retriever], weights=[1.0]  
-            )  
-        else:  
+            )
+            # Use only vector search when no documents are available
+            vector_search_retriever = VectorSearchRetriever(
+                collection_name=collection_name,
+                embedding_function=embedding_function,
+                top_k=k,
+            )
+            ensemble_retriever = EnsembleRetriever(
+                retrievers=[vector_search_retriever], weights=[1.0]
+            )
+        else:
             # BM_25 required only if weight is greater than 0
             if hybrid_bm25_weight > 0:
                 log.debug(f"query_doc_with_hybrid_search:doc {collection_name}")

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -125,7 +125,9 @@ def query_doc_with_hybrid_search(
 ) -> dict:
     try:
         if not collection_result.documents[0]:  
-            log.warning(f"Collection {collection_name} is empty, falling back to vector search only")  
+            log.info(
+                f"Collection {collection_name} is empty, falling back to vector search only"
+            )  
             # Use only vector search when no documents are available  
             vector_search_retriever = VectorSearchRetriever(  
                 collection_name=collection_name,  

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2075,7 +2075,9 @@ def query_doc_handler(
     user=Depends(get_verified_user),
 ):
     try:
-        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (
+            form_data.hybrid is None or form_data.hybrid
+        ):
             collection_results = {}
             collection_results[form_data.collection_name] = VECTOR_DB_CLIENT.get(
                 collection_name=form_data.collection_name
@@ -2145,7 +2147,9 @@ def query_collection_handler(
     user=Depends(get_verified_user),
 ):
     try:
-        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (
+            form_data.hybrid is None or form_data.hybrid
+        ):
             return query_collection_with_hybrid_search(
                 collection_names=form_data.collection_names,
                 queries=[form_data.query],

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2075,7 +2075,7 @@ def query_doc_handler(
     user=Depends(get_verified_user),
 ):
     try:
-        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH:
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
             collection_results = {}
             collection_results[form_data.collection_name] = VECTOR_DB_CLIENT.get(
                 collection_name=form_data.collection_name
@@ -2145,7 +2145,7 @@ def query_collection_handler(
     user=Depends(get_verified_user),
 ):
     try:
-        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH:
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
             return query_collection_with_hybrid_search(
                 collection_names=form_data.collection_names,
                 queries=[form_data.query],


### PR DESCRIPTION
### FIX: hybrid param in query collection not handled 

Fix  Issue: https://github.com/open-webui/open-webui/issues/16896

Problem:
- The QueryCollectionsForm model defines a hybrid field, but the handler logic only checks the global configuration ENABLE_RAG_HYBRID_SEARCH.
- division by zero error in the query_doc_with_hybrid_search function when BM25Retriever.from_texts() is called with an empty document list.

This PR fix this two issues adding this param to logic checks & logic for check emptry result sets in Hybrid Search (utils.py)

Also, same is added to _query_doc_handler_ that have same logic check.


Note: In the mentioned issue https://github.com/open-webui/open-webui/issues/16896 is showed another "issue" that arise in hybrid search & when there are empty result sets or malformed similarity scores in the specific collection data. This issue doesn't arise if hybrid=false.
Note1: Added Fix for solve both.

____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
