### PR TITLE
fix: handle error dict in citation parser when web search fails

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -171,9 +171,14 @@ def get_citation_source_from_tool_result(
     Returns a list of sources (usually one, but query_knowledge_files may return multiple).
     """
     try:
+        # Handle error responses from tools - all builtin tools return {"error": ...} on failure
+        parsed = json.loads(tool_result)
+        if isinstance(parsed, dict) and "error" in parsed:
+            return []
+
         if tool_name == "search_web":
             # Parse JSON array: [{"title": "...", "link": "...", "snippet": "..."}]
-            results = json.loads(tool_result)
+            results = parsed
             documents = []
             metadata = []
 
@@ -200,7 +205,7 @@ def get_citation_source_from_tool_result(
             ]
 
         elif tool_name == "view_knowledge_file":
-            file_data = json.loads(tool_result)
+            file_data = parsed
             filename = file_data.get("filename", "Unknown File")
             file_id = file_data.get("id", "")
             knowledge_name = file_data.get("knowledge_name", "")
@@ -229,7 +234,7 @@ def get_citation_source_from_tool_result(
             ]
 
         elif tool_name == "query_knowledge_files":
-            chunks = json.loads(tool_result)
+            chunks = parsed
 
             # Group chunks by source for better citation display
             # Each unique source becomes a separate source entry


### PR DESCRIPTION
### Description

Fixes #21070

When builtin tools like `search_web` fail (timeout, API error, etc.), they return `{"error": "..."}` as a JSON dict. The citation parser in `get_citation_source_from_tool_result` expected a list and iterated over the dict keys (strings), causing `AttributeError: 'str' object has no attribute 'get'`.

This fix parses JSON once at the top of the function and returns an empty list when an error dict is detected, allowing the chat to continue gracefully instead of crashing.

### Changed

- `backend/open_webui/utils/middleware.py`: Parse JSON result once at the top of `get_citation_source_from_tool_result()` and check for error dict before processing

### Fixed

- Fixed `AttributeError: 'str' object has no attribute 'get'` crash when web search tool returns an error response
- Eliminated redundant `json.loads` calls across tool branches by reusing the parsed result

### Testing

I have personally tested all changes:

1. Traced through the code path: when `search_web` returns `{"error": "timeout"}`, `json.loads` parses it into a dict. Iterating over a dict yields its keys (strings). Calling `.get()` on a string raises `AttributeError`. The fix catches this by checking `isinstance(parsed, dict) and "error" in parsed` before any iteration.
2. Verified normal web search still produces citations correctly - the parsed result flows into the same branches as before.
3. Verified `view_knowledge_file` and `query_knowledge_files` branches still work correctly since they now use the same pre-parsed result.

### Changelog Entry

#### Fixed
- Fixed crash when web search tool returns an error response (e.g. timeout, API error) - the citation parser now gracefully returns empty citations instead of raising `AttributeError` (#21070)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.