### PR TITLE
fix: prevent RuntimeError in process_metadata when excluding keys

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -4,6 +4,7 @@ KEYS_TO_EXCLUDE = ["content", "pages", "tables", "paragraphs", "sections", "figu
 
 
 def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
+    # Removes large/redundant fields from metadata dict.
     metadata = {
         key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE
     }
@@ -13,16 +14,15 @@ def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
 def process_metadata(
     metadata: dict[str, any],
 ) -> dict[str, any]:
+    # Removes large fields and converts non-serializable types (datetime, list, dict) to strings.
+    result = {}
     for key, value in metadata.items():
-        # Remove large fields
+        # Skip large fields
         if key in KEYS_TO_EXCLUDE:
-            del metadata[key]
-
+            continue
         # Convert non-serializable fields to strings
-        if (
-            isinstance(value, datetime)
-            or isinstance(value, list)
-            or isinstance(value, dict)
-        ):
-            metadata[key] = str(value)
-    return metadata
+        if isinstance(value, (datetime, list, dict)):
+            result[key] = str(value)
+        else:
+            result[key] = value
+    return result


### PR DESCRIPTION
Fixed `process_metadata` function that would raise `RuntimeError: dictionary changed size during iteration` when metadata contained any of the excluded keys (`content`, `pages`, `tables`, `paragraphs`, `sections`, `figures`).

<ins>**The function was deleting keys while iterating over `dict.items()`, which invalidates the iterator in Python 3. Now builds a new dict instead of mutating the original.**</ins>

## Why this has never been reported

This bug has never surfaced in practice due to how the code paths are structured:

1. **Multitenancy mode users** - The multitenancy Milvus client (and others) doesn't call `process_metadata` at all, passing metadata directly without processing.

2. **Standard mode users** - <ins>**Before metadata reaches `process_metadata`, it passes through `filter_metadata` first (in `process_file`), which already removes the excluded keys. By the time `process_metadata` is called, those keys are already gone.**</ins>

3. **Document loaders** - The custom loaders (MinerU, Mistral OCR, Datalab Marker, Docling, Tika) don't include these keys in their metadata output. <ins>**Only certain LangChain loaders like `AzureAIDocumentIntelligenceLoader` might return them, but they get filtered upstream.**</ins>

## Why it should still be fixed

<ins>**Despite being unreachable in current code paths, this is a latent bug that could cause failures**</ins> if:
- A new code path calls `process_metadata` directly without prior filtering
- A new document loader returns metadata with these keys
- Someone refactors the existing flow and removes the upstream `filter_metadata` call

Fixing it ensures the function works correctly in isolation, as its signature and docstring imply it should.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
