### PR TITLE
fix: stop default prompt suggestions from refreshing on model picker hover

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -381,14 +381,6 @@
 			false)
 				? 'dark:placeholder-gray-100 placeholder-gray-800'
 				: 'placeholder-gray-400'}"
-			on:mouseenter={async () => {
-				models.set(
-					await getModels(
-						localStorage.token,
-						$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
-					)
-				);
-			}}
 		>
 			{#if selectedModel}
 				{selectedModel.label}


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- This pull request addresses an issue where hovering the mouse over the model selector on the "New Chat" page would unintentionally refresh the default prompt suggestions. This change ensures that the suggestions remain static unless a new model is explicitly selected from the dropdown menu, improving the user experience by preventing unwanted UI updates.

### Removed
- Removed the `on:mouseenter` event handler from the model selector trigger component (`src/lib/components/chat/ModelSelector/Selector.svelte`). This handler was responsible for re-fetching the model list on hover, which caused the undesirable refresh of prompt suggestions.

### Fixed
- Fixed a bug that caused the default prompt suggestions to be re-randomized whenever the user's mouse pointer hovered over the model selector, even without clicking or changing the selection.

### Additional Information
- The root cause of the issue was an API call (`getModels`) being triggered by the `on:mouseenter` event. By removing this event handler, the API is no longer called on hover, and the prompt suggestions only update when a new model is actually selected, as intended.

### Screenshots or Videos
**Before (Hovering the mouse pointer over the model picker, moving the mouse a little, and moving the mouse pointer back would result in the `models` endpoint being called each time):**
<img width="2559" height="449" alt="image" src="https://github.com/user-attachments/assets/84b41064-a562-48d6-96f8-3f1fdea0d24f" />

**After (Now, only a single call is made to the Ollama `version` endpoint when the model picker is opened and no network activity is created from the previous reproduction steps to trigger requests to the `models` endpoint):**
<img width="2559" height="449" alt="image" src="https://github.com/user-attachments/assets/07df2f99-0501-4112-aff1-87fc26dee96b" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.