### PR TITLE
docs: clarify docker image tagging for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ This will start the Open WebUI server, which you can access at [http://localhost
 > [!TIP]  
 > If you wish to utilize Open WebUI with Ollama included or CUDA acceleration, we recommend utilizing our official images tagged with either `:cuda` or `:ollama`. To enable CUDA, you must install the [Nvidia CUDA container toolkit](https://docs.nvidia.com/dgx/nvidia-container-runtime-upgrade/) on your Linux/WSL system.
 
+### Using image tags in production
+
+If you want to always run the latest version of Open WebUI, you can use the `:main`, `:cuda`, or `:ollama` image tags, depending on your setup.
+
+For `production environments` where stability and reproducibility are important, it is recommended to pin a specific release version instead of using these floating tags. Versioned images follow this format:
+
+```
+ghcr.io/open-webui/open-webui:<RELEASE_VERSION>-<TYPE>
+```
+
+Examples (pinned versions for illustration purposes only):
+```
+ghcr.io/open-webui/open-webui:v0.6.41
+ghcr.io/open-webui/open-webui:v0.6.41-ollama
+ghcr.io/open-webui/open-webui:v0.6.41-cuda
+```
+
 ### Installation with Default Configuration
 
 - **If Ollama is on your computer**, use this command:
@@ -187,6 +204,14 @@ docker run -d --network=host -v open-webui:/app/backend/data -e OLLAMA_BASE_URL=
 ```
 
 ### Keeping Your Docker Installation Up-to-Date
+
+In case you want to update your local Docker installation to the latest version, you can do it with [Watchtower](https://containrrr.dev/watchtower/):
+
+```bash
+docker run --rm --volume /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --run-once open-webui
+```
+
+In the last part of the command, replace `open-webui` with your container name if it is different.
 
 Check our Updating Guide available in our [Open WebUI Documentation](https://docs.openwebui.com/getting-started/updating).
 


### PR DESCRIPTION
# Changelog Entry

### Description

- Added documentation to clarify docker image tag usage for production deployments, explaining the difference between floating tags and pinned release versions to encourage stable and reproducible setups.

### Added

- Documentation examples showing how to use versioned Docker image tags for production environments.

### Changed

- Updated the README to include image tag best practices and clarify when to use `:main`, `:cuda`, `:ollama`, versus pinned release versions.

**FYI** : I also made a PR on the `docs` project, and it has been merged:
https://github.com/open-webui/docs/pull/893

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
