### PR TITLE
feat: Implemented redis hash TTL to enable accurate live user count.

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -386,12 +386,14 @@ REDIS_KEY_PREFIX = os.environ.get("REDIS_KEY_PREFIX", "open-webui")
 REDIS_SENTINEL_HOSTS = os.environ.get("REDIS_SENTINEL_HOSTS", "")
 REDIS_SENTINEL_PORT = os.environ.get("REDIS_SENTINEL_PORT", "26379")
 
+
 def _get_redis_ttl(env_path: str):
     try:
         ttl = os.environ.get(env_path, None)
         return int(ttl) if ttl else ttl
     except Exception:
         return None
+
 
 REDIS_TTL_SESSION_POOL = _get_redis_ttl("REDIS_TTL_SESSION_POOL")
 REDIS_TTL_USER_POOL = _get_redis_ttl("REDIS_TTL_USER_POOL")

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -386,6 +386,17 @@ REDIS_KEY_PREFIX = os.environ.get("REDIS_KEY_PREFIX", "open-webui")
 REDIS_SENTINEL_HOSTS = os.environ.get("REDIS_SENTINEL_HOSTS", "")
 REDIS_SENTINEL_PORT = os.environ.get("REDIS_SENTINEL_PORT", "26379")
 
+def _get_redis_ttl(env_path: str):
+    try:
+        ttl = os.environ.get(env_path, None)
+        return int(ttl) if ttl else ttl
+    except Exception:
+        return None
+
+REDIS_TTL_SESSION_POOL = _get_redis_ttl("REDIS_TTL_SESSION_POOL")
+REDIS_TTL_USER_POOL = _get_redis_ttl("REDIS_TTL_USER_POOL")
+REDIS_TTL_USAGE_POOL = _get_redis_ttl("REDIS_TTL_USAGE_POOL")
+
 # Maximum number of retries for Redis operations when using Sentinel fail-over
 REDIS_SENTINEL_MAX_RETRY_COUNT = os.environ.get("REDIS_SENTINEL_MAX_RETRY_COUNT", "2")
 try:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -39,7 +39,7 @@ from open_webui.env import (
     WEBSOCKET_SERVER_ENGINEIO_LOGGING,
     REDIS_TTL_SESSION_POOL,
     REDIS_TTL_USER_POOL,
-    REDIS_TTL_USAGE_POOL
+    REDIS_TTL_USAGE_POOL,
 )
 from open_webui.utils.auth import decode_token
 from open_webui.socket.utils import RedisDict, RedisLock, YdocManager
@@ -271,12 +271,14 @@ def get_active_status_by_user_id(user_id):
         return True
     return False
 
+
 def refresh_user_pool(user_id: str, sid: str):
     if user_id in USER_POOL:
         if sid not in USER_POOL[user_id]:
             USER_POOL[user_id] = USER_POOL[user_id] + [sid]
     else:
         USER_POOL[user_id] = [sid]
+
 
 @sio.on("usage")
 async def usage(sid, data):
@@ -803,13 +805,10 @@ def get_event_call(request_info):
             to=request_info["session_id"],
         )
         return response
-    
-    if (
-        "session_id" in request_info
-        and "user_id" in request_info
-    ):
-        refresh_user_pool(request_info['user_id'], request_info['session_id'])
-    
+
+    if "session_id" in request_info and "user_id" in request_info:
+        refresh_user_pool(request_info["user_id"], request_info["session_id"])
+
     if (
         "session_id" in request_info
         and "chat_id" in request_info

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -47,7 +47,14 @@ class RedisLock:
 
 
 class RedisDict:
-    def __init__(self, name, redis_url, redis_sentinels=[], redis_cluster=False, ttl: int | None = None):
+    def __init__(
+        self,
+        name,
+        redis_url,
+        redis_sentinels=[],
+        redis_cluster=False,
+        ttl: int | None = None,
+    ):
         self.name = name
         self.redis = get_redis_connection(
             redis_url,
@@ -55,7 +62,7 @@ class RedisDict:
             redis_cluster=redis_cluster,
             decode_responses=True,
         )
-        self.ttl = ttl #Note: Only available for Redis Version >= 7.4.0.
+        self.ttl = ttl  # Note: Only available for Redis Version >= 7.4.0.
 
     def __setitem__(self, key, value):
         serialized_value = json.dumps(value)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

As described in https://github.com/open-webui/open-webui/discussions/16074, the active user field within the UI is incorrectly displaying how many user are currently active. This is because active user relies on the USER_POOL redis hash to count the total active users; however said hash is never cleared leading to a build up of non active users being counted. 
<img width="355" height="182" alt="image" src="https://github.com/user-attachments/assets/6f01121c-0915-4e8d-bae1-bb674fda0f92" />
This PR addresses this problem by 
1) Updating Redis Dict class with a TTL variable that will expire a hash field when set.
2) Creating a refresh_user_pool function that is called when get_event_call() is executed.
3) Adding an environment variable called REDIS_TTL_USER_POOL. If not set, then the hash field will not expire.

Effectively a user inside of the user pool will now expire unless an event such as a model call is made.
 
### Added

- Environment variable called REDIS_TTL_USER_POOL that sets the expiration time in seconds for the user pool hash field. If not set, the hash field will not expire.

### Changed

- RedisDict class to accept a ttl variable that, if set, expires the hash field.  

### Fixed

- Active User displaying accurate count (if REDIS_TTL_USER_POOL is set)


---

### Additional Information

- PR also includes REDIS_TTL_SESSION_POOL and REDIS_TTL_USAGE_POOL which can expire both session_pool and usage_pool hash fields respectively; however the usefulness for these two environment variables are unknown to me at this time.

- Setting the REDIS_TTL_USER_POOL is an art more than a science. Therefore it should be up to the users discretion to select the time window they want to keep for determining "what is an active user"

- To use the ttl variable inside of RedisDict, the redis instance should be version >= [7.4.0](https://redis.io/docs/latest/commands/hexpire/) (or [valkey](https://valkey.io/commands/hexpire/) version >= 9.0) 

### Screenshots or Videos

- Before TTL expires
<img width="307" height="173" alt="image" src="https://github.com/user-attachments/assets/822a6e28-0fd1-4c86-9d5f-2bcc8ccf004a" />

- After TTL expires
<img width="270" height="178" alt="image" src="https://github.com/user-attachments/assets/98e26442-47b2-4336-9901-112c090a0fc5" />



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
