### PR TITLE
FIX: Auto RTL-LTR text orientation in Messages & Reversion previous PR

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -37,7 +37,7 @@
 	export let code = '';
 	export let attributes = {};
 
-	export let className = 'my-2 !text-left !direction-ltr';
+	export let className = 'my-2';
 	export let editorClassName = '';
 	export let stickyButtonsClassName = 'top-0';
 

--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -44,7 +44,7 @@
 	export let topPadding = false;
 </script>
 
-<li
+<div
 	class="flex flex-col justify-between px-5 mb-3 w-full {($settings?.widescreenMode ?? null)
 		? 'max-w-full'
 		: 'max-w-5xl'} mx-auto rounded-lg group"
@@ -120,4 +120,4 @@
 			/>
 		{/if}
 	{/if}
-</li>
+</div>

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -639,12 +639,7 @@
 			</Name>
 
 			<div>
-				<div
-					class="chat-{message.role} w-full min-w-full markdown-prose {$settings.chatDirection ===
-					'RTL'
-						? 'text-right'
-						: ''}"
-				>
+				<div class="chat-{message.role} w-full min-w-full markdown-prose">
 					<div>
 						{#if (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length > 0}
 							{@const status = (

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -329,7 +329,7 @@
 								? `max-w-[90%] px-5 py-2  bg-gray-50 dark:bg-gray-850 ${
 										message.files ? 'rounded-tr-lg' : ''
 									}`
-								: ' w-full'} {$settings.chatDirection === 'RTL' ? 'text-right' : ''}"
+								: ' w-full'}"
 						>
 							{#if message.content}
 								<Markdown id={`${chatId}-${message.id}`} content={message.content} {topPadding} />


### PR DESCRIPTION
### FIX: Auto RTL-LTR text orientation in Messages & Reversion previous PR https://github.com/open-webui/open-webui/pull/16878
___

As commented in https://github.com/open-webui/open-webui/discussions/16827 the proposal PR https://github.com/open-webui/open-webui/pull/16878 doesn't fix the real problem.

After recheck previous behaviour I found that the problem is in 
https://github.com/open-webui/open-webui/blob/1db8dec4f52fc0fa8f8f7bfbb8ea5bde41fee17d/src/lib/components/chat/Messages/Message.svelte#L47
 This tag was a `<div>` and changed by `<li>` in commit https://github.com/open-webui/open-webui/commit/bb6864dd127e8bc0b0467dfb9eb87f460acecfa8#r164667886
& this change broke the previous behavior of auto text orientation.

As reverting this change fix the auto text orientation the changes done in PR https://github.com/open-webui/open-webui/pull/16878 are unnecessaries & its are reverted in this PR too.

___

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
