### PR TITLE
fix: Reindex not working

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
+from fastapi.concurrency import run_in_threadpool
 import logging
 
 from open_webui.models.knowledge import (
@@ -223,7 +224,8 @@ async def reindex_knowledge_files(request: Request, user=Depends(get_verified_us
             failed_files = []
             for file in files:
                 try:
-                    process_file(
+                    await run_in_threadpool(
+                        process_file,
                         request,
                         ProcessFileForm(
                             file_id=file.id, collection_name=knowledge_base.id


### PR DESCRIPTION
Other embedding endpoints work fine, because they are sync

Reindex specifically is an **async** FASTAPI api endpoint.
Because it is async we have an issue:
we are trying to go from

async reindex -> process file (sync) -> save to vector db (sync) -> asnyc call

async inside async chain doesnt work

therefore i am here implementing a run in threadpool, this should BREAK the async chain by spawning a worker thread for handling the subsequent embedding functions and therefore not cause any loop issues anymore


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
