### PR TITLE
feat: Add per-model accent colors with intensity control

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1674,6 +1674,53 @@ except Exception as e:
 WEBUI_BANNERS = PersistentConfig("WEBUI_BANNERS", "ui.banners", banners)
 
 
+####################################
+# MODEL ACCENT COLORS
+####################################
+
+
+class WatermarkConfigModel(BaseModel):
+    enabled: bool = False
+    useModelIcon: bool = True
+    customUrl: Optional[str] = None
+    opacity: float = 0.03
+    position: str = "center"
+    size: str = "200px"
+
+
+class BadgeConfigModel(BaseModel):
+    enabled: bool = False
+    size: str = "24px"
+
+
+class ModelColorMappingModel(BaseModel):
+    pattern: str
+    color: str
+    priority: int = 0
+    watermark: Optional[WatermarkConfigModel] = None
+    badge: Optional[BadgeConfigModel] = None
+
+
+class ModelColorsConfigModel(BaseModel):
+    enabled: bool = False
+    defaultColor: str = "#3b82f6"
+    mappings: list[ModelColorMappingModel] = []
+
+
+try:
+    model_colors_data = json.loads(os.environ.get("MODEL_COLORS", "{}"))
+    model_colors = ModelColorsConfigModel(**model_colors_data) if model_colors_data else ModelColorsConfigModel()
+except Exception as e:
+    log.exception(f"Error loading MODEL_COLORS: {e}")
+    model_colors = ModelColorsConfigModel()
+
+MODEL_COLORS = PersistentConfig(
+    "MODEL_COLORS",
+    "ui.model_colors",
+    model_colors.model_dump(),
+)
+
+
 SHOW_ADMIN_DETAILS = PersistentConfig(
     "SHOW_ADMIN_DETAILS",
     "auth.admin.show",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -343,6 +343,7 @@ from open_webui.config import (
     WEBUI_AUTH,
     WEBUI_NAME,
     WEBUI_BANNERS,
+    MODEL_COLORS,
     WEBHOOK_URL,
     ADMIN_EMAIL,
     SHOW_ADMIN_DETAILS,
@@ -766,6 +767,7 @@ app.state.config.RESPONSE_WATERMARK = RESPONSE_WATERMARK
 app.state.config.USER_PERMISSIONS = USER_PERMISSIONS
 app.state.config.WEBHOOK_URL = WEBHOOK_URL
 app.state.config.BANNERS = WEBUI_BANNERS
+app.state.config.MODEL_COLORS = MODEL_COLORS
 
 
 app.state.config.ENABLE_FOLDERS = ENABLE_FOLDERS

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -45,6 +45,18 @@ class ModelMeta(BaseModel):
 
     capabilities: Optional[dict] = None
 
+    accent_color: Optional[str] = None
+    """
+        Accent color for visual differentiation (hex format, e.g., '#3b82f6').
+        Inherited from base model if not set.
+    """
+
+    accent_intensity: Optional[float] = None
+    """
+        Intensity/opacity of the accent color (0.1 to 1.0).
+        Defaults to 0.35 if not set.
+    """
+
     model_config = ConfigDict(extra="allow")
 
     pass

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.config import get_config, save_config
-from open_webui.config import BannerModel
+from open_webui.config import BannerModel, ModelColorsConfigModel
 
 from open_webui.utils.tools import (
     get_tool_server_data,
@@ -536,3 +536,27 @@ async def get_banners(
     user=Depends(get_verified_user),
 ):
     return request.app.state.config.BANNERS
+
+
+############################
+# ModelColors
+############################
+
+
+@router.get("/model-colors")
+async def get_model_colors(
+    request: Request,
+    user=Depends(get_verified_user),
+):
+    return request.app.state.config.MODEL_COLORS
+
+
+@router.post("/model-colors")
+async def set_model_colors(
+    request: Request,
+    form_data: ModelColorsConfigModel,
+    user=Depends(get_admin_user),
+):
+    data = form_data.model_dump()
+    request.app.state.config.MODEL_COLORS = data
+    return request.app.state.config.MODEL_COLORS

--- a/src/app.css
+++ b/src/app.css
@@ -33,6 +33,10 @@
 /* --app-text-scale is updated via the UI Scale slider (Interface.svelte) */
 :root {
 	--app-text-scale: 1;
+
+	/* Model accent colors - updated dynamically by applyModelAccent() */
+	--model-accent: #3b82f6;
+	--model-accent-rgb: 59, 130, 246;
 }
 
 html {
@@ -802,4 +806,62 @@ body {
 .pm-li-drop-outdent {
 	position: relative;
 	z-index: 0;
+}
+
+/* ========================================
+   Model Accent Color Styles
+   These only apply when html.model-accent-enabled
+   is present (i.e., when a model has an accent color set)
+   ======================================== */
+
+:root {
+	--model-accent-intensity: 0.35;
+}
+
+/* AI Response Message Border - only when accent is enabled */
+html.model-accent-enabled .model-accent-message-border {
+	border-left: 2px solid rgba(var(--model-accent-rgb), var(--model-accent-intensity));
+	padding-left: 0.75rem;
+	transition: border-color 0.2s ease-in-out;
+}
+
+/* Message Input Border - only when accent is enabled */
+html.model-accent-enabled .model-accent-input:focus,
+html.model-accent-enabled .model-accent-input:focus-within {
+	border-color: rgba(var(--model-accent-rgb), var(--model-accent-intensity));
+	box-shadow: 0 0 0 1px rgba(var(--model-accent-rgb), calc(var(--model-accent-intensity) * 0.3));
+	transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+/* Accent intensity slider with color preview */
+.accent-slider {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 8px;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--slider-color) calc(var(--slider-opacity) * 100%), transparent);
+	outline: none;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.accent-slider::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--slider-color);
+	cursor: pointer;
+	border: 2px solid white;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.accent-slider::-moz-range-thumb {
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--slider-color);
+	cursor: pointer;
+	border: 2px solid white;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -1,5 +1,5 @@
 import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
-import type { Banner } from '$lib/types';
+import type { Banner, ModelColorsConfig } from '$lib/types';
 
 export const importConfig = async (token: string, config) => {
 	let error = null;
@@ -431,6 +431,64 @@ export const setBanners = async (token: string, banners: Banner[]) => {
 		body: JSON.stringify({
 			banners: banners
 		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelColorsConfig = async (token: string): Promise<ModelColorsConfig> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/model-colors`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const setModelColorsConfig = async (
+	token: string,
+	config: ModelColorsConfig
+): Promise<ModelColorsConfig> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/model-colors`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(config)
 	})
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();

--- a/src/lib/components/admin/Settings/Interface/ModelColors.svelte
+++ b/src/lib/components/admin/Settings/Interface/ModelColors.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+	import Switch from '$lib/components/common/Switch.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import EllipsisVertical from '$lib/components/icons/EllipsisVertical.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+	import Sortable from 'sortablejs';
+	import { getContext } from 'svelte';
+	import type { ModelColorsConfig, ModelColorMapping } from '$lib/types';
+
+	const i18n = getContext('i18n');
+
+	export let config: ModelColorsConfig;
+	export let models: { id: string; name: string }[] = [];
+
+	let sortable: Sortable | null = null;
+	let mappingListElement: HTMLElement | null = null;
+
+	const positionChangeHandler = () => {
+		if (!mappingListElement) return;
+		const mappingIdOrder = Array.from(mappingListElement.children).map((child) =>
+			child.id.replace('mapping-item-', '')
+		);
+
+		config.mappings = mappingIdOrder.map((pattern) => {
+			const index = config.mappings.findIndex((m) => m.pattern === pattern);
+			return config.mappings[index];
+		});
+	};
+
+	$: if (config.mappings) {
+		initSortable();
+	}
+
+	const initSortable = () => {
+		if (sortable) {
+			sortable.destroy();
+		}
+
+		if (mappingListElement) {
+			sortable = new Sortable(mappingListElement, {
+				animation: 150,
+				handle: '.item-handle',
+				onUpdate: async () => {
+					positionChangeHandler();
+				}
+			});
+		}
+	};
+
+	const addMapping = () => {
+		const lastMapping = config.mappings.at(-1);
+		if (config.mappings.length === 0 || (lastMapping && lastMapping.pattern !== '')) {
+			config.mappings = [
+				...config.mappings,
+				{
+					pattern: '',
+					color: '#3b82f6',
+					priority: 0
+				}
+			];
+		}
+	};
+
+	const removeMapping = (index: number) => {
+		config.mappings.splice(index, 1);
+		config.mappings = config.mappings;
+	};
+</script>
+
+<div class="space-y-3">
+	<div class="flex w-full items-center justify-between">
+		<div class="self-center text-xs font-medium">
+			{$i18n.t('Enable Model Accent Colors')}
+		</div>
+		<Switch bind:state={config.enabled} />
+	</div>
+
+	{#if config.enabled}
+		<div class="space-y-3">
+			<div class="flex items-center gap-3">
+				<div class="text-xs">{$i18n.t('Default Color')}</div>
+				<input
+					type="color"
+					class="w-8 h-8 rounded cursor-pointer border border-gray-200 dark:border-gray-700"
+					bind:value={config.defaultColor}
+				/>
+				<input
+					type="text"
+					class="w-24 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600"
+					bind:value={config.defaultColor}
+					placeholder="#3b82f6"
+				/>
+			</div>
+
+			<div class="flex w-full justify-between items-center">
+				<div class="self-center text-xs">
+					{$i18n.t('Model Color Mappings')}
+				</div>
+
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition"
+					type="button"
+					on:click={addMapping}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 20 20"
+						fill="currentColor"
+						class="w-4 h-4"
+					>
+						<path
+							d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			<div
+				class="flex flex-col gap-3 {config.mappings?.length > 0 ? 'mt-2' : ''}"
+				bind:this={mappingListElement}
+			>
+				{#each config.mappings as mapping, idx (mapping.pattern || idx)}
+					<div
+						class="flex justify-between items-center -ml-1"
+						id="mapping-item-{mapping.pattern || idx}"
+					>
+						<EllipsisVertical className="size-4 cursor-move item-handle" />
+
+						<div class="flex flex-row flex-1 gap-2 items-center">
+							<input
+								type="text"
+								list="model-suggestions"
+								class="flex-1 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600 px-1 py-1"
+								placeholder={$i18n.t('Model ID or pattern (e.g., gpt-*, claude-*)')}
+								bind:value={mapping.pattern}
+							/>
+
+							<input
+								type="color"
+								class="w-7 h-7 rounded cursor-pointer border border-gray-200 dark:border-gray-700"
+								bind:value={mapping.color}
+							/>
+
+							<input
+								type="text"
+								class="w-20 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600"
+								bind:value={mapping.color}
+								placeholder="#hex"
+							/>
+
+							<Tooltip content={$i18n.t('Priority (higher = checked first)')}>
+								<input
+									type="number"
+									class="w-12 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600 text-center"
+									bind:value={mapping.priority}
+									min="0"
+									placeholder="0"
+								/>
+							</Tooltip>
+						</div>
+
+						<button class="pr-3 pl-2" type="button" on:click={() => removeMapping(idx)}>
+							<XMark className={'size-4'} />
+						</button>
+					</div>
+				{/each}
+			</div>
+
+			{#if models.length > 0}
+				<datalist id="model-suggestions">
+					{#each models as model}
+						<option value={model.id}>{model.name}</option>
+					{/each}
+				</datalist>
+			{/if}
+
+			<div class="text-xs text-gray-500 dark:text-gray-400">
+				{$i18n.t('Use * as wildcard (e.g., gpt-* matches all GPT models). Higher priority mappings are checked first.')}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -53,7 +53,10 @@
 		getPromptVariables,
 		processDetails,
 		removeAllDetails,
-		getCodeBlockContents
+		getCodeBlockContents,
+		resolveModelAccent,
+		applyModelAccent,
+		setModelAccentIntensity
 	} from '$lib/utils';
 	import { AudioQueue } from '$lib/utils/audio';
 
@@ -241,6 +244,17 @@
 		sessionStorage.selectedModels = selectedModelsString;
 		console.log('saveSessionSelectedModels', selectedModels, sessionStorage.selectedModels);
 	};
+
+	// Apply model accent color and intensity when selected model changes
+	$: if (selectedModels && selectedModels[0] && $models) {
+		const accent = resolveModelAccent(selectedModels[0], $models);
+		if (accent) {
+			applyModelAccent(accent.color);
+			setModelAccentIntensity(accent.intensity);
+		} else {
+			applyModelAccent(null);
+		}
+	}
 
 	let oldSelectedModelIds = [''];
 	$: if (JSON.stringify(selectedModelIds) !== JSON.stringify(oldSelectedModelIds)) {

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1059,7 +1059,7 @@
 
 						<div
 							id="message-input-container"
-							class="flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {$temporaryChatEnabled
+							class="model-accent-input flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {$temporaryChatEnabled
 								? 'border-dashed border-gray-100 dark:border-gray-800 hover:border-gray-200 focus-within:border-gray-200 hover:dark:border-gray-700 focus-within:dark:border-gray-700'
 								: ' border-gray-100 dark:border-gray-850 hover:border-gray-200 focus-within:border-gray-100 hover:dark:border-gray-800 focus-within:dark:border-gray-800'}  transition px-1 bg-white/5 dark:bg-gray-500/5 backdrop-blur-sm dark:text-gray-100"
 							dir={$settings?.chatDirection ?? 'auto'}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -767,7 +767,7 @@
 
 						<div
 							bind:this={contentContainerElement}
-							class="w-full flex flex-col relative {edit ? 'hidden' : ''}"
+							class="w-full flex flex-col relative model-accent-message-border {edit ? 'hidden' : ''}"
 							id="response-content-container"
 						>
 							{#if message.content === '' && !message.error && ((model?.info?.meta?.capabilities?.status_updates ?? true) ? (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length === 0 || (message?.statusHistory?.at(-1)?.hidden ?? false) : true)}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,7 +1,7 @@
 import { APP_NAME } from '$lib/constants';
 import { type Writable, writable } from 'svelte/store';
 import type { ModelConfig } from '$lib/apis';
-import type { Banner } from '$lib/types';
+import type { Banner, ModelColorsConfig } from '$lib/types';
 import type { Socket } from 'socket.io-client';
 
 import emojiShortCodes from '$lib/emoji-shortcodes.json';
@@ -70,6 +70,12 @@ export const functions = writable(null);
 export const toolServers = writable([]);
 
 export const banners: Writable<Banner[]> = writable([]);
+
+export const modelColorsConfig: Writable<ModelColorsConfig> = writable({
+	enabled: false,
+	defaultColor: '#3b82f6',
+	mappings: []
+});
 
 export const settings: Writable<Settings> = writable({});
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -8,6 +8,34 @@ export type Banner = {
 	timestamp: number;
 };
 
+export type WatermarkConfig = {
+	enabled: boolean;
+	useModelIcon: boolean;
+	customUrl?: string;
+	opacity: number;
+	position: 'center' | 'bottom-right' | 'bottom-center';
+	size: string;
+};
+
+export type BadgeConfig = {
+	enabled: boolean;
+	size: string;
+};
+
+export type ModelColorMapping = {
+	pattern: string;
+	color: string;
+	priority: number;
+	watermark?: WatermarkConfig;
+	badge?: BadgeConfig;
+};
+
+export type ModelColorsConfig = {
+	enabled: boolean;
+	defaultColor: string;
+	mappings: ModelColorMapping[];
+};
+
 export enum TTS_RESPONSE_SPLIT {
 	PUNCTUATION = 'punctuation',
 	PARAGRAPHS = 'paragraphs',

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,7 +15,7 @@
 	import { getAllTags } from '$lib/apis/chats';
 	import { getPrompts } from '$lib/apis/prompts';
 	import { getTools } from '$lib/apis/tools';
-	import { getBanners } from '$lib/apis/configs';
+	import { getBanners, getModelColorsConfig } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
 
 	import { WEBUI_VERSION } from '$lib/constants';
@@ -32,6 +32,7 @@
 		functions,
 		tags,
 		banners,
+		modelColorsConfig,
 		showSettings,
 		showShortcuts,
 		showChangelog,
@@ -140,6 +141,11 @@
 		banners.set(bannersData);
 	};
 
+	const setModelColors = async () => {
+		const modelColorsData = await getModelColorsConfig(localStorage.token);
+		modelColorsConfig.set(modelColorsData);
+	};
+
 	const setTools = async () => {
 		const toolsData = await getTools(localStorage.token);
 		tools.set(toolsData);
@@ -158,6 +164,7 @@
 		await Promise.all([
 			checkLocalDBChats(),
 			setBanners(),
+			setModelColors(),
 			setTools(),
 			setUserSettings(async () => {
 				await Promise.all([setModels(), setToolServers()]);


### PR DESCRIPTION
## Summary

Add the ability to set custom accent colors for models that provide visual distinction during conversations. This helps users quickly identify which model they're interacting with.

### Features
- **Per-model accent color**: Color picker with direct hex input support in Model Editor
- **Adjustable intensity**: Slider with live preview showing the color at selected opacity
- **Color inheritance**: Child models inherit accent color and intensity from base models
- **Subtle visual indicators**: 
  - Left border on AI response messages
  - Focus ring on chat input when typing
- **Opt-in behavior**: No styling changes unless a model explicitly has an accent color set

### Design Decisions
- Intensity defaults to 35% for subtle, non-distracting appearance
- Both color and intensity support "Default" mode for inheritance
- Color picker includes hex text input for precise color matching
- Slider track itself shows the color preview at current intensity

## Test Plan
- [ ] Set accent color on a model, verify it appears in chat
- [ ] Adjust intensity slider, verify preview updates in real-time
- [ ] Create child model, verify it inherits parent's accent color
- [ ] Clear accent color, verify UI returns to default (no accent)
- [ ] Enter hex value directly, verify color updates
- [ ] Test with multiple models to verify colors switch correctly

## Contributor License Agreement

I have read and agree to the [Contributor License Agreement](https://github.com/open-webui/open-webui/blob/main/CLA.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)