### PR TITLE
fix: preserve access_control when cloning prompts

### DIFF
--- a/src/routes/(app)/workspace/prompts/create/+page.svelte
+++ b/src/routes/(app)/workspace/prompts/create/+page.svelte
@@ -49,7 +49,7 @@
 				title: _prompt.title,
 				command: _prompt.command,
 				content: _prompt.content,
-				access_control: null
+				access_control: _prompt.access_control ?? {}
 			};
 		});
 
@@ -68,7 +68,7 @@
 				title: _prompt.title,
 				command: _prompt.command,
 				content: _prompt.content,
-				access_control: null
+				access_control: _prompt.access_control ?? {}
 			};
 		}
 	});

--- a/src/routes/(app)/workspace/prompts/create/+page.svelte
+++ b/src/routes/(app)/workspace/prompts/create/+page.svelte
@@ -49,7 +49,7 @@
 				title: _prompt.title,
 				command: _prompt.command,
 				content: _prompt.content,
-				access_control: _prompt.access_control ?? {}
+				access_control: _prompt.access_control !== undefined ? _prompt.access_control : {}
 			};
 		});
 
@@ -68,7 +68,7 @@
 				title: _prompt.title,
 				command: _prompt.command,
 				content: _prompt.content,
-				access_control: _prompt.access_control ?? {}
+				access_control: _prompt.access_control !== undefined ? _prompt.access_control : {}
 			};
 		}
 	});

--- a/src/routes/(app)/workspace/tools/create/+page.svelte
+++ b/src/routes/(app)/workspace/tools/create/+page.svelte
@@ -87,7 +87,7 @@
 			name={tool?.name ?? ''}
 			meta={tool?.meta ?? { description: '' }}
 			content={tool?.content ?? ''}
-			access_control={null}
+			accessControl={tool?.access_control !== undefined ? tool.access_control : {}}
 			{clone}
 			onSave={(value) => {
 				saveHandler(value);


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry
### Description
- This PR fixes issue #19360 where cloned prompts lose their `access_control` settings. When a prompt was cloned, the `access_control` property was explicitly set to `null`, causing the cloned prompt to default to public access instead of inheriting the original's access permissions.
- Additionally, the tools create page had a prop name mismatch (`access_control` vs `accessControl`) that prevented access control from being passed to the editor at all.

### Changed
**Prompts:**
Modified `/workspace/prompts/create/+page.svelte` (lines 52, 71) to preserve `access_control` using `!== undefined` check instead of hardcoding to `null`.

**Tools:**
- Modified `/workspace/tools/create/+page.svelte` (line 90) to:
1. Preserve `access_control` using `!== undefined` check
2. Fixed prop name from `access_control` to `accessControl` to match ToolkitEditor's expected prop
Why `!== undefined` instead of `??` operator: The nullish coalescing operator (`??`) treats both `null` and `undefined` as falsy, which would incorrectly convert public items (`null`) to private (`{}`). By explicitly checking `!== undefined`, we preserve:
Public (`null`) → stays `null` ✅
Private (`{}`) → stays `{}` ✅
Custom permissions → stays preserved ✅
Undefined → defaults to `{}` (private) ✅

### Fixed
- Fixed cloned prompts losing their access control settings: Cloned prompts now inherit `access_control` from the original.
- Fixed cloned tools losing their access control settings: Cloned tools now correctly inherit `access_control` from the original.
- Fixed tools not receiving access control data at all due to prop name mismatch (`access_control` vs `accessControl`).
- Fixed public items being incorrectly converted to private when cloned.

### Security
- Improved security by ensuring cloned private/restricted items remain private/restricted instead of accidentally becoming public, and vice versa.

---

### Additional Information
- Related Issue: #19360
- Models already handle access control preservation correctly via `ModelEditor.svelte` and do not need changes.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
