### PR TITLE
feat: persist filter-modified model ID to message metadata

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1701,7 +1701,7 @@ async def chat_completion(
                             metadata["message_id"],
                             {
                                 "parentId": metadata.get("parent_message_id", None),
-                                "model": model_id,
+                                "model": form_data.get("model", model_id),
                             },
                         )
                 except:

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -384,6 +384,13 @@
 					message.embeds = data.embeds;
 				} else if (type === 'chat:message:error') {
 					message.error = data.error;
+				} else if (type === 'chat:model') {
+					// Filter changed the model - update in-memory message so it persists correctly
+					message.model = data.model;
+					const model = $models.find((m) => m.id === data.model);
+					if (model) {
+						message.modelName = model.name ?? model.id;
+					}
 				} else if (type === 'chat:message:follow_ups') {
 					message.followUps = data.follow_ups;
 


### PR DESCRIPTION
## Summary

RELATED / FIXES: https://github.com/open-webui/open-webui/discussions/20294

When a filter function modifies the model in its inlet hook to route messages to a different model, the database now correctly stores the updated model ID. Filters can also emit a chat:model event to update the UI in real-time.

## Problem

The model_id variable was captured at the start of the chat_completion function, but the database save was using this pre-captured value instead of the potentially-modified value from form_data after inlet filters run.

**Before:**

1. User selects Model A
2. Inlet filter changes model to Model B
3. Model B processes the message
4. Database stores model: Model A (wrong)
5. UI shows Model A

**After this feature introduction:**

1. User selects Model A
2. Inlet filter changes model to Model B
3. Model B processes the message
4. Database stores model: Model B (correct)
5. Filter emits chat:model event, UI shows Model B

# Use Case: Model Routing in Filters

Filter authors can now implement model routing that persists correctly:

```
"""
title: Model Router Test Filter
author: Test
version: 0.2.0
description: Routes to gpt-5.2 when "this is a hard task" is in the message
"""

from pydantic import BaseModel, Field
from typing import Optional


class Filter:
    class Valves(BaseModel):
        priority: int = Field(default=0, description="Filter priority")
        target_model: str = Field(
            default="gpt-5.2", description="Model to route hard tasks to"
        )

    def __init__(self):
        self.valves = self.Valves()

    async def inlet(
        self, body: dict, __event_emitter__, __user__: Optional[dict] = None
    ) -> dict:
        # Get the last user message
        messages = body.get("messages", [])
        if not messages:
            return body

        last_message = messages[-1].get("content", "")

        # Check for trigger phrase (case-insensitive)
        if "this is a hard task" in last_message.lower():
            new_model = self.valves.target_model
            print(f"[Model Router] Routing to {new_model}")
            body["model"] = new_model

            # Emit event to update frontend UI with new model
            await __event_emitter__(
                {
                    "type": "chat:model",
                    "data": {"model": new_model},
                }
            )

        return body
```

The selected model will now be correctly displayed in the chat UI after the response.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
