### PR TITLE
Feat: Add separate Client ID for Personal OneDrive to fix authentication

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2181,6 +2181,12 @@ ONEDRIVE_CLIENT_ID = PersistentConfig(
     os.environ.get("ONEDRIVE_CLIENT_ID", ""),
 )
 
+ONEDRIVE_PERSONAL_CLIENT_ID = PersistentConfig(
+    "ONEDRIVE_PERSONAL_CLIENT_ID",
+    "onedrive.personal_client_id",
+    os.environ.get("ONEDRIVE_PERSONAL_CLIENT_ID", ""),
+)
+
 ONEDRIVE_SHAREPOINT_URL = PersistentConfig(
     "ONEDRIVE_SHAREPOINT_URL",
     "onedrive.sharepoint_url",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -302,6 +302,7 @@ from open_webui.config import (
     GOOGLE_DRIVE_API_KEY,
     ENABLE_ONEDRIVE_INTEGRATION,
     ONEDRIVE_CLIENT_ID,
+    ONEDRIVE_PERSONAL_CLIENT_ID,
     ONEDRIVE_SHAREPOINT_URL,
     ONEDRIVE_SHAREPOINT_TENANT_ID,
     ENABLE_ONEDRIVE_PERSONAL,
@@ -1744,6 +1745,7 @@ async def get_app_config(request: Request):
                 },
                 "onedrive": {
                     "client_id": ONEDRIVE_CLIENT_ID.value,
+                    "personal_client_id": ONEDRIVE_PERSONAL_CLIENT_ID.value,
                     "sharepoint_url": ONEDRIVE_SHAREPOINT_URL.value,
                     "sharepoint_tenant_id": ONEDRIVE_SHAREPOINT_TENANT_ID.value,
                 },


### PR DESCRIPTION
**PR Title:** Feat: Add separate Client ID for Personal OneDrive to fix authentication

**PR Description:**

This pull request resolves a long-standing architectural flaw in the Microsoft OneDrive integration, as detailed in issue [#550](https://github.com/open-webui/docs/issues/550).

#### **The Problem**

The original implementation used a single environment variable, `ONEDRIVE_CLIENT_ID`, for both "Work/School" and "Personal" OneDrive authentication flows. This is fundamentally incompatible with Microsoft's identity platform, where business and consumer applications must be registered separately.

This led to a critical bug: if an administrator configured `ONEDRIVE_CLIENT_ID` for a business tenant (the primary use case), the "Personal OneDrive" feature would inevitably fail with an `unauthorized_client` error because the business-only Client ID was being presented to the consumer login service (`login.live.com`).

#### **The Solution**

This PR introduces a complete technical fix by separating the configurations for the two account types:

1.  **Backend Changes (`config.py`, `main.py`):**
    *   A new environment variable, `ONEDRIVE_PERSONAL_CLIENT_ID`, has been introduced to hold the Client ID for a separate, consumer-facing Azure App Registration.
    *   The `/api/config` endpoint has been updated to expose this new `personal_client_id` to the frontend, ensuring the client-side has all necessary credentials.

2.  **Frontend Changes (`onedrive-file-picker.ts`):**
    *   The core MSAL logic has been refactored. The `getMsalInstance` function now dynamically selects the correct Client ID based on the `authorityType` (`personal` or `organizations`).
    *   If a user selects "Personal OneDrive," the new `personalClientId` is used.
    *   If a user selects "Work/School OneDrive," the original `clientId` is used.

#### **Impact**

*   **Fixes Issue (Docs) 550:** This change directly resolves the core complaint from the issue, making the personal OneDrive integration functional without breaking the business/SharePoint integration.
*   **Enables Full Functionality:** Administrators can now configure **both** personal and business OneDrive integrations, and they will work independently and correctly as the UI implies.
*   **Improves User Experience:** This eliminates a frustrating and confusing dead-end for users and administrators who were previously unable to use the personal OneDrive feature.

#### **Documentation**

To support this change and address all other points from Docs issue 550, the documentation has been comprehensively updated in a parallel effort:
1.  A new tutorial, **"Configuring OneDrive & SharePoint Integration,"** has been created to provide a full, step-by-step guide for setting up both business and personal integrations.
2.  The **Environment Variables** reference page has been updated to include the new `ONEDRIVE_PERSONAL_CLIENT_ID` variable and clarify the specific roles of each configuration setting.

This PR, combined with the updated documentation, provides a complete and robust solution for the OneDrive integration.

Updated env var config (dev) based on THIS PR's CHANGES:  https://github.com/open-webui/docs/blob/main/docs/getting-started/env-configuration.md#OneDrive

NEW OneDrive setup guide (dev) based on THIS PR's CHANGES: https://github.com/open-webui/docs/blob/dev/docs/tutorials/integrations/onedrive-sharepoint.mdx

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.