### PR TITLE
UPD:FEAT: Notes and Collections to folders with drag and drop

### DIFF
--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -178,6 +178,15 @@ class NoteTable:
 
             return results
 
+    def check_access_by_user_id(self, id, user_id, permission="write") -> bool:
+        file = self.get_notes_by_id(id)
+        if not file:
+            return False
+        if file.user_id == user_id:
+            return True
+        # Implement additional access control logic here as needed
+        return False
+
     def get_note_by_id(self, id: str) -> Optional[NoteModel]:
         with get_db() as db:
             note = db.query(Note).filter(Note.id == id).first()

--- a/src/lib/components/chat/MessageInput/InputMenu.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu.svelte
@@ -79,17 +79,29 @@
 		init();
 	}
 
-	const onSelect = (item) => {
-		if (files.find((f) => f.id === item.id)) {
-			return;
-		}
-		files = [
-			...files,
-			{
-				...item,
-				status: 'processed'
+	export let attachNoteToChat: Function;
+	export let attachChatToChat: Function;
+	export let attachKnowledgeToChat: Function;
+
+	const onSelect = async (item) => {
+		if (item.type === 'note') {
+			await attachNoteToChat(item.id);
+		} else if (item.type === 'chat') {
+			await attachChatToChat(item.id);
+		} else if (item.type === 'collection') {
+			await attachKnowledgeToChat(item.id);
+		} else {
+			if (files.find((f) => f.id === item.id)) {
+				return;
 			}
-		];
+			files = [
+				...files,
+				{
+					...item,
+					status: 'processed'
+				}
+			];
+		}
 
 		show = false;
 	};

--- a/src/lib/components/chat/MessageInput/InputMenu/Notes.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Notes.svelte
@@ -48,6 +48,14 @@
 					...note,
 					type: 'note',
 					name: note.title,
+					content: note.data,
+					file: {
+						data: {
+							content: note.data?.content?.md || ''
+						}
+					},
+					data: note.data,
+					url: `/notes/${note.id}`,
 					description: dayjs(note.updated_at / 1000000).fromNow()
 				};
 			})
@@ -100,6 +108,12 @@
 							<div class="line-clamp-1 flex-1">
 								{decodeString(item?.name)}
 							</div>
+
+							{#if item.content}
+								<div class="text-xs text-gray-500 line-clamp-2 pl-5.5">
+									{item.content}
+								</div>
+							{/if}
 						</Tooltip>
 					</div>
 				</button>

--- a/src/lib/components/chat/Placeholder/ChatList.svelte
+++ b/src/lib/components/chat/Placeholder/ChatList.svelte
@@ -11,6 +11,7 @@
 	dayjs.extend(localizedFormat);
 
 	export let chats = [];
+	export let show = false;
 
 	let chatList = null;
 

--- a/src/lib/components/chat/Placeholder/FolderPlaceholder.svelte
+++ b/src/lib/components/chat/Placeholder/FolderPlaceholder.svelte
@@ -8,6 +8,14 @@
 	import FolderKnowledge from './FolderKnowledge.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import { getChatListByFolderId } from '$lib/apis/chats';
+	import { getKnowledgeById } from '$lib/apis/knowledge';
+	import { getNoteById } from '$lib/apis/notes';
+	import dayjs from '$lib/dayjs';
+	import duration from 'dayjs/plugin/duration';
+	import relativeTime from 'dayjs/plugin/relativeTime';
+
+	dayjs.extend(duration);
+	dayjs.extend(relativeTime);
 
 	export let folder = null;
 
@@ -15,7 +23,9 @@
 
 	let chats = null;
 	let page = 1;
-
+	let notes = null;
+	let notesPage = 1;
+	let collections = null;
 	const setChatList = async () => {
 		chats = null;
 
@@ -32,31 +42,81 @@
 		}
 	};
 
+	const setNoteList = async () => {
+		notes = null;
+
+		if (folder && folder.id && folder.data?.notes) {
+			try {
+				const notePromises = folder.data.notes.map((noteId) =>
+					getNoteById(localStorage.token, noteId)
+				);
+				notes = await Promise.all(notePromises);
+			} catch (error) {
+				console.error('Error loading notes:', error);
+				notes = [];
+			}
+		} else {
+			notes = [];
+		}
+	};
+
+	const setCollectionList = async () => {
+		collections = null;
+
+		if (folder && folder.data?.collections) {
+			try {
+				collections = await Promise.all(
+					folder.data.collections.map(async (collectionId) => {
+						return await getKnowledgeById(localStorage.token, collectionId).catch(() => null);
+					})
+				).then((results) => results.filter((c) => c !== null));
+			} catch (error) {
+				console.error('Error loading notes:', error);
+				collections = [];
+			}
+		} else {
+			collections = [];
+		}
+	};
+
 	$: if (folder) {
 		setChatList();
+		setNoteList();
+		setCollectionList();
 	}
 </script>
 
 <div>
-	<!-- <div class="mb-1">
+	<div class="mb-1">
 		<div
-			class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent py-1 touch-auto pointer-events-auto"
+			class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent py-1"
 		>
 			<button
 				class="min-w-fit p-1.5 {selectedTab === 'knowledge'
 					? ''
-					: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-				type="button"
+					: 'text-gray-300 dark:text-gray-600'} transition"
 				on:click={() => {
 					selectedTab = 'knowledge';
-				}}>{$i18n.t('Knowledge')}</button
+				}}
 			>
+				{$i18n.t('Knowledge')}
+			</button>
+
+			<button
+				class="min-w-fit p-1.5 {selectedTab === 'notes'
+					? ''
+					: 'text-gray-300 dark:text-gray-600'} transition"
+				on:click={() => {
+					selectedTab = 'notes';
+				}}
+			>
+				{$i18n.t('Notes')}
+			</button>
 
 			<button
 				class="min-w-fit p-1.5 {selectedTab === 'chats'
 					? ''
-					: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-				type="button"
+					: 'text-gray-300 dark:text-gray-600'} transition"
 				on:click={() => {
 					selectedTab = 'chats';
 				}}
@@ -64,11 +124,64 @@
 				{$i18n.t('Chats')}
 			</button>
 		</div>
-	</div> -->
+	</div>
 
 	<div class="">
 		{#if selectedTab === 'knowledge'}
-			<FolderKnowledge />
+			{#if collections !== null}
+				{#if collections.length > 0}
+					<div class="gap-2.5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+						{#each collections as collection}
+							<div
+								class="flex space-x-4 cursor-pointer w-full px-4.5 py-4 border border-gray-50 dark:border-gray-850 bg-transparent dark:hover:bg-gray-850 hover:bg-white rounded-2xl transition"
+							>
+								<a href="/workspace/knowledge/{collection.id}" class="w-full">
+									<div class="flex flex-col gap-1">
+										<div class="font-semibold line-clamp-1 text-sm">
+											{collection.name}
+										</div>
+									</div>
+								</a>
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<div class="flex flex-col items-center justify-center py-10 text-gray-500">
+						<div class="text-sm">{$i18n.t('No collection in this folder')}</div>
+					</div>
+				{/if}
+			{:else}
+				<div class="py-10"><Spinner /></div>
+			{/if}
+		{:else if selectedTab === 'notes'}
+			{#if notes !== null}
+				{#if notes.length > 0}
+					<div class="gap-2.5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+						{#each notes as note}
+							<div
+								class="flex space-x-4 cursor-pointer w-full px-4.5 py-4 border border-gray-50 dark:border-gray-850 bg-transparent dark:hover:bg-gray-850 hover:bg-white rounded-2xl transition"
+							>
+								<a href="/notes/{note.id}" class="w-full">
+									<div class="flex flex-col gap-1">
+										<div class="font-semibold line-clamp-1 text-sm">
+											{note.title}
+										</div>
+										<div class="text-xs text-gray-500 dark:text-gray-500">
+											{dayjs(note.updated_at / 1000000).fromNow()}
+										</div>
+									</div>
+								</a>
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<div class="flex flex-col items-center justify-center py-10 text-gray-500">
+						<div class="text-sm">{$i18n.t('No notes in this folder')}</div>
+					</div>
+				{/if}
+			{:else}
+				<div class="py-10"><Spinner /></div>
+			{/if}
 		{:else if selectedTab === 'chats'}
 			{#if chats !== null}
 				<ChatList {chats} />

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -580,7 +580,7 @@
 	};
 
 	const selectTemplate = () => {
-		if (value !== '') {
+		if (value !== '' && editor?.view) {
 			// After updating the state, try to find and select the next template
 			setTimeout(() => {
 				const templateFound = selectNextTemplate(editor.view.state, editor.view.dispatch);

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -25,6 +25,7 @@
 		isApp,
 		models,
 		selectedFolder,
+		chatListRefresh,
 		WEBUI_NAME
 	} from '$lib/stores';
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
@@ -62,6 +63,8 @@
 	import PinnedModelList from './Sidebar/PinnedModelList.svelte';
 	import Note from '../icons/Note.svelte';
 	import { slide } from 'svelte/transition';
+
+	let lastRefreshTimestamp = 0;
 
 	const BREAKPOINT = 768;
 
@@ -205,6 +208,9 @@
 		scrollPaginationEnabled.set(true);
 	};
 
+	$: if ($chatListRefresh) {
+		initChatList();
+	}
 	const loadMoreChats = async () => {
 		chatListLoading = true;
 

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -27,7 +27,8 @@
 		showSidebar,
 		currentChatPage,
 		tags,
-		selectedFolder
+		selectedFolder,
+		chatListRefresh
 	} from '$lib/stores';
 
 	import ChatMenu from './ChatMenu.svelte';
@@ -90,6 +91,14 @@
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 			await pinnedChats.set(await getPinnedChatList(localStorage.token));
 
+			// Trigger global refresh with folder context
+			if (chat?.folder_id) {
+				chatListRefresh.update((v) => ({
+					timestamp: Date.now(),
+					folderId: chat.folder_id
+				}));
+			}
+
 			dispatch('change');
 		}
 	};
@@ -129,6 +138,13 @@
 				await chatId.set('');
 				await tick();
 			}
+			// Trigger global refresh with folder context
+			if (chat?.folder_id) {
+				chatListRefresh.update((v) => ({
+					timestamp: Date.now(),
+					folderId: chat.folder_id
+				}));
+			}
 
 			dispatch('change');
 		}
@@ -136,6 +152,16 @@
 
 	const archiveChatHandler = async (id) => {
 		await archiveChatById(localStorage.token, id);
+		chatListRefresh.set({ timestamp: Date.now(), folderId: chat.folder_id });
+
+		// Trigger global refresh with folder context
+		if (chat?.folder_id) {
+			chatListRefresh.update((v) => ({
+				timestamp: Date.now(),
+				folderId: chat.folder_id
+			}));
+		}
+
 		dispatch('change');
 	};
 

--- a/src/lib/components/layout/Sidebar/CollectionItem.svelte
+++ b/src/lib/components/layout/Sidebar/CollectionItem.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { getContext, createEventDispatcher } from 'svelte';
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher();
+
+	import { mobile, showSidebar } from '$lib/stores';
+	import Database from '$lib/components/icons/Database.svelte'; // Or appropriate icon
+	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
+	import CollectionMenu from './CollectionMenu.svelte';
+	import DragGhost from '$lib/components/common/DragGhost.svelte';
+	import Document from '$lib/components/icons/Document.svelte';
+
+	export let id;
+	export let name;
+	export let className = '';
+	export let folderId;
+
+	let itemElement;
+	let dragged = false;
+
+	let x = 0;
+	let y = 0;
+	const dragImage = new Image();
+	dragImage.src =
+		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+	const onDragStart = (e, collectionId, currentFolderId) => {
+		e.stopPropagation();
+		e.dataTransfer.setDragImage(dragImage, 0, 0);
+		e.dataTransfer.setData(
+			'text/plain',
+			JSON.stringify({
+				type: 'collection',
+				id: id,
+				sourceFolderId: folderId
+			})
+		);
+		dragged = true;
+		e.dataTransfer.effectAllowed = 'move';
+		e.target.style.opacity = '0.5';
+		itemElement.style.opacity = '0.5'; // Optional: Visual cue to show it's being dragged
+	};
+
+	const onDragEnd = (e) => {
+		e.stopPropagation();
+		e.target.style.opacity = '1';
+		itemElement.style.opacity = '1';
+		dragged = false;
+	};
+</script>
+
+{#if dragged && x && y}
+	<DragGhost {x} {y}>
+		<div class=" bg-black/80 backdrop-blur-2xl px-2 py-1 rounded-lg w-fit max-w-40">
+			<div class="flex items-center gap-1">
+				<Document className=" size-[18px]" strokeWidth="2" />
+				<div class=" text-xs text-white line-clamp-1">
+					{name}
+				</div>
+			</div>
+		</div>
+	</DragGhost>
+{/if}
+
+<div
+	bind:this={itemElement}
+	class="group relative w-full {className}"
+	draggable="true"
+	role="button"
+	tabindex="0"
+	on:dragstart={onDragStart}
+	on:dragend={onDragEnd}
+>
+	<button
+		class="flex items-center gap-2 px-2 py-1.5 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-900 transition w-full text-left"
+		on:click={async () => {
+			await goto(`/workspace/knowledge/${id}`, { replaceState: false, invalidateAll: true });
+			if ($mobile) {
+				showSidebar.set(!$showSidebar);
+			}
+		}}
+	>
+		<div class="flex flex-1 items-center gap-2 overflow-hidden">
+			<div class="flex-shrink-0">
+				<Database className="size-4" />
+			</div>
+			<div class="flex-1 text-sm line-clamp-1">
+				{name}
+			</div>
+		</div>
+	</button>
+
+	<div class="absolute right-2 top-1/2 -translate-y-1/2 invisible group-hover:visible">
+		<CollectionMenu
+			on:remove={() => {
+				dispatch('remove', { id });
+			}}
+		>
+			<button class="p-1 hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg">
+				<EllipsisHorizontal className="size-4" strokeWidth="2.5" />
+			</button>
+		</CollectionMenu>
+	</div>
+</div>

--- a/src/lib/components/layout/Sidebar/CollectionMenu.svelte
+++ b/src/lib/components/layout/Sidebar/CollectionMenu.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { DropdownMenu } from 'bits-ui';
+	import { flyAndScale } from '$lib/utils/transitions';
+	import { getContext, createEventDispatcher } from 'svelte';
+
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher();
+
+	import Dropdown from '$lib/components/common/Dropdown.svelte';
+	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+
+	export let onClose = () => {};
+
+	let show = false;
+</script>
+
+<Dropdown
+	bind:show
+	on:change={(e) => {
+		if (e.detail === false) {
+			onClose();
+		}
+	}}
+>
+	<Tooltip content={$i18n.t('More')}>
+		<slot />
+	</Tooltip>
+
+	<div slot="content">
+		<DropdownMenu.Content
+			class="w-full max-w-[200px] rounded-2xl px-1 py-1 border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg transition"
+			sideOffset={-2}
+			side="bottom"
+			align="start"
+			transition={flyAndScale}
+		>
+			<DropdownMenu.Item
+				class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+				on:click={() => {
+					dispatch('remove');
+				}}
+			>
+				<GarbageBin strokeWidth="1.5" />
+				<div class="flex items-center">{$i18n.t('Remove from Folder')}</div>
+			</DropdownMenu.Item>
+		</DropdownMenu.Content>
+	</div>
+</Dropdown>

--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -28,7 +28,9 @@
 	};
 	let data = {
 		system_prompt: '',
-		files: []
+		files: [],
+		notes: [],
+		collections: []
 	};
 
 	let loading = false;
@@ -91,7 +93,8 @@
 		};
 		data = {
 			system_prompt: '',
-			files: []
+			files: [],
+			notes: []
 		};
 	}
 </script>

--- a/src/lib/components/layout/Sidebar/NoteMenu.svelte
+++ b/src/lib/components/layout/Sidebar/NoteMenu.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { DropdownMenu } from 'bits-ui';
+	import { flyAndScale } from '$lib/utils/transitions';
+	import { getContext, createEventDispatcher } from 'svelte';
+
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher();
+
+	import Dropdown from '$lib/components/common/Dropdown.svelte';
+	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+
+	export let onClose = () => {};
+
+	let show = false;
+</script>
+
+<Dropdown
+	bind:show
+	on:change={(e) => {
+		if (e.detail === false) {
+			onClose();
+		}
+	}}
+>
+	<Tooltip content={$i18n.t('More')}>
+		<slot />
+	</Tooltip>
+
+	<div slot="content">
+		<DropdownMenu.Content
+			class="w-full max-w-[200px] rounded-2xl px-1 py-1 border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg transition"
+			sideOffset={-2}
+			side="bottom"
+			align="start"
+			transition={flyAndScale}
+		>
+			<DropdownMenu.Item
+				class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
+				on:click={() => {
+					dispatch('remove');
+				}}
+			>
+				<GarbageBin strokeWidth="1.5" />
+				<div class="flex items-center">{$i18n.t('Remove from Folder')}</div>
+			</DropdownMenu.Item>
+		</DropdownMenu.Content>
+	</div>
+</Dropdown>

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -56,6 +56,8 @@
 	let noteItems = [];
 	let fuse = null;
 
+	let draggable = true;
+
 	let selectedNote = null;
 	let notes = {};
 	$: if (fuse) {
@@ -260,6 +262,30 @@
 	};
 
 	let dragged = false;
+	let x = 0;
+	let y = 0;
+	const dragImage = new Image();
+	dragImage.src =
+		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+	const onDragStart = (event, noteId) => {
+		event.stopPropagation();
+		event.dataTransfer.setData(
+			'text/plain',
+			JSON.stringify({
+				type: 'note',
+				id: noteId
+			})
+		);
+		dragged = true;
+		event.target.style.opacity = '0.5'; // Optional: Visual cue to show it's being dragged
+	};
+
+	const onDragEnd = (event) => {
+		event.stopPropagation();
+		event.target.style.opacity = '1';
+		dragged = false;
+	};
 
 	const onDragOver = (e) => {
 		e.preventDefault();
@@ -386,6 +412,9 @@
 						>
 							{#each notes[timeRange] as note, idx (note.id)}
 								<div
+									draggable={true}
+									on:dragstart={(e) => onDragStart(e, note.id)}
+									on:dragend={onDragEnd}
 									class=" flex space-x-4 cursor-pointer w-full px-4.5 py-4 border border-gray-50 dark:border-gray-850 bg-transparent dark:hover:bg-gray-850 hover:bg-white rounded-2xl transition"
 								>
 									<div class=" flex flex-1 space-x-4 cursor-pointer w-full">

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -94,6 +94,27 @@
 			: (knowledge?.files ?? []);
 	}
 
+	let currentId = null;
+
+	// React to route parameter changes
+	$: if ($page.params.id && $page.params.id !== currentId) {
+		currentId = $page.params.id;
+		loadKnowledge(currentId);
+	}
+
+	async function loadKnowledge(collectionId) {
+		const res = await getKnowledgeById(localStorage.token, collectionId).catch((e) => {
+			toast.error(`${e}`);
+			return null;
+		});
+
+		if (res) {
+			knowledge = res;
+		} else {
+			goto('/workspace/knowledge');
+		}
+	}
+
 	let selectedFile = null;
 	let selectedFileId = null;
 	let selectedFileContent = '';

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -45,6 +45,7 @@ export const TTSWorker = writable(null);
 
 export const chatId = writable('');
 export const chatTitle = writable('');
+export const chatListRefresh = writable({ timestamp: Date.now(), folderId: null });
 
 export const channels = writable([]);
 export const chats = writable(null);


### PR DESCRIPTION
### Update of folders feature

Added drag and drop for notes and collections to folders and from folders items to message input. Enabled the FolderPlaceHolder for those items.


https://github.com/user-attachments/assets/cd738447-065d-4d88-9bf5-83607d27f17e

Here’s a grouped summary of the changes.

Backend
- backend/open_webui/models/notes.py
  - Added Notes.check_access_by_user_id(id, user_id, permission="write") -> bool:
    - Fetches note by id and returns True if the note exists and user_id matches the note owner; otherwise returns False. (Placeholder for more access logic.)

API / Routers
- backend/open_webui/routers/folders.py
  - Import Notes model.
  - When building folder responses, filter folder.data["notes"] to only include notes the current user has read access to:
    - Calls Notes.get_notes_by_permission(user.id, "read") to get accessible notes and rewrites folder.data["notes"] to only the accessible ones.
    - Persists the filtered folder data back to the DB via folder update.

Frontend — major features and components
- Added support for dragging/dropping and attaching Notes, Chats, and Knowledge collections into chats and folders, plus UI to view/manage notes and collections in folders.

Message input and attaching files
- src/lib/components/chat/MessageInput.svelte
  - Imports: getNoteById, getChatById, getKnowledgeById.
  - Prevent duplicate file attachments.
  - Improve drag-over detection to detect files and plain text, reduce blinking.
  - Add attachNoteToChat(noteId), attachChatToChat(chatId), attachKnowledgeToChat(knowledgeId):
    - Fetch the resource via API, create a file-like entry in the chat input’s files list, show toast notifications.
  - onDrop: parse dataTransfer text/plain JSON to handle note/chat/collection drops (calls corresponding attach handlers); fall back to file drops.
  - Prevent the text input from swallowing note/chat drops (block drop on text input if it’s note/chat type).
  - Pass new handlers down into FilesOverlay and InputMenu. Update modal logic to include notes and chats as modal types.

- src/lib/components/chat/MessageInput/FilesOverlay.svelte
  - New props: attachNoteToChat, attachChatToChat, attachKnowledgeToChat, inputFilesHandler.
  - handleOverlayDrop: parse JSON payloads and call appropriate handlers; fallback to handling dropped files.
  - Added dragover handler to prevent default.

- src/lib/components/chat/MessageInput/InputMenu.svelte
  - New props: attachNoteToChat, attachChatToChat, attachKnowledgeToChat.
  - onSelect now routes note/chat/collection selections to attach handlers (instead of only adding file objects).

- src/lib/components/chat/MessageInput/InputMenu/Notes.svelte
  - When mapping notes into selectable items, include content/file.data.content and data metadata so notes have a snippet and proper URL.

- src/lib/components/chat/MessageInput/FilesOverlay.svelte and InputMenu usage updated in MessageInput.svelte.

Notes UI and draggable notes
- src/lib/components/notes/Notes.svelte
  - Make notes draggable:
    - Add drag start/end handlers that set dataTransfer JSON (type: 'note', id).
    - Add drag attributes on each note item.

Folder, Sidebar and folder UI
- src/lib/stores/index.ts
  - Added chatListRefresh = writable({ timestamp: Date.now(), folderId: null }) to allow cross-component refresh triggers.

- Sidebar and folder-related components:
  - src/lib/components/layout/Sidebar.svelte
    - Import and react to chatListRefresh (calls initChatList on change).
  - New components (added):
    - src/lib/components/layout/Sidebar/CollectionItem.svelte
    - src/lib/components/layout/Sidebar/CollectionMenu.svelte
    - src/lib/components/layout/Sidebar/NoteItem.svelte
    - src/lib/components/layout/Sidebar/NoteMenu.svelte
      - Used to display draggable collection & note items in sidebar folders and to provide per-item menus (e.g., Remove from Folder).
  - src/lib/components/layout/Sidebar/ChatItem.svelte
    - Now updates chatListRefresh when chats are moved/archived to refresh folder context (folder-scoped refresh).
  - src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
    - Folder data structure initialized/cleared to include notes and collections arrays.
  - src/lib/components/layout/Sidebar/RecursiveFolder.svelte
    - Import getNoteById and getKnowledgeById.
    - Add NoteItem and CollectionItem to folder child lists and UI.
    - React to chatListRefresh to refresh folder contents.
    - Implement drop handling for items of type 'note' and 'collection':
      - On drop: add item to target folder, optionally remove from source folder if sourceFolderId provided, update via updateFolderById API, refresh folder displays and show toasts.
    - setFolderItems now fetches and populates full note and collection metadata for the folder (calls APIs to get detailed items) and sets selectedFolder.
    - UI changes to show notes and collections under a folder and allow removing them (with API calls & toasts).
    - Adjusted many conditional checks to consider notes/collections existence (loading spinners when null).

Folder placeholder and folder content listing
- src/lib/components/chat/Placeholder/FolderPlaceholder.svelte
  - Add fetching and display of:
    - notes (via getNoteById)
    - collections (via getKnowledgeById)
  - Add tabs to switch between Knowledge / Notes / Chats and display spinner while loading. Added dayjs plugins for duration/relative time.

Chat list placeholder
- src/lib/components/chat/Placeholder/ChatList.svelte
  - Add exported prop show = false (minor).

Workspace Knowledge and KnowledgeBase
- src/lib/components/workspace/Knowledge.svelte
  - Make knowledge items draggable (dragstart/dragend handlers) and attach event listeners on mount/destroy.
- src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
  - Added reactive logic to watch $page.params.id:
    - When route id changes, loadKnowledge(collectionId) via getKnowledgeById; if not found, redirect to /workspace/knowledge.

Misc frontend tweaks and fixes
- src/lib/components/common/RichTextInput.svelte
  - Fix the template selection guard to ensure editor.view exists before using it (if (value !== '' && editor?.view)).

- MessageInput.svelte: prevent duplicates for files.

- FilesOverlay usage updated in MessageInput.svelte to pass drop handlers and inputFilesHandler.

General behavior introduced
- Drag-and-drop support for notes, chats, and collections across UI:
  - Notes can be dragged from the Notes list or Sidebar into folders and chats.
  - Collections (knowledge bases) can be dragged into folders and chats.
  - Chats can be attached to chats and folders.
- Folder data now supports notes and collections in addition to files:
  - New UI to list, add, remove, and move notes & collections inside folders.
- Cross-component refresh mechanism via chatListRefresh store to propagate folder/chat list updates.

New files added (components)
- CollectionItem.svelte
- CollectionMenu.svelte
- NoteItem.svelte
- NoteMenu.svelte

Summary of intent
- These changes primarily add first-class support for notes and knowledge collections: viewing them in folders, dragging/dropping them, attaching them to chats, preventing duplicate attachments, and ensuring folder displays only include notes the current user can access. Also includes UI/UX polish around drag overlays and selection behavior and a small backend helper for checking note access.

___

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
