### PR TITLE
fix: update max_tokens input minimum from -2 to 1

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -508,7 +508,7 @@
 					<input
 						id="steps-range"
 						type="range"
-						min="-2"
+						min="1"
 						max="131072"
 						step="1"
 						bind:value={params.max_tokens}
@@ -520,7 +520,7 @@
 						bind:value={params.max_tokens}
 						type="number"
 						class=" bg-transparent text-center w-14"
-						min="-2"
+						min="1"
 						step="1"
 					/>
 				</div>


### PR DESCRIPTION
# fix(ui): update `max_tokens` input minimum from -2 to 1

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.  
- [x] **Description:** Provide a concise description of the changes made in this pull request.  
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.  
- [ ] **Documentation:** No documentation updates required.  
- [ ] **Dependencies:** No new dependencies added.  
- [x] **Testing:** Manually tested to confirm correct slider and input behavior.  
- [x] **Agentic AI Code:** This PR has been manually written and reviewed.  
- [x] **Code review:** Performed self-review to ensure code consistency.  
- [x] **Title Prefix:** Verified correct `fix` prefix.

---

# Changelog Entry

### Description

- Updated the `max_tokens` input component to prevent invalid negative values.  
- Previously, the minimum value was set to `-2`, which is not supported by any LLM model.  
- This change updates it to `1` to ensure consistency and proper validation across the UI.

### Added

- N/A

### Changed

- Updated the `min` attribute of the `max_tokens` range and number input from `-2` to `1`.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Prevented users from setting invalid negative `max_tokens` values.

### Security

- N/A

### Breaking Changes

- None

---

### Additional Information

- This fix improves user experience by aligning UI behavior with valid model parameter limits.  
- Manually verified in the parameter panel to confirm correct input range behavior.

### Screenshots or Videos

*(Optional — include if you want)*  
Before: slider allowed `-2`  
After: minimum value starts at `1`

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
