### PR TITLE
fix: Validate 'order_by' parameter in chat query to prevent AttributeError

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -9,6 +9,7 @@ from open_webui.models.tags import TagModel, Tag, Tags
 from open_webui.models.folders import Folders
 from open_webui.env import SRC_LOG_LEVELS
 
+from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, JSON, Index
 from sqlalchemy import or_, func, select, and_, text
@@ -440,11 +441,14 @@ class ChatTable:
                 order_by = filter.get("order_by")
                 direction = filter.get("direction")
 
-                if order_by and direction and getattr(Chat, order_by):
+                if order_by and direction:
+                    col = getattr(Chat, order_by, None)
+                    if col is None:
+                        raise HTTPException(status_code=422, detail="Invalid 'order_by' value")
                     if direction.lower() == "asc":
-                        query = query.order_by(getattr(Chat, order_by).asc())
+                        query = query.order_by(col.asc())
                     elif direction.lower() == "desc":
-                        query = query.order_by(getattr(Chat, order_by).desc())
+                        query = query.order_by(col.desc())
                     else:
                         raise ValueError("Invalid direction for ordering")
             else:


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR addresses an error handling issue in the archived chats functionality. Details can be found in https://github.com/open-webui/open-webui/discussions/18383. The fix adds proper validation to check if the requested column exists before attempting to use it, returning a ValidationError instead of an AttributeError.

### Added

- Input validation for `order_by` parameter in chat queries

### Changed

N/A

### Deprecated

N/A

### Removed

N/A

### Fixed

- Input validation for `order_by` parameter in chat queries

### Security

N/A

### Breaking Changes

N/A

---

### Additional Information

Ran the same test script mentioned in https://github.com/open-webui/open-webui/discussions/18383:

<details>

<summary>Testing script:</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

BASE="<your-domain>"
EP="/api/v1/chats/archived"
AUTH="<your-token>"

echo "---- Normal Case (Expect 200) ----"
for p in \
  "archived" \
  "created_at" \
  "updated_at" \
  "title" \
  "id" \
  "user_id" \
  "share_id" \
  "folder_id" \
  "pinned" \
  "meta" \
  ""; do
  printf "payload=%-12s -> " "$p"
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Bearer $AUTH" \
    -H "Accept: application/json" \
    "$BASE$EP?page=1&order_by=$p&direction=desc"
done

echo
echo "---- Abnormal Case (Expect 422: Path Traversal Only) ----"

for p in \
  "../etc/passwd" \
  "..%2f..%2fetc%2fpasswd" \
  "..%2F..%2Fetc%2Fpasswd" \
  "%2e%2e%2f%2e%2e%2f" \
  "..%252f..%252fetc%252fpasswd" \
  "..%c0%af..%c0%afetc%c0%afpasswd" \
  "%2e%2e/%2e%2e/etc/passwd" \
  "..\\..\\windows\\system32" \
  ".%255c." \
  "%00etc%00passwd"; do
  printf "payload=%-30s -> " "$p"
  # For payloads already containing %, send them as-is without re-encoding
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Bearer $AUTH" \
    -H "Accept: application/json" \
    "$BASE$EP?page=1&direction=desc&order_by=$p"
done
```

</details>

<details>

<summary>Container logs after the fix:</summary>

```
2025-10-17 16:17:40.745 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:22266 - "GET /api/v1/chats/archived?page=1&order_by=archived&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.756 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:23176 - "GET /api/v1/chats/archived?page=1&order_by=created_at&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.767 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:38865 - "GET /api/v1/chats/archived?page=1&order_by=updated_at&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.777 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:51803 - "GET /api/v1/chats/archived?page=1&order_by=title&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.789 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:22680 - "GET /api/v1/chats/archived?page=1&order_by=id&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.803 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:52571 - "GET /api/v1/chats/archived?page=1&order_by=user_id&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.815 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:20771 - "GET /api/v1/chats/archived?page=1&order_by=share_id&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.827 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:19444 - "GET /api/v1/chats/archived?page=1&order_by=folder_id&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.839 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:53508 - "GET /api/v1/chats/archived?page=1&order_by=pinned&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.850 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:26199 - "GET /api/v1/chats/archived?page=1&order_by=meta&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.860 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:28584 - "GET /api/v1/chats/archived?page=1&order_by=&direction=desc HTTP/1.1" 200
2025-10-17 16:17:40.870 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:24399 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=../etc/passwd HTTP/1.1" 422
2025-10-17 16:17:40.879 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:17492 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=..%2f..%2fetc%2fpasswd HTTP/1.1" 422
2025-10-17 16:17:40.889 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:57053 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=..%2F..%2Fetc%2Fpasswd HTTP/1.1" 422
2025-10-17 16:17:40.899 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:45218 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=%2e%2e%2f%2e%2e%2f HTTP/1.1" 422
2025-10-17 16:17:40.909 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:58421 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=..%252f..%252fetc%252fpasswd HTTP/1.1" 422
2025-10-17 16:17:40.917 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:40943 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=..%c0%af..%c0%afetc%c0%afpasswd HTTP/1.1" 422
2025-10-17 16:17:40.927 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:42851 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=%2e%2e/%2e%2e/etc/passwd HTTP/1.1" 422
2025-10-17 16:17:40.937 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:43393 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=..\..\windows\system32 HTTP/1.1" 422
2025-10-17 16:17:40.947 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:55153 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=.%255c. HTTP/1.1" 422
2025-10-17 16:17:40.956 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 192.168.65.1:42142 - "GET /api/v1/chats/archived?page=1&direction=desc&order_by=%00etc%00passwd HTTP/1.1" 422
```

</details>


<details>

<summary>Container logs before the fix:</summary>

```
open-webui  |   File "/app/backend/open_webui/routers/chats.py", line 348, in get_archived_session_user_chat_list
open-webui  |     for chat in Chats.get_archived_chat_list_by_user_id(
open-webui  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
open-webui  |   File "/app/backend/open_webui/models/chats.py", line 443, in get_archived_chat_list_by_user_id
open-webui  |     if order_by and direction and getattr(Chat, order_by):
open-webui  |                                   ^^^^^^^^^^^^^^^^^^^^^^^
open-webui  | AttributeError: type object 'Chat' has no attribute 'etcpasswd'
```

</details>

### Screenshots or Videos

N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
