### PR TITLE
feat: add dynamic enum support for UserValves/Valves with API-driven dropdowns

### DIFF
--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -6,9 +6,167 @@
 	import Switch from './Switch.svelte';
 	import MapSelector from './Valves/MapSelector.svelte';
 	import { split } from 'postcss/lib/list';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	export let valvesSpec = null;
 	export let valves = {};
+
+	// Dynamic enum support
+	let dynamicEnumCache = {};
+	let dynamicEnumLoading = {};
+	let dynamicEnums = {};
+
+	/**
+	 * Fetch dynamic enum options from an API endpoint
+	 */
+	async function fetchDynamicEnum(property, config) {
+		// Normalize config to object format
+		const normalizedConfig = typeof config === 'string' ? { endpoint: config } : config;
+
+		const {
+			endpoint,
+			method = 'GET',
+			response_path = null,
+			value_field = 'id',
+			label_field = null,
+			cache_ttl = 300,
+			fallback = []
+		} = normalizedConfig;
+
+		const cacheKey = endpoint;
+		const now = Date.now();
+		const fullUrl = `${WEBUI_API_BASE_URL}${endpoint}`;
+
+		// Check cache
+		if (
+			dynamicEnumCache[cacheKey] &&
+			now - dynamicEnumCache[cacheKey].timestamp < cache_ttl * 1000
+		) {
+			return dynamicEnumCache[cacheKey].data;
+		}
+
+		// Prevent duplicate simultaneous requests
+		if (dynamicEnumLoading[cacheKey]) {
+			return dynamicEnumLoading[cacheKey];
+		}
+
+		// Start fetch
+		dynamicEnumLoading[cacheKey] = fetch(fullUrl, {
+			method,
+			headers: {
+				Authorization: `Bearer ${localStorage.token}`,
+				'Content-Type': 'application/json'
+			}
+		})
+			.then(async (res) => {
+				if (!res.ok) {
+					throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+				}
+				return res.json();
+			})
+			.then((data) => {
+				// Extract array from response using response_path
+				let items = data;
+				if (response_path) {
+					// Support dot notation for nested paths
+					const pathParts = response_path.split('.');
+					for (const part of pathParts) {
+						items = items?.[part];
+					}
+				}
+
+				// Ensure we have an array
+				if (!Array.isArray(items)) {
+					items = [items];
+				}
+
+				// Map to {value, label} format
+				const options = items.map((item) => ({
+					value: item[value_field],
+					label: item[label_field || value_field]
+				}));
+
+				// Cache results
+				dynamicEnumCache[cacheKey] = {
+					data: options,
+					timestamp: now
+				};
+
+				delete dynamicEnumLoading[cacheKey];
+				return options;
+			})
+			.catch((err) => {
+				console.error(`Failed to fetch dynamic enum from ${endpoint}:`, err);
+				delete dynamicEnumLoading[cacheKey];
+
+				// Return fallback options
+				return fallback.length > 0 ? fallback : [];
+			});
+
+		return dynamicEnumLoading[cacheKey];
+	}
+
+	/**
+	 * Refresh dynamic enum options for a specific property (clears cache)
+	 */
+	async function refreshDynamicEnum(property) {
+		const spec = valvesSpec?.properties?.[property];
+		const dynamicEnumConfig = spec?.dynamic_enum;
+
+		if (!dynamicEnumConfig) return;
+
+		// Clear cache for this endpoint
+		const normalizedConfig =
+			typeof dynamicEnumConfig === 'string' ? { endpoint: dynamicEnumConfig } : dynamicEnumConfig;
+		const endpoint = normalizedConfig.endpoint;
+
+		if (endpoint) {
+			delete dynamicEnumCache[endpoint];
+			delete dynamicEnumLoading[endpoint];
+		}
+
+		// Fetch fresh data
+		try {
+			const options = await fetchDynamicEnum(property, dynamicEnumConfig);
+			dynamicEnums = { ...dynamicEnums, [property]: options };
+		} catch (err) {
+			console.error(`Error refreshing dynamic enum for ${property}:`, err);
+		}
+	}
+
+	/**
+	 * Initialize dynamic enums when the component mounts or valvesSpec changes
+	 */
+	async function initializeDynamicEnums() {
+		if (!valvesSpec || !valvesSpec.properties) {
+			return;
+		}
+
+		const newDynamicEnums = {};
+
+		for (const property in valvesSpec.properties) {
+			const spec = valvesSpec.properties[property];
+			const dynamicEnumConfig = spec.dynamic_enum;
+
+			if (dynamicEnumConfig) {
+				try {
+					const options = await fetchDynamicEnum(property, dynamicEnumConfig);
+					newDynamicEnums[property] = options;
+				} catch (err) {
+					console.error(`Error initializing dynamic enum for ${property}:`, err);
+					newDynamicEnums[property] = [];
+				}
+			}
+		}
+
+		// Reassign the entire object to trigger reactivity
+		dynamicEnums = newDynamicEnums;
+	}
+
+	// Re-initialize when valvesSpec changes
+	$: if (valvesSpec) {
+		initializeDynamicEnums();
+	}
 </script>
 
 {#if valvesSpec && Object.keys(valvesSpec?.properties ?? {}).length}
@@ -63,6 +221,7 @@
 				<div class="flex mt-0.5 mb-0.5 space-x-2">
 					<div class=" flex-1">
 						{#if valvesSpec.properties[property]?.enum ?? null}
+							<!-- Static enum -->
 							<select
 								class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100 dark:border-gray-850"
 								bind:value={valves[property]}
@@ -76,6 +235,55 @@
 									</option>
 								{/each}
 							</select>
+						{:else if valvesSpec.properties[property]?.dynamic_enum}
+							<!-- Dynamic enum -->
+							<div class="flex items-center space-x-2">
+								<select
+									class="flex-1 rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100 dark:border-gray-850"
+									bind:value={valves[property]}
+									on:change={() => {
+										dispatch('change');
+									}}
+								>
+									{#if !dynamicEnums[property] || dynamicEnums[property].length === 0}
+										<option value="" disabled>
+											{dynamicEnumLoading[
+												valvesSpec.properties[property].dynamic_enum?.endpoint ||
+													valvesSpec.properties[property].dynamic_enum
+											]
+												? $i18n.t('Loading options...')
+												: $i18n.t('No options available')}
+										</option>
+									{:else}
+										{#each dynamicEnums[property] as option}
+											<option value={option.value} selected={option.value === valves[property]}>
+												{option.label}
+											</option>
+										{/each}
+									{/if}
+								</select>
+
+								<!-- Refresh button -->
+								<button
+									type="button"
+									class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+									title={$i18n.t('Refresh options')}
+									on:click={() => refreshDynamicEnum(property)}
+								>
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+										class="w-4 h-4"
+									>
+										<path
+											fill-rule="evenodd"
+											d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.243a.75.75 0 00.53-.219z"
+											clip-rule="evenodd"
+										/>
+									</svg>
+								</button>
+							</div>
 						{:else if (valvesSpec.properties[property]?.type ?? null) === 'boolean'}
 							<div class="flex justify-between items-center">
 								<div class="text-xs text-gray-500">


### PR DESCRIPTION
# feat: Add dynamic enum support for UserValves/Valves with API-driven dropdowns

### Description

This pull request introduces dynamic enum population for UserValves and Valves in Functions and Tools. Instead of hardcoding dropdown options, developers can now specify API endpoints that are queried at runtime with user authentication, allowing for user-specific, permission-based dropdown options.

This enhancement solves a critical limitation where dropdown options couldn't be personalized based on the authenticated user's context. For example, a UserValve for "preferred model" can now show only the models the specific user has access to, rather than all models in the system.

**Key Benefits:**
- User-specific dropdown options based on permissions
- Real-time data from API endpoints
- Smart caching with configurable TTL
- Manual refresh capability for testing
- Zero breaking changes to existing code

### Added

- **Dynamic enum configuration via `json_schema_extra`**: Pydantic Field definitions now support a `dynamic_enum` parameter that tells the frontend which API endpoint to query
- **Frontend dynamic enum fetching in `Valves.svelte`**: 
  - Automatic detection and initialization of dynamic enum fields
  - HTTP requests with Bearer token authentication
  - Response path extraction for nested data structures
  - Per-endpoint caching with configurable TTL (default 5 minutes)
  - Request deduplication to prevent simultaneous duplicate calls
- **Refresh button UI**: Manual cache invalidation button next to each dynamic enum dropdown for testing and development

### Changed

- **`src/lib/components/common/Valves.svelte`**: Extended to detect and render dynamic enum fields with API-driven options
- Enhanced valve rendering logic to support three dropdown types: static enum, dynamic enum, and boolean switches

### Deprecated

- None

### Removed

- None

### Fixed

- None (this is a new feature)

### Security

- All API requests include user Bearer token authentication
- Endpoints validate user permissions server-side
- Frontend sanitizes API responses before rendering
- No CORS issues (uses existing WEBUI_API_BASE_URL)

### Breaking Changes

- None. This is a fully backward-compatible opt-in feature. Existing Valves/UserValves continue working unchanged.

---

### Additional Information

**Configuration Example:**

```python
from pydantic import BaseModel, Field

class UserValves(BaseModel):
    preferred_model: str = Field(
        default="",
        description="Select your preferred chat model",
        json_schema_extra={
            "dynamic_enum": {
                "endpoint": "/models",
                "response_path": "data",  # Extract array from nested response
                "value_field": "id",
                "label_field": "name",
                "cache_ttl": 300,  # Cache for 5 minutes
                "fallback": []     # Fallback options if fetch fails
            }
        }
    )
```

**Technical Implementation:**
- Pydantic extracts `json_schema_extra` fields to the top level of the JSON schema, making `dynamic_enum` directly accessible on property specs
- Frontend reactive initialization ensures dynamic enums load when valve modal opens
- Smart caching strategy balances performance with data freshness
- Graceful degradation with fallback options and error messages

**Use Cases:**
- Model selection filtered by user permissions
- Knowledge base selection showing only user-accessible bases
- Tool/resource dropdowns based on user role
- Any scenario requiring user-context-dependent options

### Screenshots or Videos

<img width="551" height="410" alt="image" src="https://github.com/user-attachments/assets/147278c4-e29a-4ab4-aa08-0960235c955a" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.