### PR TITLE
fix: Return usage information correctly for google models

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2031,6 +2031,22 @@ async def process_chat_response(
                                     )
                                 else:
                                     choices = data.get("choices", [])
+
+                                    usage = data.get("usage", {})
+                                    if usage:
+                                        usage.update(
+                                            data.get("timing", {})
+                                        )  # llama.cpp
+
+                                        await event_emitter(
+                                            {
+                                                "type": "chat:completion",
+                                                "data": {
+                                                    "usage": usage,
+                                                },
+                                            }
+                                        )
+
                                     if not choices:
                                         error = data.get("error", {})
                                         if error:
@@ -2042,21 +2058,7 @@ async def process_chat_response(
                                                     },
                                                 }
                                             )
-                                            continue
-                                    usage = data.get("usage", {})
-                                    if usage:
-                                        usage.update(
-                                            data.get("timings", {})
-                                        )  # llama.cpp
-
-                                        await event_emitter(
-                                            {
-                                                "type": "chat:completion",
-                                                "data": {
-                                                    "usage": usage,
-                                                },
-                                            }
-                                        )
+                                        continue
 
                                     delta = choices[0].get("delta", {})
                                     delta_tool_calls = delta.get("tool_calls", None)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2042,21 +2042,21 @@ async def process_chat_response(
                                                     },
                                                 }
                                             )
-                                        usage = data.get("usage", {})
+                                            continue
+                                    usage = data.get("usage", {})
+                                    if usage:
                                         usage.update(
                                             data.get("timings", {})
                                         )  # llama.cpp
 
-                                        if usage:
-                                            await event_emitter(
-                                                {
-                                                    "type": "chat:completion",
-                                                    "data": {
-                                                        "usage": usage,
-                                                    },
-                                                }
-                                            )
-                                        continue
+                                        await event_emitter(
+                                            {
+                                                "type": "chat:completion",
+                                                "data": {
+                                                    "usage": usage,
+                                                },
+                                            }
+                                        )
 
                                     delta = choices[0].get("delta", {})
                                     delta_tool_calls = delta.get("tool_calls", None)


### PR DESCRIPTION
…viders will send everything together.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- While streaming the response from a model, we assumed that the usage information would be sent only after all the delta content, in a separate interation, as OpenAI usually does. Some providers send the data together with the last chunk of data tough, so the usage information would be lost.

### Added
### Changed
### Deprecated
### Removed
### Fixed

- An issue was resolved that prevented usage data from being correctly collected in some cases.

### Security
### Breaking Changes
### Additional Information

The code assumed the usage information would be always sent by the provider separated from the choices tag (as OpenAI usually does). But Google often just sends everything together when the generation is small:
`{
    "choices": [
        {
            "delta": {
                "content": "Olá! Como posso ajudar?",
                "role": "assistant"
            },
            "finish_reason": "stop",
            "index": 0
        }
    ],
    "created": 1757736622,
    "id": "ru7EaIjuDKWgz7IP48a6kAM",
    "model": "gemini-2.5-flash",
    "object": "chat.completion.chunk",
    "usage": {
        "completion_tokens": 6,
        "prompt_tokens": 3,
        "total_tokens": 41
    }
}`

Even when it's big, it sends the usage with every iteration, updating the token values as it goes. The last iteration contains both the last chunk and the last usage information.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

It's a simple fix but It's important for people that use filters to register the usage with langfuse or other tools.
