### PR TITLE
fix: support sending body data in DELETE request to an external tool

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -754,7 +754,7 @@ async def execute_tool_server(
         ) as session:
             request_method = getattr(session, http_method.lower())
 
-            if http_method in ["post", "put", "patch"]:
+            if http_method in ["post", "put", "patch", "delete"]:
                 async with request_method(
                     final_url,
                     json=body_params,


### PR DESCRIPTION
# Pull Request Checklist

Patch the issue https://github.com/open-webui/open-webui/issues/18287

# Changelog Entry

### Fixed

- Calling an external tool using a DELETE method will lead to body data being sent, like already done for POST, PUT and PATCH.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
