### PR TITLE
fix: prevent event loop blocking during file processing 

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1377,7 +1377,7 @@ def merge_docs_to_target_size(
     return processed_chunks
 
 
-def save_docs_to_vector_db(
+async def save_docs_to_vector_db(
     request: Request,
     docs,
     collection_name,
@@ -1460,7 +1460,8 @@ def save_docs_to_vector_db(
                 chunk_overlap=request.app.state.config.CHUNK_OVERLAP,
                 add_start_index=True,
             )
-            docs = text_splitter.split_documents(docs)
+            # Run CPU-bound text splitting in thread pool to avoid blocking event loop
+            docs = await run_in_threadpool(text_splitter.split_documents, docs)
         elif request.app.state.config.TEXT_SPLITTER == "token":
             log.info(
                 f"Using token text splitter: {request.app.state.config.TIKTOKEN_ENCODING_NAME}"
@@ -1473,7 +1474,8 @@ def save_docs_to_vector_db(
                 chunk_overlap=request.app.state.config.CHUNK_OVERLAP,
                 add_start_index=True,
             )
-            docs = text_splitter.split_documents(docs)
+            # Run CPU-bound text splitting in thread pool to avoid blocking event loop
+            docs = await run_in_threadpool(text_splitter.split_documents, docs)
         else:
             raise ValueError(ERROR_MESSAGES.DEFAULT("Invalid text splitter"))
 
@@ -1538,13 +1540,11 @@ def save_docs_to_vector_db(
             enable_async=request.app.state.config.ENABLE_ASYNC_EMBEDDING,
         )
 
-        # Run async embedding in sync context
-        embeddings = asyncio.run(
-            embedding_function(
-                list(map(lambda x: x.replace("\n", " "), texts)),
-                prefix=RAG_EMBEDDING_CONTENT_PREFIX,
-                user=user,
-            )
+        # Await async embedding function (non-blocking)
+        embeddings = await embedding_function(
+            list(map(lambda x: x.replace("\n", " "), texts)),
+            prefix=RAG_EMBEDDING_CONTENT_PREFIX,
+            user=user,
         )
         log.info(f"embeddings generated {len(embeddings)} for {len(texts)} items")
 
@@ -1578,7 +1578,7 @@ class ProcessFileForm(BaseModel):
 
 
 @router.post("/process/file")
-def process_file(
+async def process_file(
     request: Request,
     form_data: ProcessFileForm,
     user=Depends(get_verified_user),
@@ -1747,7 +1747,7 @@ def process_file(
                 }
             else:
                 try:
-                    result = save_docs_to_vector_db(
+                    result = await save_docs_to_vector_db(
                         request,
                         docs=docs,
                         collection_name=collection_name,
@@ -1840,8 +1840,8 @@ async def process_text(
     text_content = form_data.content
     log.debug(f"text_content: {text_content}")
 
-    result = await run_in_threadpool(
-        save_docs_to_vector_db, request, docs, collection_name, user=user
+    result = await save_docs_to_vector_db(
+        request, docs, collection_name, user=user
     )
     if result:
         return {
@@ -1876,8 +1876,7 @@ async def process_web(
                 collection_name = calculate_sha256_string(form_data.url)[:63]
 
             if not request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:
-                await run_in_threadpool(
-                    save_docs_to_vector_db,
+                await save_docs_to_vector_db(
                     request,
                     docs,
                     collection_name,
@@ -2354,8 +2353,7 @@ async def process_web_search(
             )
 
             try:
-                await run_in_threadpool(
-                    save_docs_to_vector_db,
+                await save_docs_to_vector_db(
                     request,
                     docs,
                     collection_name,
@@ -2678,8 +2676,7 @@ async def process_files_batch(
     # Save all documents in one batch
     if all_docs:
         try:
-            await run_in_threadpool(
-                save_docs_to_vector_db,
+            await save_docs_to_vector_db(
                 request,
                 all_docs,
                 collection_name,


### PR DESCRIPTION
## Description

Fixes event loop blocking during file upload and document processing that causes liveness probe failures and pod restarts in Kubernetes deployments.

### Problem

`save_docs_to_vector_db()` used `asyncio.run()` to call the async embedding function, which blocks the entire event loop. During large file uploads, this prevents uvicorn from responding to any requests (including health checks), causing Kubernetes to kill pods.

Additionally, CPU-bound text splitting operations (`split_documents()`) can block the event loop for extended periods on large files.

### Solution

1. Convert `save_docs_to_vector_db()` and `process_file()` to async functions
2. Replace `asyncio.run(embedding_function(...))` with `await embedding_function(...)`
3. Wrap CPU-bound text splitting in `run_in_threadpool()` to prevent blocking
4. Update all callers in `files.py` and `retrieval.py` to await the async functions, including the inner `_process_handler` function

### Testing

I initially implemented this from branching off the v0.6.43 tag. I've been running this in our prod environment for about a week. It has been modified further due to changes on the dev branch to apply cleanly and account for upstream changes.

### AI disclaimer

AI wrote some of this MR description and reviewed the code for this MR. 