### PR TITLE
FIX:style_dark_mode_select_boxes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -152,6 +152,15 @@ select {
 	-webkit-appearance: none;
 }
 
+.dark select {  
+    background-color: rgb(23, 23, 23); /* gray-900 */  
+    color: rgb(209, 213, 219); /* gray-300 */  
+}  
+  
+.dark select option {  
+    background-color: rgb(38, 38, 38); /* gray-850 */  
+    color: rgb(255, 255, 255);  
+}
 @keyframes shimmer {
 	0% {
 		background-position: 200% 0;

--- a/src/app.css
+++ b/src/app.css
@@ -152,15 +152,16 @@ select {
 	-webkit-appearance: none;
 }
 
-.dark select {  
-    background-color: rgb(23, 23, 23); /* gray-900 */  
-    color: rgb(209, 213, 219); /* gray-300 */  
-}  
-  
-.dark select option {  
-    background-color: rgb(38, 38, 38); /* gray-850 */  
-    color: rgb(255, 255, 255);  
+.dark select {
+	background-color: rgb(23, 23, 23); /* gray-900 */
+	color: rgb(209, 213, 219); /* gray-300 */
 }
+
+.dark select option {
+	background-color: rgb(38, 38, 38); /* gray-850 */
+	color: rgb(255, 255, 255);
+ }
+
 @keyframes shimmer {
 	0% {
 		background-position: 200% 0;


### PR DESCRIPTION
### UPD_Styles: Add dark mode styles for select elements and options.

Actually some select "boxes" have css dark theme support, but other not.
This PR add CSS for dark theme selects.

E.g. of fix:
<img width="521" height="268" alt="openwebui_dark_selectors" src="https://github.com/user-attachments/assets/77d6c179-7385-4680-b9fc-9bfaa1d79e67" />
<img width="521" height="268" alt="openwebui_dark_selectors0" src="https://github.com/user-attachments/assets/bea65bdb-6481-4982-acd9-0011704b9d23" />
<img width="888" height="224" alt="openwebui_dark_selectors1" src="https://github.com/user-attachments/assets/20d362a1-61e3-473b-9bba-013667edf810" />
<img width="888" height="224" alt="openwebui_dark_selectors2" src="https://github.com/user-attachments/assets/b287cf7f-b80e-4c51-a5b7-3d29d0dda6f7" />



___

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
