### PR TITLE
feat: merge llama.cpp timing statistics into usage field

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1964,6 +1964,11 @@ async def process_chat_response(
                                                 }
                                             )
                                         usage = data.get("usage", {})
+                                        timing = data.get("timing", {})
+
+                                        usage.update(timing)
+                                        data["usage"] = usage
+
                                         if usage:
                                             await event_emitter(
                                                 {


### PR DESCRIPTION
# Changelog Entry

### Description

OpenWebUI only displays statistics from the usage field. This PR merges the timing data returned by llama.cpp into the usage object to ensure timing statistics are visible in the UI.

### Added

Merging llama.cpp timing statistics into usage.

### Changed

Updated backend response handling to ensure timing is always included in usage.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
