### PR TITLE
fix(chat): prevent duplicate prompt suggestions causing UI freeze

### DIFF
--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -29,6 +29,9 @@
 	// Only increase version if something wirklich geändert hat
 	$: getFilteredPrompts(inputValue);
 
+	// Deduplicate prompts to prevent Svelte key errors
+	$: uniquePrompts = [...new Map(filteredPrompts.map(prompt => [prompt.id || prompt.content, prompt])).values()];
+
 	// Helper function to check if arrays are the same
 	// (based on unique IDs oder content)
 	function arraysEqual(a, b) {
@@ -84,7 +87,7 @@
 <div class="h-40 w-full">
 	{#if filteredPrompts.length > 0}
 		<div role="list" class="max-h-40 overflow-auto scrollbar-none items-start {className}">
-			{#each filteredPrompts as prompt, idx (prompt.id || prompt.content)}
+			{#each uniquePrompts as prompt, idx (prompt.id || prompt.content)}
 				<!-- svelte-ignore a11y-no-interactive-element-to-noninteractive-role -->
 				<button
 					role="listitem"


### PR DESCRIPTION
## Summary
Add reactive deduplication logic to prevent duplicate prompt suggestions from causing UI freeze in Svelte each block.

## Issue
Fixes #18566 - Duplicate prompt suggestions freezes webpage and throws JS error (2 bugs!)

## Changes Made
- [x] Added reactive deduplication using Map for filteredPrompts
- [x] Ensured unique keys in Svelte each block
- [x] Prevented "Cannot have duplicate keys" error
- [x] Maintained existing prompt filtering functionality

## Testing
- [x] Reproduced duplicate prompt suggestions freeze
- [x] Verified fix prevents UI freeze
- [x] Tested with multiple duplicate prompts
- [x] Confirmed no console errors after fix

## Additional Information
This fix addresses the root cause of browser freezing when duplicate prompt content exists by ensuring unique keys in the Svelte each block.

I agree to the terms of the Contributor License Agreement (CLA) and grant the necessary rights for my contributions to be included in this open-source project.

💘 Generated with Crush