### PR TITLE
fix: prevent invalidate_token crash when decode_token returns None

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -230,6 +230,10 @@ async def is_valid_token(request, decoded) -> bool:
 async def invalidate_token(request, token):
     decoded = decode_token(token)
 
+    # If token is invalid/expired, nothing to revoke
+    if not decoded:
+        return
+
     # Require Redis to store revoked tokens
     if request.app.state.redis:
         jti = decoded.get("jti")


### PR DESCRIPTION
Add null check after decode_token() before calling decoded.get(). Invalid/expired tokens now gracefully exit instead of crashing with AttributeError.


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
