### PR TITLE
fix: await uploadFileHandler and preserve error message

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -332,8 +332,9 @@ def upload_file_handler(
                     detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
                 )
 
-    except HTTPException:
+    except HTTPException as he:
         # Re-raise HTTPException to preserve original message
+        log.exception(he)
         raise
     except Exception as e:
         log.exception(e)

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -332,6 +332,9 @@ def upload_file_handler(
                     detail=ERROR_MESSAGES.DEFAULT("Error uploading file"),
                 )
 
+    except HTTPException:
+        # Re-raise HTTPException to preserve original message
+        raise
     except Exception as e:
         log.exception(e)
         raise HTTPException(

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -743,13 +743,13 @@
 						const blob = await (await fetch(imageUrl)).blob();
 						const compressedFile = new File([blob], file.name, { type: file.type });
 
-						uploadFileHandler(compressedFile, false);
+						await uploadFileHandler(compressedFile, false);
 					}
 				};
 
 				reader.readAsDataURL(file['type'] === 'image/heic' ? await convertHeicToJpeg(file) : file);
 			} else {
-				uploadFileHandler(file);
+				await uploadFileHandler(file);
 			}
 		});
 	};


### PR DESCRIPTION
# Changelog Entry

### Description

When uploading files not allowed by the `RAG_ALLOWED_FILE_EXTENSIONS` variable, there should be a red error message in the top-right corner of the screen explaining why the upload has failed. Instead OpenWebUI fails silently, displaying only a generic violation of the CSP in the JS console.

I found that the error message should already be printed, but `uploadFileHandler` is not awaited, so the message doesn't actually shows. Moreover, the default error message is too generic and the user will only see `Error uploading file`, so I added an `except` block to propagate a more specific error.

### Fixed

- `uploadFileHandler` is now awaited
- Show a better error message when upload fails due to CSP


---

### Additional Information

Issue I opened: https://github.com/open-webui/open-webui/issues/20662

### TEST: Screenshots or Videos

I performed a manual test:

Built the image with the changes:

```bash
docker build -t oui:await-fix .
```

Ran a container

```bash
docker run -d \
  -p 3000:8080 \
  -e RAG_ALLOWED_FILE_EXTENSIONS="pdf,txt,docx" \
  -v open-webui:/app/backend/data \
  --name open-webui-test \
  oui:await-fix
```

Clicked the plus icon, then the attach icon, selected a zip file and this is what shows:

<img width="377" height="62" alt="Screenshot 2026-01-14 at 13 42 40" src="https://github.com/user-attachments/assets/ba1adcab-2c37-47be-bc97-e135c1191d5c" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
