### PR TITLE
fix: generate discovery URLs with path prefix

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -255,6 +255,17 @@ def get_discovery_urls(server_url) -> list[str]:
                 base_url, f"/.well-known/openid-configuration{parsed.path.rstrip('/')}"
             )
         )
+        urls.append(
+            urllib.parse.urljoin(
+                base_url,
+                f"{parsed.path.rstrip('/')}/.well-known/oauth-authorization-server",
+            )
+        )
+        urls.append(
+            urllib.parse.urljoin(
+                base_url, f"{parsed.path.rstrip('/')}/.well-known/openid-configuration"
+            )
+        )
 
     return urls
 


### PR DESCRIPTION
OAuth discovery URLs are generated based on the original OAuth URL: Two URLs are generated excluding any passed URL path and two URLs are generated with the original URL path as a postfix. With this PR two additional URLs are generated with the URL path as a prefix. 

This fixes cases where a URL path is used as a proxy identifier (e.g. http://example.com/oauth_server). 

Without this change http://example.com/.well-known/oauth-authorization-server and http://example.com/.well-known/oauth-authorization-server/oauth_server are queried.

With this change http://example.com/oauth_server/.well-known/oauth-authorization-server is checked as well.

# Changelog Entry

### Fixed

- generate discovery URLs with path prefix

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
