### PR TITLE
feat: use RedisDict for MODELS state when Redis is available

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -50,7 +50,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import Response, StreamingResponse
 from starlette.datastructures import Headers
 
-
+from open_webui.socket.utils import RedisDict
 from open_webui.utils import logger
 from open_webui.utils.audit import AuditLevel, AuditLoggingMiddleware
 from open_webui.utils.logger import start_logger
@@ -1140,8 +1140,17 @@ app.state.config.AUTOCOMPLETE_GENERATION_INPUT_MAX_LENGTH = (
 # WEBUI
 #
 ########################################
-
-app.state.MODELS = {}
+if REDIS_URL:
+    app.state.MODELS = RedisDict(
+        "open-webui:models",
+        redis_url=REDIS_URL,
+        redis_sentinels=get_sentinels_from_env(
+            REDIS_SENTINEL_HOSTS, REDIS_SENTINEL_PORT
+        ),
+        redis_cluster=REDIS_CLUSTER,
+    )
+else:
+    app.state.MODELS = {}
 
 
 class RedirectMiddleware(BaseHTTPMiddleware):

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -107,6 +107,16 @@ class RedisDict:
             self[key] = default
         return self[key]
 
+    def get_pipeline(self):
+        return self.redis.pipeline()
+
+    def replace_all(self, mapping: dict):
+        pipe = self.redis.pipeline()
+        pipe.delete(self.name)
+        if mapping:
+            pipe.hset(self.name, mapping={k: json.dumps(v) for k, v in mapping.items()})
+        pipe.execute()
+
 
 class YdocManager:
     def __init__(

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -12,7 +12,7 @@ from open_webui.functions import get_function_models
 
 from open_webui.models.functions import Functions
 from open_webui.models.models import Models
-
+from open_webui.socket.utils import RedisDict
 
 from open_webui.utils.plugin import (
     load_function_module_by_id,
@@ -308,7 +308,12 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     log.debug(f"get_all_models() returned {len(models)} models")
 
-    request.app.state.MODELS = {model["id"]: model for model in models}
+    new_models = {model["id"]: model for model in models}
+    if isinstance(request.app.state.MODELS, RedisDict):
+        request.app.state.MODELS.replace_all(new_models)
+    else:
+        request.app.state.MODELS = new_models
+
     return models
 
 


### PR DESCRIPTION
# Pull Request Checklist
### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
**Before submitting, make sure you've checked the following:**
- [ ] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work
# Changelog Entry
### Description
- Introduced Redis-backed storage for application models (`MODELS`) to replace the in-memory dictionary when `REDIS_URL` is configured.
- Motivation: ensure model state is properly synchronized across multiple instances in distributed deployments, as local in-memory state does not propagate.
- Implemented `replace_all` in `RedisDict` using Redis pipelines for atomic operations, preventing potential race conditions between `DELETE` and `HSET`.

### Added
- `RedisDict.replace_all(mapping)` method with pipeline support (`pipe.delete` + `pipe.hset` + `pipe.execute`), ensuring atomic replacement of all model entries.

### Changed
- `app.state.MODELS` initialization now conditionally uses `RedisDict` instead of plain `{}` when Redis is available.
- Model updates now call `RedisDict.replace_all` if using Redis storage, ensuring full state synchronization across instances.

### Deprecated
- None

### Removed
- Previous approach of using only in-memory `dict` to manage models.

### Fixed
- Fixed issue where model state changes were not propagated across multiple instances, leading to inconsistent application state.

### Security
- None

### Breaking Changes
- **BREAKING CHANGE**: In environments where Redis is enabled, `app.state.MODELS` is now backed by Redis instead of an in-memory dict, potentially changing persistence and runtime behavior.

---
### Additional Information
- Implemented Redis pipelines in `replace_all` to ensure atomic state replacement and avoid transient states during delete/set operations.
- Maintains backward compatibility by falling back to an in-memory dict if no Redis connection is configured.
- Related motivation: prevent model state desynchronization in multi-instance deployments.
### Screenshots or Videos
- N/A
### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.