### PR TITLE
fix: validate and normalize model tags to prevent UI crash

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -9,7 +9,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, Users, UserResponse
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from sqlalchemy import String, cast, or_, and_, func
 from sqlalchemy.dialects import postgresql, sqlite
@@ -48,7 +48,20 @@ class ModelMeta(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    pass
+    @model_validator(mode="before")
+    @classmethod
+    def validate_tags(cls, data):
+        if isinstance(data, dict) and "tags" in data:
+            tags = data["tags"]
+            if isinstance(tags, list):
+                normalized = []
+                for tag in tags:
+                    if isinstance(tag, str):
+                        normalized.append({"name": tag})
+                    elif isinstance(tag, dict) and "name" in tag:
+                        normalized.append(tag)
+                data["tags"] = normalized
+        return data
 
 
 class Model(Base):

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -138,10 +138,16 @@ async def get_model_tags(
         if model.meta:
             meta = model.meta.model_dump()
             for tag in meta.get("tags", []):
-                tags_set.add((tag.get("name")))
+                if isinstance(tag, dict):
+                    tag_name = tag.get("name")
+                elif isinstance(tag, str):
+                    tag_name = tag
+                else:
+                    continue
+                if tag_name:
+                    tags_set.add(tag_name)
 
-    tags = [tag for tag in tags_set]
-    tags.sort()
+    tags = sorted(tags_set)
     return tags
 
 


### PR DESCRIPTION
## Summary
- Fixes model tags validation so the `/api/models` endpoint and `/api/v1/models/tags` don't crash when tags are stored as plain strings (e.g., `["tag1", "tag2"]`) instead of the expected `[{"name": "tag1"}]` format
- Adds a Pydantic `model_validator` to `ModelMeta` that normalizes string tags to dict format on input
- Adds defensive type checking in `get_model_tags` to handle both formats gracefully

## Root Cause
Direct API calls to `/api/v1/models/model/update` can save tags in any format since there's no backend validation. When incorrectly formatted tags (plain strings) are stored, the `get_model_tags` endpoint crashes with `AttributeError: 'str' object has no attribute 'get'` because `tag.get('name')` fails on string objects. This causes a 500 error on the models list API, leaving the UI stuck in an infinite loading state.

## Test Results

```python
# Test 1: String tags get normalized to dict format
meta = ModelMeta(tags=['tag1', 'tag2'])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 2: Dict tags pass through unchanged
meta = ModelMeta(tags=[{'name': 'tag1'}, {'name': 'tag2'}])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 3: No tags - no crash
meta = ModelMeta()
assert 'tags' not in meta.model_dump()  # PASS

# Test 4: Mixed/invalid tags - invalid entries skipped, strings normalized
meta = ModelMeta(tags=['tag1', {'name': 'tag2'}, 123])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 5: get_model_tags handles both formats without crash
tags_set = set()
for tag in [{'name': 'a'}, 'b', 42]:
    if isinstance(tag, dict):
        tag_name = tag.get('name')
    elif isinstance(tag, str):
        tag_name = tag
    else:
        continue
    if tag_name:
        tags_set.add(tag_name)
assert sorted(tags_set) == ['a', 'b']  # PASS
```

**Before fix:** API call with string tags causes 500 Internal Server Error, UI shows infinite loading.
**After fix:** String tags are auto-normalized to the correct format. Existing data with string tags is handled gracefully.

Fixes #20819