### PR TITLE
feat: expose ADMIN_EMAIL setting in Admin Panel

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -977,6 +977,7 @@ async def get_admin_details(
 async def get_admin_config(request: Request, user=Depends(get_admin_user)):
     return {
         "SHOW_ADMIN_DETAILS": request.app.state.config.SHOW_ADMIN_DETAILS,
+        "ADMIN_EMAIL": request.app.state.config.ADMIN_EMAIL,
         "WEBUI_URL": request.app.state.config.WEBUI_URL,
         "ENABLE_SIGNUP": request.app.state.config.ENABLE_SIGNUP,
         "ENABLE_API_KEYS": request.app.state.config.ENABLE_API_KEYS,
@@ -999,6 +1000,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
 
 class AdminConfig(BaseModel):
     SHOW_ADMIN_DETAILS: bool
+    ADMIN_EMAIL: Optional[str] = None
     WEBUI_URL: str
     ENABLE_SIGNUP: bool
     ENABLE_API_KEYS: bool
@@ -1023,6 +1025,7 @@ async def update_admin_config(
     request: Request, form_data: AdminConfig, user=Depends(get_admin_user)
 ):
     request.app.state.config.SHOW_ADMIN_DETAILS = form_data.SHOW_ADMIN_DETAILS
+    request.app.state.config.ADMIN_EMAIL = form_data.ADMIN_EMAIL
     request.app.state.config.WEBUI_URL = form_data.WEBUI_URL
     request.app.state.config.ENABLE_SIGNUP = form_data.ENABLE_SIGNUP
 
@@ -1067,6 +1070,7 @@ async def update_admin_config(
 
     return {
         "SHOW_ADMIN_DETAILS": request.app.state.config.SHOW_ADMIN_DETAILS,
+        "ADMIN_EMAIL": request.app.state.config.ADMIN_EMAIL,
         "WEBUI_URL": request.app.state.config.WEBUI_URL,
         "ENABLE_SIGNUP": request.app.state.config.ENABLE_SIGNUP,
         "ENABLE_API_KEYS": request.app.state.config.ENABLE_API_KEYS,

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -334,6 +334,23 @@
 						<Switch bind:state={adminConfig.SHOW_ADMIN_DETAILS} />
 					</div>
 
+				{#if adminConfig.SHOW_ADMIN_DETAILS}
+					<div class="mb-2.5 w-full justify-between">
+						<div class="flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">{$i18n.t('Admin Contact Email')}</div>
+						</div>
+
+						<div class="flex mt-2 space-x-2">
+							<input
+								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+								type="email"
+								placeholder={$i18n.t('Leave empty to use first admin user')}
+								bind:value={adminConfig.ADMIN_EMAIL}
+							/>
+						</div>
+					</div>
+				{/if}
+
 					<div class="mb-2.5">
 						<div class=" self-center text-xs font-medium mb-2">
 							{$i18n.t('Pending User Overlay Title')}


### PR DESCRIPTION
# Description

Adds an "Admin Contact Email" input field to the Admin Settings → General page, allowing administrators to configure which email is displayed in the "Account Pending" overlay directly from the UI.

Previously, this setting could only be changed via the ADMIN_EMAIL environment variable. This PR exposes it in the admin panel for easier configuration.

## Changes

**Backend (routers/auths.py):**
- Added ADMIN_EMAIL to get_admin_config endpoint response
- Added ADMIN_EMAIL to AdminConfig Pydantic model
- Added ADMIN_EMAIL handling in update_admin_config endpoint

**Frontend (components/admin/Settings/General.svelte):**
- Added conditional "Admin Contact Email" input field that appears when "Show Admin Details in Account Pending Overlay" is enabled
- Placeholder text explains the fallback behavior: "Leave empty to use first admin user"

## Behavior

- If a value is entered: That email will be displayed in the pending account overlay
- If left empty: Falls back to the first user in the database (existing behavior)
- Supports any email address, including ones not in the system (matching env var behavior)

Closes #12500

<img width="2110" height="155" alt="image" src="https://github.com/user-attachments/assets/bfe74444-6003-4a41-9b45-0152b8b8c755" />


Tested, works

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
