### PR TITLE
fix: prevent worker death during document upload by using run_coroutine_threadsafe

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -589,6 +589,10 @@ https://github.com/open-webui/open-webui
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Store reference to main event loop for sync->async calls (e.g., embedding generation)
+    # This allows sync functions to schedule work on the main loop without blocking health checks
+    app.state.main_loop = asyncio.get_running_loop()
+
     app.state.instance_id = INSTANCE_ID
     start_logger()
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1578,14 +1578,17 @@ def save_docs_to_vector_db(
             enable_async=request.app.state.config.ENABLE_ASYNC_EMBEDDING,
         )
 
-        # Run async embedding in sync context
-        embeddings = asyncio.run(
+        # Run async embedding in sync context using the main event loop
+        # This allows the main loop to stay responsive to health checks during long operations
+        future = asyncio.run_coroutine_threadsafe(
             embedding_function(
                 list(map(lambda x: x.replace("\n", " "), texts)),
                 prefix=RAG_EMBEDDING_CONTENT_PREFIX,
                 user=user,
-            )
+            ),
+            request.app.state.main_loop,
         )
+        embeddings = future.result(timeout=600)
         log.info(f"embeddings generated {len(embeddings)} for {len(texts)} items")
 
         items = [

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1580,6 +1580,9 @@ def save_docs_to_vector_db(
 
         # Run async embedding in sync context using the main event loop
         # This allows the main loop to stay responsive to health checks during long operations
+        embedding_timeout_str = os.environ.get("RAG_EMBEDDING_TIMEOUT")
+        embedding_timeout = int(embedding_timeout_str) if embedding_timeout_str else None
+
         future = asyncio.run_coroutine_threadsafe(
             embedding_function(
                 list(map(lambda x: x.replace("\n", " "), texts)),
@@ -1588,7 +1591,7 @@ def save_docs_to_vector_db(
             ),
             request.app.state.main_loop,
         )
-        embeddings = future.result(timeout=600)
+        embeddings = future.result(timeout=embedding_timeout)
         log.info(f"embeddings generated {len(embeddings)} for {len(texts)} items")
 
         items = [


### PR DESCRIPTION
Best solution would be to fully propagate async/await the entire chain but this is a lot more work.

Replace asyncio.run() with asyncio.run_coroutine_threadsafe() in save_docs_to_vector_db() to prevent uvicorn worker health check failures.

The issue: asyncio.run() creates a new event loop and blocks the thread completely, preventing the worker from responding to health checks during long-running embedding operations (>5 seconds default timeout).

The fix: Schedule the async embedding work on the main event loop using run_coroutine_threadsafe(). This keeps the main loop responsive to health check pings while the sync caller waits for the result.

Changes:
- main.py: Store main event loop reference in app.state.main_loop at startup
- retrieval.py: Use run_coroutine_threadsafe() instead of asyncio.run()

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
