### PR TITLE
Feat: optionally add user headers external websearch

### DIFF
--- a/backend/open_webui/retrieval/web/external.py
+++ b/backend/open_webui/retrieval/web/external.py
@@ -3,7 +3,8 @@ from typing import Optional, List
 
 import requests
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS, ENABLE_FORWARD_USER_INFO_HEADERS
+from open_webui.utils.headers import include_user_info_headers
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])
@@ -15,14 +16,23 @@ def search_external(
     query: str,
     count: int,
     filter_list: Optional[List[str]] = None,
+    user=None,
+    chat_id: Optional[str] = None,
 ) -> List[SearchResult]:
     try:
+        headers = {
+            "User-Agent": "Open WebUI (https://github.com/open-webui/open-webui) RAG Bot",
+            "Authorization": f"Bearer {external_api_key}",
+        }
+
+        if ENABLE_FORWARD_USER_INFO_HEADERS and user:
+            headers = include_user_info_headers(headers, user)
+            if chat_id:
+                headers["X-OpenWebUI-Chat-Id"] = chat_id
+
         response = requests.post(
             external_url,
-            headers={
-                "User-Agent": "Open WebUI (https://github.com/open-webui/open-webui) RAG Bot",
-                "Authorization": f"Bearer {external_api_key}",
-            },
+            headers=headers,
             json={
                 "query": query,
                 "count": count,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1811,7 +1811,7 @@ def process_web(
         )
 
 
-def search_web(request: Request, engine: str, query: str) -> list[SearchResult]:
+def search_web(request: Request, engine: str, query: str, user=None, chat_id: Optional[str] = None) -> list[SearchResult]:
     """Search the web using a search engine and return the results as a list of SearchResult objects.
     Will look for a search engine API key in environment variables in the following order:
     - SEARXNG_QUERY_URL
@@ -2074,6 +2074,8 @@ def search_web(request: Request, engine: str, query: str) -> list[SearchResult]:
             query,
             request.app.state.config.WEB_SEARCH_RESULT_COUNT,
             request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            user=user,
+            chat_id=chat_id,
         )
     else:
         raise Exception("No search engine API key found in environment variables")
@@ -2092,12 +2094,15 @@ async def process_web_search(
             f"trying to web search with {request.app.state.config.WEB_SEARCH_ENGINE, form_data.queries}"
         )
 
+        chat_id = getattr(request.state, 'chat_id', None)
         search_tasks = [
             run_in_threadpool(
                 search_web,
                 request,
                 request.app.state.config.WEB_SEARCH_ENGINE,
                 query,
+                user,
+                chat_id,
             )
             for query in form_data.queries
         ]

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -174,20 +174,13 @@ Based on the user's instruction, update and enhance the existing notes or select
 				: '') +
 			(selectedContent ? `\n<selection>${selectedContent?.text}</selection>` : '');
 
-		// Clean messages by removing internal fields before sending to API
-		const cleanedMessages = messages.map(({ role, content, name }) => {
-			const cleaned = { role, content };
-			if (name) cleaned.name = name;
-			return cleaned;
-		});
-
 		const chatMessages = JSON.parse(
 			JSON.stringify([
 				{
 					role: 'system',
 					content: `${system}`
 				},
-				...cleanedMessages
+				...messages
 			])
 		);
 

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -174,13 +174,20 @@ Based on the user's instruction, update and enhance the existing notes or select
 				: '') +
 			(selectedContent ? `\n<selection>${selectedContent?.text}</selection>` : '');
 
+		// Clean messages by removing internal fields before sending to API
+		const cleanedMessages = messages.map(({ role, content, name }) => {
+			const cleaned = { role, content };
+			if (name) cleaned.name = name;
+			return cleaned;
+		});
+
 		const chatMessages = JSON.parse(
 			JSON.stringify([
 				{
 					role: 'system',
 					content: `${system}`
 				},
-				...messages
+				...cleanedMessages
 			])
 		);
 


### PR DESCRIPTION
## Forward user info headers to external web search engine

Adds conditional forwarding of user information headers to the external web search engine when `ENABLE_FORWARD_USER_INFO_HEADERS` is enabled.

### Changes
- Modified `search_external()` to accept optional `user` and `chat_id` parameters
- Uses `include_user_info_headers()` helper to conditionally add X-OpenWebUI headers when enabled
- Updated `search_web()` and `process_web_search()` to pass user context through the call chain
- Gracefully extracts `chat_id` from request state if available

### Headers forwarded (when enabled)
- X-OpenWebUI-User-Name
- X-OpenWebUI-User-Id  
- X-OpenWebUI-User-Email
- X-OpenWebUI-User-Role
- X-OpenWebUI-Chat-Id (if available)

Maintains backward compatibility - all new parameters are optional with default values.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
