### PR TITLE
feat: Restrict Sharing to Specific Groups (backwards compatible)

### DIFF
--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -73,6 +73,9 @@
 			web_search: true,
 			image_generation: true,
 			code_interpreter: true
+		},
+		group: {
+			allow_sharing_to: true
 		}
 	};
 	export let userIds = [];

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -47,6 +47,9 @@
 			image_generation: true,
 			code_interpreter: true,
 			notes: true
+		},
+		group: {
+			allow_sharing_to: true
 		}
 	};
 
@@ -65,7 +68,8 @@
 			workspace: { ...defaults.workspace, ...obj.workspace },
 			sharing: { ...defaults.sharing, ...obj.sharing },
 			chat: { ...defaults.chat, ...obj.chat },
-			features: { ...defaults.features, ...obj.features }
+			features: { ...defaults.features, ...obj.features },
+			group: { ...defaults.group, ...obj.group }
 		};
 	}
 
@@ -231,6 +235,28 @@
 				<Switch bind:state={permissions.sharing.public_notes} />
 			</div>
 			{#if defaultPermissions?.sharing?.public_notes && !permissions.sharing.public_notes}
+				<div>
+					<div class="text-xs text-gray-500">
+						{$i18n.t('This is a default user permission and will remain enabled.')}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<hr class=" border-gray-100 dark:border-gray-850" />
+
+	<div>
+		<div class=" mb-2 text-sm font-medium">{$i18n.t('Group Settings')}</div>
+
+		<div class="flex flex-col w-full">
+			<div class="flex w-full justify-between my-1">
+				<div class=" self-center text-xs font-medium">
+					{$i18n.t('Allow Sharing to Group')}
+				</div>
+				<Switch bind:state={permissions.group.allow_sharing_to} />
+			</div>
+			{#if defaultPermissions?.group?.allow_sharing_to && !permissions.group.allow_sharing_to}
 				<div>
 					<div class="text-xs text-gray-500">
 						{$i18n.t('This is a default user permission and will remain enabled.')}

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -176,7 +176,7 @@
 									<option class=" text-gray-700" value="" disabled selected
 										>{$i18n.t('Select a group')}</option
 									>
-									{#each groups.filter((group) => !(accessControl?.read?.group_ids ?? []).includes(group.id)) as group}
+									{#each groups.filter((group) => !(accessControl?.read?.group_ids ?? []).includes(group.id) && (group.permissions?.group?.allow_sharing_to !== false)) as group}
 										<option class=" text-gray-700" value={group.id}>{group.name}</option>
 									{/each}
 								</select>


### PR DESCRIPTION
# Pull Request Checklist

Closes: https://github.com/open-webui/open-webui/issues/18887 and works towards https://github.com/open-webui/open-webui/discussions/16793 in a complimentary manner

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [x] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Tried to keep this super minimal and surgical, I think this is the cleanest way we can implement cc @Classic298 who was interested in this and @tjbck
When running an instance with a large user population, sharing becomes extremely messy. We've restricted public sharing (a feature I also contributed for the same underlying reason) but users have effectively bypassed that control by sharing with large groups synced in from the IdP. This results in their work-in-progress, limited value, or otherwise not useful models, knowledge collections, and such getting forced into user views and confusing folks.

This PR implements a new "Allow Sharing to Group" toggle in the Edit Group modal under Permissions. When disabled, groups remain functional for all other purposes but won't appear as options in the sharing UI, preventing users from bypassing public sharing controls by targeting large groups.

### Added

- New "Allow Sharing to Group" toggle in Edit Group modal under Permissions tab
- New "Group Settings" section in group permissions UI
- Default value of `true` for `permissions.group.allow_sharing_to` to maintain backward compatibility
- Filtering logic in AccessControl component to hide groups where `allow_sharing_to` is `false`

### Changed

- Updated `DEFAULT_PERMISSIONS` in Permissions.svelte to include `group` section with `allow_sharing_to` field
- Updated default permissions object in EditGroupModal.svelte to include group settings
- Modified `fillMissingProperties` function to merge group permissions
- Enhanced group filtering in AccessControl.svelte dropdown to respect `allow_sharing_to` permission

### Deprecated

- None

### Removed

- None

### Fixed

- Prevents users from bypassing public sharing restrictions by sharing to large IdP-synced groups

### Security

- Improves sharing control capabilities for administrators managing large user populations

### Breaking Changes

- None - defaults to `true` (enabled) for backward compatibility with existing groups

---

### Additional Information

- This change follows the existing pattern used for public sharing controls (e.g., "Models Public Sharing", "Tools Public Sharing")
- Groups with the toggle disabled remain fully functional for all other purposes - they simply don't appear as sharing targets
- No backend changes required as the `permissions` field already supports arbitrary JSON structures
- Alternative approach of using a "group size" threshold (e.g., any group with more than 1000 users) was considered but this permission-based approach fits better with the current permission scheme and provides more granular admin control

### Screenshots or Videos
<img width="741" height="534" alt="image" src="https://github.com/user-attachments/assets/48296b06-b552-495e-a7c7-396bafe6d480" />
<img width="477" height="61" alt="image" src="https://github.com/user-attachments/assets/8906ce61-8d18-4767-832d-112a981b05c1" />
(Results in ->)
<img width="1234" height="315" alt="image" src="https://github.com/user-attachments/assets/01165e53-992c-4bb8-be90-6b1cad68d856" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
