### PR TITLE
feat: Add support for model parsing in OpenAI proxy handler

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1122,7 +1122,13 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
             headers["api-version"] = api_version
 
             if payload is None and body:
-                payload = json.loads(body)
+                try:
+                    payload = json.loads(body)
+                except json.JSONDecodeError:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Invalid JSON payload",
+                    )
             url, payload = convert_to_azure_payload(url, payload, api_version)
             body = json.dumps(payload).encode()
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1125,7 +1125,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
 
             headers["api-version"] = api_version
 
-            if payload is None:
+            if payload is None and body:
                 payload = json.loads(body)
             url, payload = convert_to_azure_payload(url, payload, api_version)
             body = json.dumps(payload).encode()

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1090,12 +1090,8 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
     if model:
         await get_all_models(request, user=user)
         model_entry = request.app.state.OPENAI_MODELS.get(model)
-        if not model_entry:
-            raise HTTPException(
-                status_code=404,
-                detail="Model not found",
-            )
-        idx = model_entry["urlIdx"]
+        if model_entry:
+            idx = model_entry["urlIdx"]
 
     url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
     key = request.app.state.config.OPENAI_API_KEYS[idx]

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1088,8 +1088,12 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
 
     idx = 0
     if model:
-        await get_all_models(request, user=user)
+        # First try to use an existing model mapping to avoid unnecessary
+        # calls to get_all_models on every proxy request.
         model_entry = request.app.state.OPENAI_MODELS.get(model)
+        if not model_entry:
+            await get_all_models(request, user=user)
+            model_entry = request.app.state.OPENAI_MODELS.get(model)
         if model_entry:
             idx = model_entry["urlIdx"]
 


### PR DESCRIPTION
### Description
- Ensure proxy forwards requests to the correct upstream by parsing JSON proxy payloads and honoring the `model` field when present.
- Use the resolved model routing in `OPENAI_MODELS` to pick the correct `OPENAI_API_BASE_URLS`/keys/configs instead of always using index `0`.
- If the model is not found, default to using index `0`.

### Motivation
- My backend is vLLM which supports /skills and /v1/responses endpoints. When using multiple models in OpenWebUI the proxy routes only use the OpenAI URL defined via ENV, if not present it defaults to whatever last model is on the list of OpenAI urls.
- The proxy routes do not allo using the models defined in OpenWebUI.
- This pull request will allow users to define models in OpenWebUI and proxy to their backends to use routes defined there, ex: skills, responses.

### Note
- The dev branch is failing ruff formatting, but from my checks the code in this file is correctly formatted.
- This PR was created with the help of codex and copilot.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.