### PR TITLE
fix: has_access_to_file check kb file_ids as well

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -73,6 +73,15 @@ def has_access_to_file(
             user.id, access_type
         )
         for knowledge_base in knowledge_bases:
+            if (
+                f"file-{file_id}" == knowledge_base_id
+                and file_id in knowledge_base.data["file_ids"]
+            ):
+                log.debug(
+                    f"Access to file {file_id} exists via file_ids of knowledge base {knowledge_base.id}"
+                )
+                has_access = True
+                break
             if knowledge_base.id == knowledge_base_id:
                 has_access = True
                 break


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

We validate file_id against knowledge base file_ids. Some files contained in knowledge base have 'collection_name':'file-ID'. Eg. {'name': 'test.pdf', 'content_type': 'application/pdf', 'size': 583193, 'data': {}, 'collection_name': 'file-e37e205a-a79b-43ce-bfa8-92a8d95d3627'} When such file is detected we are performing a check against file_ids of user knowledge base.

The result is users having the posibility to normaly view the citations or files in knowledge base.

### Fixed

We validate file_id against knowledge base file_ids, displaying some files previously unable to show.

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

Before no access to file and error 404.
```
Nov 26 16:23:22 open-webui open-webui[653599]: 2025-11-26 16:23:22.348 | DEBUG    | open_webui.routers.files:has_access_to_file:60 - Checking if user has read access to file
Nov 26 16:23:22 open-webui open-webui[653599]: 2025-11-26 16:23:22.353 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 195.167.38.92:0 - "GET /api/v1/files/e37e205a-a79b-43ce-bfa8-92a8d95d3627 HTTP/1.1" 404
```

After: 

```
Nov 26 17:08:25 open-webui open-webui[654978]: 2025-11-26 17:08:25.470 | DEBUG    | open_webui.routers.files:has_access_to_file:60 - Checking if user has read access to file
Nov 26 17:08:25 open-webui open-webui[654978]: 2025-11-26 17:08:25.474 | DEBUG    | open_webui.routers.files:has_access_to_file:84 - Access to file e37e205a-a79b-43ce-bfa8-92a8d95d3627  exists via file_ids of knowledge base 149c9633-77de-4426-a107-1155a87e3207
Nov 26 17:08:25 open-webui open-webui[654978]: 2025-11-26 17:08:25.475 | INFO     | uvicorn.protocols.http.httptools_impl:send:476 - 195.167.38.92:0 - "GET /api/v1/files/e37e205a-a79b-43ce-bfa8-92a8d95d3627/content HTTP/1.1" 200
```

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
