### PR TITLE
feat: make changelog modal X button persist dismissal like "Okay, Let's Go!" button

### DIFF
--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -23,6 +23,13 @@
 		changelog = await getChangelog();
 	};
 
+	const closeModal = async () => {
+		localStorage.version = $config.version;
+		await settings.set({ ...$settings, ...{ version: $config.version } });
+		await updateUserSettings(localStorage.token, { ui: $settings });
+		show = false;
+	};
+
 	$: if (show) {
 		init();
 	}
@@ -38,12 +45,7 @@
 			</div>
 			<button
 				class="self-center"
-				on:click={async () => {
-					localStorage.version = $config.version;
-					await settings.set({ ...$settings, ...{ version: $config.version } });
-					await updateUserSettings(localStorage.token, { ui: $settings });
-					show = false;
-				}}
+				on:click={closeModal}
 				aria-label={$i18n.t('Close')}
 			>
 				<XMark className={'size-5'}>
@@ -104,12 +106,7 @@
 		</div>
 		<div class="flex justify-end pt-3 text-sm font-medium">
 			<button
-				on:click={async () => {
-					localStorage.version = $config.version;
-					await settings.set({ ...$settings, ...{ version: $config.version } });
-					await updateUserSettings(localStorage.token, { ui: $settings });
-					show = false;
-				}}
+				on:click={closeModal}
 				class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
 			>
 				<span class="relative">{$i18n.t("Okay, Let's Go!")}</span>

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -38,8 +38,10 @@
 			</div>
 			<button
 				class="self-center"
-				on:click={() => {
+				on:click={async () => {
 					localStorage.version = $config.version;
+					await settings.set({ ...$settings, ...{ version: $config.version } });
+					await updateUserSettings(localStorage.token, { ui: $settings });
 					show = false;
 				}}
 				aria-label={$i18n.t('Close')}


### PR DESCRIPTION
## Summary
The X (close) button on the "What's New" changelog modal now has the same behavior as the "Okay, Let's Go!" button, properly persisting the dismissal so the modal doesn't reappear until the next update.

This will kill some frustrations some users have who do not know these buttons behave differently, that keep on opening issues again and again because they do not know they need to click on "Okay, Let's Go!" for the modal to permanently disappear.

## Problem
Previously, clicking the X button to close the changelog modal only set the version in localStorage and closed the modal. This was inconsistent with the "Okay, Let's Go!" button which also synced the version to user settings on the server. This could cause the modal to reappear unexpectedly in certain scenarios (e.g., clearing localStorage, logging in from another device).

## Solution
Updated the X button click handler in ChangelogModal.svelte to match the "Okay, Let's Go!" button behavior:
- Set version in localStorage
- Update the settings store with the current version
- Sync settings to the server via updateUserSettings API
- Close the modal
This ensures both dismissal methods have consistent behavior.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
