### PR TITLE
fix: add missing env var parameter pass through for enable async embedding

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1031,6 +1031,7 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
         if app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
         else None
     ),
+    enable_async=app.state.config.ENABLE_ASYNC_EMBEDDING,
 )
 
 app.state.RERANKING_FUNCTION = get_reranking_function(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1401,6 +1401,7 @@ def save_docs_to_vector_db(
                 if request.app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
                 else None
             ),
+            enable_async=request.app.state.config.ENABLE_ASYNC_EMBEDDING,
         )
 
         # Run async embedding in sync context


### PR DESCRIPTION
My original PR which included this didn't get merged unfortunately.

User reported in #19725 that when setting this only from environment variables the value is not correctly passed through to the functions.

| Location | `enable_async` passed? | Result |
|----------|----------------------|--------|
| `main.py` initialization | ❌ No | Always defaults to `True` |
| `save_docs_to_vector_db` | ❌ No | Always defaults to `True` |
| `update_embedding_config` | ✓ Yes | Works correctly |

**If you update the embedding config through the UI after startup, it would work correctly but not if you do it only via environment variables.**

Therefore there were two missing locations where this must be added.
These are added here.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
