### PR TITLE
fix: remove invalid expunge call on Pydantic FileModel

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1766,13 +1766,12 @@ def process_file(
                 }
             else:
                 try:
-                    # Release the database connection relative to the 'file' object
-                    # to prevent holding the connection during the slow embedding step.
-                    db.expunge(file)
+                    # Commit any pending changes before the slow embedding step.
+                    # Note: file is already a Pydantic model (not ORM), so no expunge needed.
                     db.commit()
 
                     # External embedding API takes time (5-60s+).
-                    # No DB connection is held here.
+                    # Subsequent updates use fresh sessions via get_db().
                     result = save_docs_to_vector_db(
                         request,
                         docs=docs,


### PR DESCRIPTION
fix: remove invalid expunge call on Pydantic FileModel Files.get_file_by_id() returns a Pydantic FileModel, not an SQLAlchemy ORM object. Calling db.expunge() on a Pydantic model fails with UnmappedInstanceError since it lacks _sa_instance_state. The expunge was also unnecessary because subsequent DB updates already use fresh sessions via get_db() context manager.
Fixes #20925

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
