### PR TITLE
feat: set TOOL_SERVER_CONNECTIONS using a local file

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1076,13 +1076,29 @@ ENABLE_BASE_MODELS_CACHE = PersistentConfig(
 # TOOL_SERVERS
 ####################################
 
+tool_server_connections = []
+
 try:
-    tool_server_connections = json.loads(
+    tool_server_connections = tool_server_connections + json.loads(
         os.environ.get("TOOL_SERVER_CONNECTIONS", "[]")
     )
 except Exception as e:
     log.exception(f"Error loading TOOL_SERVER_CONNECTIONS: {e}")
-    tool_server_connections = []
+
+
+tool_server_connections_file_path = os.environ.get("TOOL_SERVER_CONNECTIONS_FILE", None)
+if tool_server_connections_file_path:
+    try:
+        with open(tool_server_connections_file_path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+        if isinstance(loaded, list):
+            tool_server_connections = tool_server_connections + loaded
+        else: 
+            log.exception(
+                f"Error loading TOOL_SERVER_CONNECTIONS_FILE: '{tool_server_connections_file_path}' does not contain a list"
+            )
+    except Exception as e:
+        log.exception(f"Error loading TOOL_SERVER_CONNECTIONS_FILE: {e}")
 
 
 TOOL_SERVER_CONNECTIONS = PersistentConfig(

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -503,6 +503,8 @@ from open_webui.utils.redis import get_sentinels_from_env
 
 from open_webui.constants import ERROR_MESSAGES
 
+from open_webui.tool_servers.watcher import start_tool_server_connections_file_watcher, stop_tool_server_connections_file_watcher
+
 
 if SAFE_MODE:
     print("SAFE MODE ENABLED")
@@ -549,6 +551,7 @@ https://github.com/open-webui/open-webui
 async def lifespan(app: FastAPI):
     app.state.instance_id = INSTANCE_ID
     start_logger()
+    start_tool_server_connections_file_watcher(app, TOOL_SERVER_CONNECTIONS)
 
     if RESET_CONFIG_ON_START:
         reset_config()
@@ -603,6 +606,7 @@ async def lifespan(app: FastAPI):
         )
 
     yield
+    stop_tool_server_connections_file_watcher(app)
 
     if hasattr(app.state, "redis_task_command_listener"):
         app.state.redis_task_command_listener.cancel()

--- a/backend/open_webui/tool_servers/watcher.py
+++ b/backend/open_webui/tool_servers/watcher.py
@@ -1,0 +1,89 @@
+import os
+import json
+import time
+import threading
+import hashlib
+import logging
+from typing import Optional
+from open_webui.config import PersistentConfig
+
+log = logging.getLogger("open_webui.tool_servers.watcher")
+
+
+def start_tool_server_connections_file_watcher(app, persistent_tool_server_connections):
+    file_path = os.environ.get("TOOL_SERVER_CONNECTIONS_FILE")
+    if file_path:
+        watcher = ToolServerConnectionsFileWatcher(persistent_tool_server_connections, file_path)
+        watcher.start()
+        app.state.tool_server_connections_file_watcher = watcher
+
+def stop_tool_server_connections_file_watcher(app):
+    watcher = getattr(app.state, "tool_server_connections_file_watcher", None)
+    if watcher:
+        watcher.stop()
+
+
+class ToolServerConnectionsFileWatcher:
+    def __init__(self, persistent_config: PersistentConfig, file_path: str):
+        self.persistent_config = persistent_config
+        self.file_path = file_path
+        self.poll_interval = 60  # seconds
+        self._stop_event = threading.Event()
+        self._last_signature = None
+        self._last_content_hash = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        log.info(f"[tool_servers/watch] Watcher started (interval={self.poll_interval}s, file='{self.file_path}')")
+
+    def stop(self):
+        self._stop_event.set()
+        if hasattr(self, '_thread'):
+            self._thread.join(timeout=2)
+            log.info("[tool_servers/watch] Watcher stopped.")
+
+    def _poll_loop(self):
+        while not self._stop_event.is_set():
+            try:
+                self._check_once()
+            except Exception as e:
+                log.exception(f"[tool_servers/watch] Exception in poll loop: {e}")
+            time.sleep(self.poll_interval)
+
+    def _check_once(self):
+        try:
+            with open(self.file_path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            if not isinstance(loaded, list):
+                log.warning(f"[tool_servers/watch] File '{self.file_path}' does not contain a list; ignoring.")
+                return
+        except Exception as e:
+            log.warning(f"[tool_servers/watch] Error reading file: {e}")
+            return
+        content_hash = hashlib.sha256(json.dumps(loaded, sort_keys=True).encode()).hexdigest()
+        if content_hash == self._last_content_hash:
+            return
+        self._last_content_hash = content_hash
+        self._handle_new_tool_servers(loaded)
+
+    def _handle_new_tool_servers(self, file_list):
+        self.persistent_config.update()
+        def get_info_id(entry):
+            if isinstance(entry, dict):
+                info = entry.get('info')
+                if isinstance(info, dict):
+                    return info.get('id')
+            return None
+
+        current = self.persistent_config.value or []
+        by_id = {get_info_id(entry): entry for entry in current if get_info_id(entry) is not None}
+        for entry in file_list:
+            entry_id = get_info_id(entry)
+            if entry_id is not None:
+                by_id[entry_id] = entry
+        updated = list(by_id.values())
+        if updated != current:
+            log.info(f"[tool_servers/watch] Tool server(s) updated due to file change. New state: {updated}")
+            self.persistent_config.value = updated
+            self.persistent_config.save()


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [c] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [c] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

In this PR I introduced a new env var TOOL_SERVER_CONNECTIONS_FILE. It let's you specify the path of a json file in the open-webui container that contains the starting configuration of available tool server. My testing example looked as follows:

`
[
      {
        "url": "http://test.default.svc.cluster.local",
        "path": "openapi.json",
        "type": "openapi",
        "auth_type": "bearer",
        "key": "replaced",
        "config": {
          "enable": true,
          "access_control": null
        },
        "spec_type": "url",
        "spec": "",
        "info": {
          "id": "test",
          "name": "test",
          "description": "test"
        }
     }
]
`

The main difference towards the existing env var TOOL_SERVER_CONNECTIONS is that there is a watcher looking for changes to the json file (every 60 seconds). It uses the value of info.id to see if a tool listed in the json file needs to be added/updated in the PersistentConfig. Because it uses info.id to identify the tools that are relevant to the json file, it won't touch tools added using the UI (unless the user give it the exact same id as a tool from the json). It also won't delete any tools and will only start if the env var TOOL_SERVER_CONNECTIONS_FILE was set. 

The goal was to be able to edit the json file inside the docker container through sidecar containers, which let's us add mcp servers on the fly using code. In my specific use case I have a service that discovers available mcp server in my kubernetes cluster. This service is inside a sidecar container and also has the json file specified in TOOL_SERVER_CONNECTIONS_FILE mounted. When it discovers a new mcp server, it can add it to the json and then the watcher in open-webui will pick up on the change and make it available to the user. 

### Added

- new env var TOOL_SERVER_CONNECTIONS_FILE and a new class ToolServerConnectionsFileWatcher

### Additional Information

I also opened a discussion here: https://github.com/open-webui/open-webui/discussions/18589

If this is as a general concept is wanted for this project I can of course add more type checks on the provided json, more error handling and also add the required documentation. Since I was not sure if this PR would go anywhere, I tried to keep the code small and just did some manual tests using a kubernetes pod with two containers for now. 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
