### PR TITLE
feat: add safety_identifier to the payload when making requests to OpenAI-Compatible server

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -486,6 +486,10 @@ ENABLE_COMPRESSION_MIDDLEWARE = (
     os.environ.get("ENABLE_COMPRESSION_MIDDLEWARE", "True").lower() == "true"
 )
 
+ENABLE_SAFETY_IDENTIFIER = (
+    os.environ.get("ENABLE_SAFETY_IDENTIFIER", "False").lower() == "true"
+)
+
 ####################################
 # OAUTH Configuration
 ####################################

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -31,6 +31,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     BYPASS_MODEL_ACCESS_CONTROL,
+    ENABLE_SAFETY_IDENTIFIER,
 )
 from open_webui.models.users import UserModel
 
@@ -875,7 +876,8 @@ async def generate_chat_completion(
             "role": user.role,
         }
 
-    payload["safety_identifier"] = generate_safety_identifier(user.id)
+    if ENABLE_SAFETY_IDENTIFIER:
+        payload["safety_identifier"] = generate_safety_identifier(user.id)
 
     url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
     key = request.app.state.config.OPENAI_API_KEYS[idx]

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -875,6 +875,8 @@ async def generate_chat_completion(
             "role": user.role,
         }
 
+    payload["safety_identifier"] = user.id
+
     url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
     key = request.app.state.config.OPENAI_API_KEYS[idx]
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -49,7 +49,7 @@ from open_webui.utils.misc import (
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access
-from open_webui.utils.headers import include_user_info_headers
+from open_webui.utils.headers import include_user_info_headers, generate_safety_identifier
 
 
 log = logging.getLogger(__name__)
@@ -875,7 +875,7 @@ async def generate_chat_completion(
             "role": user.role,
         }
 
-    payload["safety_identifier"] = user.id
+    payload["safety_identifier"] = generate_safety_identifier(user.id)
 
     url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
     key = request.app.state.config.OPENAI_API_KEYS[idx]

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -50,7 +50,10 @@ from open_webui.utils.misc import (
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access
-from open_webui.utils.headers import include_user_info_headers, generate_safety_identifier
+from open_webui.utils.headers import (
+    include_user_info_headers,
+    include_safety_identifier,
+)
 
 
 log = logging.getLogger(__name__)
@@ -877,7 +880,7 @@ async def generate_chat_completion(
         }
 
     if ENABLE_SAFETY_IDENTIFIER:
-        payload["safety_identifier"] = generate_safety_identifier(user.id)
+        payload["safety_identifier"] = include_safety_identifier(user.id)
 
     url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
     key = request.app.state.config.OPENAI_API_KEYS[idx]

--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -4,7 +4,7 @@ from urllib.parse import quote
 from open_webui.env import WEBUI_SECRET_KEY
 
 
-def generate_safety_identifier(user_id: str) -> str:
+def include_safety_identifier(user_id: str) -> str:
     salted_value = f"{WEBUI_SECRET_KEY}{user_id}".encode('utf-8')
     hash_object = hashlib.sha256(salted_value)
     return hash_object.hexdigest()

--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -1,4 +1,13 @@
+import hashlib
 from urllib.parse import quote
+
+from open_webui.env import WEBUI_SECRET_KEY
+
+
+def generate_safety_identifier(user_id: str) -> str:
+    salted_value = f"{WEBUI_SECRET_KEY}{user_id}".encode('utf-8')
+    hash_object = hashlib.sha256(salted_value)
+    return hash_object.hexdigest()
 
 
 def include_user_info_headers(headers, user):


### PR DESCRIPTION
# Pull Request Checklist

Related discussions
https://github.com/open-webui/open-webui/discussions/19847

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
    - https://github.com/open-webui/docs/pull/892
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Adds a secure identifier to requests sent to OpenAI-compatible servers.  
This enables OpenAI API-compatible server providers to accurately identify which user initiated each request.

In the Open WebUI, the same access token is used for all requests to OpenAI-compatible API servers, preventing the server from determining which user made each request.  
While `ENABLE_FORWARD_USER_INFO_HEADERS` exists as a solution to this issue, using User IDs directly may contain personal information for external services, and some services may not support custom headers.
The OpenAI endpoint already supports functionality for this purpose, and we are adding this feature to provide a more secure identifier.
https://platform.openai.com/docs/guides/safety-best-practices#implement-safety-identifiers

Note: We will use a salted hash of `user.id` as the identifier, but whether it's safe to transmit this to external services depends on the specific circumstances. Therefore, this feature will only be available when explicitly enabled by the administrator.

### Added

- Added `ENABLE_SAFETY_IDENTIFIER` to include a `safety_identifier` in the payload when sending requests to OpenAI-compatible servers.

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
