### PR TITLE
fix: use keyword arg for IndicesClient.refresh() (opensearch-py 3.x)

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -211,7 +211,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def upsert(self, collection_name: str, items: list[VectorItem]):
         self._create_index_if_not_exists(
@@ -234,7 +234,7 @@ class OpenSearchClient(VectorDBBase):
                 for item in batch
             ]
             bulk(self.client, actions)
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def delete(
         self,
@@ -263,7 +263,7 @@ class OpenSearchClient(VectorDBBase):
             self.client.delete_by_query(
                 index=self._get_index_name(collection_name), body=query_body
             )
-        self.client.indices.refresh(self._get_index_name(collection_name))
+        self.client.indices.refresh(index=self._get_index_name(collection_name))
 
     def reset(self):
         indices = self.client.indices.get(index=f"{self.index_prefix}_*")


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of Keep a Changelog is added at the bottom of the PR description.
- [x] **Testing:** Performed manual tests to verify the implemented fix works as intended.
- [x] **Agentic AI Code:** This Pull Request has gone through additional human review AND manual testing.
- [x] **Code review:** Performed a self-review of the code.
- [x] **Title Prefix:** Prefixed with `fix:` to categorize this pull request.

# Changelog Entry

### Description

Fixes `TypeError: IndicesClient.refresh() takes 1 positional argument but 2 positional arguments` when using OpenSearch as vector database backend with `opensearch-py >= 3.0.0`. Changes the index name from positional to keyword argument in all three `refresh()` calls.

Supersedes #21236 (closed due to missing CLA and wrong target branch).
Fixes #20649

### Changed

- Modified `backend/open_webui/retrieval/vector/dbs/opensearch.py`:
  - Changed `self.client.indices.refresh(self._get_index_name(collection_name))` to use keyword argument: `self.client.indices.refresh(index=self._get_index_name(collection_name))`
  - Applied to all 3 `refresh()` calls in `insert()`, `upsert()`, and `delete()` methods

### Fixed

- Fixed `TypeError` crash when adding documents to knowledge base with OpenSearch backend and `opensearch-py >= 3.0.0`

---

### Additional Information

**Root Cause**

The project pins `opensearch-py==3.1.0` in `requirements.txt`. In opensearch-py >= 3.0.0, `IndicesClient.refresh()` changed its API signature: the `index` parameter became keyword-only. The existing code passes it as a positional argument, causing a `TypeError` on every document upload, upsert, or delete operation.

All other client calls in the file (`create`, `delete`, `exists`, `search`, `get`, `delete_by_query`) already use keyword arguments correctly. Only `refresh()` was missed.

**Backward Compatibility**

Using `index=` keyword arg is backward-compatible with `opensearch-py < 3.0.0`, so this change is safe for all versions.

### Screenshots or Videos

**Before fix:**
```
open-webui | ERROR | open_webui.routers.retrieval:process_file:1792 - IndicesClient.refresh() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```
Document upload to knowledge bases fails completely.

**After fix:**
```python
# Verified the API signature in opensearch-py 3.1.0
from opensearchpy import OpenSearch
import inspect
sig = inspect.signature(OpenSearch().indices.refresh)
# refresh(*, index=None, ...) -- index is keyword-only
```

**Testing verification:**
- ✅ Document upload to knowledge base with OpenSearch backend works without TypeError
- ✅ Upsert operations complete successfully
- ✅ Delete operations complete successfully
- ✅ All refresh() calls now use keyword arguments

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.