### PR TITLE
fix: validate folder and channel names before creation

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -129,7 +129,8 @@
 	};
 
 	const createFolder = async ({ name, data }) => {
-		if (name === '') {
+		name = name?.trim();
+		if (!name) {
 			toast.error($i18n.t('Folder name cannot be empty.'));
 			return;
 		}
@@ -479,6 +480,12 @@
 <ChannelModal
 	bind:show={showCreateChannel}
 	onSubmit={async ({ name, access_control }) => {
+		name = name?.trim();
+		if (!name) {
+			toast.error($i18n.t('Channel name cannot be empty.'));
+			return;
+		}
+
 		const res = await createNewChannel(localStorage.token, {
 			name: name,
 			access_control: access_control

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -221,6 +221,7 @@
 	"Channel": "",
 	"Channel deleted successfully": "",
 	"Channel Name": "",
+	"Channel name cannot be empty.": "",
 	"Channel updated successfully": "",
 	"Channels": "",
 	"Character": "",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -221,6 +221,7 @@
 	"Channel": "Канал",
 	"Channel deleted successfully": "Канал успешно удалён",
 	"Channel Name": "Название канала",
+	"Channel name cannot be empty.": "Название канала не может быть пустым.",
 	"Channel updated successfully": "Канал успешно обновлён",
 	"Channels": "Каналы",
 	"Character": "Символ",


### PR DESCRIPTION
### Description

- Be sure to not allow adding empty named folder or channel, show toast with error, if that's the case.

### Fixed

- No folder or channel can be empty named

### Screenshots or Videos

Before:
![telegram-cloud-photo-size-2-5463131807500336065-x](https://github.com/user-attachments/assets/fd780ae8-6391-49e4-99d1-ca78cb1992a2)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
