### PR TITLE
Fix: NoneType in chat title for Reasoning Models

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1565,16 +1565,24 @@ async def process_chat_response(
                             )
 
                             if res and isinstance(res, dict):
+                                title_string = None
                                 if len(res.get("choices", [])) == 1:
                                     title_string = (
                                         res.get("choices", [])[0]
                                         .get("message", {})
                                         .get(
-                                            "content",
-                                            message.get("content", user_message),
+                                            "content", message.get("content", user_message)
                                         )
                                     )
-                                else:
+                                    if title_string is None:
+                                        title_string = (
+                                            res.get("choices", [])[0]
+                                            .get("message", {})
+                                            .get(
+                                                "reasoning_content", message.get("reasoning_content", user_message)
+                                            )
+                                        )
+                                if title_string is None:
                                     title_string = ""
 
                                 title_string = title_string[


### PR DESCRIPTION
Some Reasoning Models don't return the key `content` in their response, instead they return the contet in the key `reasoning_content`

# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]


### Fixed

- Chat title generation for Reasoning Models (#17573)

---

### Additional Information

- Added change from Discussion https://github.com/open-webui/open-webui/discussions/17573

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
