### PR TITLE
fix: prevent delete_chat_by_id crash when chat is None

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1028,6 +1028,11 @@ async def delete_chat_by_id(
 ):
     if user.role == "admin":
         chat = Chats.get_chat_by_id(id, db=db)
+        if not chat:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
         for tag in chat.meta.get("tags", []):
             if Chats.count_chats_by_tag_name_and_user_id(tag, user.id, db=db) == 1:
                 Tags.delete_tag_by_name_and_user_id(tag, user.id, db=db)
@@ -1045,6 +1050,11 @@ async def delete_chat_by_id(
             )
 
         chat = Chats.get_chat_by_id(id, db=db)
+        if not chat:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
         for tag in chat.meta.get("tags", []):
             if Chats.count_chats_by_tag_name_and_user_id(tag, user.id, db=db) == 1:
                 Tags.delete_tag_by_name_and_user_id(tag, user.id, db=db)


### PR DESCRIPTION
Add null check after Chats.get_chat_by_id() in both admin and user code paths. When chat doesn't exist, now raises HTTP 404 instead of crashing with AttributeError when accessing chat.meta.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
