### PR TITLE
perf: Fetched user_group_ids prior to looping through models with has_access to reduce DB hits for group membership

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -12,6 +12,7 @@ from open_webui.functions import get_function_models
 
 from open_webui.models.functions import Functions
 from open_webui.models.models import Models
+from open_webui.models.groups import Groups
 
 
 from open_webui.utils.plugin import (
@@ -356,6 +357,7 @@ def get_filtered_models(models, user):
         or (user.role == "admin" and not BYPASS_ADMIN_ACCESS_CONTROL)
     ) and not BYPASS_MODEL_ACCESS_CONTROL:
         filtered_models = []
+        user_group_ids = {group.id for group in Groups.get_groups_by_member_id(user.id)}
         for model in models:
             if model.get("arena"):
                 if has_access(
@@ -364,6 +366,7 @@ def get_filtered_models(models, user):
                     access_control=model.get("info", {})
                     .get("meta", {})
                     .get("access_control", {}),
+                    user_group_ids=user_group_ids,
                 ):
                     filtered_models.append(model)
                 continue
@@ -377,6 +380,7 @@ def get_filtered_models(models, user):
                         user.id,
                         type="read",
                         access_control=model_info.access_control,
+                        user_group_ids=user_group_ids,
                     )
                 ):
                     filtered_models.append(model)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

https://github.com/open-webui/open-webui/issues/18950

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [N/A] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [N/A] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [PENDING] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

Optimized /api/models endpoint for large model lists by pre-fetching group IDs for user before looping through models evaluating permissions. Current implementation goes to DB to lookup groups for every model.

### Description

Optimized /api/models endpoint for large model lists by pre-fetching group IDs for user before looping through models evaluating permissions. Current implementation goes to DB to lookup groups for every model.

### Added

N/A

### Changed

/api/models API

### Deprecated

N/A

### Removed

N/A

### Fixed

https://github.com/open-webui/open-webui/issues/18950

### Security

N/A

### Breaking Changes

N/A
---

### Additional Information

This is the same logic employed by the get_models_by_user_id function

### Screenshots or Videos

N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
