### PR TITLE
fix: prevent icon layout shift near system instructions in Chat component

### DIFF
--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -224,7 +224,7 @@
 							{$i18n.t('System Instructions')}
 						</div>
 
-						{#if !showSystem}
+						{#if !showSystem && system.trim()}
 							<div class=" flex-1 text-gray-500 line-clamp-1">
 								{system}
 							</div>


### PR DESCRIPTION
### Description

There is a layout shift when click on the pencil and then on a chevron icon even if the system prompt is empty 

### Fixed

Remove layout shift bug

### Screenshots or Videos

https://github.com/user-attachments/assets/d45da204-d1f2-4f9e-955f-513d62b69061

https://github.com/user-attachments/assets/2dc5863a-e65d-42d5-b953-3daafd6b530d

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
