### PR TITLE
UPD: Improve Ollama endpoint validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Ollama verify endpoint now validates 200 responses to ensure they are JSON objects containing a properly formatted version string (leading 'v' required), while preserving original error behavior for non-200 responses.
+
+### Fixed
+- Corrected misuse of `await` on the response status (`r.status`).
+
+### Added
+- Unit tests for the Ollama verify endpoint covering valid version responses, missing version field, and non-200 responses.
+
+### Security
+- Incremental hardening of Ollama connection verification. Note: this is not a full SSRF mitigation; additional allowlisting and IP/redirect checks are recommended.
+
 ## [0.6.28] - 2025-09-10
 
 ### Added

--- a/backend/open_webui/test/routers/test_ollama_verify.py
+++ b/backend/open_webui/test/routers/test_ollama_verify.py
@@ -1,0 +1,112 @@
+import pytest
+
+import aiohttp
+from fastapi import HTTPException
+
+from open_webui.routers.ollama import verify_connection, ConnectionVerificationForm
+
+
+class _FakeResponse:
+    def __init__(self, status: int, json_data=None, text_data: str = ""):
+        self.status = status
+        self._json = json_data
+        self._text = text_data
+
+    async def json(self):
+        if self._json is None:
+            raise Exception("no json")
+        return self._json
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeGetCtx:
+    def __init__(self, response: _FakeResponse):
+        self._resp = response
+
+    async def __aenter__(self):
+        return self._resp
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._resp = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, *args, **kwargs):
+        return _FakeGetCtx(self._resp)
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_valid_version(monkeypatch):
+    # Arrange: mock ClientSession to return a 200 with valid version JSON
+    fake_response = _FakeResponse(status=200, json_data={"version": "v0.1.30"})
+
+    def _fake_client_session(*args, **kwargs):
+        return _FakeSession(fake_response)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _fake_client_session)
+
+    form = ConnectionVerificationForm(url="http://example.com", key=None)
+
+    # Act
+    res = await verify_connection(form_data=form, user=None)
+
+    # Assert
+    assert isinstance(res, dict)
+    assert res.get("version") == "v0.1.30"
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_invalid_version_missing_field(monkeypatch):
+    # Arrange: mock ClientSession to return a 200 with JSON lacking 'version'
+    fake_response = _FakeResponse(status=200, json_data={"ok": True})
+
+    def _fake_client_session(*args, **kwargs):
+        return _FakeSession(fake_response)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _fake_client_session)
+
+    form = ConnectionVerificationForm(url="http://example.com", key=None)
+
+    # Act / Assert
+    with pytest.raises(HTTPException) as excinfo:
+        await verify_connection(form_data=form, user=None)
+
+    assert excinfo.value.status_code == 400
+    assert "missing 'version'" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_non_200_raises(monkeypatch):
+    # Arrange: mock ClientSession to return a 401 with plain text
+    fake_response = _FakeResponse(status=401, json_data=None, text_data="Unauthorized")
+
+    def _fake_client_session(*args, **kwargs):
+        return _FakeSession(fake_response)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", _fake_client_session)
+
+    form = ConnectionVerificationForm(url="http://example.com", key=None)
+
+    # Assert
+    with pytest.raises(HTTPException) as excinfo:
+        await verify_connection(form_data=form, user=None)
+
+    assert excinfo.value.status_code == 500
+    assert "HTTP Error: 401" in excinfo.value.detail


### PR DESCRIPTION
# Pull Request Checklist
Note to first-time contributors: Please open a discussion post in Discussions and describe your changes before submitting a pull request.

Before submitting, make sure you've checked the following:

- [x] Target branch: Please verify that the pull request targets the dev branch.
- [x] Description: Provide a concise description of the changes made in this pull request.
- [x] Changelog: Ensure a changelog entry following the format of Keep a Changelog is added at the bottom of the PR description.
- [x] Documentation: Have you updated relevant documentation Open WebUI Docs, or other documentation sources?
- [ ] Dependencies: Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] Testing: Have you written and run sufficient tests to validate the changes?
- [ ] Code review: Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] Prefix: To clearly categorize this pull request, prefix the pull request title using one of the following:
 - UPD


## Changelog Entry
### Added
  - Unit tests for the Ollama verify endpoint covering valid version responses, missing version field, and non-200 responses.
  - Ollama verify endpoint now validates 200 responses to ensure they are JSON objects containing a properly formatted version string (leading 'v' required), while preserving original error behavior for non-200 responses.
### Fixed
  - Corrected misuse of await on the response status (r.status).

### Description
Discussion link: https://github.com/open-webui/open-webui/discussions/17416

Incremental improvement to the verify_connection() function in `backend/open_webui/routers/ollama.py`. This update checks for a valid version string that should be returned by ` f"{url}/api/version"`. 