### PR TITLE
refactor(retrieval): remove duplicate MistralLoader code block

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -393,15 +393,6 @@ class Loader:
             loader = MistralLoader(
                 api_key=self.kwargs.get("MISTRAL_OCR_API_KEY"), file_path=file_path
             )
-        elif (
-            self.engine == "external"
-            and self.kwargs.get("MISTRAL_OCR_API_KEY") != ""
-            and file_ext
-            in ["pdf"]  # Mistral OCR currently only supports PDF and images
-        ):
-            loader = MistralLoader(
-                api_key=self.kwargs.get("MISTRAL_OCR_API_KEY"), file_path=file_path
-            )
         else:
             if file_ext == "pdf":
                 loader = PyPDFLoader(


### PR DESCRIPTION
## Summary
Remove duplicate MistralLoader code block with incorrect conditional logic in document loader main.py.

## Issue
Fixes #17256 - Duplicate external document loader entry

## Changes Made
- [x] Removed duplicate MistralLoader block (lines 364-372)
- [x] Kept the correct MistralLoader implementation
- [x] Cleaned up incorrect conditional logic

## Testing
- [x] Verified duplicate code block existed
- [x] Confirmed removal doesn't break functionality
- [x] Tested document loading with various file types

## Additional Information
This refactor removes code duplication and incorrect loader assignment that could cause issues with document processing.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

💘 Generated with Crush