### PR TITLE
fix: resolve infinite recursion and connection pool exhaustion in message retrieval

### DIFF
--- a/backend/open_webui/models/messages.py
+++ b/backend/open_webui/models/messages.py
@@ -138,7 +138,11 @@ class MessageResponse(MessageReplyToResponse):
 
 class MessageTable:
     def insert_new_message(
-        self, form_data: MessageForm, channel_id: str, user_id: str, db: Optional[Session] = None
+        self,
+        form_data: MessageForm,
+        channel_id: str,
+        user_id: str,
+        db: Optional[Session] = None,
     ) -> Optional[MessageModel]:
         with get_db_context(db) as db:
             channel_member = Channels.join_channel(channel_id, user_id)
@@ -170,7 +174,9 @@ class MessageTable:
             db.refresh(result)
             return MessageModel.model_validate(result) if result else None
 
-    def get_message_by_id(self, id: str, db: Optional[Session] = None) -> Optional[MessageResponse]:
+    def get_message_by_id(
+        self, id: str, db: Optional[Session] = None
+    ) -> Optional[MessageResponse]:
         with get_db_context(db) as db:
             message = db.get(Message, id)
             if not message:
@@ -201,7 +207,25 @@ class MessageTable:
                 }
             )
 
-    def get_thread_replies_by_message_id(self, id: str, db: Optional[Session] = None) -> list[MessageReplyToResponse]:
+    def get_message_by_id_slim(
+        self, id: str, db: Optional[Session] = None
+    ) -> Optional[MessageUserSlimResponse]:
+        with get_db_context(db) as db:
+            message = db.get(Message, id)
+            if not message:
+                return None
+
+            user = Users.get_user_by_id(message.user_id, db=db)
+            return MessageUserSlimResponse.model_validate(
+                {
+                    **MessageModel.model_validate(message).model_dump(),
+                    "user": user.model_dump() if user else None,
+                }
+            )
+
+    def get_thread_replies_by_message_id(
+        self, id: str, db: Optional[Session] = None
+    ) -> list[MessageReplyToResponse]:
         with get_db_context(db) as db:
             all_messages = (
                 db.query(Message)
@@ -213,7 +237,7 @@ class MessageTable:
             messages = []
             for message in all_messages:
                 reply_to_message = (
-                    self.get_message_by_id(message.reply_to_id, db=db)
+                    self.get_message_by_id_slim(message.reply_to_id, db=db)
                     if message.reply_to_id
                     else None
                 )
@@ -231,7 +255,9 @@ class MessageTable:
                 )
             return messages
 
-    def get_reply_user_ids_by_message_id(self, id: str, db: Optional[Session] = None) -> list[str]:
+    def get_reply_user_ids_by_message_id(
+        self, id: str, db: Optional[Session] = None
+    ) -> list[str]:
         with get_db_context(db) as db:
             return [
                 message.user_id
@@ -239,7 +265,11 @@ class MessageTable:
             ]
 
     def get_messages_by_channel_id(
-        self, channel_id: str, skip: int = 0, limit: int = 50, db: Optional[Session] = None
+        self,
+        channel_id: str,
+        skip: int = 0,
+        limit: int = 50,
+        db: Optional[Session] = None,
     ) -> list[MessageReplyToResponse]:
         with get_db_context(db) as db:
             all_messages = (
@@ -254,7 +284,7 @@ class MessageTable:
             messages = []
             for message in all_messages:
                 reply_to_message = (
-                    self.get_message_by_id(message.reply_to_id, db=db)
+                    self.get_message_by_id_slim(message.reply_to_id, db=db)
                     if message.reply_to_id
                     else None
                 )
@@ -273,7 +303,12 @@ class MessageTable:
             return messages
 
     def get_messages_by_parent_id(
-        self, channel_id: str, parent_id: str, skip: int = 0, limit: int = 50, db: Optional[Session] = None
+        self,
+        channel_id: str,
+        parent_id: str,
+        skip: int = 0,
+        limit: int = 50,
+        db: Optional[Session] = None,
     ) -> list[MessageReplyToResponse]:
         with get_db_context(db) as db:
             message = db.get(Message, parent_id)
@@ -297,7 +332,7 @@ class MessageTable:
             messages = []
             for message in all_messages:
                 reply_to_message = (
-                    self.get_message_by_id(message.reply_to_id, db=db)
+                    self.get_message_by_id_slim(message.reply_to_id, db=db)
                     if message.reply_to_id
                     else None
                 )
@@ -315,7 +350,9 @@ class MessageTable:
                 )
             return messages
 
-    def get_last_message_by_channel_id(self, channel_id: str, db: Optional[Session] = None) -> Optional[MessageModel]:
+    def get_last_message_by_channel_id(
+        self, channel_id: str, db: Optional[Session] = None
+    ) -> Optional[MessageModel]:
         with get_db_context(db) as db:
             message = (
                 db.query(Message)
@@ -326,7 +363,11 @@ class MessageTable:
             return MessageModel.model_validate(message) if message else None
 
     def get_pinned_messages_by_channel_id(
-        self, channel_id: str, skip: int = 0, limit: int = 50, db: Optional[Session] = None
+        self,
+        channel_id: str,
+        skip: int = 0,
+        limit: int = 50,
+        db: Optional[Session] = None,
     ) -> list[MessageModel]:
         with get_db_context(db) as db:
             all_messages = (
@@ -359,7 +400,11 @@ class MessageTable:
             return MessageModel.model_validate(message) if message else None
 
     def update_is_pinned_by_id(
-        self, id: str, is_pinned: bool, pinned_by: Optional[str] = None, db: Optional[Session] = None
+        self,
+        id: str,
+        is_pinned: bool,
+        pinned_by: Optional[str] = None,
+        db: Optional[Session] = None,
     ) -> Optional[MessageModel]:
         with get_db_context(db) as db:
             message = db.get(Message, id)
@@ -371,7 +416,11 @@ class MessageTable:
             return MessageModel.model_validate(message) if message else None
 
     def get_unread_message_count(
-        self, channel_id: str, user_id: str, last_read_at: Optional[int] = None, db: Optional[Session] = None
+        self,
+        channel_id: str,
+        user_id: str,
+        last_read_at: Optional[int] = None,
+        db: Optional[Session] = None,
     ) -> int:
         with get_db_context(db) as db:
             query = db.query(Message).filter(
@@ -410,7 +459,9 @@ class MessageTable:
             db.refresh(result)
             return MessageReactionModel.model_validate(result) if result else None
 
-    def get_reactions_by_message_id(self, id: str, db: Optional[Session] = None) -> list[Reactions]:
+    def get_reactions_by_message_id(
+        self, id: str, db: Optional[Session] = None
+    ) -> list[Reactions]:
         with get_db_context(db) as db:
             # JOIN User so all user info is fetched in one query
             results = (


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes a `RecursionError` and potential connection pool exhaustion caused by a cyclic dependency in message retrieval methods.

**The Issue:**
The `get_thread_replies_by_message_id` method called `get_message_by_id` to hydrate the `reply_to_message` field. However, `get_message_by_id` recursively calls `get_thread_replies_by_message_id` to populate thread replies. This created an infinite recursion loop when fetching messages that were part of a reply chain or thread, leading to a stack overflow and rapid consumption of database connections.

**The Fix:**
- Introduced `get_message_by_id_slim`: A new method that fetches a message and its user *without* recursively fetching thread replies or other nested relationships.
- Refactored `get_thread_replies_by_message_id`, `get_messages_by_channel_id`, and `get_messages_by_parent_id` to use `get_message_by_id_slim` when populating the `reply_to_message` field. This effectively breaks the recursion cycle.

### Added

- `get_message_by_id_slim` method to `MessageTable`.

### Changed

- Updated `get_thread_replies_by_message_id` to use `get_message_by_id_slim`.
- Updated `get_messages_by_channel_id` to use `get_message_by_id_slim`.
- Updated `get_messages_by_parent_id` to use `get_message_by_id_slim`.

### Fixed

- `RecursionError: maximum recursion depth exceeded while calling a Python object` in message retrieval.
- Resolved potential DB connection pool exhaustion due to deep recursion.

This PR solves the following error:
```js
self.get_message_by_id(message.reply_to_id, db=db)
  File "/app/backend/open_webui/models/messages.py", line 186, in get_message_by_id
    thread_replies = self.get_thread_replies_by_message_id(id, db=db)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/models/messages.py", line 216, in get_thread_replies_by_message_id
    self.get_message_by_id(message.reply_to_id, db=db)
  File "/app/backend/open_webui/models/messages.py", line 186, in get_message_by_id
    thread_replies = self.get_thread_replies_by_message_id(id, db=db)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/open_webui/models/messages.py", line 208, in get_thread_replies_by_message_id
    .filter_by(parent_id=id)
     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/query.py", line 1991, in filter_by
    clauses = [
              ^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/query.py", line 1992, in <listcomp>
    _entity_namespace_key(from_entity, key) == value
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/operators.py", line 584, in __eq__
    return self.operate(eq, other)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/attributes.py", line 453, in operate
    return op(self.comparator, *other, **kwargs)  # type: ignore[no-any-return]  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/operators.py", line 584, in __eq__
    return self.operate(eq, other)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/properties.py", line 479, in operate
    return op(self.__clause_element__(), *other, **kwargs)  # type: ignore[no-any-return]  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/annotation.py", line 371, in __eq__
    return self.__element.__class__.__eq__(self, other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/operators.py", line 584, in __eq__
    return self.operate(eq, other)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 1535, in operate
    return op(self.comparator, *other, **kwargs)  # type: ignore[no-any-return]  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/operators.py", line 584, in __eq__
    return self.operate(eq, other)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/type_api.py", line 210, in operate
    return op_fn(self.expr, op, *other, **addtl_kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/default_comparator.py", line 120, in _boolean_compare
    obj = coercions.expect(
          ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/coercions.py", line 396, in expect
    resolved = impl._literal_coercion(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/coercions.py", line 804, in _literal_coercion
    return expr._bind_param(operator, element, type_=bindparam_type)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 4669, in _bind_param
    return BindParameter(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 2000, in __init__
    self.key = _anonymous_label.safe_construct(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 5545, in safe_construct
    body = re.sub(r"[%\(\) \$]+", "_", body)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 185, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 274, in _compile
    if isinstance(flags, RegexFlag):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
```
---

### Screenshots

### Before

<img width="1339" height="1282" alt="image" src="https://github.com/user-attachments/assets/8e192981-0248-4aab-b5f2-7397438abe2d" />

### After

<img width="887" height="1273" alt="image" src="https://github.com/user-attachments/assets/7dfc364d-c14b-4b25-9d4d-48126316a748" />

### Additional Information

- This issue was causing backend crashes when loading chat history with threaded replies.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.