### PR TITLE
fix: load default settings when sessionStorage is empty

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -192,6 +192,8 @@
 						codeInterpreterEnabled = input.codeInterpreterEnabled;
 					}
 				} catch (e) {}
+			} else {
+				await setDefaults();
 			}
 
 			const chatInput = document.getElementById('chat-input');


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verified that the pull request targets the `dev` branch.  
- [x] **Description:** Added fallback behavior for chat initialization when `sessionStorage` data is missing.  
- [x] **Changelog:** Included changelog entry following [Keep a Changelog](https://keepachangelog.com/).  
- [ ] **Documentation:** No documentation updates required.  
- [ ] **Dependencies:** No new dependencies added.  
- [x] **Testing:** Manually tested tab close/reopen and new chat scenarios.  
- [x] **Agentic AI Code:** This PR was manually written and tested.  
- [x] **Code review:** Self-review completed.  
- [x] **Title Prefix:** Verified correct `fix` prefix.

---

# Changelog Entry

### Description

- Added a call to `setDefaults()` inside the chat navigation logic (`navigateHandler`) to properly initialize the chat state when no previous session data exists in `sessionStorage`.

### Added

- N/A

### Changed

- Modified `navigateHandler` to include an `else` condition that triggers `setDefaults()` when `sessionStorage` does not contain chat input data.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed an issue where reopening a tab or starting a new session without `sessionStorage` data caused chat parameters (e.g., model settings, filters) not to load properly.

### Security

- N/A

### Breaking Changes

- None

---

### Additional Information

- When a user closes and reopens a tab, `sessionStorage` is cleared, which previously resulted in missing chat configuration (e.g., model, tools, filters).  
- This update ensures that in such cases, default settings are reloaded automatically through `setDefaults()`.

### Screenshots or Videos

*(Optional)*  
N/A

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.






