### PR TITLE
UPD_FEAT-Refresh_Sidebar_ChatList_after_actions

### DIFF
--- a/src/lib/components/chat/Placeholder/FolderTitle.svelte
+++ b/src/lib/components/chat/Placeholder/FolderTitle.svelte
@@ -9,7 +9,7 @@
 
 	import { toast } from 'svelte-sonner';
 
-	import { selectedFolder } from '$lib/stores';
+	import { selectedFolder, chatListRefresh } from '$lib/stores';
 
 	import { deleteFolderById, getFolderById, updateFolderById } from '$lib/apis/folders';
 	import { getChatsByFolderId } from '$lib/apis/chats';
@@ -93,6 +93,10 @@
 			});
 
 			await selectedFolder.set(_folder);
+			chatListRefresh.update((v) => ({
+				timestamp: Date.now(),
+				folderId: folder.id
+			}));
 			onUpdate(_folder);
 		}
 	};

--- a/src/lib/components/layout/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/ArchivedChatsModal.svelte
@@ -127,7 +127,7 @@
 				// Trigger global refresh
 				timestamp: Date.now(),
 				folderId: null // Refresh all since we don't have folder context here
-			}));			
+			}));
 			onUpdate();
 			await init();
 		} catch (error) {

--- a/src/lib/components/layout/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/ArchivedChatsModal.svelte
@@ -11,7 +11,7 @@
 		unarchiveAllChats
 	} from '$lib/apis/chats';
 	import { chatListRefresh } from '$lib/stores';
-	
+
 	import ChatsModal from './ChatsModal.svelte';
 	import UnarchiveAllConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Spinner from '../common/Spinner.svelte';
@@ -108,10 +108,11 @@
 			toast.error(`${error}`);
 		});
 
-	    chatListRefresh.update(v => ({    // Trigger global refresh  
-	        timestamp: Date.now(),
-	        folderId: null  			// Refresh all since we don't have folder context here  
-	    }));
+		chatListRefresh.update((v) => ({
+			// Trigger global refresh
+			timestamp: Date.now(),
+			folderId: null // Refresh all since we don't have folder context here
+		}));
 		onUpdate();
 		init();
 	};
@@ -122,10 +123,11 @@
 			await unarchiveAllChats(localStorage.token);
 			toast.success($i18n.t('All chats have been unarchived.'));
 
-		    chatListRefresh.update(v => ({    // Trigger global refresh  
-		        timestamp: Date.now(),
-		        folderId: null  			// Refresh all since we don't have folder context here  
-		    }));			
+			chatListRefresh.update((v) => ({
+				// Trigger global refresh
+				timestamp: Date.now(),
+				folderId: null // Refresh all since we don't have folder context here
+			}));			
 			onUpdate();
 			await init();
 		} catch (error) {

--- a/src/lib/components/layout/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/ArchivedChatsModal.svelte
@@ -10,7 +10,8 @@
 		getArchivedChatList,
 		unarchiveAllChats
 	} from '$lib/apis/chats';
-
+	import { chatListRefresh } from '$lib/stores';
+	
 	import ChatsModal from './ChatsModal.svelte';
 	import UnarchiveAllConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Spinner from '../common/Spinner.svelte';
@@ -107,6 +108,10 @@
 			toast.error(`${error}`);
 		});
 
+	    chatListRefresh.update(v => ({    // Trigger global refresh  
+	        timestamp: Date.now(),
+	        folderId: null  			// Refresh all since we don't have folder context here  
+	    }));
 		onUpdate();
 		init();
 	};
@@ -116,6 +121,11 @@
 		try {
 			await unarchiveAllChats(localStorage.token);
 			toast.success($i18n.t('All chats have been unarchived.'));
+
+		    chatListRefresh.update(v => ({    // Trigger global refresh  
+		        timestamp: Date.now(),
+		        folderId: null  			// Refresh all since we don't have folder context here  
+		    }));			
 			onUpdate();
 			await init();
 		} catch (error) {

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -209,7 +209,7 @@
 	};
 
 	$: if ($chatListRefresh) {
-    	initChatList();
+		initChatList();
 	}
 
 	const loadMoreChats = async () => {

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -25,6 +25,7 @@
 		isApp,
 		models,
 		selectedFolder,
+		chatListRefresh,
 		WEBUI_NAME
 	} from '$lib/stores';
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
@@ -62,6 +63,8 @@
 	import PinnedModelList from './Sidebar/PinnedModelList.svelte';
 	import Note from '../icons/Note.svelte';
 	import { slide } from 'svelte/transition';
+
+	let lastRefreshTimestamp = 0;
 
 	const BREAKPOINT = 768;
 
@@ -204,6 +207,10 @@
 		// Enable pagination
 		scrollPaginationEnabled.set(true);
 	};
+
+	$: if ($chatListRefresh) {
+    	initChatList();
+	}
 
 	const loadMoreChats = async () => {
 		chatListLoading = true;

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -27,7 +27,8 @@
 		showSidebar,
 		currentChatPage,
 		tags,
-		selectedFolder
+		selectedFolder,
+		chatListRefresh
 	} from '$lib/stores';
 
 	import ChatMenu from './ChatMenu.svelte';
@@ -69,6 +70,15 @@
 		}
 	};
 
+	const refreshChatList = () => {
+	    if (chat?.folder_id) {
+	        chatListRefresh.update(v => ({
+	            timestamp: Date.now(),
+ 	           folderId: chat.folder_id
+	        }));  
+ 	   }  
+	};
+
 	let showShareChatModal = false;
 	let confirmEdit = false;
 
@@ -90,6 +100,7 @@
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 			await pinnedChats.set(await getPinnedChatList(localStorage.token));
 
+			refreshChatList();
 			dispatch('change');
 		}
 	};
@@ -107,6 +118,7 @@
 		});
 
 		if (res) {
+			refreshChatList();
 			goto(`/c/${res.id}`);
 
 			currentChatPage.set(1);
@@ -122,6 +134,7 @@
 		});
 
 		if (res) {
+			refreshChatList();
 			tags.set(await getAllTags(localStorage.token));
 			if ($chatId === id) {
 				await goto('/');
@@ -136,6 +149,8 @@
 
 	const archiveChatHandler = async (id) => {
 		await archiveChatById(localStorage.token, id);
+
+		refreshChatList();
 		dispatch('change');
 	};
 
@@ -153,6 +168,7 @@
 				await chats.set(await getChatList(localStorage.token, $currentChatPage));
 				await pinnedChats.set(await getPinnedChatList(localStorage.token));
 
+				refreshChatList();
 				dispatch('change');
 
 				toast.success($i18n.t('Chat moved successfully'));

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -76,7 +76,7 @@
 				timestamp: Date.now(),
 				folderId: chat.folder_id
 			}));
-		} 
+		}
 	};
 
 	let showShareChatModal = false;

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -71,12 +71,12 @@
 	};
 
 	const refreshChatList = () => {
-	    if (chat?.folder_id) {
-	        chatListRefresh.update(v => ({
-	            timestamp: Date.now(),
- 	           folderId: chat.folder_id
-	        }));  
- 	   }  
+		if (chat?.folder_id) {
+			chatListRefresh.update((v) => ({
+				timestamp: Date.now(),
+				folderId: chat.folder_id
+			}));
+		} 
 	};
 
 	let showShareChatModal = false;

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -11,7 +11,7 @@
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
 
-	import { chatId, mobile, selectedFolder, showSidebar } from '$lib/stores';
+	import { chatId, mobile, selectedFolder, showSidebar, chatListRefresh } from '$lib/stores';
 
 	import {
 		deleteFolderById,
@@ -68,6 +68,10 @@
 	let clickTimer = null;
 
 	let name = '';
+
+	$: if ($chatListRefresh) {
+    	setFolderItems();  
+	}
 
 	const onDragOver = (e) => {
 		e.preventDefault();

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -70,7 +70,7 @@
 	let name = '';
 
 	$: if ($chatListRefresh) {
-    	setFolderItems();  
+		setFolderItems();
 	}
 
 	const onDragOver = (e) => {

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -343,6 +343,11 @@
 					await selectedFolder.set(folder);
 				}
 			}
+
+			chatListRefresh.update((v) => ({
+				timestamp: Date.now(),
+				folderId: folder.id
+			}));
 			dispatch('update');
 		}
 	};

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -45,6 +45,7 @@ export const TTSWorker = writable(null);
 
 export const chatId = writable('');
 export const chatTitle = writable('');
+export const chatListRefresh = writable({ timestamp: Date.now(), folderId: null });
 
 export const channels = writable([]);
 export const chats = writable(null);


### PR DESCRIPTION
### UPD_FEAT-Refresh_Sidebar_ChatList_after_actions

Add function for refresh sidebar chat list.
Fix some realtime rendering issues.

Added:
- store for chatList refresh trigger.
- refresh actions in Folders & Sidebar.
- refresh trigger and calls after chat list actions in ChatItem.
- refresh trigger after unarchive chat/s in ArchiveChatsModal.


https://github.com/user-attachments/assets/abbf8c93-2b6e-4b5b-9bd6-fefe62e10556


____

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
