### PR TITLE
fix: formatting toolbar partially hidden under image in Chat

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -997,7 +997,7 @@
 			<div
 				class="{($settings?.widescreenMode ?? null)
 					? 'max-w-full'
-					: 'max-w-6xl'} px-2.5 mx-auto inset-x-0"
+					: 'max-w-6xl'} px-2.5 mx-auto inset-x-0 relative z-[9999]"
 			>
 				<div class="">
 					<input
@@ -1443,7 +1443,9 @@
 										</InputMenu>
 
 										{#if showWebSearchButton || showImageGenerationButton || showCodeInterpreterButton || showToolsButton || (toggleFilters && toggleFilters.length > 0)}
-											<div class="flex self-center w-[1px] h-4 mx-1 bg-gray-200/50 dark:bg-gray-800/50" />
+											<div
+												class="flex self-center w-[1px] h-4 mx-1 bg-gray-200/50 dark:bg-gray-800/50"
+											/>
 
 											<IntegrationsMenu
 												selectedModels={atSelectedModel ? [atSelectedModel.id] : selectedModels}


### PR DESCRIPTION
### Description

When formatting toolbar is on and there is an image in a chat - toolbar partially hidden under the image

### Fixed

- Toolbar is now always displayed above images

### Screenshots or Videos

![telegram-cloud-photo-size-2-5465383607314021588-y](https://github.com/user-attachments/assets/2c4aedfe-005b-4269-a18b-c5e70307e844)
![telegram-cloud-photo-size-2-5465383607314021614-y](https://github.com/user-attachments/assets/1b4befdd-7429-49dd-84e4-756fc915ab12)


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
