### PR TITLE
FIX: Pipeline save settings - Handle undefined valves property

### DIFF
--- a/src/lib/components/admin/Settings/Pipelines.svelte
+++ b/src/lib/components/admin/Settings/Pipelines.svelte
@@ -47,7 +47,7 @@
 		if (pipeline && (pipeline?.valves ?? false)) {
 			for (const property in valves_spec.properties) {
 				if (valves_spec.properties[property]?.type === 'array') {
-					valves[property] = valves[property].split(',').map((v) => v.trim());
+					valves[property] = (valves[property] ?? '').split(',').map((v) => v.trim());
 				}
 			}
 


### PR DESCRIPTION
### FIX: Pipeline save settings - Handle undefined valves property

When a Pipeline valve have a null value the settings isn't saved. The error occurs because the code tries to call `.split()` on a `null` value when saving pipeline valves. This happens when you set a valve to "None" (null) and then click save.

This PR Fix this issue.

___
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
