### PR TITLE
fix: correct authorization header format for Docling

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -143,7 +143,7 @@ class DoclingLoader:
         with open(self.file_path, "rb") as f:
             headers = {}
             if self.api_key:
-                headers["X-Api-Key"] = f"Bearer {self.api_key}"
+                headers["X-Api-Key"] = f"{self.api_key}"
 
             r = requests.post(
                 f"{self.url}/v1/convert/file",


### PR DESCRIPTION
# Changelog Entry

### Description

- Docling expects API keys for authorization in the header under `X-Api-Key` WITHOUT the `Bearer` prefix. These changes allow #16841 to work properly.
See https://github.com/docling-project/docling-serve/blob/main/docs/configuration.md

### Fixed

- Removes the lingering `Bearer` prefix for the previously incorrect `Authorization` header type

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
