### PR TITLE
feat: enhance LLM context with reactions and quoted messages

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -935,6 +935,30 @@ async def model_response_handler(request, channel, message, user, db=None):
                     db=db,
                 )[::-1]
 
+                parent_id = message.parent_id if message.parent_id else message.id
+
+                # Ensure context always includes the parent message (thread starter)
+                if parent_id:
+                    if not any(m.id == parent_id for m in thread_messages):
+                        parent_message = Messages.get_message_by_id(parent_id)
+                        if parent_message:
+                            thread_messages.insert(0, parent_message)
+
+                if message.reply_to_id:
+                    if not any(m.id == message.reply_to_id for m in thread_messages):
+                        reply_to_message = Messages.get_message_by_id(
+                            message.reply_to_id
+                        )
+                        if reply_to_message:
+                            # Insert reply_to_message before the current message
+                            for i, m in enumerate(thread_messages):
+                                if m.id == message.id:
+                                    thread_messages.insert(i, reply_to_message)
+                                    break
+                            else:
+                                # If the message is not found, append it to the beginning
+                                thread_messages.insert(0, reply_to_message)
+
                 response_message, channel = await new_message_handler(
                     request,
                     channel.id,
@@ -981,8 +1005,23 @@ async def model_response_handler(request, channel, message, user, db=None):
                     else:
                         username = message_user.name if message_user else "Unknown"
 
+                    # Fetch current reactions FIRST
+                    reactions = Messages.get_reactions_by_message_id(thread_message.id)
+                    reaction_context = ""
+                    if reactions:
+                        reaction_strings = []
+                        for reaction in reactions:
+                            user_names = [user["name"] for user in reaction.users]
+                            reaction_strings.append(
+                                f"{reaction.name} from {', '.join(user_names)}"
+                            )
+                        reaction_context = (
+                            f"[CURRENT REACTIONS: {'; '.join(reaction_strings)}]\n"
+                        )
+
+                    # Build message entry with reactions BEFORE content
                     thread_history.append(
-                        f"{username}: {replace_mentions(thread_message.content)}"
+                        f"{reaction_context}{username}: {replace_mentions(thread_message.content)}"
                     )
 
                     thread_message_files = thread_message.data.get("files", [])
@@ -999,7 +1038,7 @@ async def model_response_handler(request, channel, message, user, db=None):
                     "role": "system",
                     "content": f"You are {model.get('name', model_id)}, participating in a threaded conversation. Be concise and conversational."
                     + (
-                        f"Here's the thread history:\n\n\n{thread_history_string}\n\n\nContinue the conversation naturally as {model.get('name', model_id)}, addressing the most recent message while being aware of the full context."
+                        f"Here's the thread history:\n\n\n{thread_history_string}\n\n\nContinue the conversation naturally as {model.get('name', model_id)}, addressing the most recent message while being aware of the full context.\n\nIMPORTANT: [CURRENT REACTIONS: ...] tags show the live, up-to-date state of emoji reactions on each message. These tags are the ONLY authoritative source for reaction data. Ignore any textual descriptions of reactions within message content, as those may be outdated. Always refer to the [CURRENT REACTIONS: ...] tags when discussing or analyzing reactions."
                         if thread_history
                         else ""
                     ),

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -948,6 +948,8 @@
 
 								const { state } = view;
 								const { $from } = state.selection;
+								if ($from.depth === 0) return false;
+
 								const lineStart = $from.before($from.depth);
 								const lineEnd = $from.after($from.depth);
 								const lineText = state.doc.textBetween(lineStart, lineEnd, '\n', '\0').trim();


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR enhances the LLM's context awareness in channel chats by injecting current emoji reactions and ensuring quoted/replied messages are always included in the history. It also fixes a `RangeError` in `RichTextInput.svelte`.

**Key Changes:**
1.  **Reaction Context:** The LLM now receives `[CURRENT REACTIONS: ...]` tags for messages, allowing it to "see" and respond to user reactions (e.g., upvotes, custom emojis). A system prompt update instructs the model to prioritize these tags over text content.
2.  **Thread Continuity:** Guaranteed inclusion of the thread's root message and any directly quoted/replied messages in the context sent to the LLM, fixing issues where the model lacked context for specific replies.
3.  **Bug Fix:** Resolved a `RangeError` in `RichTextInput.svelte` caused by accessing depth on a root node.

### Added

- Logic to fetch and format emoji reactions into the LLM context string.
- System prompt instruction to handle `[CURRENT REACTIONS: ...]` tags.
- Logic to trace and include `parent_id` (thread root) and `reply_to_id` (quoted message) in the `thread_messages` list.

### Changed

- Updated `model_response_handler` in `backend/open_webui/routers/channels.py` to process reactions and manage message history more robustly.

### Fixed

- `RichTextInput.svelte`: Added a check `if ($from.depth === 0) return false;` to prevent errors when querying node depth.
- Fixed missing context for LLMs when replying to messages that fell out of the immediate history window.

---

### Additional Information

- This addresses the need for the LLM to understand social cues (reactions) and follow complex thread structures more accurately.
- If this PR were merged, it would fulfill and satisfy the feature request I've submitted in the Open WebUI Discord server on October 12, 2025.
<img width="1103" height="300" alt="image" src="https://github.com/user-attachments/assets/43831e4c-5cff-4fd8-9222-ba1cc8b72545" />

### Screenshots
**See https://github.com/open-webui/open-webui/pull/20175 (closed PR) for screenshots, as that PR was originally opened up containing 3 out of the 4 commits also included in this PR.**

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.