### PR TITLE
feat: Add MATLAB syntax highlighting support for code blocks

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -544,8 +544,10 @@
 								result) &&
 								'border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;'}"><code
 								class="language-{lang} rounded-t-none whitespace-pre text-sm"
-								>{@html hljs.highlightAuto(code, hljs.getLanguage(lang)?.aliases).value ||
-									code}</code
+								>{@html (hljs.getLanguage(lang)
+										? hljs.highlight(code, { language: lang })
+										: hljs.highlightAuto(code)
+									).value || code}</code
 							></pre>
 					{/if}
 				{:else}

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -544,10 +544,8 @@
 								result) &&
 								'border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;'}"><code
 								class="language-{lang} rounded-t-none whitespace-pre text-sm"
-								>{@html (hljs.getLanguage(lang)
-										? hljs.highlight(code, { language: lang })
-										: hljs.highlightAuto(code)
-									).value || code}</code
+								>{@html hljs.highlightAuto(code, hljs.getLanguage(lang)?.aliases).value ||
+									code}</code
 							></pre>
 					{/if}
 				{:else}

--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -104,6 +104,12 @@
 		})
 	);
 
+	// Add 'matlab' alias to Octave language (MATLAB-compatible syntax)
+	const octaveLang = languages.find((l) => l.name === 'Octave');
+	if (octaveLang && !octaveLang.alias.includes('matlab')) {
+		octaveLang.alias.push('matlab');
+	}
+
 	const getLang = async () => {
 		const language = languages.find((l) => l.alias.includes(lang));
 		return await language?.load();


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Add MATLAB syntax highlighting support for code blocks by fixing issues in both CodeEditor and CodeBlock components.

### Changed

- `src/lib/components/common/CodeEditor.svelte`: Added 'matlab' alias to CodeMirror's Octave language (Octave uses MATLAB-compatible syntax)
- `src/lib/components/chat/Messages/CodeBlock.svelte`: Fixed highlight.js usage to use `highlight()` directly when language is recognized, falling back to `highlightAuto()` only for unknown languages

### Fixed

- MATLAB code blocks now display proper syntax highlighting in both editable (CodeEditor) and read-only (CodeBlock) modes

---

### Additional Information

- MATLAB was already supported by highlight.js (192 languages) but wasn't working due to two bugs:
1. CodeMirror's Octave language only registered 'octave' as an alias, not 'matlab'
2. CodeBlock.svelte incorrectly used `highlightAuto()` with undefined aliases instead of `highlight()`
- Uses existing Octave language package (MATLAB-compatible syntax) for CodeMirror integration
- **Related Issue**: Closes [#20719](https://github.com/open-webui/open-webui/issues/20719)

### Testing

- This PR has been tested manually locally and works as expected. MATLAB code blocks now display proper syntax highlighting in both editable and read-only modes.

### Before

<img width="2560" height="1275" alt="image" src="https://github.com/user-attachments/assets/60696959-7cf8-434c-b4ff-7160d9a8f073" />

### After

<img width="2560" height="1275" alt="image" src="https://github.com/user-attachments/assets/1ad0243f-979b-4e22-870f-11db03b39e6b" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.