### PR TITLE
Fix opensearch-py 3.0+ compatibility in refresh() calls

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
## Summary
- Fixes TypeError when using opensearch-py >= 3.0.0
- Updates refresh() calls to use keyword argument syntax
- Restores ability to upload files to knowledge base with OpenSearch backend

## Problem
The `IndicesClient.refresh()` method signature changed in opensearch-py 3.0.0 to accept only keyword-only arguments. The code was calling `refresh()` with a positional argument, causing:

```
TypeError: IndicesClient.refresh() takes 1 positional argument but 2 
positional arguments (and 2 keyword-only arguments) were given
```

This prevented document uploads to knowledge base when using OpenSearch as the vector database backend. The error occurred in `save_docs_to_vector_db()` when `VECTOR_DB_CLIENT.insert()` was called.

## Solution
Changed all three `refresh()` calls in `opensearch.py` to use keyword argument syntax:

**Before:**
```python
self.client.indices.refresh(self._get_index_name(collection_name))
```

**After:**
```python
self.client.indices.refresh(index=self._get_index_name(collection_name))
```

Changes made in:
1. `insert()` method (line 214)
2. `upsert()` method (line 237)
3. `delete()` method (line 266)

## Manual Testing
### Test Setup
- Open WebUI v0.7.2 (Docker)
- OpenSearch cluster running (version 2.x)
- Python opensearch-py library version 3.0.0+ installed
- Created test knowledge base

### Before Fix
1. Created a new knowledge base via Web UI
2. Attempted to upload a PDF document
3. Result: Upload failed with TypeError
```
ERROR | open_webui.routers.retrieval:process_file:1792 - IndicesClient.refresh() takes 1 
positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```
4. Document was not added to knowledge base
5. File upload process reported failure

### After Fix
1. Created a new knowledge base via Web UI
2. Uploaded PDF document
3. Result: Upload successful, no errors
4. Document indexed correctly in OpenSearch
5. Verified knowledge base search returns correct results
6. Tested upsert operation: existing documents updated successfully
7. Tested delete operation: documents removed correctly
8. Checked OpenSearch logs: refresh operations completed without errors

### Compatibility Testing
- Verified fix works with opensearch-py 3.0.0+
- Confirmed backward compatibility with opensearch-py < 3.0 (keyword args supported in older versions)
- Tested with multiple document types: PDF, TXT, DOCX
- Tested batch operations with multiple files
- All insert/upsert/delete operations working correctly

### OpenSearch Verification
- Checked indices were created properly
- Confirmed documents were indexed with correct metadata
- Verified vector embeddings stored correctly
- Search functionality working as expected

## Root Cause
In opensearch-py >= 3.0.0, the API changed to require keyword-only arguments for better clarity and to prevent positional argument errors. The old positional syntax:
```python
client.indices.refresh(index_name)
```

Must now be:
```python
client.indices.refresh(index=index_name)
```

This is part of opensearch-py's effort to align with modern Python best practices and improve API consistency.

Fixes #20649

Generated with [Claude Code](https://claude.com/claude-code)