### PR TITLE
Add reasonable min and max height to textarea

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -69,6 +69,11 @@ textarea::placeholder {
 	direction: auto;
 }
 
+textarea {
+	min-height: 40px;
+	max-height: 600px;
+}
+
 .input-prose {
 	@apply prose dark:prose-invert prose-headings:font-semibold prose-hr:my-4 prose-hr:border-gray-50 prose-hr:dark:border-gray-850 prose-p:my-1 prose-img:my-1 prose-headings:my-2 prose-pre:my-0 prose-table:my-1 prose-blockquote:my-0 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 whitespace-pre-line;
 }


### PR DESCRIPTION
### Description

Add a reasonable min and max height to textarea so it can't be extra small or extra large

### Added

- min and max height to textarea

### Screenshots or Videos

Representative example:
![telegram-cloud-photo-size-2-5465383607314021300-y](https://github.com/user-attachments/assets/d277212c-85ff-49de-ace8-b38af5cd69aa)

New:
<img width="652" height="174" alt="image" src="https://github.com/user-attachments/assets/b8b0473f-ba18-498c-a3e3-fbd0125a09f7" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
