### PR TITLE
Revert "feat: Dynamically load CodeEditor.svelte to improve first-screen loading speed (-1MB)"

### DIFF
--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -4,6 +4,7 @@
 
 	const i18n = getContext('i18n');
 
+	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Badge from '$lib/components/common/Badge.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -366,22 +367,20 @@ class Pipe:
 				</div>
 
 				<div class="mb-2 flex-1 overflow-auto h-0 rounded-lg">
-					{#await import('$lib/components/common/CodeEditor.svelte') then { default: CodeEditor }}
-						<CodeEditor
-							bind:this={codeEditor}
-							value={content}
-							lang="python"
-							{boilerplate}
-							onChange={(e) => {
-								_content = e;
-							}}
-							onSave={async () => {
-								if (formElement) {
-									formElement.requestSubmit();
-								}
-							}}
-						/>
-					{/await}
+					<CodeEditor
+						bind:this={codeEditor}
+						value={content}
+						lang="python"
+						{boilerplate}
+						onChange={(e) => {
+							_content = e;
+						}}
+						onSave={async () => {
+							if (formElement) {
+								formElement.requestSubmit();
+							}
+						}}
+					/>
 				</div>
 
 				<div class="pb-3 flex justify-between">

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -7,6 +7,7 @@
 	import 'highlight.js/styles/github-dark.min.css';
 
 	import PyodideWorker from '$lib/workers/pyodide.worker?worker';
+	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import SvgPanZoom from '$lib/components/common/SVGPanZoom.svelte';
 	import { config } from '$lib/stores';
 	import { executeCode } from '$lib/apis/utils';
@@ -480,19 +481,17 @@
 
 				{#if !collapsed}
 					{#if edit}
-						{#await import('$lib/components/common/CodeEditor.svelte') then { default: CodeEditor }}
-							<CodeEditor
-								value={code}
-								{id}
-								{lang}
-								onSave={() => {
-									saveCode();
-								}}
-								onChange={(value) => {
-									_code = value;
-								}}
-							/>
-						{/await}
+						<CodeEditor
+							value={code}
+							{id}
+							{lang}
+							onSave={() => {
+								saveCode();
+							}}
+							onChange={(value) => {
+								_code = value;
+							}}
+						/>
 					{:else}
 						<pre
 							class=" hljs p-4 px-5 overflow-x-auto"

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -3,6 +3,7 @@
 
 	const i18n = getContext('i18n');
 
+	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import { goto } from '$app/navigation';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Badge from '$lib/components/common/Badge.svelte';
@@ -285,22 +286,20 @@ class Tools:
 				</div>
 
 				<div class="mb-2 flex-1 overflow-auto h-0 rounded-lg">
-					{#await import('$lib/components/common/CodeEditor.svelte') then { default: CodeEditor }}
-						<CodeEditor
-							bind:this={codeEditor}
-							value={content}
-							lang="python"
-							{boilerplate}
-							onChange={(e) => {
-								_content = e;
-							}}
-							onSave={async () => {
-								if (formElement) {
-									formElement.requestSubmit();
-								}
-							}}
-						/>
-					{/await}
+					<CodeEditor
+						bind:this={codeEditor}
+						value={content}
+						lang="python"
+						{boilerplate}
+						onChange={(e) => {
+							_content = e;
+						}}
+						onSave={async () => {
+							if (formElement) {
+								formElement.requestSubmit();
+							}
+						}}
+					/>
 				</div>
 
 				<div class="pb-3 flex justify-between">


### PR DESCRIPTION
Reverts open-webui/open-webui#17498

fix #17684

I tried alternative approaches to fix this issue, but they would introduce a significant amount of extra code (since the Markdown component is used in too many places).

Personally, I find this unnecessary and believe it unnecessarily increases code complexity. Therefore, I'm reverting this change.