### PR TITLE
fix: default model not populating for standard users (#18450)

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -953,8 +953,10 @@
 					selectedModels = JSON.parse(sessionStorage.selectedModels);
 					sessionStorage.removeItem('selectedModels');
 				} else {
-					if ($settings?.models) {
-						selectedModels = $settings?.models;
+					// Check if user has valid models set (not just an empty array or array with empty strings)
+					const hasValidUserModels = $settings?.models?.length > 0 && $settings.models.some((m) => m);
+					if (hasValidUserModels) {
+						selectedModels = $settings.models;
 					} else if ($config?.default_models) {
 						console.log($config?.default_models.split(',') ?? '');
 						selectedModels = $config?.default_models.split(',');

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -796,8 +796,10 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 	onMount(async () => {
 		await tick();
 
-		if ($settings?.models) {
-			selectedModelId = $settings?.models[0];
+		// Check if user has valid models set (not just an empty array or array with empty strings)
+		const hasValidUserModels = $settings?.models?.length > 0 && $settings.models.some((m) => m);
+		if (hasValidUserModels) {
+			selectedModelId = $settings.models[0];
 		} else if ($config?.default_models) {
 			selectedModelId = $config?.default_models.split(',')[0];
 		} else {

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -198,8 +198,10 @@
 			await goto('/');
 		}
 
-		if ($settings?.models) {
-			selectedModelId = $settings?.models[0];
+		// Check if user has valid models set (not just an empty array or array with empty strings)
+		const hasValidUserModels = $settings?.models?.length > 0 && $settings.models.some((m) => m);
+		if (hasValidUserModels) {
+			selectedModelId = $settings.models[0];
 		} else if ($config?.default_models) {
 			selectedModelId = $config?.default_models.split(',')[0];
 		} else {

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -108,8 +108,10 @@
 			await goto('/');
 		}
 
-		if ($settings?.models) {
-			selectedModelId = $settings?.models[0];
+		// Check if user has valid models set (not just an empty array or array with empty strings)
+		const hasValidUserModels = $settings?.models?.length > 0 && $settings.models.some((m) => m);
+		if (hasValidUserModels) {
+			selectedModelId = $settings.models[0];
 		} else if ($config?.default_models) {
 			selectedModelId = $config?.default_models.split(',')[0];
 		} else {


### PR DESCRIPTION
fix: default model not populating for standard users (#18450)

The admin's default model setting was not being applied to standard users when opening or refreshing the chat page. This occurred because the check for user-configured models used a truthy check on the models array, which evaluates to true even for empty arrays.

When a user's saved model was removed or access was revoked, their settings would contain an empty models array. This empty array satisfied the truthy condition, preventing the fallback to the admin-configured default models.

Changed the condition to explicitly verify the user has at least one valid, non-empty model ID before using their settings.  If not, the admin default models are now correctly applied as intended.

Affected components: Chat, NoteEditor, Playground Chat, Playground Completions



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
