### PR TITLE
feat: model provider's web search

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1749,6 +1749,7 @@
 				tool_servers: $toolServers,
 
 				features: {
+					...(model.info?.meta?.capabilities ?? {}),
 					image_generation:
 						$config?.features?.enable_image_generation &&
 						($user?.role === 'admin' || $user?.permissions?.features?.image_generation)

--- a/src/lib/components/workspace/Models/Capabilities.svelte
+++ b/src/lib/components/workspace/Models/Capabilities.svelte
@@ -19,6 +19,10 @@
 			label: $i18n.t('Web Search'),
 			description: $i18n.t('Model can search the web for information')
 		},
+		native_web_search: {
+			label: $i18n.t('Native Web Search'),
+			description: $i18n.t('Model has built-in web search capabilities')
+		},
 		image_generation: {
 			label: $i18n.t('Image Generation'),
 			description: $i18n.t('Model can generate images based on text prompts')
@@ -43,6 +47,7 @@
 		vision?: boolean;
 		file_upload?: boolean;
 		web_search?: boolean;
+		native_web_search?: boolean;
 		image_generation?: boolean;
 		code_interpreter?: boolean;
 		usage?: boolean;


### PR DESCRIPTION
# Changelog Entry

### Description

Models like [gemini](https://ai.google.dev/gemini-api/docs/google-search) and [openai](https://platform.openai.com/docs/guides/tools) provide web search directly from their end. Currently there is no way to indicate to openwebui or pipelines to make use of model provider's web search tool instead of "web_search" implemented within openwebui.

To utilize model provider's web search tool:
- If `native_web_search` capability is on, pass "web_search" as a tool to model pipeline just like we do for "function calling" feature, and skip running the web_search implemented within openwebui
- in pipeline, detect the tool definition presence `body["tools"]` and add the web search tool of model provider in inference call.

### Added

- Flag to using model provider's web search

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
