### PR TITLE
perf: resolve N+1 queries in models router (list and import)

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -246,19 +246,19 @@ async def import_models(
     try:
         data = form_data.models
         if isinstance(data, list):
-            # Collect valid model IDs and batch-fetch existing models
-            valid_model_ids = [
-                import_item.get("id") for import_item in data
-                if import_item.get("id") and is_valid_model_id(import_item.get("id"))
+            # Batch-fetch existing models to avoid N+1 queries in loop
+            model_ids_to_import = [
+                model_data.get("id") for model_data in data
+                if model_data.get("id") and is_valid_model_id(model_data.get("id"))
             ]
-            existing_models = Models.get_models_by_ids(valid_model_ids, db=db)
-            existing_models_by_id = {db_model.id: db_model for db_model in existing_models}
+            existing_models = Models.get_models_by_ids(model_ids_to_import, db=db)
+            existing_by_id = {model.id: model for model in existing_models}
 
             for model_data in data:
                 model_id = model_data.get("id")
 
                 if model_id and is_valid_model_id(model_id):
-                    existing_model = existing_models_by_id.get(model_id)
+                    existing_model = existing_by_id.get(model_id)
                     if existing_model:
                         # Update existing model
                         model_data["meta"] = model_data.get("meta", {})

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -246,12 +246,19 @@ async def import_models(
     try:
         data = form_data.models
         if isinstance(data, list):
+            # Collect valid model IDs and batch-fetch existing models
+            valid_model_ids = [
+                import_item.get("id") for import_item in data
+                if import_item.get("id") and is_valid_model_id(import_item.get("id"))
+            ]
+            existing_models = Models.get_models_by_ids(valid_model_ids, db=db)
+            existing_models_by_id = {db_model.id: db_model for db_model in existing_models}
+
             for model_data in data:
-                # Here, you can add logic to validate model_data if needed
                 model_id = model_data.get("id")
 
                 if model_id and is_valid_model_id(model_id):
-                    existing_model = Models.get_model_by_id(model_id, db=db)
+                    existing_model = existing_models_by_id.get(model_id)
                     if existing_model:
                         # Update existing model
                         model_data["meta"] = model_data.get("meta", {})


### PR DESCRIPTION
## Summary
Eliminates N+1 database queries in two models router endpoints.
## Changes
**GET /models/list (get_models)**
- Pre-compute user_group_ids from already-fetched groups
- Pass to has_access to avoid re-querying groups per model
**POST /models/import (import_models)**
- Batch-fetch all existing models using get_models_by_ids before the import loop
- Use dict lookup instead of per-model database query
## Performance Impact
get_models: N+1 → 1 query (reuses groups already fetched for filtering)
import_models: N+1 → 1 query (single batch fetch with SQL IN clause)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
