### PR TITLE
enh: tool call prompt

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1593,8 +1593,7 @@ async def query_knowledge_files(
     __model_knowledge__: list[dict] = None,
 ) -> str:
     """
-    Search knowledge base files using semantic/vector search. This should be your first
-    choice for finding information before searching the web. Searches across collections (KBs),
+    Search knowledge base files using semantic/vector search. Searches across collections (KBs),
     individual files, and notes that the user has access to.
 
     :param query: The search query to find semantically relevant content


### PR DESCRIPTION
I know that this line "Use this before web search" is there deliberately, but this is undesired behaviour in many cases.
Models will use the query_knowledge_files again and again without results, wasting time and token - just to then output "yeah i found nothing". Yeah of course you found nothing - search the web!

I know this PR will probably be closed, but then we would need a way to customize the tool descriptions just like we can customize the tool descriptions for all other custom tools and other prompts sent to task models for example - because many models will indeed follow this behaviour and call the query_knowledge_files all the time instead of using search_web because of this tool description.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
