### PR TITLE
feat: rate limit for login attempts

### DIFF
--- a/backend/open_webui/utils/login_rate_limit.py
+++ b/backend/open_webui/utils/login_rate_limit.py
@@ -23,5 +23,4 @@ class RateLimiter:
         return True
 
     def reset(self, key: str):
-        if key in self.attempts:
-            del self.attempts[key]
+        self.attempts.pop(key)

--- a/backend/open_webui/utils/login_rate_limit.py
+++ b/backend/open_webui/utils/login_rate_limit.py
@@ -23,4 +23,4 @@ class RateLimiter:
         return True
 
     def reset(self, key: str):
-        self.attempts.pop(key)
+        self.attempts.pop(key, None)

--- a/backend/open_webui/utils/login_rate_limit.py
+++ b/backend/open_webui/utils/login_rate_limit.py
@@ -1,0 +1,27 @@
+import time
+from collections import defaultdict
+
+class RateLimiter:
+    def __init__(self, max_attempts: int, window_seconds: int):
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self.attempts = defaultdict(list)
+
+    def check(self, key: str) -> bool:
+        """
+        Check if the rate limit has been exceeded for the given key.
+        Returns True if the request is allowed, False otherwise.
+        """
+        current_time = time.time()
+        # Filter out timestamps older than the window
+        self.attempts[key] = [t for t in self.attempts[key] if current_time - t < self.window_seconds]
+        
+        if len(self.attempts[key]) >= self.max_attempts:
+            return False
+        
+        self.attempts[key].append(current_time)
+        return True
+
+    def reset(self, key: str):
+        if key in self.attempts:
+            del self.attempts[key]


### PR DESCRIPTION
# Changelog Entry

Add rate limit for login attempts to make password attacks slow.

### Description

At present the system allows unlimited attempts to log in with email/password method. An attacker can try at high-rate techniques to break user's password such as [dictionary attack](https://en.wikipedia.org/wiki/Dictionary_attack). This pull request adds a basic rate limit on `/signin` route

### Security

Add rate limit for failed login attempts.

### Additional Information

The implemented rate limit solution is basic. In deployments running multiple replicas of openwebui, it will not provide perfect rate-limit as defined but it still provides some protection rather than no protection.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
