### PR TITLE
fix: OTEL instrumentation for redis in cluster mode

### DIFF
--- a/backend/open_webui/utils/telemetry/instrumentors.py
+++ b/backend/open_webui/utils/telemetry/instrumentors.py
@@ -22,6 +22,7 @@ from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.trace import Span, StatusCode
 from redis import Redis
+from redis.cluster import RedisCluster
 from requests import PreparedRequest, Response
 from sqlalchemy import Engine
 from fastapi import status
@@ -59,16 +60,28 @@ def response_hook(span: Span, request: PreparedRequest, response: Response):
     span.set_status(StatusCode.ERROR if response.status_code >= 400 else StatusCode.OK)
 
 
-def redis_request_hook(span: Span, instance: Redis, args, kwargs):
+def redis_request_hook(span: Span, instance: Union[Redis|RedisCluster], args, kwargs):
     """
     Redis Request Hook
     """
 
+    # In cluster mode, the instance can be of two types:
+    # - redis.asyncio.cluster.RedisCluster
+    # - redis.cluster.RedisCluster
+    # Instead of checking the type, we check if the instance has a nodes_manager attribute.
     try:
-        connection_kwargs: dict = instance.connection_pool.connection_kwargs
-        host = connection_kwargs.get("host")
-        port = connection_kwargs.get("port")
-        db = connection_kwargs.get("db")
+        db = ""
+        if hasattr(instance, 'nodes_manager'):
+            default_node = instance.nodes_manager.default_node
+            if not default_node:
+                return
+            host = default_node.host
+            port = default_node.port
+        else:
+            connection_kwargs: dict = instance.connection_pool.connection_kwargs
+            host = connection_kwargs.get("host")
+            port = connection_kwargs.get("port")
+            db = connection_kwargs.get("db")
         span.set_attributes(
             {
                 SpanAttributes.DB_INSTANCE: f"{host}/{db}",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **Not targeting the `dev` branch will lead to immediate closure of the PR.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** If necessary, update relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs) like environment variables, the tutorials, or other documentation sources.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Take this as an opportunity to **make screenshots of the feature/fix and include it in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes the OTEL instrumentation for Redis when Redis is used in cluster mode (e.g. AWS Elasticache Serverless).

### Added

### Changed

### Deprecated

### Removed

### Fixed

This PR fixes the OTEL instrumentation for Redis when Redis is used in cluster mode (e.g. AWS Elasticache Serverless).

### Security

### Breaking Changes

---

### Additional Information

Without this change, the OTEL instrumentation does not work because a `RedisCluster` object does not have the `connection_pool` property.

We've been using this change in production for two month now without issues (setup with AWS Elasticache Serverless).

### Screenshots or Videos

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
