### PR TITLE
perf: batch fetch filter functions to eliminate N+1 queries

### DIFF
--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -195,6 +195,26 @@ class FunctionsTable:
         except Exception:
             return None
 
+    def get_functions_by_ids(
+        self, ids: list[str], db: Optional[Session] = None
+    ) -> list[FunctionModel]:
+        """
+        Batch fetch multiple functions by their IDs in a single query.
+        Returns functions in the same order as the input IDs (None entries filtered out).
+        """
+        if not ids:
+            return []
+        try:
+            with get_db_context(db) as db:
+                functions = db.query(Function).filter(Function.id.in_(ids)).all()
+                # Create a dict for O(1) lookup
+                func_dict = {f.id: FunctionModel.model_validate(f) for f in functions}
+                # Return in original order, filtering out any not found
+                return [func_dict[id] for id in ids if id in func_dict]
+        except Exception:
+            return []
+
+
     def get_functions(
         self, active_only=False, include_valves=False, db: Optional[Session] = None
     ) -> list[FunctionModel | FunctionWithValvesModel]:

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -341,12 +341,8 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
     }
 
     try:
-        filter_functions = [
-            Functions.get_function_by_id(filter_id)
-            for filter_id in get_sorted_filter_ids(
-                request, model, metadata.get("filter_ids", [])
-            )
-        ]
+        filter_ids = get_sorted_filter_ids(request, model, metadata.get("filter_ids", []))
+        filter_functions = Functions.get_functions_by_ids(filter_ids)
 
         result, _ = await process_filter_functions(
             request=request,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1570,12 +1570,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         raise e
 
     try:
-        filter_functions = [
-            Functions.get_function_by_id(filter_id)
-            for filter_id in get_sorted_filter_ids(
-                request, model, metadata.get("filter_ids", [])
-            )
-        ]
+        filter_ids = get_sorted_filter_ids(request, model, metadata.get("filter_ids", []))
+        filter_functions = Functions.get_functions_by_ids(filter_ids)
 
         form_data, flags = await process_filter_functions(
             request=request,


### PR DESCRIPTION
## Summary
Adds a batch method to fetch multiple functions by ID in a single database query, eliminating N+1 query patterns in filter function loading.
## Changes
- Added get_functions_by_ids batch method in FunctionsTable
- Updated chat_completed in utils/chat.py to use batch fetch
- Updated process_chat_payload in utils/middleware.py to use batch fetch
## Performance Impact
For a request with N filter functions:
- Before: N separate database queries
- After: 1 database query

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
