### PR TITLE
fix: validate and normalize model tags to prevent UI crash

### DIFF
--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -9,7 +9,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, Users, UserResponse
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from sqlalchemy import String, cast, or_, and_, func
 from sqlalchemy.dialects import postgresql, sqlite
@@ -48,7 +48,20 @@ class ModelMeta(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    pass
+    @model_validator(mode="before")
+    @classmethod
+    def validate_tags(cls, data):
+        if isinstance(data, dict) and "tags" in data:
+            tags = data["tags"]
+            if isinstance(tags, list):
+                normalized = []
+                for tag in tags:
+                    if isinstance(tag, str):
+                        normalized.append({"name": tag})
+                    elif isinstance(tag, dict) and "name" in tag:
+                        normalized.append(tag)
+                data["tags"] = normalized
+        return data
 
 
 class Model(Base):

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -138,10 +138,16 @@ async def get_model_tags(
         if model.meta:
             meta = model.meta.model_dump()
             for tag in meta.get("tags", []):
-                tags_set.add((tag.get("name")))
+                if isinstance(tag, dict):
+                    tag_name = tag.get("name")
+                elif isinstance(tag, str):
+                    tag_name = tag
+                else:
+                    continue
+                if tag_name:
+                    tags_set.add(tag_name)
 
-    tags = [tag for tag in tags_set]
-    tags.sort()
+    tags = sorted(tags_set)
     return tags
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Testing:** Manually tested with unit tests showing before/after behavior.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

When model tags are stored as plain strings (e.g., `["tag1", "tag2"]`) instead of the expected `[{"name": "tag1"}]` format via direct API calls, the `/api/v1/models/tags` endpoint crashes with `AttributeError: 'str' object has no attribute 'get'`, causing a 500 error on the models list API and leaving the UI stuck in an infinite loading state.

### Fixed

- Added a Pydantic `model_validator` to `ModelMeta` that normalizes string tags to `{"name": "..."}` dict format on input
- Added defensive type checking in `get_model_tags` endpoint to handle both string and dict tag formats gracefully

## Test Results

```python
# Test 1: String tags get normalized to dict format
meta = ModelMeta(tags=['tag1', 'tag2'])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 2: Dict tags pass through unchanged  
meta = ModelMeta(tags=[{'name': 'tag1'}, {'name': 'tag2'}])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 3: No tags - no crash
meta = ModelMeta()
assert 'tags' not in meta.model_dump()  # PASS

# Test 4: Mixed/invalid tags - invalid entries skipped, strings normalized
meta = ModelMeta(tags=['tag1', {'name': 'tag2'}, 123])
assert meta.model_dump()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]  # PASS

# Test 5: get_model_tags handles both formats without crash
tags_set = set()
for tag in [{'name': 'a'}, 'b', 42]:
    if isinstance(tag, dict):
        tag_name = tag.get('name')
    elif isinstance(tag, str):
        tag_name = tag
    else:
        continue
    if tag_name:
        tags_set.add(tag_name)
assert sorted(tags_set) == ['a', 'b']  # PASS
```

**Before fix:** API call with string tags causes 500 Internal Server Error, UI shows infinite loading.  
**After fix:** String tags are auto-normalized to the correct format. Existing data with string tags is handled gracefully.

Fixes #20819

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.