### PR TITLE
fix: correct pending_user_overlay type definition in Config

### DIFF
--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -284,7 +284,7 @@ type Config = {
 	};
 	ui?: {
 		pending_user_overlay_title?: string;
-		pending_user_overlay_description?: string;
+		pending_user_overlay_content?: string;
 	};
 };
 


### PR DESCRIPTION
The Config type incorrectly defined 'pending_user_overlay_description' but the backend returns 'pending_user_overlay_content' and the AccountPending.svelte component correctly accesses that property.

This fixes the type mismatch to align with the actual backend response.

Fixes #20284

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
