### PR TITLE
fix: resolve Firecrawl import error and Socket.IO CORS warning

### DIFF
--- a/backend/open_webui/retrieval/web/firecrawl.py
+++ b/backend/open_webui/retrieval/web/firecrawl.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.env import SRC_LOG_LEVELS
 
-from firecrawl import Firecrawl
+from firecrawl import FirecrawlApp
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
@@ -18,7 +18,7 @@ def search_firecrawl(
     filter_list: Optional[List[str]] = None,
 ) -> List[SearchResult]:
     try:
-        firecrawl = Firecrawl(api_key=firecrawl_api_key, api_url=firecrawl_url)
+        firecrawl = FirecrawlApp(api_key=firecrawl_api_key, api_url=firecrawl_url)
         response = firecrawl.search(
             query=query, limit=count, ignore_invalid_urls=True, timeout=count * 3
         )

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -41,7 +41,7 @@ from open_webui.config import (
 )
 from open_webui.env import SRC_LOG_LEVELS
 
-from firecrawl import Firecrawl
+from firecrawl import FirecrawlApp
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
@@ -227,7 +227,7 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
             self.params,
         )
         try:
-            firecrawl = Firecrawl(api_key=self.api_key, api_url=self.api_url)
+            firecrawl = FirecrawlApp(api_key=self.api_key, api_url=self.api_url)
             result = firecrawl.batch_scrape(
                 self.web_paths,
                 formats=["markdown"],
@@ -266,7 +266,7 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
             self.params,
         )
         try:
-            firecrawl = Firecrawl(api_key=self.api_key, api_url=self.api_url)
+            firecrawl = FirecrawlApp(api_key=self.api_key, api_url=self.api_url)
             result = firecrawl.batch_scrape(
                 self.web_paths,
                 formats=["markdown"],

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -53,6 +53,9 @@ log.setLevel(SRC_LOG_LEVELS["SOCKET"])
 
 REDIS = None
 
+# Socket.IO requires '*' as a string, not ['*'] as a list for wildcard CORS
+SOCKETIO_CORS_ORIGINS = '*' if CORS_ALLOW_ORIGIN == ['*'] else CORS_ALLOW_ORIGIN
+
 if WEBSOCKET_MANAGER == "redis":
     if WEBSOCKET_SENTINEL_HOSTS:
         mgr = socketio.AsyncRedisManager(
@@ -63,7 +66,7 @@ if WEBSOCKET_MANAGER == "redis":
     else:
         mgr = socketio.AsyncRedisManager(WEBSOCKET_REDIS_URL)
     sio = socketio.AsyncServer(
-        cors_allowed_origins=CORS_ALLOW_ORIGIN,
+        cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode="asgi",
         transports=(["websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,
@@ -72,7 +75,7 @@ if WEBSOCKET_MANAGER == "redis":
     )
 else:
     sio = socketio.AsyncServer(
-        cors_allowed_origins=CORS_ALLOW_ORIGIN,
+        cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode="asgi",
         transports=(["websocket"] if ENABLE_WEBSOCKET_SUPPORT else ["polling"]),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,


### PR DESCRIPTION
## Description
Fixes #18973 

This PR resolves two issues:
1. **Firecrawl Import Error**: Updates imports to use `FirecrawlApp` instead of `Firecrawl` (firecrawl v1.12.0+ API change)
2. **Socket.IO CORS Warning**: Properly handles wildcard CORS origins for Socket.IO

## Changes
- Updated `backend/open_webui/retrieval/web/utils.py`: Changed Firecrawl imports and instantiations
- Updated `backend/open_webui/retrieval/web/firecrawl.py`: Changed Firecrawl imports and instantiations  
- Updated `backend/open_webui/socket/main.py`: Added proper CORS origin handling for Socket.IO

## Testing
- ✅ Application starts without ImportError
- ✅ Socket.IO connects without CORS warnings
- ✅ Firecrawl integration works with current package version (v1.12.0)

## Root Cause Analysis

### Firecrawl Import Error
The firecrawl package changed its exported class name from `Firecrawl` to `FirecrawlApp` in recent versions. Open-WebUI was still importing the old class name, causing:
```
ImportError: cannot import name 'Firecrawl' from 'firecrawl'
```

### Socket.IO CORS Warning
Open-WebUI's `CORS_ALLOW_ORIGIN` config splits on `;` resulting in `['*']` when set to `'*'`. Socket.IO's `cors_allowed_origins` parameter expects the string `'*'` for wildcard, not a list `['*']`, causing origin validation warnings.

## Additional Context
- The firecrawl package (v1.12.0+) only exports `FirecrawlApp`
- Socket.IO documentation specifies wildcard origins must be a string, not a list
- Both fixes are backwards compatible and non-breaking