### PR TITLE
fix: format date according to DEFAULT_LOCALE in chat search

### DIFF
--- a/src/lib/components/layout/ChatsModal.svelte
+++ b/src/lib/components/layout/ChatsModal.svelte
@@ -4,8 +4,10 @@
 
 	import dayjs from 'dayjs';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
+	import calendar from 'dayjs/plugin/calendar'
 
 	dayjs.extend(localizedFormat);
+	dayjs.extend(calendar);
 
 	import { deleteChatById } from '$lib/apis/chats';
 
@@ -242,7 +244,14 @@
 
 									<div class="basis-2/5 flex items-center justify-end">
 										<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
-											{dayjs(chat?.updated_at * 1000).calendar()}
+											{$i18n.t(dayjs(chat?.updated_at * 1000).calendar(null, {
+												sameDay: '[Today]',
+												nextDay: '[Tomorrow]',
+												nextWeek: 'dddd',
+												lastDay: '[Yesterday]',
+												lastWeek: '[Last] dddd',
+												sameElse: 'L' // use localized format, otherwise dayjs.calendar() defaults to DD/MM/YYYY
+											}))}
 										</div>
 
 										<div class="flex justify-end pl-2.5 text-gray-600 dark:text-gray-300">

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -9,6 +9,7 @@
 	import Spinner from '../common/Spinner.svelte';
 
 	import dayjs from '$lib/dayjs';
+	import localizedFormat from 'dayjs/plugin/localizedFormat';
 	import calendar from 'dayjs/plugin/calendar';
 	import Loader from '../common/Loader.svelte';
 	import { createMessagesList } from '$lib/utils';
@@ -18,6 +19,7 @@
 	import PencilSquare from '../icons/PencilSquare.svelte';
 	import PageEdit from '../icons/PageEdit.svelte';
 	dayjs.extend(calendar);
+	dayjs.extend(localizedFormat);
 
 	export let show = false;
 	export let onClose = () => {};
@@ -387,7 +389,14 @@
 							</div>
 
 							<div class=" pl-3 shrink-0 text-gray-500 dark:text-gray-400 text-xs">
-								{dayjs(chat?.updated_at * 1000).calendar()}
+								{$i18n.t(dayjs(chat?.updated_at * 1000).calendar(null, {
+												sameDay: '[Today]',
+												nextDay: '[Tomorrow]',
+												nextWeek: 'dddd',
+												lastDay: '[Yesterday]',
+												lastWeek: '[Last] dddd',
+												sameElse: 'L' // use localized format, otherwise dayjs.calendar() defaults to DD/MM/YYYY
+											}))}
 							</div>
 						</a>
 					{/each}

--- a/src/lib/dayjs.js
+++ b/src/lib/dayjs.js
@@ -101,5 +101,6 @@ import 'dayjs/locale/yo';
 import 'dayjs/locale/zh';
 import 'dayjs/locale/zh-tw';
 import 'dayjs/locale/et';
+import 'dayjs/locale/en-gb'
 
 export default dayjs;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -53,6 +53,7 @@
 	import AppSidebar from '$lib/components/app/AppSidebar.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import { getUserSettings } from '$lib/apis/users';
+	import dayjs from 'dayjs';
 
 	// handle frontend updates (https://svelte.dev/docs/kit/configuration#version)
 	beforeNavigate(({ willUnload, to }) => {
@@ -635,6 +636,7 @@
 				? backendConfig.default_locale
 				: bestMatchingLanguage(languages, browserLanguages, 'en-US');
 			changeLanguage(lang);
+			dayjs.locale(lang);
 		}
 
 		if (backendConfig) {


### PR DESCRIPTION
# Pull Request Checklist

# Changelog Entry

### Description

- Format date in chat search (chat search, admin settings -> user chat's search) according to DEFAULT_LOCALE

### Added

- added `en-gb` locale to $lib/dayjs based on user request

### Changed

- n/a

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- Dates were previously always MM/DD/YYYY format. This PR automatically formats the date according to user's set DEFAULT_LOCALE environment variable, for example if `DEFAULT_LOCALE='en-gb'`, then date will be formatted as DD/MM/YYYY

### Security

- n/a

### Breaking Changes

- n/a

---

### Additional Information

- closes issue #19020
- this PR addresses date formatting issues in two frequently used chat search modals:
- main chat search modal.
 -Admin Settings -> User Chat Search modal.
The changes ensure that both use DEFAULT_LOCALE for date formatting. Further investigation will identify and correct any additional occurrences of improper date formatting in future PRs, once this solution is validated

### Screenshots or Videos
The following have `DEFAULT_LOCALE='en-gb'`

- Chat Search
<img width="1421" height="922" alt="Screenshot 2025-11-19 at 5 29 59 PM" src="https://github.com/user-attachments/assets/324ce836-c369-4c93-bf63-79d91aa05bc2" />


- Admin Settings -> Users -> Chat Search
<img width="1237" height="423" alt="image" src="https://github.com/user-attachments/assets/9e3db205-87ee-45b3-824b-939a61599a2e" />



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
