### PR TITLE
fix: Duplicate instructions in tool selection calling prompt

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -302,13 +302,17 @@ async def chat_completion_tools_handler(
     def get_tools_function_calling_payload(messages, task_model_id, content):
         user_message = get_last_user_message(messages)
 
+        if user_message and messages and messages[-1]["role"] == "user":
+            # Remove the last user message to avoid duplication
+            messages = messages[:-1]
+
         recent_messages = messages[-4:] if len(messages) > 4 else messages
         chat_history = "\n".join(
             f"{message['role'].upper()}: \"\"\"{get_content_from_message(message)}\"\"\""
             for message in recent_messages
         )
 
-        prompt = f"History:\n{chat_history}\nQuery: {user_message}"
+        prompt = f"History:\n{chat_history}\nQuery: {user_message}" if chat_history else f"Query: {user_message}"
 
         return {
             "model": task_model_id,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -314,7 +314,7 @@ async def chat_completion_tools_handler(
             "model": task_model_id,
             "messages": [
                 {"role": "system", "content": content},
-                {"role": "user", "content": f"Query: {prompt}"},
+                {"role": "user", "content": prompt},
             ],
             "stream": False,
             "metadata": {"task": str(TASKS.FUNCTION_CALLING)},


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- This PR updates the logic for constructing the prompt payload in `backend/open_webui/utils/middleware.py` to avoid duplication and improve clarity when preparing messages for tools selection and calling. The main changes focus on removing redundant instructions and user messages in the prompt.

### Added

None.

### Changed

- Updated function `get_tools_function_calling_payload` in `chat_completion_tools_handler` in `backend/open_webui/utils/middleware.py` to remove duplicated "Query:" prefix and duplicated user message in the prompt used for tools selection and calling.
- Updated function `get_tools_function_calling_payload` in `chat_completion_tools_handler` in `backend/open_webui/utils/middleware.py` to omit the chat history if only the user query (last user message) is present.

### Deprecated

None.

### Removed

None.

### Fixed

None.

### Security

None.

### Breaking Changes

None.

---

### Additional Information

This PR addresses & fixes #19121.

Updated prompts were manually tested and verified using a proxy OpenAI-compatible proxy API to inspect system & user messages.

Tool Selection Request prompt with changes from this PR:

`````
Messages since the last assistant response:
- system
```
Available Tools: [{"name": "calculator", "description": "\n        Calculate the result of an equation.\n        ", "parameters": {"properties": {"equation": {"description": "The mathematical equation to calculate.", "type": "string"}}, "required": ["equation"], "type": "object"}}, {"name": "get_current_time", "description": "\n        Get the current time in a more human-readable format.\n        ", "parameters": {"properties": {}, "type": "object"}}, {"name": "get_current_weather", "description": "\n        Get the current weather for a given city.\n        ", "parameters": {"properties": {"city": {"default": "New York, NY", "description": "Get the current weather for a given city.", "type": "string"}}, "type": "object"}}, {"name": "get_user_name_and_email_and_id", "description": "\n        Get the user name, Email and ID from the user object.\n        ", "parameters": {"properties": {}, "type": "object"}}]

Your task is to choose and return the correct tool(s) from the list of available tools based on the query. Follow these guidelines:

- Return only the JSON object, without any additional text or explanation.

- If no tools match the query, return an empty array: 
   {
     "tool_calls": []
   }

- If one or more tools match the query, construct a JSON response containing a "tool_calls" array with objects that include:
   - "name": The tool's name.
   - "parameters": A dictionary of required parameters and their corresponding values.

The format for the JSON response is strictly:
{
  "tool_calls": [
    {"name": "toolName1", "parameters": {"key1": "value1"}},
    {"name": "toolName2", "parameters": {"key2": "value2"}}
  ]
}
```
- user
```
Query: what time is it?
```
`````

In a conversation with chat history, the user message is sent like this in the Tool Selection Request prompt:

`````
- user
```
History:
USER: """what time is it?"""
ASSISTANT: """Current Date and Time = Tuesday, November 11, 2025, 02:21:04 PM."""
Query: Are you sure? what time is it?
```
`````

### Screenshots or Videos

None.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
