### PR TITLE
fix: add RTL text direction support for Notes section

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -628,7 +628,7 @@ input[type='number'] {
 
 /* Table styling for tiptap editors */
 .tiptap table {
-	@apply w-full text-sm text-left text-gray-500 dark:text-gray-400 max-w-full;
+	@apply w-full text-sm text-start text-gray-500 dark:text-gray-400 max-w-full;
 }
 
 .tiptap thead {
@@ -641,7 +641,7 @@ input[type='number'] {
 }
 
 .tiptap th {
-	@apply cursor-pointer text-left text-xs text-gray-700 dark:text-gray-400 font-semibold uppercase bg-gray-50 dark:bg-gray-850;
+	@apply cursor-pointer text-start text-xs text-gray-700 dark:text-gray-400 font-semibold uppercase bg-gray-50 dark:bg-gray-850;
 }
 
 .tiptap td {

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -1156,5 +1156,6 @@
 
 <div
 	bind:this={element}
+	dir="auto"
 	class="relative w-full min-w-full {className} {!editable ? 'cursor-not-allowed' : ''}"
 />


### PR DESCRIPTION
## Summary
- Add `dir="auto"` attribute to RichTextInput container for automatic RTL text direction detection
- Change `text-left` to `text-start` in table CSS for RTL compatibility

Fixes #19743

## Test plan
- [ ] Open Notes section and create a note with Persian/Arabic text
- [ ] Verify text aligns to the right and displays correctly
- [ ] Test with mixed LTR/RTL content to ensure direction switches appropriately