### PR TITLE
feat: Add Chat Context Awareness

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2511,6 +2511,24 @@ RAG_FILE_MAX_COUNT = PersistentConfig(
     ),
 )
 
+ENABLE_CHAT_CONTEXT = PersistentConfig(
+    "ENABLE_CHAT_CONTEXT",
+    "chat_context.enable",
+    os.environ.get("ENABLE_CHAT_CONTEXT", "False").lower() == "true",
+)
+
+CHAT_CONTEXT_MODE = PersistentConfig(
+    "CHAT_CONTEXT_MODE",
+    "chat_context.mode",
+    os.environ.get("CHAT_CONTEXT_MODE", "recent"),
+)
+
+CHAT_CONTEXT_TOP_K = PersistentConfig(
+    "CHAT_CONTEXT_TOP_K",
+    "chat_context.top_k",
+    int(os.environ.get("CHAT_CONTEXT_TOP_K", "3")),
+)
+
 RAG_FILE_MAX_SIZE = PersistentConfig(
     "RAG_FILE_MAX_SIZE",
     "rag.file.max_size",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -220,6 +220,9 @@ from open_webui.config import (
     RAG_HYBRID_BM25_WEIGHT,
     RAG_ALLOWED_FILE_EXTENSIONS,
     RAG_FILE_MAX_COUNT,
+    ENABLE_CHAT_CONTEXT,
+    CHAT_CONTEXT_MODE,
+    CHAT_CONTEXT_TOP_K,
     RAG_FILE_MAX_SIZE,
     FILE_IMAGE_COMPRESSION_WIDTH,
     FILE_IMAGE_COMPRESSION_HEIGHT,
@@ -811,6 +814,9 @@ app.state.config.TOP_K_RERANKER = RAG_TOP_K_RERANKER
 app.state.config.RELEVANCE_THRESHOLD = RAG_RELEVANCE_THRESHOLD
 app.state.config.HYBRID_BM25_WEIGHT = RAG_HYBRID_BM25_WEIGHT
 
+app.state.config.ENABLE_CHAT_CONTEXT = ENABLE_CHAT_CONTEXT
+app.state.config.CHAT_CONTEXT_MODE = CHAT_CONTEXT_MODE
+app.state.config.CHAT_CONTEXT_TOP_K = CHAT_CONTEXT_TOP_K
 
 app.state.config.ALLOWED_FILE_EXTENSIONS = RAG_ALLOWED_FILE_EXTENSIONS
 app.state.config.FILE_MAX_SIZE = RAG_FILE_MAX_SIZE
@@ -1776,6 +1782,11 @@ async def get_app_config(request: Request):
                 if user is not None
                 else {}
             ),
+        },
+        "chat_context": {
+            "enable": app.state.config.ENABLE_CHAT_CONTEXT,
+            "mode": app.state.config.CHAT_CONTEXT_MODE,
+            "top_k": app.state.config.CHAT_CONTEXT_TOP_K,
         },
         **(
             {

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -848,6 +848,9 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,
+        "ENABLE_CHAT_CONTEXT": request.app.state.config.ENABLE_CHAT_CONTEXT,
+        "CHAT_CONTEXT_MODE": request.app.state.config.CHAT_CONTEXT_MODE,
+        "CHAT_CONTEXT_TOP_K": request.app.state.config.CHAT_CONTEXT_TOP_K,
     }
 
 
@@ -868,6 +871,9 @@ class AdminConfig(BaseModel):
     PENDING_USER_OVERLAY_TITLE: Optional[str] = None
     PENDING_USER_OVERLAY_CONTENT: Optional[str] = None
     RESPONSE_WATERMARK: Optional[str] = None
+    ENABLE_CHAT_CONTEXT: bool
+    CHAT_CONTEXT_MODE: str
+    CHAT_CONTEXT_TOP_K: int
 
 
 @router.post("/admin/config")
@@ -914,6 +920,10 @@ async def update_admin_config(
 
     request.app.state.config.RESPONSE_WATERMARK = form_data.RESPONSE_WATERMARK
 
+    request.app.state.config.ENABLE_CHAT_CONTEXT = form_data.ENABLE_CHAT_CONTEXT
+    request.app.state.config.CHAT_CONTEXT_MODE = form_data.CHAT_CONTEXT_MODE
+    request.app.state.config.CHAT_CONTEXT_TOP_K = form_data.CHAT_CONTEXT_TOP_K
+
     return {
         "SHOW_ADMIN_DETAILS": request.app.state.config.SHOW_ADMIN_DETAILS,
         "WEBUI_URL": request.app.state.config.WEBUI_URL,
@@ -931,6 +941,9 @@ async def update_admin_config(
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,
+        "ENABLE_CHAT_CONTEXT": request.app.state.config.ENABLE_CHAT_CONTEXT,
+        "CHAT_CONTEXT_MODE": request.app.state.config.CHAT_CONTEXT_MODE,
+        "CHAT_CONTEXT_TOP_K": request.app.state.config.CHAT_CONTEXT_TOP_K,
     }
 
 

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -685,97 +685,74 @@
 
 					<hr class=" border-gray-100 dark:border-gray-850 my-2" />
 
-					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
-						<div class=" self-center text-xs font-medium">
-							{$i18n.t('Enable Chat Context')}
-						</div>
-						<Tooltip
-							content={$i18n.t(
-								'When enabled, recent chats are automatically injected into the conversation context to provide continuity across sessions'
-							)}
-						>
+					<Tooltip
+						content={$i18n.t(
+							'When enabled, recent chats are automatically injected into the conversation context to provide continuity across sessions'
+						)}
+						placement="top-start"
+					>
+						<div class="mb-2.5 flex w-full items-center justify-between pr-2">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Enable Chat Context')}
+							</div>
 							<Switch bind:state={adminConfig.ENABLE_CHAT_CONTEXT} />
-						</Tooltip>
-					</div>
-
-					{#if adminConfig.ENABLE_CHAT_CONTEXT}
-						<div class="mb-2.5">
-							<div class="flex w-full justify-between mb-2">
-								<div class=" self-center text-xs font-medium">
-									{$i18n.t('Chat Context Mode')}
-								</div>
-								<Tooltip
-									content={$i18n.t(
-										'Choose how chats are selected for context. "Recent" uses most recent chats. "Pinned" only includes user-pinned chats. "Relevant" (coming soon) will use AI to select contextually relevant chats.'
-									)}
-								>
-									<button class="cursor-pointer" type="button">
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											stroke-width="1.5"
-											stroke="currentColor"
-											class="size-3"
-										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
-											/>
-										</svg>
-									</button>
-								</Tooltip>
-							</div>
-							<select
-								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-none"
-								bind:value={adminConfig.CHAT_CONTEXT_MODE}
-							>
-								<option value="recent">{$i18n.t('Recent Chats')}</option>
-								<option value="pinned">{$i18n.t('Pinned Chats')}</option>
-								<option value="relevant" disabled>{$i18n.t('Relevant Chats (Coming Soon)')}</option>
-							</select>
 						</div>
-
-						<div class="mb-2.5">
-							<div class="flex w-full justify-between mb-2">
+					</Tooltip>
+					{#if adminConfig.ENABLE_CHAT_CONTEXT}
+						<div class="  mb-2.5 w-full justify-between">
+							<div class="flex w-full justify-between">
 								<div class=" self-center text-xs font-medium">
-									{$i18n.t('Number of Chats')}
+									<Tooltip
+										content={$i18n.t(
+											'Choose how chats are selected for context. "Recent" uses most recent chats. "Pinned" only includes user-pinned chats. "Relevant" (coming soon) will use AI to select contextually relevant chats.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Chat Context Mode')}
+									</Tooltip>
 								</div>
-								<Tooltip
-									content={$i18n.t(
-										'Maximum number of chats to include in context. Higher values provide more history but may slow down responses.'
-									)}
-								>
-									<button class="cursor-pointer" type="button">
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											stroke-width="1.5"
-											stroke="currentColor"
-											class="size-3"
-										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
-											/>
-										</svg>
-									</button>
-								</Tooltip>
 							</div>
-							<input
-								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-none"
-								type="number"
-								min="1"
-								max="10"
-								placeholder="3"
-								value={adminConfig.CHAT_CONTEXT_TOP_K || 3}
-								on:input={(e) => {
-									adminConfig.CHAT_CONTEXT_TOP_K = Number(e.currentTarget.value);
-								}}
-							/>
+
+							<div class="flex mt-2 space-x-2">
+								<select
+									class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+									bind:value={adminConfig.CHAT_CONTEXT_MODE}
+								>
+									<option value="recent">{$i18n.t('Recent Chats')}</option>
+									<option value="pinned">{$i18n.t('Pinned Chats')}</option>
+									<option value="relevant" disabled
+										>{$i18n.t('Relevant Chats (Coming Soon)')}</option
+									>
+								</select>
+							</div>
+						</div>
+						<div class="  mb-2.5 w-full justify-between">
+							<div class="flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Maximum number of chats to include in context. Higher values provide more history but may slow down responses.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Chat Context Top K')}
+									</Tooltip>
+								</div>
+							</div>
+
+							<div class="flex mt-2 space-x-2">
+								<input
+									class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+									type="number"
+									min="1"
+									max="10"
+									placeholder="3"
+									value={adminConfig.CHAT_CONTEXT_TOP_K || 3}
+									on:input={(e) => {
+										adminConfig.CHAT_CONTEXT_TOP_K = Number(e.currentTarget.value);
+									}}
+								/>
+							</div>
 						</div>
 					{/if}
 				</div>

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -678,6 +678,112 @@
 
 						<Switch bind:state={adminConfig.ENABLE_USER_WEBHOOKS} />
 					</div>
+				</div>
+
+				<div class="mb-3">
+					<div class=" mb-2.5 text-base font-medium">{$i18n.t('Chat Context')}</div>
+
+					<hr class=" border-gray-100 dark:border-gray-850 my-2" />
+
+					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
+						<div class=" self-center text-xs font-medium">
+							{$i18n.t('Enable Chat Context')}
+						</div>
+						<Tooltip
+							content={$i18n.t(
+								'When enabled, recent chats are automatically injected into the conversation context to provide continuity across sessions'
+							)}
+						>
+							<Switch bind:state={adminConfig.ENABLE_CHAT_CONTEXT} />
+						</Tooltip>
+					</div>
+
+					{#if adminConfig.ENABLE_CHAT_CONTEXT}
+						<div class="mb-2.5">
+							<div class="flex w-full justify-between mb-2">
+								<div class=" self-center text-xs font-medium">
+									{$i18n.t('Chat Context Mode')}
+								</div>
+								<Tooltip
+									content={$i18n.t(
+										'Choose how chats are selected for context. "Recent" uses most recent chats. "Pinned" only includes user-pinned chats. "Relevant" (coming soon) will use AI to select contextually relevant chats.'
+									)}
+								>
+									<button class="cursor-pointer" type="button">
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke-width="1.5"
+											stroke="currentColor"
+											class="size-3"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+											/>
+										</svg>
+									</button>
+								</Tooltip>
+							</div>
+							<select
+								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-none"
+								bind:value={adminConfig.CHAT_CONTEXT_MODE}
+							>
+								<option value="recent">{$i18n.t('Recent Chats')}</option>
+								<option value="pinned">{$i18n.t('Pinned Chats')}</option>
+								<option value="relevant" disabled>{$i18n.t('Relevant Chats (Coming Soon)')}</option>
+							</select>
+						</div>
+
+						<div class="mb-2.5">
+							<div class="flex w-full justify-between mb-2">
+								<div class=" self-center text-xs font-medium">
+									{$i18n.t('Number of Chats')}
+								</div>
+								<Tooltip
+									content={$i18n.t(
+										'Maximum number of chats to include in context. Higher values provide more history but may slow down responses.'
+									)}
+								>
+									<button class="cursor-pointer" type="button">
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke-width="1.5"
+											stroke="currentColor"
+											class="size-3"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+											/>
+										</svg>
+									</button>
+								</Tooltip>
+							</div>
+							<input
+								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-none"
+								type="number"
+								min="1"
+								max="10"
+								placeholder="3"
+								value={adminConfig.CHAT_CONTEXT_TOP_K || 3}
+								on:input={(e) => {
+									adminConfig.CHAT_CONTEXT_TOP_K = Number(e.currentTarget.value);
+								}}
+							/>
+						</div>
+					{/if}
+				</div>
+
+				<div class="mb-3">
+					<div class=" mb-2.5 text-base font-medium">{$i18n.t('Miscellaneous')}</div>
+
+					<hr class=" border-gray-100 dark:border-gray-850 my-2" />
 
 					<div class="mb-2.5">
 						<div class=" self-center text-xs font-medium mb-2">

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1751,6 +1751,10 @@
 			features = { ...features, memory: true };
 		}
 
+		if ($config?.chat_context?.enable ?? false) {
+			features = { ...features, chat_context: true };
+		}
+
 		return features;
 	};
 


### PR DESCRIPTION
# Changelog Entry

### Description

Implements automatic Chat Context injection that adds recent or pinned chat history to conversation context.
I believe this feature will enhance the user experience by personalizing model context. Find an example in the screenshot below.

### Added

- Backend config: `ENABLE_CHAT_CONTEXT`, `CHAT_CONTEXT_MODE`, `CHAT_CONTEXT_TOP_K` in `config.py`
- Middleware handler `chat_context_handler()` in `utils/middleware.py` supporting:
  - Recent mode: retrieves last N chats (skip=1 to exclude current)
  - Pinned mode: retrieves user-pinned chats (early return if none exist)
  - Structured extraction: first_user_message + last_messages{user, assistant}
  - Conditional prompts: encouraging for pinned, discouraging for recent
  - JSON-in-XML injection format
- Admin UI in `General.svelte`: enable toggle, mode dropdown, top K input
- Feature flag in `Chat.svelte`: checks `$config.chat_context.enable`
- Config exposure via `/api/config` endpoint

### Changed

- `AdminConfig` model now includes chat context fields
- `get_admin_config()` and `update_admin_config()` handle chat context settings
- Middleware pipeline calls `chat_context_handler()` when feature enabled

### Additional Information

**Design decisions:**
- Skip=1 in recent mode prevents self-reference
- No skip in pinned mode
- Early return for empty pinned chats
- Multimodal content support extracts text from arrays

**Chat format injected:**
\`\`\`json
[
  {
    "title": "Chat Title",
    "created_at": "2024-01-15T10:30:00-0500",
    "updated_at": "2024-01-15T11:45:00-0500",
    "first_user_message": "...",
    "last_messages": {
      "user": "...",
      "assistant": "..."
    }
  }
]
\`\`\`

**Testing:** Manual testing of enable/disable, mode switching, top K validation, pinned empty/full, recent mode, config persistence, feature flag, JSON structure, multimodal handling.
### Screenshots or Videos

<img width="1014" height="856" alt="image" src="https://github.com/user-attachments/assets/2abf0756-59c7-4728-9914-9581f5d10082" />
<img width="1012" height="856" alt="image" src="https://github.com/user-attachments/assets/eaf55000-51fd-4cf9-8e09-60ebb12ec6fe" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
