### PR TITLE
fix: prevent get_user_ids_from_room crash on missing session

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -246,7 +246,11 @@ def get_user_ids_from_room(room):
     active_session_ids = get_session_ids_from_room(room)
 
     active_user_ids = list(
-        set([SESSION_POOL.get(session_id)["id"] for session_id in active_session_ids])
+        set([
+            SESSION_POOL.get(session_id)["id"]
+            for session_id in active_session_ids
+            if SESSION_POOL.get(session_id) is not None
+        ])
     )
     return active_user_ids
 


### PR DESCRIPTION
Add null check in list comprehension before accessing session['id']. When a session_id exists in the room but has been removed from SESSION_POOL, the function now skips it instead of crashing with TypeError.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
