### PR TITLE
fix: Knowledge Selector dropdown appearing behind Create Folder modal

### DIFF
--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -112,7 +112,7 @@
 
 	<div slot="content">
 		<DropdownMenu.Content
-			class=" text-black dark:text-white rounded-2xl shadow-lg border border-gray-200 dark:border-gray-800 flex flex-col bg-white dark:bg-gray-850 w-70 p-1.5"
+			class="z-[10000] text-black dark:text-white rounded-2xl shadow-lg border border-gray-200 dark:border-gray-800 flex flex-col bg-white dark:bg-gray-850 w-70 p-1.5"
 			sideOffset={8}
 			side="bottom"
 			align="start"


### PR DESCRIPTION
### Description
Fixed z-index issue where the Knowledge Selector dropdown menu was rendering behind the Create Folder modal, making it unusable.
### Fixed
- Knowledge Selector dropdown now correctly appears above the modal by adding `z-[10000]` to `DropdownMenu.Content` (modal uses `z-9999`)
---
### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.