### PR TITLE
fix: correct model property paths to prevent tool deselection bug

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -268,33 +268,33 @@
 		const model = atSelectedModel ?? $models.find((m) => m.id === selectedModels[0]);
 		if (model) {
 			// Set Default Tools
-			if (model?.info?.meta?.toolIds) {
+			if (model?.meta?.toolIds) {
 				selectedToolIds = [
 					...new Set(
-						[...(model?.info?.meta?.toolIds ?? [])].filter((id) => $tools.find((t) => t.id === id))
+						[...(model?.meta?.toolIds ?? [])].filter((id) => $tools.find((t) => t.id === id))
 					)
 				];
 			}
 
 			// Set Default Filters (Toggleable only)
-			if (model?.info?.meta?.defaultFilterIds) {
-				selectedFilterIds = model.info.meta.defaultFilterIds.filter((id) =>
+			if (model?.meta?.defaultFilterIds) {
+				selectedFilterIds = model.meta.defaultFilterIds.filter((id) =>
 					model?.filters?.find((f) => f.id === id)
 				);
 			}
 
 			// Set Default Features
-			if (model?.info?.meta?.defaultFeatureIds) {
-				if (model.info?.meta?.capabilities?.['image_generation']) {
-					imageGenerationEnabled = model.info.meta.defaultFeatureIds.includes('image_generation');
+			if (model?.meta?.defaultFeatureIds) {
+				if (model?.meta?.capabilities?.['image_generation']) {
+					imageGenerationEnabled = model.meta.defaultFeatureIds.includes('image_generation');
 				}
 
-				if (model.info?.meta?.capabilities?.['web_search']) {
-					webSearchEnabled = model.info.meta.defaultFeatureIds.includes('web_search');
+				if (model?.meta?.capabilities?.['web_search']) {
+					webSearchEnabled = model.meta.defaultFeatureIds.includes('web_search');
 				}
 
-				if (model.info?.meta?.capabilities?.['code_interpreter']) {
-					codeInterpreterEnabled = model.info.meta.defaultFeatureIds.includes('code_interpreter');
+				if (model?.meta?.capabilities?.['code_interpreter']) {
+					codeInterpreterEnabled = model.meta.defaultFeatureIds.includes('code_interpreter');
 				}
 			}
 		}
@@ -1678,7 +1678,7 @@
 						message.files?.some((file) => file.type === 'image')
 					);
 
-					if (hasImages && !(model.info?.meta?.capabilities?.vision ?? true)) {
+					if (hasImages && !(model?.meta?.capabilities?.vision ?? true)) {
 						toast.error(
 							$i18n.t('Model {{modelName}} is not vision capable', {
 								modelName: model.name ?? model.id
@@ -1737,7 +1737,7 @@
 		const currentModels = atSelectedModel?.id ? [atSelectedModel.id] : selectedModels;
 		if (
 			currentModels.filter(
-				(model) => $models.find((m) => m.id === model)?.info?.meta?.capabilities?.web_search ?? true
+				(model) => $models.find((m) => m.id === model)?.meta?.capabilities?.web_search ?? true
 			).length === currentModels.length
 		) {
 			if ($config?.features?.enable_web_search && ($settings?.webSearch ?? false) === 'always') {
@@ -1797,7 +1797,7 @@
 		}
 
 		const stream =
-			model?.info?.params?.stream_response ??
+			model?.params?.stream_response ??
 			$settings?.params?.stream_response ??
 			params?.stream_response ??
 			true;
@@ -1908,7 +1908,7 @@
 					follow_up_generation: $settings?.autoFollowUps ?? true
 				},
 
-				...(stream && (model.info?.meta?.capabilities?.usage ?? false)
+				...(stream && (model?.meta?.capabilities?.usage ?? false)
 					? {
 							stream_options: {
 								include_usage: true


### PR DESCRIPTION
Fixed incorrect property paths in Chat.svelte that were causing tools to deselect when navigating between chats. The model object structure uses `model.meta` and `model.params` directly, not `model.info.meta` or `model.info.params`.

Changes:
- Fixed tool selection restoration (setDefaults function)
- Fixed default filter and feature initialization
- Fixed vision capability checks
- Fixed web search capability checks
- Fixed stream response parameter access
- Fixed usage capability checks

This ensures that when a model has default tools configured, they are properly restored when returning to a chat using that model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [ ] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [ ] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [ ] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]

### Added

- N/A

### Changed

- Updated property access paths in src/lib/components/chat/Chat.svelte from model.info.meta to model.meta
Updated property access paths from model.info.params to model.params

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed tool selection restoration in setDefaults() function (lines 271, 274)
- Fixed default filter initialization (lines 280-281)
- Fixed default feature initialization for image generation, web search, and code interpreter (lines 287-297)
- Fixed vision capability check (line 1681)
- Fixed web search capability check (line 1740)
- Fixed stream response parameter access (line 1800)
- Fixed usage capability check (line 1911)

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- Testing Required
This fix requires manual testing to verify:

Navigate to a chat with a model that has default tools configured
Navigate away from the chat
Return to the chat and verify tools are properly restored
Verify default features (image generation, web search, code interpreter) are properly restored
Verify vision and web search capabilities are correctly detected


AI Assistance Notice
⚠️ Important: This PR was developed with assistance from Claude Code (AI agent). Human review and manual testing are REQUIRED before merging, as per the contribution guidelines.


### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
