### PR TITLE
fix: multi-worker direct connection chat streaming timeout

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -641,6 +641,7 @@ async def lifespan(app: FastAPI):
     if hasattr(app.state, "redis_direct_chat_listener"):
         app.state.redis_direct_chat_listener.cancel()
 
+
 app = FastAPI(
     title="Open WebUI",
     docs_url="/docs" if ENV == "dev" else None,
@@ -1322,7 +1323,7 @@ class APIKeyRestrictionMiddleware(BaseHTTPMiddleware):
 
                 if not is_allowed:
                     return JSONResponse(
-                        status_code=status.HTTP_403_FORBIDDEN,
+                        status_code=status.HTTP_43_FORBIDDEN,
                         content={
                             "detail": "API key not allowed to access this endpoint."
                         },

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1323,7 +1323,7 @@ class APIKeyRestrictionMiddleware(BaseHTTPMiddleware):
 
                 if not is_allowed:
                     return JSONResponse(
-                        status_code=status.HTTP_43_FORBIDDEN,
+                        status_code=status.HTTP_403_FORBIDDEN,
                         content={
                             "detail": "API key not allowed to access this endpoint."
                         },

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -283,6 +283,7 @@ from open_webui.config import (
     MISTRAL_OCR_API_BASE_URL,
     MISTRAL_OCR_API_KEY,
     RAG_TEXT_SPLITTER,
+    ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER,
     TIKTOKEN_ENCODING_NAME,
     PDF_EXTRACT_IMAGES,
     YOUTUBE_LOADER_LANGUAGE,
@@ -640,7 +641,6 @@ async def lifespan(app: FastAPI):
     if hasattr(app.state, "redis_direct_chat_listener"):
         app.state.redis_direct_chat_listener.cancel()
 
-
 app = FastAPI(
     title="Open WebUI",
     docs_url="/docs" if ENV == "dev" else None,
@@ -897,6 +897,10 @@ app.state.config.MINERU_API_TIMEOUT = MINERU_API_TIMEOUT
 app.state.config.MINERU_PARAMS = MINERU_PARAMS
 
 app.state.config.TEXT_SPLITTER = RAG_TEXT_SPLITTER
+app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER = (
+    ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER
+)
+
 app.state.config.TIKTOKEN_ENCODING_NAME = TIKTOKEN_ENCODING_NAME
 
 app.state.config.CHUNK_SIZE = CHUNK_SIZE
@@ -1611,7 +1615,7 @@ async def chat_completion(
             stream_delta_chunk_size = model_info_params.get("stream_delta_chunk_size")
 
         if model_info_params.get("reasoning_tags") is not None:
-            reasoning_tags = model_info_params.get("reasoning_tags")
+            reasoning_tags = model_info_params
 
         metadata = {
             "user_id": user.id,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1615,7 +1615,7 @@ async def chat_completion(
             stream_delta_chunk_size = model_info_params.get("stream_delta_chunk_size")
 
         if model_info_params.get("reasoning_tags") is not None:
-            reasoning_tags = model_info_params
+            reasoning_tags = model_info_params.get("reasoning_tags")
 
         metadata = {
             "user_id": user.id,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -450,7 +450,8 @@
 
 											for (const line of lines) {
 												console.log(line);
-												$socket?.emit(channel, line);
+												// Use global event for cross-worker routing
+												$socket?.emit('direct-chat-stream', { channel, data: line });
 											}
 										}
 									};
@@ -473,8 +474,10 @@
 					console.error('chatCompletion', error);
 					cb(error);
 				} finally {
-					$socket.emit(channel, {
-						done: true
+					// Use global event for cross-worker routing
+					$socket.emit('direct-chat-stream', {
+						channel,
+						data: { done: true }
 					});
 				}
 			} else {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -450,8 +450,7 @@
 
 											for (const line of lines) {
 												console.log(line);
-												// Use global event for cross-worker routing
-												$socket?.emit('direct-chat-stream', { channel, data: line });
+												$socket?.emit(channel, line);
 											}
 										}
 									};
@@ -474,10 +473,8 @@
 					console.error('chatCompletion', error);
 					cb(error);
 				} finally {
-					// Use global event for cross-worker routing
-					$socket.emit('direct-chat-stream', {
-						channel,
-						data: { done: true }
+					$socket.emit(channel, {
+						done: true
 					});
 				}
 			} else {


### PR DESCRIPTION
## Problem

When using direct connection mode with multiple backend workers (uvicorn workers > 1 or multiple k8s pods), streaming chat requests intermittently timeout and never complete.

**Root Cause:** The generate_direct_chat_completion function dynamically registers a Socket.IO event handler using sio.on(channel, handler) for each streaming request. This handler only exists in the local worker's memory. When the browser's WebSocket connection lives on a different worker, streaming chunks arrive at that worker but no handler exists there - causing messages to be silently dropped and the original request to wait forever.

## Solution

Replace per-request dynamic handler registration with a global static handler and Redis pub/sub routing:

1. **Global Queue Registry**: Add DIRECT_CHAT_QUEUES dictionary to track channel-to-queue mappings per worker
2. **Static Global Handler**: Add a sio.on("direct-chat-stream") handler that exists in all workers and routes messages to local queues or publishes via Redis
3. **Redis Pub/Sub Listener**: Each worker subscribes to direct chat channel patterns and delivers messages to local queues when present
4. **Frontend Update**: Changed socket.emit to use the global event name with channel metadata instead of dynamic channel names

## Flow After Fix

1. HTTP request arrives at Worker A, registers queue in DIRECT_CHAT_QUEUES
2. Browser emits streaming chunks to "direct-chat-stream" global event
3. Worker B (holding WebSocket) receives event via global handler
4. Worker B publishes to Redis since queue is not local
5. Worker A receives Redis message, finds local queue, delivers data
6. Streaming completes successfully

## Files Changed

- backend/open_webui/socket/main.py - Added global handler and Redis pub/sub listener
- backend/open_webui/utils/chat.py - Use queue registry instead of dynamic sio.on()
- backend/open_webui/main.py - Start Redis listener on startup
- src/routes/+layout.svelte - Emit to global event with channel metadata

## Testing

- Deploy with WEBSOCKET_MANAGER=redis and multiple workers
- Enable direct connection mode in user settings
- Send concurrent streaming chat requests
- Verify all requests complete without timeout

Closes #15162

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
