### PR TITLE
perf: eliminate N+1 queries in tools and channel messages

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -831,6 +831,10 @@ async def get_channel_messages(
     user_ids = list(set(m.user_id for m in message_list))
     users = {u.id: u for u in Users.get_users_by_user_ids(user_ids, db=db)}
 
+    # Batch fetch all reactions in a single query (fixes N+1 problem)
+    message_ids = [m.id for m in message_list]
+    all_reactions = Messages.get_reactions_by_message_ids(message_ids, db=db)
+
     messages = []
     for message in message_list:
         thread_replies = Messages.get_thread_replies_by_message_id(message.id, db=db)
@@ -849,9 +853,7 @@ async def get_channel_messages(
                     **message.model_dump(),
                     "reply_count": len(thread_replies),
                     "latest_reply_at": latest_thread_reply_at,
-                    "reactions": Messages.get_reactions_by_message_id(
-                        message.id, db=db
-                    ),
+                    "reactions": all_reactions.get(message.id, []),
                     "user": user_info,
                 }
             )

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -65,7 +65,7 @@ async def get_tools(
 
     # Local Tools
     for tool in Tools.get_tools(db=db):
-        tool_module = get_tool_module(request, tool.id)
+        tool_module = get_tool_module(request, tool.id, load_from_db=False)
         tools.append(
             ToolUserResponse(
                 **{


### PR DESCRIPTION
## Summary
Reduces database queries in two high-traffic endpoints by using caching and batch fetching.
## Changes
### routers/tools.py
- Use cached tool modules when listing tools instead of re-fetching from DB per tool
### models/messages.py
- Added get_reactions_by_message_ids batch method for fetching reactions across multiple messages in one query
### routers/channels.py
- Updated get_channel_messages to batch fetch reactions instead of per-message queries
## Performance Impact
- GET /tools: N+1 → 1 query (or 0 if cached)
- GET /channels/{id}/messages: N+1 reaction queries → 1 query

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
