### PR TITLE
fix: image editing with uploaded images after file storage refactor

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -868,6 +868,27 @@ async def image_edits(
 
                     return f"data:{mime_type};base64,{image_data}"
 
+            elif data.startswith("data:"):
+                # Already base64 encoded, return as-is
+                return data
+
+            else:
+                # Assume it's a raw file ID (frontend sends file.url = file_id)
+                try:
+                    file_response = await get_file_content_by_id(data, user)
+
+                    if isinstance(file_response, FileResponse):
+                        file_path = file_response.path
+
+                        with open(file_path, "rb") as f:
+                            file_bytes = f.read()
+                            image_data = base64.b64encode(file_bytes).decode("utf-8")
+                            mime_type, _ = mimetypes.guess_type(file_path)
+
+                        return f"data:{mime_type};base64,{image_data}"
+                except Exception:
+                    pass
+
             return data
 
         # Load image(s) from URL(s) if necessary

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -722,7 +722,11 @@ def get_images_from_messages(message_list):
 
         message_images = []
         for file in message.get("files", []):
-            if file.get("type") == "image":
+            # Check for type == "image" OR content_type starting with "image/"
+            # Uploaded images have type="file" but content_type="image/..."
+            if file.get("type") == "image" or (
+                file.get("content_type") or ""
+            ).startswith("image/"):
                 message_images.append(file.get("url"))
 
         if message_images:

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -665,14 +665,14 @@
 							<StatusHistory statusHistory={message?.statusHistory} />
 						{/if}
 
-						{#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}
+						{#if message?.files && message.files?.filter((f) => f.type === 'image' || (f?.content_type ?? '').startsWith('image/')).length > 0}
 							<div
 								class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap"
 								dir={$settings?.chatDirection ?? 'auto'}
 							>
 								{#each message.files as file}
 									<div>
-										{#if file.type === 'image'}
+										{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
 											<Image src={file.url} alt={message.content} />
 										{:else}
 											<FileItem

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -221,7 +221,7 @@
 					{#if (editedFiles ?? []).length > 0}
 						<div class="flex items-center flex-wrap gap-2 -mx-2 mb-1">
 							{#each editedFiles as file, fileIdx}
-								{#if file.type === 'image'}
+								{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
 									<div class=" relative group">
 										<div class="relative flex items-center">
 											<Image

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -221,11 +221,15 @@
 					{#if (editedFiles ?? []).length > 0}
 						<div class="flex items-center flex-wrap gap-2 -mx-2 mb-1">
 							{#each editedFiles as file, fileIdx}
+								{@const fileUrl =
+									file.url.startsWith('data') || file.url.startsWith('http')
+										? file.url
+										: `${WEBUI_API_BASE_URL}/files/${file.url}${file?.content_type ? '/content' : ''}`}
 								{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
 									<div class=" relative group">
 										<div class="relative flex items-center">
 											<Image
-												src={file.url}
+												src={fileUrl}
 												alt="input"
 												imageClassName=" size-14 rounded-xl object-cover"
 											/>

--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -206,7 +206,7 @@
 							/>
 						{/if}
 					{:else if typeof file === 'object'}
-						{#if file.type === 'image' && file.url}
+						{#if (file.type === 'image' || (file?.content_type ?? '').startsWith('image/')) && file.url}
 							<Image
 								id={`${collapsibleId}-tool-calls-${attributes?.id}-result-${idx}`}
 								src={file.url}

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -777,7 +777,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		await tick();
 
 		for (const file of files) {
-			if (file.type === 'image') {
+			if (file.type === 'image' || (file?.content_type ?? '').startsWith('image/')) {
 				const e = new CustomEvent('data', { files: files });
 
 				const img = document.getElementById(`image:${file.id}`);

--- a/src/lib/components/notes/NoteEditor/Controls.svelte
+++ b/src/lib/components/notes/NoteEditor/Controls.svelte
@@ -68,7 +68,7 @@
 				{/each}
 
 				<div class="flex items-center flex-wrap gap-2 mt-1.5">
-					{#each files.filter((file) => file.type === 'image') as file, fileIdx}
+					{#each files.filter((file) => file.type === 'image' || (file?.content_type ?? '').startsWith('image/')) as file, fileIdx}
 						<Image
 							src={file.url}
 							imageClassName=" size-14 rounded-xl object-cover"


### PR DESCRIPTION
## Description

This PR fixes image handling issues that broke after the v0.42/v0.43 refactoring which changed how images are stored in chats. Previously, images were stored as base64 data directly in the chat JSON. After the refactor, images are stored as Files in the database and referenced in the chat JSON as URLs (file IDs) for page loading speedup and caching benefits.

This change inadvertently broke:
1. **Image editing** - backend code was not updated to handle the new image storage format
2. **Image display** - uploaded images were displayed as file icons instead of actual images in several UI locations
3. **Edit mode preview** - pasting/uploading images while editing a message showed broken previews

## Root Cause Analysis

### Bug 1: `get_images_from_messages` only checked `type == "image"`

**Location:** `backend/open_webui/utils/middleware.py`

The function extracts images from chat messages to determine whether to trigger image editing vs image generation. It only checked for `file.get("type") == "image"`.

However, when images are uploaded through the file upload API (non-temporary chats), they are stored with:
- `type: 'file'` (not `'image'`)
- `content_type: 'image/png'` (or other image MIME type)
- `url: '{file_id}'`

This caused uploaded images to be completely ignored, resulting in the image generation path being taken instead of image editing.

### Bug 2: `load_url_image` didn't handle raw file IDs

**Location:** `backend/open_webui/routers/images.py`

The `load_url_image` function converts image URLs to base64 data before sending to the image editing API. It handled:
- URLs starting with `http://` or `https://`
- URLs starting with `/api/v1/files`
- Base64 data URLs (returned as-is)

However, when an image is uploaded via the file upload API, the frontend sets `file.url` to just the file ID (e.g., `abc123-def456-...`), not a full URL path. This caused the function to return the raw file ID unchanged, which is not valid image data for the editing API.

### Bug 3: Frontend only checked `type === 'image'` in multiple components

**Location:** Multiple frontend components

Several components only checked `file.type === 'image'` without also checking `content_type`, causing uploaded images to be displayed as generic file icons instead of actual image previews.

### Bug 4: Edit mode used `file.url` directly without URL transformation

**Location:** `src/lib/components/chat/Messages/UserMessage.svelte`

When editing a message and pasting/uploading an image, the edit mode was using `file.url` directly (which could be a raw file ID) instead of constructing the proper API URL, resulting in broken image previews.

## Changes Made

### Backend

#### 1. `backend/open_webui/utils/middleware.py`

Updated `get_images_from_messages()` to also check for `content_type` starting with `'image/'`:

```python
# Before
if file.get("type") == "image":

# After  
if file.get("type") == "image" or (
    file.get("content_type") or ""
).startswith("image/"):
``` 

#### 2. backend/open_webui/routers/images.py

Updated load_url_image() to handle raw file IDs by attempting to retrieve the file content:

```
else:
    # Assume it's a raw file ID (frontend sends file.url = file_id)
    try:
        file_response = await get_file_content_by_id(data, user)
        if isinstance(file_response, FileResponse):
            # Read file and convert to base64
            ...
    except Exception:
        pass
```

#### Frontend

#### 3. Updated image type detection in multiple components

Added content_type check to match the pattern already used in Chat.svelte and MessageInput.svelte:


File | Change
-- | --
UserMessage.svelte (edit mode) | Added content_type check
ResponseMessage.svelte | Added content_type check
Collapsible.svelte | Added content_type check
NoteEditor.svelte | Added content_type check
NoteEditor/Controls.svelte | Added content_type check

```
<!-- Before -->
{#if file.type === 'image'}
```

```
<!-- After -->
{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
```

4. UserMessage.svelte - Fixed edit mode image preview URL
Added URL transformation to edit mode to handle raw file IDs:

```
{@const fileUrl =
    file.url.startsWith('data') || file.url.startsWith('http')
        ? file.url
        : `${WEBUI_API_BASE_URL}/files/${file.url}${file?.content_type ? '/content' : ''}
```

### Additional Notes

- This fix is backward compatible - it still handles the old type: 'image' format for temporary chats where images are stored as base64 data URLs
- The fix aligns backend and all frontend components with the consistent pattern for identifying images using both type and content_type
- Fixes #20237

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
