### PR TITLE
Fix: Handle empty strings in OAuth registration response (#19129)

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -330,6 +330,10 @@ async def get_oauth_client_info_with_dynamic_client_registration(
                     registration_response_json = (
                         await oauth_client_registration_response.json()
                     )
+
+                    # The mcp package requires optional unset values to be None. If an empty string is passed, it gets validated and fails.
+                    # This replaces all empty strings with None.
+                    registration_response_json = {k: (None if v == "" else v) for k, v in registration_response_json.items()}
                     oauth_client_info = OAuthClientInformationFull.model_validate(
                         {
                             **registration_response_json,


### PR DESCRIPTION
Fixes #19129 - The mcp package requires optional unset values to be None. If an empty string is passed, it gets validated and fails. This PR replaces all empty strings in the Dynamic Client Registration response with None.

# Changelog Entry

### Fixed

- ignore empty optional URLs in the Dynamic Client Registration response

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
