### PR TITLE
fix: skip path validation for MCP mode in tool server connection

### DIFF
--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -98,7 +98,7 @@
 			return;
 		}
 
-		if (path === '') {
+		if (['', 'openapi'].includes(type) && path === '') {
 			toast.error($i18n.t('Please enter a valid path'));
 			return;
 		}


### PR DESCRIPTION
Only validate path field for OpenAPI type, as MCP mode doesn't require an OpenAPI spec path. This fixes the validation error that occurred when switching from OpenAPI to MCP mode.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed unnecessary path field validation error that occurred in MCP mode during tool server connection verification.
- Added conditional validation logic to only check the path field for OpenAPI type, reflecting that MCP (Streamable HTTP) mode doesn't require an OpenAPI specification path.
- Resolved "Please enter a valid path" error that occurred when users switched from OpenAPI to MCP mode and clicked the "Verify Connection" button.

### Added

- None

### Changed

- Modified `verifyHandler` function in `src/lib/components/AddToolServerModal.svelte`
- Added type check condition to path validation logic: `if (['', 'openapi'].includes(type) && path === '')`
- Path field now only required for OpenAPI mode

### Deprecated

- None

### Removed

- None

### Fixed

- Fixed false positive path validation error when switching to MCP mode
- Applied appropriate field validation based on tool server connection type

### Security

- None

### Breaking Changes

- None

---

### Additional Information

#### Problem Scenario
1. Open "Add Connection" modal in tool settings
2. Start with default OpenAPI type
3. Clear or delete the default `openapi.json` value in the OpenAPI Spec field
4. Click Type button to switch to MCP (Streamable HTTP) mode
5. Click "Verify Connection" button
6. ❌ "Please enter a valid path" error occurs (even though MCP doesn't need path)

#### Root Cause
- The `verifyHandler` function validates the path field for all types
- MCP mode doesn't use OpenAPI specification, so path field is not required
- When switching types, validation still runs for fields irrelevant to the selected type

#### Solution
```typescript
// Before (Line 101-104)
if (path === '') {
    toast.error($i18n.t('Please enter a valid path'));
    return;
}

// After (Line 101-104)
if (['', 'openapi'].includes(type) && path === '') {
    toast.error($i18n.t('Please enter a valid path'));
    return;
}
```

#### Impact Scope
- Affected file: `src/lib/components/AddToolServerModal.svelte`
- Affected function: `verifyHandler` (Line 95-143)
- User experience improvement: Removed unnecessary validation step when using MCP mode

#### Related Links
- Related Discussion: https://github.com/open-webui/open-webui/discussions/17988

### Screenshots or Videos
**Before (Problem):**
<img width="491" height="701" alt="image" src="https://github.com/user-attachments/assets/014dc57a-2c8f-4a00-8ac8-7c6732301e37" />
<img width="866" height="300" alt="image" src="https://github.com/user-attachments/assets/8ede0512-3f97-406b-a225-aa90ffda8ded" />

**After (Fixed):**
<img width="493" height="270" alt="image" src="https://github.com/user-attachments/assets/0eafc647-c4c2-492e-99f6-c96bdbe89e23" />
<img width="858" height="305" alt="image" src="https://github.com/user-attachments/assets/7836bf36-fc5b-46d7-a8d7-9baa5d4357e8" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
