### PR TITLE
fix: coerce LLM tool call parameters to correct types in knowledge query

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1599,6 +1599,25 @@ async def query_knowledge_files(
     if not __user__:
         return json.dumps({"error": "User context not available"})
 
+    # Coerce parameters from LLM tool calls (may come as strings)
+    if isinstance(count, str):
+        try:
+            count = int(count)
+        except ValueError:
+            count = 5  # Default fallback
+
+    # Handle knowledge_ids being string "None", "null", or empty
+    if isinstance(knowledge_ids, str):
+        if knowledge_ids.lower() in ("none", "null", ""):
+            knowledge_ids = None
+        else:
+            # Try to parse as JSON array if it looks like one
+            try:
+                knowledge_ids = json.loads(knowledge_ids)
+            except json.JSONDecodeError:
+                # Treat as single ID
+                knowledge_ids = [knowledge_ids]
+
     try:
         from open_webui.models.knowledge import Knowledges
         from open_webui.models.files import Files


### PR DESCRIPTION
## fix: coerce LLM tool call parameters to correct types in knowledge query

### Description

Fixes an issue where knowledge base queries would intermittently fail with "slice indices must be integers" errors.

**Root Cause:** When the LLM makes tool calls to query_knowledge_files, it sometimes formats parameters as strings instead of their proper types:
- count as "5" instead of 5
- knowledge_ids as "None" instead of null

This caused the slice operation in merge_and_sort_query_results to fail since you cannot slice a list with a string index.

**Fix:** Added type coercion at the start of query_knowledge_files to:
- Convert count from string to int (with fallback to default)
- Handle knowledge_ids being the literal strings "None", "null", or empty by converting to actual None
- Parse knowledge_ids as JSON array if passed as a string representation

Closes #20704

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
