### PR TITLE
fix: truncate long names in delete confirmation modals

### DIFF
--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -595,7 +595,7 @@
 		deleteHandler(selectedFunction);
 	}}
 >
-	<div class=" text-sm text-gray-500">
+	<div class=" text-sm text-gray-500 truncate">
 		{$i18n.t('This will delete')} <span class="  font-semibold">{selectedFunction.name}</span>.
 	</div>
 </DeleteConfirmDialog>

--- a/src/lib/components/chat/ToolServersModal.svelte
+++ b/src/lib/components/chat/ToolServersModal.svelte
@@ -46,8 +46,8 @@
 				<div class=" text-sm dark:text-gray-300 mb-1">
 					{#each selectedTools as tool}
 						<Collapsible buttonClassName="w-full mb-0.5">
-							<div>
-								<div class="text-sm font-medium dark:text-gray-100 text-gray-800">
+							<div class="truncate">
+								<div class="text-sm font-medium dark:text-gray-100 text-gray-800 truncate">
 									{tool?.name}
 								</div>
 

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -340,7 +340,7 @@
 				showDeleteConfirm = false;
 			}}
 		>
-			<div class=" text-sm text-gray-500">
+			<div class=" text-sm text-gray-500 truncate">
 				{$i18n.t('This will delete')} <span class="  font-semibold">{selectedNote.title}</span>.
 			</div>
 		</DeleteConfirmDialog>

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -156,7 +156,7 @@
 			deleteHandler(deletePrompt);
 		}}
 	>
-		<div class=" text-sm text-gray-500">
+		<div class=" text-sm text-gray-500 truncate">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{deletePrompt.command}</span>.
 		</div>
 	</DeleteConfirmDialog>

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -522,7 +522,7 @@
 			deleteHandler(selectedTool);
 		}}
 	>
-		<div class=" text-sm text-gray-500">
+		<div class=" text-sm text-gray-500 truncate">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{selectedTool.name}</span>.
 		</div>
 	</DeleteConfirmDialog>


### PR DESCRIPTION
# Pull Request Checklist
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- The deletion confirmation modals for Notes, Prompts, Tools, and Functions have been updated to truncate long item names, preventing them from overflowing the modal.
- The "Available Tools" modal has been updated to correctly truncate long tool names using inline js `truncate`.

### Added
- [List any new features, functionalities, or additions]

### Changed
- [List any changes, updates, refactorings, or optimizations]

### Fixed
- [List any fixes, corrections, or bug fixes]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Before changes applied:

<img width="2299" height="1275" alt="image" src="https://github.com/user-attachments/assets/4392f5d5-1a95-4a05-9bd4-c4f837bd84b7" />

<img width="2299" height="1275" alt="image" src="https://github.com/user-attachments/assets/a584f51a-5664-4d2c-bc51-2bb8fd4815ce" />

<img width="2299" height="1275" alt="image" src="https://github.com/user-attachments/assets/a794ff73-8f14-4413-9ac5-880fdf5b165d" />

<img width="2299" height="1275" alt="image" src="https://github.com/user-attachments/assets/1b26fb59-c5bd-402f-ba2c-deb33de9a6c3" />

<img width="2299" height="1275" alt="image" src="https://github.com/user-attachments/assets/4dc8a866-e0db-458f-9f0a-ebe0650cc714" />


### After changes have been applied:
<img width="549" height="232" alt="image" src="https://github.com/user-attachments/assets/ea54223e-0b85-4e70-9fe4-afa8e34c98e1" />

<img width="818" height="366" alt="image" src="https://github.com/user-attachments/assets/8e0df09d-6620-4214-a6c0-69eafb9f5028" />

<img width="818" height="366" alt="image" src="https://github.com/user-attachments/assets/c6551d20-d763-4291-bb30-6fde6c96ec8d" />

<img width="818" height="366" alt="image" src="https://github.com/user-attachments/assets/4afcebf9-1221-4de3-978a-c2c33d859b45" />

<img width="818" height="366" alt="image" src="https://github.com/user-attachments/assets/0e06e034-f68b-4884-b142-1d37dd25c2c8" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.