### PR TITLE
fix: MultiResponseMessages crashes when navigating history after model removal

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -224,6 +224,10 @@
 		mergeResponses(messageId, responses, chatId);
 	};
 
+	$: if (messageId && messageId !== currentMessageId) {
+		initHandler();
+	}
+
 	onMount(async () => {
 		await initHandler();
 		await tick();
@@ -282,7 +286,7 @@
 						</div>
 					</div>
 
-					{#if selectedModelIdx !== null}
+					{#if selectedModelIdx !== null && groupedMessageIds[selectedModelIdx]?.messageIds}
 						{@const _messageId =
 							groupedMessageIds[selectedModelIdx].messageIds[
 								groupedMessageIdsIdx[selectedModelIdx]


### PR DESCRIPTION
Fixes #18599: a TypeError crash in MultiResponseMessages component when navigating message history after removing a model from the selector. The component's `initHandler()` only ran on mount, never re-running when the `messageId` prop changed during navigation. This caused `groupedMessageIds[selectedModelIdx]` to be undefined when the current model selection didn't match the historical message's model count.

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes a TypeError crash in MultiResponseMessages component when navigating message history after removing a model from the selector. The component's `initHandler()` only ran on mount, never re-running when the `messageId` prop changed during navigation. This caused `groupedMessageIds[selectedModelIdx]` to be undefined when the current model selection didn't match the historical message's model count.

### Added

- Reactive statement to re-initialize `groupedMessageIds` when `messageId` changes

### Fixed

- TypeError: "Cannot read properties of undefined (reading 'messageIds')" when navigating message history in multi-model tab view after changing selected models
- Blank/frozen response area when viewing previous messages with different model selection than current

---

### Screenshots or Videos

Before:
<img width="1268" height="481" alt="Screenshot 2025-12-11 at 4 44 43 PM" src="https://github.com/user-attachments/assets/7a9146b9-6a1f-4c17-b30b-1c4dbb7e50f3" />

After:
<img width="1054" height="227" alt="Screenshot 2025-12-11 at 4 35 33 PM" src="https://github.com/user-attachments/assets/c6e5b042-26aa-4058-883c-6a5c8d97e89e" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
