### PR TITLE
fix: handle None value for capabilities in get_model_capability helper

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -400,7 +400,7 @@ def get_builtin_tools(
         return (
             model.get("info", {})
             .get("meta", {})
-            .get("capabilities", {})
+            .get("capabilities") or {}
             .get(name, default)
         )
 


### PR DESCRIPTION
### Description
- Fixes #20565 - AttributeError when model capabilities are None

### Added
- N/A

### Changed
- Added `or {}` to handle None value for capabilities in `get_model_capability()` helper function

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- **Model capabilities check**: Fixed AttributeError when model metadata capabilities field is None
- Previously, when a model's `meta.capabilities` was `None`, calling `.get()` on it would crash
- Now the code properly converts None to empty dict before accessing capabilities
- Affects models imported from external OpenAI-compatible connections with incomplete metadata

### Security
- N/A

### Breaking Changes
- N/A

---

### Additional Information
- Issue: #20565
- Applies the same fix pattern used in `middleware.py` to the `get_model_capability()` helper in `tools.py`
- Example affected models: XiaomiMiMo/MiMo-V2-Flash and others with `capabilities: None` in metadata
- Workaround of re-saving models in Admin Panel is no longer needed

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.