### PR TITLE
fix: prevent getChatList crash on null API response

### DIFF
--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -142,6 +142,10 @@ export const getChatList = async (
 		throw error;
 	}
 
+	if (!res) {
+		return [];
+	}
+
 	return res.map((chat) => ({
 		...chat,
 		time_range: getTimeRange(chat.updated_at)


### PR DESCRIPTION
Add null check before calling .map() on the API response in getChatList(). When the fetch fails silently or returns null, the function now gracefully returns an empty array instead of crashing with 'Cannot read property map of null'.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
