### PR TITLE
MCP: get __files__ information from OpenWebUI

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1370,6 +1370,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
                         def make_tool_function(client, function_name):
                             async def tool_function(**kwargs):
+                                if "__files__" in kwargs:
+                                    files_list = form_data.get("metadata", {}).get("files", kwargs.get("__files__", []))
+                                    kwargs["__files__"] = {file_item["id"]: file_item for file_item in files_list}
+                                    print(kwargs["__files__"])
                                 return await client.call_tool(
                                     function_name,
                                     function_args=kwargs,


### PR DESCRIPTION
### Description

- Tools in Openwebui have access to some reserved variable names, for example to the attached files in a chat. For MCP this so far doesn't work. This PR introduces reserved variable names (to be more precise: __files__) to also work with MCP.
A MCP server that accepts __files__: dict get access to the file information

Example mcp tool:

```
@mcp.tool
def process_files(__files__: dict):
    """
    give information on the attached file
    """
    print(str(__files__))
    return str(__files__)
```


This allows an mcp server, with minimal parsing of the dict to know the id and local url on the file server, making it easy to access files via api or on the local file structure to be processed within an mcp tool. 

### Added

- reserved __files__ word to also be considered for mcp tool calls.


### Screenshots or Videos

<img width="1054" height="522" alt="Screenshot 2025-11-17 at 21 04 45" src="https://github.com/user-attachments/assets/154cee98-6bf5-48e7-8fd2-59a8ae1e0fdc" />

This is the result of the above mcp tool

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


