### PR TITLE
FIX: Hybrid Search 

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -128,8 +128,6 @@ def query_doc_with_hybrid_search(
             log.warning(f"query_doc_with_hybrid_search:no_docs {collection_name}")
             return {"documents": [], "metadatas": [], "distances": []}
 
-        # BM_25 required only if weight is greater than 0
-        if hybrid_bm25_weight > 0:
             log.debug(f"query_doc_with_hybrid_search:doc {collection_name}")
             bm25_retriever = BM25Retriever.from_texts(
                 texts=collection_result.documents[0],
@@ -343,8 +341,7 @@ def query_collection_with_hybrid_search(
     # Fetch collection data once per collection sequentially
     # Avoid fetching the same data multiple times later
     collection_results = {}
-    # Only retrieve entire collection if bm_25 calculation is required
-    if hybrid_bm25_weight > 0:
+
         for collection_name in collection_names:
             try:
                 log.debug(
@@ -356,9 +353,7 @@ def query_collection_with_hybrid_search(
             except Exception as e:
                 log.exception(f"Failed to fetch collection {collection_name}: {e}")
                 collection_results[collection_name] = None
-    else:
-        for collection_name in collection_names:
-            collection_results[collection_name] = []
+                
     log.info(
         f"Starting hybrid search for {len(queries)} queries in {len(collection_names)} collections..."
     )

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -1104,10 +1104,10 @@
 												<div class="py-0.5">
 													<div class="flex w-full justify-between">
 														<div class=" text-left text-xs font-small">
-															{$i18n.t('lexical')}
+															{$i18n.t('semantic')}
 														</div>
 														<div class=" text-right text-xs font-small">
-															{$i18n.t('semantic')}
+															{$i18n.t('lexical')}
 														</div>
 													</div>
 												</div>


### PR DESCRIPTION
### FIX Error in Hybrid Search

Fix 2 errors in hibryd Search:
- lexical-semantic terms are inverted
BM25 weight=1 --> lexical
BM25 weight=0 --> semantic

- Errors when Hybrid Search when bm25_weight=0.
   As noted in https://github.com/open-webui/open-webui/issues/17046 & https://github.com/open-webui/open-webui/discussions/16957 errors arise in this condition due to return empty list instead of fetching the actual collection data.
   
I opted for revert  the bypass when bm25_weight=0 done in PR https://github.com/open-webui/open-webui/commit/74b1c801 because this proposal sought to save calls if bm25 weight=0, which makes sense, since that setting practically implies the same thing as disabling hybrid search.
However, it was not considered that running hybrid search with bm25 weight=0 can also be used to perform a new reranking with different cutoff values ​​(both in terms of the number of results and the relevance threshold).

--------------------
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
