### PR TITLE
feat: support per-model RAG template override

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1170,10 +1170,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         if prompt is None:
             raise Exception("No user message found")
 
+        model_rag_template = (
+            model.get("info", {}).get("params", {}).get("rag_template", "")
+            or request.app.state.config.RAG_TEMPLATE
+        )
+
         if context_string != "":
             form_data["messages"] = add_or_update_user_message(
                 rag_template(
-                    request.app.state.config.RAG_TEMPLATE,
+                    model_rag_template,
                     context_string,
                     prompt,
                 ),

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -63,6 +63,7 @@
 	}
 
 	let system = '';
+	let rag_template = '';
 	let info = {
 		id: '',
 		base_model_id: null,
@@ -74,12 +75,14 @@
 			tags: []
 		},
 		params: {
-			system: ''
+			system: '',
+			rag_template: ''
 		}
 	};
 
-	let params = {
-		system: ''
+	let params: {
+		system: '';
+		rag_template: '';
 	};
 
 	let knowledge = [];
@@ -203,6 +206,7 @@
 		}
 
 		info.params.system = system.trim() === '' ? null : system;
+		info.params.rag_template = rag_template.trim() === '' ? null : rag_template;
 		info.params.stop = params.stop ? params.stop.split(',').filter((s) => s.trim()) : null;
 		Object.keys(info.params).forEach((key) => {
 			if (info.params[key] === '' || info.params[key] === null) {
@@ -250,6 +254,7 @@
 			}
 
 			system = model?.params?.system ?? '';
+			rag_template = model?.params?.rag_template ?? '';
 
 			params = { ...params, ...model?.params };
 			params.stop = params?.stop
@@ -614,6 +619,18 @@
 										)}
 										rows={4}
 										bind:value={system}
+									/>
+								</div>
+							</div>
+
+							<div class="my-1">
+								<div class=" text-xs font-semibold mb-2">{$i18n.t('RAG Template')}</div>
+								<div>
+									<Textarea
+										placeholder={$i18n.t(
+											'Leave empty to use the default prompt, or enter a custom prompt'
+										)}
+										bind:value={rag_template}
 									/>
 								</div>
 							</div>


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

Add `rag_template` as a configurable parameter in model settings, allowing each model to define its own RAG template instead of always using the global default.
- Middleware now selects the model-specific RAG template if provided.
- Model editor UI updated to allow editing and saving `rag_template`.
- Fallback to global `RAG_TEMPLATE` remains when no override is set.


### Added

-  Support per-model RAG template override


### Breaking Changes

- **BREAKING CHANGE**: NONE

---

### Screenshots or Videos

By default the model screen will have an empty template and global rag template will be used.

<img width="1468" height="401" alt="image" src="https://github.com/user-attachments/assets/62e818bc-5d36-4aa2-a50a-fc329dc53de8" />

We can override the default by setting our customized rag template.

<img width="1432" height="790" alt="image" src="https://github.com/user-attachments/assets/b3b338c7-e99a-441e-bb88-16219097605d" />

Here is an example rag template, based on default, without citations.

```
### Task:
Respond to the user query using the provided context.

### Guidelines:
- If you don't know the answer, clearly state that.
- If uncertain, ask the user for clarification.
- Respond in the same language as the user's query.
- If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
- If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
- Do not cite any <source> tag
- Do not use XML tags in your response.

### Output:
Provide a clear and direct response to the user's query.

<context>
{{CONTEXT}}
</context>

<user_query>
{{QUERY}}
</user_query>
```

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
