### PR TITLE
fix: set finish_reason to "tool_calls" when tool calls are present in API responses

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -368,7 +368,9 @@ def openai_chat_chunk_message_template(
     if tool_calls:
         template["choices"][0]["delta"]["tool_calls"] = tool_calls
 
-    if not content and not reasoning_content and not tool_calls:
+    if tool_calls:
+        template["choices"][0]["finish_reason"] = "tool_calls"
+    elif not content and not reasoning_content:
         template["choices"][0]["finish_reason"] = "stop"
 
     if usage:
@@ -393,7 +395,7 @@ def openai_chat_completion_message_template(
             **({"tool_calls": tool_calls} if tool_calls else {}),
         }
 
-    template["choices"][0]["finish_reason"] = "stop"
+    template["choices"][0]["finish_reason"] = "tool_calls" if tool_calls else "stop"
 
     if usage:
         template["usage"] = usage


### PR DESCRIPTION
fix: set finish_reason to "tool_calls" when tool calls are present in API responses

When Open WebUI converts Ollama responses to OpenAI format, finish_reason was always set to "stop" even when tool_calls were present. This caused external API clients (like OpenCode) to stop after receiving tool calls instead of continuing the conversation.

Per the OpenAI API specification, finish_reason should be "tool_calls" when the model returns tool calls, signaling to clients that they should execute the tools and continue. This fix updates both streaming and non-streaming response templates to set the correct finish_reason based on whether tool_calls are present.




### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
