### PR TITLE
fix(mobile, menu): hide controls button on mobile based on permissions

### DIFF
--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -312,7 +312,7 @@
 				<div class="flex items-center">{$i18n.t('Settings')}</div>
 			</DropdownMenu.Item> -->
 
-			{#if $mobile}
+			{#if $mobile && ($user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true))}
 				<DropdownMenu.Item
 					class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full"
 					id="chat-controls-button"


### PR DESCRIPTION
Prevents chat controls from appearing on mobile unless the user is an admin or has explicit chat control permissions. Improves access control and user experience by hiding options from unauthorized users.

# Changelog Entry

### Description

Prevents chat controls from appearing on mobile unless the user is an admin or has explicit chat control permissions. Improves access control and user experience by hiding options from unauthorized users.

### Fixed

- Controls button is now properly hidden for mobile users

### Security

- None: actual chat controls page would still not render even if the button was available

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
