### PR TITLE
fix: Fixed get_tools_function_calling_payload prompt message history order

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -146,7 +146,7 @@ async def chat_completion_tools_handler(
         user_message = get_last_user_message(messages)
         history = "\n".join(
             f"{message['role'].upper()}: \"\"\"{message['content']}\"\"\""
-            for message in messages[::-1][:4]
+            for message in messages[-4:]
         )
 
         prompt = f"History:\n{history}\nQuery: {user_message}"


### PR DESCRIPTION
### Description
Chat message history is being provided in the tool call prompt in reverse order. This leads to poorer prompt adherence.

### Fixed
- Fixed get_tools_function_calling_payload prompt message history order
