### PR TITLE
perf: resolve N+1 query in prompts list access control check

### DIFF
--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -99,12 +99,17 @@ async def get_prompt_list(
     if direction:
         filter["direction"] = direction
 
+    # Fetch user's groups once - used for both filter and access control checks
+    groups = []
     if not (user.role == "admin" and BYPASS_ADMIN_ACCESS_CONTROL):
         groups = Groups.get_groups_by_member_id(user.id, db=db)
         if groups:
             filter["group_ids"] = [group.id for group in groups]
 
         filter["user_id"] = user.id
+
+    # Pre-compute user's group IDs to avoid N+1 queries in has_access
+    user_group_ids = {group.id for group in groups}
 
     result = Prompts.search_prompts(user.id, filter=filter, skip=skip, limit=limit, db=db)
 
@@ -115,7 +120,7 @@ async def get_prompt_list(
                 write_access=(
                     (user.role == "admin" and BYPASS_ADMIN_ACCESS_CONTROL)
                     or user.id == prompt.user_id
-                    or has_access(user.id, "write", prompt.access_control, db=db)
+                    or has_access(user.id, "write", prompt.access_control, user_group_ids=user_group_ids, db=db)
                 ),
             )
             for prompt in result.items


### PR DESCRIPTION
## Summary
Eliminates N+1 database query in get_prompt_list endpoint (/prompts/list). Previously, the has_access function would query the database for user groups on each prompt in the list.
## Changes
routers/prompts.py get_prompt_list endpoint:
- Initialize groups before the condition block
- Pre-compute user_group_ids from already-fetched groups
- Pass user_group_ids to has_access to skip redundant DB lookups
## Performance Impact
Before: N+1 queries - Groups.get_groups_by_member_id called once per prompt
After: 1 query total - reuses groups already fetched for filter construction

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
