### PR TITLE
feat: Add DEFAULT_STREAM_RESPONSE environment variable

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1190,6 +1190,12 @@ RESPONSE_WATERMARK = PersistentConfig(
     os.environ.get("RESPONSE_WATERMARK", ""),
 )
 
+DEFAULT_STREAM_RESPONSE = PersistentConfig(
+    "DEFAULT_STREAM_RESPONSE",
+    "ui.default_stream_response",
+    os.environ.get("DEFAULT_STREAM_RESPONSE", "True").lower() == "true",
+)
+
 
 USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS = (
     os.environ.get("USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS", "False").lower()

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1800,6 +1800,7 @@
 			model?.info?.params?.stream_response ??
 			$settings?.params?.stream_response ??
 			params?.stream_response ??
+			$config?.default_stream_response ??
 			true;
 
 		let messages = [


### PR DESCRIPTION
## Description
Adds `DEFAULT_STREAM_RESPONSE` environment variable to control default streaming behavior at deployment level.

## Changelog

### Added
- `DEFAULT_STREAM_RESPONSE` environment variable (defaults to `true`)
- PersistentConfig in `backend/open_webui/config.py` 
- Config fallback in `src/lib/components/chat/Chat.svelte`

### Changed
- Streaming logic now checks `$config?.default_stream_response` before hardcoded default

## Usage
```bash
DEFAULT_STREAM_RESPONSE=false


Testing
 Defaults to true (backward compatible)
 User/model settings override the default
 Config properly loaded to frontend
Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.

Actually I see someone else made a very similar pr recently https://github.com/open-webui/open-webui/pull/18764