### PR TITLE
fix: prevent empty embeds attribute from rendering as {} in tool calls UI

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2385,8 +2385,8 @@ async def process_chat_response(
                                         break
 
                                 if tool_result is not None:
-                                    tool_result_embeds = result.get("embeds", "")
-                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds))}">\n<summary>Tool Executed</summary>\n</details>\n'
+                                    tool_result_embeds = result.get("embeds", [])
+                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds)) if tool_result_embeds else ""}">\n<summary>Tool Executed</summary>\n</details>\n'
                                 else:
                                     tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="false" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}">\n<summary>Executing...</summary>\n</details>\n'
 


### PR DESCRIPTION
## Summary

Fixes #20991

When a tool call has no embeds, an empty `{}` is incorrectly rendered in the UI. This is caused by the default value for `embeds` being an empty string `""` instead of an empty list `[]`.

## Changes

- Changed default value for `tool_result_embeds` from `""` to `[]`
- Only include `embeds` attribute in HTML when non-empty

## Root Cause

The empty string default gets JSON-encoded to `'""'` and HTML-escaped to `'&quot;&quot;'`. The frontend's `parseJSONString()` then fails to parse this correctly, resulting in a JSON parse error and `{}` being rendered.

## Testing

- Before: Tool calls without embeds show `{}` and console error
- After: Tool calls without embeds render cleanly with no spurious content

## Checklist

- [x] Code follows project style guidelines
- [x] Minimal change to fix the issue
- [x] No breaking changes to existing functionality