### PR TITLE
feat: introduce REDIS_SOCKET_CONNECT_TIMEOUT with sane default (for smooth failover)

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -395,6 +395,18 @@ try:
 except ValueError:
     REDIS_SENTINEL_MAX_RETRY_COUNT = 2
 
+# Socket/Connect timeout for connections to Redis/Sentinel nodes
+REDIS_SOCKET_CONNECT_TIMEOUT = os.environ.get(
+    "REDIS_SOCKET_CONNECT_TIMEOUT", "5"
+)
+try:
+    if REDIS_SOCKET_CONNECT_TIMEOUT.lower() == "none":
+        REDIS_SOCKET_CONNECT_TIMEOUT = None
+    else:
+        REDIS_SOCKET_CONNECT_TIMEOUT = max(float(REDIS_SOCKET_CONNECT_TIMEOUT), 0.0)
+except ValueError:
+    REDIS_SOCKET_CONNECT_TIMEOUT = 5.0
+
 ####################################
 # UVICORN WORKERS
 ####################################

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -32,6 +32,7 @@ from open_webui.env import (
     WEBSOCKET_SENTINEL_PORT,
     WEBSOCKET_SENTINEL_HOSTS,
     REDIS_KEY_PREFIX,
+    REDIS_SOCKET_CONNECT_TIMEOUT,
     WEBSOCKET_REDIS_OPTIONS,
     WEBSOCKET_SERVER_PING_TIMEOUT,
     WEBSOCKET_SERVER_PING_INTERVAL,
@@ -62,17 +63,22 @@ REDIS = None
 SOCKETIO_CORS_ORIGINS = "*" if CORS_ALLOW_ORIGIN == ["*"] else CORS_ALLOW_ORIGIN
 
 if WEBSOCKET_MANAGER == "redis":
+    mgr_redis_options = {**WEBSOCKET_REDIS_OPTIONS} if WEBSOCKET_REDIS_OPTIONS else {}
+    if "socket_connect_timeout" not in mgr_redis_options:
+        mgr_redis_options["socket_connect_timeout"] = REDIS_SOCKET_CONNECT_TIMEOUT
+
     if WEBSOCKET_SENTINEL_HOSTS:
         mgr = socketio.AsyncRedisManager(
             get_sentinel_url_from_env(
                 WEBSOCKET_REDIS_URL, WEBSOCKET_SENTINEL_HOSTS, WEBSOCKET_SENTINEL_PORT
             ),
-            redis_options=WEBSOCKET_REDIS_OPTIONS,
+            redis_options=mgr_redis_options,
         )
     else:
         mgr = socketio.AsyncRedisManager(
-            WEBSOCKET_REDIS_URL, redis_options=WEBSOCKET_REDIS_OPTIONS
+            WEBSOCKET_REDIS_URL, redis_options=mgr_redis_options
         )
+
     sio = socketio.AsyncServer(
         cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode="asgi",

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -11,6 +11,7 @@ from open_webui.env import (
     REDIS_SENTINEL_MAX_RETRY_COUNT,
     REDIS_SENTINEL_PORT,
     REDIS_URL,
+    REDIS_SOCKET_CONNECT_TIMEOUT,
 )
 
 log = logging.getLogger(__name__)
@@ -162,6 +163,7 @@ def get_redis_connection(
                 username=redis_config["username"],
                 password=redis_config["password"],
                 decode_responses=decode_responses,
+                socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
             )
             connection = SentinelRedisProxy(
                 sentinel,
@@ -188,6 +190,7 @@ def get_redis_connection(
                 username=redis_config["username"],
                 password=redis_config["password"],
                 decode_responses=decode_responses,
+                socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
             )
             connection = SentinelRedisProxy(
                 sentinel,


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

I'm the author of Open WebUI's initial Redis Sentinel implementation and while I would like to believe that I confirmed failover working as expected in all relevant cases back then, I found that at least with the current implementation (which saw several changes) there are major issues with failover in the case when a node that is currently *master* goes offline *permanently*:
1) Open WebUI will turn unresponsive and not recover
2) At least if the *first node in the list of Sentinels* is the affected, the application will even hang on startup

I have done extensive research and testing to find the minimal set of changes to prevent both manifestations of the issue, specifically achieving:
1) Short (seconds, not minutes) downtime of the application
2) Chats / response streaming working immediately
3) Application can be restarted normally

It turned out that all 3 points get addressed by merely setting the option `socket_connect_timeout` for Redis and Sentinel constructors of redis-py to a sane value (e.g. 5 seconds). Per default it is `None`, leading to the observed permanent blocking.
Of course I also tried to set `socket_timeout`, but it is not required to achieve the effect and does not play well with pubsub in python-socketio (see https://github.com/miguelgrinberg/python-socketio/pull/1532). This is still the case with python-socketio 5.15.0, which is used since https://github.com/open-webui/open-webui/commit/4df5b7eb2e4b39eb01d488de4c95444ce6dea88c.
Furthermore, it is not enough to set the timeouts just for the Sentinel connections inside `sentinel_kwargs` (but setting `socket_connect_timeout` on the top level will apply to both Redis and Sentinel).

Also, if the timeout is set everywhere *except* for `AsyncRedisManager` of python-socketio, you will see the following effect:
1) Application becomes responsive after short break
2) Chats won't work for several minutes

So setting the option also for `AsyncRedisManager` is definitely warranted. In the present implementation this is achieved by adding the value of `REDIS_SOCKET_CONNECT_TIMEOUT` as `socket_connect_timeout` into the options given by `WEBSOCKET_REDIS_OPTIONS`, while a `socket_connect_timeout` present in the latter will take precedence. This ensures a sane default, while maintaing the configurability.

It is still possible to set  `REDIS_SOCKET_CONNECT_TIMEOUT` to `None` to achieve the current configuration. I have confirmed that setting the option to `None` restores the broken failover. Per default it will be 5 seconds, which ensures a short downtime without being too aggressive.

### Added

- env `REDIS_SOCKET_CONNECT_TIMEOUT`, default 5 seconds

### Changed

- apply `REDIS_SOCKET_CONNECT_TIMEOUT` as `socket_connect_timeout` to all Redis/Sentinel connections

### Fixed

- several issues with failover in Redis Sentinel setups

### Breaking Changes

- although the default is changed I don't consider this breaking in any way

### Notes

I'm happy to make the required addition to the docs as soon as the PR is approved.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
