### PR TITLE
UPD: Centralization of dayjs 

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -5,29 +5,12 @@
 	import { getContext } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import dayjs from '$lib/dayjs';
+	import dayjs from '$lib/stores/dayjs';
 	import duration from 'dayjs/plugin/duration';
 	import relativeTime from 'dayjs/plugin/relativeTime';
 
 	dayjs.extend(duration);
 	dayjs.extend(relativeTime);
-
-	async function loadLocale(locales) {
-		if (!locales || !Array.isArray(locales)) {
-			return;
-		}
-		for (const locale of locales) {
-			try {
-				dayjs.locale(locale);
-				break; // Stop after successfully loading the first available locale
-			} catch (error) {
-				console.error(`Could not load locale '${locale}':`, error);
-			}
-		}
-	}
-
-	// Assuming $i18n.languages is an array of language codes
-	$: loadLocale($i18n.languages);
 
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -14,7 +14,7 @@
 
 	import { goto } from '$app/navigation';
 
-	import dayjs from '$lib/dayjs';
+	import dayjs from '$lib/stores/dayjs';
 	import calendar from 'dayjs/plugin/calendar';
 	import duration from 'dayjs/plugin/duration';
 	import relativeTime from 'dayjs/plugin/relativeTime';
@@ -47,20 +47,6 @@
 	import Chat from './NoteEditor/Chat.svelte';
 
 	import AccessControlModal from '$lib/components/workspace/common/AccessControlModal.svelte';
-
-	async function loadLocale(locales) {
-		for (const locale of locales) {
-			try {
-				dayjs.locale(locale);
-				break; // Stop after successfully loading the first available locale
-			} catch (error) {
-				console.error(`Could not load locale '${locale}':`, error);
-			}
-		}
-	}
-
-	// Assuming $i18n.languages is an array of language codes
-	$: loadLocale($i18n.languages);
 
 	import { deleteNoteById, getNoteById, updateNoteById } from '$lib/apis/notes';
 

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -8,26 +8,12 @@
 	import jsPDF from 'jspdf';
 	import html2canvas from 'html2canvas-pro';
 
-	import dayjs from '$lib/dayjs';
+	import dayjs from '$lib/stores/dayjs';
 	import duration from 'dayjs/plugin/duration';
 	import relativeTime from 'dayjs/plugin/relativeTime';
 
 	dayjs.extend(duration);
 	dayjs.extend(relativeTime);
-
-	async function loadLocale(locales) {
-		for (const locale of locales) {
-			try {
-				dayjs.locale(locale);
-				break; // Stop after successfully loading the first available locale
-			} catch (error) {
-				console.error(`Could not load locale '${locale}':`, error);
-			}
-		}
-	}
-
-	// Assuming $i18n.languages is an array of language codes
-	$: loadLocale($i18n.languages);
 
 	import { goto } from '$app/navigation';
 	import { onMount, getContext, onDestroy } from 'svelte';

--- a/src/lib/dayjs.js
+++ b/src/lib/dayjs.js
@@ -102,4 +102,17 @@ import 'dayjs/locale/zh';
 import 'dayjs/locale/zh-tw';
 import 'dayjs/locale/et';
 
+// Default to browser locale
+import { browser } from '$app/environment';
+
+// Initialize with browser locale if available
+if (browser) {
+    const browserLocale = navigator.language.split('-')[0];
+    try {
+        dayjs.locale(browserLocale);
+    } catch (error) {
+        dayjs.locale('en'); // fallback
+    }
+}
+
 export default dayjs;

--- a/src/lib/stores/dayjs.js
+++ b/src/lib/stores/dayjs.js
@@ -1,0 +1,31 @@
+import { writable } from 'svelte/store';
+import dayjs from '$lib/dayjs';
+import i18n from '$lib/i18n';
+
+export const dayjsLocale = writable('en');
+
+// Global locale loader
+async function loadDayjsLocale(locales) {
+    if (!locales || !Array.isArray(locales)) {
+        return;
+    }
+
+    for (const locale of locales) {
+        try {
+            dayjs.locale(locale);
+            dayjsLocale.set(locale);
+            break;
+        } catch (error) {
+            console.error(`Could not load dayjs locale '${locale}':`, error);
+        }
+    }
+}
+
+// Subscribe to i18n language changes
+i18n.subscribe(($i18n) => {
+    if ($i18n?.languages) {
+        loadDayjsLocale($i18n.languages);
+    }
+});
+// Export dayjs as default so components can import it
+export default dayjs;


### PR DESCRIPTION
### UPD: Centralization of dayjs 

Centralization of dayjs localization for easier and more consistent across components.
Solve https://github.com/open-webui/open-webui/issues/17357

Added: 
Global dayjs store at $lib/stores/dayjs.js

Modified:
- $lib/dayjs.js to include global locale management.
- Components: Collapsable, Notes & NoteEditor to use centralize dayjs

NOTE:
In future use of dayjs in components use `import dayjs from '$lib/stores/dayjs';` instead of `import dayjs from '$lib/dayjs';`  + individual loadLocale


![openwebui_fix_dayjs2](https://github.com/user-attachments/assets/ae548698-0831-406b-962c-c28c63d030e6)
![openwebui_fix_dayjs1](https://github.com/user-attachments/assets/0018f3de-5d75-4250-b09f-900f72bdff54)
![openwebui_fix_dayjs](https://github.com/user-attachments/assets/9c5478ba-3258-4c10-a946-ca0f3707798b)

____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
