### PR TITLE
fix(auth): Decode trusted name header to support non-ASCII usernames

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -4,6 +4,7 @@ import time
 import datetime
 import logging
 from aiohttp import ClientSession
+import urllib.parse
 
 from open_webui.models.auths import (
     AddUserForm,
@@ -471,7 +472,14 @@ async def signin(request: Request, response: Response, form_data: SigninForm):
         name = email
 
         if WEBUI_AUTH_TRUSTED_NAME_HEADER:
-            name = request.headers.get(WEBUI_AUTH_TRUSTED_NAME_HEADER, email)
+            raw_name = request.headers.get(WEBUI_AUTH_TRUSTED_NAME_HEADER)
+            if raw_name is not None:
+                try:
+                    decoded_name = urllib.parse.unquote(raw_name, encoding='utf-8')
+                    if decoded_name:
+                        name = decoded_name
+                except Exception:
+                    pass
 
         if not Users.get_user_by_email(email.lower()):
             await signup(


### PR DESCRIPTION
## Description

This PR fixes an issue where usernames containing non-ASCII characters (e.g., Korean, Japanese, Cyrillic) were displayed incorrectly during trusted header authentication.

The name would appear as a raw URL-encoded string (like `%ED%99%8D...`) instead of the actual characters (e.g., `홍길동`).

## How it was fixed

The problem occurred because the backend was reading the `WEBUI_AUTH_TRUSTED_NAME_HEADER` value directly without decoding it.

This fix introduces `urllib.parse.unquote` to the sign-in logic. This correctly decodes the header value, converting any URL-encoded sequences back into their original characters before assigning the name to the user.

This ensures usernames in all languages are displayed correctly while still allowing for safe transport of non-ASCII characters in HTTP headers.

## Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.