### PR TITLE
feat: Allow customizing user info header names via environment variables

### DIFF
--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -1,11 +1,12 @@
 from urllib.parse import quote
+import os
 
 
 def include_user_info_headers(headers, user):
     return {
         **headers,
-        "X-OpenWebUI-User-Name": quote(user.name, safe=" "),
-        "X-OpenWebUI-User-Id": user.id,
-        "X-OpenWebUI-User-Email": user.email,
-        "X-OpenWebUI-User-Role": user.role,
+        os.environ.get("FORWARD_USER_INFO_NAME", "X-OpenWebUI-User-Name"): quote(user.name, safe=" "),
+        os.environ.get("FORWARD_USER_INFO_ID", "X-OpenWebUI-User-Id"): user.id,
+        os.environ.get("FORWARD_USER_INFO_EMAIL", "X-OpenWebUI-User-Email"): user.email,
+        os.environ.get("FORWARD_USER_INFO_ROLE", "X-OpenWebUI-User-Role"): user.role,
     }


### PR DESCRIPTION
# Changelog Entry

### Description

Support for customizing user information header names through environment variables, while maintaining backward compatibility with the default `X-OpenWebUI-User-*` headers. This allows deployments to use custom header names that fit their infrastructure requirements.

**Motivation:**
When integrating with existing infrastructure or reverse proxies, some deployments may need to use different header names to avoid conflicts or comply with internal standards. For instance, AWS Bedrock AgentCore only accepts headers prefixed with `X-Amzn-Bedrock-AgentCore-Runtime-Custom-`, making it impossible to forward user information with the hardcoded `X-OpenWebUI-User-*` headers. This change enables compatibility with such services while maintaining backward compatibility for existing deployments.


### Added

- Environment variable support for customizing user info header names:
  - `FORWARD_USER_INFO_NAME` - customize the user name header (default: `X-OpenWebUI-User-Name`)
  - `FORWARD_USER_INFO_ID` - customize the user ID header (default: `X-OpenWebUI-User-Id`)
  - `FORWARD_USER_INFO_EMAIL` - customize the user email header (default: `X-OpenWebUI-User-Email`)
  - `FORWARD_USER_INFO_ROLE` - customize the user role header (default: `X-OpenWebUI-User-Role`)


### Changed

- Modified `include_user_info_headers()` function to read header names from environment variables
- Header names now use `os.environ.get()` with fallback to original default values


### Deprecated

N/A

### Removed

N/A

### Fixed

N/A

### Security

N/A

### Breaking Changes

Fully backward compatible. If environment variables are not set, the original header names are used.

---

### Additional Information

N/A

### Screenshots or Videos

N/A

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
