### PR TITLE
FIX: hybrid_search-instances_checker

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -127,11 +127,19 @@ def query_doc_with_hybrid_search(
     hybrid_bm25_weight: float,
 ) -> dict:
     try:
+        log.debug(f"query_doc_with_hybrid_search:doc {collection_name}")
+        # Add type checking before accessing documents
+        if isinstance(collection_result, list):
+            log.warning(f"Collection result is a list instead of GetResult object for {collection_name}")
+            return {"documents": [], "metadatas": [], "distances": []}
         if not collection_result.documents[0]:
             log.warning(f"query_doc_with_hybrid_search:no_docs {collection_name}")
             return {"documents": [], "metadatas": [], "distances": []}
-
-        log.debug(f"query_doc_with_hybrid_search:doc {collection_name}")
+        # Ensure query is a string before BM25Retriever
+        if isinstance(query, list):
+            query = ' '.join(query) if query else ""
+        elif not isinstance(query, str):
+            query = str(query)
 
         bm25_retriever = BM25Retriever.from_texts(
             texts=collection_result.documents[0],


### PR DESCRIPTION
### FIX: hybrid_search-fails  due to inconsistence in parameters type received in some circunstances.

In some circunstances hybrid search fail, as it's exposed in issue https://github.com/open-webui/open-webui/issues/17046

- query_doc_with_hybrid_search function expects collection_result to be an object with a documents attribute, but it's receiving a list or None instead (e.g. qdrant return None if collections don't exist, which could cause the issue)

- when query is as list (e.g. query_doc_with_hybrid_search function called for queries)

This PR add a couple of checkers for that.

____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
