### PR TITLE
take into account vlm_pipeline_model_api when it's added to DOCLING_PARAMS

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -199,7 +199,10 @@ class DoclingLoader:
 
                 if self.params.get("pipeline"):
                     params["pipeline"] = self.params.get("pipeline")
-
+                    if params["pipeline"] =="vlm" and self.params.get("vlm_pipeline_model_api"):
+                        params["vlm_pipeline_model_api"] = json.dumps(
+                                self.params.get("vlm_pipeline_model_api", {})
+                            )
             endpoint = f"{self.url}/v1/convert/file"
             r = requests.post(endpoint, files=files, data=params)
 


### PR DESCRIPTION

### Description

vlm_pipeline_model_api could not be added and taken into account. 
This PR ensures that when vlm_pipeline_model_api  json is defined in DOCLING_PARAMS, it's taken into account and sent to the request to Docling 

### Added

- vlm_pipeline_model_api support

### Changed
the following lines were added to take into account vlm_pipeline_model_api
```
if self.params.get("pipeline"):
                    params["pipeline"] = self.params.get("pipeline")
                    if params["pipeline"] =="vlm" and self.params.get("vlm_pipeline_model_api"):
                        params["vlm_pipeline_model_api"] = json.dumps(
                                self.params.get("vlm_pipeline_model_api", {})
                            )
```


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
