### PR TITLE
fix: NOTES: Fix broken message submission to completions endpoin

### DIFF
--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -175,7 +175,9 @@ Based on the user's instruction, update and enhance the existing notes or select
 			(selectedContent ? `\n<selection>${selectedContent?.text}</selection>` : '');
 
 		// Clean messages by removing internal fields before sending to API
-		const cleanedMessages = messages.map(({ role, content, name }) => {
+		const cleanedMessages = messages
+		.filter(msg => !(msg.role === 'assistant' && msg.content === ''))
+		.map(({ role, content, name }) => {
 			const cleaned = { role, content };
 			if (name) cleaned.name = name;
 			return cleaned;

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -174,13 +174,20 @@ Based on the user's instruction, update and enhance the existing notes or select
 				: '') +
 			(selectedContent ? `\n<selection>${selectedContent?.text}</selection>` : '');
 
+		// Clean messages by removing internal fields before sending to API
+		const cleanedMessages = messages.map(({ role, content, name }) => {
+			const cleaned = { role, content };
+			if (name) cleaned.name = name;
+			return cleaned;
+		});
+
 		const chatMessages = JSON.parse(
 			JSON.stringify([
 				{
 					role: 'system',
 					content: `${system}`
 				},
-				...messages
+				...cleanedMessages
 			])
 		);
 


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

This PR fixes a bug in the Notes Chat feature that caused 400 Bad Request errors when sending messages to AI models. The issue was caused by internal UI state fields being incorrectly included in API requests.

*Root Cause:** The Notes Chat feature was creating placeholder assistant messages with internal UI state fields (`done: false`) for streaming response management. These messages were being sent directly to the API without sanitization, violating the OpenAI message format specification.

**Solution:** Implemented a message cleaning pipeline that:
1. Filters out empty assistant messages used as UI placeholders
2. Maps messages to only include standard OpenAI fields (role, content, and optionally name)
3. Removes all internal state management fields before API transmission

### Changed

- Refactored message preparation to filter out empty assistant messages and internal UI fields before API calls
- Messages are now cleaned to only include OpenAI-compliant fields (role, content, name)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
