### PR TITLE
enh.: Allow to disable icon inversion

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1397,7 +1397,7 @@
 													<div class="size-4">
 														<img
 															src={action.icon}
-															class="w-4 h-4 {action.icon.includes('svg')
+															class="w-4 h-4 {action.iconDarkInvert ?? action.icon?.startsWith('data:image/svg')
 																? 'dark:invert-[80%]'
 																: ''}"
 															style="fill: currentColor;"

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1397,7 +1397,9 @@
 													<div class="size-4">
 														<img
 															src={action.icon}
-															class="w-4 h-4 {action.meta?.manifest?.icon_dark_invert === 'true' || action.icon?.startsWith('data:image/svg')
+															class="w-4 h-4 {(action.meta?.manifest?.icon_dark_invert !== undefined
+															    ? action.meta.manifest.icon_dark_invert === 'true'
+															    : action.icon?.startsWith('data:image/svg'))
 																? 'dark:invert-[80%]'
 																: ''}"
 															style="fill: currentColor;"

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1397,7 +1397,7 @@
 													<div class="size-4">
 														<img
 															src={action.icon}
-															class="w-4 h-4 {action.iconDarkInvert ?? action.icon?.startsWith('data:image/svg')
+															class="w-4 h-4 {action.meta?.manifest?.icon_dark_invert === 'true' ?? action.icon?.startsWith('data:image/svg')
 																? 'dark:invert-[80%]'
 																: ''}"
 															style="fill: currentColor;"

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1397,7 +1397,7 @@
 													<div class="size-4">
 														<img
 															src={action.icon}
-															class="w-4 h-4 {action.meta?.manifest?.icon_dark_invert === 'true' ?? action.icon?.startsWith('data:image/svg')
+															class="w-4 h-4 {action.meta?.manifest?.icon_dark_invert === 'true' || action.icon?.startsWith('data:image/svg')
 																? 'dark:invert-[80%]'
 																: ''}"
 															style="fill: currentColor;"


### PR DESCRIPTION
### Problem
Icons were being inverted in dark mode based on whether the string `svg` 
appeared *anywhere* in the icon URL. This caused PNG icons to randomly 
get inverted if their base64 encoding happened to contain "svg" by coincidence.

### Solution
- Added configurable `icon_dark_invert` frontmatter property for actions
- Changed logic to:
  1. Use explicit `icon_dark_invert: true/false` if defined in docstring
  2. Fall back to checking actual MIME type (`startsWith('data:image/svg')`) 
     instead of `.includes('svg')`

### Usage
```python
"""
title: Export to PDF
icon_url: data:image/png;base64,...
icon_dark_invert: false
"""
```
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
