### PR TITLE
UPD: Add Chat Tittle to navbar

### DIFF
--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -105,6 +105,12 @@
 					{#if showModelSelector}
 						<ModelSelector bind:selectedModels showSetDefault={!shareEnabled} />
 					{/if}
+					
+	                <div class="flex-1 flex items-center justify-center overflow-hidden max-w-full py-0.5">
+                        <h1 class="text-sm font-medium text-gray-900 dark:text-white truncate text-center">
+                            {title}
+                        </h1>
+                    </div>
 				</div>
 
 				<div class="self-start flex flex-none items-center text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
### UPD: Add Chat Tittle to navbar

Sometimes, when we are in a chat is difficult to now in what we are, there isn't hightlight or focus, just the chat_id on address url. Easier to know were we are with chat tittle visible.

I set it with small font because is less disturbing on mobile.

With PR:
![openwebui_chat_title0](https://github.com/user-attachments/assets/1a20ca97-3be9-4549-97eb-a8d49efc08a0)

mobile
![openwebui_chat_title1](https://github.com/user-attachments/assets/e5273af9-54c6-4f77-b318-508c03d9fac3)
____
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
