### PR TITLE
fix: allow trusted header auth to auto-register new users

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -580,11 +580,12 @@ async def signin(
                 pass
 
         if not Users.get_user_by_email(email.lower(), db=db):
-            await signup(
+            await _signup(
                 request,
                 response,
                 SignupForm(email=email, password=str(uuid.uuid4()), name=name),
                 db=db,
+                bypass_signup_restriction=True,
             )
 
         user = Auths.authenticate_user_by_email(email, db=db)
@@ -611,7 +612,7 @@ async def signin(
             if Users.has_users(db=db):
                 raise HTTPException(400, detail=ERROR_MESSAGES.EXISTING_USERS)
 
-            await signup(
+            await _signup(
                 request,
                 response,
                 SignupForm(email=admin_email, password=admin_password, name="User"),
@@ -704,22 +705,33 @@ async def signup(
     form_data: SignupForm,
     db: Session = Depends(get_session),
 ):
+    return await _signup(request, response, form_data, db=db)
+
+
+async def _signup(
+    request: Request,
+    response: Response,
+    form_data: SignupForm,
+    db: Session = None,
+    bypass_signup_restriction: bool = False,
+):
     has_users = Users.has_users(db=db)
 
-    if WEBUI_AUTH:
-        if (
-            not request.app.state.config.ENABLE_SIGNUP
-            or not request.app.state.config.ENABLE_LOGIN_FORM
-        ):
-            if has_users or not ENABLE_INITIAL_ADMIN_SIGNUP:
+    if not bypass_signup_restriction:
+        if WEBUI_AUTH:
+            if (
+                not request.app.state.config.ENABLE_SIGNUP
+                or not request.app.state.config.ENABLE_LOGIN_FORM
+            ):
+                if has_users or not ENABLE_INITIAL_ADMIN_SIGNUP:
+                    raise HTTPException(
+                        status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED
+                    )
+        else:
+            if has_users:
                 raise HTTPException(
                     status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED
                 )
-    else:
-        if has_users:
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED
-            )
 
     if not validate_email_format(form_data.email.lower()):
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Fixes Trusted Header Authentication (`WEBUI_AUTH_TRUSTED_EMAIL_HEADER`) not auto-registering new users after the first admin account is created
- Extracts signup logic into an internal `_signup()` function with a `bypass_signup_restriction` parameter
- The trusted header flow passes `bypass_signup_restriction=True` to skip signup restrictions
- The `/signup` API endpoint remains unchanged -- the bypass parameter is NOT exposed to external callers

## Root Cause
When using Trusted Header Auth, the typical configuration is:
```
WEBUI_AUTH=True
ENABLE_SIGNUP=False        # Don't want public signup form
ENABLE_LOGIN_FORM=False    # Don't need login form with trusted headers
```

The `signin` handler correctly detects new users from the trusted header and calls `signup()` to auto-register them. However, `signup()` checks `ENABLE_SIGNUP` and `ENABLE_LOGIN_FORM` and raises 403 when either is False AND users already exist. This means:
- First user (admin): works, because `has_users` is False
- Second user onwards: fails with 403, because `has_users` is True and signup restrictions apply

## Test Results

**Scenario: Trusted header auth with ENABLE_SIGNUP=False, ENABLE_LOGIN_FORM=False**

| Step | Before Fix | After Fix |
|------|-----------|-----------|
| 1. Request with `X-User-Email: admin@example.com` | User created as admin | User created as admin |
| 2. Request with `X-User-Email: newuser@example.com` | **403 Access Prohibited** | User created with `DEFAULT_USER_ROLE` |
| 3. Direct POST to `/api/v1/auths/signup` with signup disabled | 403 Access Prohibited | 403 Access Prohibited (unchanged) |

**Code flow verification:**
```python
# signin() handler - trusted header flow
if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
    email = request.headers[WEBUI_AUTH_TRUSTED_EMAIL_HEADER].lower()
    if not Users.get_user_by_email(email.lower(), db=db):
        await _signup(..., bypass_signup_restriction=True)  # Bypasses check
    user = Auths.authenticate_user_by_email(email, db=db)

# /signup API endpoint - no bypass possible
@router.post('/signup')
async def signup(request, response, form_data, db):
    return await _signup(request, response, form_data, db=db)  # bypass=False (default)
```

The bypass parameter is only accessible through the internal `_signup()` function, not through the HTTP API.

Fixes #21016