### PR TITLE
fix: native tool calling message updates for sequential tool calls

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -106,13 +106,14 @@ async def get_tool_function_with_updated_params(
 
         if inspect.iscoroutinefunction(original_func):
             return await original_func(**filtered_params, **tool_params)
-        else:
-            result = original_func(**filtered_params, **tool_params)
-            if inspect.isawaitable(result):
-                return await result
-            return result
-    else:
-        return await callable_func(**tool_params)
+
+        result = original_func(**filtered_params, **tool_params)
+        if inspect.isawaitable(result):
+            return await result
+            
+        return result
+            
+    return await callable_func(**tool_params)
 
 
 async def get_tools(

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -110,9 +110,9 @@ async def get_tool_function_with_updated_params(
         result = original_func(**filtered_params, **tool_params)
         if inspect.isawaitable(result):
             return await result
-            
+
         return result
-            
+
     return await callable_func(**tool_params)
 
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

- 🛠️ Fixed native tool calling to support sequential tool calls with shared context, allowing tools to access images and data from previous tool executions in the same conversation.

### Description

## Description

**Fixed native tool calling to support sequential tool calls with shared context**

In native function calling mode, tools were unable to access conversation history from previous tool calls within the same conversation. This prevented workflows like:
1. User: "Generate an image of a bear"
2. Tool generates image
3. User: "Make the bear's eyes blue" 
4. Tool cannot find the previously generated image ❌

This occurred because tool functions were created with frozen `__messages__` parameters using `functools.partial`, which captured only the initial conversation state. Subsequent tool calls in the same conversation continued using the stale frozen parameters instead of the updated message history.

**Solution**: Modified the tool calling system to dynamically update context parameters (`__messages__`, `__files__`) on each tool execution in native mode by storing a reference to the original unwrapped function and re-applying parameters with current state.

### Fixed

- Fixed native tool calling mode to provide updated `__messages__` and `__files__` parameters to tools on each execution
- Tools in native mode can now access data (images, files, etc.) generated by previous tool calls in the same conversation
- Enables multi-step workflows where tools build upon each other's outputs (e.g., generate image → edit image)

### Changed

- `backend/open_webui/utils/tools.py`:
  - Modified `get_async_tool_function_and_apply_extra_params()` to store references to original function and initial parameters
  - Added `get_tool_function_with_updated_params()` helper function to re-call tools with updated context
- `backend/open_webui/utils/middleware.py`:
  - Modified native tool execution path to check for stored original function and re-apply parameters with current `form_data["messages"]`

---

## Additional Information

- This fix only affects **native function calling mode**. Default mode was unaffected as it executes tools before the LLM in a single pass without recursion.
- The solution maintains backward compatibility - tools without `__original_function__` fall back to normal execution.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
