### PR TITLE
fix: matplotlub bug that shows the base64 image data

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -163,11 +163,8 @@
 								];
 							}
 
-							if (stdout.includes(`${line}\n`)) {
-								stdout = stdout.replace(`${line}\n`, ``);
-							} else if (stdout.includes(`${line}`)) {
-								stdout = stdout.replace(`${line}`, ``);
-							}
+							stdout = stdout.replace(`${line}\n`, ``);
+							stdout = stdout.replace(line, ``);
 						}
 					}
 				}
@@ -271,11 +268,8 @@
 							];
 						}
 
-						if (stdout.includes(`${line}\n`)) {
-							stdout = stdout.replace(`${line}\n`, ``);
-						} else if (stdout.includes(`${line}`)) {
-							stdout = stdout.replace(`${line}`, ``);
-						}
+						stdout = stdout.replace(`${line}\n`, ``);
+						stdout = stdout.replace(line, ``);
 					}
 				}
 			}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request. https://github.com/open-webui/open-webui/issues/17568 

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- Prevent large base64-encoded image data from appearing in the rendered stdout output while still displaying the image in the UI.  
- Updated the stdout replacement so it removes the image data line regardless of its position. Previously, the removal logic only worked when the data was on the first line.  

### Added
- N/A

### Changed
- Updated `CodeBlock.svelte` to replace/remove base64-encoded image data lines from `stdout`.  

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed issue where base64 image data appeared in the stdout output if not located on the first line.  

### Security
- N/A

### Breaking Changes
- None

---

### Additional Information

- https://github.com/open-webui/open-webui/issues/17476

### Screenshots or Videos

- What the issue looks like: 
<img width="719" height="290" alt="image" src="https://github.com/user-attachments/assets/8b5e435b-5f5b-424b-9b95-729daea12820" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
