### PR TITLE
fix: correct typo 'seperate' to 'separate'

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -655,7 +655,7 @@
 					continue;
 				}
 
-				// Not sure why you have to call webkitGetAsEntry and isDirectory seperate, but it won't work if you try item.webkitGetAsEntry().isDirectory
+				// Not sure why you have to call webkitGetAsEntry and isDirectory separate, but it won't work if you try item.webkitGetAsEntry().isDirectory
 				const wkentry = item.webkitGetAsEntry();
 				const isDirectory = wkentry.isDirectory;
 				if (isDirectory) {


### PR DESCRIPTION
Fixed a typo in KnowledgeBase.svelte:
- Changed 'seperate' to 'separate' in a comment