### PR TITLE
fix: When enabling an MCP server with OAuth 2.1 authentication, close tab after successful authentication

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -606,7 +606,25 @@ class OAuthClientManager:
             redirect_url = f"{redirect_url}/?error={error_message}"
             return RedirectResponse(url=redirect_url, headers=response.headers)
 
-        response = RedirectResponse(url=redirect_url, headers=response.headers)
+        from fastapi.responses import HTMLResponse
+        close_tab_html = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Authentication Complete</title>
+        </head>
+        <body>
+            <script>
+                const channel = new BroadcastChannel(`server:{client_id}:oauth`);
+                channel.postMessage('oauth_complete');
+                channel.close();
+                window.close();
+            </script>
+            <p>Authentication complete. You can close this tab.</p>
+        </body>
+        </html>
+        """
+        response = HTMLResponse(content=close_tab_html, headers=response.headers)
         return response
 
 

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -336,6 +336,24 @@
 
 									let parts = toolId.split(':');
 									let serverId = parts?.at(-1) ?? toolId;
+									
+									const channel = new BroadcastChannel(`${toolId}:oauth`);							
+									channel.onmessage = (event) => {
+										if (event.data === 'oauth_complete') {
+											_tools.update(currentTools => {
+												const currentTool = currentTools.find(t => t.id === toolId);
+												if (currentTool) {
+													currentTool.authenticated = true;
+												}
+												return currentTools;
+											});
+
+											tools[toolId].authenticated = true;
+											tools[toolId].enabled = true;
+											
+											channel.close();
+										}
+									};
 
 									const authUrl = getOAuthClientAuthorizationUrl(serverId, 'mcp');
 									window.open(authUrl, '_blank', 'noopener');


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Improve user experience when enabling an MCP server tool with OAuth 2.1 authentication

### Fixed

- Fixes this behaviour: When enabling an MCP server with OAuth 2.1 in chat tools, a new tab is opened asking the user to log in, but the original tab is never notified about the result.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
