### PR TITLE
perf: unblock async event loop in pipelines router

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -9,6 +9,7 @@ from fastapi import (
     status,
     APIRouter,
 )
+import asyncio
 import aiohttp
 import os
 import logging
@@ -226,14 +227,16 @@ async def upload_pipeline(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        with open(file_path, "rb") as f:
-            files = {"file": f}
-            r = requests.post(
-                f"{url}/pipelines/upload",
-                headers={"Authorization": f"Bearer {key}"},
-                files=files,
-            )
+        def _upload():
+            with open(file_path, "rb") as f:
+                files = {"file": f}
+                return requests.post(
+                    f"{url}/pipelines/upload",
+                    headers={"Authorization": f"Bearer {key}"},
+                    files=files,
+                )
 
+        r = await asyncio.to_thread(_upload)
         r.raise_for_status()
         data = r.json()
 
@@ -279,7 +282,8 @@ async def add_pipeline(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.post(
+        r = await asyncio.to_thread(
+            requests.post,
             f"{url}/pipelines/add",
             headers={"Authorization": f"Bearer {key}"},
             json={"url": form_data.url},
@@ -324,7 +328,8 @@ async def delete_pipeline(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.delete(
+        r = await asyncio.to_thread(
+            requests.delete,
             f"{url}/pipelines/delete",
             headers={"Authorization": f"Bearer {key}"},
             json={"id": form_data.id},
@@ -362,7 +367,9 @@ async def get_pipelines(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(f"{url}/pipelines", headers={"Authorization": f"Bearer {key}"})
+        r = await asyncio.to_thread(
+            requests.get, f"{url}/pipelines", headers={"Authorization": f"Bearer {key}"}
+        )
 
         r.raise_for_status()
         data = r.json()
@@ -399,8 +406,10 @@ async def get_pipeline_valves(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(
-            f"{url}/{pipeline_id}/valves", headers={"Authorization": f"Bearer {key}"}
+        r = await asyncio.to_thread(
+            requests.get,
+            f"{url}/{pipeline_id}/valves",
+            headers={"Authorization": f"Bearer {key}"},
         )
 
         r.raise_for_status()
@@ -438,7 +447,8 @@ async def get_pipeline_valves_spec(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.get(
+        r = await asyncio.to_thread(
+            requests.get,
             f"{url}/{pipeline_id}/valves/spec",
             headers={"Authorization": f"Bearer {key}"},
         )
@@ -479,7 +489,8 @@ async def update_pipeline_valves(
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
         key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
 
-        r = requests.post(
+        r = await asyncio.to_thread(
+            requests.post,
             f"{url}/{pipeline_id}/valves/update",
             headers={"Authorization": f"Bearer {key}"},
             json={**form_data},


### PR DESCRIPTION
## Summary

Wrap synchronous `requests` calls with `asyncio.to_thread()` in the pipelines router to prevent blocking the FastAPI event loop during external pipeline API calls.

## Problem

The pipelines router uses synchronous `requests` library calls inside `async def` endpoints. This blocks the entire Python event loop while waiting for external network I/O, preventing the server from handling other concurrent requests.

## Solution

Wrap all blocking `requests.get()`, `requests.post()`, and `requests.delete()` calls with `await asyncio.to_thread()` to offload them to a thread pool. This allows the server to process other requests while waiting for pipeline operations to complete.

### Changed

- Wrapped blocking `requests` calls with `asyncio.to_thread()` in 7 endpoints:
  - `upload_pipeline`
  - `add_pipeline`
  - `delete_pipeline`
  - `get_pipelines`
  - `get_pipeline_valves`
  - `get_pipeline_valves_spec`
  - `update_pipeline_valves`

### Fixed

- Event loop blocking during external pipeline API calls

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.