### PR TITLE
feat: add toggle to show/hide chat title in browser tab

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2230,7 +2230,7 @@
 
 <svelte:head>
 	<title>
-		{$chatTitle
+		{$settings.useChatTitleAsTabTitle !== false && $chatTitle
 			? `${$chatTitle.length > 30 ? `${$chatTitle.slice(0, 30)}...` : $chatTitle} • ${$WEBUI_NAME}`
 			: `${$WEBUI_NAME}`}
 	</title>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -66,6 +66,7 @@
 	let chatFadeStreamingText = true;
 	let collapseCodeBlocks = false;
 	let expandDetails = false;
+	let useChatTitleAsTabTitle = true;
 
 	let showFloatingActionButtons = true;
 	let floatingActionButtons = null;
@@ -224,6 +225,7 @@
 		temporaryChatByDefault = $settings?.temporaryChatByDefault ?? false;
 		chatDirection = $settings?.chatDirection ?? 'auto';
 		userLocation = $settings?.userLocation ?? false;
+		useChatTitleAsTabTitle = $settings?.useChatTitleAsTabTitle ?? true;
 
 		notificationSound = $settings?.notificationSound ?? true;
 		notificationSoundAlways = $settings?.notificationSoundAlways ?? false;
@@ -323,6 +325,25 @@
 							bind:state={highContrastMode}
 							on:change={() => {
 								saveSettings({ highContrastMode });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="use-chat-title-as-tab-title-label" class=" self-center text-xs">
+						{$i18n.t("Use the chat title as the browser's tab title")}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="use-chat-title-as-tab-title-label"
+							tooltip={true}
+							bind:state={useChatTitleAsTabTitle}
+							on:change={() => {
+								saveSettings({ useChatTitleAsTabTitle });
 							}}
 						/>
 					</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -184,6 +184,7 @@ type Settings = {
 	notificationEnabled?: boolean;
 	highContrastMode?: boolean;
 	title?: TitleSettings;
+	useChatTitleAsTabTitle?: boolean;
 	splitLargeDeltas?: boolean;
 	chatDirection?: 'LTR' | 'RTL' | 'auto';
 	ctrlEnterToSend?: boolean;


### PR DESCRIPTION
This commit introduces a new setting in the Interface settings that allows users to control whether the chat title is used as the browser's tab title.

Default: True
Can be set to False; if turned off, will write only "Open WebUI" and not include the title anymore.

The following changes were made:
- Added `useChatTitleAsTabTitle` to the `Settings` type in `src/lib/stores/index.ts`.
- Added a toggle switch in `src/lib/components/chat/Settings/Interface.svelte` to manage this new setting.
- Updated `src/lib/components/chat/Chat.svelte` to conditionally set the document title based on the `useChatTitleAsTabTitle` setting.

Related: https://github.com/open-webui/open-webui/issues/17847

With it turned on:

<img width="2000" height="699" alt="image" src="https://github.com/user-attachments/assets/23e06f66-0a76-4331-8882-152e6a428ed8" />

Turning it off

<img width="1124" height="144" alt="image" src="https://github.com/user-attachments/assets/23456fbd-e7f7-4893-acd8-d692bea09066" />

With it turned off:

<img width="2006" height="666" alt="image" src="https://github.com/user-attachments/assets/0b71a4b1-eb09-4ce5-96ef-8fe0a94b51c3" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
