### PR TITLE
enh: More detailed OAuth2.1 tool callback error handling + fix for editing existing tools 

### DIFF
--- a/backend/open_webui/models/oauth_sessions.py
+++ b/backend/open_webui/models/oauth_sessions.py
@@ -262,5 +262,16 @@ class OAuthSessionTable:
             log.error(f"Error deleting OAuth sessions by user ID: {e}")
             return False
 
+    def delete_sessions_by_provider(self, provider: str) -> bool:
+        """Delete all OAuth sessions for a provider"""
+        try:
+            with get_db() as db:
+                db.query(OAuthSession).filter_by(provider=provider).delete()
+                db.commit()
+                return True
+        except Exception as e:
+            log.error(f"Error deleting OAuth sessions by provider {provider}: {e}")
+            return False
+
 
 OAuthSessions = OAuthSessionTable()

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -1,4 +1,5 @@
 import logging
+import copy
 from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel, ConfigDict
 import aiohttp
@@ -15,6 +16,7 @@ from open_webui.utils.tools import (
     set_tool_servers,
 )
 from open_webui.utils.mcp.client import MCPClient
+from open_webui.models.oauth_sessions import OAuthSessions
 
 from open_webui.env import SRC_LOG_LEVELS
 
@@ -165,11 +167,58 @@ async def set_tool_servers_config(
     form_data: ToolServersConfigForm,
     user=Depends(get_admin_user),
 ):
-    request.app.state.config.TOOL_SERVER_CONNECTIONS = [
+    old_connections = copy.deepcopy(
+        request.app.state.config.TOOL_SERVER_CONNECTIONS or []
+    )
+
+    new_connections = [
         connection.model_dump() for connection in form_data.TOOL_SERVER_CONNECTIONS
     ]
 
+    old_mcp_connections = {
+        conn.get("info", {}).get("id"): conn
+        for conn in old_connections
+        if conn.get("type") == "mcp"
+    }
+    new_mcp_connections = {
+        conn.get("info", {}).get("id"): conn
+        for conn in new_connections
+        if conn.get("type") == "mcp"
+    }
+
+    purge_oauth_clients = set()
+
+    for server_id, old_conn in old_mcp_connections.items():
+        if not server_id:
+            continue
+
+        old_auth_type = old_conn.get("auth_type", "none")
+        new_conn = new_mcp_connections.get(server_id)
+
+        if new_conn is None:
+            if old_auth_type == "oauth_2.1":
+                purge_oauth_clients.add(server_id)
+            continue
+
+        new_auth_type = new_conn.get("auth_type", "none")
+
+        if old_auth_type == "oauth_2.1":
+            if (
+                new_auth_type != "oauth_2.1"
+                or old_conn.get("url") != new_conn.get("url")
+                or old_conn.get("info", {}).get("oauth_client_info")
+                != new_conn.get("info", {}).get("oauth_client_info")
+            ):
+                purge_oauth_clients.add(server_id)
+
+    request.app.state.config.TOOL_SERVER_CONNECTIONS = new_connections
+
     await set_tool_servers(request)
+
+    for server_id in purge_oauth_clients:
+        client_key = f"mcp:{server_id}"
+        request.app.state.oauth_client_manager.remove_client(client_key)
+        OAuthSessions.delete_sessions_by_provider(client_key)
 
     for connection in request.app.state.config.TOOL_SERVER_CONNECTIONS:
         server_type = connection.get("type", "openapi")

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -486,9 +486,7 @@ class OAuthClientManager:
                         try:
                             payload = json.loads(body_text)
                             error = payload.get("error")
-                            error_description = payload.get(
-                                "error_description", ""
-                            )
+                            error_description = payload.get("error_description", "")
                         except json.JSONDecodeError:
                             error = None
                             error_description = ""
@@ -496,7 +494,11 @@ class OAuthClientManager:
                         error_description = body_text
 
                     combined = f"{error or ''} {error_description}".lower()
-                    if "invalid_client" in combined or "invalid client" in combined or "client id" in combined:
+                    if (
+                        "invalid_client" in combined
+                        or "invalid client" in combined
+                        or "client id" in combined
+                    ):
                         log.warning(
                             "OAuth client preflight detected invalid registration for %s: %s %s",
                             client_info.client_id,
@@ -577,9 +579,7 @@ class OAuthClientManager:
         log.info("Re-registered OAuth client %s for MCP tool server", client_id)
         return True
 
-    async def _ensure_valid_client_registration(
-        self, request, client_id: str
-    ) -> None:
+    async def _ensure_valid_client_registration(self, request, client_id: str) -> None:
         if not client_id.startswith("mcp:"):
             return
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import hashlib
 import logging
 import mimetypes
@@ -417,6 +418,205 @@ class OAuthClientManager:
             log.info(f"Removed OAuth client {client_id}")
         return True
 
+    def _find_mcp_connection(self, request, client_id: str):
+        try:
+            connections = request.app.state.config.TOOL_SERVER_CONNECTIONS or []
+        except Exception:
+            connections = []
+
+        normalized_client_id = client_id.split(":")[-1]
+
+        for idx, connection in enumerate(connections):
+            if not isinstance(connection, dict):
+                continue
+            if connection.get("type") != "mcp":
+                continue
+
+            info = connection.get("info") or {}
+            server_id = info.get("id")
+            if not server_id:
+                continue
+
+            normalized_server_id = server_id.split(":")[-1]
+            if normalized_server_id == normalized_client_id:
+                return idx, connection
+
+        return None, None
+
+    async def _preflight_authorization_url(
+        self, client, client_info: OAuthClientInformationFull
+    ) -> bool:
+        # Only perform preflight checks for Starlette OAuth clients
+        if not hasattr(client, "create_authorization_url"):
+            return True
+
+        redirect_uri = None
+        if client_info.redirect_uris:
+            redirect_uri = str(client_info.redirect_uris[0])
+
+        try:
+            auth_data = await client.create_authorization_url(redirect_uri=redirect_uri)
+            authorize_url = auth_data.get("url")
+            if not authorize_url:
+                return True
+        except Exception as e:
+            log.debug(
+                "Skipping OAuth preflight for client %s: %s",
+                client_info.client_id,
+                e,
+            )
+            return True
+
+        try:
+            async with aiohttp.ClientSession(trust_env=True) as session:
+                async with session.get(
+                    authorize_url,
+                    allow_redirects=False,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                ) as resp:
+                    if resp.status < 400:
+                        return True
+
+                    body_text = await resp.text()
+                    error = None
+                    error_description = ""
+                    content_type = resp.headers.get("content-type", "")
+
+                    if "application/json" in content_type:
+                        try:
+                            payload = json.loads(body_text)
+                            error = payload.get("error")
+                            error_description = payload.get(
+                                "error_description", ""
+                            )
+                        except json.JSONDecodeError:
+                            error = None
+                            error_description = ""
+                    else:
+                        error_description = body_text
+
+                    combined = f"{error or ''} {error_description}".lower()
+                    if "invalid_client" in combined or "invalid client" in combined or "client id" in combined:
+                        log.warning(
+                            "OAuth client preflight detected invalid registration for %s: %s %s",
+                            client_info.client_id,
+                            error,
+                            error_description,
+                        )
+                        return False
+        except Exception as e:
+            log.debug(
+                "Skipping OAuth preflight network check for client %s: %s",
+                client_info.client_id,
+                e,
+            )
+
+        return True
+
+    async def _re_register_client(self, request, client_id: str) -> bool:
+        idx, connection = self._find_mcp_connection(request, client_id)
+        if idx is None or connection is None:
+            log.warning(
+                "Unable to locate MCP tool server configuration for client %s during re-registration",
+                client_id,
+            )
+            return False
+
+        server_url = connection.get("url")
+        oauth_server_key = (connection.get("config") or {}).get("oauth_server_key")
+
+        try:
+            oauth_client_info = (
+                await get_oauth_client_info_with_dynamic_client_registration(
+                    request,
+                    client_id,
+                    server_url,
+                    oauth_server_key,
+                )
+            )
+        except Exception as e:
+            log.error(
+                "Dynamic client re-registration failed for %s: %s",
+                client_id,
+                e,
+            )
+            return False
+
+        encrypted_info = encrypt_data(oauth_client_info.model_dump(mode="json"))
+
+        updated_connections = copy.deepcopy(
+            request.app.state.config.TOOL_SERVER_CONNECTIONS or []
+        )
+        if idx >= len(updated_connections):
+            log.error(
+                "MCP tool server index %s out of range during OAuth client re-registration for %s",
+                idx,
+                client_id,
+            )
+            return False
+
+        updated_connection = copy.deepcopy(connection)
+        updated_connection.setdefault("info", {})
+        updated_connection["info"]["oauth_client_info"] = encrypted_info
+        updated_connections[idx] = updated_connection
+
+        try:
+            request.app.state.config.TOOL_SERVER_CONNECTIONS = updated_connections
+        except Exception as e:
+            log.error(
+                "Failed to persist updated OAuth client info for %s: %s",
+                client_id,
+                e,
+            )
+            return False
+
+        self.remove_client(client_id)
+        self.add_client(client_id, oauth_client_info)
+        OAuthSessions.delete_sessions_by_provider(client_id)
+
+        log.info("Re-registered OAuth client %s for MCP tool server", client_id)
+        return True
+
+    async def _ensure_valid_client_registration(
+        self, request, client_id: str
+    ) -> None:
+        if not client_id.startswith("mcp:"):
+            return
+
+        client = self.get_client(client_id)
+        client_info = self.get_client_info(client_id)
+        if client is None or client_info is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+        is_valid = await self._preflight_authorization_url(client, client_info)
+        if is_valid:
+            return
+
+        log.info(
+            "Detected invalid OAuth client %s; attempting re-registration",
+            client_id,
+        )
+        re_registered = await self._re_register_client(request, client_id)
+        if not re_registered:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to re-register OAuth client",
+            )
+
+        client = self.get_client(client_id)
+        client_info = self.get_client_info(client_id)
+        if client is None or client_info is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="OAuth client unavailable after re-registration",
+            )
+
+        if not await self._preflight_authorization_url(client, client_info):
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="OAuth client registration is still invalid after re-registration",
+            )
+
     def get_client(self, client_id):
         client = self.clients.get(client_id)
         return client["client"] if client else None
@@ -602,10 +802,11 @@ class OAuthClientManager:
             return None
 
     async def handle_authorize(self, request, client_id: str) -> RedirectResponse:
+        await self._ensure_valid_client_registration(request, client_id)
+
         client = self.get_client(client_id)
         if client is None:
             raise HTTPException(404)
-
         client_info = self.get_client_info(client_id)
         if client_info is None:
             raise HTTPException(404)
@@ -613,7 +814,8 @@ class OAuthClientManager:
         redirect_uri = (
             client_info.redirect_uris[0] if client_info.redirect_uris else None
         )
-        return await client.authorize_redirect(request, str(redirect_uri))
+        redirect_uri_str = str(redirect_uri) if redirect_uri else None
+        return await client.authorize_redirect(request, redirect_uri_str)
 
     async def handle_callback(self, request, client_id: str, user_id: str, response):
         client = self.get_client(client_id)

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -401,8 +401,19 @@ class OAuthClientManager:
         return self.clients[client_id]
 
     def remove_client(self, client_id):
+        removed = False
         if client_id in self.clients:
             del self.clients[client_id]
+            removed = True
+        if hasattr(self.oauth, "_clients"):
+            if client_id in self.oauth._clients:
+                self.oauth._clients.pop(client_id, None)
+                removed = True
+        if hasattr(self.oauth, "_registry"):
+            if client_id in self.oauth._registry:
+                self.oauth._registry.pop(client_id, None)
+                removed = True
+        if removed:
             log.info(f"Removed OAuth client {client_id}")
         return True
 


### PR DESCRIPTION
# Pull Request Checklist

Closes https://github.com/open-webui/open-webui/discussions/18309

@tjbck I have tested this one extensively and it solves several of my real world issues. Will continue to build on the degree of specificity in the error messages but I'd call this safe to merge as-is. 

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Sharpen OAuth callback error messaging and ensure edited OAuth 2.1 MCP connections refresh their client registrations so traffic routes to the updated endpoint without `unauthorized_client` failures.
- Added a preflight authorize check that automatically re-registers MCP OAuth clients when the stored client ID no longer exists on the server, so the browser flow never hits the stale-ID failure

### Added

- Helper `_build_oauth_callback_error_message` to translate backend exceptions into actionable callback detail strings.
- Provider-wide OAuth session purge utility to support MCP connection resets.
- Preflight auth check that automatically re-registers MCP OAuth clients when the stored client ID no longer exists on the server, so the browser flow never hits the stale-ID failure

### Changed

- MCP connection save flow now drops and re-registers OAuth 2.1 clients when identifiers, auth modes, or endpoints change.
- Authlib client removal clears internal caches to prevent stale dynamic-registration metadata from persisting across edits.
- Redirect error payloads are URL-encoded with the detailed message.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Resolved stale OAuth client registrations that caused `unauthorized_client` errors after editing streamable-http MCP endpoints.
- Replaced the generic “OAuth callback error” UI message with contextual feedback sourced from the upstream provider responses.

### Security

- No change

### Breaking Changes

- No change

---

### Additional Information

### Screenshots or Videos
<img width="437" height="140" alt="Screenshot 2025-10-18 at 2 07 15 PM" src="https://github.com/user-attachments/assets/be598036-877e-4879-9bcf-cbc352714a6b" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.