### PR TITLE
fix: prevent update_user_settings_by_id crash when user is None

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -613,7 +613,11 @@ class UsersTable:
     def update_user_settings_by_id(self, id: str, updated: dict, db: Optional[Session] = None) -> Optional[UserModel]:
         try:
             with get_db_context(db) as db:
-                user_settings = db.query(User).filter_by(id=id).first().settings
+                user = db.query(User).filter_by(id=id).first()
+                if not user:
+                    return None
+
+                user_settings = user.settings
 
                 if user_settings is None:
                     user_settings = {}


### PR DESCRIPTION
Get user first and check for None before accessing .settings attribute. Returns None gracefully instead of crashing with AttributeError.



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
