### PR TITLE
perf: fix N+1 query issue in get_models method

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -175,9 +175,16 @@ class ModelsTable:
 
     def get_models(self) -> list[ModelUserResponse]:
         with get_db() as db:
+            all_models = db.query(Model).filter(Model.base_model_id != None).all()
+
+            user_ids = list(set(model.user_id for model in all_models))
+
+            users = Users.get_users_by_user_ids(user_ids) if user_ids else []
+            users_dict = {user.id: user for user in users}
+
             models = []
-            for model in db.query(Model).filter(Model.base_model_id != None).all():
-                user = Users.get_user_by_id(model.user_id)
+            for model in all_models:
+                user = users_dict.get(model.user_id)
                 models.append(
                     ModelUserResponse.model_validate(
                         {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixed a critical N+1 query performance issue in the `get_models` method where user information was being fetched individually for each model. This optimization replaces multiple individual user queries with a single batch query, significantly improving database performance and reducing query load.

This completes the N+1 query optimization across the core model listing methods (prompts, knowledge bases, and models), ensuring consistent performance improvements throughout the application.

### Changed
- Modified `get_models` method in `ModelsTable` class to use batch user fetching
- Implemented dictionary-based O(1) user lookup instead of individual queries
- Reduced database query count from 1+N to 1+1 pattern for model listings
- Applied consistent optimization pattern matching prompts and knowledge base modules


### Fixed

- Fixed N+1 query problem causing excessive database load when retrieving models with user information
- Improved response times for model list endpoints through optimized database access patterns
- Enhanced scalability for applications with large numbers of models and users
- Completed N+1 query fixes across all major listing endpoints


---

### Additional Information

- **File affected:** `backend/open_webui/models/models.py` (lines 176-196)
- **Query optimization:** Changed from `1 + N` queries to `1 + 1` queries
- **Performance impact:** Up to 99%+ reduction in database queries for large datasets
- **Memory efficiency:** Duplicate user_id filtering prevents redundant data fetching
- **Scope:** Only affects models with `base_model_id != None`


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
