### PR TITLE
fix: reposition sub-menus to prevent overlap with right-hand sidebar

### DIFF
--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -385,6 +385,7 @@
 				<DropdownMenu.SubContent
 					class="w-full rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100  dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 					transition={flyAndScale}
+					side={$showControls ? 'left' : 'right'}
 					sideOffset={8}
 				>
 					{#if $user?.role === 'admin' || ($user.permissions?.chat?.export ?? true)}
@@ -448,6 +449,7 @@
 					<DropdownMenu.SubContent
 						class="w-full rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100  dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 						transition={flyAndScale}
+						side={$showControls ? 'left' : 'right'}
 						sideOffset={8}
 					>
 						{#each $folders.sort((a, b) => b.updated_at - a.updated_at) as folder}

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -66,8 +66,8 @@
 		<DropdownMenu.Content
 			class="w-full {className}  rounded-2xl px-1 py-1  border border-gray-100  dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg text-sm"
 			sideOffset={4}
-			side="bottom"
-			align="start"
+			side="top"
+			align="end"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
 			<DropdownMenu.Item

--- a/src/lib/components/notes/Notes/NoteMenu.svelte
+++ b/src/lib/components/notes/Notes/NoteMenu.svelte
@@ -5,7 +5,7 @@
 	import { flyAndScale } from '$lib/utils/transitions';
 	import { fade, slide } from 'svelte/transition';
 
-	import { showSettings, mobile, showSidebar, user } from '$lib/stores';
+	import { showSettings, mobile, showSidebar, user, showControls } from '$lib/stores';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ArchiveBox from '$lib/components/icons/ArchiveBox.svelte';
@@ -60,6 +60,7 @@
 					transition={flyAndScale}
 					sideOffset={8}
 					align="end"
+					side={showControls ? 'left' : 'right'}
 				>
 					<DropdownMenu.Item
 						class="flex gap-2 items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
@@ -104,6 +105,7 @@
 						transition={flyAndScale}
 						sideOffset={8}
 						align="end"
+						side={showControls ? 'left' : 'right'}
 					>
 						{#if onCopyLink}
 							<DropdownMenu.Item


### PR DESCRIPTION
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [X] **Target branch:** Verify that the pull request targets the `dev` branch. Not targeting the `dev` branch may lead to immediate closure of the PR.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to verify the implemented fix/feature works as intended AND does not break any other functionality. Take this as an opportunity to make screenshots of the feature/fix and include it in the PR description.
- [X] **Agentic AI Code:**: Confirm this Pull Request is **not written by any AI Agent** or has at least gone through additional human review **and** manual testing. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- This pull request repositions multiple UI menus to prevent them from overlapping with the "Chat Controls" sidebar when it is open. The user menu, the "Download" submenu, and the "Move" to folder submenu have all been adjusted to ensure all UI elements remain visible and accessible. **There are no breaking changes with this PR despite the usage of the word "reposition".**

### Changed
- Updated `src/lib/components/layout/Sidebar/UserMenu.svelte` to change the `side` and `align` props of the `DropdownMenu.Content` component, making the menu open upwards and to the left.
- Updated `src/lib/components/layout/Navbar/Menu.svelte` to conditionally change the `side` prop for the "Download" and "Move" submenus. They will now open to the left when the "Chat Controls" sidebar is active.

### Fixed
- The user menu was overlapping with the "Chat Controls" sidebar.
- The "Download" options submenu was overlapping with the "Chat Controls" sidebar.
- The "Move" to folder submenu was overlapping with the "Chat Controls" sidebar.

### Screenshots or Videos
### Before
<img width="484" height="391" alt="image" src="https://github.com/user-attachments/assets/76b4d0c1-cc91-4b96-9728-45820bccf15c" />

### After
<img width="625" height="397" alt="image" src="https://github.com/user-attachments/assets/eb98bbcc-cda5-49ba-bd4c-86aedc837223" />

### Before
<img width="645" height="390" alt="image" src="https://github.com/user-attachments/assets/b2e318a1-a084-482d-96e7-335baaa73ba0" />

### After
<img width="840" height="423" alt="image" src="https://github.com/user-attachments/assets/3680e6d2-faa5-45ee-970f-155db55a2ac7" />

### Before
<img width="840" height="423" alt="image" src="https://github.com/user-attachments/assets/cb5a7ecd-70df-468d-b66f-bcacb488e988" />

### After
<img width="840" height="423" alt="image" src="https://github.com/user-attachments/assets/b7291a24-020e-4a31-be9b-117d85e62544" />

### Before
<img width="727" height="219" alt="image" src="https://github.com/user-attachments/assets/4c1dc4ef-65f9-432c-8698-c53d2fe4566c" />

### After
<img width="886" height="232" alt="image" src="https://github.com/user-attachments/assets/13aba513-e7f8-4439-ac79-10976b93533f" />

### Before
<img width="727" height="219" alt="image" src="https://github.com/user-attachments/assets/200b3e6c-41de-4aed-bccb-e15489bf02f0" />

### After
<img width="889" height="201" alt="image" src="https://github.com/user-attachments/assets/46e10bae-1bfb-4031-be97-d802c984502c" />

### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.