### PR TITLE
feat: Add Microsoft Entra ID OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,37 @@ FORWARDED_ALLOW_IPS='*'
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# =============================================================================
+# Microsoft Entra ID OAuth Configuration
+# =============================================================================
+# All 3 Microsoft variables are required for "Sign in with Microsoft" button
+# Get these from Azure Portal > App registrations > Your App
+
+# Application (client) ID from Azure app registration
+MICROSOFT_CLIENT_ID=''
+
+# Client secret value (create in Certificates & secrets)
+MICROSOFT_CLIENT_SECRET=''
+
+# Tenant ID options:
+#   - 'consumers' = Personal Microsoft accounts only (outlook.com, hotmail.com, gmail-linked)
+#   - 'organizations' = Work/school accounts only
+#   - 'common' = Both (may have issuer validation issues)
+#   - '<your-tenant-id>' = Specific organization only
+MICROSOFT_CLIENT_TENANT_ID='consumers'
+
+# Security key for JWT and OAuth token encryption (generate with: openssl rand -hex 32)
+WEBUI_SECRET_KEY=''
+
+# Base URL for OAuth redirect URIs
+WEBUI_URL='http://localhost:3000'
+
+# Allow new users to sign up via OAuth
+ENABLE_OAUTH_SIGNUP=true
+
+# OpenID Connect discovery URL for logout functionality
+OPENID_PROVIDER_URL='https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration'
+
+# Post-logout redirect URL (where to go after signing out of Microsoft)
+WEBUI_AUTH_SIGNOUT_REDIRECT_URL='http://localhost:3000/auth'

--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,4 @@ dist
 cypress/videos
 cypress/screenshots
 .vscode/settings.json
+.devswarm-temp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
 
 # Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,14 @@ services:
       - ${OPEN_WEBUI_PORT-3000}:8080
     environment:
       - 'OLLAMA_BASE_URL=http://ollama:11434'
-      - 'WEBUI_SECRET_KEY='
+      - 'WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}'
+      - 'MICROSOFT_CLIENT_ID=${MICROSOFT_CLIENT_ID}'
+      - 'MICROSOFT_CLIENT_SECRET=${MICROSOFT_CLIENT_SECRET}'
+      - 'MICROSOFT_CLIENT_TENANT_ID=${MICROSOFT_CLIENT_TENANT_ID}'
+      - 'WEBUI_URL=${WEBUI_URL:-http://localhost:3000}'
+      - 'ENABLE_OAUTH_SIGNUP=${ENABLE_OAUTH_SIGNUP:-true}'
+      - 'OPENID_PROVIDER_URL=${OPENID_PROVIDER_URL:-}'
+      - 'WEBUI_AUTH_SIGNOUT_REDIRECT_URL=${WEBUI_AUTH_SIGNOUT_REDIRECT_URL:-}'
     extra_hosts:
       - host.docker.internal:host-gateway
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds "Sign in with Microsoft" button to the login page
- Supports personal Microsoft accounts (outlook.com, hotmail.com, gmail-linked accounts)
- Includes logout redirect back to Open WebUI

## Changes
- **docker-compose.yaml**: Added Microsoft OAuth environment variables
- **.env.example**: Documented all OAuth configuration options
- **Dockerfile**: Enabled NODE_OPTIONS for build memory issues
- **.gitignore**: Added .devswarm-temp/

## Configuration Required
Create a `.env` file with:
```bash
MICROSOFT_CLIENT_ID=<from-azure-app-registration>
MICROSOFT_CLIENT_SECRET=<from-azure-secrets>
MICROSOFT_CLIENT_TENANT_ID=consumers
WEBUI_SECRET_KEY=<generate-with-openssl-rand-hex-32>
WEBUI_URL=https://ai-ui.coolestdomain.win
ENABLE_OAUTH_SIGNUP=true
OPENID_PROVIDER_URL=https://login.microsoftonline.com/consumers/v2.0/.well-known/openid-configuration
WEBUI_AUTH_SIGNOUT_REDIRECT_URL=https://ai-ui.coolestdomain.win/auth
```

## Azure App Registration Setup
1. Create app in Azure Portal > App registrations
2. Set "Supported account types" to include personal Microsoft accounts
3. Add redirect URIs:
   - `https://ai-ui.coolestdomain.win/oauth/microsoft/callback`
   - `https://ai-ui.coolestdomain.win/auth`
4. Create a client secret

## Test plan
- [x] Login with Microsoft works on localhost
- [x] Logout redirects back to login page
- [ ] Login works on production (ai-ui.coolestdomain.win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)