### PR TITLE
fix: remove duplicate pymilvus version in [all] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ all = [
     "elasticsearch==9.2.0",
 
     "qdrant-client==1.16.2",
-    "pymilvus==2.6.4",
     "weaviate-client==4.19.0",
     "pymilvus==2.6.5",
     "pinecone==6.0.2",


### PR DESCRIPTION
## Summary
Fixes #20141 

The `[all]` optional-dependencies in `pyproject.toml` had conflicting pymilvus versions:
- Line 153: `pymilvus==2.6.4`
- Line 155: `pymilvus==2.6.5`

This caused package resolver failures when installing with `pip install open-webui[all]` or `uv add open-webui[all]`.

## Changes
Removed the duplicate `pymilvus==2.6.4` entry, keeping `pymilvus==2.6.5` which:
1. Is the latest version
2. Matches `backend/requirements.txt` (line 121)

## Testing
- Verified only one pymilvus entry remains in pyproject.toml
- Fix resolves the `No solution found when resolving tool dependencies` error reported in #20141

---
contributor license agreement