### PR TITLE
fix: Remove trailing spaces added to prompts after sending

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -32,7 +32,8 @@
 	import { gfm } from '@joplin/turndown-plugin-gfm';
 	const turndownService = new TurndownService({
 		codeBlockStyle: 'fenced',
-		headingStyle: 'atx'
+		headingStyle: 'atx',
+		br: '\n'
 	});
 	turndownService.escape = (string) => string;
 

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -32,8 +32,7 @@
 	import { gfm } from '@joplin/turndown-plugin-gfm';
 	const turndownService = new TurndownService({
 		codeBlockStyle: 'fenced',
-		headingStyle: 'atx',
-		br: '\n'
+		headingStyle: 'atx'
 	});
 	turndownService.escape = (string) => string;
 
@@ -783,17 +782,13 @@
 				if (richText) {
 					mdValue = turndownService
 						.turndown(
-							htmlValue
-								.replace(/<p><\/p>/g, '<br/>')
-								.replace(/ {2,}/g, (m) => m.replace(/ /g, '\u00a0'))
+							htmlValue.replace(/ {2,}/g, (m) => m.replace(/ /g, '\u00a0'))
 						)
 						.replace(/\u00a0/g, ' ');
 				} else {
 					mdValue = turndownService
 						.turndown(
 							htmlValue
-								// Replace empty paragraphs with line breaks
-								.replace(/<p><\/p>/g, '<br/>')
 								// Replace multiple spaces with non-breaking spaces
 								.replace(/ {2,}/g, (m) => m.replace(/ /g, '\u00a0'))
 								// Replace tabs with non-breaking spaces (preserve indentation)


### PR DESCRIPTION
# fix: Remove trailing spaces added to prompts after sending

Fixes #20198

TurndownService was using the default `br` option which converts `<br>` tags to `"  \n"` (two trailing spaces + newline). This caused extra spaces to appear in user prompts when editing or copying messages that contained paragraph breaks.

Changed TurndownService config to use `br: '\n'` to convert line breaks without adding trailing spaces.

### Fixed

- Extra trailing spaces being added to user prompts containing double-newlines when clicking Edit or Copy

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.