### PR TITLE
feat/change: Make usage be True / ON by default

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2009,7 +2009,7 @@
 					follow_up_generation: $settings?.autoFollowUps ?? true
 				},
 
-				...(stream && (model.info?.meta?.capabilities?.usage ?? false)
+				...(stream && (model.info?.meta?.capabilities?.usage ?? true)
 					? {
 							stream_options: {
 								include_usage: true

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -101,7 +101,7 @@
 		code_interpreter: true,
 		citations: true,
 		status_updates: true,
-		usage: undefined,
+		usage: true,
 		builtin_tools: true
 	};
 	let defaultFeatureIds = [];


### PR DESCRIPTION
Changed the default value of the usage capability from undefined/false to true, ensuring that token usage information is included in API responses by default. This affects:
- ModelEditor: usage capability now defaults to true for new models
- Chat: usage fallback now defaults to true when not explicitly set


### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
