### PR TITLE
fix: handle error dict in citation parser when web search fails

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -160,9 +160,14 @@ def get_citation_source_from_tool_result(
     Returns a list of sources (usually one, but query_knowledge_files may return multiple).
     """
     try:
+        # Handle error responses from tools - all builtin tools return {"error": ...} on failure
+        parsed = json.loads(tool_result)
+        if isinstance(parsed, dict) and "error" in parsed:
+            return []
+
         if tool_name == "search_web":
             # Parse JSON array: [{"title": "...", "link": "...", "snippet": "..."}]
-            results = json.loads(tool_result)
+            results = parsed
             documents = []
             metadata = []
 
@@ -189,7 +194,7 @@ def get_citation_source_from_tool_result(
             ]
 
         elif tool_name == "view_knowledge_file":
-            file_data = json.loads(tool_result)
+            file_data = parsed
             filename = file_data.get("filename", "Unknown File")
             file_id = file_data.get("id", "")
             knowledge_name = file_data.get("knowledge_name", "")
@@ -218,7 +223,7 @@ def get_citation_source_from_tool_result(
             ]
 
         elif tool_name == "query_knowledge_files":
-            chunks = json.loads(tool_result)
+            chunks = parsed
 
             # Group chunks by source for better citation display
             # Each unique source becomes a separate source entry


### PR DESCRIPTION
## Summary
- When builtin tools like `search_web` fail (timeout, API error, etc.), they return `{"error": "..."}` as a JSON dict. The citation parser in `get_citation_source_from_tool_result` expected a list and iterated over the dict keys (strings), causing `AttributeError: 'str' object has no attribute 'get'`.
- Parse JSON once at the top of the function and return an empty list when an error dict is detected, allowing the chat to continue gracefully.
- Also reuses the parsed JSON result across all tool branches, eliminating redundant `json.loads` calls.

Fixes #21070

## Test plan
- [ ] Configure web search with a search engine, then trigger a search while the API is unavailable/times out. Verify the chat continues without crashing.
- [ ] Verify normal web search still produces citations correctly.
- [ ] Verify `view_knowledge_file` and `query_knowledge_files` citations still work correctly.

