### PR TITLE
**fix** respect AIOHTTP_CLIENT_TIMEOUT in agenerate_ollama_batch_embeddings

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -45,6 +45,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
 )
 from open_webui.config import (
+    AIOHTTP_CLIENT_TIMEOUT,
     RAG_EMBEDDING_QUERY_PREFIX,
     RAG_EMBEDDING_CONTENT_PREFIX,
     RAG_EMBEDDING_PREFIX_FIELD_NAME,
@@ -596,7 +597,8 @@ async def agenerate_openai_batch_embeddings(
         if ENABLE_FORWARD_USER_INFO_HEADERS and user:
             headers = include_user_info_headers(headers, user)
 
-        async with aiohttp.ClientSession(trust_env=True) as session:
+        timeout = aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
+        async with aiohttp.ClientSession(trust_env=True, timeout=timeout) as session:
             async with session.post(
                 f"{url}/embeddings", headers=headers, json=form_data
             ) as r:


### PR DESCRIPTION
# Changelog Entry

### Description

Fixed problem where embeddings generation did not respect the AIOHTTP_CLIENT_TIMEOUT and timed out after 300s (default). 

### Added

Added timeout to agenerate_ollama_batch_embeddings()

### Additional Information

Tested manually on local setup.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
