### PR TITLE
feat: add markdown rendering toggle for citations and file modals

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2487,6 +2487,12 @@ ENABLE_ONEDRIVE_INTEGRATION = PersistentConfig(
     os.getenv("ENABLE_ONEDRIVE_INTEGRATION", "False").lower() == "true",
 )
 
+ENABLE_MARKDOWN_RENDERING = PersistentConfig(
+    "ENABLE_MARKDOWN_RENDERING",
+    "ui.enable_markdown_rendering",
+    os.getenv("ENABLE_MARKDOWN_RENDERING", "False").lower() == "true",
+)
+
 
 ENABLE_ONEDRIVE_PERSONAL = (
     os.environ.get("ENABLE_ONEDRIVE_PERSONAL", "True").lower() == "true"

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -347,6 +347,7 @@ from open_webui.config import (
     ENABLE_RAG_LOCAL_WEB_FETCH,
     ENABLE_WEB_LOADER_SSL_VERIFICATION,
     ENABLE_GOOGLE_DRIVE_INTEGRATION,
+    ENABLE_MARKDOWN_RENDERING,
     UPLOAD_DIR,
     EXTERNAL_WEB_SEARCH_URL,
     EXTERNAL_WEB_SEARCH_API_KEY,
@@ -967,6 +968,7 @@ app.state.config.BYPASS_WEB_SEARCH_WEB_LOADER = BYPASS_WEB_SEARCH_WEB_LOADER
 
 app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION = ENABLE_GOOGLE_DRIVE_INTEGRATION
 app.state.config.ENABLE_ONEDRIVE_INTEGRATION = ENABLE_ONEDRIVE_INTEGRATION
+app.state.config.ENABLE_MARKDOWN_RENDERING = ENABLE_MARKDOWN_RENDERING
 
 app.state.config.OLLAMA_CLOUD_WEB_SEARCH_API_KEY = OLLAMA_CLOUD_WEB_SEARCH_API_KEY
 app.state.config.SEARXNG_QUERY_URL = SEARXNG_QUERY_URL
@@ -1951,6 +1953,7 @@ async def get_app_config(request: Request):
                     "enable_google_drive_integration": app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION,
                     "enable_onedrive_integration": app.state.config.ENABLE_ONEDRIVE_INTEGRATION,
                     "enable_memories": app.state.config.ENABLE_MEMORIES,
+                    "enable_markdown_rendering": app.state.config.ENABLE_MARKDOWN_RENDERING,
                     **(
                         {
                             "enable_onedrive_personal": ENABLE_ONEDRIVE_PERSONAL,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -517,6 +517,8 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         # Integration settings
         "ENABLE_GOOGLE_DRIVE_INTEGRATION": request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION,
         "ENABLE_ONEDRIVE_INTEGRATION": request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION,
+        # UI/Display settings
+        "ENABLE_MARKDOWN_RENDERING": request.app.state.config.ENABLE_MARKDOWN_RENDERING,
         # Web search settings
         "web": {
             "ENABLE_WEB_SEARCH": request.app.state.config.ENABLE_WEB_SEARCH,
@@ -716,6 +718,9 @@ class ConfigForm(BaseModel):
     # Integration settings
     ENABLE_GOOGLE_DRIVE_INTEGRATION: Optional[bool] = None
     ENABLE_ONEDRIVE_INTEGRATION: Optional[bool] = None
+
+    # UI/Display settings
+    ENABLE_MARKDOWN_RENDERING: Optional[bool] = None
 
     # Web search settings
     web: Optional[WebConfig] = None
@@ -1047,6 +1052,13 @@ async def update_rag_config(
         form_data.ENABLE_ONEDRIVE_INTEGRATION
         if form_data.ENABLE_ONEDRIVE_INTEGRATION is not None
         else request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION
+    )
+
+    # UI/Display settings
+    request.app.state.config.ENABLE_MARKDOWN_RENDERING = (
+        form_data.ENABLE_MARKDOWN_RENDERING
+        if form_data.ENABLE_MARKDOWN_RENDERING is not None
+        else request.app.state.config.ENABLE_MARKDOWN_RENDERING
     )
 
     if form_data.web is not None:

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -763,6 +763,22 @@
 						</div>
 
 						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">
+								<Tooltip
+									content={$i18n.t(
+										'Render document content as markdown in citations and file previews. When disabled, content is displayed as plain text.'
+									)}
+									placement="top-start"
+								>
+									{$i18n.t('Enable Markdown Rendering')}
+								</Tooltip>
+							</div>
+							<div class="flex items-center relative">
+								<Switch bind:state={RAGConfig.ENABLE_MARKDOWN_RENDERING} />
+							</div>
+						</div>
+
+						<div class="  mb-2.5 flex w-full justify-between">
 							<div class=" flex gap-1.5 w-full">
 								<div class="  w-full justify-between">
 									<div class="self-center text-xs font-medium min-w-fit mb-1">

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -3,7 +3,8 @@
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
-	import { settings } from '$lib/stores';
+	import { settings, config } from '$lib/stores';
+	import Markdown from '$lib/components/chat/Messages/Markdown.svelte';
 
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
@@ -215,6 +216,15 @@
 									srcdoc={document.document}
 									title={$i18n.t('Content')}
 								></iframe>
+							{:else if $config?.features?.enable_markdown_rendering}
+								<div class="mt-2 p-3 rounded-lg bg-gray-50 dark:bg-gray-850 border border-gray-100 dark:border-gray-800">
+									<div class="prose prose-sm dark:prose-invert max-w-full prose-headings:text-base prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-headings:mt-3 prose-headings:mb-2 prose-p:my-2 prose-p:leading-relaxed prose-pre:text-xs prose-li:my-1">
+										<Markdown
+											content={document.document.trim().replace(/\n\n+/g, '\n\n')}
+											id="citation-markdown-{documentIdx}"
+										/>
+									</div>
+								</div>
 							{:else}
 								<pre class="text-sm dark:text-gray-400 whitespace-pre-line">{document.document
 										.trim()

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -93,7 +93,7 @@
 <Modal size="lg" bind:show>
 	<div>
 		<div class=" flex justify-between dark:text-gray-300 px-4.5 pt-3 pb-2">
-			<div class=" text-lg font-medium self-center flex items-center">
+			<div class=" text-lg font-medium self-center flex items-center gap-2">
 				{#if citation?.source?.name}
 					{@const document = mergedDocuments?.[0]}
 					{#if document?.metadata?.file_id || document.source?.url?.includes('http')}
@@ -123,6 +123,9 @@
 				{:else}
 					{$i18n.t('Citation')}
 				{/if}
+				<span class="text-xs font-normal px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+					{mergedDocuments.length} {mergedDocuments.length === 1 ? $i18n.t('snippet') : $i18n.t('snippets')}
+				</span>
 			</div>
 			<button
 				class="self-center"

--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -7,6 +7,7 @@
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import { getKnowledgeById } from '$lib/apis/knowledge';
 	import { getFileById, getFileContentById } from '$lib/apis/files';
+	import { config } from '$lib/stores';
 
 	import CodeBlock from '$lib/components/chat/Messages/CodeBlock.svelte';
 	import Markdown from '$lib/components/chat/Messages/Markdown.svelte';
@@ -340,13 +341,29 @@
 
 				{#if selectedTab === ''}
 					{#if item?.file?.data}
-						<div class="max-h-96 overflow-scroll scrollbar-hidden text-xs whitespace-pre-wrap">
-							{(item?.file?.data?.content ?? '').trim() || 'No content'}
-						</div>
+						{#if $config?.features?.enable_markdown_rendering}
+							<div class="max-h-96 overflow-scroll scrollbar-hidden p-3 rounded-lg bg-gray-50 dark:bg-gray-850 border border-gray-100 dark:border-gray-800">
+								<div class="prose prose-sm dark:prose-invert max-w-full prose-headings:text-base prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-headings:mt-3 prose-headings:mb-2 prose-p:my-2 prose-p:leading-relaxed prose-pre:text-xs prose-li:my-1">
+									<Markdown content={(item?.file?.data?.content ?? '').trim() || 'No content'} id="file-content-markdown" />
+								</div>
+							</div>
+						{:else}
+							<div class="max-h-96 overflow-scroll scrollbar-hidden text-xs whitespace-pre-wrap">
+								{(item?.file?.data?.content ?? '').trim() || 'No content'}
+							</div>
+						{/if}
 					{:else if item?.content}
-						<div class="max-h-96 overflow-scroll scrollbar-hidden text-xs whitespace-pre-wrap">
-							{(item?.content ?? '').trim() || 'No content'}
-						</div>
+						{#if $config?.features?.enable_markdown_rendering}
+							<div class="max-h-96 overflow-scroll scrollbar-hidden p-3 rounded-lg bg-gray-50 dark:bg-gray-850 border border-gray-100 dark:border-gray-800">
+								<div class="prose prose-sm dark:prose-invert max-w-full prose-headings:text-base prose-h1:text-lg prose-h2:text-base prose-h3:text-sm prose-headings:mt-3 prose-headings:mb-2 prose-p:my-2 prose-p:leading-relaxed prose-pre:text-xs prose-li:my-1">
+									<Markdown content={(item?.content ?? '').trim() || 'No content'} id="file-content-markdown-2" />
+								</div>
+							</div>
+						{:else}
+							<div class="max-h-96 overflow-scroll scrollbar-hidden text-xs whitespace-pre-wrap">
+								{(item?.content ?? '').trim() || 'No content'}
+							</div>
+						{/if}
 					{/if}
 				{:else if selectedTab === 'preview'}
 					{#if isAudio}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -274,6 +274,7 @@ type Config = {
 		enable_admin_chat_access: boolean;
 		enable_community_sharing: boolean;
 		enable_memories: boolean;
+		enable_markdown_rendering?: boolean;
 		enable_autocomplete_generation: boolean;
 		enable_direct_connections: boolean;
 		enable_version_update_check: boolean;


### PR DESCRIPTION
### Description:

  Adds admin toggle to enable markdown rendering in citations and file preview modals with enhanced styling.

  ## Features:
  - Toggle in Documents settings (under "Markdown Header Text Splitter")
  - Conditional markdown rendering in CitationModal and FileItemModal
  - Styled containers with controlled typography (smaller headings, better spacing)
  - Snippet count badge in citation modal header
  - Default: disabled (backward compatible)

  ## Technical:
  - Backend: ENABLE_MARKDOWN_RENDERING config in retrieval.py, main.py, config.py
  - Frontend: Updates to CitationModal.svelte, FileItemModal.svelte, stores/index.ts

### Screenshots or Videos

- FileItemModal
<img width="927" height="524" alt="image" src="https://github.com/user-attachments/assets/9adcba2e-cf1a-4be6-a025-cc9855fce114" />

- CitationsModal
<img width="947" height="458" alt="image" src="https://github.com/user-attachments/assets/2a362766-1577-4912-8c7a-f8b2cab778e2" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
