### PR TITLE
fix: web search not working in native FC mode when builtin_tools is disabled

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1835,6 +1835,28 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             if name not in tools_dict:
                 tools_dict[name] = tool_dict
 
+    # Web search fallback when builtin_tools is disabled but web search is enabled
+    elif (
+        metadata.get("params", {}).get("function_calling") == "native"
+        and getattr(request.app.state.config, "ENABLE_WEB_SEARCH", False)
+        and model.get("info", {})
+        .get("meta", {})
+        .get("capabilities", {})
+        .get("web_search", True)
+    ):
+        builtin_tools = get_builtin_tools(
+            request,
+            {
+                **extra_params,
+                "__event_emitter__": event_emitter,
+            },
+            features,
+            model,
+        )
+        for name in ("search_web", "fetch_url"):
+            if name in builtin_tools and name not in tools_dict:
+                tools_dict[name] = builtin_tools[name]
+
     if tools_dict:
         if metadata.get("params", {}).get("function_calling") == "native":
             # If the function calling is native, then call the tools function calling handler


### PR DESCRIPTION
## Summary

Relates to #20549

When `builtin_tools` capability is disabled on a model (e.g. to prevent builtin tools from being injected into API calls, as described in #20549), the entire `get_builtin_tools()` call is skipped in native function calling mode. This also disables web search, even when `ENABLE_WEB_SEARCH=True` and the model has `web_search` capability enabled.

This PR adds an `elif` fallback that injects only `search_web` and `fetch_url` tools when `builtin_tools` is off but web search should be available.

## Changes

- `backend/open_webui/utils/middleware.py` — 22 lines added (pure addition, zero existing lines modified)

## Behavior matrix

| builtin_tools | web_search | Result |
|:---:|:---:|---|
| ON | ON | All tools injected (unchanged) |
| ON | OFF | All tools injected (unchanged, WIP per #20595) |
| **OFF** | **ON** | **Only web search tools injected (FIXED)** |
| OFF | OFF | No tools injected (unchanged) |
| non-native FC | any | RAG path (unaffected) |

## Contributor License Agreement

contributor license agreement