### PR TITLE
i18n: Fix typo in Spanish translation ("Eriquetas" → "Etiquetas")

### DIFF
--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -1237,7 +1237,7 @@
 	"Read more →": "Leer más →",
 	"Reason": "Razonamiento",
 	"Reasoning Effort": "Esfuerzo del Razonamiento",
-	"Reasoning Tags": "Eriquetas de Razonamiento",
+	"Reasoning Tags": "Etiquetas de Razonamiento",
 	"Record": "Grabar",
 	"Record voice": "Grabar voz",
 	"Redirecting you to Open WebUI Community": "Redireccionando a la Comunidad Open-WebUI",


### PR DESCRIPTION
Typo fixed in Spanish translation file at line 1240 of `open-webui/src/lib/i18n/locales/es-ES/translation.json`:

- Incorrect: "Eriquetas de Razonamiento"
- Correct:   "Etiquetas de Razonamiento"

This improves clarity and consistency in the UI.

### Changelog Entry

### Fixed
- Corrected typo in Spanish translation: "Eriquetas de Razonamiento" → "Etiquetas de Razonamiento"

I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.