### PR TITLE
Fix #19750 : flow of image edit with reference

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -716,19 +716,36 @@ async def chat_web_search_handler(
     return form_data
 
 
-def get_last_images(message_list):
+
+
+def get_last_user_images(message_list):
+    """Get all images from the last USER message only"""
     images = []
     for message in reversed(message_list):
-        images_flag = False
-        for file in message.get("files", []):
-            if file.get("type") == "image":
-                images.append(file.get("url"))
-                images_flag = True
-
-        if images_flag:
-            break
-
+        if message.get("role") == "user":
+            for file in message.get("files", []):
+                if file.get("type") == "image":
+                    images.append(file.get("url"))
+            break  # Only from most recent user message
     return images
+
+def get_last_assistant_image(message_list):
+    """Get the most recent ASSISTANT-generated image"""
+    for message in reversed(message_list):
+        if message.get("role") == "assistant":
+            for file in message.get("files", []):
+                if file.get("type") == "image":
+                    return file.get("url")
+    return None
+
+def get_last_images(message_list):
+    assistant_image = get_last_assistant_image(message_list)
+    user_images = get_last_user_images(message_list)
+
+    if assistant_image:
+        return [assistant_image] + user_images 
+
+    return user_images
 
 
 def get_image_urls(delta_images, request, metadata, user) -> list[str]:


### PR DESCRIPTION
# Changelog Entry

### Description
Fixes a bug where uploading a reference image after generating an image would ignore the previously generated image and only use the reference image.

Discussion here: https://github.com/open-webui/open-webui/discussions/19754

### Fixed

Modified `get_last_images()` to:
- Separate user-uploaded images from assistant-generated images
- Prioritize latest supplied images for editing

---

### Additional Information

- [x] Tested: Generate image → Upload reference → Edit (now correctly passes both images)
- [x] Tested: Upload reference → Generate (works as before)
- [x] Tested: Generate → Edit without reference (works as before)
- [x] Tested: Multiple parallel assistant chats with references (only active branch will be considered)
- [x] Tested successfully with editing capable models supported by OUI: openai gpt-image-1, gemini flash 2.5 image, gemini 3 pro preview. 
- [?] Tested unsuccessfully with openai dall-e-2 but for unrelated reasons (dall-2 can only accept a single image as reference, after https://github.com/open-webui/open-webui/commit/0c18cd67d54af51a513144c9f48f0503c8182744 we always pass an array, even with a single image). Fixing this in images.py uncovered a further error with dall-e-2 only supporting png in RGBA format, which is not how the assistant returns images (An error occurred while generating the image: [ERROR: Invalid input image - format must be in ['RGBA', 'LA', 'L'], got RGB.]) . Will document this further, up for discussion best way to fix this. 
- [ ] Need testing with ComfyUI

the current image creation / edit flow is as follows:
A) user1 w. no image → image creation method → assistant1 w. image
B) user1 w. image → image editing method → assistant1 w. image
C) user1 w. no image → assistant 1 w. image → user2 w. no image → image edit based on assistant 1
D) user1 w. image → assistant 1 w. image → user2 w. no image → image edit base on assistant 1 **only**
E) and F) user 1 w. or w.no image → assistant1 w. image → user2 w. image → image edit based on assistant 1 **and** user 2.
G) user1 w. image -> assistant1 w. no image (regular query) -> user2 w. no image with image request -> image edit based on user1

### Screenshots or Videos

<img width="738" height="786" alt="2025-12-08_16h26_52" src="https://github.com/user-attachments/assets/654916c7-14af-4137-ab02-fcd08a6fd802" />
<img width="805" height="172" alt="2025-12-08_16h25_07" src="https://github.com/user-attachments/assets/e35a065a-ea70-4011-9fd5-f5aa86fe0c2c" />
<img width="775" height="634" alt="2025-12-08_16h26_10" src="https://github.com/user-attachments/assets/fcf95c40-ca71-4a9e-b664-e8a7d193a629" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


