### PR TITLE
fix: Artifacts render when code in reasoning

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -52,6 +52,7 @@
 		createMessagesList,
 		getPromptVariables,
 		processDetails,
+		removeDetails,
 		removeAllDetails,
 		getCodeBlockContents,
 		isYoutubeUrl
@@ -845,7 +846,7 @@
 					html: htmlContent,
 					css: cssContent,
 					js: jsContent
-				} = getCodeBlockContents(message.content);
+				} = getCodeBlockContents(removeDetails(message.content, ['reasoning']));
 
 				if (htmlContent || cssContent || jsContent) {
 					const renderedContent = `


### PR DESCRIPTION
# Changelog Entry

### Description

- This resolves the issue where HTML, CSS, and JavaScript code generated during model inference may be incorrectly rendered as Artifacts.
- Fixes: #20801

### Fixed

- Fixed Artifacts render when code in reasoning

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
