### PR TITLE
feat(prompts): add support for prompts as prompt variables

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -287,7 +287,9 @@ async def generate_function_chat_completion(
         if params:
             system = params.pop("system", None)
             form_data = apply_model_params_to_body_openai(params, form_data)
-            form_data = apply_system_prompt_to_body(system, form_data, metadata, user)
+            form_data = apply_system_prompt_to_body(
+                system, form_data, metadata, user, model={"user_id": model_info.user_id}
+            )
 
     pipe_id = get_pipe_id(form_data)
     function_module = get_function_module_by_id(request, pipe_id)

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1338,7 +1338,9 @@ async def generate_chat_completion(
             system = params.pop("system", None)
 
             payload = apply_model_params_to_body_ollama(params, payload)
-            payload = apply_system_prompt_to_body(system, payload, metadata, user)
+            payload = apply_system_prompt_to_body(
+                system, payload, metadata, user, model={"user_id": model_info.user_id}
+            )
 
         # Check if user has access to the model
         if not bypass_filter and user.role == "user":
@@ -1527,7 +1529,9 @@ async def generate_openai_chat_completion(
             system = params.pop("system", None)
 
             payload = apply_model_params_to_body_openai(params, payload)
-            payload = apply_system_prompt_to_body(system, payload, metadata, user)
+            payload = apply_system_prompt_to_body(
+                system, payload, metadata, user, model={"user_id": model_info.user_id}
+            )
 
         # Check if user has access to the model
         if user.role == "user":

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -831,7 +831,9 @@ async def generate_chat_completion(
             system = params.pop("system", None)
 
             payload = apply_model_params_to_body_openai(params, payload)
-            payload = apply_system_prompt_to_body(system, payload, metadata, user)
+            payload = apply_system_prompt_to_body(
+                system, payload, metadata, user, model={"user_id": model_info.user_id}
+            )
 
         # Check if user has access to the model
         if not bypass_filter and user.role == "user":

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1005,10 +1005,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if system_message:  # Chat Controls/User Settings
         try:
             form_data = apply_system_prompt_to_body(
-                system_message.get("content"), form_data, metadata, user, replace=True
+                system_message.get("content"),
+                form_data,
+                metadata,
+                user,
+                replace=True,
+                model=model,
             )  # Required to handle system prompt variables
-        except:
-            pass
+        except Exception:
+            log.exception("Error applying system prompt")
 
     event_emitter = get_event_emitter(metadata)
     event_call = get_event_call(metadata)
@@ -1063,7 +1068,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             if folder and folder.data:
                 if "system_prompt" in folder.data:
                     form_data = apply_system_prompt_to_body(
-                        folder.data["system_prompt"], form_data, metadata, user
+                        folder.data["system_prompt"],
+                        form_data,
+                        metadata,
+                        user,
+                        model=model,
                     )
                 if "files" in folder.data:
                     form_data["files"] = [

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -22,7 +22,6 @@ def apply_system_prompt_to_body(
     metadata: Optional[dict] = None,
     user=None,
     replace: bool = False,
-    current_prompt_command: Optional[str] = None,
     model: Optional[dict] = None,
 ) -> dict:
     if not system:
@@ -71,8 +70,8 @@ def apply_system_prompt_to_body(
             log = logging.getLogger(__name__)
             log.warning(f"Error fetching user prompts: {e}")
 
-    # Legacy (API Usage) - now with prompts support
-    system = prompt_template(system, user, user_prompts, current_prompt_command)
+    # Legacy (API Usage) - now with prompts support and nested resolution
+    system = prompt_template(system, user, user_prompts)
 
     if replace:
         form_data["messages"] = replace_system_message_content(

--- a/src/lib/apis/prompts/index.ts
+++ b/src/lib/apis/prompts/index.ts
@@ -7,6 +7,38 @@ type PromptItem = {
 	access_control?: null | object;
 };
 
+export const validatePrompt = async (token: string, prompt: PromptItem) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/prompts/validate`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			...prompt,
+			command: `/${prompt.command}`
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const createNewPrompt = async (token: string, prompt: PromptItem) => {
 	let error = null;
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

This PR introduces a powerful new feature that combines workspace prompts with prompt variables, allowing users to reference workspace prompts using `{{PROMPTS.prompt_name}}` syntax within model system prompts and other contexts. The feature includes intelligent access control that respects user permissions while providing elevated access for admin-owned models, ensuring security without sacrificing functionality.

### Added

- **Prompt Variable Substitution**: New `{{PROMPTS.prompt_name}}` variable syntax that allows referencing workspace prompts by their command name
- **Recursive Variable Resolution**: Variables within referenced prompts (like `{{CURRENT_DATETIME}}`, `{{USER_NAME}}`, etc.) are automatically resolved
- **Self-injection Prevention**: Built-in protection against infinite recursion when prompts reference themselves
- **Admin-Owned Model Privilege Escalation**: Models created by admin users can access ALL workspace prompts, regardless of the end user's permissions
- Helper functions in `task.py`:
  - `_get_user_variables()`: Extracts user information into a dictionary for template processing
  - `_resolve_basic_variables()`: Handles resolution of date/time and user-related variables
  - `replace_prompts_variable()`: Core function for `{{PROMPTS.*}}` substitution with recursion prevention

### Changed

- Modified `apply_system_prompt_to_body()` in `payload.py` to accept optional `model` parameter for ownership checks
- Updated `apply_system_prompt_to_body()` to fetch appropriate prompts based on model ownership (all prompts for admin-owned models, accessible prompts for others)
- Refactored template processing functions to use DRY principles with shared helper functions
- Updated all call sites of `apply_system_prompt_to_body()` in:
  - `middleware.py` (2 locations)
  - `openai.py` (1 location)
  - `ollama.py` (2 locations)
  - `functions.py` (1 location)

### Deprecated

- None

### Removed

- None

### Fixed

- Eliminated code duplication in variable extraction and date formatting logic
- Removed unused import of `Prompts` from `task.py`

### Security

- **Access Control**: Respects prompt access control settings - users can only reference prompts they have read access to
- **Recursion Prevention**: Prevents infinite loops when prompts reference themselves or create circular dependencies
- **Privilege Escalation**: Admin-owned models can access all prompts, allowing admins to create powerful system prompts that work for all users without requiring individual permission grants

### Breaking Changes

- None - This is a purely additive feature with backward compatibility

---

### Additional Information

#### Use Cases

1. **Reusable System Prompt Components**: Create modular prompt components that can be referenced and reused across multiple models
2. **Dynamic Prompt Composition**: Compose complex system prompts by referencing multiple workspace prompts
3. **Admin-Managed Templates**: Admins can create models with prompts that reference private or restricted workspace prompts, and those models will work for all users

#### Example Usage

Create a workspace prompt with command `expert-persona`:
```markdown
You are an expert in software development with deep knowledge of Python, JavaScript, and system design.
Current time: {{CURRENT_DATETIME}}
```

Reference it in a model's system prompt:
```markdown
{{PROMPTS.expert-persona}}

Additional instructions: Help the user debug their code and provide best practices.
User: {{USER_NAME}}
```

The final resolved prompt will include the expert persona content with all variables expanded.

#### Technical Implementation Details

- Prompts are fetched once per request and cached for the duration of the template processing
- Variable resolution happens in order: metadata variables → basic variables (dates, user info) → prompt references
- Nested `{{PROMPTS.*}}` references within referenced prompts are intentionally not resolved to prevent complexity and potential circular dependencies
- Model ownership is determined by checking if the model's `user_id` belongs to a user with `role == "admin"`

### Screenshots or Videos

- N/A - Backend feature, behavior visible in chat interactions

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
