### PR TITLE
fix(telemetry): respect OTel env headers and instrument LLM token usage

### DIFF
--- a/backend/open_webui/utils/telemetry/metrics.py
+++ b/backend/open_webui/utils/telemetry/metrics.py
@@ -65,7 +65,7 @@ def _build_meter_provider(resource: Resource) -> MeterProvider:
         readers: List[PeriodicExportingMetricReader] = [
             PeriodicExportingMetricReader(
                 OTLPHttpMetricExporter(
-                    endpoint=OTEL_METRICS_EXPORTER_OTLP_ENDPOINT, headers=headers
+                    endpoint=OTEL_METRICS_EXPORTER_OTLP_ENDPOINT, headers=(headers or None)
                 ),
                 export_interval_millis=_EXPORT_INTERVAL_MILLIS,
             )
@@ -76,7 +76,7 @@ def _build_meter_provider(resource: Resource) -> MeterProvider:
                 OTLPMetricExporter(
                     endpoint=OTEL_METRICS_EXPORTER_OTLP_ENDPOINT,
                     insecure=OTEL_METRICS_EXPORTER_OTLP_INSECURE,
-                    headers=headers,
+                    headers=(headers or None),
                 ),
                 export_interval_millis=_EXPORT_INTERVAL_MILLIS,
             )

--- a/backend/open_webui/utils/telemetry/setup.py
+++ b/backend/open_webui/utils/telemetry/setup.py
@@ -42,13 +42,13 @@ def setup(app: FastAPI, db_engine: Engine):
         if OTEL_OTLP_SPAN_EXPORTER == "http":
             exporter = HttpOTLPSpanExporter(
                 endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
-                headers=headers,
+                headers=(headers or None),
             )
         else:
             exporter = OTLPSpanExporter(
                 endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
                 insecure=OTEL_EXPORTER_OTLP_INSECURE,
-                headers=headers,
+                headers=(headers or None),
             )
         trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(exporter))
         Instrumentor(app=app, db_engine=db_engine).instrument()


### PR DESCRIPTION
## Problem
1. **OTel Headers Ignored**: In [setup.py](cci:7://file:///opt/stacks/openwebui/data/patches/setup.py:0:0-0:0) and [metrics.py](cci:7://file:///opt/stacks/openwebui/data/patches/metrics.py:0:0-0:0), the `headers` argument was explicitly initialized as `[]` (if no internal basic auth was set). This value is passed to the OTel exporter, causing it to ignore the standard `OTEL_EXPORTER_OTLP_HEADERS` environment variable. This broke integration with OTel providers that rely on header-based authentication (e.g., Braintrust, Honeycomb).
2. **Missing Token Usage**: When using Open WebUI as a proxy, token usage data returned by upstream providers (like LiteLLM) in HTTP headers (e.g., `x-openai-usage`) was not being captured in the OTel traces.

## Solution
1. **Allow Env Var Fallback**: Changed the exporter initialization to pass `headers=(headers or None)`. Passing `None` allows the OpenTelemetry SDK to correctly fall back to reading headers from the environment.
2. **Capture Usage Headers**: Updated [instrumentors.py](cci:7://file:///opt/stacks/openwebui/data/patches/instrumentors.py:0:0-0:0) to inspect response headers in `aiohttp` and `httpx` hooks. Start capturing headers matching "usage", "token", or "x-request-id" and add them as span attributes (prefixed with `llm.header.`).