### PR TITLE
feat: Private sharing permissions for Workspace entities

### DIFF
--- a/src/lib/components/AddServerModal.svelte
+++ b/src/lib/components/AddServerModal.svelte
@@ -14,6 +14,7 @@
 	import Tags from './common/Tags.svelte';
 	import { getToolServerData } from '$lib/apis';
 	import { verifyToolServerConnection } from '$lib/apis/configs';
+	import { getGroups } from '$lib/apis/groups';
 	import AccessControl from './workspace/common/AccessControl.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
@@ -34,6 +35,7 @@
 	let key = '';
 
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	let id = '';
 	let name = '';
@@ -153,8 +155,13 @@
 		init();
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		init();
+
+		let groups = await getGroups(localStorage.token);
+
+		// There is no setting governing private sharing this entity, so allow all groups
+		allowedPrivate = groups.map((group) => group.id);
 	});
 </script>
 
@@ -397,7 +404,7 @@
 
 							<div class="my-2 -mx-2">
 								<div class="px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
-									<AccessControl bind:accessControl />
+									<AccessControl bind:accessControl  {allowedPrivate}/>
 								</div>
 							</div>
 						{/if}

--- a/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
@@ -3,6 +3,7 @@
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
 
+	import { getGroups } from '$lib/apis/groups';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import { models } from '$lib/stores';
@@ -45,6 +46,7 @@
 	let filterMode = 'include';
 
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	let imageInputElement;
 	let loading = false;
@@ -115,8 +117,13 @@
 		initModel();
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		initModel();
+
+		let groups = await getGroups(localStorage.token);
+
+		// There is no setting governing private sharing this entity, so allow all groups
+		allowedPrivate = groups.map((group) => group.id);
 	});
 </script>
 
@@ -294,7 +301,7 @@
 
 						<div class="my-2 -mx-2">
 							<div class="px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
-								<AccessControl bind:accessControl />
+								<AccessControl bind:accessControl {allowedPrivate}/>
 							</div>
 						</div>
 

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -62,7 +62,12 @@
 			public_models: false,
 			public_knowledge: false,
 			public_prompts: false,
-			public_tools: false
+			public_tools: false,
+			private_models: false,
+			private_knowledge: false,
+			private_prompts: false,
+			private_tools: false
+
 		},
 		chat: {
 			controls: true,

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -230,7 +230,7 @@
 							{#if selectedTab == 'general'}
 								<Display bind:name bind:description />
 							{:else if selectedTab == 'permissions'}
-								<Permissions bind:permissions />
+								<Permissions bind:permissions groupId={group?.id}/>
 							{:else if selectedTab == 'users'}
 								<Users bind:userIds {users} />
 							{/if}

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -17,7 +17,11 @@
 			public_models: false,
 			public_knowledge: false,
 			public_prompts: false,
-			public_tools: false
+			public_tools: false,
+			private_models: false,
+			private_knowledge: false,
+			private_prompts: false,
+			private_tools: false
 		},
 		chat: {
 			controls: true,
@@ -218,34 +222,66 @@
 	<hr class=" border-gray-100 dark:border-gray-850 my-2" />
 
 	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Sharing Permissions')}</div>
+		<div class="mb-2 text-sm font-medium">{$i18n.t('Sharing Permissions')}</div>
 
-		<div class="  flex w-full justify-between my-2 pr-2">
-			<div class=" self-center text-xs font-medium">
+		<!-- Public -->
+		<div class="mt-1 mb-1 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+			{$i18n.t('Public')}
+		</div>
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
 				{$i18n.t('Models Public Sharing')}
 			</div>
 			<Switch bind:state={permissions.sharing.public_models} />
 		</div>
-
-		<div class="  flex w-full justify-between my-2 pr-2">
-			<div class=" self-center text-xs font-medium">
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
 				{$i18n.t('Knowledge Public Sharing')}
 			</div>
 			<Switch bind:state={permissions.sharing.public_knowledge} />
 		</div>
-
-		<div class="  flex w-full justify-between my-2 pr-2">
-			<div class=" self-center text-xs font-medium">
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
 				{$i18n.t('Prompts Public Sharing')}
 			</div>
 			<Switch bind:state={permissions.sharing.public_prompts} />
 		</div>
-
-		<div class="  flex w-full justify-between my-2 pr-2">
-			<div class=" self-center text-xs font-medium">
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
 				{$i18n.t('Tools Public Sharing')}
 			</div>
 			<Switch bind:state={permissions.sharing.public_tools} />
+		</div>
+
+		<hr class="border-gray-100 dark:border-gray-850 my-1" />
+
+		<!-- Private -->
+		<div class="mt-1 mb-1 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+			{$i18n.t('Private')}
+		</div>
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
+				{$i18n.t('Models Private Sharing')}
+			</div>
+			<Switch bind:state={permissions.sharing.private_models} />
+		</div>
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
+				{$i18n.t('Knowledge Private Sharing')}
+			</div>
+			<Switch bind:state={permissions.sharing.private_knowledge} />
+		</div>
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
+				{$i18n.t('Prompts Private Sharing')}
+			</div>
+			<Switch bind:state={permissions.sharing.private_prompts} />
+		</div>
+		<div class="flex w-full justify-between my-2 pr-2">
+			<div class="self-center text-xs font-medium">
+				{$i18n.t('Tools Private Sharing')}
+			</div>
+			<Switch bind:state={permissions.sharing.private_tools} />
 		</div>
 	</div>
 

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -54,6 +54,8 @@
 	};
 
 	export let permissions = {};
+	// Group ID these permissions apply to. For user-level permissions, leave null
+	export let groupId = null;
 
 	// Reactive statement to ensure all fields are present in `permissions`
 	$: {
@@ -73,6 +75,7 @@
 
 	onMount(() => {
 		permissions = fillMissingProperties(permissions, defaultPermissions);
+		console.log(groupId);
 	});
 </script>
 
@@ -253,36 +256,37 @@
 			<Switch bind:state={permissions.sharing.public_tools} />
 		</div>
 
-		<hr class="border-gray-100 dark:border-gray-850 my-1" />
-
-		<!-- Private -->
-		<div class="mt-1 mb-1 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
-			{$i18n.t('Private')}
-		</div>
-		<div class="flex w-full justify-between my-2 pr-2">
-			<div class="self-center text-xs font-medium">
-				{$i18n.t('Models Private Sharing')}
+		{#if groupId !== null}
+			<!-- Private -->
+			<hr class="border-gray-100 dark:border-gray-850 my-1" />
+			<div class="mt-1 mb-1 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+				{$i18n.t('Private')}
 			</div>
-			<Switch bind:state={permissions.sharing.private_models} />
-		</div>
-		<div class="flex w-full justify-between my-2 pr-2">
-			<div class="self-center text-xs font-medium">
-				{$i18n.t('Knowledge Private Sharing')}
+			<div class="flex w-full justify-between my-2 pr-2">
+				<div class="self-center text-xs font-medium">
+					{$i18n.t('Models Private Sharing')}
+				</div>
+				<Switch bind:state={permissions.sharing.private_models} />
 			</div>
-			<Switch bind:state={permissions.sharing.private_knowledge} />
-		</div>
-		<div class="flex w-full justify-between my-2 pr-2">
-			<div class="self-center text-xs font-medium">
-				{$i18n.t('Prompts Private Sharing')}
+			<div class="flex w-full justify-between my-2 pr-2">
+				<div class="self-center text-xs font-medium">
+					{$i18n.t('Knowledge Private Sharing')}
+				</div>
+				<Switch bind:state={permissions.sharing.private_knowledge} />
 			</div>
-			<Switch bind:state={permissions.sharing.private_prompts} />
-		</div>
-		<div class="flex w-full justify-between my-2 pr-2">
-			<div class="self-center text-xs font-medium">
-				{$i18n.t('Tools Private Sharing')}
+			<div class="flex w-full justify-between my-2 pr-2">
+				<div class="self-center text-xs font-medium">
+					{$i18n.t('Prompts Private Sharing')}
+				</div>
+				<Switch bind:state={permissions.sharing.private_prompts} />
 			</div>
-			<Switch bind:state={permissions.sharing.private_tools} />
-		</div>
+			<div class="flex w-full justify-between my-2 pr-2">
+				<div class="self-center text-xs font-medium">
+					{$i18n.t('Tools Private Sharing')}
+				</div>
+				<Switch bind:state={permissions.sharing.private_tools} />
+			</div>
+		{/if}
 	</div>
 
 	<hr class=" border-gray-100 dark:border-gray-850 my-2" />

--- a/src/lib/components/layout/Sidebar/ChannelModal.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getContext, createEventDispatcher, onMount } from 'svelte';
 	import { createNewChannel, deleteChannelById } from '$lib/apis/channels';
+	import { getGroups } from '$lib/apis/groups';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
@@ -22,6 +23,7 @@
 
 	let name = '';
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	let loading = false;
 
@@ -68,6 +70,13 @@
 
 		show = false;
 	};
+
+	onMount(async () => {
+		let groups = await getGroups(localStorage.token);
+
+		// There is no setting governing private sharing this entity, so allow all groups
+		allowedPrivate = groups.map((group) => group.id);
+	});
 </script>
 
 <Modal size="sm" bind:show>
@@ -116,7 +125,7 @@
 
 					<div class="my-2 -mx-2">
 						<div class="px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
-							<AccessControl bind:accessControl />
+							<AccessControl bind:accessControl {allowedPrivate}/>
 						</div>
 					</div>
 

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -14,6 +14,7 @@
 
 	import { goto } from '$app/navigation';
 
+	import { getGroups } from '$lib/apis/groups';
 	import dayjs from '$lib/dayjs';
 	import calendar from 'dayjs/plugin/calendar';
 	import duration from 'dayjs/plugin/duration';
@@ -132,6 +133,7 @@
 
 	let showDeleteConfirm = false;
 	let showAccessControlModal = false;
+	let allowedPrivate = [];
 
 	let ignoreBlur = false;
 	let titleInputFocused = false;
@@ -878,6 +880,11 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		// dropzoneElement?.addEventListener('dragover', onDragOver);
 		// dropzoneElement?.addEventListener('drop', onDrop);
 		// dropzoneElement?.addEventListener('dragleave', onDragLeave);
+
+		let groups = await getGroups(localStorage.token);
+
+		// There is no setting governing private sharing this entity, so allow all groups
+		allowedPrivate = groups.map((group) => group.id);
 	});
 
 	onDestroy(() => {
@@ -907,6 +914,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		bind:show={showAccessControlModal}
 		bind:accessControl={note.access_control}
 		accessRoles={['read', 'write']}
+		{allowedPrivate}
 		onChange={() => {
 			changeDebounceHandler();
 		}}

--- a/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
@@ -1,11 +1,12 @@
 <script>
 	import { goto } from '$app/navigation';
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	const i18n = getContext('i18n');
 
 	import { createNewKnowledge, getKnowledgeBases } from '$lib/apis/knowledge';
 	import { toast } from 'svelte-sonner';
 	import { knowledge, user } from '$lib/stores';
+	import { getGroups } from '$lib/apis/groups';
 	import AccessControl from '../common/AccessControl.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 
@@ -14,6 +15,7 @@
 	let name = '';
 	let description = '';
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	const submitHandler = async () => {
 		loading = true;
@@ -43,6 +45,14 @@
 
 		loading = false;
 	};
+
+	onMount(async () => {
+		let groups = await getGroups(localStorage.token);
+
+		allowedPrivate = groups
+			.filter((group) => group.permissions?.sharing?.private_knowledge || $user?.role === 'admin')
+			.map((group) => group.id);
+	});
 </script>
 
 <div class="w-full max-h-full">
@@ -117,6 +127,7 @@
 					bind:accessControl
 					accessRoles={['read', 'write']}
 					allowPublic={$user?.permissions?.sharing?.public_knowledge || $user?.role === 'admin'}
+					{allowedPrivate}
 				/>
 			</div>
 		</div>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -24,6 +24,7 @@
 		deleteFileById,
 		getFileById
 	} from '$lib/apis/files';
+	import { getGroups } from '$lib/apis/groups';
 	import {
 		addFileToKnowledgeById,
 		getKnowledgeById,
@@ -75,6 +76,8 @@
 	let showAddTextContentModal = false;
 	let showSyncConfirmModal = false;
 	let showAccessControlModal = false;
+
+	let allowedPrivate = [];
 
 	let inputFiles = null;
 
@@ -613,6 +616,12 @@
 		dropZone?.addEventListener('dragover', onDragOver);
 		dropZone?.addEventListener('drop', onDrop);
 		dropZone?.addEventListener('dragleave', onDragLeave);
+
+		let groups = await getGroups(localStorage.token);
+
+		allowedPrivate = groups
+			.filter((group) => group.permissions?.sharing?.private_knowledge || $user?.role === 'admin')
+			.map((group) => group.id);
 	});
 
 	onDestroy(() => {
@@ -703,6 +712,7 @@
 			bind:show={showAccessControlModal}
 			bind:accessControl={knowledge.access_control}
 			allowPublic={$user?.permissions?.sharing?.public_knowledge || $user?.role === 'admin'}
+			{allowedPrivate}
 			onChange={() => {
 				changeDebounceHandler();
 			}}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -13,6 +13,7 @@
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import { getTools } from '$lib/apis/tools';
 	import { getFunctions } from '$lib/apis/functions';
+	import { getGroups } from '$lib/apis/groups';
 	import { getKnowledgeBases } from '$lib/apis/knowledge';
 	import AccessControl from '../common/AccessControl.svelte';
 	import { stringify } from 'postcss';
@@ -96,6 +97,7 @@
 	let actionIds = [];
 
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	const addUsage = (base_model_id) => {
 		const baseModel = $models.find((m) => m.id === base_model_id);
@@ -283,7 +285,14 @@
 			};
 
 			console.log(model);
+
 		}
+
+		let groups = await getGroups(localStorage.token);
+
+		allowedPrivate = groups
+			.filter((group) => group.permissions?.sharing?.private_models || $user?.role === 'admin')
+			.map((group) => group.id);
 
 		loaded = true;
 	});
@@ -566,6 +575,7 @@
 								bind:accessControl
 								accessRoles={['read', 'write']}
 								allowPublic={$user?.permissions?.sharing?.public_models || $user?.role === 'admin'}
+								{allowedPrivate}
 							/>
 						</div>
 					</div>

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount, tick, getContext } from 'svelte';
+	import { getGroups } from '$lib/apis/groups';
 
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import { toast } from 'svelte-sonner';
@@ -25,6 +26,7 @@
 	let content = '';
 
 	let accessControl = {};
+	let allowedPrivate = [];
 
 	let showAccessControlModal = false;
 
@@ -76,6 +78,12 @@
 
 			accessControl = prompt?.access_control === undefined ? {} : prompt?.access_control;
 		}
+
+		let groups = await getGroups(localStorage.token);
+
+		allowedPrivate = groups
+			.filter((group) => group.permissions?.sharing?.private_prompts || $user?.role === 'admin')
+			.map((group) => group.id);
 	});
 </script>
 
@@ -84,6 +92,7 @@
 	bind:accessControl
 	accessRoles={['read', 'write']}
 	allowPublic={$user?.permissions?.sharing?.public_prompts || $user?.role === 'admin'}
+	{allowedPrivate}
 />
 
 <div class="w-full max-h-full flex justify-center">

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -13,6 +13,8 @@
 	import AccessControlModal from '../common/AccessControlModal.svelte';
 	import { user } from '$lib/stores';
 
+	import { getGroups } from '$lib/apis/groups';
+
 	let formElement = null;
 	let loading = false;
 
@@ -31,6 +33,7 @@
 	};
 	export let content = '';
 	export let accessControl = {};
+	let allowedPrivate = [];
 
 	let _content = '';
 
@@ -57,7 +60,7 @@ class Tools:
         pass
 
     # Add your custom tools using pure Python code here, make sure to add type hints and descriptions
-	
+
     def get_user_name_and_email_and_id(self, __user__: dict = {}) -> str:
         """
         Get the user name, Email and ID from the user object.
@@ -183,6 +186,15 @@ class Tools:
 			}
 		}
 	};
+
+
+	onMount(async () => {
+		let groups = await getGroups(localStorage.token);
+
+		allowedPrivate = groups
+			.filter((group) => group.permissions?.sharing?.private_tools || $user?.role === 'admin')
+			.map((group) => group.id);
+	});
 </script>
 
 <AccessControlModal
@@ -190,6 +202,7 @@ class Tools:
 	bind:accessControl
 	accessRoles={['read', 'write']}
 	allowPublic={$user?.permissions?.sharing?.public_tools || $user?.role === 'admin'}
+	{allowedPrivate}
 />
 
 <div class=" flex flex-col justify-between w-full overflow-y-auto h-full">

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -16,6 +16,7 @@
 	export let accessControl = {};
 
 	export let allowPublic = true;
+	export let allowedPrivate = [];
 
 	let selectedGroupId = '';
 	let groups = [];
@@ -186,7 +187,8 @@
 									<option class=" text-gray-700" value="" disabled selected
 										>{$i18n.t('Select a group')}</option
 									>
-									{#each groups.filter((group) => !accessControl.read.group_ids.includes(group.id)) as group}
+									<pre>{console.log("allowedPrivate", allowedPrivate)}</pre>
+									{#each groups.filter((group) => !accessControl.read.group_ids.includes(group.id) && allowedPrivate.includes(group.id)) as group}
 										<option class=" text-gray-700" value={group.id}>{group.name}</option>
 									{/each}
 								</select>

--- a/src/lib/components/workspace/common/AccessControlModal.svelte
+++ b/src/lib/components/workspace/common/AccessControlModal.svelte
@@ -10,6 +10,7 @@
 	export let accessControl = {};
 	export let accessRoles = ['read'];
 	export let allowPublic = true;
+	export let allowedPrivate = [];
 
 	export let onChange = () => {};
 </script>
@@ -31,7 +32,7 @@
 		</div>
 
 		<div class="w-full px-5 pb-4 dark:text-white">
-			<AccessControl bind:accessControl {onChange} {accessRoles} {allowPublic} />
+			<AccessControl bind:accessControl {onChange} {accessRoles} {allowPublic} {allowedPrivate} />
 		</div>
 	</div>
 </Modal>


### PR DESCRIPTION
##
# Description

This PR introduces permissions for "Private Sharing" of Workspace entities. If Private Sharing is allowed for a Group, a member of that Group can share their creations with this Group.  "Private Sharing" can be toggled independently for each Workspace component.

## Documentation
Documentation has not yet been updated.

## Dependencies
This PR introduces no new external dependencies. 

## Testing
I have not written any tests but have validated the intended behavior manually.

## Code review
I have self-reviewed my code, and tried to adhere to existing style and coding standards

# Changelog Entry

### Description

This PR addresses the points mentioned in discussion #15100 by introducing the concept of "Private Sharing" permissions: A Group now has an additional set of permissions that govern whether members of this Group can share Workspace creations with the Group privately. 

With this feature, the following scenarios can be avoided by deactivating private sharing permissions (from the discussion linked above):

> **Universities:** Students in a shared "Students" group can spam each other's interfaces by sharing personal models, uploading irrelevant knowledge bases, creating joke prompts, or publishing buggy tools
>
> **Large organizations:** Employees can flood departmental groups with personal workspace items, making it difficult for colleagues to find legitimate shared resources
>
> **Multi-tenant environments:** Users can clutter shared spaces with experimental or low-quality content that affects the entire group's productivity

### Added

- A set of permissions on Groups that govern privately sharing Workspace entities within the group

### Changed

- Added a prop `allowedPrivate` to `AccessControl`: This array holds the IDs of all groups that should appear in the group selector when sharing is set to Private.
- Added the same prop to `AccessControlModal` (a little bit of prop drilling, but follows existing patterns)
- Initialized `allowedPrivate` in all components that use an `AccessControl` or `AccessControlModal`:
   - If the component is part of one of the Workspace entities, use the new permissions to find the appropriate groups for private sharing (or all if admin)
   - If the component is not one of the Workspace entities (e.g. non-direct Tool Server connections, Notes, ...), allow all groups for private sharing. 

---
### Screenshots or Videos

The new options in the Permissions dialog:

<img width="687" height="485" alt="permissions dialog" src="https://github.com/user-attachments/assets/c07636fa-10c3-42b0-ae54-183a72b38d35" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
