### PR TITLE
perf: eliminate redundant query after memory update

### DIFF
--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -82,7 +82,8 @@ class MemoriesTable:
                 memory.updated_at = int(time.time())
 
                 db.commit()
-                return self.get_memory_by_id(id)
+                db.refresh(memory)
+                return MemoryModel.model_validate(memory)
             except Exception:
                 return None
 


### PR DESCRIPTION
## Summary
Eliminates redundant database query in update_memory_by_id_and_user_id. Previously, after modifying the memory object, it called get_memory_by_id which opened a new session and queried again.
## Changes
models/memories.py update_memory_by_id_and_user_id:
- Replace self.get_memory_by_id(id) with db.refresh(memory)
- Return the same memory object that was already modified
## Performance Impact
Before: 2 queries (get + get_memory_by_id)
After: 1 query + refresh on same session

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
