### PR TITLE
perf: parallelize image loading in image_edits endpoint

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -910,7 +910,8 @@ async def image_edits(
         if isinstance(form_data.image, str):
             form_data.image = await load_url_image(form_data.image)
         elif isinstance(form_data.image, list):
-            form_data.image = [await load_url_image(img) for img in form_data.image]
+            # Load all images in parallel for better performance
+            form_data.image = list(await asyncio.gather(*[load_url_image(img) for img in form_data.image]))
     except Exception as e:
         raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(e))
 


### PR DESCRIPTION
## Summary

Use `asyncio.gather()` to load multiple images concurrently in the `image_edits` endpoint instead of loading them sequentially.

## Problem

When editing multiple images, the current implementation loads them one by one:
```python
form_data.image = [await load_url_image(img) for img in form_data.image]
```

This means if you have 5 images that each take 1 second to load, the total time is 5 seconds.

## Solution

Use `asyncio.gather()` to load all images in parallel:
```python
form_data.image = list(await asyncio.gather(*[load_url_image(img) for img in form_data.image]))
```

With this change, all 5 images load concurrently, reducing total time to ~1 second.

### Changed

- Image loading in `image_edits` endpoint now uses `asyncio.gather()` for parallel execution

### Fixed

- Sequential image loading causing unnecessary latency in multi-image edit operations

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.