### PR TITLE
fix: reword misleading knowledge base warning in documents settings

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -978,7 +978,7 @@
 
 							<div class="mt-1 mb-1 text-xs text-gray-400 dark:text-gray-500">
 								{$i18n.t(
-									'Warning: If you update or change your embedding model, you will need to re-import all documents.'
+									'Note: After updating or changing the embedding model, you must reindex the knowledge base for the changes to take effect. You can do this using the "Reindex" button below.'
 								)}
 							</div>
 						</div>

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -978,7 +978,7 @@
 
 							<div class="mt-1 mb-1 text-xs text-gray-400 dark:text-gray-500">
 								{$i18n.t(
-									'Note: After updating or changing the embedding model, you must reindex the knowledge base for the changes to take effect. You can do this using the "Reindex" button below.'
+									'After updating or changing the embedding model, you must reindex the knowledge base for the changes to take effect. You can do this using the "Reindex" button below.'
 								)}
 							</div>
 						</div>


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- Rephrased the misleading warning message in the admin document settings beneath the `Embedding Model` input field. The previous text incorrectly suggested that users needed to re-import all documents after changing the embedding model due to the warning being outdated. The updated text now correctly instructs users to use the "Reindex Knowledge Base Vectors" button, improving clarity and preventing user confusion.

### Changed
- The warning text in `src/lib/components/admin/Settings/Documents.svelte` has been updated to provide clear instructions instead of a potentially alarming warning.

### Fixed
- Corrected a misleading UI message that could lead to unnecessary work for administrators managing knowledge bases.

### Additional Information
- This change addresses the confusing nature of the previous warning message, leading to a better user experience.

### Screenshots or Videos
**Before:**
<img width="660" height="84" alt="image" src="https://github.com/user-attachments/assets/069db389-f67c-4f3a-b8c5-b9788e48f8eb" />

**After:**
<img width="1026" height="126" alt="image" src="https://github.com/user-attachments/assets/0c5bb719-68a8-4dc2-8784-238f075d647d" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.