### PR TITLE
fix: clear file hash when processing fails to prevent false duplicate

### DIFF
--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -257,7 +257,7 @@ class FilesTable:
                 return None
 
     def update_file_hash_by_id(
-        self, id: str, hash: str, db: Optional[Session] = None
+        self, id: str, hash: Optional[str], db: Optional[Session] = None
     ) -> Optional[FileModel]:
         with get_db_context(db) as db:
             try:

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1698,6 +1698,8 @@ def process_file(
                 {"status": "failed"},
                 db=db,
             )
+            # Clear the hash so the file can be re-uploaded after fixing the issue
+            Files.update_file_hash_by_id(file.id, None, db=db)
 
             if "No pandoc was found" in str(e):
                 raise HTTPException(


### PR DESCRIPTION
When file processing fails (e.g., OCR errors), the file hash was stored in the database before the error occurred. This caused subsequent upload attempts of the same file to be incorrectly blocked as duplicates, even though the file was never successfully processed.

Changes:

- Clear file hash in the exception handler of process_file()

- Update type hint to accept Optional[str] for hash parameter

Fixes #19264

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
