### PR TITLE
fix: Use SCAN instead of KEYS for Redis cluster compatibility

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -190,7 +190,9 @@ class YdocManager:
 
     async def remove_user_from_all_documents(self, user_id: str):
         if self._redis:
-            keys = await self._redis.keys(f"{self._redis_key_prefix}:*")
+            keys = []
+            async for key in self._redis.scan_iter(match=f"{self._redis_key_prefix}:*", count=100):
+                keys.append(key)
             for key in keys:
                 if key.endswith(":users"):
                     await self._redis.srem(key, user_id)


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
- This PR fixes the error `redis.exceptions.ResponseError: unknown command 'keys', with args beginning with: {open-webui}:ydoc:documents:*` as documented at https://github.com/open-webui/open-webui/discussions/15834 
- The root cause is that the`KEYS` command is commonly disabled in production Redis environments like [serverless AWS ElastiCache](https://repost.aws/questions/QUVJ3PbTE8RXmmhsDNJq8Oig/redis-cache-serverless-keys). 

### Added
- None

### Changed
 - Replaced `redis.keys()` with `scan_iter()` in`YdocManager.remove_user_from_all_documents()` (backend/open_webui/socket/utils.py:194-196)

### Deprecated
- None

### Removed
- None

### Fixed
- Fixed `redis.exceptions.ResponseError: unknown command 'keys'` when using Redis instances with KEYS command disabled 

### Security
- None

### Breaking Changes
- None

---

### Additional Information
- This has been tested on a production openwebui instance, with the error no longer appearing in the server logs.
- I set the default batch count to 100, which is a reasonable default for production redis. If an explicit count value is not set, redis-py defaults to 10. 
- `scan_iter()` is non-blocking and production-safe, unlike `KEYS` which can block the entire Redis instance

### Screenshots or Videos

- None

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
