### PR TITLE
fix: prevent integrations menu from closing when valves modal is open

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -117,6 +117,11 @@
 	let showValvesModal = false;
 	let selectedValvesType = 'tool'; // 'tool' or 'function'
 	let selectedValvesItemId = null;
+	let integrationsMenuCloseOnOutsideClick = true;
+
+	$: if (!showValvesModal) {
+		integrationsMenuCloseOnOutsideClick = true;
+	}
 
 	$: onChange({
 		prompt,
@@ -944,6 +949,9 @@
 	on:save={async () => {
 		await tick();
 	}}
+	on:close={() => {
+		integrationsMenuCloseOnOutsideClick = true;
+	}}
 />
 
 {#if loaded}
@@ -1463,11 +1471,13 @@
 												bind:webSearchEnabled
 												bind:imageGenerationEnabled
 												bind:codeInterpreterEnabled
+												closeOnOutsideClick={integrationsMenuCloseOnOutsideClick}
 												onShowValves={(e) => {
 													const { type, id } = e;
 													selectedValvesType = type;
 													selectedValvesItemId = id;
 													showValvesModal = true;
+													integrationsMenuCloseOnOutsideClick = false;
 												}}
 												onClose={async () => {
 													await tick();

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -42,6 +42,7 @@
 
 	export let onShowValves: Function;
 	export let onClose: Function;
+	export let closeOnOutsideClick = true;
 
 	let show = false;
 	let tab = '';
@@ -93,6 +94,7 @@
 
 <Dropdown
 	bind:show
+	{closeOnOutsideClick}
 	on:change={(e) => {
 		if (e.detail === false) {
 			onClose();

--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -9,12 +9,15 @@
 	export let show = false;
 	export let side = 'bottom';
 	export let align = 'start';
+	export let closeOnOutsideClick = true;
+
 	const dispatch = createEventDispatcher();
 </script>
 
 <DropdownMenu.Root
 	bind:open={show}
 	closeFocus={false}
+	{closeOnOutsideClick}
 	onOpenChange={(state) => {
 		dispatch('change', state);
 	}}


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- This pull request fixes a bug where the "Integrations" menu would incorrectly close when a user clicked outside of the "Valves" modal that was opened from it. The expected behavior is for the modal to close first, without affecting the underlying menu. This change ensures the menu remains open, providing a more intuitive user experience.

### Changed
- `src/lib/components/common/Dropdown.svelte`: Modified to accept a `closeOnOutsideClick` prop to programmatically control the closing behavior.
- `src/lib/components/chat/MessageInput.svelte`: Updated to manage the state of the `IntegrationsMenu` dropdown, disabling `closeOnOutsideClick` when the `ValvesModal` is open and re-enabling it when the modal is closed.
- `src/lib/components/chat/MessageInput/IntegrationsMenu.svelte`: Updated to receive and pass the `closeOnOutsideClick` prop to the `Dropdown` component.

### Fixed
- The "Integrations" menu no longer closes prematurely when a user clicks outside the "Valves" modal.

### To reproduce what this Pull Request solves (try this before trying to reproduce the issue via this PR):
- Open up the `Integrations` menu via the button in the chat input area:
<img width="386" height="208" alt="image" src="https://github.com/user-attachments/assets/5b12f923-94dc-4171-b2cc-ccf606a736c1" />

- Click `Tools` in the `Integrations menu`:
<img width="351" height="368" alt="image" src="https://github.com/user-attachments/assets/692159a4-90a1-4377-b8ac-0ae117120286" />

- Click on the `Valves` button for a tool:
<img width="351" height="368" alt="image" src="https://github.com/user-attachments/assets/80a7a9ec-2e5a-455d-b429-8212705d6847" />

- Once the `Valves` modal opens, click **outside** of this modal.
- Witness that the `Integrations` menu that was in the background was closed upon the primary click.
- Click once more. Now the `Valves` model that was in the foreground closes upon the secondary click.

### Additional Information
- This fix improves the user experience by making the interaction with nested UI elements (modal within a dropdown menu) behave as expected.

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.