### PR TITLE
fix: i81n.t and correct button layout issue

### DIFF
--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -296,7 +296,7 @@
 					<div
 						class="flex justify-between flex-col sm:flex-row items-start sm:items-center gap-2 mt-2"
 					>
-						<div class="flex-1 shrink-0">
+						<div class="shrink-0">
 							<button
 								type="button"
 								class="px-3.5 py-1.5 text-sm font-medium bg-gray-50 hover:bg-gray-100 text-gray-900 dark:bg-gray-850 dark:hover:bg-gray-800 dark:text-gray-200 transition rounded-lg shrink-0 {($settings?.highContrastMode ??

--- a/src/routes/(app)/workspace/models/create/+page.svelte
+++ b/src/routes/(app)/workspace/models/create/+page.svelte
@@ -16,7 +16,7 @@
 	const onSubmit = async (modelInfo) => {
 		if ($models.find((m) => m.id === modelInfo.id)) {
 			toast.error(
-				i18n.t(
+				$i18n.t(
 					"Error: A model with the ID '{{modelId}}' already exists. Please select a different ID to proceed.",
 					{ modelId: modelInfo.id }
 				)


### PR DESCRIPTION
# Pull Request Checklist
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- **i18n Regression:** A latent bug in `src/routes/(app)/workspace/models/create/+page.svelte` was causing an `i18n.t is not a function` error. This was due to an incorrect call to the `i18n` Svelte store. The fix corrects the call to use the proper auto-subscription syntax (`$i18n.t()`).

- **Vertical Button Text:** In `src/lib/components/playground/Chat.svelte`, the "Assistant"/"User" role button's text was displaying vertically. This was caused by a `flex-1` class on its container, which has been removed.

### Changed
- Updated `src/routes/(app)/workspace/models/create/+page.svelte` to use the correct Svelte store auto-subscription syntax for the `i18n` object.

### Removed
- Removed the `flex-1` utility class from a container `div` in `src/lib/components/playground/Chat.svelte`.

### Fixed
- Corrected a latent bug that caused an `i18n.t is not a function` error on the model creation page by fixing the Svelte store subscription.
- Fixed a layout issue causing the "Assistant/User" button text to render vertically in the Playground chat interface.

### Before the fix is applied:
<img width="2299" height="300" alt="image" src="https://github.com/user-attachments/assets/6dd9e441-6ea3-4b28-951a-c388551967ea" />

<img width="2296" height="216" alt="image" src="https://github.com/user-attachments/assets/dfed70f4-cc8e-424c-8f6e-2b0eb00ee38a" />

### After the fix has been applied:
<img width="2297" height="160" alt="image" src="https://github.com/user-attachments/assets/9add2376-53a5-4483-af38-94928def7a5a" />

<img width="2297" height="160" alt="image" src="https://github.com/user-attachments/assets/de0f89ed-d85f-4196-9bd1-5fc91c59f608" />

### Pro Tip
In VS Code's search panel (with regex mode **on**), use this pattern:

```
(?<!\$)i18n\.t\(
```

Explanation  
- `(?<!\$)` – negative look-behind: the preceding character must **not** be a literal `$`.  
- `i18n\.t\(` – matches the literal text `i18n.t(`.

This will find every `i18n.t(` that is **not** already prefixed with `$`. Thankfully, having done so myself only resulted in 1 match from the `src/lib/components/playground/Chat.svelte` file, which I solve promptly with this PR.

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.