### PR TITLE
feat(websockets): Enable multi-tab support by isolating WebSocket connections

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -237,7 +237,7 @@ async def generate_function_chat_completion(
 
     if metadata:
         if all(k in metadata for k in ("session_id", "chat_id", "message_id")):
-            __event_emitter__ = get_event_emitter(metadata)
+            __event_emitter__ = get_event_emitter(metadata, broadcast=False)
             __event_call__ = get_event_call(metadata)
         __task__ = metadata.get("task", None)
         __task_body__ = metadata.get("task_body", None)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -638,20 +638,29 @@ async def disconnect(sid):
         # print(f"Unknown session ID {sid} disconnected")
 
 
-def get_event_emitter(request_info, update_db=True):
+def get_event_emitter(request_info, update_db=True, broadcast: bool = True):
     async def __event_emitter__(event_data):
         user_id = request_info["user_id"]
 
-        session_ids = list(
-            set(
-                USER_POOL.get(user_id, [])
-                + (
-                    [request_info.get("session_id")]
-                    if request_info.get("session_id")
-                    else []
+        if broadcast:
+            # Broadcast to all user sessions (default behavior)
+            session_ids = list(
+                set(
+                    USER_POOL.get(user_id, [])
+                    + (
+                        [request_info.get("session_id")]
+                        if request_info.get("session_id")
+                        else []
+                    )
                 )
             )
-        )
+        else:
+            # Target only the originating session (for streaming chat responses)
+            session_ids = (
+                [request_info.get("session_id")]
+                if request_info.get("session_id")
+                else []
+            )
 
         chat_id = request_info.get("chat_id", None)
         message_id = request_info.get("message_id", None)

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -322,7 +322,7 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
     }
 
     extra_params = {
-        "__event_emitter__": get_event_emitter(metadata),
+        "__event_emitter__": get_event_emitter(metadata, broadcast=False),
         "__event_call__": get_event_call(metadata),
         "__user__": user.model_dump() if isinstance(user, UserModel) else {},
         "__metadata__": metadata,
@@ -383,7 +383,8 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
             "message_id": data["id"],
             "session_id": data["session_id"],
             "user_id": user.id,
-        }
+        },
+        broadcast=False,
     )
     __event_call__ = get_event_call(
         {

--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -2,10 +2,11 @@
 	import { toast } from 'svelte-sonner';
 	import { Pane, PaneGroup, PaneResizer } from 'paneforge';
 
-	import { onDestroy, onMount, tick } from 'svelte';
+	import { onDestroy, onMount, tick, getContext } from 'svelte';
 	import { goto } from '$app/navigation';
 
-	import { chatId, showSidebar, socket, user } from '$lib/stores';
+	import { chatId, showSidebar, user } from '$lib/stores';
+	const socket = getContext('socket');
 	import { getChannelById, getChannelMessages, sendMessage } from '$lib/apis/channels';
 
 	import Messages from './Messages.svelte';

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -5,8 +5,9 @@
 	import { tick, getContext, onMount, onDestroy } from 'svelte';
 
 	const i18n = getContext('i18n');
+	const socket = getContext('socket');
 
-	import { config, mobile, settings, socket, user } from '$lib/stores';
+	import { config, mobile, settings, user } from '$lib/stores';
 	import {
 		convertHeicToJpeg,
 		compressImage,

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 
-	import { socket, user } from '$lib/stores';
+	import { user } from '$lib/stores';
 
 	import { getChannelThreadMessages, sendMessage } from '$lib/apis/channels';
 
@@ -13,6 +13,7 @@
 	import Spinner from '../common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
+	const socket = getContext('socket');
 
 	export let threadId = null;
 	export let channel = null;

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -5,6 +5,7 @@
 
 	import { getContext, onDestroy, onMount, tick } from 'svelte';
 	const i18n: Writable<i18nType> = getContext('i18n');
+	const socket: Writable<any> = getContext('socket');
 
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
@@ -25,7 +26,6 @@
 		WEBUI_NAME,
 		banners,
 		user,
-		socket,
 		showControls,
 		showCallOverlay,
 		currentChatPage,

--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -6,6 +6,7 @@
 
 	import { getContext, tick, onDestroy } from 'svelte';
 	const i18n = getContext('i18n');
+	const socket = getContext('socket');
 
 	import { chatCompletion } from '$lib/apis/openai';
 
@@ -13,7 +14,7 @@
 	import LightBulb from '$lib/components/icons/LightBulb.svelte';
 	import Markdown from '../Messages/Markdown.svelte';
 	import Skeleton from '../Messages/Skeleton.svelte';
-	import { chatId, models, socket } from '$lib/stores';
+	import { chatId, models } from '$lib/stores';
 
 	export let id = '';
 	export let messageId = '';

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -922,6 +922,11 @@
 
 								const { state } = view;
 								const { $from } = state.selection;
+
+								// Guard against invalid positions at document start
+								if ($from.pos === 0 || state.doc.content.size === 0) {
+									return false; // Let ProseMirror handle it normally
+								}
 								const lineStart = $from.before($from.depth);
 								const lineEnd = $from.after($from.depth);
 								const lineText = state.doc.textBetween(lineStart, lineEnd, '\n', '\0').trim();

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -20,7 +20,6 @@
 		currentChatPage,
 		temporaryChatEnabled,
 		channels,
-		socket,
 		config,
 		isApp,
 		models,
@@ -30,6 +29,7 @@
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 
 	const i18n = getContext('i18n');
+	const socket = getContext('socket');
 
 	import {
 		getChatList,

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -5,6 +5,7 @@
 	const { saveAs } = fileSaver;
 
 	const i18n = getContext('i18n');
+	const socket = getContext('socket');
 
 	import { marked } from 'marked';
 	import { toast } from 'svelte-sonner';
@@ -33,7 +34,6 @@
 		models,
 		settings,
 		showSidebar,
-		socket,
 		user,
 		WEBUI_NAME
 	} from '$lib/stores';

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -21,7 +21,7 @@ export const MODEL_DOWNLOAD_POOL = writable({});
 
 export const mobile = writable(false);
 
-export const socket: Writable<null | Socket> = writable(null);
+export const socket: Writable<null | any> = writable(null);
 export const activeUserIds: Writable<null | string[]> = writable(null);
 export const USAGE_POOL: Writable<null | string[]> = writable(null);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
 	worker: {
 		format: 'es'
 	},
+	optimizeDeps: {
+		include: ['y-protocols/awareness']
+	},
 	esbuild: {
 		pure: process.env.ENV === 'dev' ? [] : ['console.log', 'console.debug', 'console.error']
 	}


### PR DESCRIPTION
This change introduces WebSocket connection isolation for each browser tab,
  resolving interference issues when multiple Open WebUI tabs are open
  simultaneously.

  Previously, all tabs shared a single WebSocket event stream, causing messages and
  UI updates intended for one tab to incorrectly appear in others. This also led to
  connection drops and unresponsive chats.

  Key changes:

  - **Backend:** The `get_event_emitter` function now accepts a `broadcast: bool`
  parameter. By setting `broadcast=False` for user-specific events (like chat
  streaming), messages are now directed only to the originating client's session ID
  (sid).

  - **Frontend:** Refactored the WebSocket handling to use Svelte's Context API. Each
   tab's component tree now maintains its own isolated socket instance, preventing
  cross-tab state pollution. This affects Chat, Channel, and other real-time
  components.

  - **Bug Fix:** A `RangeError` in `RichTextInput` (ProseMirror) is now guarded
  against, improving editor stability.

  - **Build:** Added `y-protocols/awareness` to `vite.config.ts` optimizeDeps to
  prevent potential pre-bundling issues.

  Closes #16219

  # Pull Request Checklist

  **Before submitting, make sure you've checked the following:**

  - [x] **Target branch:** Verify that the pull request targets the `dev` branch.
  - [x] **Description:** Provide a concise description of the changes made in this
  pull request.
  - [x] **Changelog:** Ensure a changelog entry following the format of [Keep a
  Changelog](https://keepachangelog.com/) is added at the bottom of the PR
  description.
  - [ ] **Documentation:** If necessary, update relevant documentation.
  - [ ] **Dependencies:** No new dependencies added.
  - [x] **Testing:** Manual testing performed across multiple tabs, direct
  connections, and pipeline requests.
  - [x] **Agentic AI Code:** This PR has gone through human review and manual
  testing.
  - [x] **Code review:** Self-review performed.
  - [x] **Title Prefix:** `feat` prefix used to indicate new feature.

  # Changelog Entry

  ### Description

  Enables true multi-tab support by isolating WebSocket connections per browser tab.
  Fixes issue where chat responses and UI updates from one tab would incorrectly
  appear in other tabs, causing connection interference and unresponsive chats.

  ### Added

  - Backend `broadcast` parameter to `get_event_emitter` function for targeted
  message delivery
  - Frontend Context API-based socket management for tab isolation
  - Guard clause in `RichTextInput.svelte` to prevent ProseMirror RangeError

  ### Changed

  - Backend: Modified `get_event_emitter` in `socket/main.py` to accept `broadcast:
  bool` parameter
  - Backend: Updated `utils/chat.py` to use `broadcast=False` for chat streaming
  events (2 locations)
  - Backend: Updated `functions.py` to use `broadcast=False` for function execution
  events
  - Frontend: Refactored `+layout.svelte` to create tab-specific socket instances
  using Context API
  - Frontend: Updated 7 components to consume socket from context instead of global
  store:
    - `Chat.svelte`
    - `ContentRenderer/FloatingButtons.svelte`
    - `Channel.svelte`
    - `Thread.svelte`
    - `MessageInput.svelte`
    - `Sidebar.svelte`
    - `NoteEditor.svelte`
  - Build: Added `y-protocols/awareness` to `vite.config.ts` optimizeDeps

  ### Fixed

  - WebSocket connection interference between multiple browser tabs
  - Chat responses appearing in wrong tabs
  - Connection drops when multiple tabs are active
  - Unresponsive pipeline and direct connection requests in multi-tab scenarios
  - ProseMirror RangeError when cursor is at position 0 in `RichTextInput`

  ### Additional Information

  **Testing performed:**
  1. Opened two separate browser tabs
  2. Started chat in Tab 1 with streaming response
  3. Started different chat in Tab 2 while Tab 1 was still streaming
  4. Verified responses were isolated to correct tabs
  5. Tested direct connections and pipeline requests in both tabs
  6. Confirmed no connection drops or interference

  **Technical approach:**
  - Backend uses session ID (sid) targeting instead of broadcasting to all user
  connections
  - Frontend uses Svelte's `getContext`/`setContext` to provide tab-local socket
  instances
  - Each tab's component tree maintains independent WebSocket state

  ### Contributor License Agreement

  By submitting this pull request, I confirm that I have read and fully agree to the
  Contributor License Agreement (CLA), and I am providing my contributions under its
  terms.