### PR TITLE
fix: replace month input with dropdowns for Firefox compatibility

### DIFF
--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -196,16 +196,58 @@
 														{...variableAttributes}
 													/>
 												{:else if variables[variable]?.type === 'month'}
-													<input
-														type="month"
-														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
-														placeholder={variables[variable]?.placeholder ?? ''}
-														bind:value={variableValues[variable]}
-														autocomplete="off"
-														id="input-variable-{idx}"
-														required={variables[variable]?.required ?? false}
-														{...variableAttributes}
-													/>
+													{@const currentYear = new Date().getFullYear()}
+													{@const years = Array.from(
+														{ length: 21 },
+														(_, i) => currentYear - 10 + i
+													)}
+													{@const months = [
+														{ value: '01', label: 'January' },
+														{ value: '02', label: 'February' },
+														{ value: '03', label: 'March' },
+														{ value: '04', label: 'April' },
+														{ value: '05', label: 'May' },
+														{ value: '06', label: 'June' },
+														{ value: '07', label: 'July' },
+														{ value: '08', label: 'August' },
+														{ value: '09', label: 'September' },
+														{ value: '10', label: 'October' },
+														{ value: '11', label: 'November' },
+														{ value: '12', label: 'December' }
+													]}
+													<div class="flex gap-2">
+														<select
+															class="flex-1 rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+															id="input-variable-{idx}"
+															value={variableValues[variable]?.split('-')[0] ?? ''}
+															on:change={(e) => {
+																const month = variableValues[variable]?.split('-')[1] ?? '';
+																variableValues[variable] = month
+																	? `${e.target.value}-${month}`
+																	: e.target.value;
+															}}
+														>
+															<option value="" disabled>{$i18n.t('Year')}</option>
+															{#each years as year}
+																<option value={year}>{year}</option>
+															{/each}
+														</select>
+														<select
+															class="flex-1 rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+															value={variableValues[variable]?.split('-')[1] ?? ''}
+															on:change={(e) => {
+																const year = variableValues[variable]?.split('-')[0] ?? '';
+																variableValues[variable] = year
+																	? `${year}-${e.target.value}`
+																	: `-${e.target.value}`;
+															}}
+														>
+															<option value="" disabled>{$i18n.t('Month')}</option>
+															{#each months as month}
+																<option value={month.value}>{$i18n.t(month.label)}</option>
+															{/each}
+														</select>
+													</div>
 												{:else if variables[variable]?.type === 'number'}
 													<input
 														type="number"


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Testing:** Manually tested on Firefox and Chrome.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

- Replace native `<input type="month">` with two dropdown selects (year and month)
- Firefox does not support `<input type="month">`, causing the picker to not render
- The dropdown approach works consistently across all browsers

### Fixed

- Fixed month input type not showing in prompts on Firefox (#20151)

---

### Additional Information

- Fixes #20151
- Output format remains `YYYY-MM` for compatibility with existing prompt configurations
- Year range: 10 years before and 10 years after the current year
- Month names are internationalized using the existing i18n system

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.