### PR TITLE
UPD_style: dark_mode_select_boxes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -152,6 +152,16 @@ select {
 	-webkit-appearance: none;
 }
 
+.dark select {  
+	background-color: rgb(23, 23, 23); /* gray-900 */  
+	color: rgb(209, 213, 219); /* gray-300 */  
+}  
+
+.dark select option {  
+	background-color: rgb(38, 38, 38); /* gray-850 */  
+	color: rgb(255, 255, 255);  
+}
+
 @keyframes shimmer {
 	0% {
 		background-position: 200% 0;


### PR DESCRIPTION
### UPD_Styles: Add dark mode styles for select elements and options.

Actually some select "boxes" have css dark theme support, but other not. This PR add CSS for dark theme selects.

Fix e.g.:
<img width="521" height="268" alt="openwebui_dark_selectors" src="https://github.com/user-attachments/assets/50b0f028-f293-4bdd-9860-3a067164d7f6" />
<img width="521" height="268" alt="openwebui_dark_selectors0" src="https://github.com/user-attachments/assets/80018980-994b-47b2-aa42-cf2c33878de9" />
<img width="888" height="224" alt="openwebui_dark_selectors1" src="https://github.com/user-attachments/assets/159758c2-0a4b-4208-98f3-d5621587eee6" />
<img width="888" height="224" alt="openwebui_dark_selectors2" src="https://github.com/user-attachments/assets/8c8d5697-aa14-4f22-9033-b443027e4033" />

___

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
