### PR TITLE
fix: duplicated prompt when RAG template is used

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -121,6 +121,16 @@ def pop_system_message(messages: list[dict]) -> tuple[Optional[dict], list[dict]
     return get_system_message(messages), remove_system_message(messages)
 
 
+def replace_message_content(message: dict, content: str) -> dict:
+    if isinstance(message["content"], list):
+        for item in message["content"]:
+            if item["type"] == "text":
+                item["text"] = content
+    else:
+        message["content"] = content
+    return message
+
+
 def update_message_content(message: dict, content: str, append: bool = True) -> dict:
     if isinstance(message["content"], list):
         for item in message["content"]:

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -121,16 +121,6 @@ def pop_system_message(messages: list[dict]) -> tuple[Optional[dict], list[dict]
     return get_system_message(messages), remove_system_message(messages)
 
 
-def replace_message_content(message: dict, content: str) -> dict:
-    if isinstance(message["content"], list):
-        for item in message["content"]:
-            if item["type"] == "text":
-                item["text"] = content
-    else:
-        message["content"] = content
-    return message
-
-
 def update_message_content(message: dict, content: str, append: bool = True) -> dict:
     if isinstance(message["content"], list):
         for item in message["content"]:
@@ -187,7 +177,7 @@ def replace_user_message(content: str, messages: list[dict]) -> dict:
     """
 
     if messages and messages[-1].get("role") == "user":
-        messages[-1] = replace_message_content(messages[-1], content)
+        messages[-1]["content"] = content
     else:
         # Insert at the end
         messages.append({"role": "user", "content": content})

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -176,6 +176,25 @@ def add_or_update_system_message(
     return messages
 
 
+def replace_user_message(content: str, messages: list[dict]) -> dict:
+    """
+    Replaces the existing user message at the end of the messages list
+    or adds a new user message at the end.
+
+    :param content: The message content to be set.
+    :param messages: The list of message dictionaries.
+    :return: The updated list of message dictionaries.
+    """
+
+    if messages and messages[-1].get("role") == "user":
+        messages[-1] = replace_message_content(messages[-1], content)
+    else:
+        # Insert at the end
+        messages.append({"role": "user", "content": content})
+
+    return messages
+
+
 def add_or_update_user_message(content: str, messages: list[dict], append: bool = True):
     """
     Adds a new user message at the end of the messages list


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- This PR fixes prompt and context duplication in chat requests that occurred when prepending the RAG template formatted text to the user message, particularly when invoking tools. This improves prompt clarity and prevents repeated information or instructions being sent to the language model.

### Added

- Added a new `replace_user_message` function in `backend/open_webui/utils/misc.py` to replace the existing last user message or add a new one.

### Changed

- Updated the RAG context handling in `process_chat_payload` in `backend/open_webui/utils/middleware.py` to use either `add_or_update_user_message` or the new `replace_user_message` depending on whether the RAG template contains the prompt. This ensures the correct user message is set based on the template's structure, avoiding prompt duplication.

### Deprecated

None.

### Removed

None.

### Fixed

- Eliminates duplication of prompt and context observed when RAG template is formatted and prepended to the user message in `process_chat_payload` in `backend/open_webui/utils/middleware.py`.

### Security

None.

### Breaking Changes

None.

---

### Additional Information

This PR addresses & fixes #19098.

Updated prompts were manually tested and verified using a proxy OpenAI-compatible proxy API to inspect system & user messages.

LLM Chat Query prompt with changes from this PR:

`````
Messages since the last assistant response:
- user
```
### Task:
Respond to the user query using the provided context, incorporating inline citations in the format [id] **only when the <source> tag includes an explicit id attribute** (e.g., <source id="1">).

### Guidelines:
- If you don't know the answer, clearly state that.
- If uncertain, ask the user for clarification.
- Respond in the same language as the user's query.
- If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
- If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
- **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
- Do not cite if the <source> tag does not contain an id attribute.
- Do not use XML tags in your response.
- Ensure citations are concise and directly related to the information provided.

### Example of Citation:
If the user asks about a specific topic and the information is found in a source with a provided id attribute, the response should include the citation like in the following example:
* "According to the study, the proposed method increases efficiency by 20% [1]."

### Output:
Provide a clear and direct response to the user's query, including inline citations in the format [id] only when the <source> tag with id attribute is present in the context.

<context>
<source id="1" name="test/get_current_time">Current Date and Time = Tuesday, November 11, 2025, 01:14:49 AM</source>
</context>

<user_query>
what time is it?
</user_query>

```
`````

This PR specifically addresses the code that prepends the RAG template formatted text to the user message:

https://github.com/open-webui/open-webui/blob/e0d5de16978786b8a7538adf1efcde5258f38faf/backend/open_webui/utils/middleware.py#L1493-L1502

It does not modify the other code block referenced in the issue, which appends the tool result context to the user message:

https://github.com/open-webui/open-webui/blob/e0d5de16978786b8a7538adf1efcde5258f38faf/backend/open_webui/utils/middleware.py#L484-L488

### Screenshots or Videos

None.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
