### PR TITLE
fix: decode HTML entities in tool call results for multi-turn conversations

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -357,9 +357,9 @@ export const generateInitialsImage = (name) => {
 	const initials =
 		sanitizedName.length > 0
 			? sanitizedName[0] +
-				(sanitizedName.split(' ').length > 1
-					? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
-					: '')
+			(sanitizedName.split(' ').length > 1
+				? sanitizedName[sanitizedName.lastIndexOf(' ') + 1]
+				: '')
 			: '';
 
 	ctx.fillText(initials.toUpperCase(), canvas.width / 2, canvas.height / 2);
@@ -515,10 +515,10 @@ export const compareVersion = (latest, current) => {
 	return current === '0.0.0'
 		? false
 		: current.localeCompare(latest, undefined, {
-				numeric: true,
-				sensitivity: 'case',
-				caseFirst: 'upper'
-			}) < 0;
+			numeric: true,
+			sensitivity: 'case',
+			caseFirst: 'upper'
+		}) < 0;
 };
 
 export const extractCurlyBraceWords = (text) => {
@@ -872,7 +872,7 @@ export const processDetails = (content) => {
 			}
 
 			if (attributes.result) {
-				content = content.replace(match, `"${attributes.result}"`);
+				content = content.replace(match, unescapeHtml(attributes.result));
 			}
 		}
 	}


### PR DESCRIPTION
### Problem

In multi-turn conversations involving tool calls, messages retrieved from the database contain HTML-escaped JSON (e.g., `&quot;`, `&amp;`, `&#x27;`). The processDetails function in the frontend inserted this HTML-escaped content directly into messages, causing the LLM to receive malformed, hard-to-parse content.
This degraded model performance in tool-heavy chats, as subsequent turns would contain escaped entities.

### Solution
Use the existing unescapeHtml utility function to decode HTML entities in tool call results before inserting them into the message content.

### Changes
- src/lib/utils/index.ts: Modified the processDetails function to call unescapeHtml on attributes.result before replacement

### Testing
1. Started a new chat and sent a message triggering a tool call (e.g., web search)
2. Sent a follow-up message
3. Inspected the request payload in browser DevTools
4. Verified the assistant's previous message now contains clean JSON without HTML entities

Fixes #20600

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
