### PR TITLE
feat: Added support for redis as session storage

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -50,6 +50,11 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import Response, StreamingResponse
 from starlette.datastructures import Headers
 
+from starsessions import (
+    SessionMiddleware as StarSessionsMiddleware,
+    SessionAutoloadMiddleware,
+)
+from starsessions.stores.redis import RedisStore
 
 from open_webui.utils import logger
 from open_webui.utils.audit import AuditLevel, AuditLoggingMiddleware
@@ -1897,13 +1902,42 @@ async def get_current_usage(user=Depends(get_verified_user)):
 
 # SessionMiddleware is used by authlib for oauth
 if len(OAUTH_PROVIDERS) > 0:
-    app.add_middleware(
-        SessionMiddleware,
-        secret_key=WEBUI_SECRET_KEY,
-        session_cookie="oui-session",
-        same_site=WEBUI_SESSION_COOKIE_SAME_SITE,
-        https_only=WEBUI_SESSION_COOKIE_SECURE,
-    )
+    try:
+        # Try to create Redis store for sessions
+        if REDIS_URL:
+            redis_session_store = RedisStore(
+                url=REDIS_URL,
+                prefix=(
+                    f"{REDIS_KEY_PREFIX}:session:" if REDIS_KEY_PREFIX else "session:"
+                ),
+            )
+
+            # Add SessionAutoloadMiddleware first to handle session loading
+            app.add_middleware(SessionAutoloadMiddleware)
+
+            app.add_middleware(
+                StarSessionsMiddleware,
+                store=redis_session_store,
+                cookie_name="oui-session",
+                cookie_same_site=WEBUI_SESSION_COOKIE_SAME_SITE,
+                cookie_https_only=WEBUI_SESSION_COOKIE_SECURE,
+            )
+            log.info("Using StarSessions with Redis for session management")
+        else:
+            raise ValueError("Redis URL not configured")
+
+    except Exception as e:
+        log.warning(
+            f"Failed to initialize Redis sessions, falling back to cookie based sessions: {e}"
+        )
+        # Fallback to existing SessionMiddleware
+        app.add_middleware(
+            SessionMiddleware,
+            secret_key=WEBUI_SECRET_KEY,
+            session_cookie="oui-session",
+            same_site=WEBUI_SESSION_COOKIE_SAME_SITE,
+            https_only=WEBUI_SESSION_COOKIE_SECURE,
+        )
 
 
 @app.get("/oauth/{provider}/login")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ aiocache
 aiofiles
 starlette-compress==1.6.0
 httpx[socks,http2,zstd,cli,brotli]==0.28.1
+starsessions[redis]==2.2.1
 
 sqlalchemy==2.0.38
 alembic==1.14.0


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Added support for using Redis for session storage during oAuth redirects for better state handling, with fallback to current session handling.

### Added

- Added support for using Redis for session storage during oAuth redirects for better state handling.

---

### Additional Information

In Kubernetes with multi pod setup, we see a lot of these errors: `OAuth callback error: mismatching_state: CSRF Warning! State not equal in request and response.`

And from what I have been able to figure out. The current session handling is stored browser side and encrypted. This may fail do to browser setting or extension.

This PR adds support for using Redis as storage across pod's, with fallback to the current session handling.

See issue: https://github.com/open-webui/open-webui/issues/15373

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
