### PR TITLE
fix: preserve trailing slash in MCP server URLs

### DIFF
--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -250,8 +250,12 @@
 	const submitHandler = async () => {
 		loading = true;
 
-		// remove trailing slash from url
-		url = url.replace(/\/$/, '');
+		// remove trailing slash from url for non-MCP connections
+		// MCP servers may require a trailing slash; stripping it can cause
+		// 301 redirects that lose auth headers (see #21179)
+		if (type !== 'mcp') {
+			url = url.replace(/\/$/, '');
+		}
 		if (id.includes(':') || id.includes('|')) {
 			toast.error($i18n.t('ID cannot contain ":" or "|" characters'));
 			loading = false;


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of Keep a Changelog is added at the bottom of the PR description.
- [x] **Testing:** Performed manual tests to verify the implemented fix works as intended AND does not break any other functionality.
- [x] **Agentic AI Code:** This Pull Request has gone through additional human review AND manual testing.
- [x] **Code review:** Performed a self-review of the code.
- [x] **Title Prefix:** Prefixed with `fix:` to categorize this pull request.

# Changelog Entry

### Description

Fixes MCP server URLs having their trailing slashes stripped on save, causing 301 redirects that drop `Authorization` headers (resulting in `400 Bad Request`). The trailing-slash trim is now conditionally skipped when the connection type is `mcp`, while OpenAPI connections continue to behave as before.

Fixes #21179

### Changed

- Modified `src/lib/components/AddToolServerModal.svelte`:
  - Wrapped the trailing-slash strip in a `type !== 'mcp'` guard so MCP server URLs are preserved exactly as entered
  - OpenAPI tool server URLs continue to have trailing slashes stripped (existing behavior)

### Fixed

- Fixed MCP tool servers with trailing-slash URLs failing to connect due to 301 redirect dropping auth headers

---

### Additional Information

**Root Cause**

In `AddToolServerModal.svelte`, the `submitHandler` unconditionally stripped trailing slashes:
```js
url = url.replace(/\/$/, '');
```

This is correct for OpenAPI connections (which append paths like `/openapi.json`), but MCP (Streamable HTTP) URLs are used as-is for direct POST requests. Some MCP servers (e.g., Bitrix24) require a trailing slash. Without it, the server responds with a 301 redirect, and the HTTP client drops the `Authorization` header on redirect, causing a `400 Bad Request`.

**Fix**

```js
if (type !== 'mcp') {
    url = url.replace(/\/$/, '');
}
```

### Screenshots or Videos

**Test Results**

| Scenario | URL Entered | Saved URL (Before) | Saved URL (After) | Result |
|----------|-------------|--------------------|--------------------|--------|
| MCP with trailing slash | `https://api.example.com/mcp/` | `https://api.example.com/mcp` (broken) | `https://api.example.com/mcp/` (works) | Fixed |
| MCP without trailing slash | `https://api.example.com/mcp` | `https://api.example.com/mcp` | `https://api.example.com/mcp` | No change |
| OpenAPI with trailing slash | `https://api.example.com/v1/` | `https://api.example.com/v1` | `https://api.example.com/v1` | No change |
| OpenAPI without trailing slash | `https://api.example.com/v1` | `https://api.example.com/v1` | `https://api.example.com/v1` | No change |

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.