### PR TITLE
fix: resolve SQLAlchemy connection exhaustion and enhance LLM reaction context for channels

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -967,6 +967,20 @@ async def model_response_handler(request, channel, message, user):
                         f"{username}: {replace_mentions(thread_message.content)}"
                     )
 
+                    # Reactions
+                    reactions = Messages.get_reactions_by_message_id(thread_message.id)
+                    if reactions:
+                        reaction_strings = []
+                        for reaction in reactions:
+                            user_names = [user["name"] for user in reaction.users]
+                            reaction_strings.append(
+                                f"{reaction.name} from {', '.join(user_names)}"
+                            )
+
+                        thread_history[-1] += (
+                            f"\n[Reactions: {'; '.join(reaction_strings)}]"
+                        )
+
                     thread_message_files = thread_message.data.get("files", [])
                     for file in thread_message_files:
                         if file.get("type", "") == "image":

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -918,6 +918,21 @@ async def model_response_handler(request, channel, message, user):
                     message.parent_id if message.parent_id else message.id,
                 )[::-1]
 
+                if message.reply_to_id:
+                    if not any(m.id == message.reply_to_id for m in thread_messages):
+                        reply_to_message = Messages.get_message_by_id(
+                            message.reply_to_id
+                        )
+                        if reply_to_message:
+                            # Insert reply_to_message before the current message
+                            for i, m in enumerate(thread_messages):
+                                if m.id == message.id:
+                                    thread_messages.insert(i, reply_to_message)
+                                    break
+                            else:
+                                # If the message is not found, append it to the beginning
+                                thread_messages.insert(0, reply_to_message)
+
                 response_message, channel = await new_message_handler(
                     request,
                     channel.id,

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -925,6 +925,8 @@
 
 								const { state } = view;
 								const { $from } = state.selection;
+								if ($from.depth === 0) return false;
+
 								const lineStart = $from.before($from.depth);
 								const lineEnd = $from.after($from.depth);
 								const lineText = state.doc.textBetween(lineStart, lineEnd, '\n', '\0').trim();


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
This PR introduces three key improvements:
1.  **LLM Reaction Awareness**: Enhances the channel context fed to LLMs by including message reaction data (reaction names and counts) in the message formatting. This allows the LLM to understand and reference user reactions in its responses.
2.  **Recursion and Connection Pool Fix**: Resolves a critical `RecursionError` and `QueuePool limit` exhaustion issue in `backend/open_webui/models/messages.py`. The recursive fetching of `reply_to_message` was causing infinite loops and depleting DB connections. This is fixed by:
    -   Implementing inline, non-recursive fetching for `reply_to_message`.
    -   Explicitly reusing the SQLAlchemy `db` session in recursive/nested calls.
    -   Correcting Pydantic validation for `UserNameResponse` to handle ORM objects using `from_attributes=True`.
3.  **RichTextInput Bug Fix**: Prevents a `RangeError` (invalid position) in the `RichTextInput.svelte` component when the selection depth is 0.

### Added
-   Reaction context (name, count, user names) is now appended to message content in `model_response_handler` within `backend/open_webui/routers/channels.py`.

### Changed
-   Refactored `get_message_by_id`, `get_thread_replies_by_message_id`, and `get_reactions_by_message_id` in `backend/open_webui/models/messages.py` to accept an optional `db` session for reuse.
-   Replaced recursive `self.get_message_by_id` calls for `reply_to_message` with inline DB queries to break the recursion loop.
-   Updated `UserNameResponse` validation to use `from_attributes=True`.

### Fixed
-   Fixed `RecursionError: maximum recursion depth exceeded` when fetching nested message replies.
-   Fixed `QueuePool limit of size 5 overflow 10 reached` (SQLAlchemy connection exhaustion) by ensuring session reuse.
-   Fixed `Uncaught RangeError: There is no position before the top-level node` in `src/lib/components/common/RichTextInput.svelte`.
- Fixed missing context for quoted messages ("Direct Reply") by explicitly injecting the `reply_to_message` into the LLM thread history if it's not already present.

---

### Additional Information
- The database session management refactor is a native solution that avoids the need for valid "lite" message fetching methods, ensuring robust and complete data retrieval without performance penalties from connection overhead.
- This PR should also solve https://github.com/open-webui/open-webui/issues/20157.
- This PR would address a feature request of my own
<img width="1781" height="306" alt="image" src="https://github.com/user-attachments/assets/9c9a408e-f5c6-4500-bdf7-0d22f0b851d7" />

## Screenshots

<img width="2285" height="1280" alt="image" src="https://github.com/user-attachments/assets/a4b95320-a6bd-49ea-bb6b-1c7a537cae81" />

<img width="2285" height="1280" alt="image" src="https://github.com/user-attachments/assets/dcf4135c-d64a-48cb-ab70-5ab777f9f70f" />

<img width="1141" height="600" alt="image" src="https://github.com/user-attachments/assets/a69c03ca-f395-4237-aec1-1a257a5c2ec8" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
