### PR TITLE
fix: Connection error when generation an image using OpenAI

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -549,9 +549,7 @@ async def image_generations(
             if ENABLE_FORWARD_USER_INFO_HEADERS:
                 headers = include_user_info_headers(headers, user)
 
-            url = (
-                f"{request.app.state.config.IMAGES_OPENAI_API_BASE_URL}/images/generations",
-            )
+            url = f"{request.app.state.config.IMAGES_OPENAI_API_BASE_URL}/images/generations"
             if request.app.state.config.IMAGES_OPENAI_API_VERSION:
                 url = f"{url}?api-version={request.app.state.config.IMAGES_OPENAI_API_VERSION}"
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This pull request fixes a bug that blocks image generation. 
The error happens since url is represented as tuple instead of string

### Fixed

- Fixed a connection error while generating an image

---

### Additional Information and Screenshots

**Test plan**
1) Start a new chat
2) Enable image integration
3) Submit "Photo of a blue cat" message

**Context**:
I am running openwebui using ghcr.io/open-webui/open-webui:v0.6.38 docker contaner

My images settings
<img width="1816" height="953" alt="image" src="https://github.com/user-attachments/assets/01b0974f-b604-4542-b4c1-7a8e9ee43dd0" />

**Before**:
Getting "An error occurred while generating an image" when trying to generate an image.

<img width="1289" height="428" alt="image" src="https://github.com/user-attachments/assets/be7c252c-a977-4730-938e-9bac2531ceef" />

I can find this error in DEBUG logs
```
Image generation was attempted but failed. The system is currently unable to generate the image. Tell the user that an error occurred: [ERROR: No connection adapters were found for "(\'https://api.imagerouter.io/v1/openai/images/generations\',)"]
```
which comes from backend\open_webui\utils\middleware.py:931

It happens since url in backend\open_webui\routers\images.py:552 is a tuple, not a string

**After**:

Image generation works as expected

<img width="1294" height="904" alt="image" src="https://github.com/user-attachments/assets/2a14ff1d-5aa3-4c59-af65-0c97cd58d772" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
