### PR TITLE
fix: reset pagination when filtering users in admin panel

### DIFF
--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -97,6 +97,15 @@
 		}
 	};
 
+	// Track previous query to detect actual changes and reset pagination
+	let previousQuery = query;
+	$: {
+		if (query !== previousQuery) {
+			previousQuery = query;
+			page = 1;
+		}
+	}
+
 	$: if (query !== null && page !== null && orderBy !== null && direction !== null) {
 		getUserList();
 	}


### PR DESCRIPTION

# Changelog Entry

### Description

Fixed a bug where filtering users by name while on any page other than the first would show an empty list despite displaying the correct total count.
When a user navigated to page 2+ of the user list and then used the search filter, the page number wasn't reset to 1. This caused the API to return the correct total count but attempt to display results for page 2 of the filtered set, which was often empty.

### Fixed

- Added a few lines that track query changes and automatically reset the page number to 1 whenever the search query is modified.

---

### TEST: Screenshots or Videos

I performed a manual test:

1. Built the image with the changes:

```bash
docker build -t oui:user-list-fix .
```

2. Ran a container

```bash
docker run -d \
  -p 3000:8080 \
  -v open-webui:/app/backend/data \
  --name open-webui-test \
  oui:user-list-fix
```

Log in with this credentials:
email: `admin@admin.com`
name: `admin`
password: `admin`

3. Ran a script to create a bunch of users

You can use this: [oui_create_users_in_bulk.go](https://gist.github.com/lorenzophys/bad1240c605567eeff813bbd0c235bb2)
```bash
go run ./oui_create_users_in_bulk.go
```

5. Open the Admin panel and navigate to a page other than the first
6. Try to filter users by name

#### BEFORE (note the `Users 1` on the top left corner)

<img width="1256" height="614" alt="Screenshot 2026-01-16 at 12 32 13" src="https://github.com/user-attachments/assets/b15ff435-9830-4aa8-bfd4-81797d0b25db" />

#### AFTER (note that now the user actually shows)

<img width="1253" height="154" alt="Screenshot 2026-01-16 at 12 32 42" src="https://github.com/user-attachments/assets/02c42abe-848e-4fae-9b58-5467f58fa20d" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.