### PR TITLE
fix: Set logging level of retrieved documents to "debug"

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1249,7 +1249,7 @@ def save_docs_to_vector_db(
 
         return ", ".join(docs_info)
 
-    log.info(
+    log.debug(
         f"save_docs_to_vector_db: document {_get_docs_info(docs)} {collection_name}"
     )
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Target branch: This PR targets the `dev` branch.
- [x] Description: Added below.
- [x] Changelog: Added below.
- [x] Documentation: No documentation updates required.
- [x] Dependencies: No new dependencies.
- [x] Testing: Manually tested that the change works as expected and does not affect other functionality.
- [x] Agentic AI Code: This PR was written, reviewed, and tested by hand.
- [x] Code review: Performed self‑review.
- [x] Title Prefix: fix

---

# Changelog Entry

Changed a log statement in save_docs_to_vector_db from info to debug to avoid exposing potentially sensitive document content in normal logs.

### Description

This PR adjusts a logging call in `save_docs_to_vector_db` within `retrieval.py`, changing it from `log.info` to `log.debug`. This ensures that verbose document‑level logging does not appear in standard logs and only shows up in debug mode. This is an issue if the documents have sensitive data. For example in our OpenWebUI this leaks web searches that users do.

### Added

- Nothing added.

### Changed

- Logging level updated from info to debug for the message emitted when saving documents to the vector database.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevents leaking potentially sensitive data in the logging output

### Security

- No security‑related changes.

### Breaking Changes

- None.

---

### Additional Information

- This change is purely related to logging verbosity.
- No behavioral or functional changes to retrieval logic.

### Screenshots or Videos

- Not applicable for this change.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.