### PR TITLE
feat: show generated retrieval queries

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -312,7 +312,15 @@
 
 				if (type === 'status') {
 					if (message?.statusHistory) {
-						message.statusHistory.push(data);
+						// Check if we already have a status with the same action
+						const existingIndex = message.statusHistory.findIndex(s => s.action === data.action);
+						if (existingIndex !== -1) {
+							// Update existing status
+							message.statusHistory[existingIndex] = data;
+						} else {
+							// Add new status
+							message.statusHistory.push(data);
+						}
 					} else {
 						message.statusHistory = [data];
 					}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -38,6 +38,7 @@
 	import RateComment from './RateComment.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import WebSearchResults from './ResponseMessage/WebSearchResults.svelte';
+	import QueryGenerationResults from './ResponseMessage/QueryGenerationResults.svelte';
 	import Sparkles from '$lib/components/icons/Sparkles.svelte';
 
 	import DeleteConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
@@ -643,10 +644,8 @@
 				<div class="chat-{message.role} w-full min-w-full markdown-prose">
 					<div>
 						{#if (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length > 0}
-							{@const status = (
-								message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]
-							).at(-1)}
-							{#if !status?.hidden}
+							{@const allStatuses = message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]}
+							{#each allStatuses.filter(s => !s?.hidden) as status}
 								<div class="status-description flex items-center gap-2 py-0.5">
 									{#if status?.action === 'web_search' && status?.urls}
 										<WebSearchResults {status}>
@@ -674,6 +673,24 @@
 												</div>
 											</div>
 										</WebSearchResults>
+									{:else if status?.action === 'retrieval_query_generation'}
+										<QueryGenerationResults {status}>
+											<div class="flex flex-col justify-center -space-y-0.5">
+												<div
+													class="{status?.done === false
+														? 'shimmer'
+														: ''} text-base line-clamp-1 text-wrap"
+												>
+													{#if status?.description.includes('{{count}}')}
+														{$i18n.t(status?.description, {
+															count: status?.queries?.length || 0
+														})}
+													{:else}
+														{status?.description}
+													{/if}
+												</div>
+											</div>
+										</QueryGenerationResults>
 									{:else if status?.action === 'knowledge_search'}
 										<div class="flex flex-col justify-center -space-y-0.5">
 											<div
@@ -711,7 +728,7 @@
 										</div>
 									{/if}
 								</div>
-							{/if}
+							{/each}
 						{/if}
 
 						{#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}

--- a/src/lib/components/chat/Messages/ResponseMessage/QueryGenerationResults.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/QueryGenerationResults.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import ChevronUp from '$lib/components/icons/ChevronUp.svelte';
+	import Search from '$lib/components/icons/Search.svelte';
+	import Collapsible from '$lib/components/common/Collapsible.svelte';
+
+	export let status = { queries: [] };
+	let state = false;
+</script>
+
+<Collapsible bind:open={state} className="w-full space-y-1">
+	<div
+		class="flex items-center gap-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition"
+	>
+		<slot />
+
+		{#if state}
+			<ChevronUp strokeWidth="3.5" className="size-3.5 " />
+		{:else}
+			<ChevronDown strokeWidth="3.5" className="size-3.5 " />
+		{/if}
+	</div>
+	<div
+		class="text-sm border border-gray-300/30 dark:border-gray-700/50 rounded-xl mb-1.5"
+		slot="content"
+	>
+		{#each status.queries || [] as query, queryIdx}
+			<div
+				class="flex w-full items-center p-3 px-4 {queryIdx === (status.queries || []).length - 1
+					? ''
+					: 'border-b border-gray-300/30 dark:border-gray-700/50'} group/item justify-between font-normal text-gray-800 dark:text-gray-300"
+			>
+				<div class="flex gap-2 items-center">
+					<Search />
+
+					<div class=" line-clamp-1">
+						{query}
+					</div>
+				</div>
+			</div>
+		{/each}
+	</div>
+</Collapsible>

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1261,6 +1261,7 @@
 	"SearchApi API Key": "",
 	"SearchApi Engine": "",
 	"Searched {{count}} sites": "",
+	"Generated {{count}} queries": "",
 	"Searching \"{{searchQuery}}\"": "",
 	"Searching Knowledge for \"{{searchQuery}}\"": "",
 	"Searching the web...": "",


### PR DESCRIPTION
# Changelog Entry

### Description

At present, when user asks a question against a knowledge collection and "Retrieval Query Generation" is on, QUERY_GENERATION_PROMPT_TEMPLATE is used to break down the question and then search in the collection. The user is unable to see what queries were made. This makes it difficult to understand why a source was fetched, cannot know what/how many queries the original question was broken into, cannot see impact of template change on queries easily. Showing the actual queries sent will help solve these.

This PR shows users what queries were actually sent to database for RAG too. It is solves the problems mentioned above.

Example:
If user asks "How much is OPD limit?", OPD can mean "Out Patient Department" or "Optical Power Density". Similarly, IPD can mean "In Patient Department" or "Inter Pupillary Distance".
I myself, have seen sub-query generation actually generate "Inter Pupillary Distance limit" when asked for "How much is IPD limit?" on a knowledge base having health related policies. I could see in citations that it fetched the right chunk, but since the sub-query was not related at all, model did not provide the answer.

### Added

- Show generated sub-queries for retrieval

---

### Additional Information

I had tried to introduce same feature in https://github.com/open-webui/open-webui/pull/14175. It got closed because the UI was not good. This time the UI is better. The UI is aligned also with how list of websites get shown if "Web Search" is on.

### Screenshots or Videos

https://github.com/user-attachments/assets/a8d9efbd-a56a-417d-a6de-f77619a18a85


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
