### PR TITLE
fix: handle None usage data in chat response processing

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2033,7 +2033,7 @@ async def process_chat_response(
                                     choices = data.get("choices", [])
 
                                     # 17421
-                                    usage = data.get("usage", {})
+                                    usage = data.get("usage") or {}
                                     usage.update(data.get("timings", {}))  # llama.cpp
                                     if usage:
                                         await event_emitter(


### PR DESCRIPTION
Update usage data handling to use 'or {}' instead of default parameter to properly handle None values from API responses.

some api server return data like 

```
data: {"id": "chatcmpl-5jR1Fhd9KUk4P6N3zWo2y4coMscGu", "object": "chat.completion.chunk", "created": 1758113545, "model": "claude-neptune-v3", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "3会更精确。"}, "logprobs": null, "finish_reason": null}], "usage": null, "system_fingerprint": "fp_d576307f90"}
```

The code `usage = data.get("usage", {})` gets None, which causes the open-webui to not display the message correctly.

![Screenshot_20250917_211643_ B@95c440d](https://github.com/user-attachments/assets/0e79a94b-5975-4375-931d-600e75f2a34e)
