### PR TITLE
Fix(RAG): Pass playwright_timeout to browser connect method

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -464,7 +464,9 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
         async with async_playwright() as p:
             # Use remote browser if ws_endpoint is provided, otherwise use local browser
             if self.playwright_ws_url:
-                browser = await p.chromium.connect(self.playwright_ws_url)
+                browser = await p.chromium.connect(
+                    self.playwright_ws_url, timeout=self.playwright_timeout
+                )
             else:
                 browser = await p.chromium.launch(
                     headless=self.headless, proxy=self.proxy


### PR DESCRIPTION
Description:

The application currently ignores the PLAYWRIGHT_TIMEOUT environment variable when using the Playwright web loader. This causes web searches to fail with a Connection timed out error after exactly 30 seconds, which appears to be the hard-coded default timeout of the Playwright library's connect method.

Evidence:

    The open-webui log consistently shows the process timing out after ~30 seconds, regardless of the PLAYWRIGHT_TIMEOUT value set in the environment or the UI.

    The corresponding browserless log shows that it receives the connection request and successfully launches a Chrome instance in under a second. It then waits idle for 30 seconds until the client disconnects.

    This proves the server-side (browserless) is working correctly and the timeout is client-side (open-webui).

The Fix:

This commit resolves the issue by passing the self.playwright_timeout value to the p.chromium.connect() call in /backend/open_webui/retrieval/web/utils.py, ensuring the user-configured timeout is respected.
