### PR TITLE
perf: reduce triple query to single fetch in model toggle

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -394,17 +394,16 @@ class ModelsTable:
     ) -> Optional[ModelModel]:
         with get_db_context(db) as db:
             try:
-                is_active = db.query(Model).filter_by(id=id).first().is_active
+                model = db.query(Model).filter_by(id=id).first()
+                if not model:
+                    return None
 
-                db.query(Model).filter_by(id=id).update(
-                    {
-                        "is_active": not is_active,
-                        "updated_at": int(time.time()),
-                    }
-                )
+                model.is_active = not model.is_active
+                model.updated_at = int(time.time())
                 db.commit()
+                db.refresh(model)
 
-                return self.get_model_by_id(id, db=db)
+                return ModelModel.model_validate(model)
             except Exception:
                 return None
 


### PR DESCRIPTION
## Summary
Eliminates redundant database queries in toggle_model_by_id. Previously, the function made 3 separate queries to toggle a model's active state.
## Changes
models/models.py toggle_model_by_id:
- Fetch model once with query().filter_by().first()
- Toggle is_active directly on the object
- Commit and refresh the same object
- Return the validated model
## Performance Impact
Before: 3 queries (fetch is_active, update, fetch model)
After: 1 query + commit + refresh on same object

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
