### PR TITLE
fix: prevent getOpenAIUrls and getOpenAIKeys crash on null response

### DIFF
--- a/src/lib/apis/openai/index.ts
+++ b/src/lib/apis/openai/index.ts
@@ -103,7 +103,7 @@ export const getOpenAIUrls = async (token: string = '') => {
 		throw error;
 	}
 
-	return res.OPENAI_API_BASE_URLS;
+	return res?.OPENAI_API_BASE_URLS ?? [];
 };
 
 export const updateOpenAIUrls = async (token: string = '', urls: string[]) => {
@@ -170,7 +170,7 @@ export const getOpenAIKeys = async (token: string = '') => {
 		throw error;
 	}
 
-	return res.OPENAI_API_KEYS;
+	return res?.OPENAI_API_KEYS ?? [];
 };
 
 export const updateOpenAIKeys = async (token: string = '', keys: string[]) => {


### PR DESCRIPTION
Use optional chaining and nullish coalescing when accessing res.OPENAI_API_BASE_URLS and res.OPENAI_API_KEYS. Returns empty array instead of crashing with 'Cannot read property of null'.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
