### PR TITLE
perf: Update milvus_multitenancy remove flush

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
@@ -157,7 +157,6 @@ class MilvusClient(VectorDBBase):
             for item in items
         ]
         collection.insert(entities)
-        collection.flush()
 
     def search(
         self, collection_name: str, vectors: List[List[float]], limit: int


### PR DESCRIPTION
### Description

Calling `collection.flush()` after every upsert creates severe performance bottlenecks and causes 'Rate limit exceeded' errors on standard Milvus configurations. It also leads to the 'small file problem' in MinIO/S3 and puts unnecessary load on etcd. Milvus handles persistence automatically via WAL and auto-flush policies. Removing manual flush allows Milvus to manage segments more efficiently.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
