### PR TITLE
fix: hide Chat Controls button/sidebar when all granular permissions are disabled

### DIFF
--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -30,7 +30,7 @@
 		</button>
 	</div>
 
-	{#if $user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)}
+	{#if $user?.role === 'admin' || (($user?.permissions.chat?.controls ?? true) && (($user?.permissions.chat?.valves ?? true) || ($user?.permissions.chat?.system_prompt ?? true) || ($user?.permissions.chat?.params ?? true)))}
 		<div class=" dark:text-gray-200 text-sm font-primary py-0.5 px-0.5">
 			{#if chatFiles.length > 0}
 				<Collapsible title={$i18n.t('Files')} open={true} buttonClassName="w-full">

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -210,7 +210,7 @@
 						</Menu>
 					{/if}
 
-					{#if $user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)}
+					{#if $user?.role === 'admin' || (($user?.permissions.chat?.controls ?? true) && (($user?.permissions.chat?.valves ?? true) || ($user?.permissions.chat?.system_prompt ?? true) || ($user?.permissions.chat?.params ?? true)))}
 						<Tooltip content={$i18n.t('Controls')}>
 							<button
 								class=" flex cursor-pointer px-2 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -313,7 +313,7 @@
 				<div class="flex items-center">{$i18n.t('Settings')}</div>
 			</DropdownMenu.Item> -->
 
-			{#if $mobile && ($user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true))}
+			{#if $mobile && ($user?.role === 'admin' || (($user?.permissions.chat?.controls ?? true) && (($user?.permissions.chat?.valves ?? true) || ($user?.permissions.chat?.system_prompt ?? true) || ($user?.permissions.chat?.params ?? true))))}
 				<DropdownMenu.Item
 					class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full"
 					id="chat-controls-button"


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Hide the `Chat Controls` button and the `Chat Controls` sidebar entirely when all three granular permissions (`Allow Chat Valves`, `Allow Chat System Prompt`, and `Allow Chat Params`) are disabled. Previously, the button/sidebar remained visible but empty, providing no value to users.

### Changed

- Updated `Chat Controls` visibility logic in `Navbar.svelte`, `Menu.svelte`, and `Controls.svelte` to check that at least one granular permission is enabled before showing the `Chat Controls` button/sidebar.

### Fixed

- `Chat Controls` button and sidebar are now hidden when no granular permissions are enabled (replicates behavior of `Allow Chat Controls` permission toggle when `OFF`).

---

### Additional Information

- **Files modified:**
  - `src/lib/components/chat/Navbar.svelte` - Updated `Chat Controls` button visibility condition
  - `src/lib/components/layout/Navbar/Menu.svelte` - Updated mobile menu `Chat Controls` visibility condition
  - `src/lib/components/chat/Controls/Controls.svelte` - Updated sidebar content wrapper visibility condition
- **Logic change:** The visibility condition now checks `(chat.controls && (valves || system_prompt || params))` instead of just `chat.controls`, ensuring the button/sidebar is only shown when there's actually content to display.

### Solves

<img width="462" height="1286" alt="image" src="https://github.com/user-attachments/assets/71b48bca-327d-4305-8c76-79c64c87ea0a" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
