### PR TITLE
fix: retry Brave Search on HTTP 429 rate limit with 1s delay

### DIFF
--- a/backend/open_webui/retrieval/web/brave.py
+++ b/backend/open_webui/retrieval/web/brave.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Optional
 
 import requests
@@ -25,6 +26,14 @@ def search_brave(
     params = {"q": query, "count": count}
 
     response = requests.get(url, headers=headers, params=params)
+
+    # Handle 429 rate limiting - Brave free tier allows 1 request/second
+    # If rate limited, wait 1 second and retry once before failing
+    if response.status_code == 429:
+        log.warning("Brave Search API rate limited (429), retrying after 1 second...")
+        time.sleep(1)
+        response = requests.get(url, headers=headers, params=params)
+
     response.raise_for_status()
 
     json_response = response.json()

--- a/backend/open_webui/retrieval/web/brave.py
+++ b/backend/open_webui/retrieval/web/brave.py
@@ -30,7 +30,7 @@ def search_brave(
     # Handle 429 rate limiting - Brave free tier allows 1 request/second
     # If rate limited, wait 1 second and retry once before failing
     if response.status_code == 429:
-        log.warning("Brave Search API rate limited (429), retrying after 1 second...")
+        log.info("Brave Search API rate limited (429), retrying after 1 second...")
         time.sleep(1)
         response = requests.get(url, headers=headers, params=params)
 


### PR DESCRIPTION
### Summary
Adds automatic retry logic to the Brave Search integration when a 429 (Too Many Requests) response is received. This addresses the issue where Brave's free tier enforces a strict 1 request per second limit that can be hit even when concurrent requests is set to 1.

### Problem
Setting WEB_SEARCH_CONCURRENT_REQUESTS to 1 prevents parallel requests, but does not add any delay between sequential requests. If your internet connection is fast enough, back-to-back requests can still exceed Brave's 1 request/second limit, resulting in 429 errors.

### Solution
When the Brave API returns HTTP 429, the code now:
1. Logs a warning
2. Waits 1 second
3. Retries the request once
4. Proceeds with normal error handling if the retry also fails

This is a minimal, targeted fix that only affects Brave Search and respects the documented API rate limit without requiring additional configuration.

### Related Issues
Fixes #15134

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
