### PR TITLE
fix: workspace models returning "Model not found" error

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1278,6 +1278,9 @@ async def generate_chat_completion(
         del payload["metadata"]
 
     model_id = payload["model"]
+    # When called internally (not via HTTP), db may be a Depends object, not a Session
+    if not isinstance(db, Session):
+        db = None
     model_info = Models.get_model_by_id(model_id, db=db)
 
     if model_info:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -811,6 +811,9 @@ async def generate_chat_completion(
     metadata = payload.pop("metadata", None)
 
     model_id = form_data.get("model")
+    # When called internally (not via HTTP), db may be a Depends object, not a Session
+    if not isinstance(db, Session):
+        db = None
     model_info = Models.get_model_by_id(model_id, db=db)
 
     # Check model info and override the payload


### PR DESCRIPTION
### Problem
Workspace models (custom models created via Workspace > Models) were returning "Model not found" (404) errors when attempting to chat with them.


https://github.com/open-webui/open-webui/issues/20340

### Root Cause
When the generate_chat_completion functions in openai.py and ollama.py are called internally from chat.py (not via HTTP), the db parameter defaults to a Depends(get_session) object rather than an actual Session. This Depends object is truthy, so get_db_context attempted to use it as a session, causing Models.get_model_by_id to fail silently and return None.

With model_info being None, the base_model_id resolution was skipped, and the workspace model ID was passed directly to the API instead of its underlying base model.

### Solution
Added a check in both openai.py and ollama.py to verify that db is an actual Session instance before using it. If not, db is set to None so get_db_context creates a fresh session.

### Changes
- openai.py: Added isinstance check for db parameter in generate_chat_completion
- ollama.py: Added isinstance check for db parameter in generate_chat_completion

@tjbck 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
