### PR TITLE
fix: use keyword arg for IndicesClient.refresh() (opensearch-py 3.x)

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
## Summary
- Fixes `TypeError: IndicesClient.refresh() takes 1 positional argument but 2 positional arguments` when using OpenSearch as vector database backend
- Changes the index name from positional to keyword argument in all three `refresh()` calls

## Root Cause
The project pins `opensearch-py==3.1.0` in `requirements.txt`. In opensearch-py >= 3.0.0, `IndicesClient.refresh()` changed its API signature: the `index` parameter became keyword-only. The existing code passes it as a positional argument, causing a `TypeError` on every document upload, upsert, or delete operation.

## Changes
```diff
- self.client.indices.refresh(self._get_index_name(collection_name))
+ self.client.indices.refresh(index=self._get_index_name(collection_name))
```

Applied to all 3 `refresh()` calls in:
- `insert()` method (after bulk indexing)
- `upsert()` method (after bulk upsert)
- `delete()` method (after bulk delete / delete_by_query)

## Test Results

**Before fix:**
```
open-webui | ERROR | open_webui.routers.retrieval:process_file:1792 - IndicesClient.refresh() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```
Document upload to knowledge bases fails completely.

**After fix:**
```python
# Verified the API signature in opensearch-py 3.1.0
from opensearchpy import OpenSearch
import inspect
sig = inspect.signature(OpenSearch().indices.refresh)
# refresh(*, index=None, ...) -- index is keyword-only
```
All other client calls in the file (`create`, `delete`, `exists`, `search`, `get`, `delete_by_query`) already use keyword arguments correctly. Only `refresh()` was missed.

Fixes #20649