### PR TITLE
feat: Enable Rich UI embed support for action functions

### DIFF
--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -448,6 +448,30 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
             else:
                 data = action(**params)
 
+            # Process action result for Rich UI embeds (HTMLResponse, tuple with headers)
+            # Deferred import to avoid circular dependency (middleware imports chat)
+            from open_webui.utils.middleware import process_tool_result
+
+            processed_result, _, action_embeds = process_tool_result(
+                request,
+                action_id,
+                data,
+                "action",
+            )
+
+            if action_embeds:
+                await __event_emitter__(
+                    {
+                        "type": "embeds",
+                        "data": {
+                            "embeds": action_embeds,
+                        },
+                    }
+                )
+                # Replace data with the processed status dict so we don't
+                # try to serialize the raw HTMLResponse / tuple back to the client
+                data = processed_result
+
         except Exception as e:
             raise Exception(f"Error: {e}")
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -860,7 +860,7 @@ def process_tool_result(
         else:
             tool_result = tool_result.body.decode("utf-8", "replace")
 
-    elif (tool_type == "external" and isinstance(tool_result, tuple)) or (
+    elif (tool_type in ("external", "action") and isinstance(tool_result, tuple)) or (
         direct_tool and isinstance(tool_result, list) and len(tool_result) == 2
     ):
         tool_result, tool_response_headers = tool_result


### PR DESCRIPTION
Action functions can now return HTMLResponse objects or (html, headers) tuples with Content-Disposition: inline to render rich UI iframes in chat, matching the existing tool behavior.

# Why?

<ins>**Actions and Tools are extremely similar - the only difference is who activates them**</ins>

Tools get activated by LLMs
Actions get activated by Humans

Otherwise they behave the same. They get called on-demand and do something

So they should have the same capabilities and abilities for developers.

If you want to display beautiful graphs and charts with Actions, you have to inject a codeblock with the HTML content into the assistant's message by modifying the body - and even then it is only shown as an Artifact and not as a rich UI embed like the tools have available.


---

How action authors can now use Rich UI
Option A — HTMLResponse:

```
from fastapi.responses import HTMLResponse

async def action(self, body, __event_emitter__=None):
    html = "<html><body><h1>Dashboard</h1></body></html>"
    return HTMLResponse(content=html, headers={"Content-Disposition": "inline"})
```

Option B — Tuple with headers:

```
async def action(self, body, __event_emitter__=None):
    html = "<h1>Interactive Chart</h1><script>...</script>"
    return (html, {"Content-Disposition": "inline", "Content-Type": "text/html"})
```

No frontend changes were needed — the socket handler at Chat.svelte:416 already receives "embeds" events generically and renders them via FullHeightIframe.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
