### PR TITLE
fix: Decode HTML entities in tool call results before sending to LLM

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -872,7 +872,8 @@ export const processDetails = (content) => {
 			}
 
 			if (attributes.result) {
-				content = content.replace(match, `"${attributes.result}"`);
+				const unescapedResult = unescapeHtml(attributes.result);
+				content = content.replace(match, `"${unescapedResult}"`);
 			}
 		}
 	}


### PR DESCRIPTION
### Description
- Fixes #20600 - HTML entities in tool call results not decoded before sending to LLM

### Added
- N/A

### Changed
- Applied `unescapeHtml()` function to decode HTML entities in tool call results before inserting into messages

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- **Tool call results**: Fixed HTML entities like `&quot;`, `&amp;`, `&#x27;` not being decoded before sending to LLM
- Previously, tool results were stored with HTML-escaped content and retrieved from DB with entities still present
- Now `processDetails()` properly decodes HTML entities before inserting tool call results into messages
- This ensures the LLM receives clean JSON instead of malformed escaped entities

### Security
- N/A

### Breaking Changes
- N/A

---

### Additional Information
- Issue: #20600
- Affects multi-turn conversations with tool calls
- Improves LLM performance by providing clean, properly formatted JSON

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.