### PR TITLE
fix: allow calculate_sha256 to accept file objects for GGUF URL upload

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -334,12 +334,22 @@ def get_gravatar_url(email):
     return f"https://www.gravatar.com/avatar/{hash_hex}?d=mp"
 
 
-def calculate_sha256(file_path, chunk_size):
+def calculate_sha256(file_path_or_obj, chunk_size):
     # Compute SHA-256 hash of a file efficiently in chunks
+    # Accepts either a file path (str/bytes/PathLike) or a file-like object
     sha256 = hashlib.sha256()
-    with open(file_path, "rb") as f:
-        while chunk := f.read(chunk_size):
+    
+    # Check if input is a file-like object (has read method)
+    if hasattr(file_path_or_obj, 'read'):
+        # It's a file object, read directly
+        file_path_or_obj.seek(0)  # Ensure we're at the start
+        while chunk := file_path_or_obj.read(chunk_size):
             sha256.update(chunk)
+    else:
+        # It's a file path, open it
+        with open(file_path_or_obj, "rb") as f:
+            while chunk := f.read(chunk_size):
+                sha256.update(chunk)
     return sha256.hexdigest()
 
 


### PR DESCRIPTION
Update calculate_sha256 in misc.py to accept both file paths and file-like objects. This fixes TypeError when downloading GGUF models via URL, where download_file_stream passes a BufferedReader instead of a file path. Fixes #20263

https://github.com/open-webui/open-webui/issues/20263

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
