### PR TITLE
fix: WebSearch settings form validation errors

### DIFF
--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -43,29 +43,42 @@
 
 	const submitHandler = async () => {
 		// Convert domain filter string to array before sending
-		if (webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST) {
+		if (typeof webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST === 'string' && webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST) {
 			webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.split(',')
 				.map((domain) => domain.trim())
 				.filter((domain) => domain.length > 0);
-		} else {
+		} else if (!Array.isArray(webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST)) {
 			webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = [];
 		}
 
 		// Convert Youtube loader language string to array before sending
-		if (webConfig.YOUTUBE_LOADER_LANGUAGE) {
+		if (typeof webConfig.YOUTUBE_LOADER_LANGUAGE === 'string' && webConfig.YOUTUBE_LOADER_LANGUAGE) {
 			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.split(',')
 				.map((lang) => lang.trim())
 				.filter((lang) => lang.length > 0);
-		} else {
+		} else if (!Array.isArray(webConfig.YOUTUBE_LOADER_LANGUAGE)) {
 			webConfig.YOUTUBE_LOADER_LANGUAGE = [];
+		}
+
+		// Convert numeric timeout values to strings (backend expects strings)
+		if (typeof webConfig.FIRECRAWL_TIMEOUT === 'number') {
+			webConfig.FIRECRAWL_TIMEOUT = webConfig.FIRECRAWL_TIMEOUT.toString();
+		}
+		if (typeof webConfig.PLAYWRIGHT_TIMEOUT === 'number') {
+			webConfig.PLAYWRIGHT_TIMEOUT = webConfig.PLAYWRIGHT_TIMEOUT.toString();
 		}
 
 		const res = await updateRAGConfig(localStorage.token, {
 			web: webConfig
 		});
 
-		webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
-		webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
+		// Convert arrays back to strings for display
+		if (Array.isArray(webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST)) {
+			webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
+		}
+		if (Array.isArray(webConfig.YOUTUBE_LOADER_LANGUAGE)) {
+			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
+		}
 	};
 
 	onMount(async () => {
@@ -75,11 +88,31 @@
 			webConfig = res.web;
 
 			// Convert array back to comma-separated string for display
-			if (webConfig?.WEB_SEARCH_DOMAIN_FILTER_LIST) {
+			if (Array.isArray(webConfig?.WEB_SEARCH_DOMAIN_FILTER_LIST)) {
 				webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST.join(',');
+			} else if (!webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST) {
+				webConfig.WEB_SEARCH_DOMAIN_FILTER_LIST = '';
 			}
 
-			webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
+			if (Array.isArray(webConfig?.YOUTUBE_LOADER_LANGUAGE)) {
+				webConfig.YOUTUBE_LOADER_LANGUAGE = webConfig.YOUTUBE_LOADER_LANGUAGE.join(',');
+			} else if (!webConfig.YOUTUBE_LOADER_LANGUAGE) {
+				webConfig.YOUTUBE_LOADER_LANGUAGE = '';
+			}
+
+			// Convert timeout strings to numbers for number input fields
+			if (webConfig.FIRECRAWL_TIMEOUT && typeof webConfig.FIRECRAWL_TIMEOUT === 'string') {
+				const parsed = parseInt(webConfig.FIRECRAWL_TIMEOUT);
+				if (!isNaN(parsed)) {
+					webConfig.FIRECRAWL_TIMEOUT = parsed;
+				}
+			}
+			if (webConfig.PLAYWRIGHT_TIMEOUT && typeof webConfig.PLAYWRIGHT_TIMEOUT === 'string') {
+				const parsed = parseInt(webConfig.PLAYWRIGHT_TIMEOUT);
+				if (!isNaN(parsed)) {
+					webConfig.PLAYWRIGHT_TIMEOUT = parsed;
+				}
+			}
 		}
 	});
 </script>


### PR DESCRIPTION
  ## Summary
  Fixes two validation errors in the WebSearch settings form that prevented users from saving configuration.

  ## Issues Fixed
  1. **`.split()` is not a function error**: Domain filter list and YouTube language fields were attempting to call `.split()` on arrays instead of strings
  2. **Type validation error**: Timeout fields (`FIRECRAWL_TIMEOUT`, `PLAYWRIGHT_TIMEOUT`) were being sent as numbers from `type="number"` inputs, but backend expects strings

  ## Changes
  - Added type checking before calling `.split()` on array/string fields in `submitHandler`
  - Convert numeric timeout values to strings before sending to backend
  - Convert timeout strings back to numbers when loading from backend for proper display in number inputs
  - Handle both array and string formats for domain filter and language fields

  ## Recreate
  **Issue 1: `.split()` error**
  1. Go to Admin Settings → Web Search
  2. Leave "Domain Filter List" empty
  3. Click Save
  4. Error: `Uncaught TypeError: $.get(...).WEB_SEARCH_DOMAIN_FILTER_LIST.split is not a function`

  **Issue 2: Timeout validation error**
  1. Go to Admin Settings → Web Search
  2. Select "firecrawl" as Web Search Engine
  3. Enter `300` in "Firecrawl Timeout (s)" field
  4. Click Save
  5. Error: `Input should be a valid string, input: 300`

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
