### PR TITLE
feat: refactor prompts import to a single backend endpoint for massive speedup

### DIFF
--- a/src/lib/apis/prompts/index.ts
+++ b/src/lib/apis/prompts/index.ts
@@ -39,6 +39,34 @@ export const createNewPrompt = async (token: string, prompt: PromptItem) => {
 	return res;
 };
 
+export const importPrompts = async (token: string, prompts: object[]) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/prompts/import`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ prompts: prompts })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getPrompts = async (token: string = '') => {
 	let error = null;
 

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -158,7 +158,7 @@
 			deleteHandler(deletePrompt);
 		}}
 	>
-		<div class=" text-sm text-gray-500">
+		<div class=" text-sm text-gray-500 truncate">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{deletePrompt.command}</span>.
 		</div>
 	</DeleteConfirmDialog>


### PR DESCRIPTION
# Pull Request Checklist
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- This pull request refactors the prompt import functionality, moving the processing logic from the frontend to the backend. Instead of the client parsing a JSON file and sending an individual API request for each prompt, the frontend now sends the parsed data in a single request to a new backend endpoint, which handles the batch import. This significantly improves performance and efficiency.

### Added
- A new backend endpoint `POST /api/v1/prompts/import` that accepts a list of prompts and creates them in the database.

### Changed
- The "Import Prompts" functionality now reads the selected file on the client, parses it, and sends the data to the new backend endpoint in a single transaction.
- The import button on the Prompts page now shows a loading indicator during the import process.

### Removed
- The client-side logic that iterated through imported prompts and sent an individual `createNewPrompt` request for each one.

### Security
- The new `/api/v1/prompts/import` endpoint is restricted to admin users, ensuring that only authorized users can perform bulk imports.

### Additional Information
- This change mirrors the refactoring done for the model import functionality, creating a more consistent and efficient pattern across the application for bulk data imports.

### Screenshots or Videos
**Time to import model preset from a JSON file previously (MANY REQUESTS, >2MB BUT SLOWER):**
<img width="2558" height="350" alt="image" src="https://github.com/user-attachments/assets/1d289ed7-9366-4d06-aca7-e418aab95d5c" />

**Time to import model preset from a JSON file with these changes applied (99% LESS REQUESTS, >2MB, EXTREMELY FAST):**
<img width="2558" height="350" alt="image" src="https://github.com/user-attachments/assets/fc747f9c-6d8a-4bc0-a4d3-ba89c8826a17" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.