### PR TITLE
fix: large base64 images streaming [Openrouter Issue]

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -704,6 +704,17 @@ else:
     except Exception:
         AIOHTTP_CLIENT_TIMEOUT = 300
 
+# Buffer size for reading streamed responses (bytes)
+# Default: 4MB to handle large base64-encoded images in streaming responses
+AIOHTTP_CLIENT_READ_BUFSIZE = os.environ.get("AIOHTTP_CLIENT_READ_BUFSIZE", "")
+if AIOHTTP_CLIENT_READ_BUFSIZE == "":
+    AIOHTTP_CLIENT_READ_BUFSIZE = 4 * 1024 * 1024  # 4MB default
+else:
+    try:
+        AIOHTTP_CLIENT_READ_BUFSIZE = int(AIOHTTP_CLIENT_READ_BUFSIZE)
+    except Exception:
+        AIOHTTP_CLIENT_READ_BUFSIZE = 4 * 1024 * 1024
+
 
 AIOHTTP_CLIENT_SESSION_SSL = (
     os.environ.get("AIOHTTP_CLIENT_SESSION_SSL", "True").lower() == "true"

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -65,6 +65,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+    AIOHTTP_CLIENT_READ_BUFSIZE,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
 from open_webui.constants import ERROR_MESSAGES
@@ -126,7 +127,9 @@ async def send_post_request(
     r = None
     try:
         session = aiohttp.ClientSession(
-            trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            read_bufsize=AIOHTTP_CLIENT_READ_BUFSIZE,  # Handle large streaming chunks
         )
 
         headers = {

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -32,6 +32,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+    AIOHTTP_CLIENT_READ_BUFSIZE,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
@@ -938,7 +939,9 @@ async def generate_chat_completion(
 
     try:
         session = aiohttp.ClientSession(
-            trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            read_bufsize=AIOHTTP_CLIENT_READ_BUFSIZE,  # Handle large streaming chunks
         )
 
         r = await session.request(
@@ -1024,7 +1027,10 @@ async def embeddings(request: Request, form_data: dict, user):
         request, url, key, api_config, user=user
     )
     try:
-        session = aiohttp.ClientSession(trust_env=True)
+        session = aiohttp.ClientSession(
+            trust_env=True,
+            read_bufsize=AIOHTTP_CLIENT_READ_BUFSIZE,  # Handle large streaming chunks
+        )
         r = await session.request(
             method="POST",
             url=f"{url}/embeddings",
@@ -1114,7 +1120,10 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
         else:
             request_url = f"{url}/{path}"
 
-        session = aiohttp.ClientSession(trust_env=True)
+        session = aiohttp.ClientSession(
+            trust_env=True,
+            read_bufsize=AIOHTTP_CLIENT_READ_BUFSIZE,  # Handle large streaming chunks
+        )
         r = await session.request(
             method=request.method,
             url=request_url,


### PR DESCRIPTION
When streaming is enabled with **OpenRouter** for image generation, aiohttp throws a ValueError: Chunk too big error. This happens because **aiohttp.ClientSession** has a default read_bufsize of 64KB, but base64-encoded images in SSE streaming responses can be several megabytes.

Solution:
- Add configurable **AIOHTTP_CLIENT_READ_BUFSIZE** environment variable
- Default to 4MB buffer to handle large base64-encoded images
- Apply to streaming endpoints in openai.py (3 places) and ollama.py (1 place)

This allows the streaming response reader to handle lines up to ~8MB (2x the buffer size), which accommodates large base64-encoded images from providers like OpenRouter.

Files changed:
- backend/open_webui/env.py: Add AIOHTTP_CLIENT_READ_BUFSIZE config
- backend/open_webui/routers/openai.py: Apply buffer to streaming sessions
- backend/open_webui/routers/ollama.py: Apply buffer to streaming session

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [ ] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [ ] **Description:** Provide a concise description of the changes made in this pull request down below.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed ValueError: Chunk too big error when streaming image generation responses from providers like **OpenRouter**. The aiohttp library has a default read buffer of 64KB, but base64-encoded images in SSE streaming responses can be several megabytes. This PR adds a configurable buffer size (default 4MB) to handle large streaming chunks.

### Added

- **AIOHTTP_CLIENT_READ_BUFSIZE** environment variable to configure the aiohttp client read buffer size (default: 4MB)

### Changed

- Updated **aiohttp.ClientSession** in streaming endpoints to use the configurable buffer size:
     openai.py: generate_chat_completion, embeddings, and proxy functions
     ollama.py: send_post_request function

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Fixed streaming failures when receiving large base64-encoded images from OpenAI-compatible providers (e.g., OpenRouter image generation). The increased buffer size (4MB default, supporting lines up to ~8MB) accommodates large image payloads in SSE responses.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
