### PR TITLE
Fix: native tool calling model parameter persistence

### DIFF
--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -286,7 +286,9 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
     Returns:
         dict: A modified payload compatible with the Ollama API.
     """
-    ollama_payload = {}
+    # Start by copying all fields from the original payload to preserve unknown/Ollama-specific fields
+    # This is important for preserving parameters across tool calling loops
+    ollama_payload = {**openai_payload}
 
     # Mapping basic model and message details
     ollama_payload["model"] = openai_payload.get("model")
@@ -299,12 +301,13 @@ def convert_payload_openai_to_ollama(openai_payload: dict) -> dict:
 
     if "max_tokens" in openai_payload:
         ollama_payload["num_predict"] = openai_payload["max_tokens"]
-        del openai_payload["max_tokens"]
+        del ollama_payload["max_tokens"]
 
     # If there are advanced parameters in the payload, format them in Ollama's options field
     if openai_payload.get("options"):
-        ollama_payload["options"] = openai_payload["options"]
-        ollama_options = openai_payload["options"]
+        # Create a copy of options to avoid mutating the original
+        ollama_options = dict(openai_payload["options"])
+        ollama_payload["options"] = ollama_options
 
         def parse_json(value: str) -> dict:
             """


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. ✅ Branch is based on `upstream/dev`
- [x] **Description:** Provide a concise description of the changes made in this pull request down below. ✅ Provided below
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description. ✅ Included below
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources. ✅ N/A - Backend fix only, no new user-facing features or env vars
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation? ✅ No new dependencies
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. ✅ Manually tested with filter setting `body["options"]["think"] = False` and verified parameter persists through tool call loops
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. ✅ Code has been reviewed and manually tested - fix is minimal and focused (7 insertions, 4 deletions), tested manually in local and docker deployments with different models.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards? ✅ Self-reviewed - changes follow existing code patterns
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following: ✅ Using `fix:` prefix


Description
Fixes parameter reset issue during native tool calls where filter-set or UI-set parameters (like Ollama's think) were being lost after tool execution, causing inconsistent behavior in hybrid models during tool calling loops.

Problem:

Adressing : https://github.com/open-webui/open-webui/issues/19864

When parameters are set via filters or frontend settings, they get reset after native tool calls. The convert_payload_openai_to_ollama() function was:

Creating a new empty dictionary, losing previously moved root-level parameters
Using references instead of copies for the options dict, causing mutation issues
Being called multiple times during tool calling loops, resetting parameters each time
This caused hybrid models to ignore configured parameters during tool execution, leading to inconsistent thinking behavior.

Solution
Modified convert_payload_openai_to_ollama() in backend/open_webui/utils/payload.py:

Preserve all fields during conversion:

# Before: ollama_payload = {}
# After: ollama_payload = {**openai_payload}
This maintains root-level parameters like think across multiple conversions.

Fix options dict mutation:

# Before: ollama_options = openai_payload["options"]
# After: ollama_options = dict(openai_payload["options"])
Creates proper copy to avoid mutating the original payload.

Fix incorrect deletion target:

# Before: del openai_payload["max_tokens"]
# After: del ollama_payload["max_tokens"]

Deletes from the correct dictionary.

Testing Performed

✅ Tested with filter setting body["options"]["think"] = False
✅ Verified parameter persists through multiple tool call iterations
✅ Confirmed hybrid models respect thinking parameter throughout conversation
✅ Validated both filter-set and UI-set parameters are maintained
✅ Verified existing functionality remains unaffected

Impact

- No breaking changes - all existing functionality preserved
- Fixes filter and UI setted parameter persistence for Ollama models
- Improves tool calling reliability
- Ensures UI parameter settings are respected throughout conversations
- 
Changelog Entry

Description

Fixed parameter preservation in Ollama payload conversion function to ensure filter-set and UI-set parameters persist through native tool calling loops, resolving inconsistent behavior where parameters like think were being reset after tool execution.

Added

None

Changed

convert_payload_openai_to_ollama() now preserves all fields by copying entire payload instead of creating empty dict
Options dictionary is now properly copied instead of referenced to prevent mutation issues
Fixed deletion target from openai_payload to ollama_payload for max_tokens
Deprecated

None

Removed

None

Fixed

- Fixed parameter reset during native tool calls where filter-set parameters were lost
- Fixed convert_payload_openai_to_ollama() losing root-level parameters like think during multiple conversions
- Fixed options dict mutation issues causing unintended side effects
- Fixed incorrect dictionary mutation when deleting max_tokens
- Resolved inconsistent thinking behavior in hybrid models during tool execution

Security

None

Breaking Changes

None

Additional Information

Root Cause Analysis:

The conversion function was creating a new empty dictionary (ollama_payload = {}) and only copying specific known fields. During tool calling loops, this function is called multiple times:

First call: think parameter moves from options to root level
Tool call loop creates new request with all fields
Second call: Empty dict created again, losing root-level think
Parameters reset to defaults
Additionally, using ollama_options = openai_payload["options"] created a reference, causing mutations to affect the original payload.

Files Modified:

backend/open_webui/utils/payload.py (7 insertions, 4 deletions)
Related Context:

Affects Ollama models using parameters like think, keep_alive, format
Critical for filters modifying model behavior during tool calls
Ensures consistent parameter handling in multi-turn tool calling scenarios
Fixes behavior for hybrid models (e.g., qwen3 14b with native tool calling)

Screenshots or Videos

BEFORE:

<img width="2301" height="1252" alt="Screenshot from 2025-12-10 10-55-14" src="https://github.com/user-attachments/assets/157f5d7f-b66c-406e-a78c-9c669dc545c7" />

AFTER:

<img width="2301" height="1252" alt="Screenshot from 2025-12-10 11-28-11" src="https://github.com/user-attachments/assets/0ef48b3b-f3a1-4534-b98b-174f0e51159a" />



Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.