### PR TITLE
fix: Block read-only users from accessing tool edit page

### DIFF
--- a/src/routes/(app)/workspace/tools/edit/+page.svelte
+++ b/src/routes/(app)/workspace/tools/edit/+page.svelte
@@ -13,6 +13,7 @@
 	const i18n = getContext('i18n');
 
 	let tool = null;
+	let isAllowed = false;
 
 	const saveHandler = async (data) => {
 		console.log(data);
@@ -63,11 +64,19 @@
 			});
 
 			console.log(tool);
+
+			if (tool && !tool.write_access) {
+				toast.error($i18n.t('You do not have permission to edit this tool'));
+				goto('/workspace/tools');
+				return;
+			}
+
+			isAllowed = true;
 		}
 	});
 </script>
 
-{#if tool}
+{#if isAllowed}
 	<ToolkitEditor
 		edit={true}
 		id={tool.id}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Prevent users with read-only access from accessing the tool edit page by directly navigating to its URL. The fix adds a permission check that redirects unauthorized users back to the tools list with an appropriate error message.

### Added
- Added `isAllowed` state variable to control when the editor component renders
- Added permission check to verify `write_access` before rendering the ToolkitEditor

### Changed

- Modified template condition from `{#if tool}` to `{#if isAllowed}` to prevent editor flash before redirect

### Fixed

- Users with only read permissions to a tool can no longer view the edit page

---

### Additional Information

- This fix leverages the existing `write_access` field already returned by the backend `/tools/id/{id}` endpoint.
- The user will see a loading spinner during the permission check, then either the editor (if allowed) or be redirected to the tools list (if unauthorized) with an error toast.
- Related backend endpoints already correctly block write operations from unauthorized users; this fix addresses the frontend UX gap.

### Screenshots or Videos

<img width="402" height="112" alt="image" src="https://github.com/user-attachments/assets/963b1873-58c3-415f-afab-36b33d2d461a" />

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
