### PR TITLE
fix: Use keyword argument for IndicesClient.refresh() opensearch-py >= 3.0.0

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
### Description
- Fixes #20649 - TypeError when using OpenSearch with opensearch-py >= 3.0.0

### Added
- N/A

### Changed
- Changed `IndicesClient.refresh()` calls to use keyword argument `index=` instead of positional argument

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- **OpenSearch integration**: Fixed TypeError when uploading documents to knowledge base with OpenSearch backend
- In opensearch-py >= 3.0.0, `IndicesClient.refresh()` method signature changed to only accept keyword-only arguments
- Changed: `self.client.indices.refresh(self._get_index_name(collection_name))`
- To: `self.client.indices.refresh(index=self._get_index_name(collection_name))`

### Security
- N/A

### Breaking Changes
- N/A

---

### Additional Information
- Issue: #20649
- Related to opensearch-py library version >= 3.0.0 breaking change
- Fixes file upload to knowledge base when using OpenSearch as vector database backend

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.