### PR TITLE
fix: reconstruct tool_calls from history to prevent model hallucinations

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -857,33 +857,16 @@ export const removeDetails = (content, types) => {
 };
 
 export const removeAllDetails = (content) => {
+	// Preserve tool_calls details for backend reconstruction
 	return replaceOutsideCode(content, (segment) => {
-		return segment.replace(/<details[^>]*>.*?<\/details>/gis, '');
+		return segment.replace(/<details(?![^>]*type="tool_calls")[^>]*>.*?<\/details>/gis, '');
 	});
 };
 
 export const processDetails = (content) => {
-	content = removeDetails(content, ['reasoning', 'code_interpreter']);
-
-	// This regex matches <details> tags with type="tool_calls" and captures their attributes to convert them to a string
-	const detailsRegex = /<details\s+type="tool_calls"([^>]*)>([\s\S]*?)<\/details>/gis;
-	const matches = content.match(detailsRegex);
-	if (matches) {
-		for (const match of matches) {
-			const attributesRegex = /(\w+)="([^"]*)"/g;
-			const attributes = {};
-			let attributeMatch;
-			while ((attributeMatch = attributesRegex.exec(match)) !== null) {
-				attributes[attributeMatch[1]] = attributeMatch[2];
-			}
-
-			if (attributes.result) {
-				content = content.replace(match, `"${attributes.result}"`);
-			}
-		}
-	}
-
-	return content;
+	// Only remove reasoning and code_interpreter details
+	// Preserve tool_calls details for backend reconstruction
+	return removeDetails(content, ['reasoning', 'code_interpreter']);
 };
 
 // This regular expression matches code blocks marked by triple backticks


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Changelog:** Provided below
- [x] **Documentation:** No changes needed
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually tested with Qwen3 + web_search tool
- [x] **Agentic AI Code:** Co-authored with Claude, reviewed and tested by human
- [x] **Code review:** Self-reviewed
- [x] **Title Prefix:** `fix:`

---

# Changelog Entry

### Description

Fixes #20600 - Tool call results not decoded from HTML entities before sending to LLM

This PR addresses a critical bug where models (especially Qwen3) hallucinate/fake tool calls as text after 2-3 iterations of actual tool use.

**Root Cause:**
1. `processDetails()` converts `<details type="tool_calls">` to plain text with HTML-escaped entities
2. `removeAllDetails()` strips ALL `<details>` tags before sending to backend
3. Model receives history without proper tool call structure and mimics the pattern

**Solution:**
- Frontend: Preserve `<details type="tool_calls">` tags
- Backend: Add `reconstruct_tool_messages()` to reconstruct OpenAI format

### Added

- `reconstruct_tool_messages()` function in `backend/open_webui/utils/middleware.py` to parse `<details type="tool_calls">` tags and reconstruct proper OpenAI-compatible message structure

### Changed

- `removeAllDetails()` in `src/lib/utils/index.ts`: Added negative lookahead to preserve `<details type="tool_calls">` tags
- `processDetails()` in `src/lib/utils/index.ts`: Simplified to only remove `reasoning` and `code_interpreter` details, leaving `tool_calls` intact

### Fixed

- #20600 - HTML entities encoding bug in tool call results
- Model hallucinations where models fake tool calls as text instead of making real tool calls

---

### How It Works

1. Frontend preserves `<details type="tool_calls" id="..." name="..." arguments="..." result="...">` in message content
2. Backend parses these tags before sending to LLM via `reconstruct_tool_messages()`
3. Converts flat assistant messages to proper structure:
   - Assistant message with `tool_calls` array
   - Tool role messages with `tool_call_id` and result content

### Testing Steps

1. Enable tools for a model (e.g., web_search)
2. Trigger a tool call
3. Send follow-up message in the same conversation
4. Verify model makes REAL tool calls, not text imitations like:
   ```
   <tool_call>{"name": "web_search", "arguments": {...}}</tool_call>
   ```

### Related Issues
- #20600 - HTML entities encoding bug (this PR fixes)
- #9435 - Native mode doesn't call model again after tool call (related)

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.