### PR TITLE
fix: Hide dropdown options for tools/functions with empty Uservalves

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -96,6 +96,7 @@ async def get_tools(
                     .get("access_control", None),
                     "updated_at": int(time.time()),
                     "created_at": int(time.time()),
+                    "has_user_valves": False,
                 }
             )
         )
@@ -133,6 +134,7 @@ async def get_tools(
                         ),
                         "updated_at": int(time.time()),
                         "created_at": int(time.time()),
+                        "has_user_valves": False,
                         **(
                             {
                                 "authenticated": session_token is not None,

--- a/src/lib/components/chat/Controls/Valves.svelte
+++ b/src/lib/components/chat/Controls/Valves.svelte
@@ -172,7 +172,7 @@
 									>{$i18n.t('Select a tool')}</option
 								>
 
-								{#each $tools.filter((tool) => !tool?.id?.startsWith('server:')) as tool, toolIdx}
+								{#each $tools.filter((tool) => !tool?.id?.startsWith('server:') && tool.has_user_valves) as tool, toolIdx}
 									<option value={tool.id} class="bg-gray-100 dark:bg-gray-800">{tool.name}</option>
 								{/each}
 							{:else if tab === 'functions'}
@@ -180,7 +180,7 @@
 									>{$i18n.t('Select a function')}</option
 								>
 
-								{#each $functions as func, funcIdx}
+								{#each $functions.filter((func) => func.has_user_valves) as func, funcIdx}
 									<option value={func.id} class="bg-gray-100 dark:bg-gray-800">{func.name}</option>
 								{/each}
 							{/if}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- This fix hides the Chat Controls dropdown options for tools/functions that have empty `Valves` or `UserValves` classes (containing only `pass` or docstrings). This improves UX by not showing configuration options when there are no actual fields to configure.

### Added

- `_has_configurable_valves()` static method in `FunctionsTable` to detect if a function's Valves class has actual configurable fields
- `_has_configurable_user_valves()` static method in `FunctionsTable` to detect if a function's UserValves class has actual configurable fields
- `has_valves` field to `FunctionResponse` and `FunctionUserResponse` models
- `has_user_valves` field to `FunctionResponse` and `FunctionUserResponse` models
- `has_user_valves: False` for OpenAPI and MCP tool servers

### Changed

- `get_functions()` in `FunctionsTable` now returns `FunctionResponse` with `has_valves` and `has_user_valves` fields populated
- Chat Controls `Valves.svelte` dropdowns now filter to show only tools/functions with configurable UserValves

### Fixed

- Empty Valves classes (only `pass` or docstrings) no longer show gear icons or appear in dropdowns
- Handles edge cases: single-line docstrings, multi-line docstrings, methods after empty Valves class

---

### Additional Information

- Related to PR work done at https://github.com/open-webui/open-webui/pull/20810 and https://github.com/open-webui/open-webui/pull/20691
- The detection logic parses Python source to find class `Valves(BaseModel):` or class `UserValves(BaseModel):` and checks for actual field definitions (lines containing `:` that aren't def/class/decorator/method definitions)

### Before - Shows all tools and functions, regardless if it has configurable Uservalves or not

<img width="350" height="1280" alt="image" src="https://github.com/user-attachments/assets/57706782-3a30-445e-b99a-9d62962ddad6" />

<img width="350" height="1280" alt="image" src="https://github.com/user-attachments/assets/d56fffe1-3492-482c-8dc3-20e5bea92969" />

### After - Respects whether or not the tool or function has Uservalves and filters out tools and functions that doesn't have any configurable Uservalves

<img width="350" height="1280" alt="image" src="https://github.com/user-attachments/assets/3e13067e-5366-4382-86cb-9be6ad9daf9a" />

<img width="350" height="1280" alt="image" src="https://github.com/user-attachments/assets/039e3cec-4397-4d87-b537-1c323330a9f9" />


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.