### PR TITLE
feat: Add OAUTH_PRESERVE_LOCAL_GROUPS option to protect local groups during OAuth sync

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -531,6 +531,12 @@ ENABLE_OAUTH_GROUP_CREATION = PersistentConfig(
     os.environ.get("ENABLE_OAUTH_GROUP_CREATION", "False").lower() == "true",
 )
 
+OAUTH_PRESERVE_LOCAL_GROUPS = PersistentConfig(
+    "OAUTH_PRESERVE_LOCAL_GROUPS",
+    "oauth.preserve_local_groups",
+    os.environ.get("OAUTH_PRESERVE_LOCAL_GROUPS", "False").lower() == "true",
+)
+
 
 OAUTH_BLOCKED_GROUPS = PersistentConfig(
     "OAUTH_BLOCKED_GROUPS",


### PR DESCRIPTION
## 🎯 **Problem**

Currently, OAuth group synchronization overwrites all local groups, removing users from locally managed groups when they login via OAuth. This creates management conflicts between OAuth-managed and locally-managed groups.

## 🚀 **Solution**

This PR introduces a new optional configuration `OAUTH_PRESERVE_LOCAL_GROUPS` that allows administrators to preserve locally created groups while still enabling OAuth group synchronization.

## 📋 **Changes**

### New Configuration Option
- **`OAUTH_PRESERVE_LOCAL_GROUPS`** (default: `false`) - Enables protection of local groups during OAuth sync

### Core Functionality
- **OAuth Metadata Tracking**: Groups now track their origin (`oauth_source` in metadata)
- **Smart Group Management**: Distinguishes between local and OAuth-managed groups
- **Name Conflict Resolution**: Local groups take priority over OAuth groups with same names
- **Backward Compatibility**: Default behavior unchanged (fully backward compatible)

### Modified Files
- **`backend/open_webui/config.py`**: Added new configuration option
- **`backend/open_webui/models/groups.py`**: Extended group creation with OAuth tracking
- **`backend/open_webui/utils/oauth.py`**: Enhanced group sync logic for local group preservation

## 🔧 **Usage**

```bash
# Enable local group preservation
OAUTH_PRESERVE_LOCAL_GROUPS=true
```

## 🧪 **Scenarios Covered**

1. **Preserved Local Groups**: Users stay in local "poweruser" group + get OAuth groups
2. **Department Changes**: Users removed from old OAuth departments but keep local groups  
3. **Name Conflicts**: Local "admin" group preserved, OAuth "admin" group skipped
4. **Legacy Mode**: Works exactly as before when disabled (default)

## 🔄 **Backward Compatibility**

- ✅ **Default behavior unchanged** (OAUTH_PRESERVE_LOCAL_GROUPS=false)
- ✅ **No database migrations required**
- ✅ **Existing APIs unchanged**
- ✅ **Zero breaking changes**