### PR TITLE
perf: add keys to Svelte {#each} blocks for efficient DOM diffing

### DIFF
--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -335,7 +335,7 @@
 		{#if (filteredItems ?? []).length !== 0}
 			<!-- Before they call, I will answer; while they are yet speaking, I will hear. -->
 			<div class="gap-2 grid my-2 px-3 lg:grid-cols-2">
-				{#each filteredItems as prompt}
+				{#each filteredItems as prompt (prompt.command)}
 					<a
 						class=" flex space-x-4 cursor-pointer text-left w-full px-3 py-2.5 dark:hover:bg-gray-850/50 hover:bg-gray-50 transition rounded-2xl"
 						href={`/workspace/prompts/edit?command=${encodeURIComponent(prompt.command)}`}

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -355,7 +355,7 @@
 
 		{#if (filteredItems ?? []).length !== 0}
 			<div class=" my-2 gap-2 grid px-3 lg:grid-cols-2">
-				{#each filteredItems as tool}
+				{#each filteredItems as tool (tool.id)}
 					<Tooltip content={tool?.meta?.description ?? tool?.id}>
 						<div
 							class=" flex space-x-4 text-left w-full px-3 py-2.5 transition rounded-2xl {tool.write_access

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -160,7 +160,7 @@
 
 					{#if accessGroups.length > 0}
 						<div class="flex flex-col gap-1.5 mb-2 px-0.5 mx-0.5">
-							{#each accessGroups as group}
+							{#each accessGroups as group (group.id)}
 								<div class="flex items-center gap-3 justify-between text-sm w-full transition">
 									<div class="flex items-center gap-1.5 w-full">
 										<div>
@@ -246,7 +246,7 @@
 										<option class=" text-gray-700" value="" disabled selected
 											>{$i18n.t('Select a group')}</option
 										>
-										{#each groups.filter((group) => !(accessControl?.read?.group_ids ?? []).includes(group.id)) as group}
+										{#each groups.filter((group) => !(accessControl?.read?.group_ids ?? []).includes(group.id)) as group (group.id)}
 											<option class=" text-gray-700" value={group.id}>{group.name}</option>
 										{/each}
 									</select>

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -97,7 +97,7 @@
 					{$i18n.t('groups')}
 				</div>
 				<div class="flex gap-1 flex-wrap">
-					{#each groupIds as id}
+					{#each groupIds as id (id)}
 						{#if selectedGroup[id]}
 							<button
 								type="button"
@@ -129,7 +129,7 @@
 					{$i18n.t('users')}
 				</div>
 				<div class="flex gap-1 flex-wrap">
-					{#each userIds as id}
+					{#each userIds as id (id)}
 						{#if selectedUsers[id]}
 							<button
 								type="button"

--- a/src/lib/components/workspace/common/TagSelector.svelte
+++ b/src/lib/components/workspace/common/TagSelector.svelte
@@ -58,7 +58,7 @@
 		align="start"
 	>
 		<slot>
-			{#each items as item}
+			{#each items as item (item.value)}
 				<Select.Item
 					class="flex  gap-2  items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl capitalize"
 					value={item.value}

--- a/src/lib/components/workspace/common/ViewSelector.svelte
+++ b/src/lib/components/workspace/common/ViewSelector.svelte
@@ -43,7 +43,7 @@
 		align="start"
 	>
 		<slot>
-			{#each items as item}
+			{#each items as item (item.value)}
 				<Select.Item
 					class="flex  gap-2  items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
 					value={item.value}


### PR DESCRIPTION
## Summary

Add unique keys to `{#each}` blocks in workspace components to enable Svelte's efficient keyed DOM patching instead of full re-renders.

## Problem

Multiple `{#each}` blocks in workspace components iterate over lists without a unique key. This forces Svelte to diff the entire DOM subtree on updates, which is inefficient especially for large lists.

## Solution

Add unique keys to `{#each}` blocks:
- `ViewSelector.svelte`: `{#each items as item (item.value)}`
- `TagSelector.svelte`: `{#each items as item (item.value)}`
- `MemberSelector.svelte`: `{#each groupIds as id (id)}` and `{#each userIds as id (id)}`
- `AccessControl.svelte`: `{#each accessGroups as group (group.id)}`
- `Tools.svelte`: `{#each filteredItems as tool (tool.id)}`
- `Prompts.svelte`: `{#each filteredItems as prompt (prompt.command)}`

## Test plan

- [x] Verified all components render correctly
- [x] Tested list filtering/sorting works as expected
- [x] Confirmed no visual regressions

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.