### PR TITLE
fix: Prevents redundant file processing on Knowledge Base upload

### DIFF
--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -1,7 +1,7 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { splitStream } from '$lib/utils';
 
-export const uploadFile = async (token: string, file: File, metadata?: object | null) => {
+export const uploadFile = async (token: string, file: File, metadata?: object | null,process: boolean = true) => {
 	const data = new FormData();
 	data.append('file', file);
 	if (metadata) {
@@ -9,8 +9,9 @@ export const uploadFile = async (token: string, file: File, metadata?: object | 
 	}
 
 	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/files/`, {
+	const queryParams = new URLSearchParams();
+	queryParams.append('process', process.toString());
+	const res = await fetch(`${WEBUI_API_BASE_URL}/files/?${queryParams.toString()}`, {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json',

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -177,7 +177,7 @@
 				};
 			}
 
-			const uploadedFile = await uploadFile(localStorage.token, file, metadata).catch((e) => {
+			const uploadedFile = await uploadFile(localStorage.token, file, metadata, false).catch((e) => {
 				toast.error(`${e}`);
 				return null;
 			});


### PR DESCRIPTION
Fixes #18689
Related to #18571, #14457, #11868, #8240, #11331
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixes a bug where uploading a file to a Knowledge Base creates two separate, redundant vector collections. This was caused by the frontend calling two different API endpoints that both triggered processing.

### Added

- N/A

### Changed

- `src/lib/apis/files/index.ts`: The `uploadFile` function was updated to accept a `process` parameter (defaulting to `true`) and pass it as a query param in its `fetch` call.
- `src/lib/components/workspace/Knowledge/KnowledgeBase.svelte`: The `uploadFileHandler` function now calls `uploadFile` with `process=false` to prevent the first, redundant processing job.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- **Duplicate Processing:** Stops the redundant file processing and resource waste when adding new files to a Knowledge Base.
- **Storage Waste:** Ensures only one vector collection is created per file, which is correctly associated with the Knowledge Base ID (e.g., `1393d538...`) instead of the generic file ID (e.g., `file-bb97c4f9...`)] solving duplicate data reports like #8240.
- **Access Errors:** Fixes a critical race condition where users would get 404 errors or "file not found" because the app was trying to access the wrong vector collection (`file-{uuid}` instead of the Knowledge Base ID). This solves issues like #18689 and #18571.
- **Upload Timeouts:** Prevents `504 Gateway Timeout` errors on large file uploads (like in #14457 and #11868) by skipping the first, redundant processing job that was causing the timeout.


### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- This fix directly addresses the root cause of issues like #18689, where users report seeing two different `collection_name` values (`file-{uuid}` and the Knowledge Base ID) for the same file.
- This fix is safe and does not break the file upload feature in the main chat window, which relies on the `process=True` default.
- This frontend fix works by targeting the conditional logic in the backend.
- The `routers/files.py` file accepts a `process: bool = Query(True)` parameter. The `upload_file_handler` in that same file only runs the processing inside an `if process:` block.
- By sending `process=false` from the Knowledge Base, we are telling the backend to skip this block for the first API call, which prevents the redundant processing.

### How to Test This Fix

1.  **Run the `main` branch (without this fix).**
2.  Open the console and go to the "Network" tab to monitor API calls.
3.  Go to a Knowledge Base and upload a file.
4.  **Observe:** You will see two processing jobs:
    * `POST /api/v1/files/?process=true` (Job 1)
    * `POST /api/v1/knowledge/.../file/add` (Job 2)
5.  Check your `vector_db` folder. You will see **two** new collections (one `file-...` and one with the KB ID).
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
6.  **Now, run this `fix/...` branch.**
7.  Clear your console and go to a Knowledge Base.
8.  Upload the same file.
9.  **Observe:** You will now only see one *real* processing job:
    * `POST /api/v1/files/?process=false` (Job 1 - **skips processing**)
    * `POST /api/v1/knowledge/.../file/add` (Job 2 - **processes the file**)
10. Check your `vector_db` folder. You will see **only one** new collection (the one with the KB ID).

### Screenshots or Videos

- N/A (This is a code-only change to the upload workflow.)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
