### PR TITLE
fix: cross-chat data corruption and tiptap editor access errors

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -346,6 +346,10 @@
 	};
 
 	const saveMessage = async (messageId, message) => {
+		if (!history.messages[messageId]) {
+			return;
+		}
+
 		history.messages[messageId] = message;
 		await updateChat();
 	};

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -346,7 +346,7 @@
 	};
 
 	const saveMessage = async (messageId, message) => {
-		if (!history.messages[messageId]) {
+		if (!history.messages?.[messageId]) {
 			return;
 		}
 

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -416,7 +416,7 @@
 	};
 
 	export const setText = (text: string) => {
-		if (!editor) return;
+		if (!editor || !editor.view) return;
 		text = text.replaceAll('\n\n', '\n');
 
 		// reset the editor content
@@ -448,11 +448,15 @@
 		}
 
 		selectNextTemplate(editor.view.state, editor.view.dispatch);
-		focus();
+
+		// Ensure the editor is still valid before trying to focus
+		if (editor && editor.view) {
+			focus();
+		}
 	};
 
 	export const insertContent = (content) => {
-		if (!editor) return;
+		if (!editor || !editor.view) return;
 		const { state, view } = editor;
 		const { schema, tr } = state;
 
@@ -466,7 +470,7 @@
 	};
 
 	export const replaceVariables = (variables) => {
-		if (!editor) return;
+		if (!editor || !editor.view) return;
 		const { state, view } = editor;
 		const { doc } = state;
 
@@ -509,11 +513,16 @@
 	};
 
 	export const focus = () => {
-		if (editor) {
+		if (editor && editor.view) {
+			// Check if the editor is destroyed
+			if (editor.isDestroyed) {
+				return;
+			}
+
 			try {
-				editor.view?.focus();
+				editor.view.focus();
 				// Scroll to the current selection
-				editor.view?.dispatch(editor.view.state.tr.scrollIntoView());
+				editor.view.dispatch(editor.view.state.tr.scrollIntoView());
 			} catch (e) {
 				// sometimes focusing throws an error, ignore
 				console.warn('Error focusing editor', e);
@@ -743,7 +752,7 @@
 							})
 						]
 					: []),
-				...(richText && showFormattingToolbar
+						...(richText && showFormattingToolbar
 					? [
 							BubbleMenu.configure({
 								element: bubbleMenuElement,
@@ -753,6 +762,14 @@
 									placement: 'top',
 									theme: 'transparent',
 									offset: [0, 2]
+								},
+								shouldShow: ({ editor, view, state, oldState, from, to }) => {
+									// safety check
+									if (!editor || !editor.view || editor.isDestroyed) {
+										return false;
+									}
+									// default logic
+									return from !== to;
 								}
 							}),
 							FloatingMenu.configure({
@@ -763,6 +780,14 @@
 									placement: floatingMenuPlacement,
 									theme: 'transparent',
 									offset: [-12, 4]
+								},
+								shouldShow: ({ editor, view, state, oldState }) => {
+									// safety check
+									if (!editor || !editor.view || editor.isDestroyed) {
+										return false;
+									}
+									// default logic
+									return editor.isActive('paragraph');
 								}
 							})
 						]

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -450,9 +450,7 @@
 		selectNextTemplate(editor.view.state, editor.view.dispatch);
 
 		// Ensure the editor is still valid before trying to focus
-		if (editor && editor.view) {
-			focus();
-		}
+		focus();
 	};
 
 	export const insertContent = (content) => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

This PR addresses two critical stability issues in the chat interface:
1.  **Cross-Chat Data Corruption**: Fixes a race condition where background tasks (like image generation) from a previous chat could overwrite and corrupt the history of the currently active chat after navigation. (Related - https://github.com/open-webui/open-webui/pull/20264)
2.  **TipTap Editor Crashes**: Fixes "editor view is not available" errors caused by plugins or async methods attempting to access the TipTap editor instance after it has been destroyed or is not yet mounted.

### Fixed

- **Cross-Chat Corruption**: Added a safeguard in `Messages.svelte`'s `saveMessage` to ignore updates if the target message ID does not exist in the current chat history.
- **TipTap Access Errors**: Added null checks for `editor` and `editor.view` in `RichTextInput.svelte` methods (`setText`, `focus`, `insertContent`, `replaceVariables`) and in the `shouldShow` callback for `BubbleMenu` and `FloatingMenu` plugins.

## How to reproduce the error this PR fixes

1. **Open a new chat** and enable **Image** generation (the “Image” toggle should be on).  
2. **Send a prompt** that asks the model to generate an image.  
   - Wait until the model finishes generating the image **and** the full text response.  
3. **Open a second chat** (toggle **Image** on once more if needed).  
4. **Send a different prompt** that also requests an image.  
   - Again, wait for the model to finish and display the image.  
5. **Stay in the second chat** and click the **“Generate Image”** button that appears below the model’s response.  
6. **Immediately after clicking “Generate Image,”** start switching **back and forth** between the first chat (the one you created in step 1) and the second chat (the one you’re currently in).  
   - Do this rapidly – a few seconds of toggling is enough.
7. **Observe the behavior:**  
   - **Before this fix:** the background image‑generation task from the first chat can finish while you’re looking at the second chat, causing the first chat’s message to be written into the second chat’s history (cross‑chat data corruption).  
   - **Also before the fix:** the TipTap editor may try to access its `view` after the component has been destroyed, resulting in an error like *“editor view is not available.”*  

If you see either of those issues (corrupted chat history or a TipTap crash) while performing the steps above, you’ve reproduced the bug that this PR addresses. After applying the fix, switching between chats during image re‑generation no longer corrupts the history, and the editor no longer throws “view is not available” errors.

---

### Additional Information

- **Corruption Fix Details**: Previously, `saveMessage` would write to `history` based on `messageId`. If the user switched chats while an async operation was pending for the old chat, the operation would complete and write the old message into the *new* chat's `history` object, corrupting state. The fix ensures the message belongs to the current view before updating.
- **Editor Stability Details**: The TipTap `BubbleMenu` and `FloatingMenu` plugins could attempt to update their visibility state asynchronously (e.g. via `setTimeout`) after the editor component was destroyed, leading to `Uncaught Error: The editor view is not available`. Explicit lifecycle checks prevent this.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.