### PR TITLE
fix: add spacing between source buttons

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/Source.svelte
+++ b/src/lib/components/chat/Messages/Markdown/Source.svelte
@@ -50,7 +50,7 @@
 
 {#if attributes.title !== 'N/A'}
 	<button
-		class="text-xs font-medium w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/60 dark:hover:text-white bg-gray-50 text-black/60 hover:text-black transition rounded-lg"
+		class="[&+button]:ms-1 text-xs font-medium w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/60 dark:hover:text-white bg-gray-50 text-black/60 hover:text-black transition rounded-lg"
 		on:click={() => {
 			onClick(id, attributes.data);
 		}}


### PR DESCRIPTION
### Description

- Fix gap between sources

### Screenshots or Videos

Before:
![telegram-cloud-photo-size-2-5463131807500336047-x](https://github.com/user-attachments/assets/16911e5d-c3a0-4fd3-826c-42edbb04b55f)

After:
![telegram-cloud-photo-size-2-5463131807500336046-y](https://github.com/user-attachments/assets/d090e95e-b602-4c85-b2e3-746050f40b92)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
