### PR TITLE
fix: <details> tags for reasoning not identified if tag is present in user message

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1952,20 +1952,22 @@ async def process_chat_response(
                         if content and not content.endswith("\n"):
                             content += "\n"
 
+                        escaped_reasoning_display_content = html.escape(reasoning_display_content)
+
                         if reasoning_duration is not None:
                             if raw:
                                 content = (
                                     f'{content}{start_tag}{block["content"]}{end_tag}\n'
                                 )
                             else:
-                                content = f'{content}<details type="reasoning" done="true" duration="{reasoning_duration}">\n<summary>Thought for {reasoning_duration} seconds</summary>\n{reasoning_display_content}\n</details>\n'
+                                content = f'{content}<details type="reasoning" done="true" duration="{reasoning_duration}">\n<summary>Thought for {reasoning_duration} seconds</summary>\n{escaped_reasoning_display_content}\n</details>\n'
                         else:
                             if raw:
                                 content = (
                                     f'{content}{start_tag}{block["content"]}{end_tag}\n'
                                 )
                             else:
-                                content = f'{content}<details type="reasoning" done="false">\n<summary>Thinking…</summary>\n{reasoning_display_content}\n</details>\n'
+                                content = f'{content}<details type="reasoning" done="false">\n<summary>Thinking…</summary>\n{escaped_reasoning_display_content}\n</details>\n'
 
                     elif block["type"] == "code_interpreter":
                         attributes = block.get("attributes", {})

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -8,6 +8,7 @@
 
 	import { marked, type Token } from 'marked';
 	import { unescapeHtml } from '$lib/utils';
+	import { decode } from 'html-entities';
 
 	import { WEBUI_BASE_URL } from '$lib/constants';
 
@@ -294,6 +295,15 @@
 			</ul>
 		{/if}
 	{:else if token.type === 'details'}
+		<!-- We are escaping the contents of the reasoning block,
+		so if the LLM returns <details> inside their response,
+		it doesn't conflict with the actual <details> block we're using to display.
+
+		Hence, we need to decode the text before passing to marked.
+		
+		Can be extended with other attribute types if needed in the future. -->
+		{@const shouldDecodeTokens = ['reasoning'].includes(token?.attributes?.type)}
+
 		<Collapsible
 			title={token.summary}
 			open={$settings?.expandDetails ?? false}
@@ -304,7 +314,7 @@
 			<div class=" mb-1.5" slot="content">
 				<svelte:self
 					id={`${id}-${tokenIdx}-d`}
-					tokens={marked.lexer(token.text)}
+					tokens={marked.lexer(shouldDecodeTokens ? decode(token.text) : token.text)}
 					attributes={token?.attributes}
 					{done}
 					{editCodeBlock}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes this bug presented in https://github.com/open-webui/open-webui/issues/18294 . 

See "Additional information" for technical details.

### Added

None

### Changed

None

### Deprecated

None

### Removed

None

### Fixed

Fixes issue https://github.com/open-webui/open-webui/issues/18294

### Security

None

### Breaking Changes

None

---

### Additional Information

Before, as the contents were not escaped, the block had some troubles deciding which one is the actual `<details>` block. The main reason was because the serialization of reasoning blocks in `middleware.py` is not escaped.

This is different from tool_calls that already do it:

```py
                                if tool_result is not None:
                                    tool_result_embeds = result.get("embeds", "")
                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds))}">\n<summary>Tool Executed</summary>\n</details>\n'
                                else:
                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="false" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}">\n<summary>Executing...</summary>\n</details>\n'
```

or `code_interpreter` that does it too:

```py
                        if output:
                            output = html.escape(json.dumps(output))

                            if raw:
                                content = f'{content}<code_interpreter type="code" lang="{lang}">\n{block["content"]}\n</code_interpreter>\n```output\n{output}\n```\n'
                            else:
                                content = f'{content}<details type="code_interpreter" done="true" output="{output}">\n<summary>Analyzed</summary>\n```{lang}\n{block["content"]}\n```\n</details>\n'
                        else:
                            if raw:
                                content = f'{content}<code_interpreter type="code" lang="{lang}">\n{block["content"]}\n</code_interpreter>\n'
                            else:
                                content = f'{content}<details type="code_interpreter" done="false">\n<summary>Analyzing...</summary>\n```{lang}\n{block["content"]}\n```\n</details>\n'
```

By following the same logic to perform HTML escape in the reasoning part, i.e. adding:

```py
escaped_reasoning_display_content = html.escape(reasoning_display_content)
```

and properly decoding it at the frontend, this problem is solved.

### Screenshots or Videos

https://github.com/user-attachments/assets/1990b9a8-d7be-414c-9b0d-5a2babaa30ca

<img width="1239" height="379" alt="image" src="https://github.com/user-attachments/assets/752521fb-a5d7-4e75-afc9-ae267e00e18a" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
