### PR TITLE
feat: Add REDIS_RECONNECT_DELAY environment variable as positive float for handle retry delay on timeout/connection errors for redis

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -392,6 +392,22 @@ try:
     REDIS_SOCKET_CONNECT_TIMEOUT = float(REDIS_SOCKET_CONNECT_TIMEOUT)
 except ValueError:
     REDIS_SOCKET_CONNECT_TIMEOUT = None
+    
+REDIS_RECONNECT_DELAY = os.environ.get(
+    "REDIS_RECONNECT_DELAY", ""
+)
+
+if REDIS_RECONNECT_DELAY == "":
+    REDIS_RECONNECT_DELAY = None
+else:
+    try:
+        REDIS_RECONNECT_DELAY = float(
+            REDIS_RECONNECT_DELAY
+        )
+        if REDIS_RECONNECT_DELAY < 0:
+            REDIS_RECONNECT_DELAY = None
+    except Exception:
+        REDIS_RECONNECT_DELAY = None
 
 ####################################
 # UVICORN WORKERS

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -1,5 +1,7 @@
 import inspect
 from urllib.parse import urlparse
+import asyncio
+import time
 
 import logging
 
@@ -12,6 +14,7 @@ from open_webui.env import (
     REDIS_SENTINEL_MAX_RETRY_COUNT,
     REDIS_SENTINEL_PORT,
     REDIS_URL,
+    REDIS_RECONNECT_DELAY,
 )
 
 log = logging.getLogger(__name__)
@@ -63,6 +66,8 @@ class SentinelRedisProxy:
                                         i + 1,
                                         REDIS_SENTINEL_MAX_RETRY_COUNT,
                                     )
+                                    if REDIS_RECONNECT_DELAY:
+                                        time.sleep(REDIS_RECONNECT_DELAY / 1000)
                                     continue
                                 log.error(
                                     "Redis operation failed after %s retries: %s",
@@ -94,6 +99,8 @@ class SentinelRedisProxy:
                                 i + 1,
                                 REDIS_SENTINEL_MAX_RETRY_COUNT,
                             )
+                            if REDIS_RECONNECT_DELAY:
+                                await asyncio.sleep(REDIS_RECONNECT_DELAY / 1000)
                             continue
                         log.error(
                             "Redis operation failed after %s retries: %s",
@@ -122,6 +129,8 @@ class SentinelRedisProxy:
                                 i + 1,
                                 REDIS_SENTINEL_MAX_RETRY_COUNT,
                             )
+                            if REDIS_RECONNECT_DELAY:
+                                time.sleep(REDIS_RECONNECT_DELAY / 1000)
                             continue
                         log.error(
                             "Redis operation failed after %s retries: %s",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- This pull request introduces an optional reconnect delay (in milliseconds) to Redis Sentinel retry logic, applied consistently across both synchronous and asynchronous Redis operations.
The change improves stability during Sentinel failover scenarios by preventing tight retry loops that may otherwise overwhelm Redis or block the event loop.

The reconnect delay is configurable via the existing REDIS_RECONNECT_DELAY environment variable and is fully optional. When unset or invalid, retry behavior remains unchanged.

Without a retry delay, when a Redis Sentinel master service goes down, the client enters a very fast retry loop while Sentinel is still in the process of electing and promoting a new master. During this window, all reconnection attempts are exhausted almost immediately, causing Redis-dependent services to fail even though a new master becomes available shortly after.

### Added

- Optional configurable retry delay for timeout/connection error for redis

### Changed

- Optional REDIS_RECONNECT_DELAY support for Redis Sentinel retry loops
- Millisecond-based delay handling compatible with both int and float values
- Non-blocking retry delay for async Redis operations using asyncio.sleep
- Blocking retry delay for sync Redis operations using time.sleep

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- https://github.com/open-webui/docs/issues/1039

### Screenshots or Videos

-

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
