### PR TITLE
fix(image-edit): correct config key for image edit engine

### DIFF
--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -1170,7 +1170,7 @@
 								</div>
 							</div>
 						{/if}
-					{:else if config?.IMAGE_GENERATION_ENGINE === 'gemini'}
+					{:else if config?.IMAGE_EDIT_ENGINE === 'gemini'}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
 								<div class="text-xs pr-2 shrink-0">


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed incorrect configuration key in the Gemini image edit settings section. The code was checking `IMAGE_GENERATION_ENGINE` when it should have been checking `IMAGE_EDIT_ENGINE`, which prevented the correct display of image edit configuration options for the Gemini engine.

### Added

- N/A

### Changed

- Updated condition in `src/lib/components/admin/Settings/Images.svelte` from `config?.IMAGE_GENERATION_ENGINE === 'gemini'` to `config?.IMAGE_EDIT_ENGINE === 'gemini'`

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed incorrect config key reference for Gemini image edit engine settings display

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- This was a simple typo/copy-paste error where the wrong configuration key was being checked
- The fix ensures that the Gemini image edit settings are shown when the image edit engine is set to Gemini, not when the image generation engine is set to Gemini
- File changed: `src/lib/components/admin/Settings/Images.svelte` (line 1173)

### Screenshots or Videos

- [Attach any relevant screenshots showing the corrected behavior]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
