### PR TITLE
fix: respect API stream parameter over model settings

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1625,7 +1625,8 @@ async def chat_completion(
         reasoning_tags = form_data.get("params", {}).get("reasoning_tags")
 
         # Model Params
-        if model_info_params.get("stream_response") is not None:
+        # Use stream from API if present, otherwise use model default
+        if "stream" not in form_data and model_info_params.get("stream_response") is not None:
             form_data["stream"] = model_info_params.get("stream_response")
 
         if model_info_params.get("stream_delta_chunk_size"):


### PR DESCRIPTION
## Description

This PR fixes a regression introduced by commit f138be9 (issue #19154) where the `stream` parameter sent in API requests is always overridden by the model's `stream_response` setting.

## Problem

While #19154 correctly ensured that model settings are applied, it unconditionally overwrites the `stream` parameter from API requests, breaking:
- OpenAI API compatibility
- LangChain integration (`streaming=True/False` ignored)
- Per-request streaming control for any API client

## Solution

The fix checks if `stream` exists in `form_data` before applying the model default:

```python
# Before (always overwrites):
if model_info_params.get("stream_response") is not None:
    form_data["stream"] = model_info_params.get("stream_response")

# After (respects API parameter):
if "stream" not in form_data and model_info_params.get("stream_response") is not None:
    form_data["stream"] = model_info_params.get("stream_response")
```

## Changes

- Modified `backend/open_webui/main.py` line 1628
- Added check for existing `stream` parameter before applying model default
- Added clarifying comment

## Impact

- ✅ **Maintains #19154 fix** - model setting still works as default
- ✅ **Fixes regression** - API parameter now has priority
- ✅ **OpenAI API compatible** - respects stream parameter per-request
- ✅ **Enables LangChain** - `streaming=True/False` now works
- ✅ **100% backward compatible** - no breaking changes

## Testing

Tested all scenarios:

| Test Case | API Param | Model Setting | Expected | Result |
|-----------|-----------|---------------|----------|---------|
| 1 | `stream: false` | any | No streaming | ✅ Pass |
| 2 | `stream: true` | any | Streaming | ✅ Pass |
| 3 | not provided | `false` | No streaming | ✅ Pass |
| 4 | not provided | `true` | Streaming | ✅ Pass |

## Related Issues

- Resolves: #21162
- Related: #19154 (original issue)
- Improves: OpenAI API compatibility

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Regression fix
- [x] API compatibility improvement

## Checklist

- [x] Code follows project style guidelines
- [x] Changes tested thoroughly (all 4 scenarios)
- [x] No breaking changes
- [x] Backward compatible
- [x] Maintains fix from #19154
- [x] Improves OpenAI API compatibility
