### PR TITLE
fix: prevent crash when invalid OpenAPI spec is loaded for tool servers

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -379,10 +379,9 @@ export const getToolServersData = async (servers: object[]) => {
 					}
 
 					if (res) {
-						// Detect MCP-style configs that were incorrectly used for OpenAPI tool servers
-						if (res.mcpServers && !res.paths) {
+						if (!res.paths) {
 							return {
-								error: 'Invalid OpenAPI spec: Received MCP-style configuration. Please use the MCP connection type instead.',
+								error: 'Invalid OpenAPI spec',
 								url: server?.url
 							};
 						}

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -379,6 +379,14 @@ export const getToolServersData = async (servers: object[]) => {
 					}
 
 					if (res) {
+						// Detect MCP-style configs that were incorrectly used for OpenAPI tool servers
+						if (res.mcpServers && !res.paths) {
+							return {
+								error: 'Invalid OpenAPI spec: Received MCP-style configuration. Please use the MCP connection type instead.',
+								url: server?.url
+							};
+						}
+
 						const { openapi, info, specs } = {
 							openapi: res,
 							info: res.info,
@@ -1667,7 +1675,7 @@ export interface ModelMeta {
 	profile_image_url?: string;
 }
 
-export interface ModelParams {}
+export interface ModelParams { }
 
 export type GlobalModelConfig = ModelConfig[];
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -358,9 +358,9 @@ export const generateInitialsImage = (name) => {
 	const initials =
 		sanitizedName.length > 0
 			? sanitizedName[0] +
-				(sanitizedName.split(' ').length > 1
-					? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
-					: '')
+			(sanitizedName.split(' ').length > 1
+				? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
+				: '')
 			: '';
 
 	ctx.fillText(initials.toUpperCase(), canvas.width / 2, canvas.height / 2);
@@ -516,10 +516,10 @@ export const compareVersion = (latest, current) => {
 	return current === '0.0.0'
 		? false
 		: current.localeCompare(latest, undefined, {
-				numeric: true,
-				sensitivity: 'case',
-				caseFirst: 'upper'
-			}) < 0;
+			numeric: true,
+			sensitivity: 'case',
+			caseFirst: 'upper'
+		}) < 0;
 };
 
 export const extractCurlyBraceWords = (text) => {
@@ -1249,6 +1249,11 @@ function resolveSchema(schemaRef, components, resolvedSchemas = new Set()) {
 // Main conversion function
 export const convertOpenApiToToolPayload = (openApiSpec) => {
 	const toolPayload = [];
+
+	// Guard against invalid or non-OpenAPI specs (e.g., MCP-style configs)
+	if (!openApiSpec || !openApiSpec.paths) {
+		return toolPayload;
+	}
 
 	for (const [path, methods] of Object.entries(openApiSpec.paths)) {
 		for (const [method, operation] of Object.entries(methods)) {


### PR DESCRIPTION
Description:
Adds defensive checks to prevent the frontend from crashing when an invalid or non-OpenAPI spec is configured for External Tool connections.
Changes:
- Guard against undefined paths in convertOpenApiToToolPayload to prevent Object.entries crash
- Detect MCP-style configs used for OpenAPI connections and return a helpful error message instead of breaking the UI
This fixes the infinite loading screen that occurred when users accidentally configured an MCP server using the OpenAPI connection type.
Fixes #20207

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
