### PR TITLE
fix: respect built-in tool toggles in native function calling mode

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -434,27 +434,34 @@ def get_builtin_tools(
     if features.get("memory"):
         builtin_functions.extend([search_memories, add_memory, replace_memory_content])
 
-    # Add web search tools if enabled globally AND model has web_search capability
-    if getattr(
-        request.app.state.config, "ENABLE_WEB_SEARCH", False
-    ) and get_model_capability("web_search"):
+    # Add web search tools if enabled globally AND model has web_search capability AND toggle is ON
+    if (
+        getattr(request.app.state.config, "ENABLE_WEB_SEARCH", False)
+        and get_model_capability("web_search")
+        and features.get("web_search")
+    ):
         builtin_functions.extend([search_web, fetch_url])
 
-    # Add image generation/edit tools if enabled globally AND model has image_generation capability
-    if getattr(
-        request.app.state.config, "ENABLE_IMAGE_GENERATION", False
-    ) and get_model_capability("image_generation"):
+    # Add image generation/edit tools if enabled globally AND model has image_generation capability AND toggle is ON
+    if (
+        getattr(request.app.state.config, "ENABLE_IMAGE_GENERATION", False)
+        and get_model_capability("image_generation")
+        and features.get("image_generation")
+    ):
         builtin_functions.append(generate_image)
-    if getattr(
-        request.app.state.config, "ENABLE_IMAGE_EDIT", False
-    ) and get_model_capability("image_generation"):
+    if (
+        getattr(request.app.state.config, "ENABLE_IMAGE_EDIT", False)
+        and get_model_capability("image_generation")
+        and features.get("image_generation")
+    ):
         builtin_functions.append(edit_image)
 
-    # Add code interpreter tool if enabled globally AND model has code_interpreter capability
+    # Add code interpreter tool if enabled globally AND model has code_interpreter capability AND toggle is ON
     # Supports both pyodide (via frontend event call) and jupyter engines
     if (
         getattr(request.app.state.config, "ENABLE_CODE_INTERPRETER", True)
         and get_model_capability("code_interpreter")
+        and features.get("code_interpreter")
     ):
         builtin_functions.append(execute_code)
 


### PR DESCRIPTION
# fix: built-in tool toggles ignored in native function calling mode

Fixes: https://github.com/open-webui/open-webui/issues/20641

## Problem

When using Native function calling mode with Built-in Tools capability enabled on a model, the chat interface toggles (web search ON/OFF, image generation ON/OFF, code interpreter ON/OFF) were completely ignored. All built-in tools were injected into the model's tool list regardless of the toggle state.

### Impact
**User Control Broken:**
- Users explicitly turning OFF web search still had web search tools available to the model
- Users could not prevent the model from performing unwanted actions (web searches, image generation, code execution)
- The toggle UI in the chat interface was effectively non-functional in Native mode

**Admin Control Broken:**
- Admins using inlet() filters to programmatically disable tools (e.g., disabling web search when documents are attached) had no effect
- Security and compliance policies could not be enforced via tool control in Native mode

**Inconsistent Behavior:**
- Default mode correctly respected toggles (toggles control whether task model is prompted about each tool)
- Native mode ignored toggles entirely
- This created confusion where the same UI behaved differently depending on function calling mode

### Reproduction Steps
1. Configure a model with Native function calling enabled and Built-in Tools capability ON
2. Start a new chat
3. Turn OFF the web search toggle in the chat interface
4. Send a message like "Search the web for the latest AI news"
5. Observe that the model still has search_web in its tool list and can perform searches

## Root Cause
In the get_builtin_tools function, the pattern for checking whether to inject a tool was inconsistent:

**Memory tools (correct pattern):**
- Checked features.get("memory") — the toggle state from the chat interface
- Tools only injected when toggle is ON

**Web search, image generation, code interpreter (broken pattern):**  
- Only checked global config (e.g., ENABLE_WEB_SEARCH) and model capability
- Did NOT check the toggle state from features dict
- Tools injected whenever global config and model capability allowed, regardless of toggle
The features dict is populated from form_data after inlet() filters run, so this also meant inlet() filter modifications to toggle state had no effect on Native mode tool injection.

## Solution
Added the missing feature toggle checks to align with the memory tools pattern:
**Web search tools:**
- Added: `and features.get("web_search")`
**Image generation/edit tools:**
- Added: `and features.get("image_generation")`
**Code interpreter tool:**
- Added: `and features.get("code_interpreter")`
Now all built-in tools follow the same three-layer control model:
1. Global config must enable the feature (admin-level master switch)
2. Model capability must allow it (per-model configuration)
3. Per-chat toggle must be ON (user control / inlet() filter control)

## Behavior After Fix
| Global Config | Model Capability | Chat Toggle | Tool Injected? |
|---------------|------------------|-------------|----------------|
| OFF | Any | Any | No |
| ON | OFF | Any | No |
| ON | ON | OFF | No |
| ON | ON | ON | Yes |

## Backward Compatibility
- Default mode behavior is completely unchanged (this code path is only for Native function calling)
- No changes to API contracts or data structures
- Existing configurations will work — users who had toggles ON will continue to have tools available

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
