### PR TITLE
feat: Display keyboard shortcut in collapsed sidebar tooltips for New Chat and Search

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -64,8 +64,31 @@
 	import Note from '../icons/Note.svelte';
 	import { slide } from 'svelte/transition';
 	import HotkeyHint from '../common/HotkeyHint.svelte';
+	import { shortcuts } from '$lib/shortcuts';
+	import { browser } from '$app/environment';
 
 	const BREAKPOINT = 768;
+
+	let mounted = false;
+
+	onMount(() => {
+		mounted = true;
+	});
+
+	$: newChatShortcut = mounted ? ` • ${formatShortcutKeys(shortcuts.newChat?.keys ?? [])}` : '';
+	$: searchShortcut = mounted ? ` • ${formatShortcutKeys(shortcuts.search?.keys ?? [])}` : '';
+
+	function formatShortcutKeys(keys: string[]): string {
+		const isMac = browser && /Mac/i.test(navigator.userAgent);
+		return keys
+			.map((key) => {
+				const lowerKey = key.toLowerCase();
+				if (lowerKey === 'mod') return isMac ? '⌘' : 'Ctrl';
+				if (lowerKey === 'shift') return isMac ? '⇧' : 'Shift';
+				return key;
+			})
+			.join(isMac ? '' : '+');
+	}
 
 	let scrollTop = 0;
 
@@ -683,7 +706,7 @@
 
 			<div class="-mt-[0.5px]">
 				<div class="">
-					<Tooltip content={$i18n.t('New Chat')} placement="right">
+					<Tooltip content={`${$i18n.t('New Chat')}${newChatShortcut}`} placement="right">
 						<a
 							class=" cursor-pointer flex rounded-xl hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
 							href="/"
@@ -705,7 +728,7 @@
 				</div>
 
 				<div>
-					<Tooltip content={$i18n.t('Search')} placement="right">
+					<Tooltip content={`${$i18n.t('Search')}${searchShortcut}`} placement="right">
 						<button
 							class=" cursor-pointer flex rounded-xl hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
 							on:click={(e) => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Added keyboard shortcut hints to tooltips for `New Chat` and `Search` buttons when the sidebar is collapsed. When users hover over these buttons, they now see the associated keyboard shortcut displayed with platform-appropriate symbols (e.g., "`New Chat • ⌘⇧O`" on Mac or "`New Chat • Ctrl+Shift+O`" on Windows/Linux).

### Added

- Keyboard shortcut display in collapsed sidebar tooltips for `New Chat` and `Search` buttons
- `formatShortcutKeys` helper function to format keyboard shortcuts with platform-appropriate symbols (⌘ for Cmd, ⇧ for Shift)
- Reactive tooltip content that updates after component mount for accurate platform detection

### Changed

- Updated Tooltip content for `New Chat` and `Search` sidebar buttons to include formatted keyboard shortcut

---

### Additional Information

- Related to existing keyboard shortcut functionality defined in `src/lib/shortcuts.ts`
- Uses the same keyboard shortcut formatting logic as the existing `HotkeyHint` component
- Platform-aware: displays Mac symbols (⌘, ⇧) on macOS and Windows/Linux labels (Ctrl, Shift) on other platforms
- The bullet separator (•) provides visual separation between the action name and shortcut
- Properly handles SSR by deferring platform detection to client-side mount

### Screenshots or Videos

### Before

Tooltip only shows "New Chat"
<img width="236" height="195" alt="image" src="https://github.com/user-attachments/assets/8e84cd4d-c641-4a8f-9a40-3c4afa2a9c2b" />

Tooltip only shows "Search"
<img width="236" height="195" alt="image" src="https://github.com/user-attachments/assets/f16cfecd-f42e-4d18-aaad-2930580759e6" />

### After

<img width="236" height="195" alt="image" src="https://github.com/user-attachments/assets/a0764528-c986-4934-910e-cf9f60007a41" />

<img width="240" height="208" alt="image" src="https://github.com/user-attachments/assets/b6eb5799-b2f6-4450-8193-b2b77fd92fa8" />

<img width="236" height="195" alt="image" src="https://github.com/user-attachments/assets/93ba8910-84f4-4d58-b4d6-b83b4cde1b53" />

<img width="240" height="208" alt="image" src="https://github.com/user-attachments/assets/4b8e7c71-3b80-4842-a513-1dad73403ab3" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.