### PR TITLE
fix: use sharded pub/sub for Redis Cluster task commands

### DIFF
--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -23,13 +23,30 @@ REDIS_ITEM_TASKS_KEY = f"{REDIS_KEY_PREFIX}:tasks:item"
 REDIS_PUBSUB_CHANNEL = f"{REDIS_KEY_PREFIX}:tasks:commands"
 
 
+def _is_redis_cluster(redis_client) -> bool:
+    """
+    Check if the redis client is a RedisCluster instance.
+    RedisCluster has a 'nodes_manager' attribute that regular Redis clients don't have.
+    """
+    return hasattr(redis_client, 'nodes_manager')
+
+
 async def redis_task_command_listener(app):
     redis: Redis = app.state.redis
     pubsub = redis.pubsub()
-    await pubsub.subscribe(REDIS_PUBSUB_CHANNEL)
+    
+    # Use sharded pub/sub for Redis Cluster, regular pub/sub otherwise
+    # In Redis Cluster, regular PUBLISH only reaches subscribers on a single node,
+    # but Sharded Pub/Sub (SSUBSCRIBE/SPUBLISH) properly broadcasts to all nodes.
+    if _is_redis_cluster(redis):
+        await pubsub.ssubscribe(REDIS_PUBSUB_CHANNEL)
+        expected_message_type = "smessage"
+    else:
+        await pubsub.subscribe(REDIS_PUBSUB_CHANNEL)
+        expected_message_type = "message"
 
     async for message in pubsub.listen():
-        if message["type"] != "message":
+        if message["type"] != expected_message_type:
             continue
         try:
             command = json.loads(message["data"])
@@ -74,7 +91,16 @@ async def redis_list_item_tasks(redis: Redis, item_id: str) -> List[str]:
 
 
 async def redis_send_command(redis: Redis, command: dict):
-    await redis.publish(REDIS_PUBSUB_CHANNEL, json.dumps(command))
+    command_json = json.dumps(command)
+    
+    # Use sharded pub/sub for Redis Cluster, regular pub/sub otherwise
+    # In Redis Cluster, regular PUBLISH only reaches subscribers on a single node,
+    # but Sharded Pub/Sub (SPUBLISH) properly broadcasts to all nodes.
+    if _is_redis_cluster(redis):
+        # RedisCluster may not expose spublish as a method, use execute_command
+        await redis.execute_command('SPUBLISH', REDIS_PUBSUB_CHANNEL, command_json)
+    else:
+        await redis.publish(REDIS_PUBSUB_CHANNEL, command_json)
 
 
 async def cleanup_task(redis, task_id: str, id=None):


### PR DESCRIPTION
### Summary
Fixes task stop commands not working when using Redis Cluster mode.

### Problem
When Open WebUI is configured with Redis Cluster (`REDIS_CLUSTER=true`), the task stop endpoint fails because:

1. `RedisCluster` object doesn't have a direct `publish` method
2. Even using `execute_command('PUBLISH', ...)` doesn't work because standard Redis PUBLISH is node-local in cluster mode — messages only reach subscribers connected to that specific node

### Solution
Implement sharded pub/sub (`SPUBLISH`/`SSUBSCRIBE`) for Redis Cluster mode:

- Add helper to detect cluster mode via `nodes_manager` attribute
- Update send command function to use `SPUBLISH` for cluster, `publish` for standard
- Update task command listener to use `ssubscribe` for cluster, `subscribe` for standard
- Handle different message types (`"smessage"` vs `"message"`)

Sharded pub/sub properly routes messages across all cluster nodes based on channel hash slot, ensuring all worker nodes receive task commands.

### Related
Fixes #19840

### Testing
- Standard Redis: No change in behavior, uses regular pub/sub
- Redis Cluster: Now uses sharded pub/sub for proper cross-node message delivery

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
