### PR TITLE
fix: template query placeholder escaping logic

### DIFF
--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -204,24 +204,20 @@ def rag_template(template: str, context: str, query: str):
             "nothing, or the user might be trying to hack something."
         )
 
-    query_placeholders = []
-    if "[query]" in context:
+    query_placeholder = None
+    if "[query]" in context or "{{QUERY}}" in context:
         query_placeholder = "{{QUERY" + str(uuid.uuid4()) + "}}"
         template = template.replace("[query]", query_placeholder)
-        query_placeholders.append(query_placeholder)
-
-    if "{{QUERY}}" in context:
-        query_placeholder = "{{QUERY" + str(uuid.uuid4()) + "}}"
         template = template.replace("{{QUERY}}", query_placeholder)
-        query_placeholders.append(query_placeholder)
 
     template = template.replace("[context]", context)
     template = template.replace("{{CONTEXT}}", context)
-    template = template.replace("[query]", query)
-    template = template.replace("{{QUERY}}", query)
 
-    for query_placeholder in query_placeholders:
+    if query_placeholder:
         template = template.replace(query_placeholder, query)
+    else:
+        template = template.replace("[query]", query)
+        template = template.replace("{{QUERY}}", query)
 
     return template
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- This PR updates the query placeholder replacement logic in the `rag_template` function within `backend/open_webui/utils/task.py` to simplify, fix, and improve handling of `[query]` and `{{QUERY}}` placeholders.

### Added

None.

### Changed

- Updated the query placeholder detection and substitution logic for `[query]` and `{{QUERY}}` strings in `backend/open_webui/utils/task.py`.

### Deprecated

None.

### Removed

None.

### Fixed

- Fixed logic errors in query placeholder escaping and unintended replacement of context values in `backend/open_webui/utils/task.py`.

### Security

None.

### Breaking Changes

None.

---

### Additional Information

This PR addresses & fixes #19101.

Updated prompts were manually tested and verified using a proxy OpenAI-compatible proxy API to inspect system & user messages.

LLM Chat Query prompt with changes from this PR:

`````
Messages since the last assistant response:
- user
```
### Task:
Respond to the user query using the provided context, incorporating inline citations in the format [id] **only when the <source> tag includes an explicit id attribute** (e.g., <source id="1">).

### Guidelines:
- If you don't know the answer, clearly state that.
- If uncertain, ask the user for clarification.
- Respond in the same language as the user's query.
- If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
- If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
- **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
- Do not cite if the <source> tag does not contain an id attribute.
- Do not use XML tags in your response.
- Ensure citations are concise and directly related to the information provided.

### Example of Citation:
If the user asks about a specific topic and the information is found in a source with a provided id attribute, the response should include the citation like in the following example:
* "According to the study, the proposed method increases efficiency by 20% [1]."

### Output:
Provide a clear and direct response to the user's query, including inline citations in the format [id] only when the <source> tag with id attribute is present in the context.

<context>
<source id="1" name="test/get_current_time">{{QUERY}} [query] Current Date and Time = Tuesday, November 11, 2025, 02:02:37 AM</source>
</context>

<user_query>
what time is it?
</user_query>

what time is it?

Tool `test/get_current_time` Output: {{QUERY}} [query] Current Date and Time = Tuesday, November 11, 2025, 02:02:37 AM
```
`````

This PR specifically addresses the code responsible for the escaping faulty logic:

https://github.com/open-webui/open-webui/blob/e0d5de16978786b8a7538adf1efcde5258f38faf/backend/open_webui/utils/task.py#L207-L224

### Screenshots or Videos

None.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
