### PR TITLE
fix: clean up all event listeners in +layout.svelte onMount

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -629,12 +629,12 @@
 			return nav && (el === nav || nav.contains(el));
 		}
 
-		document.addEventListener('touchstart', (e) => {
+		const touchstartHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			touchstartY = e.touches[0].clientY;
-		});
+		};
 
-		document.addEventListener('touchmove', (e) => {
+		const touchmoveHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			const touchY = e.touches[0].clientY;
 			const touchDiff = touchY - touchstartY;
@@ -642,15 +642,19 @@
 				showRefresh = true;
 				e.preventDefault();
 			}
-		});
+		};
 
-		document.addEventListener('touchend', (e) => {
+		const touchendHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			if (showRefresh) {
 				showRefresh = false;
 				location.reload();
 			}
-		});
+		};
+
+		document.addEventListener('touchstart', touchstartHandler);
+		document.addEventListener('touchmove', touchmoveHandler, { passive: false });
+		document.addEventListener('touchend', touchendHandler);
 
 		if (typeof window !== 'undefined') {
 			if (window.applyTheme) {
@@ -842,11 +846,15 @@
 
 		return () => {
 			window.removeEventListener('resize', onResize);
+			window.removeEventListener('message', windowMessageEventHandler);
+			document.removeEventListener('touchstart', touchstartHandler);
+			document.removeEventListener('touchmove', touchmoveHandler);
+			document.removeEventListener('touchend', touchendHandler);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
 		};
 	});
 
 	onDestroy(() => {
-		window.removeEventListener('message', windowMessageEventHandler);
 		bc.close();
 	});
 </script>


### PR DESCRIPTION
## Summary

Fix memory leaks in `+layout.svelte` by properly cleaning up all event listeners added in `onMount`.

## Problem

The `onMount` hook adds event listeners for `message`, `touchstart`, `touchmove`, `touchend`, `visibilitychange`, and `resize`, but the cleanup function only removes the `resize` listener. The anonymous touch handlers cannot be removed because they have no reference. This causes memory leaks during navigation and hot-reloads.

## Solution

1. Extract anonymous touch event handlers into named functions (`touchstartHandler`, `touchmoveHandler`, `touchendHandler`)
2. Add `{ passive: false }` to `touchmove` listener to allow `preventDefault()`
3. Update the `onMount` cleanup function to remove **all** event listeners

### Fixed

- Memory leaks caused by unremoved event listeners during component unmount
- Touch event handlers now properly cleaned up on navigation

### Changed

- Refactored anonymous touch handlers into named functions for proper cleanup

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.