### PR TITLE
fix: skip RAG context injection for native function calling

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4060,7 +4060,7 @@ async def process_chat_response(
                         await event_emitter({"type": "source", "data": source})
 
                     # Apply source context to messages for model
-                    if tool_call_sources:
+                    if tool_call_sources and metadata.get("params", {}).get("function_calling") != "native":
                         user_msg = get_last_user_message(form_data["messages"])
                         if user_msg:
                             form_data["messages"] = apply_source_context_to_messages(


### PR DESCRIPTION
When native function calling is enabled, tool results are already sent to the model as function_call_output messages. However, apply_source_context_to_messages() was also injecting these same results as RAG context into user messages, causing token duplication.

The fix adds a check to skip RAG context injection when function_calling is set to "native", consistent with similar checks already present for web_search, memory, and image_generation handlers.

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided above.
- [x] **Changelog:** See below.
- [x] **Documentation:** N/A - no docs changes needed.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Tested manually with native function calling enabled.
- [x] **Agentic AI Code:** Human reviewed and tested.
- [x] **Code review:** Self-reviewed.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- Skip redundant RAG context injection when using native function calling - tool results were being sent twice (as function_call_output AND as RAG context in user messages).

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Tool results no longer duplicated in requests when native function calling is enabled

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Follows the same pattern already used for web_search, memory, and image_generation handlers at lines 1573, 1580, and 1587.
- Related: #19098, #20479

### Question for Maintainers

Is the RAG context injection after tool execution intentional for native function calling?
If citation formatting is needed, perhaps a lighter approach (metadata only, 
not full content) would avoid the token duplication while preserving citations?
Maybe an alternative solution to avoid tool response duplication?

### Screenshots or Videos

- N/A - backend change only

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
