### PR TITLE
fix: prevent empty embeds from rendering as {} in tool calls UI

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2385,8 +2385,8 @@ async def process_chat_response(
                                         break
 
                                 if tool_result is not None:
-                                    tool_result_embeds = result.get("embeds", "")
-                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds))}">\n<summary>Tool Executed</summary>\n</details>\n'
+                                    tool_result_embeds = result.get("embeds", [])
+                                    tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="true" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}" result="{html.escape(json.dumps(tool_result, ensure_ascii=False))}" files="{html.escape(json.dumps(tool_result_files)) if tool_result_files else ""}" embeds="{html.escape(json.dumps(tool_result_embeds)) if tool_result_embeds else ""}">\n<summary>Tool Executed</summary>\n</details>\n'
                                 else:
                                     tool_calls_display_content = f'{tool_calls_display_content}<details type="tool_calls" done="false" id="{tool_call_id}" name="{tool_name}" arguments="{html.escape(json.dumps(tool_arguments))}">\n<summary>Executing...</summary>\n</details>\n'
 


### PR DESCRIPTION
## Summary

Fixes #20991

When a tool call has no embeds, an empty `{}` is incorrectly rendered in the UI along with a JavaScript console error: `SyntaxError: JSON.parse: unexpected character at line 1 column 1`.

## Changes

- Changed default value for `tool_result_embeds` from `""` to `[]` (line 2388)
- Only include `embeds` attribute in HTML when non-empty, matching the pattern used for `files` (line 2389)

## Root Cause

The empty string default `""` gets JSON-encoded to `'""'` and HTML-escaped. The frontend's `parseJSONString()` then fails to parse this, causing the JSON parse error and `{}` being rendered as a fallback.

## Testing

- **Before:** Tool calls without embeds show `{}` in red box and `SyntaxError: JSON.parse: unexpected character at line 1 column 1` in console
- **After:** Tool calls without embeds render cleanly with no spurious content

### Test environment
- OpenWebUI with AWS Bedrock backend via LiteLLM
- Custom tools returning markdown (no embeds)

## Checklist

- [x] Code follows project style guidelines
- [x] Minimal change to fix the issue
- [x] No breaking changes to existing functionality
- [x] Personally tested all changes

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.