### PR TITLE
feat: auto-expand sidebar folders on create/pin changes

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -87,6 +87,25 @@
 
 	let newFolderId = null;
 
+	let showPinnedModels = false;
+	let showChannels = false;
+	let showFolders = false;
+
+	let oldPinnedModelsCount = 0;
+
+	$: if ($settings?.pinnedModels) {
+		const currentCount = $settings.pinnedModels.length;
+
+		// Expand pinned models if changed and at least one pinned model exists
+		if (currentCount !== oldPinnedModelsCount && oldPinnedModelsCount > 0) {
+			// Only expand if change wasn't last pinned model being removed
+			if (currentCount > 0) {
+				showPinnedModels = true;
+			}
+		}
+		oldPinnedModelsCount = currentCount;
+	}
+
 	$: if ($selectedFolder) {
 		initFolders();
 	}
@@ -178,6 +197,8 @@
 		if (res) {
 			// newFolderId = res.id;
 			await initFolders();
+
+			showFolders = true;
 		}
 	};
 
@@ -573,6 +594,8 @@
 			$socket.emit('join-channels', { auth: { token: $user?.token } });
 			await initChannels();
 			showCreateChannel = false;
+
+			showChannels = true;
 
 			goto(`/channels/${res.id}`);
 		}
@@ -1000,6 +1023,7 @@
 				{#if ($models ?? []).length > 0 && (($settings?.pinnedModels ?? []).length > 0 || $config?.default_pinned_models)}
 					<Folder
 						id="sidebar-models"
+						bind:open={showPinnedModels}
 						className="px-2 mt-0.5"
 						name={$i18n.t('Models')}
 						chevron={false}
@@ -1012,6 +1036,7 @@
 				{#if $config?.features?.enable_channels && ($user?.role === 'admin' || ($user?.permissions?.features?.channels ?? true))}
 					<Folder
 						id="sidebar-channels"
+						bind:open={showChannels}
 						className="px-2 mt-0.5"
 						name={$i18n.t('Channels')}
 						chevron={false}
@@ -1046,6 +1071,7 @@
 				{#if $config?.features?.enable_folders && ($user?.role === 'admin' || ($user?.permissions?.features?.folders ?? true))}
 					<Folder
 						id="sidebar-folders"
+						bind:open={showFolders}
 						className="px-2 mt-0.5"
 						name={$i18n.t('Folders')}
 						chevron={false}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Implements #19772 by automatically expanding sidebar folders when:
  - Creating a new folder or channel
  - Pinning or unpinning a model

Previously, these remained collapsed after adding items, providing no visual confirmation of the user action.

#### Implementation details

Added `bind:open={state}` to the Models, Channels and Folders sections, and set the state to true after channel or folder creation.

Used $settings store to detect when pinned model changes:
```javascript
let oldPinnedModelsCount = 0;

$: if ($settings?.pinnedModels) {
    const currentCount = $settings.pinnedModels.length;
    
    // Expand pinned models if changed and at least one pinned model exists
    if (currentCount !== oldPinnedModelsCount && oldPinnedModelsCount > 0) {
	    // Only expand if change wasn't last pinned model being removed
	    if (currentCount > 0) {
		    showPinnedModels = true;
	    }
    }
    oldPinnedModelsCount = currentCount;
}
```
oldPinnedModelsCount > 0 is checked due to the Pinned Models folder already being auto expanded when the first model is added. 

localStorage state continues to be correctly set by existing onChange handler for all folders.

### Added
- Sidebar Pinned Models, Channels, and Folders sections now auto-expand on create/pin changes.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
