### PR TITLE
fix: pass token_endpoint_auth_method when creating an oauth client

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -376,7 +376,11 @@ class OAuthClientManager:
             "client_secret": oauth_client_info.client_secret,
             "client_kwargs": {
                 "scope": oauth_client_info.scope if oauth_client_info.scope else {},
-                "token_endpoint_auth_method": oauth_client_info.token_endpoint_auth_method if oauth_client_info.token_endpoint_auth_method else {}
+                "token_endpoint_auth_method": (
+                    oauth_client_info.token_endpoint_auth_method
+                    if oauth_client_info.token_endpoint_auth_method
+                    else {}
+                ),
             },
             "server_metadata_url": (
                 oauth_client_info.issuer if oauth_client_info.issuer else None

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -374,9 +374,10 @@ class OAuthClientManager:
             "name": client_id,
             "client_id": oauth_client_info.client_id,
             "client_secret": oauth_client_info.client_secret,
-            "client_kwargs": (
-                {"scope": oauth_client_info.scope} if oauth_client_info.scope else {}
-            ),
+            "client_kwargs": {
+                "scope": oauth_client_info.scope if oauth_client_info.scope else {},
+                "token_endpoint_auth_method": oauth_client_info.token_endpoint_auth_method if oauth_client_info.token_endpoint_auth_method else {}
+            },
             "server_metadata_url": (
                 oauth_client_info.issuer if oauth_client_info.issuer else None
             ),


### PR DESCRIPTION
AuthLib defaults to using basic auth when `token_endpoint_auth_method` has not been configured. This PR passes `token_endpoint_auth_method` when creating an OAuth client. Without this `authorize_access_token()` fails if the OAuth server does not accept basic auth as an authentication method. 

# Changelog Entry
### Fixed

- use client's configured endpoint authentication method, instead of defaulting to basic authentication

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
