### PR TITLE
fix: stop TTS playback when leaving chat window

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -198,6 +198,10 @@
 		}
 	};
 
+	window.navigation.addEventListener("navigate", (event) => {
+	    stopAudio();
+	})
+
 	const speak = async () => {
 		if (!(message?.content ?? '').trim().length) {
 			toast.info($i18n.t('No content to speak'));

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -201,6 +201,11 @@
 	window.navigation.addEventListener("navigate", (event) => {
 	    stopAudio();
 	})
+	document.addEventListener("visibilitychange", (event) => {
+	  if (document.visibilityState != "visible") {
+	    stopAudio();
+	  }
+	});
 
 	const speak = async () => {
 		if (!(message?.content ?? '').trim().length) {


### PR DESCRIPTION
# Changelog Entry

This pull request has not been written by an AI Agent.

### Description

The TTS playback continued speaking even if the user left chat window, so now it stops.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Stop TTS playback when leaving chat window

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Related to https://github.com/open-webui/open-webui/issues/3023

### Screenshots or Videos

https://github.com/user-attachments/assets/f3fe0aa9-679d-40a8-a5e9-3f9e9657e294

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.