### PR TITLE
feat: Chat timestamps UI toggle

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -625,7 +625,7 @@
 					</span>
 				</Tooltip>
 
-				{#if message.timestamp}
+				{#if message.timestamp && ($settings?.showChatTimestamps ?? true)}
 					<div
 						class="self-center text-xs font-medium first-letter:capitalize ml-0.5 translate-y-[1px] {($settings?.highContrastMode ??
 						false)

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -145,7 +145,7 @@
 						{$i18n.t('You')}
 					{/if}
 
-					{#if message.timestamp}
+					{#if message.timestamp && ($settings?.showChatTimestamps ?? true)}
 						<div
 							class="self-center text-xs font-medium first-letter:capitalize ml-0.5 translate-y-[1px] {($settings?.highContrastMode ??
 							false)
@@ -168,7 +168,7 @@
 					{/if}
 				</Name>
 			</div>
-		{:else if message.timestamp}
+		{:else if message.timestamp && ($settings?.showChatTimestamps ?? true)}
 			<div class="flex justify-end pr-2 text-xs">
 				<div
 					class="text-[0.65rem] font-medium first-letter:capitalize mb-0.5 {($settings?.highContrastMode ??

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -491,25 +491,6 @@
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">
-					<div id="chat-timestamps-label" class=" self-center text-xs">
-						{$i18n.t('Chat Timestamps')}
-					</div>
-
-					<div class="flex items-center gap-2 p-1">
-						<Switch
-							ariaLabelledbyId="chat-timestamps-label"
-							tooltip={true}
-							bind:state={showChatTimestamps}
-							on:change={() => {
-								saveSettings({ showChatTimestamps });
-							}}
-						/>
-					</div>
-				</div>
-			</div>
-
-			<div>
-				<div class=" py-0.5 flex w-full justify-between">
 					<div id="chat-direction-label" class=" self-center text-xs">
 						{$i18n.t('Chat direction')}
 					</div>
@@ -617,6 +598,25 @@
 					</div>
 				</div>
 			{/if}
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="chat-timestamps-label" class=" self-center text-xs">
+						{$i18n.t('Chat Timestamps')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="chat-timestamps-label"
+							tooltip={true}
+							bind:state={showChatTimestamps}
+							on:change={() => {
+								saveSettings({ showChatTimestamps });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -70,6 +70,7 @@
 
 	let showFloatingActionButtons = true;
 	let floatingActionButtons = null;
+	let showChatTimestamps = true;
 
 	let imageCompression = false;
 	let imageCompressionSize = {
@@ -240,6 +241,7 @@
 
 		showFloatingActionButtons = $settings?.showFloatingActionButtons ?? true;
 		floatingActionButtons = $settings?.floatingActionButtons ?? null;
+		showChatTimestamps = $settings?.showChatTimestamps ?? true;
 
 		imageCompression = $settings?.imageCompression ?? false;
 		imageCompressionSize = $settings?.imageCompressionSize ?? { width: '', height: '' };
@@ -486,6 +488,25 @@
 			{/if}
 
 			<div class=" my-2 text-sm font-medium">{$i18n.t('Chat')}</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="chat-timestamps-label" class=" self-center text-xs">
+						{$i18n.t('Chat Timestamps')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="chat-timestamps-label"
+							tooltip={true}
+							bind:state={showChatTimestamps}
+							on:change={() => {
+								saveSettings({ showChatTimestamps });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -190,6 +190,7 @@ type Settings = {
 	splitLargeDeltas?: boolean;
 	chatDirection?: 'LTR' | 'RTL' | 'auto';
 	ctrlEnterToSend?: boolean;
+	showChatTimestamps?: boolean;
 
 	system?: string;
 	seed?: number;


### PR DESCRIPTION
# Pull Request Checklist
- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

Changes include:
- Added `showChatTimestamps` to the settings store.
- Added a toggle switch to the interface settings component.
- Conditionally rendered timestamps in `UserMessage.svelte` and `ResponseMessage.svelte`.

# Changelog Entry
### Description
- This pull request introduces a new "Chat Timestamps" toggle option within the user's interface settings. This feature empowers users to customize their chat view by choosing to either display or hide the timestamps associated with each message. By default, timestamps remain visible, preserving the existing behavior.

### Added
- A new "Chat Timestamps" toggle switch in the "Interface" section of the user settings.
- A showChatTimestamps boolean property to the `Settings` store to manage the state of the toggle.

### Changed
- `src/lib/stores/index.ts`: Updated the `Settings` type definition to include the new `showChatTimestamps` property.
- `src/lib/components/chat/Settings/Interface.svelte`: Added the UI for the "Chat Timestamps" toggle and the logic to save the setting.
- `src/lib/components/chat/Messages/UserMessage.svelte`: Modified to conditionally render the timestamp based on the `showChatTimestamps` setting.
- `src/lib/components/chat/Messages/ResponseMessage.svelte`: Modified to conditionally render the timestamp based on the `showChatTimestamps` setting.

### Additional Information
- This feature was implemented with code provided by Jules (Asynchronous Coding Agent) and the code in this pull request is AI generated.

### Screenshots or Videos
<img width="1163" height="686" alt="image" src="https://github.com/user-attachments/assets/c13ff9a9-aa90-4f34-acd9-0ef927edd63a" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.