### PR TITLE
feat: Extend FileMetadataResponse to have hash field

### DIFF
--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -82,6 +82,7 @@ class FileModelResponse(BaseModel):
 
 class FileMetadataResponse(BaseModel):
     id: str
+    hash: Optional[str] = None
     meta: dict
     created_at: int  # timestamp in epoch
     updated_at: int  # timestamp in epoch
@@ -147,6 +148,7 @@ class FilesTable:
                 file = db.get(File, id)
                 return FileMetadataResponse(
                     id=file.id,
+                    hash=file.hash,
                     meta=file.meta,
                     created_at=file.created_at,
                     updated_at=file.updated_at,
@@ -182,12 +184,13 @@ class FilesTable:
             return [
                 FileMetadataResponse(
                     id=file.id,
+                    hash=file.hash,
                     meta=file.meta,
                     created_at=file.created_at,
                     updated_at=file.updated_at,
                 )
                 for file in db.query(
-                    File.id, File.meta, File.created_at, File.updated_at
+                    File.id, File.hash, File.meta, File.created_at, File.updated_at
                 )
                 .filter(File.id.in_(ids))
                 .order_by(File.updated_at.desc())


### PR DESCRIPTION
# Changelog Entry

### Description
- Extend the `/api/v1/knowledge/{id}` endpoint to include the `hash` value for each file returned. This supports a custom file-sync logic that compares hashes instead of re-uploading entire files, greatly improving sync performance and efficiency.

### Added
- `hash` property in the `FileMetadataResponse` model.

### Changed
- Refactored the knowledge endpoint’s response construction to include the new `hash` field.

---

### Screenshots or Videos
<img width="1709" height="840" alt="Knowledge endpoint" src="https://github.com/user-attachments/assets/28e6e892-4df9-4b6e-a594-2cbe4f00c1d8" />

## Related Discussion
See: 
https://github.com/open-webui/open-webui/discussions/18282
https://github.com/open-webui/open-webui/discussions/18323

## Related Issue
See: https://github.com/open-webui/open-webui/issues/18283

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.