### PR TITLE
fix: resolve OpenAPI spec validation errors

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -737,7 +737,10 @@ async def get_html_file_content_by_id(
 
 @router.get("/{id}/content/{file_name}")
 async def get_file_content_by_id(
-    id: str, user=Depends(get_verified_user), db: Session = Depends(get_session)
+    id: str,
+    file_name: str,
+    user=Depends(get_verified_user),
+    db: Session = Depends(get_session),
 ):
     file = Files.get_file_by_id(id, db=db)
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -837,7 +837,10 @@ async def generate_chat_completion(
             if not (
                 user.id == model_info.user_id
                 or has_access(
-                    user.id, type="read", access_control=model_info.access_control, db=db
+                    user.id,
+                    type="read",
+                    access_control=model_info.access_control,
+                    db=db,
                 )
             ):
                 raise HTTPException(
@@ -1062,10 +1065,9 @@ async def embeddings(request: Request, form_data: dict, user):
             await cleanup_response(r, session)
 
 
-@router.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
-async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
+async def _proxy_request(path: str, request: Request, user):
     """
-    Deprecated: proxy all requests to OpenAI API
+    Deprecated: proxy all requests to OpenAI API (internal implementation)
     """
 
     body = await request.body()
@@ -1153,3 +1155,27 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
     finally:
         if not streaming:
             await cleanup_response(r, session)
+
+
+@router.get("/{path:path}")
+async def proxy_get(path: str, request: Request, user=Depends(get_verified_user)):
+    """Deprecated: proxy GET requests to OpenAI API"""
+    return await _proxy_request(path, request, user)
+
+
+@router.post("/{path:path}")
+async def proxy_post(path: str, request: Request, user=Depends(get_verified_user)):
+    """Deprecated: proxy POST requests to OpenAI API"""
+    return await _proxy_request(path, request, user)
+
+
+@router.put("/{path:path}")
+async def proxy_put(path: str, request: Request, user=Depends(get_verified_user)):
+    """Deprecated: proxy PUT requests to OpenAI API"""
+    return await _proxy_request(path, request, user)
+
+
+@router.delete("/{path:path}")
+async def proxy_delete(path: str, request: Request, user=Depends(get_verified_user)):
+    """Deprecated: proxy DELETE requests to OpenAI API"""
+    return await _proxy_request(path, request, user)


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Testing:** Manually tested OpenAPI spec generation.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

- Split multi-method `api_route` into separate route handlers in `openai.py` to generate unique operationIds for each HTTP method (GET/POST/PUT/DELETE)
- Add missing `file_name` path parameter to `get_file_content_by_id` in `files.py`

### Fixed

- Fixed duplicate operationId error in OpenAPI spec for `/openai/{path}` endpoint (#20359)
- Fixed missing path parameter definition for `{file_name}` in `/api/v1/files/{id}/content/{file_name}` (#20359)

---

### Additional Information

- Fixes #20359
- The OpenAPI spec now validates correctly with tools like Gravitee's admission webhook and the openapi-spec-validator library

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.