### PR TITLE
fix: don't pass database session to channel background tasks during LLM calls

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1256,15 +1256,17 @@ async def post_new_message(
 
         active_user_ids = get_user_ids_from_room(f"channel:{channel.id}")
 
+        # NOTE: We intentionally do NOT pass db to background_handler.
+        # Background tasks should manage their own short-lived sessions to avoid
+        # holding database connections during slow operations (e.g., LLM calls).
         async def background_handler():
-            await model_response_handler(request, channel, message, user, db)
+            await model_response_handler(request, channel, message, user)
             await send_notification(
                 request.app.state.WEBUI_NAME,
                 request.app.state.config.WEBUI_URL,
                 channel,
                 message,
                 active_user_ids,
-                db=db,
             )
 
         background_tasks.add_task(background_handler)


### PR DESCRIPTION

Background tasks for channel model mentions (@mentioning a model in a channel) 
were receiving the request's database session and holding it during LLM calls.

When a user @mentions a model in a channel:
1. Request creates the message in DB (fast)
2. Background task starts to generate LLM response
3. Background task was passed db session from request scope
4. Connection held for 30+ seconds during LLM generation
5. Connection only released when background task completes

This is the same pattern fixed in auth.py - connections held during slow 
external operations instead of being released immediately.

The fix removes the db parameter from background_handler. Both 
model_response_handler and send_notification now manage their own short-lived 
sessions internally, releasing connections immediately after each database 
operation.

```
    BEFORE: Background task holds connection during LLM call
    ─────────────────────────────────────────────────
    │ create msg │ LLM call (30s) │ save response │
    │       CONNECTION HELD ENTIRE TIME           │
    ─────────────────────────────────────────────────

    AFTER: Each operation uses short-lived session
    ┌────────────┐                 ┌───────────────┐
    │ create msg │   LLM (30s)     │ save response │
    │    20ms    │  NO CONNECTION  │     20ms      │
    └────────────┘                 └───────────────┘
```

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
