### PR TITLE
fix: reconstruct tool_calls from history to prevent model hallucinations

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -852,32 +852,15 @@ export const removeDetails = (content, types) => {
 };
 
 export const removeAllDetails = (content) => {
-	content = content.replace(/<details[^>]*>.*?<\/details>/gis, '');
+	// Preserve tool_calls details for backend reconstruction
+	content = content.replace(/<details(?![^>]*type="tool_calls")[^>]*>.*?<\/details>/gis, '');
 	return content;
 };
 
 export const processDetails = (content) => {
-	content = removeDetails(content, ['reasoning', 'code_interpreter']);
-
-	// This regex matches <details> tags with type="tool_calls" and captures their attributes to convert them to a string
-	const detailsRegex = /<details\s+type="tool_calls"([^>]*)>([\s\S]*?)<\/details>/gis;
-	const matches = content.match(detailsRegex);
-	if (matches) {
-		for (const match of matches) {
-			const attributesRegex = /(\w+)="([^"]*)"/g;
-			const attributes = {};
-			let attributeMatch;
-			while ((attributeMatch = attributesRegex.exec(match)) !== null) {
-				attributes[attributeMatch[1]] = attributeMatch[2];
-			}
-
-			if (attributes.result) {
-				content = content.replace(match, `"${attributes.result}"`);
-			}
-		}
-	}
-
-	return content;
+	// Only remove reasoning and code_interpreter details
+	// Preserve tool_calls details for backend reconstruction
+	return removeDetails(content, ['reasoning', 'code_interpreter']);
 };
 
 // This regular expression matches code blocks marked by triple backticks


### PR DESCRIPTION
## Summary

Fixes #20600 - Tool call results not decoded from HTML entities before sending to LLM

This PR addresses a critical bug where models (especially Qwen3) hallucinate/fake tool calls as text after 2-3 iterations of actual tool use.

### Root Cause

1. `processDetails()` converts `<details type="tool_calls">` to plain text with HTML-escaped entities
2. `removeAllDetails()` strips ALL `<details>` tags before sending to backend
3. Model receives history without proper tool call structure and mimics the pattern

### Solution

**Frontend (`src/lib/utils/index.ts`):**
- `removeAllDetails()`: Add negative lookahead to preserve `<details type="tool_calls">` tags
- `processDetails()`: Simplify to only remove `reasoning` and `code_interpreter` details, leaving `tool_calls` intact

**Backend (`backend/open_webui/utils/middleware.py`):**
- Add `reconstruct_tool_messages()` function to parse preserved `<details type="tool_calls">` tags
- Reconstruct proper OpenAI-compatible `tool_calls` field on assistant messages
- Create `tool` role messages with results

### How It Works

1. Frontend preserves `<details type="tool_calls" id="..." name="..." arguments="..." result="...">` in message content
2. Backend parses these tags before sending to LLM
3. Converts flat assistant messages to proper structure:
   - Assistant message with `tool_calls` array
   - Tool role messages with `tool_call_id` and result content

### Model Compatibility

| Model | Support |
|-------|---------|
| Qwen3/Qwen3-VL | Native (primary fix target) |
| GPT-4/GPT-4o | Native |
| Claude | Via LiteLLM |
| Gemini | Native |

### Testing

1. Enable tools for a model
2. Trigger a tool call (e.g., web search)
3. Send follow-up message in the same conversation
4. Verify model makes REAL tool calls, not text imitations like:
   ```
   <tool_call>{"name": "web_search", "arguments": {...}}</tool_call>
   ```

### Related Issues
- #20600 - HTML entities encoding bug (this PR fixes)
- #9435 - Native mode doesn't call model again after tool call (related)

---

🤖 Generated with [Claude Code](https://claude.ai/code)