### PR TITLE
fix: UserValves contamination between multiple tools

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -244,9 +244,12 @@ async def get_tools(
                 valves = Tools.get_tool_valves_by_id(tool_id) or {}
                 module.valves = module.Valves(**valves)
             if hasattr(module, "UserValves"):
-                extra_params["__user__"]["valves"] = module.UserValves(  # type: ignore
-                    **Tools.get_user_valves_by_id_and_user_id(tool_id, user.id)
-                )
+                user_valves_data = Tools.get_user_valves_by_id_and_user_id(tool_id, user.id)
+                tool_valves = module.UserValves(**user_valves_data)
+                
+                tool_user = extra_params["__user__"].copy()
+                tool_user["valves"] = tool_valves
+                extra_params["__user__"] = tool_user
 
             for spec in tool.specs:
                 # TODO: Fix hack for OpenAI API


### PR DESCRIPTION
## Description

Fixes a critical bug where multiple tools with `UserValves` would incorrectly share the same `UserValves` instance, causing tool-specific user configuration to leak between different tools.

**Root Cause:** `functools.partial()` was freezing a reference to the shared `extra_params["__user__"]` dict rather than creating isolated instances per tool.

**Solution:** Create a shallow copy of `__user__` for each tool before setting its specific `UserValves` instance, ensuring `partial()` freezes the correct isolated configuration.

## Testing

- ✅ Tested with 3 tools (DummyToolA, DummyToolB, DummyToolC) each with unique UserValves
- ✅ Verified each tool receives only its own UserValves configuration
- ✅ Confirmed no contamination between tools
- ✅ Manual testing with Anthropic Claude pipe and OpenAI models

---

# Changelog Entry

### Description

Fixed a critical bug where multiple tools with UserValves would share the same UserValves instance due to functools.partial() freezing a reference to the shared extra_params["__user__"] dict. This caused Tool B and Tool C to incorrectly receive Tool A's UserValves instead of their own configuration.

### Added

- N/A

### Changed

- Modified `backend/open_webui/utils/tools.py` to create a shallow copy of `__user__` dict for each tool with UserValves before passing to `functools.partial()`

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed UserValves contamination where multiple tools would share the same UserValves instance
- Each tool now correctly receives its own isolated UserValves configuration

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

**Impact:**
- Performance: Minimal - one shallow dict copy per tool (not per function)
- Breaking Changes: None - purely internal fix
- Scope: Affects all tools using the UserValves feature

**Technical Details:**
- Before: `extra_params["__user__"]["valves"] = module.UserValves(...)` directly modified shared dict
- After: Creates `tool_user = extra_params["__user__"].copy()` and sets `tool_user["valves"]` before partial() freezes it

### Screenshots or Videos

N/A - Backend fix with no UI changes

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.