### PR TITLE
feat: add a metric to monitor daily unique users

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -322,6 +322,13 @@ class UsersTable:
         except Exception:
             return None
 
+    def get_num_users_active_today(self) -> Optional[int]:
+        with get_db() as db:
+            current_timestamp = int(datetime.datetime.now().timestamp())
+            today_midnight_timestamp = current_timestamp - (current_timestamp % 86400)
+            query = db.query(User).filter(User.last_active_at > today_midnight_timestamp)
+            return query.count()
+
     def update_user_role_by_id(self, id: str, role: str) -> Optional[UserModel]:
         try:
             with get_db() as db:

--- a/backend/open_webui/utils/telemetry/metrics.py
+++ b/backend/open_webui/utils/telemetry/metrics.py
@@ -99,6 +99,9 @@ def _build_meter_provider(resource: Resource) -> MeterProvider:
         View(
             instrument_name="webui.users.active",
         ),
+        View(
+            instrument_name="webui.users.active.today",
+        ),
     ]
 
     provider = MeterProvider(
@@ -157,6 +160,18 @@ def setup_metrics(app: FastAPI, resource: Resource) -> None:
         description="Number of currently active users",
         unit="users",
         callbacks=[observe_active_users],
+    )
+
+    def observe_users_active_today(
+        options: metrics.CallbackOptions,
+    ) -> Sequence[metrics.Observation]:
+        return [metrics.Observation(value=Users.get_num_users_active_today())]
+
+    meter.create_observable_gauge(
+        name="webui.users.active.today",
+        description="Number of users active since midnight today",
+        unit="users",
+        callbacks=[observe_users_active_today],
     )
 
     # FastAPI middleware


### PR DESCRIPTION
#19234

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Introduced a metric to track the number of unique users accessing Open WebUI each day, reset at midnight UTC.

### Added

- `webui.users.active.today` :  counter for the number of total users since midnight

### Additional Information

 Self tested and observed the new metrics on prometheus.



### Screenshots or Videos
<img width="1363" height="778" alt="image" src="https://github.com/user-attachments/assets/7b40d6a4-1069-4db1-ae6f-77a3ba1f4511" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
