### PR TITLE
fix: prevent null crashes in users and notes routers

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -70,19 +70,20 @@ async def get_notes(
         limit = 60
         skip = (page - 1) * limit
 
-    notes = [
-        NoteUserResponse(
-            **{
-                **note.model_dump(),
-                "user": UserResponse(
-                    **Users.get_user_by_id(note.user_id, db=db).model_dump()
-                ),
-            }
-        )
-        for note in Notes.get_notes_by_user_id(
-            user.id, "read", skip=skip, limit=limit, db=db
-        )
-    ]
+    notes = []
+    for note in Notes.get_notes_by_user_id(
+        user.id, "read", skip=skip, limit=limit, db=db
+    ):
+        note_user = Users.get_user_by_id(note.user_id, db=db)
+        if note_user:
+            notes.append(
+                NoteUserResponse(
+                    **{
+                        **note.model_dump(),
+                        "user": UserResponse(**note_user.model_dump()),
+                    }
+                )
+            )
     return notes
 
 

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -292,9 +292,11 @@ async def update_user_settings_by_session_user(
     db: Session = Depends(get_session),
 ):
     updated_user_settings = form_data.model_dump()
+    ui_settings = updated_user_settings.get("ui")
     if (
         user.role != "admin"
-        and "toolServers" in updated_user_settings.get("ui").keys()
+        and ui_settings is not None
+        and "toolServers" in ui_settings.keys()
         and not has_permission(
             user.id,
             "features.direct_tool_servers",


### PR DESCRIPTION
Add null checks for ui settings in update_user_settings_by_session_user() and for user in get_notes(). Prevents AttributeError when ui dict is None or when note's user has been deleted.



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
