### PR TITLE
feat: show number of files in knowledge base

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -902,7 +902,7 @@
 								<input
 									class=" w-full text-sm pr-4 py-1 rounded-r-xl outline-hidden bg-transparent"
 									bind:value={query}
-									placeholder={`${$i18n.t('Search Collection')}${(knowledge?.files?.length ?? 0) > 0 ? ` (${knowledge.files.length})` : ''}`}
+									placeholder={`${$i18n.t('Search Collection')} (${knowledge?.files?.length ?? 0})`}
 									on:focus={() => {
 										selectedFileId = null;
 									}}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -902,7 +902,7 @@
 								<input
 									class=" w-full text-sm pr-4 py-1 rounded-r-xl outline-hidden bg-transparent"
 									bind:value={query}
-									placeholder={$i18n.t('Search Collection')}
+									placeholder={`${$i18n.t('Search Collection')}${(knowledge?.files?.length ?? 0) > 0 ? ` (${knowledge.files.length})` : ''}`}
 									on:focus={() => {
 										selectedFileId = null;
 									}}


### PR DESCRIPTION
# Changelog Entry

### Description
To know file count in a large knowledge base, we have to manually count them. This feature will help us know the file count immediately.

### Added

- Show number of files in knowledge base.

---

### Screenshots or Videos

<img width="677" height="211" alt="image" src="https://github.com/user-attachments/assets/27a79121-56ad-44b0-b414-b0f6c3e1f224" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
