### PR TITLE
fix: Handle None value for model metadata capabilities field (#20565)

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -9,7 +9,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, Users, UserResponse
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from sqlalchemy import String, cast, or_, and_, func
 from sqlalchemy.dialects import postgresql, sqlite
@@ -45,6 +45,11 @@ class ModelMeta(BaseModel):
     """
 
     capabilities: Optional[dict] = None
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def capabilities_none_to_empty(cls, value):
+        return value if value is not None else {}
 
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
Tested locally, works

Fixes https://github.com/open-webui/open-webui/issues/20565

### Solution
Added a Pydantic field_validator to the ModelMeta class that normalizes None to an empty dict during deserialization. This fixes the issue at the data source, so all existing and future code paths automatically receive a valid dict instead of None.
<ins>**The fix is applied at read-time, so existing models with null capabilities in the database are automatically corrected when loaded - no database migration required.**</ins>

### Changes
- Added field_validator import from pydantic
- Added capabilities_none_to_empty validator to ModelMeta class

### Testing
Verified that ModelMeta(capabilities=None).capabilities returns {} and subsequent .get() calls work correctly.

Prevents 

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
