### PR TITLE
feat: add ENABLE_USER_STATUS toggle for admin-controlled user status visibility

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1574,6 +1574,12 @@ ENABLE_NOTES = PersistentConfig(
     os.environ.get("ENABLE_NOTES", "True").lower() == "true",
 )
 
+ENABLE_USER_STATUS = PersistentConfig(
+    "ENABLE_USER_STATUS",
+    "users.enable_status",
+    os.environ.get("ENABLE_USER_STATUS", "True").lower() == "true",
+)
+
 ENABLE_EVALUATION_ARENA_MODELS = PersistentConfig(
     "ENABLE_EVALUATION_ARENA_MODELS",
     "evaluation.arena.enable",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -369,6 +369,7 @@ from open_webui.config import (
     FOLDER_MAX_FILE_COUNT,
     ENABLE_CHANNELS,
     ENABLE_NOTES,
+    ENABLE_USER_STATUS,
     ENABLE_COMMUNITY_SHARING,
     ENABLE_MESSAGE_RATING,
     ENABLE_USER_WEBHOOKS,
@@ -789,6 +790,7 @@ app.state.config.ENABLE_NOTES = ENABLE_NOTES
 app.state.config.ENABLE_COMMUNITY_SHARING = ENABLE_COMMUNITY_SHARING
 app.state.config.ENABLE_MESSAGE_RATING = ENABLE_MESSAGE_RATING
 app.state.config.ENABLE_USER_WEBHOOKS = ENABLE_USER_WEBHOOKS
+app.state.config.ENABLE_USER_STATUS = ENABLE_USER_STATUS
 
 app.state.config.ENABLE_EVALUATION_ARENA_MODELS = ENABLE_EVALUATION_ARENA_MODELS
 app.state.config.EVALUATION_ARENA_MODELS = EVALUATION_ARENA_MODELS
@@ -1933,6 +1935,7 @@ async def get_app_config(request: Request):
                     "enable_community_sharing": app.state.config.ENABLE_COMMUNITY_SHARING,
                     "enable_message_rating": app.state.config.ENABLE_MESSAGE_RATING,
                     "enable_user_webhooks": app.state.config.ENABLE_USER_WEBHOOKS,
+                    "enable_user_status": app.state.config.ENABLE_USER_STATUS,
                     "enable_admin_export": ENABLE_ADMIN_EXPORT,
                     "enable_admin_chat_access": ENABLE_ADMIN_CHAT_ACCESS,
                     "enable_google_drive_integration": app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION,

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -994,6 +994,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         "ENABLE_MEMORIES": request.app.state.config.ENABLE_MEMORIES,
         "ENABLE_NOTES": request.app.state.config.ENABLE_NOTES,
         "ENABLE_USER_WEBHOOKS": request.app.state.config.ENABLE_USER_WEBHOOKS,
+        "ENABLE_USER_STATUS": request.app.state.config.ENABLE_USER_STATUS,
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,
@@ -1019,6 +1020,7 @@ class AdminConfig(BaseModel):
     ENABLE_MEMORIES: bool
     ENABLE_NOTES: bool
     ENABLE_USER_WEBHOOKS: bool
+    ENABLE_USER_STATUS: bool
     PENDING_USER_OVERLAY_TITLE: Optional[str] = None
     PENDING_USER_OVERLAY_CONTENT: Optional[str] = None
     RESPONSE_WATERMARK: Optional[str] = None
@@ -1068,6 +1070,7 @@ async def update_admin_config(
     request.app.state.config.ENABLE_MESSAGE_RATING = form_data.ENABLE_MESSAGE_RATING
 
     request.app.state.config.ENABLE_USER_WEBHOOKS = form_data.ENABLE_USER_WEBHOOKS
+    request.app.state.config.ENABLE_USER_STATUS = form_data.ENABLE_USER_STATUS
 
     request.app.state.config.PENDING_USER_OVERLAY_TITLE = (
         form_data.PENDING_USER_OVERLAY_TITLE
@@ -1097,6 +1100,7 @@ async def update_admin_config(
         "ENABLE_MEMORIES": request.app.state.config.ENABLE_MEMORIES,
         "ENABLE_NOTES": request.app.state.config.ENABLE_NOTES,
         "ENABLE_USER_WEBHOOKS": request.app.state.config.ENABLE_USER_WEBHOOKS,
+        "ENABLE_USER_STATUS": request.app.state.config.ENABLE_USER_STATUS,
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -333,8 +333,14 @@ async def update_user_settings_by_session_user(
 
 @router.get("/user/status")
 async def get_user_status_by_session_user(
+    request: Request,
     user=Depends(get_verified_user), db: Session = Depends(get_session)
 ):
+    if not request.app.state.config.ENABLE_USER_STATUS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACTION_PROHIBITED,
+        )
     user = Users.get_user_by_id(user.id, db=db)
     if user:
         return user
@@ -352,10 +358,16 @@ async def get_user_status_by_session_user(
 
 @router.post("/user/status/update")
 async def update_user_status_by_session_user(
+    request: Request,
     form_data: UserStatus,
     user=Depends(get_verified_user),
     db: Session = Depends(get_session),
 ):
+    if not request.app.state.config.ENABLE_USER_STATUS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACTION_PROHIBITED,
+        )
     user = Users.get_user_by_id(user.id, db=db)
     if user:
         user = Users.update_user_status_by_id(user.id, form_data, db=db)

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -757,6 +757,14 @@
 						<Switch bind:state={adminConfig.ENABLE_USER_WEBHOOKS} />
 					</div>
 
+					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
+						<div class=" self-center text-xs font-medium">
+							{$i18n.t('User Status')}
+						</div>
+
+						<Switch bind:state={adminConfig.ENABLE_USER_STATUS} />
+					</div>
+
 					<div class="mb-2.5">
 						<div class=" self-center text-xs font-medium mb-2">
 							{$i18n.t('Response Watermark')}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -793,7 +793,7 @@
 					{#if $user !== undefined && $user !== null}
 						<UserMenu
 							role={$user?.role}
-							profile={true}
+							profile={$config?.features?.enable_user_status ?? true}
 							showActiveUsers={false}
 							on:show={(e) => {
 								if (e.detail === 'archived-chat') {
@@ -1362,7 +1362,7 @@
 					{#if $user !== undefined && $user !== null}
 						<UserMenu
 							role={$user?.role}
-							profile={true}
+							profile={$config?.features?.enable_user_status ?? true}
 							showActiveUsers={false}
 							on:show={(e) => {
 								if (e.detail === 'archived-chat') {

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -812,6 +812,7 @@
 										aria-label={$i18n.t('Open User Profile Menu')}
 									/>
 
+									{#if $config?.features?.enable_user_status}
 									<div class="absolute -bottom-0.5 -right-0.5">
 										<span class="relative flex size-2.5">
 											<span
@@ -824,6 +825,7 @@
 											></span>
 										</span>
 									</div>
+									{/if}
 								</div>
 							</div>
 						</UserMenu>
@@ -1379,6 +1381,7 @@
 										aria-label={$i18n.t('Open User Profile Menu')}
 									/>
 
+									{#if $config?.features?.enable_user_status}
 									<div class="absolute -bottom-0.5 -right-0.5">
 										<span class="relative flex size-2.5">
 											<span
@@ -1391,6 +1394,7 @@
 											></span>
 										</span>
 									</div>
+									{/if}
 								</div>
 								<div class=" self-center font-medium">{$user?.name}</div>
 							</div>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -107,25 +107,27 @@
 						</div>
 
 						<div class=" flex items-center gap-2">
-							{#if $user?.is_active ?? true}
-								<div>
-									<span class="relative flex size-2">
-										<span
-											class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
-										/>
-										<span class="relative inline-flex rounded-full size-2 bg-green-500" />
-									</span>
-								</div>
+							{#if $config?.features?.enable_user_status}
+								{#if $user?.is_active ?? true}
+									<div>
+										<span class="relative flex size-2">
+											<span
+												class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+											/>
+											<span class="relative inline-flex rounded-full size-2 bg-green-500" />
+										</span>
+									</div>
 
-								<span class="text-xs"> {$i18n.t('Active')} </span>
-							{:else}
-								<div>
-									<span class="relative flex size-2">
-										<span class="relative inline-flex rounded-full size-2 bg-gray-500" />
-									</span>
-								</div>
+									<span class="text-xs"> {$i18n.t('Active')} </span>
+								{:else}
+									<div>
+										<span class="relative flex size-2">
+											<span class="relative inline-flex rounded-full size-2 bg-gray-500" />
+										</span>
+									</div>
 
-								<span class="text-xs"> {$i18n.t('Away')} </span>
+									<span class="text-xs"> {$i18n.t('Away')} </span>
+								{/if}
 							{/if}
 						</div>
 					</div>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -131,77 +131,80 @@
 					</div>
 				</div>
 
-				{#if $user?.status_emoji || $user?.status_message}
-					<div class="mx-1">
-						<button
-							class="mb-1 w-full gap-2 px-2.5 py-1.5 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center"
-							type="button"
-							on:click={() => {
-								show = false;
-								showUserStatusModal = true;
-							}}
-						>
-							{#if $user?.status_emoji}
-								<div class=" self-center shrink-0">
-									<Emoji className="size-4" shortCode={$user?.status_emoji} />
-								</div>
-							{/if}
-
-							<Tooltip
-								content={$user?.status_message}
-								className=" self-center line-clamp-2 flex-1 text-left"
+				{#if $config?.features?.enable_user_status}
+					{#if $user?.status_emoji || $user?.status_message}
+						<div class="mx-1">
+							<button
+								class="mb-1 w-full gap-2 px-2.5 py-1.5 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center"
+								type="button"
+								on:click={() => {
+									show = false;
+									showUserStatusModal = true;
+								}}
 							>
-								{$user?.status_message}
-							</Tooltip>
+								{#if $user?.status_emoji}
+									<div class=" self-center shrink-0">
+										<Emoji className="size-4" shortCode={$user?.status_emoji} />
+									</div>
+								{/if}
 
-							<div class="self-start">
-								<Tooltip content={$i18n.t('Clear status')}>
-									<button
-										type="button"
-										on:click={async (e) => {
-											e.preventDefault();
-											e.stopPropagation();
-											e.stopImmediatePropagation();
-
-											const res = await updateUserStatus(localStorage.token, {
-												status_emoji: '',
-												status_message: ''
-											});
-
-											if (res) {
-												toast.success($i18n.t('Status cleared successfully'));
-												user.set(await getSessionUser(localStorage.token));
-											} else {
-												toast.error($i18n.t('Failed to clear status'));
-											}
-										}}
-									>
-										<XMark className="size-4 opacity-50" strokeWidth="2" />
-									</button>
+								<Tooltip
+									content={$user?.status_message}
+									className=" self-center line-clamp-2 flex-1 text-left"
+								>
+									{$user?.status_message}
 								</Tooltip>
-							</div>
-						</button>
-					</div>
-				{:else}
-					<div class="mx-1">
-						<button
-							class="mb-1 w-full px-3 py-1.5 gap-1 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center justify-center"
-							type="button"
-							on:click={() => {
-								show = false;
-								showUserStatusModal = true;
-							}}
-						>
-							<div class=" self-center">
-								<FaceSmile className="size-4" strokeWidth="1.5" />
-							</div>
-							<div class=" self-center truncate">{$i18n.t('Update your status')}</div>
-						</button>
-					</div>
-				{/if}
 
-				<hr class=" border-gray-50/30 dark:border-gray-800/30 my-1.5 p-0" />
+								<div class="self-start">
+									<Tooltip content={$i18n.t('Clear status')}>
+										<button
+											type="button"
+											on:click={async (e) => {
+												e.preventDefault();
+												e.stopPropagation();
+												e.stopImmediatePropagation();
+
+												const res = await updateUserStatus(localStorage.token, {
+													status_emoji: '',
+													status_message: ''
+												});
+
+												if (res) {
+													toast.success($i18n.t('Status cleared successfully'));
+													user.set(await getSessionUser(localStorage.token));
+												} else {
+													toast.error($i18n.t('Failed to clear status'));
+												}
+											}}
+										>
+											<XMark className="size-4 opacity-50" strokeWidth="2" />
+										</button>
+									</Tooltip>
+								</div>
+							</button>
+						</div>
+					{:else}
+						<div class="mx-1">
+							<button
+								class="mb-1 w-full px-3 py-1.5 gap-1 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center justify-center"
+								type="button"
+								on:click={() => {
+									show = false;
+									showUserStatusModal = true;
+								}}
+							>
+								<div class=" self-center">
+									<FaceSmile className="size-4" strokeWidth="1.5" />
+								</div>
+								<div class=" self-center truncate">{$i18n.t('Update your status')}</div>
+							</button>
+						</div>
+					{/if}
+
+					<hr class=" border-gray-50/30 dark:border-gray-800/30 my-1.5 p-0" />
+				{/if}
 			{/if}
+
 
 			<DropdownMenu.Item
 				class="flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -91,7 +91,7 @@
 			align="end"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
-			{#if profile && $config?.features?.enable_user_status}
+			{#if profile}
 				<div class=" flex gap-3.5 w-full p-2.5 items-center">
 					<div class=" items-center flex shrink-0">
 						<img

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -91,7 +91,7 @@
 			align="end"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
-			{#if profile}
+			{#if profile && $config?.features?.enable_user_status}
 				<div class=" flex gap-3.5 w-full p-2.5 items-center">
 					<div class=" items-center flex shrink-0">
 						<img
@@ -107,104 +107,100 @@
 						</div>
 
 						<div class=" flex items-center gap-2">
-							{#if $config?.features?.enable_user_status}
-								{#if $user?.is_active ?? true}
-									<div>
-										<span class="relative flex size-2">
-											<span
-												class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
-											/>
-											<span class="relative inline-flex rounded-full size-2 bg-green-500" />
-										</span>
-									</div>
+							{#if $user?.is_active ?? true}
+								<div>
+									<span class="relative flex size-2">
+										<span
+											class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+										/>
+										<span class="relative inline-flex rounded-full size-2 bg-green-500" />
+									</span>
+								</div>
 
-									<span class="text-xs"> {$i18n.t('Active')} </span>
-								{:else}
-									<div>
-										<span class="relative flex size-2">
-											<span class="relative inline-flex rounded-full size-2 bg-gray-500" />
-										</span>
-									</div>
+								<span class="text-xs"> {$i18n.t('Active')} </span>
+							{:else}
+								<div>
+									<span class="relative flex size-2">
+										<span class="relative inline-flex rounded-full size-2 bg-gray-500" />
+									</span>
+								</div>
 
-									<span class="text-xs"> {$i18n.t('Away')} </span>
-								{/if}
+								<span class="text-xs"> {$i18n.t('Away')} </span>
 							{/if}
 						</div>
 					</div>
 				</div>
 
-				{#if $config?.features?.enable_user_status}
-					{#if $user?.status_emoji || $user?.status_message}
-						<div class="mx-1">
-							<button
-								class="mb-1 w-full gap-2 px-2.5 py-1.5 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center"
-								type="button"
-								on:click={() => {
-									show = false;
-									showUserStatusModal = true;
-								}}
-							>
-								{#if $user?.status_emoji}
-									<div class=" self-center shrink-0">
-										<Emoji className="size-4" shortCode={$user?.status_emoji} />
-									</div>
-								{/if}
+				{#if $user?.status_emoji || $user?.status_message}
+					<div class="mx-1">
+						<button
+							class="mb-1 w-full gap-2 px-2.5 py-1.5 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center"
+							type="button"
+							on:click={() => {
+								show = false;
+								showUserStatusModal = true;
+							}}
+						>
+							{#if $user?.status_emoji}
+								<div class=" self-center shrink-0">
+									<Emoji className="size-4" shortCode={$user?.status_emoji} />
+								</div>
+							{/if}
 
-								<Tooltip
-									content={$user?.status_message}
-									className=" self-center line-clamp-2 flex-1 text-left"
-								>
-									{$user?.status_message}
+							<Tooltip
+								content={$user?.status_message}
+								className=" self-center line-clamp-2 flex-1 text-left"
+							>
+								{$user?.status_message}
+							</Tooltip>
+
+							<div class="self-start">
+								<Tooltip content={$i18n.t('Clear status')}>
+									<button
+										type="button"
+										on:click={async (e) => {
+											e.preventDefault();
+											e.stopPropagation();
+											e.stopImmediatePropagation();
+
+											const res = await updateUserStatus(localStorage.token, {
+												status_emoji: '',
+												status_message: ''
+											});
+
+											if (res) {
+												toast.success($i18n.t('Status cleared successfully'));
+												user.set(await getSessionUser(localStorage.token));
+											} else {
+												toast.error($i18n.t('Failed to clear status'));
+											}
+										}}
+									>
+										<XMark className="size-4 opacity-50" strokeWidth="2" />
+									</button>
 								</Tooltip>
-
-								<div class="self-start">
-									<Tooltip content={$i18n.t('Clear status')}>
-										<button
-											type="button"
-											on:click={async (e) => {
-												e.preventDefault();
-												e.stopPropagation();
-												e.stopImmediatePropagation();
-
-												const res = await updateUserStatus(localStorage.token, {
-													status_emoji: '',
-													status_message: ''
-												});
-
-												if (res) {
-													toast.success($i18n.t('Status cleared successfully'));
-													user.set(await getSessionUser(localStorage.token));
-												} else {
-													toast.error($i18n.t('Failed to clear status'));
-												}
-											}}
-										>
-											<XMark className="size-4 opacity-50" strokeWidth="2" />
-										</button>
-									</Tooltip>
-								</div>
-							</button>
-						</div>
-					{:else}
-						<div class="mx-1">
-							<button
-								class="mb-1 w-full px-3 py-1.5 gap-1 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center justify-center"
-								type="button"
-								on:click={() => {
-									show = false;
-									showUserStatusModal = true;
-								}}
-							>
-								<div class=" self-center">
-									<FaceSmile className="size-4" strokeWidth="1.5" />
-								</div>
-								<div class=" self-center truncate">{$i18n.t('Update your status')}</div>
-							</button>
-						</div>
-					{/if}
-
-					<hr class=" border-gray-50/30 dark:border-gray-800/30 my-1.5 p-0" />
+							</div>
+						</button>
+					</div>
+				{:else}
+					<div class="mx-1">
+						<button
+							class="mb-1 w-full px-3 py-1.5 gap-1 rounded-xl bg-gray-50 dark:text-white dark:bg-gray-900/50 text-black transition text-xs flex items-center justify-center"
+							type="button"
+							on:click={() => {
+								show = false;
+								showUserStatusModal = true;
+							}}
+						>
+							<div class=" self-center">
+								<FaceSmile className="size-4" strokeWidth="1.5" />
+							</div>
+							<div class=" self-center truncate">{$i18n.t('Update your status')}</div>
+						</button>
+					</div>
 				{/if}
+
+				<hr class=" border-gray-50/30 dark:border-gray-800/30 my-1.5 p-0" />
 			{/if}
 
 


### PR DESCRIPTION
feat: add ENABLE_USER_STATUS toggle for admin-controlled user status visibility

Add a new admin panel toggle (Admin > Settings > General) called "User Status" that allows administrators to globally enable or disable user status functionality.

When disabled:
- User status API endpoints return 403 Forbidden
- Status emoji, message, and "Update your status" button are hidden from the user menu

The setting:
- Defaults to True (enabled)
- Can be overridden via ENABLE_USER_STATUS environment variable
- Persists across restarts using PersistentConfig

Files modified:
- backend/open_webui/config.py - Added ENABLE_USER_STATUS PersistentConfig
- backend/open_webui/main.py - App state init and features dict
- backend/open_webui/routers/auths.py - AdminConfig model and endpoints
- backend/open_webui/routers/users.py - 403 guards on status endpoints
- src/lib/components/admin/Settings/General.svelte - Toggle UI
- src/lib/components/layout/Sidebar/UserMenu.svelte - Conditional status display

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
