### PR TITLE
Add DMR_BASE_URL environment variable for Docker Model Runner support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 # The path '/ollama' will be redirected to the specified backend URL
 OLLAMA_BASE_URL='http://localhost:11434'
 
+# Alternative: Docker Model Runner URL (Ollama-compatible API)
+# If OLLAMA_BASE_URL is not set, DMR_BASE_URL will be used as fallback
+# Useful for using Docker Model Runner as backend instead of Ollama
+DMR_BASE_URL='http://localhost:12434'
+
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ![Open WebUI Banner](./banner.png)
 
-**Open WebUI is an [extensible](https://docs.openwebui.com/features/plugin/), feature-rich, and user-friendly self-hosted AI platform designed to operate entirely offline.** It supports various LLM runners like **Ollama** and **OpenAI-compatible APIs**, with **built-in inference engine** for RAG, making it a **powerful AI deployment solution**.
+**Open WebUI is an [extensible](https://docs.openwebui.com/features/plugin/), feature-rich, and user-friendly self-hosted AI platform designed to operate entirely offline.** It supports various LLM runners like **Ollama**, **Docker Model Runner** and **OpenAI-compatible APIs**, with **built-in inference engine** for RAG, making it a **powerful AI deployment solution**.
 
 Passionate about open-source AI? [Join our team →](https://careers.openwebui.com/)
 
@@ -30,6 +30,8 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 - 🚀 **Effortless Setup**: Install seamlessly using Docker or Kubernetes (kubectl, kustomize or helm) for a hassle-free experience with support for both `:ollama` and `:cuda` tagged images.
 
 - 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, and more**.
+
+- 🐳 **Docker Model Runner Integration**: Seamlessly integrate with [Docker Model Runner](https://docs.docker.com/ai/model-runner/) to manage and serve AI models directly from Docker. Pull models from **any OCI-compliant registry** (Docker Hub, private registries, etc.), package AI models as OCI Artifacts, and leverage both llama.cpp and vLLM inference engines with full GPU acceleration support.
 
 - 🛡️ **Granular Permissions and User Groups**: By allowing administrators to create detailed user roles and permissions, we ensure a secure user environment. This granularity not only enhances security but also allows for customized user experiences, fostering a sense of ownership and responsibility amongst users.
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -986,6 +986,12 @@ OLLAMA_API_BASE_URL = os.environ.get(
 )
 
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "")
+DMR_BASE_URL = os.environ.get("DMR_BASE_URL", "")
+
+# Use DMR_BASE_URL as fallback if OLLAMA_BASE_URL is not set or is the default "/ollama"
+if (not OLLAMA_BASE_URL or OLLAMA_BASE_URL == "/ollama") and DMR_BASE_URL:
+    OLLAMA_BASE_URL = DMR_BASE_URL
+
 if OLLAMA_BASE_URL:
     # Remove trailing slash
     OLLAMA_BASE_URL = (
@@ -2954,7 +2960,7 @@ RAG_AZURE_OPENAI_API_VERSION = PersistentConfig(
 RAG_OLLAMA_BASE_URL = PersistentConfig(
     "RAG_OLLAMA_BASE_URL",
     "rag.ollama.url",
-    os.getenv("RAG_OLLAMA_BASE_URL", OLLAMA_BASE_URL),
+    os.getenv("RAG_OLLAMA_BASE_URL", os.getenv("RAG_DMR_BASE_URL", OLLAMA_BASE_URL)),
 )
 
 RAG_OLLAMA_API_KEY = PersistentConfig(


### PR DESCRIPTION
# Pull Request Checklist

There have been ongoing community discussions about supporting Docker Model Runner: [](https://github.com/open-webui/open-webui/discussions/15180)<https://github.com/open-webui/open-webui/discussions/15180>

This PR provides a straightforward implementation that addresses this community need by introducing a dedicated `DMR_BASE_URL` environment variable, making it clear and simple for users to configure Docker Model Runner as their backend.

# Changelog Entry

### Description

This pull request adds support for `DMR_BASE_URL` as an alternative environment variable to `OLLAMA_BASE_URL`, enabling seamless integration with Docker Model Runner (DMR). Docker Model Runner provides an Ollama-compatible API and offers additional capabilities such as pulling models from any OCI-compliant registry. This change allows users to easily configure Open WebUI to use Docker Model Runner as their backend while maintaining full backward compatibility with existing Ollama configurations.

### Added

- __DMR_BASE_URL environment variable__: New configuration option for connecting to Docker Model Runner
- __RAG_DMR_BASE_URL environment variable__: Corresponding RAG configuration for Docker Model Runner
- __Fallback logic__: Automatic fallback from `OLLAMA_BASE_URL` to `DMR_BASE_URL` when `OLLAMA_BASE_URL` is not set
- __Documentation__: Added usage examples and explanations in `.env.example`

### Changed
- __backend/open_webui/config.py__: Modified to read and prioritize `DMR_BASE_URL` when `OLLAMA_BASE_URL` is not configured

- __.env.example__: Updated with Docker Model Runner configuration examples and usage instructions

### Deprecated

none

### Removed

none

### Fixed

none

### Security

none

### Breaking Changes

none

---

### Additional Information

__How it works:__

The implementation follows a priority-based fallback system:

1. If `OLLAMA_BASE_URL` is set → uses `OLLAMA_BASE_URL` (existing behavior preserved)
2. If `OLLAMA_BASE_URL` is NOT set but `DMR_BASE_URL` is set → uses `DMR_BASE_URL` (new functionality)
3. If neither is set → uses default behavior

__Why Docker Model Runner?__

[Docker Model Runner](https://docs.docker.com/ai/model-runner/) provides:

- Pull models from any OCI-compliant registry (Docker Hub, private registries, etc.)
- Package GGUF/Safetensors files as OCI Artifacts
- Support for both llama.cpp and vLLM inference engines
- OpenAI-compatible APIs (seamlessly compatible with Open WebUI)
- GPU acceleration support (NVIDIA, AMD ROCm, Vulkan)

# Using Docker Model Runner
export DMR_BASE_URL='http://localhost:12434'

# Or with Docker:
docker run -d -p 3000:8080 \
  -e DMR_BASE_URL='http://host.docker.internal:12434 \
  -v open-webui:/app/backend/data \
  --name open-webui \
  ghcr.io/open-webui/open-webui:main


### Screenshots or Videos

none

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
