### PR TITLE
feat: add support for passing 'steps' in image generation requests

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -463,6 +463,7 @@ class CreateImageForm(BaseModel):
     prompt: str
     size: Optional[str] = None
     n: int = 1
+    steps: Optional[int] = None
     negative_prompt: Optional[str] = None
 
 
@@ -706,8 +707,12 @@ async def image_generations(
                 "n": form_data.n,
             }
 
-            if request.app.state.config.IMAGE_STEPS is not None:
-                data["steps"] = request.app.state.config.IMAGE_STEPS
+            if request.app.state.config.IMAGE_STEPS is not None or form_data.steps is not None:
+                data["steps"] = (
+                    form_data.steps
+                    if form_data.steps is not None
+                    else request.app.state.config.IMAGE_STEPS
+                )
 
             if form_data.negative_prompt is not None:
                 data["negative_prompt"] = form_data.negative_prompt
@@ -765,8 +770,12 @@ async def image_generations(
                 "height": height,
             }
 
-            if request.app.state.config.IMAGE_STEPS is not None:
-                data["steps"] = request.app.state.config.IMAGE_STEPS
+            if request.app.state.config.IMAGE_STEPS is not None or form_data.steps is not None:
+                data["steps"] = (
+                    form_data.steps
+                    if form_data.steps is not None
+                    else request.app.state.config.IMAGE_STEPS
+                )
 
             if form_data.negative_prompt is not None:
                 data["negative_prompt"] = form_data.negative_prompt


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

This PR adds support for a `steps` parameter in the image generation API (`CreateImageForm`). 

Previously, the number of denoising steps was hardcoded to rely solely on the global configuration (`IMAGE_STEPS`). This change allows the `steps` parameter to be passed dynamically in the request (e.g., from an Action function or API call), overriding the global default if provided. This is particularly useful for custom Actions that allow users to adjust image quality/steps on a per-request basis.

The change works for both **ComfyUI** and **Automatic1111** image generation engines.

### Added

- Added `steps` optional field to `CreateImageForm` in `backend/open_webui/routers/images.py`.
- Implemented logic in `image_generations` to prioritize the request's `steps` value over the global `IMAGE_STEPS` config if present.

### Changed

- Updated `check_image_generation` logic for ComfyUI and Automatic1111 to respect the `steps` parameter from the form data.

### Additional Information

- This added behavior is desirable because it allows for granular, per-request control over image generation parameters, which is currently limited to global defaults.

### Motivation
- This change specifically helps power an update to the [Generate Image Action](https://openwebui.com/posts/3fadc3ca-c955-4c9e-9582-7438f0911b62) shared to the community platform website. It enables a new `image_steps` Valve, giving users the flexibility to adjust generation quality (steps) on the fly directly from a Valve or Uservalve, rather than being restricted to the admin `Image` settings configuration.


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.