### PR TITLE
fix: use keyword arg for IndicesClient.refresh() (opensearch-py 3.x)

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Testing:** Verified the API signature change in opensearch-py 3.x documentation and source code.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

In `opensearch-py >= 3.0.0` (pinned at `3.1.0` in `requirements.txt`), `IndicesClient.refresh()` changed its API signature: the `index` parameter became keyword-only. The existing code passes it as a positional argument, causing `TypeError: IndicesClient.refresh() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given` on every document upload, upsert, or delete operation with the OpenSearch vector database backend.

### Fixed

- Changed `self.client.indices.refresh(self._get_index_name(collection_name))` to `self.client.indices.refresh(index=self._get_index_name(collection_name))` in all three calls:
  - `insert()` method (after bulk indexing)
  - `upsert()` method (after bulk upsert)
  - `delete()` method (after bulk delete / delete_by_query)

## Test Results

**Before fix:**
```
open-webui | ERROR | open_webui.routers.retrieval:process_file:1792 - IndicesClient.refresh() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```
Document upload to knowledge bases with OpenSearch backend fails completely.

**After fix:**
```python
# Verified the API signature in opensearch-py 3.1.0
from opensearchpy import OpenSearch
import inspect
sig = inspect.signature(OpenSearch().indices.refresh)
# refresh(*, index=None, ...) -- index is keyword-only
```

All other client calls in the file (`create`, `delete`, `exists`, `search`, `get`, `delete_by_query`) already use keyword arguments correctly. Only `refresh()` was missed.

Fixes #20649

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.