### PR TITLE
fix: Fix opensearch-py 3.0+ compatibility in refresh() calls

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixes TypeError when using opensearch-py >= 3.0.0 with OpenSearch vector database backend
- Updates IndicesClient.refresh() calls to use keyword argument syntax required by opensearch-py 3.0+
- Restores ability to upload files to knowledge base when using OpenSearch

### Fixed

- Fixed TypeError "IndicesClient.refresh() takes 1 positional argument but 2 positional arguments were given" when uploading documents to knowledge base with OpenSearch backend
- Changed three instances of `refresh(index_name)` to `refresh(index=index_name)` in opensearch.py (insert, upsert, and delete methods)

### Breaking Changes

- None - maintains backward compatibility with opensearch-py < 3.0

---

### Additional Information

**Problem:**
The `IndicesClient.refresh()` method signature changed in opensearch-py 3.0.0 to accept only keyword-only arguments. The code was calling `refresh()` with a positional argument, causing:

```
TypeError: IndicesClient.refresh() takes 1 positional argument but 2 
positional arguments (and 2 keyword-only arguments) were given
```

This prevented document uploads to knowledge base when using OpenSearch as the vector database backend.

**Solution:**
Changed all three `refresh()` calls in `opensearch.py` to use keyword argument syntax:

**Before:**
```python
self.client.indices.refresh(self._get_index_name(collection_name))
```

**After:**
```python
self.client.indices.refresh(index=self._get_index_name(collection_name))
```

Changes made in:
1. `insert()` method (line 214)
2. `upsert()` method (line 237)
3. `delete()` method (line 266)

**Related:**
- Fixes #20649
- Resubmission of #21245 with correct target branch (dev instead of main)

### Screenshots or Videos

**Manual Testing Performed:**

**Test Setup:**
- Open WebUI v0.7.2 (Docker)
- OpenSearch cluster running (version 2.x)
- Python opensearch-py library version 3.0.0+ installed
- Created test knowledge base

**Before Fix:**
1. Created a new knowledge base via Web UI
2. Attempted to upload a PDF document
3. Result: Upload failed with TypeError
```
ERROR | open_webui.routers.retrieval:process_file:1792 - IndicesClient.refresh() takes 1 
positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```
4. Document was not added to knowledge base
5. File upload process reported failure

**After Fix:**
1. Created a new knowledge base via Web UI
2. Uploaded PDF document
3. Result: Upload successful, no errors
4. Document indexed correctly in OpenSearch
5. Verified knowledge base search returns correct results
6. Tested upsert operation: existing documents updated successfully
7. Tested delete operation: documents removed correctly
8. Checked OpenSearch logs: refresh operations completed without errors

**Compatibility Testing:**
- Verified fix works with opensearch-py 3.0.0+
- Confirmed backward compatibility with opensearch-py < 3.0 (keyword args supported in older versions)
- Tested with multiple document types: PDF, TXT, DOCX
- Tested batch operations with multiple files
- All insert/upsert/delete operations working correctly

**OpenSearch Verification:**
- Checked indices were created properly
- Confirmed documents were indexed with correct metadata
- Verified vector embeddings stored correctly
- Search functionality working as expected

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.