### PR TITLE
fix: add TTS voice selector to match admin audio settings UI

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -2,11 +2,12 @@
 	import { toast } from 'svelte-sonner';
 
 	import { onMount, getContext, tick } from 'svelte';
-	import { models, tools, functions, user } from '$lib/stores';
+	import { models, tools, functions, user, config } from '$lib/stores';
 	import { WEBUI_BASE_URL } from '$lib/constants';
 
 	import { getTools } from '$lib/apis/tools';
 	import { getFunctions } from '$lib/apis/functions';
+	import { getVoices } from '$lib/apis/audio';
 
 	import AdvancedParams from '$lib/components/chat/Settings/Advanced/AdvancedParams.svelte';
 	import Tags from '$lib/components/common/Tags.svelte';
@@ -108,6 +109,8 @@
 	let actionIds = [];
 	let accessControl = {};
 	let tts = { voice: '' };
+	let ttsEngine = '';
+	let voices: SpeechSynthesisVoice[] | Array<{ id: string; name: string }> = [];
 
 	const submitHandler = async () => {
 		loading = true;
@@ -224,6 +227,25 @@
 	onMount(async () => {
 		await tools.set(await getTools(localStorage.token));
 		await functions.set(await getFunctions(localStorage.token));
+
+		ttsEngine = $config?.audio?.tts?.engine ?? '';
+
+		if (ttsEngine === '') {
+			const getVoicesLoop = setInterval(() => {
+				const browserVoices = speechSynthesis.getVoices();
+				if (browserVoices.length > 0) {
+					clearInterval(getVoicesLoop);
+					voices = browserVoices;
+				}
+			}, 100);
+		} else {
+			const voicesRes = await getVoices(localStorage.token).catch((e) => {
+				toast.error(`${e}`);
+			});
+			if (voicesRes?.voices) {
+				voices = voicesRes.voices;
+			}
+		}
 
 		// Scroll to top 'workspace-container' element
 		const workspaceContainer = document.getElementById('workspace-container');
@@ -781,17 +803,38 @@
 					{/if}
 
 					<div class="my-2">
-						<div class="flex w-full justify-between mb-1">
-							<div class="self-center text-xs font-medium text-gray-500">
-								{$i18n.t('TTS Voice')}
+						<div class="flex gap-2">
+							<div class="w-full md:w-1/2">
+								<div class="mb-1.5 text-xs font-medium text-gray-500">
+									{$i18n.t('TTS Voice')}
+								</div>
+								{#if ttsEngine === ''}
+									<select
+										class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										bind:value={tts.voice}
+									>
+										<option value="">{$i18n.t('Default')}</option>
+										{#each voices as voice}
+											<option value={voice.voiceURI} class="bg-gray-100 dark:bg-gray-700">
+												{voice.name}
+											</option>
+										{/each}
+									</select>
+								{:else}
+									<input
+										list="tts-voice-list"
+										class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										bind:value={tts.voice}
+										placeholder={$i18n.t('Select a voice')}
+									/>
+									<datalist id="tts-voice-list">
+										{#each voices as voice}
+											<option value={voice.id}>{voice.name}</option>
+										{/each}
+									</datalist>
+								{/if}
 							</div>
 						</div>
-						<input
-							class="w-full text-sm bg-transparent outline-hidden"
-							type="text"
-							bind:value={tts.voice}
-							placeholder={$i18n.t('e.g. alloy, echo, shimmer')}
-						/>
 					</div>
 
 					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />


### PR DESCRIPTION
### Description
In Admin Panel > Settings > Audio, there's a voice selector dropdown, but in Model Editor you have to type the voice ID manually. Added the same dropdown to Model Editor.

Uses the same logic as Admin Panel - shows browser voices for Web API, fetches from backend for other engines.

### Screenshots
**Admin Panel > Settings > Audio (reference):**
<img width="1687" height="404" alt="image" src="https://github.com/user-attachments/assets/f5bdafb7-60da-4f44-80a6-73c131b5b83e" />
<img width="1875" height="928" alt="image" src="https://github.com/user-attachments/assets/6ceb33aa-df50-482d-9ab2-28479a83e715" />

**Model Editor > TTS Voice:**
workspace -> models  
| Before | After |
|--------|-------|
<img width="871" height="749" alt="image" src="https://github.com/user-attachments/assets/7059a34b-88ef-4733-9b01-1426e1d6415e" />
| <img width="869" height="933" alt="image" src="https://github.com/user-attachments/assets/9ec6f619-67da-4789-bd77-2b79799df9d2" />


### Added
- TTS voice selector in Model Editor
### Fixed
- UX inconsistency between Admin Settings and Model Editor
---
### Contributor License Agreement
By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.