### PR TITLE
fix: pin datasets==3.6.0 in backend/requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,8 @@ tiktoken
 langchain==0.3.26
 langchain-community==0.3.27
 
+datasets==3.6.0
+
 fake-useragent==2.2.0
 chromadb==1.0.20
 pymilvus==2.5.0


### PR DESCRIPTION
Thix fixes the problem described in https://github.com/open-webui/open-webui/discussions/16301

### Description

- Adding datasets==3.6.0 in backend/requirements.txt because the newer versions have breaking changes which result into Text-to-Speech not working.  #16301 

### Added

- `datasets==3.6.0` in backend/requirements.txt

### Changed

### Fixed

- Text-to-speech default configuration works again
