### PR TITLE
fix: add on:click and on:mouseleave to Generate Title button

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -476,6 +476,12 @@
 						on:mouseenter={() => {
 							ignoreBlur = true;
 						}}
+						on:mouseleave={() => {
+							ignoreBlur = false;
+						}}
+						on:click={() => {
+							generateTitleHandler();
+						}}
 					>
 						<Sparkles strokeWidth="2" />
 					</button>


### PR DESCRIPTION
## Summary
Add `on:click` and `on:mouseleave` handlers to the "Generate Title" button to fix silent failure in Safari.

## Problem
The button relied solely on the blur event's `relatedTarget` to trigger title generation, which behaves differently in Safari and causes the button to fail silently.

## Solution
- Add `on:click` handler to explicitly call `generateTitleHandler()`
- Add `on:mouseleave` handler to reset `ignoreBlur` flag

Fixes #19616