### PR TITLE
fix: prevent system prompt duplication in native function calling

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -165,6 +165,24 @@ def pop_system_message(messages: list[dict]) -> tuple[Optional[dict], list[dict]
 
 
 def update_message_content(message: dict, content: str, append: bool = True) -> dict:
+    # Get existing text content for duplicate check
+    existing_text = ""
+    if isinstance(message.get("content"), list):
+        for item in message["content"]:
+            if item.get("type") == "text":
+                existing_text = item.get("text", "")
+                break
+    else:
+        existing_text = message.get("content", "")
+
+    # Skip update if content already present (fixes system prompt duplication
+    # during native function calling tool iterations - GitHub #19169)
+    if existing_text and content:
+        existing_stripped = existing_text.strip()
+        content_stripped = content.strip()
+        if existing_stripped.startswith(content_stripped):
+            return message
+
     if isinstance(message["content"], list):
         for item in message["content"]:
             if item["type"] == "text":


### PR DESCRIPTION
## Summary

Prevents system prompt content from being duplicated during native function calling with MCP tools, which was causing quadratic token growth and excessive API costs.

## Problem

When using native function calling mode with MCP tools, each tool call iteration triggers `update_message_content()` which prepends the system prompt to the existing system message. This causes the same prompt to be duplicated multiple times:

```
Tool call 1: "System prompt" (~20k tokens)
Tool call 2: "System prompt\nSystem prompt" (~40k tokens)
Tool call 3: "System prompt\nSystem prompt\nSystem prompt" (~60k tokens)
```

**Impact:** A 20k token conversation can balloon to 3M+ tokens over multiple tool call iterations, causing massive unnecessary API costs.

## Root Cause

The bug occurs in the agentic tool call loop:

1. Initial request applies system prompt via `apply_system_prompt_to_body()` with `replace=True`
2. Each tool call iteration calls `generate_chat_completion()` again
3. The router applies model system prompt via `apply_system_prompt_to_body()` with `replace=False` (default)
4. This calls `update_message_content()` with `append=False`, which **prepends** the content
5. The same system prompt gets prepended on every iteration

## Fix

Add a check in `update_message_content()` to skip the update if the content is already present at the start of the existing message. This prevents duplicate prepending while preserving the ability to append genuinely new content.

## Test Plan

- [x] Enable native function calling mode
- [x] Connect MCP tool server
- [x] Trigger multiple tool calls
- [x] Verify token count stays stable (not growing by ~system_prompt_size each iteration)

**Verified:** Token count remains stable at ~12k tokens after 3 tool calls (previously would have grown to ~36k+).

Related: #19656