### PR TITLE
feat: Add configurable DDGS backend selection with UI support

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3193,6 +3193,12 @@ SERPLY_API_KEY = PersistentConfig(
     os.getenv("SERPLY_API_KEY", ""),
 )
 
+DDGS_BACKEND = PersistentConfig(
+    "DDGS_BACKEND",
+    "rag.web.search.ddgs_backend",
+    os.getenv("DDGS_BACKEND", "auto"),
+)
+
 JINA_API_KEY = PersistentConfig(
     "JINA_API_KEY",
     "rag.web.search.jina_api_key",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -312,6 +312,7 @@ from open_webui.config import (
     YACY_PASSWORD,
     SERPER_API_KEY,
     SERPLY_API_KEY,
+    DDGS_BACKEND,
     SERPSTACK_API_KEY,
     SERPSTACK_HTTPS,
     TAVILY_API_KEY,
@@ -969,6 +970,7 @@ app.state.config.SERPSTACK_API_KEY = SERPSTACK_API_KEY
 app.state.config.SERPSTACK_HTTPS = SERPSTACK_HTTPS
 app.state.config.SERPER_API_KEY = SERPER_API_KEY
 app.state.config.SERPLY_API_KEY = SERPLY_API_KEY
+app.state.config.DDGS_BACKEND = DDGS_BACKEND
 app.state.config.TAVILY_API_KEY = TAVILY_API_KEY
 app.state.config.SEARCHAPI_API_KEY = SEARCHAPI_API_KEY
 app.state.config.SEARCHAPI_ENGINE = SEARCHAPI_ENGINE

--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -13,12 +13,14 @@ def search_duckduckgo(
     count: int,
     filter_list: Optional[list[str]] = None,
     concurrent_requests: Optional[int] = None,
+    backend: Optional[str] = "auto",
 ) -> list[SearchResult]:
     """
     Search using DuckDuckGo's Search API and return the results as a list of SearchResult objects.
     Args:
         query (str): The query to search for
         count (int): The number of results to return
+        backend (str): The search backend to use (auto, duckduckgo, google, brave, etc.)
 
     Returns:
         list[SearchResult]: A list of search results
@@ -32,7 +34,7 @@ def search_duckduckgo(
         # Use the ddgs.text() method to perform the search
         try:
             search_results = ddgs.text(
-                query, safesearch="moderate", max_results=count, backend="lite"
+                query, safesearch="moderate", max_results=count, backend=backend
             )
         except RatelimitException as e:
             log.error(f"RatelimitException: {e}")

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -543,6 +543,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
             "SERPSTACK_HTTPS": request.app.state.config.SERPSTACK_HTTPS,
             "SERPER_API_KEY": request.app.state.config.SERPER_API_KEY,
             "SERPLY_API_KEY": request.app.state.config.SERPLY_API_KEY,
+            "DDGS_BACKEND": request.app.state.config.DDGS_BACKEND,
             "TAVILY_API_KEY": request.app.state.config.TAVILY_API_KEY,
             "SEARCHAPI_API_KEY": request.app.state.config.SEARCHAPI_API_KEY,
             "SEARCHAPI_ENGINE": request.app.state.config.SEARCHAPI_ENGINE,
@@ -605,6 +606,7 @@ class WebConfig(BaseModel):
     SERPSTACK_HTTPS: Optional[bool] = None
     SERPER_API_KEY: Optional[str] = None
     SERPLY_API_KEY: Optional[str] = None
+    DDGS_BACKEND: Optional[str] = None
     TAVILY_API_KEY: Optional[str] = None
     SEARCHAPI_API_KEY: Optional[str] = None
     SEARCHAPI_ENGINE: Optional[str] = None
@@ -1097,6 +1099,7 @@ async def update_rag_config(
         request.app.state.config.SERPSTACK_HTTPS = form_data.web.SERPSTACK_HTTPS
         request.app.state.config.SERPER_API_KEY = form_data.web.SERPER_API_KEY
         request.app.state.config.SERPLY_API_KEY = form_data.web.SERPLY_API_KEY
+        request.app.state.config.DDGS_BACKEND = form_data.web.DDGS_BACKEND
         request.app.state.config.TAVILY_API_KEY = form_data.web.TAVILY_API_KEY
         request.app.state.config.SEARCHAPI_API_KEY = form_data.web.SEARCHAPI_API_KEY
         request.app.state.config.SEARCHAPI_ENGINE = form_data.web.SEARCHAPI_ENGINE
@@ -2071,6 +2074,7 @@ def search_web(
             request.app.state.config.WEB_SEARCH_RESULT_COUNT,
             request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
             concurrent_requests=request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS,
+            backend=request.app.state.config.DDGS_BACKEND,
         )
     elif engine == "tavily":
         if request.app.state.config.TAVILY_API_KEY:

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -713,14 +713,14 @@
 										>
 											<option value="auto">{$i18n.t('Auto (Random)')}</option>
 											<option value="bing">{$i18n.t('Bing')}</option>
+											<option value="brave">{$i18n.t('Brave')}</option>
 											<option value="duckduckgo">{$i18n.t('DuckDuckGo')}</option>
 											<option value="google">{$i18n.t('Google')}</option>
-											<option value="brave">{$i18n.t('Brave')}</option>
+											<option value="grokipedia">{$i18n.t('Grokipedia')}</option>
 											<option value="mojeek">{$i18n.t('Mojeek')}</option>
+											<option value="wikipedia">{$i18n.t('Wikipedia')}</option>
 											<option value="yahoo">{$i18n.t('Yahoo')}</option>
 											<option value="yandex">{$i18n.t('Yandex')}</option>
-											<option value="wikipedia">{$i18n.t('Wikipedia')}</option>
-											<option value="grokipedia">{$i18n.t('Grokipedia')}</option>
 										</select>
 									</div>
 								</div>

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -697,7 +697,36 @@
 								</div>
 							</div>
 						{/if}
+
+					{#if webConfig.WEB_SEARCH_ENGINE === 'duckduckgo'}
+						<div class="mb-2.5 flex w-full flex-col">
+							<div>
+								<div class=" self-center text-xs font-medium mb-1">
+									{$i18n.t('DDGS Backend')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<select
+											class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+											bind:value={webConfig.DDGS_BACKEND}
+										>
+											<option value="auto">{$i18n.t('Auto (Random)')}</option>
+											<option value="duckduckgo">{$i18n.t('DuckDuckGo')}</option>
+											<option value="google">{$i18n.t('Google')}</option>
+											<option value="brave">{$i18n.t('Brave')}</option>
+											<option value="mojeek">{$i18n.t('Mojeek')}</option>
+											<option value="yahoo">{$i18n.t('Yahoo')}</option>
+											<option value="yandex">{$i18n.t('Yandex')}</option>
+											<option value="wikipedia">{$i18n.t('Wikipedia')}</option>
+											<option value="grokipedia">{$i18n.t('Grokipedia')}</option>
+										</select>
+									</div>
+								</div>
+							</div>
+						</div>
 					{/if}
+				{/if}
 
 					{#if webConfig.ENABLE_WEB_SEARCH}
 						<div class="mb-2.5 flex w-full flex-col">

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -712,6 +712,7 @@
 											bind:value={webConfig.DDGS_BACKEND}
 										>
 											<option value="auto">{$i18n.t('Auto (Random)')}</option>
+											<option value="bing">{$i18n.t('Bing')}</option>
 											<option value="duckduckgo">{$i18n.t('DuckDuckGo')}</option>
 											<option value="google">{$i18n.t('Google')}</option>
 											<option value="brave">{$i18n.t('Brave')}</option>


### PR DESCRIPTION
## Summary
This PR fixes issue #20330 by replacing the invalid "lite" backend with a configurable backend option for the DDGS (Dux Distributed Global Search) web search engine.

## Problem
The DDGS library was being called with backend="lite", which is not a valid backend option. This caused KeyError warnings in the logs and forced the library to fall back to "auto" mode, which randomly selects from available providers (including Google, Brave, Yahoo, etc.) - not what users expected when selecting "DDGS" as their search engine.

## Solution
- Added a new DDGS_BACKEND configuration option that defaults to "auto"
- Added environment variable support via DDGS_BACKEND
- Added a "DDGS Backend" dropdown in the Admin Settings → Web Search UI that only appears when DDGS is selected
- Backend options include: Auto (Random), Bing, Brave, DuckDuckGo, Google, Grokipedia, Mojeek, Wikipedia, Yahoo, Yandex

Closes #20330

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
