### PR TITLE
fix: audio deletes existing text/prompt

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -335,7 +335,7 @@
 
 		text = await textVariableHandler(text);
 
-		if (command) {
+		if (command && showCommands) {
 			replaceCommandWithText(text);
 		} else {
 			chatInputElement?.insertContent(text);
@@ -1019,33 +1019,36 @@
 						}}
 					/>
 
-					{#if recording}
-						<VoiceRecording
-							bind:recording
-							onCancel={async () => {
-								recording = false;
-
-								await tick();
-								document.getElementById('chat-input')?.focus();
-							}}
-							onConfirm={async (data) => {
-								const { text, filename } = data;
-
-								recording = false;
-
-								await tick();
-								await insertTextAtCursor(text);
-								await tick();
-								document.getElementById('chat-input')?.focus();
-
-								if ($settings?.speechAutoSend ?? false) {
-									dispatch('submit', prompt);
-								}
-							}}
-						/>
-					{:else}
-						<form
-							class="w-full flex flex-col gap-1.5"
+					<div class={recording ? '' : 'hidden'}>
+						{#key recording}
+							<VoiceRecording
+								bind:recording
+								onCancel={async () => {
+									recording = false;
+					
+									await tick();
+									document.getElementById('chat-input')?.focus();
+								}}
+								onConfirm={async (data) => {
+									const { text, filename } = data;
+					
+									recording = false;
+					
+									await tick();
+									await insertTextAtCursor(text);
+									await tick();
+									document.getElementById('chat-input')?.focus();
+					
+									if ($settings?.speechAutoSend ?? false) {
+										dispatch('submit', prompt);
+									}
+								}}
+							/>
+						{/key}
+					</div>
+					
+					<form
+						class="w-full flex flex-col gap-1.5 {recording ? 'hidden' : ''}"
 							on:submit|preventDefault={() => {
 								// check if selectedModels support image input
 								dispatch('submit', prompt);
@@ -1804,8 +1807,7 @@
 							{:else}
 								<div class="mb-1" />
 							{/if}
-						</form>
-					{/if}
+					</form>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes this issue: https://github.com/open-webui/open-webui/issues/18540 .

For the technical details, see the "additional information" part.

I made sure that the autocompletion for commands still work (for `/`, `@`, or `#`), as it has a little logic change at `insertTextAtCursor` which is used by it too.

### Added

None

### Changed

None

### Deprecated

None

### Removed

None

### Fixed

Fixes an issue where using STT replaces existing text/prompt.

### Security

None

### Breaking Changes

None

---

### Additional Information

Technical details:
- Using conditional rendering **resets the state**. The rich text editor will begin with a blank state every time the voice recording ends, hence resetting the prompts.
- Using CSS to hide it,  meanwhile, preserves the state.
- The `#key` at the voice component is used to reset the state of the voice recording component. If we don't have this, once you click record again, you will still see the previous waveform.
- Added `&& showCommands` to fix an issue where if you are dictating when your cursor is at the end of a word, it will replace that word (because it's considered a part of a command). This ensures that it will only replace if it's a running command (i.e. starting with '@', '/', or '#')

Issue: https://github.com/open-webui/open-webui/issues/18540

### Screenshots or Videos

https://github.com/user-attachments/assets/e84f1b4d-5bb4-4f34-9278-e98b65b3694a

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
