### PR TITLE
Add 'Use Knowledge' toggle for RAG control

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -126,6 +126,7 @@
 	let imageGenerationEnabled = false;
 	let webSearchEnabled = false;
 	let codeInterpreterEnabled = false;
+	let useKnowledgeEnabled = true;
 
 	let showCommands = false;
 
@@ -187,6 +188,7 @@
 						webSearchEnabled = input.webSearchEnabled;
 						imageGenerationEnabled = input.imageGenerationEnabled;
 						codeInterpreterEnabled = input.codeInterpreterEnabled;
+						useKnowledgeEnabled = input.useKnowledgeEnabled ?? true;
 					}
 				} catch (e) {}
 			}
@@ -501,6 +503,7 @@
 					webSearchEnabled = input.webSearchEnabled;
 					imageGenerationEnabled = input.imageGenerationEnabled;
 					codeInterpreterEnabled = input.codeInterpreterEnabled;
+					useKnowledgeEnabled = input.useKnowledgeEnabled ?? true;
 				}
 			} catch (e) {}
 		}
@@ -1644,6 +1647,11 @@
 				array.findIndex((i) => JSON.stringify(i) === JSON.stringify(item)) === index
 		);
 
+		// If knowledge is disabled, strip knowledge-bearing files from the payload
+		if (!useKnowledgeEnabled) {
+			files = [];
+		}
+
 		scrollToBottom();
 		eventTarget.dispatchEvent(
 			new CustomEvent('chat:start', {
@@ -1747,6 +1755,7 @@
 						($user?.role === 'admin' || $user?.permissions?.features?.web_search)
 							? webSearchEnabled || ($settings?.webSearch ?? false) === 'always'
 							: false,
+					knowledge: useKnowledgeEnabled,
 					memory: $settings?.memory ?? false
 				},
 				variables: {
@@ -2309,6 +2318,7 @@
 									bind:imageGenerationEnabled
 									bind:codeInterpreterEnabled
 									bind:webSearchEnabled
+									bind:useKnowledgeEnabled
 									bind:atSelectedModel
 									bind:showCommands
 									toolServers={$toolServers}
@@ -2365,6 +2375,7 @@
 									bind:imageGenerationEnabled
 									bind:codeInterpreterEnabled
 									bind:webSearchEnabled
+									bind:useKnowledgeEnabled
 									bind:atSelectedModel
 									bind:showCommands
 									toolServers={$toolServers}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -104,6 +104,7 @@
 	export let imageGenerationEnabled = false;
 	export let webSearchEnabled = false;
 	export let codeInterpreterEnabled = false;
+	export let useKnowledgeEnabled = true;
 
 	let showInputVariablesModal = false;
 	let inputVariables = {};
@@ -124,7 +125,8 @@
 		selectedFilterIds,
 		imageGenerationEnabled,
 		webSearchEnabled,
-		codeInterpreterEnabled
+		codeInterpreterEnabled,
+		useKnowledgeEnabled
 	});
 
 	const inputVariableHandler = async (text: string) => {
@@ -492,6 +494,8 @@
 		$config?.features?.enable_code_interpreter &&
 		($_user.role === 'admin' || $_user?.permissions?.features?.code_interpreter);
 
+	let showKnowledgeButton = true;
+
 	const scrollToBottom = () => {
 		const element = document.getElementById('messages-container');
 		element.scrollTo({
@@ -690,7 +694,7 @@
 				}
 
 				const compressImageHandler = async (imageUrl, settings = {}, config = {}) => {
-					// Quick shortcut so we don’t do unnecessary work.
+					// Quick shortcut so we don't do unnecessary work.
 					const settingsCompression = settings?.imageCompression ?? false;
 					const configWidth = config?.file?.image_compression?.width ?? null;
 					const configHeight = config?.file?.image_compression?.height ?? null;
@@ -1838,6 +1842,29 @@
 															<span
 																class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis leading-none pr-0.5"
 																>{$i18n.t('Code Interpreter')}</span
+															>
+														</button>
+													</Tooltip>
+												{/if}
+
+												{#if showKnowledgeButton}
+													<Tooltip content={$i18n.t('Use Knowledge (RAG)')} placement="top">
+														<button
+															aria-label={useKnowledgeEnabled ? $i18n.t('Disable Knowledge') : $i18n.t('Enable Knowledge')}
+															aria-pressed={useKnowledgeEnabled}
+															on:click|preventDefault={() => (useKnowledgeEnabled = !useKnowledgeEnabled)}
+															type="button"
+															class="px-2 @xl:px-2.5 py-2 flex gap-1.5 items-center text-sm transition-colors duration-300 max-w-full overflow-hidden hover:bg-gray-50 dark:hover:bg-gray-800 {useKnowledgeEnabled
+																? ' text-sky-500 dark:text-sky-300 bg-sky-50 dark:bg-sky-200/5'
+																: 'bg-transparent text-gray-600 dark:text-gray-300 '} {($settings?.highContrastMode ??
+																false)
+																? 'm-1'
+																: 'focus:outline-hidden rounded-full'}"
+														>
+															<Sparkles className="size-4" strokeWidth="1.75" />
+															<span
+																class="hidden @xl:block whitespace-nowrap overflow-hidden text-ellipsis leading-none pr-0.5"
+																>{$i18n.t('Use Knowledge')}</span
 															>
 														</button>
 													</Tooltip>

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -51,6 +51,7 @@
 	export let imageGenerationEnabled = false;
 	export let codeInterpreterEnabled = false;
 	export let webSearchEnabled = false;
+	export let useKnowledgeEnabled = true;
 
 	export let onSelect = (e) => {};
 	export let onChange = (e) => {};
@@ -216,6 +217,7 @@
 					bind:imageGenerationEnabled
 					bind:codeInterpreterEnabled
 					bind:webSearchEnabled
+					bind:useKnowledgeEnabled
 					bind:atSelectedModel
 					bind:showCommands
 					{toolServers}


### PR DESCRIPTION
This PR adds a per-chat ‘Use Knowledge’ toggle next to Code Interpreter and gates retrieval.\n\n- UI: toggle in MessageInput.svelte\n- State: threaded through Placeholder.svelte and Chat.svelte; persisted in session draft\n- Behavior: when OFF, files for knowledge are stripped and features.knowledge=false\n\n