### PR TITLE
fix: Prevents complex or large tool call results from being dropped in Native tool-calling UI (#18743)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1915,7 +1915,12 @@ async def process_chat_response(
 
                                 if tool_result is not None:
                                     tool_result_embeds = result.get("embeds", "")
-                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds))}">\n<summary>Tool Executed</summary>\n</details>\n'
+                                    result_json = html.escape(json.dumps(tool_result, ensure_ascii=False))
+                                    tool_calls_display_content = f'''{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds))}">
+                                    <summary>Tool Executed</summary>
+                                    <div class="tool-result" style="display:none;">{result_json}</div>
+                                    </details>
+                                    '''
                                 else:
                                     tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="false" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}">\n<summary>Executing...</summary>\n</details>\n'
 

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -47,6 +47,17 @@
 		return 'h' + depth;
 	};
 
+	const extractResultFromDetails = (token): string => {
+		if (token?.attributes?.type === 'tool_calls') {
+			const match = token.text.match(/<div class="tool-result"[^>]*>([\s\S]*?)<\/div>/);
+			if (match) {
+				return match[1];
+			}
+			return token.attributes?.result || '';
+		}
+		return '';
+	}
+
 	const exportTableToCSVHandler = (token, tokenIdx = 0) => {
 		console.log('Exporting table to CSV');
 
@@ -294,17 +305,20 @@
 			</ul>
 		{/if}
 	{:else if token.type === 'details'}
+		{@const result = extractResultFromDetails(token)}
+		{@const cleanedText = token.text.replace(/<div class="tool-result"[^>]*>[\s\S]*?<\/div>/, '')}
+
 		<Collapsible
 			title={token.summary}
 			open={$settings?.expandDetails ?? false}
-			attributes={token?.attributes}
+			attributes={{...token?.attributes, result: result}}
 			className="w-full space-y-1"
 			dir="auto"
 		>
 			<div class=" mb-1.5" slot="content">
 				<svelte:self
 					id={`${id}-${tokenIdx}-d`}
-					tokens={marked.lexer(token.text)}
+					tokens={marked.lexer(cleanedText)}
 					attributes={token?.attributes}
 					{done}
 					{editCodeBlock}

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -53,6 +53,8 @@
 			if (match) {
 				return match[1];
 			}
+
+			// Fallback to the result attribute for backward compatibility
 			return token.attributes?.result || '';
 		}
 		return '';


### PR DESCRIPTION
Implements the fix described in #18743

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

🧰 Fixed an issue where tool call results containing complex or unescaped characters (quotes, braces, Unicode, markdown syntax, etc.) were dropped from the Native tool-calling UI. Tool results now render reliably regardless of size or character composition.

### Description

We were experiencing an issue with Native tool-calling where large or complex tool results would sometimes fail to display in the UI, even though the backend executed the tool successfully.

This affects any tools that return structured or verbose data (for example, RAG searches or JSON-based functions) where the result contains long text, nested objects, or special characters (quotes, braces, markdown, Unicode, etc.).

The issue stems from the current approach of serializing the tool result into an HTML attribute in middleware.py. That mechanism is fragile for large or irregularly escaped data, causing the attribute to be dropped during parsing and leaving the result section empty in the UI, even though backend logs confirm it was sent and processed correctly.

The proposed fix moves the result into the element content instead of an attribute, ensuring tool outputs are always preserved and visible to users.

### Changed

- middleware.py - moved tool result data into element content instead of an HTML attribute
- MarkdownTokens.svelte - `extractResultFromDetails` pull the tool result from the element, falls back to the "result" attribute for backward compatibility

### Fixed

- Large/complex tool results will be properly displayed in the UI

---

### Additional Information

- In the event that others are relying on this "result" attribute in the details element, the frontend will fallback to pulling from that attribute if the tool-result div isn't present, providing backward compatibility.

### Screenshots or Videos

- To test the issue and fix, I created a tool that returns adversarial data (large amounts of unescaped quotes, emojis, markdown fences, unmatched braces, etc).
- In the following screenshot, you can see that the model clearly receives the tool result, but it's not displayed in the UI:

<img width="1036" height="457" alt="Screenshot 2025-11-03 at 11 42 08 AM" src="https://github.com/user-attachments/assets/c0085a14-b44b-401f-958f-db43551716b7" />

- The following screenshot is the same tool call result, but with the fix:
<img width="1006" height="523" alt="Screenshot 2025-11-03 at 2 17 55 PM" src="https://github.com/user-attachments/assets/6ecbfe30-a337-44ad-90dc-39a3887638b2" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
