### PR TITLE
perf: eliminate duplicate requests on Prompts page load

### DIFF
--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -58,17 +58,23 @@
 
 	let page = 1;
 
-	// Debounce only query changes
+	// Debounce only query changes (skip initial empty query)
+	let queryInitialized = false;
 	$: if (query !== undefined) {
-		loading = true;
-		clearTimeout(searchDebounceTimer);
-		searchDebounceTimer = setTimeout(() => {
-			getPromptList();
-		}, 300);
+		if (queryInitialized) {
+			loading = true;
+			clearTimeout(searchDebounceTimer);
+			searchDebounceTimer = setTimeout(() => {
+				page = 1; // Reset to first page on new search
+				getPromptList();
+			}, 300);
+		} else {
+			queryInitialized = true;
+		}
 	}
 
 	// Immediate response to page/filter changes
-	$: if (page && selectedTag !== undefined && viewOption !== undefined) {
+	$: if (loaded && page && selectedTag !== undefined && viewOption !== undefined) {
 		getPromptList();
 	}
 


### PR DESCRIPTION
## Summary
Fixes duplicate API requests and content flash when visiting the Prompts workspace page.
## Root Cause
Two reactive statements were both triggering on mount:
1. Query debounce block (fires when query goes from undefined to empty string)
2. Page/filter block (fires when page is set to 1 in onMount)
## Changes
src/lib/components/workspace/Prompts.svelte:
- Added queryInitialized guard to skip initial empty query trigger
- Added loaded check to page/filter reactive block
- Reset page to 1 when search query changes (UX improvement)
## Result
Single API request on page load instead of duplicates.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
