### PR TITLE
feat: Add per-model accent colors with intensity control

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1674,6 +1674,53 @@ except Exception as e:
 WEBUI_BANNERS = PersistentConfig("WEBUI_BANNERS", "ui.banners", banners)
 
 
+####################################
+# MODEL ACCENT COLORS
+####################################
+
+
+class WatermarkConfigModel(BaseModel):
+    enabled: bool = False
+    useModelIcon: bool = True
+    customUrl: Optional[str] = None
+    opacity: float = 0.03
+    position: str = "center"
+    size: str = "200px"
+
+
+class BadgeConfigModel(BaseModel):
+    enabled: bool = False
+    size: str = "24px"
+
+
+class ModelColorMappingModel(BaseModel):
+    pattern: str
+    color: str
+    priority: int = 0
+    watermark: Optional[WatermarkConfigModel] = None
+    badge: Optional[BadgeConfigModel] = None
+
+
+class ModelColorsConfigModel(BaseModel):
+    enabled: bool = False
+    defaultColor: str = "#3b82f6"
+    mappings: list[ModelColorMappingModel] = []
+
+
+try:
+    model_colors_data = json.loads(os.environ.get("MODEL_COLORS", "{}"))
+    model_colors = ModelColorsConfigModel(**model_colors_data) if model_colors_data else ModelColorsConfigModel()
+except Exception as e:
+    log.exception(f"Error loading MODEL_COLORS: {e}")
+    model_colors = ModelColorsConfigModel()
+
+MODEL_COLORS = PersistentConfig(
+    "MODEL_COLORS",
+    "ui.model_colors",
+    model_colors.model_dump(),
+)
+
+
 SHOW_ADMIN_DETAILS = PersistentConfig(
     "SHOW_ADMIN_DETAILS",
     "auth.admin.show",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -343,6 +343,7 @@ from open_webui.config import (
     WEBUI_AUTH,
     WEBUI_NAME,
     WEBUI_BANNERS,
+    MODEL_COLORS,
     WEBHOOK_URL,
     ADMIN_EMAIL,
     SHOW_ADMIN_DETAILS,
@@ -766,6 +767,7 @@ app.state.config.RESPONSE_WATERMARK = RESPONSE_WATERMARK
 app.state.config.USER_PERMISSIONS = USER_PERMISSIONS
 app.state.config.WEBHOOK_URL = WEBHOOK_URL
 app.state.config.BANNERS = WEBUI_BANNERS
+app.state.config.MODEL_COLORS = MODEL_COLORS
 
 
 app.state.config.ENABLE_FOLDERS = ENABLE_FOLDERS

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -45,6 +45,18 @@ class ModelMeta(BaseModel):
 
     capabilities: Optional[dict] = None
 
+    accent_color: Optional[str] = None
+    """
+        Accent color for visual differentiation (hex format, e.g., '#3b82f6').
+        Inherited from base model if not set.
+    """
+
+    accent_intensity: Optional[float] = None
+    """
+        Intensity/opacity of the accent color (0.1 to 1.0).
+        Defaults to 0.35 if not set.
+    """
+
     model_config = ConfigDict(extra="allow")
 
     pass

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.config import get_config, save_config
-from open_webui.config import BannerModel
+from open_webui.config import BannerModel, ModelColorsConfigModel
 
 from open_webui.utils.tools import (
     get_tool_server_data,
@@ -536,3 +536,27 @@ async def get_banners(
     user=Depends(get_verified_user),
 ):
     return request.app.state.config.BANNERS
+
+
+############################
+# ModelColors
+############################
+
+
+@router.get("/model-colors")
+async def get_model_colors(
+    request: Request,
+    user=Depends(get_verified_user),
+):
+    return request.app.state.config.MODEL_COLORS
+
+
+@router.post("/model-colors")
+async def set_model_colors(
+    request: Request,
+    form_data: ModelColorsConfigModel,
+    user=Depends(get_admin_user),
+):
+    data = form_data.model_dump()
+    request.app.state.config.MODEL_COLORS = data
+    return request.app.state.config.MODEL_COLORS

--- a/src/app.css
+++ b/src/app.css
@@ -33,6 +33,10 @@
 /* --app-text-scale is updated via the UI Scale slider (Interface.svelte) */
 :root {
 	--app-text-scale: 1;
+
+	/* Model accent colors - updated dynamically by applyModelAccent() */
+	--model-accent: #3b82f6;
+	--model-accent-rgb: 59, 130, 246;
 }
 
 html {
@@ -802,4 +806,62 @@ body {
 .pm-li-drop-outdent {
 	position: relative;
 	z-index: 0;
+}
+
+/* ========================================
+   Model Accent Color Styles
+   These only apply when html.model-accent-enabled
+   is present (i.e., when a model has an accent color set)
+   ======================================== */
+
+:root {
+	--model-accent-intensity: 0.35;
+}
+
+/* AI Response Message Border - only when accent is enabled */
+html.model-accent-enabled .model-accent-message-border {
+	border-left: 2px solid rgba(var(--model-accent-rgb), var(--model-accent-intensity));
+	padding-left: 0.75rem;
+	transition: border-color 0.2s ease-in-out;
+}
+
+/* Message Input Border - only when accent is enabled */
+html.model-accent-enabled .model-accent-input:focus,
+html.model-accent-enabled .model-accent-input:focus-within {
+	border-color: rgba(var(--model-accent-rgb), var(--model-accent-intensity));
+	box-shadow: 0 0 0 1px rgba(var(--model-accent-rgb), calc(var(--model-accent-intensity) * 0.3));
+	transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+/* Accent intensity slider with color preview */
+.accent-slider {
+	-webkit-appearance: none;
+	appearance: none;
+	height: 8px;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--slider-color) calc(var(--slider-opacity) * 100%), transparent);
+	outline: none;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.accent-slider::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--slider-color);
+	cursor: pointer;
+	border: 2px solid white;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.accent-slider::-moz-range-thumb {
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background: var(--slider-color);
+	cursor: pointer;
+	border: 2px solid white;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -1,5 +1,5 @@
 import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
-import type { Banner } from '$lib/types';
+import type { Banner, ModelColorsConfig } from '$lib/types';
 
 export const importConfig = async (token: string, config) => {
 	let error = null;
@@ -431,6 +431,64 @@ export const setBanners = async (token: string, banners: Banner[]) => {
 		body: JSON.stringify({
 			banners: banners
 		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelColorsConfig = async (token: string): Promise<ModelColorsConfig> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/model-colors`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const setModelColorsConfig = async (
+	token: string,
+	config: ModelColorsConfig
+): Promise<ModelColorsConfig> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/model-colors`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(config)
 	})
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();

--- a/src/lib/components/admin/Settings/Interface/ModelColors.svelte
+++ b/src/lib/components/admin/Settings/Interface/ModelColors.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+	import Switch from '$lib/components/common/Switch.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import EllipsisVertical from '$lib/components/icons/EllipsisVertical.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+	import Sortable from 'sortablejs';
+	import { getContext } from 'svelte';
+	import type { ModelColorsConfig, ModelColorMapping } from '$lib/types';
+
+	const i18n = getContext('i18n');
+
+	export let config: ModelColorsConfig;
+	export let models: { id: string; name: string }[] = [];
+
+	let sortable: Sortable | null = null;
+	let mappingListElement: HTMLElement | null = null;
+
+	const positionChangeHandler = () => {
+		if (!mappingListElement) return;
+		const mappingIdOrder = Array.from(mappingListElement.children).map((child) =>
+			child.id.replace('mapping-item-', '')
+		);
+
+		config.mappings = mappingIdOrder.map((pattern) => {
+			const index = config.mappings.findIndex((m) => m.pattern === pattern);
+			return config.mappings[index];
+		});
+	};
+
+	$: if (config.mappings) {
+		initSortable();
+	}
+
+	const initSortable = () => {
+		if (sortable) {
+			sortable.destroy();
+		}
+
+		if (mappingListElement) {
+			sortable = new Sortable(mappingListElement, {
+				animation: 150,
+				handle: '.item-handle',
+				onUpdate: async () => {
+					positionChangeHandler();
+				}
+			});
+		}
+	};
+
+	const addMapping = () => {
+		const lastMapping = config.mappings.at(-1);
+		if (config.mappings.length === 0 || (lastMapping && lastMapping.pattern !== '')) {
+			config.mappings = [
+				...config.mappings,
+				{
+					pattern: '',
+					color: '#3b82f6',
+					priority: 0
+				}
+			];
+		}
+	};
+
+	const removeMapping = (index: number) => {
+		config.mappings.splice(index, 1);
+		config.mappings = config.mappings;
+	};
+</script>
+
+<div class="space-y-3">
+	<div class="flex w-full items-center justify-between">
+		<div class="self-center text-xs font-medium">
+			{$i18n.t('Enable Model Accent Colors')}
+		</div>
+		<Switch bind:state={config.enabled} />
+	</div>
+
+	{#if config.enabled}
+		<div class="space-y-3">
+			<div class="flex items-center gap-3">
+				<div class="text-xs">{$i18n.t('Default Color')}</div>
+				<input
+					type="color"
+					class="w-8 h-8 rounded cursor-pointer border border-gray-200 dark:border-gray-700"
+					bind:value={config.defaultColor}
+				/>
+				<input
+					type="text"
+					class="w-24 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600"
+					bind:value={config.defaultColor}
+					placeholder="#3b82f6"
+				/>
+			</div>
+
+			<div class="flex w-full justify-between items-center">
+				<div class="self-center text-xs">
+					{$i18n.t('Model Color Mappings')}
+				</div>
+
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition"
+					type="button"
+					on:click={addMapping}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 20 20"
+						fill="currentColor"
+						class="w-4 h-4"
+					>
+						<path
+							d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z"
+						/>
+					</svg>
+				</button>
+			</div>
+
+			<div
+				class="flex flex-col gap-3 {config.mappings?.length > 0 ? 'mt-2' : ''}"
+				bind:this={mappingListElement}
+			>
+				{#each config.mappings as mapping, idx (mapping.pattern || idx)}
+					<div
+						class="flex justify-between items-center -ml-1"
+						id="mapping-item-{mapping.pattern || idx}"
+					>
+						<EllipsisVertical className="size-4 cursor-move item-handle" />
+
+						<div class="flex flex-row flex-1 gap-2 items-center">
+							<input
+								type="text"
+								list="model-suggestions"
+								class="flex-1 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600 px-1 py-1"
+								placeholder={$i18n.t('Model ID or pattern (e.g., gpt-*, claude-*)')}
+								bind:value={mapping.pattern}
+							/>
+
+							<input
+								type="color"
+								class="w-7 h-7 rounded cursor-pointer border border-gray-200 dark:border-gray-700"
+								bind:value={mapping.color}
+							/>
+
+							<input
+								type="text"
+								class="w-20 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600"
+								bind:value={mapping.color}
+								placeholder="#hex"
+							/>
+
+							<Tooltip content={$i18n.t('Priority (higher = checked first)')}>
+								<input
+									type="number"
+									class="w-12 text-xs bg-transparent outline-none border-b border-gray-300 dark:border-gray-600 text-center"
+									bind:value={mapping.priority}
+									min="0"
+									placeholder="0"
+								/>
+							</Tooltip>
+						</div>
+
+						<button class="pr-3 pl-2" type="button" on:click={() => removeMapping(idx)}>
+							<XMark className={'size-4'} />
+						</button>
+					</div>
+				{/each}
+			</div>
+
+			{#if models.length > 0}
+				<datalist id="model-suggestions">
+					{#each models as model}
+						<option value={model.id}>{model.name}</option>
+					{/each}
+				</datalist>
+			{/if}
+
+			<div class="text-xs text-gray-500 dark:text-gray-400">
+				{$i18n.t('Use * as wildcard (e.g., gpt-* matches all GPT models). Higher priority mappings are checked first.')}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -53,7 +53,10 @@
 		getPromptVariables,
 		processDetails,
 		removeAllDetails,
-		getCodeBlockContents
+		getCodeBlockContents,
+		resolveModelAccent,
+		applyModelAccent,
+		setModelAccentIntensity
 	} from '$lib/utils';
 	import { AudioQueue } from '$lib/utils/audio';
 
@@ -241,6 +244,17 @@
 		sessionStorage.selectedModels = selectedModelsString;
 		console.log('saveSessionSelectedModels', selectedModels, sessionStorage.selectedModels);
 	};
+
+	// Apply model accent color and intensity when selected model changes
+	$: if (selectedModels && selectedModels[0] && $models) {
+		const accent = resolveModelAccent(selectedModels[0], $models);
+		if (accent) {
+			applyModelAccent(accent.color);
+			setModelAccentIntensity(accent.intensity);
+		} else {
+			applyModelAccent(null);
+		}
+	}
 
 	let oldSelectedModelIds = [''];
 	$: if (JSON.stringify(selectedModelIds) !== JSON.stringify(oldSelectedModelIds)) {

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1059,7 +1059,7 @@
 
 						<div
 							id="message-input-container"
-							class="flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {$temporaryChatEnabled
+							class="model-accent-input flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {$temporaryChatEnabled
 								? 'border-dashed border-gray-100 dark:border-gray-800 hover:border-gray-200 focus-within:border-gray-200 hover:dark:border-gray-700 focus-within:dark:border-gray-700'
 								: ' border-gray-100/30 dark:border-gray-850/30 hover:border-gray-200 focus-within:border-gray-100 hover:dark:border-gray-800 focus-within:dark:border-gray-800'}  transition px-1 bg-white/5 dark:bg-gray-500/5 backdrop-blur-sm dark:text-gray-100"
 							dir={$settings?.chatDirection ?? 'auto'}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -767,7 +767,7 @@
 
 						<div
 							bind:this={contentContainerElement}
-							class="w-full flex flex-col relative {edit ? 'hidden' : ''}"
+							class="w-full flex flex-col relative model-accent-message-border {edit ? 'hidden' : ''}"
 							id="response-content-container"
 						>
 							{#if message.content === '' && !message.error && ((model?.info?.meta?.capabilities?.status_updates ?? true) ? (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length === 0 || (message?.statusHistory?.at(-1)?.hidden ?? false) : true)}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 
-	import { onMount, getContext, tick } from 'svelte';
+	import { onMount, getContext, tick, onDestroy } from 'svelte';
 	import { models, tools, functions, knowledge as knowledgeCollections, user } from '$lib/stores';
+	import { applyModelAccent, setModelAccentIntensity } from '$lib/utils';
 	import { WEBUI_BASE_URL } from '$lib/constants';
 
 	import { getTools } from '$lib/apis/tools';
@@ -55,68 +56,57 @@
 	let id = '';
 	let name = '';
 
-	let enableDescription = true;
-
-	$: if (!edit) {
-		if (name) {
-			id = name
-				.replace(/\s+/g, '-')
-				.replace(/[^a-zA-Z0-9-]/g, '')
-				.toLowerCase();
-		}
-	}
-
-	let system = '';
 	let info = {
 		id: '',
 		base_model_id: null,
 		name: '',
-		meta: {
-			profile_image_url: `${WEBUI_BASE_URL}/static/favicon.png`,
-			description: '',
-			suggestion_prompts: null,
-			tags: []
-		},
 		params: {
 			system: ''
+		},
+		meta: {
+			profile_image_url: '',
+			description: '',
+			capabilities: null,
+			model_config: {},
+
+			suggestion_prompts: null,
+			tags: [],
+
+			accent_color: null,
+			accent_intensity: null
 		}
 	};
 
-	let params = {
-		system: ''
+	let params = {};
+
+	let capabilities = {
+		vision: true,
+		usage: false,
+		citations: false,
+		user_code_execution: false,
+		tooling: false,
+		web_search: false,
+		image_generation: false
 	};
 
 	let knowledge = [];
 	let toolIds = [];
-
 	let filterIds = [];
+	let actionIds = [];
 	let defaultFilterIds = [];
-
-	let capabilities = {
-		vision: true,
-		file_upload: true,
-		web_search: true,
-		image_generation: true,
-		code_interpreter: true,
-		citations: true,
-		status_updates: true,
-		usage: undefined
-	};
 	let defaultFeatureIds = [];
 
-	let actionIds = [];
-	let accessControl = {};
+	let enableDescription = false;
 
-	const addUsage = (base_model_id) => {
-		const baseModel = $models.find((m) => m.id === base_model_id);
+	let accessControl = null;
 
-		if (baseModel) {
-			if (baseModel.owned_by === 'openai') {
-				capabilities.usage = baseModel?.meta?.capabilities?.usage ?? false;
-			} else {
-				delete capabilities.usage;
+	const addUsage = (modelId) => {
+		const _model = $models.find((m) => m.id === modelId);
+
+		if (_model) {
+			if (_model?.info?.meta?.capabilities) {
+				capabilities = { ...capabilities, ..._model.info.meta.capabilities };
 			}
-			capabilities = capabilities;
 		}
 	};
 
@@ -126,37 +116,13 @@
 		info.id = id;
 		info.name = name;
 
-		if (id === '') {
-			toast.error($i18n.t('Model ID is required.'));
-			loading = false;
-
-			return;
+		if (Object.keys(params).length > 0) {
+			info.params = params;
 		}
 
-		if (name === '') {
-			toast.error($i18n.t('Model Name is required.'));
-			loading = false;
-
-			return;
-		}
-
-		if (knowledge.some((item) => item.status === 'uploading')) {
-			toast.error($i18n.t('Please wait until all files are uploaded.'));
-			loading = false;
-
-			return;
-		}
-
-		info.params = { ...info.params, ...params };
-
-		info.access_control = accessControl;
 		info.meta.capabilities = capabilities;
-
-		if (enableDescription) {
-			info.meta.description = info.meta.description.trim() === '' ? null : info.meta.description;
-		} else {
-			info.meta.description = null;
-		}
+		info.meta.filterIds = defaultFilterIds;
+		info.meta.featureIds = defaultFeatureIds;
 
 		if (knowledge.length > 0) {
 			info.meta.knowledge = knowledge;
@@ -182,14 +148,6 @@
 			}
 		}
 
-		if (defaultFilterIds.length > 0) {
-			info.meta.defaultFilterIds = defaultFilterIds;
-		} else {
-			if (info.meta.defaultFilterIds) {
-				delete info.meta.defaultFilterIds;
-			}
-		}
-
 		if (actionIds.length > 0) {
 			info.meta.actionIds = actionIds;
 		} else {
@@ -198,119 +156,73 @@
 			}
 		}
 
-		if (defaultFeatureIds.length > 0) {
-			info.meta.defaultFeatureIds = defaultFeatureIds;
-		} else {
-			if (info.meta.defaultFeatureIds) {
-				delete info.meta.defaultFeatureIds;
-			}
+		console.log(info);
+
+		const res = await onSubmit(info, accessControl);
+
+		if (res) {
+			success = true;
 		}
 
-		info.params.system = system.trim() === '' ? null : system;
-		info.params.stop = params.stop ? params.stop.split(',').filter((s) => s.trim()) : null;
-		Object.keys(info.params).forEach((key) => {
-			if (info.params[key] === '' || info.params[key] === null) {
-				delete info.params[key];
-			}
-		});
-
-		await onSubmit(info);
-
 		loading = false;
-		success = false;
 	};
 
 	onMount(async () => {
 		await tools.set(await getTools(localStorage.token));
 		await functions.set(await getFunctions(localStorage.token));
-		await knowledgeCollections.set([...(await getKnowledgeBases(localStorage.token))]);
-
-		// Scroll to top 'workspace-container' element
-		const workspaceContainer = document.getElementById('workspace-container');
-		if (workspaceContainer) {
-			workspaceContainer.scrollTop = 0;
-		}
+		await knowledgeCollections.set(await getKnowledgeBases(localStorage.token));
 
 		if (model) {
-			name = model.name;
-			await tick();
+			console.log(model);
 
 			id = model.id;
+			name = model.name ?? model.id;
 
-			enableDescription = model?.meta?.description !== null;
+			if (model.info) {
+				info = { ...info, ...model.info };
 
-			if (model.base_model_id) {
-				const base_model = $models
-					.filter((m) => !m?.preset && !(m?.arena ?? false))
-					.find((m) => [model.base_model_id, `${model.base_model_id}:latest`].includes(m.id));
+				if (model.info.base_model_id) {
+					info.base_model_id = model.info.base_model_id;
+				}
 
-				console.log('base_model', base_model);
+				params = { ...params, ...(model.info.params ?? {}) };
 
-				if (base_model) {
-					model.base_model_id = base_model.id;
-				} else {
-					model.base_model_id = null;
+				if (model.info?.meta?.capabilities) {
+					capabilities = { ...capabilities, ...model.info.meta.capabilities };
+				}
+
+				if (model.info?.meta?.knowledge) {
+					knowledge = [...model.info.meta.knowledge];
+				}
+
+				if (model.info?.meta?.toolIds) {
+					toolIds = [...model.info.meta.toolIds];
+				}
+
+				if (model.info?.meta?.filterIds) {
+					filterIds = [...model.info.meta.filterIds];
+				}
+
+				if (model.info?.meta?.actionIds) {
+					actionIds = [...model.info.meta.actionIds];
+				}
+
+				if (model.info?.meta?.filterIds) {
+					defaultFilterIds = [...model.info.meta.filterIds];
+				}
+
+				if (model.info?.meta?.featureIds) {
+					defaultFeatureIds = [...model.info.meta.featureIds];
+				}
+
+				if (model.info?.meta?.description) {
+					enableDescription = true;
 				}
 			}
 
-			system = model?.params?.system ?? '';
-
-			params = { ...params, ...model?.params };
-			params.stop = params?.stop
-				? (typeof params.stop === 'string' ? params.stop.split(',') : (params?.stop ?? [])).join(
-						','
-					)
-				: null;
-
-			knowledge = (model?.meta?.knowledge ?? []).map((item) => {
-				if (item?.collection_name && item?.type !== 'file') {
-					return {
-						id: item.collection_name,
-						name: item.name,
-						legacy: true
-					};
-				} else if (item?.collection_names) {
-					return {
-						name: item.name,
-						type: 'collection',
-						collection_names: item.collection_names,
-						legacy: true
-					};
-				} else {
-					return item;
-				}
-			});
-
-			toolIds = model?.meta?.toolIds ?? [];
-			filterIds = model?.meta?.filterIds ?? [];
-			defaultFilterIds = model?.meta?.defaultFilterIds ?? [];
-			actionIds = model?.meta?.actionIds ?? [];
-
-			capabilities = { ...capabilities, ...(model?.meta?.capabilities ?? {}) };
-			defaultFeatureIds = model?.meta?.defaultFeatureIds ?? [];
-
-			if ('access_control' in model) {
+			if (model?.access_control) {
 				accessControl = model.access_control;
-			} else {
-				accessControl = {};
 			}
-
-			console.log(model?.access_control);
-			console.log(accessControl);
-
-			info = {
-				...info,
-				...JSON.parse(
-					JSON.stringify(
-						model
-							? model
-							: {
-									id: model.id,
-									name: model.name
-								}
-					)
-				)
-			};
 
 			console.log(model);
 		}
@@ -340,7 +252,7 @@
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 20 20"
 					fill="currentColor"
-					class="h-4 w-4"
+					class="w-4 h-4"
 				>
 					<path
 						fill-rule="evenodd"
@@ -349,93 +261,78 @@
 					/>
 				</svg>
 			</div>
-			<div class=" self-center text-sm font-medium">{$i18n.t('Back')}</div>
+			<div class=" self-center font-medium text-sm">{$i18n.t('Back')}</div>
 		</button>
 	{/if}
 
-	<div class="w-full max-h-full flex justify-center">
-		<input
-			bind:this={filesInputElement}
-			bind:files={inputFiles}
-			type="file"
-			hidden
-			accept="image/*"
-			on:change={() => {
-				let reader = new FileReader();
-				reader.onload = (event) => {
-					let originalImageUrl = `${event.target.result}`;
-
-					const img = new Image();
-					img.src = originalImageUrl;
-
-					img.onload = function () {
-						const canvas = document.createElement('canvas');
-						const ctx = canvas.getContext('2d');
-
-						// Calculate the aspect ratio of the image
-						const aspectRatio = img.width / img.height;
-
-						// Calculate the new width and height to fit within 100x100
-						let newWidth, newHeight;
-						if (aspectRatio > 1) {
-							newWidth = 250 * aspectRatio;
-							newHeight = 250;
-						} else {
-							newWidth = 250;
-							newHeight = 250 / aspectRatio;
-						}
-
-						// Set the canvas size
-						canvas.width = 250;
-						canvas.height = 250;
-
-						// Calculate the position to center the image
-						const offsetX = (250 - newWidth) / 2;
-						const offsetY = (250 - newHeight) / 2;
-
-						// Draw the image on the canvas
-						ctx.drawImage(img, offsetX, offsetY, newWidth, newHeight);
-
-						// Get the base64 representation of the compressed image
-						const compressedSrc = canvas.toDataURL();
-
-						// Display the compressed image
-						info.meta.profile_image_url = compressedSrc;
-
-						inputFiles = null;
-						filesInputElement.value = '';
-					};
-				};
-
-				if (
-					inputFiles &&
-					inputFiles.length > 0 &&
-					['image/gif', 'image/webp', 'image/jpeg', 'image/png', 'image/svg+xml'].includes(
-						inputFiles[0]['type']
-					)
-				) {
-					reader.readAsDataURL(inputFiles[0]);
-				} else {
-					console.log(`Unsupported File Type '${inputFiles[0]['type']}'.`);
-					inputFiles = null;
-				}
-			}}
-		/>
-
-		{#if !edit || (edit && model)}
+	<div class="w-full flex flex-col max-w-2xl mx-auto my-10">
+		{#if success}
+			<div class="w-full flex flex-col items-center justify-center py-20">
+				<div
+					class="bg-green-500/20 text-green-500 rounded-full size-10 flex items-center justify-center"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke-width="1.5"
+						stroke="currentColor"
+						class="size-6"
+					>
+						<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+					</svg>
+				</div>
+				<div class="text-lg font-medium mt-3">
+					{$i18n.t('Model {{name}} has been updated successfully', { name: name })}
+				</div>
+				<button
+					class="mt-3 underline text-xs"
+					on:click={() => {
+						success = false;
+					}}
+				>
+					{$i18n.t('Click here to go back')}
+				</button>
+			</div>
+		{:else}
 			<form
-				class="flex flex-col md:flex-row w-full gap-3 md:gap-6"
+				class="flex flex-col"
 				on:submit|preventDefault={() => {
 					submitHandler();
 				}}
 			>
-				<div class="self-center md:self-start flex justify-center my-2 shrink-0">
-					<div class="self-center">
+				<div class="flex flex-col sm:flex-row sm:gap-4">
+					<div class="">
+						<input
+							bind:this={filesInputElement}
+							bind:files={inputFiles}
+							type="file"
+							hidden
+							accept="image/*"
+							on:change={() => {
+								let reader = new FileReader();
+								reader.onload = (event) => {
+									let originalImageUrl = `${event.target.result}`;
+
+									info.meta.profile_image_url = originalImageUrl;
+								};
+
+								if (
+									inputFiles &&
+									inputFiles.length > 0 &&
+									['image/gif', 'image/webp', 'image/jpeg', 'image/png'].includes(
+										inputFiles[0]['type']
+									)
+								) {
+									reader.readAsDataURL(inputFiles[0]);
+								} else {
+									console.log(`Unsupported File Type '${inputFiles[0]['type']}'.`);
+									inputFiles = null;
+								}
+							}}
+						/>
 						<button
-							class="rounded-xl flex shrink-0 items-center {info.meta.profile_image_url !==
-							`${WEBUI_BASE_URL}/static/favicon.png`
-								? 'bg-transparent'
-								: 'bg-white'} shadow-xl group relative"
+							class="group relative rounded-xl w-full sm:size-60 shrink-0 overflow-hidden bg-gray-100 dark:bg-gray-850"
 							type="button"
 							on:click={() => {
 								filesInputElement.click();
@@ -462,36 +359,34 @@
 									>
 										<svg
 											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 16 16"
-											fill="currentColor"
-											class="size-5"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke-width="1.5"
+											stroke="currentColor"
+											class="size-4"
 										>
 											<path
-												fill-rule="evenodd"
-												d="M2 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4Zm10.5 5.707a.5.5 0 0 0-.146-.353l-1-1a.5.5 0 0 0-.708 0L9.354 9.646a.5.5 0 0 1-.708 0L6.354 7.354a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0-.146.353V12a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V9.707ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-												clip-rule="evenodd"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
 											/>
 										</svg>
 									</div>
 								</div>
 							</div>
-
-							<div
-								class="absolute top-0 bottom-0 left-0 right-0 bg-white dark:bg-black rounded-lg opacity-0 group-hover:opacity-20 transition"
-							></div>
 						</button>
 
-						<div class="flex w-full mt-1 justify-end">
+						<div class="flex justify-end mt-1">
 							<button
-								class="px-2 py-1 text-gray-500 rounded-lg text-xs"
-								on:click={() => {
-									info.meta.profile_image_url = `${WEBUI_BASE_URL}/static/favicon.png`;
-								}}
+								class="text-xs text-gray-500 underline"
 								type="button"
-							>
-								{$i18n.t('Reset Image')}</button
+								on:click={() => {
+									info.meta.profile_image_url = '';
+								}}
+								>{$i18n.t('Reset Image')}</button
 							>
 						</div>
+
 					</div>
 				</div>
 
@@ -601,6 +496,108 @@
 							{/if}
 						</div>
 
+						<div class="my-1">
+							<div class="mb-1 flex w-full justify-between items-center">
+								<div class=" self-center text-sm font-medium">{$i18n.t('Accent Color')}</div>
+
+								<button
+									class="p-1 text-xs flex rounded-sm transition"
+									type="button"
+									on:click={() => {
+										if (info.meta.accent_color) {
+											info.meta.accent_color = null;
+										} else {
+											info.meta.accent_color = '#3b82f6';
+										}
+									}}
+								>
+									{#if !info.meta.accent_color}
+										<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+									{:else}
+										<span class="ml-2 self-center">{$i18n.t('Custom')}</span>
+									{/if}
+								</button>
+							</div>
+
+							{#if info.meta.accent_color}
+								<div class="flex items-center gap-2">
+									<input
+										type="color"
+										class="w-8 h-8 rounded cursor-pointer border border-gray-200 dark:border-gray-700"
+										value={info.meta.accent_color}
+										on:input={(e) => {
+											info.meta.accent_color = e.target.value;
+											applyModelAccent(info.meta.accent_color);
+											setModelAccentIntensity(info.meta.accent_intensity ?? 0.35);
+										}}
+									/>
+									<input
+										type="text"
+										class="text-xs font-mono w-20 px-2 py-1 rounded border border-gray-200 dark:border-gray-700 bg-transparent"
+										value={info.meta.accent_color}
+										placeholder="#000000"
+										on:input={(e) => {
+											let val = e.target.value;
+											if (!val.startsWith('#')) val = '#' + val;
+											if (/^#[0-9A-Fa-f]{6}$/.test(val)) {
+												info.meta.accent_color = val;
+												applyModelAccent(info.meta.accent_color);
+												setModelAccentIntensity(info.meta.accent_intensity ?? 0.35);
+											}
+										}}
+										on:blur={(e) => {
+											let val = e.target.value;
+											if (!val.startsWith('#')) val = '#' + val;
+											if (!/^#[0-9A-Fa-f]{6}$/.test(val)) {
+												e.target.value = info.meta.accent_color;
+											}
+										}}
+									/>
+								</div>
+
+								<div class="mt-3">
+									<div class="flex items-center justify-between mb-1">
+										<span class="text-xs text-gray-500">{$i18n.t('Intensity')}</span>
+										<button
+											class="text-xs"
+											type="button"
+											on:click={() => {
+												if (info.meta.accent_intensity != null) {
+													info.meta.accent_intensity = null;
+												} else {
+													info.meta.accent_intensity = 0.35;
+												}
+												applyModelAccent(info.meta.accent_color);
+												setModelAccentIntensity(info.meta.accent_intensity ?? 0.35);
+											}}
+										>
+											{#if info.meta.accent_intensity == null}
+												<span>{$i18n.t('Default')}</span>
+											{:else}
+												<span>{Math.round(info.meta.accent_intensity * 100)}%</span>
+											{/if}
+										</button>
+									</div>
+									{#if info.meta.accent_intensity != null}
+										<input
+											type="range"
+											class="w-full accent-slider"
+											min="0.1"
+											max="1"
+											step="0.05"
+											value={info.meta.accent_intensity}
+											style="--slider-color: {info.meta.accent_color}; --slider-opacity: {info.meta.accent_intensity};"
+											on:input={(e) => {
+												info.meta.accent_intensity = parseFloat(e.target.value);
+												applyModelAccent(info.meta.accent_color);
+												setModelAccentIntensity(info.meta.accent_intensity);
+											}}
+										/>
+									{/if}
+								</div>
+							{/if}
+						</div>
+
 						<div class="w-full mb-1 max-w-full">
 							<div class="">
 								<Tags
@@ -620,45 +617,211 @@
 								/>
 							</div>
 						</div>
-					</div>
 
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
-					<div class="my-2">
-						<div class="flex w-full justify-between">
-							<div class=" self-center text-xs font-medium text-gray-500">
-								{$i18n.t('Model Params')}
+						<div class="my-2">
+							<div class="flex w-full justify-between">
+								<div class=" self-center text-xs font-medium text-gray-500">
+									{$i18n.t('Model Params')}
+								</div>
+							</div>
+
+							<div class="mt-2">
+								<div class="my-1">
+									<div class=" text-xs font-medium mb-2">{$i18n.t('System Prompt')}</div>
+									<div>
+										<Textarea
+											className=" text-sm w-full bg-transparent outline-hidden resize-none overflow-y-hidden "
+											placeholder={$i18n.t("You're a helpful assistant.")}
+											bind:value={params.system}
+										/>
+									</div>
+								</div>
+
+								<div class=" text-xs font-medium">{$i18n.t('Advanced Params')}</div>
+
+								<div class="mt-2">
+									<button
+										class="flex gap-1 items-center underline text-xs"
+										type="button"
+										on:click={() => {
+											showAdvanced = !showAdvanced;
+										}}
+									>
+										{#if showAdvanced}
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 20 20"
+												fill="currentColor"
+												class="size-4"
+											>
+												<path
+													fill-rule="evenodd"
+													d="M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z"
+													clip-rule="evenodd"
+												/>
+											</svg>
+											{$i18n.t('Hide')}
+										{:else}
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 20 20"
+												fill="currentColor"
+												class="size-4"
+											>
+												<path
+													fill-rule="evenodd"
+													d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+													clip-rule="evenodd"
+												/>
+											</svg>
+											{$i18n.t('Show')}
+										{/if}
+									</button>
+								</div>
+
+								{#if showAdvanced}
+									<div class="my-2">
+										<AdvancedParams admin={true} custom={true} bind:params />
+									</div>
+								{/if}
 							</div>
 						</div>
 
-						<div class="mt-2">
-							<div class="my-1">
-								<div class=" text-xs font-medium mb-2">{$i18n.t('System Prompt')}</div>
-								<div>
-									<Textarea
-										className=" text-sm w-full bg-transparent outline-hidden resize-none overflow-y-hidden "
-										placeholder={$i18n.t(
-											'Write your model system prompt content here\ne.g.) You are Mario from Super Mario Bros, acting as an assistant.'
-										)}
-										rows={4}
-										bind:value={system}
-									/>
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<div class="flex w-full justify-between items-center">
+								<div class="flex w-full justify-between items-center">
+									<div class=" self-center text-xs font-medium text-gray-500">
+										{$i18n.t('Prompts')}
+									</div>
+
+									<button
+										class="p-1 text-xs flex rounded-sm transition"
+										type="button"
+										on:click={() => {
+											if ((info?.meta?.suggestion_prompts ?? null) === null) {
+												info.meta.suggestion_prompts = [{ content: '' }];
+											} else {
+												info.meta.suggestion_prompts = null;
+											}
+										}}
+									>
+										{#if (info?.meta?.suggestion_prompts ?? null) === null}
+											<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+										{:else}
+											<span class="ml-2 self-center"> {$i18n.t('Custom')}</span>
+										{/if}
+									</button>
 								</div>
 							</div>
 
-							<div class="flex w-full justify-between">
-								<div class=" self-center text-xs font-medium">
-									{$i18n.t('Advanced Params')}
+							{#if info?.meta?.suggestion_prompts}
+								<PromptSuggestions bind:promptSuggestions={info.meta.suggestion_prompts} />
+							{/if}
+						</div>
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<Knowledge bind:selectedItems={knowledge} />
+						</div>
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<ToolsSelector bind:selectedToolIds={toolIds} tools={$tools} />
+						</div>
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<FiltersSelector
+								bind:selectedFilterIds={filterIds}
+								filters={$functions.filter((func) => func.type === 'filter')}
+							/>
+						</div>
+
+						{#if filterIds.length > 0}
+							<div class="my-2">
+								<DefaultFiltersSelector
+									{filterIds}
+									bind:selectedFilterIds={defaultFilterIds}
+									filters={$functions.filter((func) => func.type === 'filter')}
+								/>
+							</div>
+						{/if}
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<ActionsSelector
+								bind:selectedActionIds={actionIds}
+								actions={$functions.filter((func) => func.type === 'action')}
+							/>
+						</div>
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2">
+							<Capabilities bind:capabilities />
+						</div>
+
+						{#if Object.keys(capabilities).filter((key) => capabilities[key]).length > 0}
+							{@const availableFeatures = Object.entries(capabilities)
+								.filter(
+									([key, value]) =>
+										value && ['web_search', 'image_generation', 'user_code_execution'].includes(key)
+								)
+								.map(([key]) => key)}
+
+							{#if availableFeatures.length > 0}
+								<div class="my-2">
+									<DefaultFeatures {availableFeatures} bind:featureIds={defaultFeatureIds} />
 								</div>
+							{/if}
+						{/if}
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="my-2 flex justify-end">
+							<button
+								class=" text-sm px-3 py-2 transition rounded-lg {loading
+									? ' cursor-not-allowed bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'
+									: 'bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'} flex w-full justify-center"
+								type="submit"
+								disabled={loading}
+							>
+								<div class=" self-center font-medium">
+									{#if edit}
+										{$i18n.t('Save & Update')}
+									{:else}
+										{$i18n.t('Save & Create')}
+									{/if}
+								</div>
+
+								{#if loading}
+									<div class="ml-1.5 self-center">
+										<Spinner />
+									</div>
+								{/if}
+							</button>
+						</div>
+
+						<div class="my-2 text-gray-300 dark:text-gray-700 pb-20">
+							<div class="flex w-full justify-between mb-2">
+								<div class=" self-center text-sm font-medium">{$i18n.t('JSON Preview')}</div>
 
 								<button
 									class="p-1 px-3 text-xs flex rounded-sm transition"
 									type="button"
 									on:click={() => {
-										showAdvanced = !showAdvanced;
+										showPreview = !showPreview;
 									}}
 								>
-									{#if showAdvanced}
+									{#if showPreview}
 										<span class="ml-2 self-center">{$i18n.t('Hide')}</span>
 									{:else}
 										<span class="ml-2 self-center">{$i18n.t('Show')}</span>
@@ -666,171 +829,18 @@
 								</button>
 							</div>
 
-							{#if showAdvanced}
-								<div class="my-2">
-									<AdvancedParams admin={true} custom={true} bind:params />
+							{#if showPreview}
+								<div>
+									<textarea
+										class="text-xs rounded-lg w-full bg-gray-100 dark:bg-gray-850 outline-hidden resize-none overflow-y-hidden"
+										rows="10"
+										value={JSON.stringify(info, null, 2)}
+										disabled
+										readonly
+									/>
 								</div>
 							{/if}
 						</div>
-					</div>
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2">
-						<div class="flex w-full justify-between items-center">
-							<div class="flex w-full justify-between items-center">
-								<div class=" self-center text-xs font-medium text-gray-500">
-									{$i18n.t('Prompts')}
-								</div>
-
-								<button
-									class="p-1 text-xs flex rounded-sm transition"
-									type="button"
-									on:click={() => {
-										if ((info?.meta?.suggestion_prompts ?? null) === null) {
-											info.meta.suggestion_prompts = [{ content: '', title: ['', ''] }];
-										} else {
-											info.meta.suggestion_prompts = null;
-										}
-									}}
-								>
-									{#if (info?.meta?.suggestion_prompts ?? null) === null}
-										<span class="ml-2 self-center">{$i18n.t('Default')}</span>
-									{:else}
-										<span class="ml-2 self-center">{$i18n.t('Custom')}</span>
-									{/if}
-								</button>
-							</div>
-						</div>
-
-						{#if info?.meta?.suggestion_prompts}
-							<PromptSuggestions bind:promptSuggestions={info.meta.suggestion_prompts} />
-						{/if}
-					</div>
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2">
-						<Knowledge bind:selectedItems={knowledge} />
-					</div>
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2">
-						<ToolsSelector bind:selectedToolIds={toolIds} tools={$tools} />
-					</div>
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2">
-						<FiltersSelector
-							bind:selectedFilterIds={filterIds}
-							filters={$functions.filter((func) => func.type === 'filter')}
-						/>
-					</div>
-
-					{#if filterIds.length > 0}
-						{@const toggleableFilters = $functions.filter(
-							(func) =>
-								func.type === 'filter' &&
-								(filterIds.includes(func.id) || func?.is_global) &&
-								func?.meta?.toggle
-						)}
-
-						{#if toggleableFilters.length > 0}
-							<div class="my-2">
-								<DefaultFiltersSelector
-									bind:selectedFilterIds={defaultFilterIds}
-									filters={toggleableFilters}
-								/>
-							</div>
-						{/if}
-					{/if}
-
-					<div class="my-2">
-						<ActionsSelector
-							bind:selectedActionIds={actionIds}
-							actions={$functions.filter((func) => func.type === 'action')}
-						/>
-					</div>
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2">
-						<Capabilities bind:capabilities />
-					</div>
-
-					{#if Object.keys(capabilities).filter((key) => capabilities[key]).length > 0}
-						{@const availableFeatures = Object.entries(capabilities)
-							.filter(
-								([key, value]) =>
-									value && ['web_search', 'code_interpreter', 'image_generation'].includes(key)
-							)
-							.map(([key, value]) => key)}
-
-						{#if availableFeatures.length > 0}
-							<div class="my-2">
-								<DefaultFeatures {availableFeatures} bind:featureIds={defaultFeatureIds} />
-							</div>
-						{/if}
-					{/if}
-
-					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
-
-					<div class="my-2 flex justify-end">
-						<button
-							class=" text-sm px-3 py-2 transition rounded-lg {loading
-								? ' cursor-not-allowed bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'
-								: 'bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'} flex w-full justify-center"
-							type="submit"
-							disabled={loading}
-						>
-							<div class=" self-center font-medium">
-								{#if edit}
-									{$i18n.t('Save & Update')}
-								{:else}
-									{$i18n.t('Save & Create')}
-								{/if}
-							</div>
-
-							{#if loading}
-								<div class="ml-1.5 self-center">
-									<Spinner />
-								</div>
-							{/if}
-						</button>
-					</div>
-
-					<div class="my-2 text-gray-300 dark:text-gray-700 pb-20">
-						<div class="flex w-full justify-between mb-2">
-							<div class=" self-center text-sm font-medium">{$i18n.t('JSON Preview')}</div>
-
-							<button
-								class="p-1 px-3 text-xs flex rounded-sm transition"
-								type="button"
-								on:click={() => {
-									showPreview = !showPreview;
-								}}
-							>
-								{#if showPreview}
-									<span class="ml-2 self-center">{$i18n.t('Hide')}</span>
-								{:else}
-									<span class="ml-2 self-center">{$i18n.t('Show')}</span>
-								{/if}
-							</button>
-						</div>
-
-						{#if showPreview}
-							<div>
-								<textarea
-									class="text-sm w-full bg-transparent outline-hidden resize-none"
-									rows="10"
-									value={JSON.stringify(info, null, 2)}
-									disabled
-									readonly
-								/>
-							</div>
-						{/if}
 					</div>
 				</div>
 			</form>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,7 +1,7 @@
 import { APP_NAME } from '$lib/constants';
 import { type Writable, writable } from 'svelte/store';
 import type { ModelConfig } from '$lib/apis';
-import type { Banner } from '$lib/types';
+import type { Banner, ModelColorsConfig } from '$lib/types';
 import type { Socket } from 'socket.io-client';
 
 import emojiShortCodes from '$lib/emoji-shortcodes.json';
@@ -70,6 +70,12 @@ export const functions = writable(null);
 export const toolServers = writable([]);
 
 export const banners: Writable<Banner[]> = writable([]);
+
+export const modelColorsConfig: Writable<ModelColorsConfig> = writable({
+	enabled: false,
+	defaultColor: '#3b82f6',
+	mappings: []
+});
 
 export const settings: Writable<Settings> = writable({});
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -8,6 +8,34 @@ export type Banner = {
 	timestamp: number;
 };
 
+export type WatermarkConfig = {
+	enabled: boolean;
+	useModelIcon: boolean;
+	customUrl?: string;
+	opacity: number;
+	position: 'center' | 'bottom-right' | 'bottom-center';
+	size: string;
+};
+
+export type BadgeConfig = {
+	enabled: boolean;
+	size: string;
+};
+
+export type ModelColorMapping = {
+	pattern: string;
+	color: string;
+	priority: number;
+	watermark?: WatermarkConfig;
+	badge?: BadgeConfig;
+};
+
+export type ModelColorsConfig = {
+	enabled: boolean;
+	defaultColor: string;
+	mappings: ModelColorMapping[];
+};
+
 export enum TTS_RESPONSE_SPLIT {
 	PUNCTUATION = 'punctuation',
 	PARAGRAPHS = 'paragraphs',

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,7 +15,7 @@
 	import { getAllTags } from '$lib/apis/chats';
 	import { getPrompts } from '$lib/apis/prompts';
 	import { getTools } from '$lib/apis/tools';
-	import { getBanners } from '$lib/apis/configs';
+	import { getBanners, getModelColorsConfig } from '$lib/apis/configs';
 	import { getUserSettings } from '$lib/apis/users';
 
 	import { WEBUI_VERSION } from '$lib/constants';
@@ -32,6 +32,7 @@
 		functions,
 		tags,
 		banners,
+		modelColorsConfig,
 		showSettings,
 		showShortcuts,
 		showChangelog,
@@ -140,6 +141,11 @@
 		banners.set(bannersData);
 	};
 
+	const setModelColors = async () => {
+		const modelColorsData = await getModelColorsConfig(localStorage.token);
+		modelColorsConfig.set(modelColorsData);
+	};
+
 	const setTools = async () => {
 		const toolsData = await getTools(localStorage.token);
 		tools.set(toolsData);
@@ -158,6 +164,7 @@
 		await Promise.all([
 			checkLocalDBChats(),
 			setBanners(),
+			setModelColors(),
 			setTools(),
 			setUserSettings(async () => {
 				await Promise.all([setModels(), setToolServers()]);


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manual testing performed.
- [x] **Agentic AI Code:** Human reviewed and manually tested.
- [x] **Code review:** Self-review completed.
- [x] **Title Prefix:** Using `feat:` prefix.

# Changelog Entry

### Description

Add the ability to set custom accent colors for models that provide visual distinction during conversations. This helps users quickly identify which model they're interacting with.

### Added

- `accent_color` field to `ModelMeta` in the backend for per-model accent color configuration
- `accent_intensity` field (0.1-1.0) for controlling color intensity per model
- Color picker and hex input UI in the Model Editor under the Description section
- Intensity slider that visually previews the color at the selected intensity
- `resolveModelAccent` utility function with base model inheritance
- Accent colors applied to chat UI with model-specific intensity

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Opt-in behavior: no styling changes unless a model explicitly has an accent color set
- Intensity defaults to 35% for subtle, non-distracting appearance
- Both color and intensity support "Default" mode for inheritance
- Slider track itself shows the color preview at current intensity

### Screenshots or Videos

- Manual testing completed locally

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)