### PR TITLE
fix: enable COMFYUI_WORKFLOW_NODES and IMAGES_EDIT_COMFYUI_WORKFLOW_NODES configuration via env vars

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3462,10 +3462,16 @@ COMFYUI_WORKFLOW = PersistentConfig(
     os.getenv("COMFYUI_WORKFLOW", COMFYUI_DEFAULT_WORKFLOW),
 )
 
+comfyui_workflow_nodes = os.getenv("COMFYUI_WORKFLOW_NODES", "")
+try:
+    comfyui_workflow_nodes = json.loads(comfyui_workflow_nodes)
+except json.JSONDecodeError:
+    comfyui_workflow_nodes = []
+
 COMFYUI_WORKFLOW_NODES = PersistentConfig(
-    "COMFYUI_WORKFLOW",
+    "COMFYUI_WORKFLOW_NODES",
     "image_generation.comfyui.nodes",
-    [],
+    comfyui_workflow_nodes,
 )
 
 IMAGES_OPENAI_API_BASE_URL = PersistentConfig(

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3588,10 +3588,16 @@ IMAGES_EDIT_COMFYUI_WORKFLOW = PersistentConfig(
     os.getenv("IMAGES_EDIT_COMFYUI_WORKFLOW", ""),
 )
 
+images_edit_comfyui_workflow_nodes = os.getenv("IMAGES_EDIT_COMFYUI_WORKFLOW_NODES", "")
+try:
+    images_edit_comfyui_workflow_nodes = json.loads(images_edit_comfyui_workflow_nodes)
+except json.JSONDecodeError:
+    images_edit_comfyui_workflow_nodes = []
+
 IMAGES_EDIT_COMFYUI_WORKFLOW_NODES = PersistentConfig(
     "IMAGES_EDIT_COMFYUI_WORKFLOW_NODES",
     "images.edit.comfyui.nodes",
-    [],
+    images_edit_comfyui_workflow_nodes,
 )
 
 ####################################


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes an issue where `COMFYUI_WORKFLOW_NODES` and `IMAGES_EDIT_COMFYUI_WORKFLOW_NODES` were not being loaded from environment variables. These configurations were statically initialized as empty lists, preventing users from customizing node mappings via environment variables (e.g., for Docker deployments).

We now correctly parse these environment variables as JSON lists. Additionally, this PR fixes a copy-paste error where the [PersistentConfig](cci:2://file:///home/g30/docker-projects/open-webui-dev/backend/open_webui/config.py:164:0-220:38) key for `COMFYUI_WORKFLOW_NODES` was incorrectly set to `"COMFYUI_WORKFLOW"`, which likely caused conflicts with the workflow definition itself.

### Fixed
- Fixed `COMFYUI_WORKFLOW_NODES` and `IMAGES_EDIT_COMFYUI_WORKFLOW_NODES` to correctly load JSON list strings from environment variables.

- Corrected the [PersistentConfig](cci:2://file:///home/g30/docker-projects/open-webui-dev/backend/open_webui/config.py:164:0-220:38) key name for `COMFYUI_WORKFLOW_NODES` from `"COMFYUI_WORKFLOW"` to `"COMFYUI_WORKFLOW_NODES"`.

---

### Additional Information
The fix uses `json.loads(os.environ.get(...))` to ensure the complex list/dict structure is correctly parsed from the string environment variable, preventing iteration errors that would occur if the raw string were used directly. This PR seeks to solve the issue highlighted in https://github.com/open-webui/open-webui/discussions/19886.

### Verification Results

I verified the fix using a python script that mocks the environment variables and imports the config.

**Verification Script:**

```python
import os
import json
import sys
from unittest.mock import MagicMock
# 1. Setup Environment Variables BEFORE importing config
test_nodes = '[{"type":"model","key":"ckpt_name","node_ids":["16"]}]'
os.environ['COMFYUI_WORKFLOW_NODES'] = test_nodes
os.environ['IMAGES_EDIT_COMFYUI_WORKFLOW_NODES'] = test_nodes
# Mock other required env vars to avoid errors during import
os.environ['DATA_DIR'] = '/tmp/open-webui-test-data'
# 2. Setup Python Path
sys.path.append(os.getcwd())
sys.path.append(os.path.join(os.getcwd(), 'backend'))
# 3. Mock dependencies that might be missing or problematic in the test env
sys.modules['mimeparse'] = MagicMock()
# 4. Import the config
try:
    from backend.open_webui.config import COMFYUI_WORKFLOW_NODES, IMAGES_EDIT_COMFYUI_WORKFLOW_NODES
except ImportError:
    try:
        from open_webui.config import COMFYUI_WORKFLOW_NODES, IMAGES_EDIT_COMFYUI_WORKFLOW_NODES
    except ImportError as e:
        print(f"Error importing config: {e}")
        sys.exit(1)
# 5. Verify Results
print(f"COMFYUI_WORKFLOW_NODES type: {type(COMFYUI_WORKFLOW_NODES.value)}")
print(f"COMFYUI_WORKFLOW_NODES value: {COMFYUI_WORKFLOW_NODES.value}")
print(f"IMAGES_EDIT_COMFYUI_WORKFLOW_NODES type: {type(IMAGES_EDIT_COMFYUI_WORKFLOW_NODES.value)}")
print(f"IMAGES_EDIT_COMFYUI_WORKFLOW_NODES value: {IMAGES_EDIT_COMFYUI_WORKFLOW_NODES.value}")
expected = json.loads(test_nodes)
if COMFYUI_WORKFLOW_NODES.value == expected:
    print("SUCCESS: COMFYUI_WORKFLOW_NODES loaded correctly")
else:
    print("FAILURE: COMFYUI_WORKFLOW_NODES did not load from env")
if IMAGES_EDIT_COMFYUI_WORKFLOW_NODES.value == expected:
    print("SUCCESS: IMAGES_EDIT_COMFYUI_WORKFLOW_NODES loaded correctly")
else:
    print("FAILURE: IMAGES_EDIT_COMFYUI_WORKFLOW_NODES did not load from env")
```

Output:

```
SUCCESS: COMFYUI_WORKFLOW_NODES loaded correctly
SUCCESS: IMAGES_EDIT_COMFYUI_WORKFLOW_NODES loaded correctly
```

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
