### PR TITLE
fix: uploadFileHandler is not awaited and the error messages don't show

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -743,13 +743,13 @@
 						const blob = await (await fetch(imageUrl)).blob();
 						const compressedFile = new File([blob], file.name, { type: file.type });
 
-						uploadFileHandler(compressedFile, false);
+						await uploadFileHandler(compressedFile, false);
 					}
 				};
 
 				reader.readAsDataURL(file['type'] === 'image/heic' ? await convertHeicToJpeg(file) : file);
 			} else {
-				uploadFileHandler(file);
+				await uploadFileHandler(file);
 			}
 		});
 	};


### PR DESCRIPTION
# Changelog Entry

### Description

When uploading files not allowed by the `RAG_ALLOWED_FILE_EXTENSIONS` variable, there should be a red error message in the top-right corner of the screen explaining why the upload has failed. Instead OpenWebUI fails silently, displaying only a generic violation of the CSP in the JS console.

I found that the error message should already be printed, but uploadFileHandler is not awaited, so the message doesn't actually shows. 

### Fixed

- `uploadFileHandler` is now awaited


---

### Additional Information

- This is the first atomic part of this MR: https://github.com/open-webui/open-webui/pull/20664 Please refer to this for the tests and the screenshots

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.