### PR TITLE
perf: replace double lookup with single JOIN in authenticate_user_by_email

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
-from open_webui.models.users import UserModel, UserProfileImageResponse, Users
+from open_webui.models.users import User, UserModel, UserProfileImageResponse, Users
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, String, Text
 
@@ -155,10 +155,14 @@ class AuthsTable:
         log.info(f"authenticate_user_by_email: {email}")
         try:
             with get_db_context(db) as db:
-                auth = db.query(Auth).filter_by(email=email, active=True).first()
-                if auth:
-                    user = Users.get_user_by_id(auth.id, db=db)
-                    return user
+                # Single JOIN query instead of two separate queries
+                user = (
+                    db.query(User)
+                    .join(Auth, Auth.id == User.id)
+                    .filter(Auth.email == email, Auth.active == True)
+                    .first()
+                )
+                return UserModel.model_validate(user) if user else None
         except Exception:
             return None
 

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -156,13 +156,16 @@ class AuthsTable:
         try:
             with get_db_context(db) as db:
                 # Single JOIN query instead of two separate queries
-                user = (
-                    db.query(User)
-                    .join(Auth, Auth.id == User.id)
+                result = (
+                    db.query(Auth, User)
+                    .join(User, Auth.id == User.id)
                     .filter(Auth.email == email, Auth.active == True)
                     .first()
                 )
-                return UserModel.model_validate(user) if user else None
+                if result:
+                    _, user = result
+                    return UserModel.model_validate(user)
+                return None
         except Exception:
             return None
 


### PR DESCRIPTION
## Summary
Eliminates double database lookup in authenticate_user_by_email. Previously, the function queried the Auth table first, then fetched the User separately.
## Changes
models/auths.py authenticate_user_by_email:
- Import User model
- Replace two separate queries with single JOIN query
- Auth and User tables joined on id, filtered by email and active status
## Performance Impact
Before: 2 queries (Auth lookup + User lookup)
After: 1 query using SQL JOIN

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
