### PR TITLE
fix: __user__['valves'] should reflect current tool's UserValves when using multiple tools

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -232,16 +232,10 @@ async def get_tools(
                 module, _ = load_tool_module_by_id(tool_id)
                 request.app.state.TOOLS[tool_id] = module
 
-            extra_params["__id__"] = tool_id
-
             # Set valves for the tool
             if hasattr(module, "valves") and hasattr(module, "Valves"):
                 valves = Tools.get_tool_valves_by_id(tool_id) or {}
                 module.valves = module.Valves(**valves)
-            if hasattr(module, "UserValves"):
-                extra_params["__user__"]["valves"] = module.UserValves(  # type: ignore
-                    **Tools.get_user_valves_by_id_and_user_id(tool_id, user.id)
-                )
 
             for spec in tool.specs:
                 # TODO: Fix hack for OpenAI API
@@ -256,6 +250,12 @@ async def get_tools(
                     for key, val in spec["parameters"]["properties"].items()
                     if not key.startswith("__")
                 }
+
+                extra_params["__id__"] = tool_id
+                if hasattr(module, "UserValves"):
+                    extra_params["__user__"]["valves"] = module.UserValves(
+                        **Tools.get_user_valves_by_id_and_user_id(tool_id, user.id)
+                    )
 
                 # convert to function that takes only model params and inserts custom params
                 function_name = spec["name"]


### PR DESCRIPTION
I noticed UserValves we're incorrect when custom pipe and multiple tools are used in a request:
All Tool are getting the same `__user__["valves"]`, namely the valves from the last tool in the list, resulting in errors when calling methods who need uservalves.

I've pinpoint the root of the problem in `tool.py`, where `extra_params` is used in conjunction with `functool.partial`, which copies the dict but only references the content. When extra_params["__user__"]["valves"] gets overwritten by the next tool, it changes it for all tools, resulting in wrong uservalves per tool. Setting extra_params per method instead of per tool solved this problem.

Problem Example:
``` python
# Tool A - Function 1
extra_params["__user__"]["valves"] = UserValvesA()  # New Instance
partial_a1 = partial(func_a1, __user__=extra_params["__user__"])  # Saves reference to {"valves": UserValvesA}

# Tool B - Funktion 1
extra_params["__user__"]["valves"] = UserValvesB()  # Overwrites the value!
# extra_params["__user__"] dict is still the same object!
# partial_a1 is still pointing the this dics, but now it contains {"valves": UserValvesB}!
partial_b1 = partial(func_b1, __user__=extra_params["__user__"])
```

Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.