### PR TITLE
fix/feat: Fix changelog modal link embedding and add some usability features

### DIFF
--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -65,7 +65,10 @@
 				            <!-- 1. Make the header a button to toggle the collapsed state -->
 				            <button
 				                class="w-full flex justify-between items-center text-left"
-				                on:click={() => collapsedVersions.set(version, !isCollapsed)}
+				                on:click={() => {
+								    collapsedVersions.set(version, !isCollapsed);
+								    collapsedVersions = collapsedVersions;
+								}}
 				            >
 				                <div class="font-semibold text-xl dark:text-white">
 				                    v{version} - {changelog[version].date}

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -62,7 +62,6 @@
 				        {@const isCollapsed = collapsedVersions.get(version) ?? (i > 0)}
 
 				        <div class="mb-3 pr-2">
-				            <!-- 1. Make the header a button to toggle the collapsed state -->
 				            <button
 				                class="w-full flex justify-between items-center text-left"
 				                on:click={() => {

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -24,7 +24,7 @@
 	});
 </script>
 
-<Modal bind:show size="lg">
+<Modal bind:show size="xl">
 	<div class="px-5 pt-4 dark:text-gray-300 text-gray-700">
 		<div class="flex justify-between items-start">
 			<div class="text-xl font-semibold">
@@ -49,7 +49,7 @@
 			<div class="text-sm dark:text-gray-200">{$i18n.t('Release Notes')}</div>
 			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-200 dark:bg-gray-700" />
 			<div class="text-sm dark:text-gray-200">
-				v{WEBUI_VERSION}
+				Latest: v{WEBUI_VERSION}
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -87,7 +87,7 @@
 												<div class="font-semibold uppercase">
 													{changelog[version][section][item].title}
 												</div>
-												<div class="mb-2 mt-1">{changelog[version][section][item].content}</div>
+												<div class="mb-2 mt-1">{@html changelog[version][section][item].raw}</div>
 											</div>
 										{/each}
 									</div>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -122,28 +122,11 @@
     }
 
     :global(.changelog-content a) {
-        color: theme('colors.blue.600');
-        text-decoration-line: none; 
-    }
-
-    :global(.dark .changelog-content a) {
-        color: theme('colors.blue.400');
-    }
-
-    :global(.changelog-content a:hover) {
-        text-decoration-line: underline;
-    }
-
-	:global(.changelog-content a) {
+        text-decoration-line: underline !important;
         color: theme('colors.blue.600') !important;
-        text-decoration-line: none; 
     }
 
     :global(.dark .changelog-content a) {
         color: theme('colors.blue.400') !important;
-    }
-
-    :global(.changelog-content a:hover) {
-        text-decoration-line: underline !important;
     }
 </style>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -81,16 +81,13 @@
 										{section}
 									</div>
 
-									<div class="my-2.5 px-1.5">
-										{#each Object.keys(changelog[version][section]) as item}
-											<div class="text-sm mb-2">
-												<div class="font-semibold uppercase">
-													{changelog[version][section][item].title}
-												</div>
-												<div class="mb-2 mt-1">{@html changelog[version][section][item].raw}</div>
-											</div>
-										{/each}
-									</div>
+									<ul class="my-2.5 px-1.5 space-y-2 changelog-content">
+									    {#each changelog[version][section] as entry}
+									        <!-- The 'raw' content is already an <li>, so we just render it directly.
+									             The 'text-sm' class ensures the font size is correct. -->
+									        {@html `<div class="text-sm">${entry.raw}</div>`}
+									    {/each}
+									</ul>
 								</div>
 							{/each}
 						</div>
@@ -113,3 +110,16 @@
 		</div>
 	</div>
 </Modal>
+
+<style>
+    :global(.changelog-content li) {
+        list-style-type: none;
+        padding-left: 0;
+    }
+    :global(.changelog-content p) {
+        margin: 0;
+    }
+    :global(.changelog-content a) {
+        @apply text-blue-600 dark:text-blue-400 hover:underline;
+    }
+</style>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -133,4 +133,17 @@
     :global(.changelog-content a:hover) {
         text-decoration-line: underline;
     }
+
+	:global(.changelog-content a) {
+        color: theme('colors.blue.600') !important;
+        text-decoration-line: none; 
+    }
+
+    :global(.dark .changelog-content a) {
+        color: theme('colors.blue.400') !important;
+    }
+
+    :global(.changelog-content a:hover) {
+        text-decoration-line: underline !important;
+    }
 </style>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -119,7 +119,17 @@
     :global(.changelog-content p) {
         margin: 0;
     }
+
     :global(.changelog-content a) {
-        @apply text-blue-600 dark:text-blue-400 hover:underline;
+        color: theme('colors.blue.600');
+        text-decoration-line: none; /* Start with no underline by default */
+    }
+
+    :global(.dark .changelog-content a) {
+        color: theme('colors.blue.400');
+    }
+
+    :global(.changelog-content a:hover) {
+        text-decoration-line: underline;
     }
 </style>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -16,6 +16,7 @@
 	export let show = false;
 
 	let changelog = null;
+	let collapsedVersions = new Map();
 
 	onMount(async () => {
 		const res = await getChangelog();
@@ -57,41 +58,62 @@
 		<div class=" overflow-y-scroll max-h-96 scrollbar-hidden">
 			<div class="mb-3">
 				{#if changelog}
-					{#each Object.keys(changelog) as version}
-						<div class=" mb-3 pr-2">
-							<div class="font-semibold text-xl mb-1 dark:text-white">
-								v{version} - {changelog[version].date}
-							</div>
+				    {#each Object.keys(changelog) as version, i}
+				        {@const isCollapsed = collapsedVersions.get(version) ?? (i > 0)}
 
-							<hr class="border-gray-100 dark:border-gray-850 my-2" />
+				        <div class="mb-3 pr-2">
+				            <!-- 1. Make the header a button to toggle the collapsed state -->
+				            <button
+				                class="w-full flex justify-between items-center text-left"
+				                on:click={() => collapsedVersions.set(version, !isCollapsed)}
+				            >
+				                <div class="font-semibold text-xl dark:text-white">
+				                    v{version} - {changelog[version].date}
+				                </div>
 
-							{#each Object.keys(changelog[version]).filter((section) => section !== 'date') as section}
-								<div class="">
-									<div
-										class="font-semibold uppercase text-xs {section === 'added'
-											? 'text-white bg-blue-600'
-											: section === 'fixed'
-												? 'text-white bg-green-600'
-												: section === 'changed'
-													? 'text-white bg-yellow-600'
-													: section === 'removed'
-														? 'text-white bg-red-600'
-														: ''}  w-fit px-3 rounded-full my-2.5"
-									>
-										{section}
-									</div>
+				                <svg
+				                    class="size-4 transform transition-transform {isCollapsed ? '-rotate-90' : 'rotate-0'}"
+				                    xmlns="http://www.w3.org/2000/svg"
+				                    viewBox="0 0 20 20"
+				                    fill="currentColor"
+				                >
+				                    <path
+				                        fill-rule="evenodd"
+				                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+				                        clip-rule="evenodd"
+				                    />
+				                </svg>
+				            </button>
 
-									<ul class="my-2.5 px-1.5 space-y-2 changelog-content">
-									    {#each changelog[version][section] as entry}
-									        <!-- The 'raw' content is already an <li>, so we just render it directly.
-									             The 'text-sm' class ensures the font size is correct. -->
-									        {@html `<div class="text-sm">${entry.raw}</div>`}
-									    {/each}
-									</ul>
-								</div>
-							{/each}
-						</div>
-					{/each}
+				            <hr class="border-gray-100 dark:border-gray-850 my-2" />
+
+				            {#if !isCollapsed}
+				                {#each Object.keys(changelog[version]).filter((section) => section !== 'date') as section}
+				                    <div class="">
+				                        <div
+				                            class="font-semibold uppercase text-xs {section === 'added'
+				                                ? 'text-white bg-blue-600'
+				                                : section === 'fixed'
+				                                    ? 'text-white bg-green-600'
+				                                    : section === 'changed'
+				                                        ? 'text-white bg-yellow-600'
+				                                        : section === 'removed'
+				                                            ? 'text-white bg-red-600'
+				                                            : ''}  w-fit px-3 rounded-full my-2.5"
+				                        >
+				                            {section}
+				                        </div>
+
+				                        <ul class="my-2.5 px-1.5 space-y-2 changelog-content">
+				                            {#each changelog[version][section] as entry}
+				                                {@html `<div class="text-sm">${entry.raw}</div>`}
+				                            {/each}
+				                        </ul>
+				                    </div>
+				                {/each}
+				            {/if}
+				        </div>
+				    {/each}
 				{/if}
 			</div>
 		</div>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -116,13 +116,14 @@
         list-style-type: none;
         padding-left: 0;
     }
+
     :global(.changelog-content p) {
         margin: 0;
     }
 
     :global(.changelog-content a) {
         color: theme('colors.blue.600');
-        text-decoration-line: none; /* Start with no underline by default */
+        text-decoration-line: none; 
     }
 
     :global(.dark .changelog-content a) {


### PR DESCRIPTION
# Pull Request Checklist

[X] Yes, tested

### Added

- Possibility to collapse older versions (only newest version is expanded by default)

<img width="1126" height="537" alt="image" src="https://github.com/user-attachments/assets/2be19a78-c012-4d07-b93b-cf9b48ea313f" />

<img width="1124" height="394" alt="image" src="https://github.com/user-attachments/assets/bb939199-c58f-4cab-b911-eb22e7a0c4fb" />

<img width="1142" height="542" alt="image" src="https://github.com/user-attachments/assets/be4377e5-4394-4112-aa6e-6a1189148223" />

### Changed
- The way OLD changelogs are rendered was altered: the **fat** part of each changelog entry is no longer used as a subtitle (this change was necessary to accomondate the new other additions and fixes).
- Made modal slightly larger

**BEFORE:**

<img width="878" height="300" alt="image" src="https://github.com/user-attachments/assets/518c5e4b-eb97-43ae-b443-1d8840947301" />

**AFTER:**

<img width="1095" height="232" alt="image" src="https://github.com/user-attachments/assets/97461e4e-bf9d-44a3-8534-4199f8477004" />

### Fixed

- Embedded the links from the changelog directly into the shown visual changelog - all links are underlined for visual distinction (see screenshots above)

---

Addresses: #17309

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
