### PR TITLE
feat: support for semicolon-separated OAuth group claims

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -570,6 +570,8 @@ OAUTH_BLOCKED_GROUPS = PersistentConfig(
     os.environ.get("OAUTH_BLOCKED_GROUPS", "[]"),
 )
 
+OAUTH_GROUPS_SEPARATOR = os.environ.get("OAUTH_GROUPS_SEPARATOR", ";")
+
 OAUTH_ROLES_CLAIM = PersistentConfig(
     "OAUTH_ROLES_CLAIM",
     "oauth.roles_claim",

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -42,6 +42,7 @@ from open_webui.config import (
     ENABLE_OAUTH_GROUP_MANAGEMENT,
     ENABLE_OAUTH_GROUP_CREATION,
     OAUTH_BLOCKED_GROUPS,
+    OAUTH_GROUPS_SEPARATOR,
     OAUTH_ROLES_CLAIM,
     OAUTH_SUB_CLAIM,
     OAUTH_GROUPS_CLAIM,
@@ -1035,7 +1036,11 @@ class OAuthManager:
             if isinstance(claim_data, list):
                 user_oauth_groups = claim_data
             elif isinstance(claim_data, str):
-                user_oauth_groups = [claim_data]
+                # Split by the configured separator if present
+                if OAUTH_GROUPS_SEPARATOR in claim_data:
+                    user_oauth_groups = claim_data.split(OAUTH_GROUPS_SEPARATOR)
+                else:
+                    user_oauth_groups = [claim_data]
             else:
                 user_oauth_groups = []
 


### PR DESCRIPTION
## Description

This PR implements support for semicolon-separated OAuth group claims, addressing issue #18979.

## Changes

- Added OAUTH_GROUPS_SEPARATOR environment variable in config.py with default value of semicolon
- Updated update_user_groups function in oauth.py to split string claims by the configured separator
- Maintains backward compatibility: if separator is not found, treats claim as single group name

## Use Case

Many OIDC providers like CILogon (supporting thousands of universities worldwide) return group membership as semicolon-separated strings in the affiliation claim (e.g., Faculty@ucsc.edu;Employee@ucsc.edu;Member@ucsc.edu).

Previously, this was treated as a single monolithic group name. Now it's properly parsed into individual groups.

## Configuration

Users can customize the separator via the OAUTH_GROUPS_SEPARATOR environment variable (defaults to semicolon).

Fixes #18979


I agree to the contributor license agreement.
