### PR TITLE
feat: "create a new note" actually creates a new note from search modal

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -17,6 +17,7 @@
 	import { goto } from '$app/navigation';
 	import PencilSquare from '../icons/PencilSquare.svelte';
 	import PageEdit from '../icons/PageEdit.svelte';
+	import { createNewNote } from '$lib/apis/notes';
 	dayjs.extend(calendar);
 
 	export let show = false;
@@ -233,9 +234,40 @@
 						{
 							label: $i18n.t('Create a new note'),
 							onClick: async () => {
-								await goto(`/notes${query ? `?content=${query}` : ''}`);
-								show = false;
-								onClose();
+								const note = await createNewNote(localStorage.token, {
+									title: dayjs().format('YYYY-MM-DD'),
+									data: {
+										content: {
+											json: {
+												type: 'doc',
+												content: [
+													{
+														type: 'paragraph',
+														content: query
+															? [
+																	{
+																		type: 'text',
+																		text: query
+																	}
+																]
+															: []
+													}
+												]
+											},
+											html: `<p>${query}</p>`,
+											md: query
+										}
+									},
+									access_control: {}
+								});
+
+								if (note) {
+									await goto(`/notes/${note.id}`);
+									show = false;
+									onClose();
+								} else {
+									toast.error($i18n.t('Failed to create note'));
+								}
 							},
 							icon: PageEdit
 						}


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- This pull request overhauls the functionality of the "Create a new note" button in the chat search modal. Previously, this button would simply navigate to the main notes page. Now, it provides a more seamless user experience by immediately creating a new, private note and opening it in the editor.

### Changed
- The "Create a new note" button in the search modal now creates a new note and navigates directly to the new note's editor page, rather than the generic notes page.
- The title of the new note is now automatically set to the current date in `YYYY-MM-DD` format.
- New notes created from the search modal are now private by default.

### Security
- New notes created from the search modal are now private by default, enhancing user privacy.

### Additional Information
- This change improves the user workflow by reducing the number of steps required to create a new note from a search query.
- This PR addresses the issue raised in the following discussion post: https://github.com/open-webui/open-webui/discussions/18134#discussioncomment-14621518

### Screenshots and Videos
[Screencast from 2025-10-11 19-43-55.webm](https://github.com/user-attachments/assets/b0e6be7e-51b7-4036-9899-9879bea74889)

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.