### PR TITLE
fix: resolve MCP OAuth 2.1 token refresh failure after access token expiration

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -589,14 +589,14 @@ class OAuthClientManager:
         return client["client_info"] if client else None
 
     def get_server_metadata_url(self, client_id):
-        if client_id in self.clients:
-            client = self.clients[client_id]
-            return (
+        client = self.get_client(client_id)
+        if not client:
+            return None
+        return (
                 client._server_metadata_url
                 if hasattr(client, "_server_metadata_url")
                 else None
             )
-        return None
 
     async def get_oauth_token(
         self, user_id: str, client_id: str, force_refresh: bool = False


### PR DESCRIPTION
## Description

This pull request fixes an OAuth 2.1 token refresh issue for MCP integrations in Open WebUI.

When an MCP access token expires, Open WebUI fails to refresh it due to an incorrect client resolution inside the OpenID metadata lookup logic. This results in an exception during token refresh and prevents MCP usage in chat after token expiration.

The issue was caused by outdated logic in `get_server_metadata_url`, which attempted to resolve OpenID configuration without using the proper client retrieval mechanism.

This PR updates the implementation to consistently use `get_client` when resolving the OpenID metadata URL, ensuring the correct client configuration is used during token refresh.

---

## How to Reproduce

1. Add an MCP integration configured with OAuth 2.1 and complete registration
2. Authorize the MCP integration
3. Wait until the access token expires
4. Attempt to add or use the MCP in chat

### Observed Error

```
ERROR | open_webui.utils.oauth:_perform_token_refresh:764 - Exception during token refresh for client_id mcp:mcp_name: Constructor parameter should be str
ERROR | open_webui.utils.oauth:_refresh_token:669 - Failed to refresh token for session xxx
```

---

## Root Cause

Before performing a token refresh, Open WebUI resolves the OpenID configuration URL to determine the refresh endpoint.

The function `get_server_metadata_url` used outdated logic and did not retrieve the OAuth client in the same way as the rest of the OAuth flow. This caused an invalid client configuration to be used, leading to a runtime exception during token refresh.

---

## Solution

* Updated `get_server_metadata_url` to retrieve the OAuth client via `get_client`
* Ensured consistent and correct client resolution for OpenID metadata lookup
* Prevented invalid constructor parameters during token refresh

---

## Manual Testing

After applying the fix:

* Token refresh is triggered correctly after access token expiration
* MCP can be added and used in chat without errors

### Result

```
Successfully refreshed token for session
```

---

# Changelog Entry

### Description

Fix OAuth 2.1 token refresh failure for MCP integrations caused by incorrect OpenID client resolution.

### Fixed

* Fixed exception during MCP OAuth token refresh after access token expiration
* Restored ability to use MCP integrations in chat after token expiry

---

### Additional Information

* Affects MCP integrations using OAuth 2.1
* No new dependencies introduced
* No documentation changes required

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
