### PR TITLE
fix: normalize local CrossEncoder reranking scores for relevance threshold

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -765,8 +765,8 @@ else:
 # Whether to apply sigmoid normalization to CrossEncoder reranking scores.
 # When enabled (default), scores are normalized to 0-1 range for proper
 # relevance threshold behavior with MS MARCO models.
-RAG_RERANKING_MODEL_NORMALIZE_SCORES = (
-    os.environ.get("RAG_RERANKING_MODEL_NORMALIZE_SCORES", "True").lower() == "true"
+SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION = (
+    os.environ.get("SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION", "True").lower() == "true"
 )
 
 ####################################

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -762,6 +762,13 @@ else:
     except Exception:
         SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS = None
 
+# Whether to apply sigmoid normalization to CrossEncoder reranking scores.
+# When enabled (default), scores are normalized to 0-1 range for proper
+# relevance threshold behavior with MS MARCO models.
+RAG_RERANKING_MODEL_NORMALIZE_SCORES = (
+    os.environ.get("RAG_RERANKING_MODEL_NORMALIZE_SCORES", "True").lower() == "true"
+)
+
 ####################################
 # OFFLINE_MODE
 ####################################

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -913,9 +913,15 @@ def get_reranking_function(reranking_engine, reranking_model, reranking_function
             [(query, doc.page_content) for doc in documents], user=user
         )
     else:
-        return lambda query, documents, user=None: reranking_function.predict(
-            [(query, doc.page_content) for doc in documents]
-        )
+        import math
+        def sigmoid(x):
+            return 1 / (1 + math.exp(-x))
+        
+        return lambda query, documents, user=None: [
+            sigmoid(s) for s in reranking_function.predict(
+                [(query, doc.page_content) for doc in documents]
+            )
+        ]
 
 
 async def get_sources_from_items(

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -913,15 +913,9 @@ def get_reranking_function(reranking_engine, reranking_model, reranking_function
             [(query, doc.page_content) for doc in documents], user=user
         )
     else:
-        import math
-        def sigmoid(x):
-            return 1 / (1 + math.exp(-x))
-        
-        return lambda query, documents, user=None: [
-            sigmoid(s) for s in reranking_function.predict(
-                [(query, doc.page_content) for doc in documents]
-            )
-        ]
+        return lambda query, documents, user=None: reranking_function.predict(
+            [(query, doc.page_content) for doc in documents]
+        )
 
 
 async def get_sources_from_items(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -190,6 +190,7 @@ def get_rf(
                     raise Exception(ERROR_MESSAGES.DEFAULT(e))
             else:
                 import sentence_transformers
+                import torch
 
                 try:
                     rf = sentence_transformers.CrossEncoder(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -112,6 +112,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
+    RAG_RERANKING_MODEL_NORMALIZE_SCORES,
 )
 
 from open_webui.constants import ERROR_MESSAGES
@@ -199,7 +200,11 @@ def get_rf(
                         trust_remote_code=RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
                         backend=SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
                         model_kwargs=SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
-                        activation_fn=torch.nn.Sigmoid(),
+                        activation_fn=(
+                            torch.nn.Sigmoid()
+                            if RAG_RERANKING_MODEL_NORMALIZE_SCORES
+                            else None
+                        ),
                     )
                 except Exception as e:
                     log.error(f"CrossEncoder: {e}")

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -112,7 +112,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
-    RAG_RERANKING_MODEL_NORMALIZE_SCORES,
+    SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION,
 )
 
 from open_webui.constants import ERROR_MESSAGES
@@ -202,7 +202,7 @@ def get_rf(
                         model_kwargs=SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
                         activation_fn=(
                             torch.nn.Sigmoid()
-                            if RAG_RERANKING_MODEL_NORMALIZE_SCORES
+                            if SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION
                             else None
                         ),
                     )

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -198,6 +198,7 @@ def get_rf(
                         trust_remote_code=RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
                         backend=SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
                         model_kwargs=SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
+                        activation_fn=torch.nn.Sigmoid(),
                     )
                 except Exception as e:
                     log.error(f"CrossEncoder: {e}")


### PR DESCRIPTION
**Description:**

**Fix: Normalize local CrossEncoder reranking scores to 0-1 range**

The relevance threshold setting (0-1 range in the UI) doesn't work correctly with local CrossEncoder reranking models because MS MARCO models (the most commonly used rerankers) return raw logits (roughly -10 to +10) instead of normalized scores. When a user sets a threshold of 0.5, practically everything passes because even poor matches score above 0.5 in logit space.

**Solution:** Pass `activation_fn=torch.nn.Sigmoid()` to the CrossEncoder constructor. This is the approach recommended by the [sentence-transformers documentation](https://www.sbert.net/docs/cross_encoder/pretrained_models.html) for MS MARCO models and has the following benefits:

- Normalization runs on-device during inference rather than post-hoc in Python
- Threshold behavior now works as expected (0.5 = 50% relevance confidence)
- External rerankers are unaffected (they already return normalized scores via their APIs)

> "Note: You can initialize these models with activation_fn=torch.nn.Sigmoid() to force the model to return scores between 0 and 1. Otherwise, the raw value can reasonably range between -10 and 10.

> Example code: `model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2", activation_fn=torch.nn.Sigmoid())`"

Source: https://www.sbert.net/docs/cross_encoder/pretrained_models.html

Edge case: Models that already output 0-1 scores (like STS-B) will have sigmoid applied twice, compressing their output range. **However, STS-B models are designed for semantic similarity, not reranking and <ins>should not be used for reranking</ins>** - in practice, **reranking pipelines use MS MARCO or BGE models.** Even if someone did use an STS-B model, **ranking order is preserved (sigmoid is monotonic) and thresholds still function**, just with compressed score magnitudes.

RE: https://github.com/open-webui/open-webui/discussions/19999

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
