### PR TITLE
fix: correct MCP OAuth authorization server metadata discovery URL

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -224,7 +224,7 @@ async def verify_tool_servers_config(
     try:
         if form_data.type == "mcp":
             if form_data.auth_type == "oauth_2.1":
-                discovery_urls = get_discovery_urls(form_data.url)
+                discovery_urls = await get_discovery_urls(form_data.url)
                 for discovery_url in discovery_urls:
                     log.debug(
                         f"Trying to fetch OAuth 2.1 discovery document from {discovery_url}"


### PR DESCRIPTION
## Summary

- Fix authorization server metadata URL construction in `get_authorization_server_discovery_urls()` to comply with RFC 8414 §3 — the `/.well-known/` segment is now inserted between the host and the path instead of appended to the end of the issuer URL
- Fix missing `await` on async `get_discovery_urls()` call in the verify endpoint, which caused a `TypeError` when iterating over the unawaited coroutine

## Test plan

- [ ] Verify that an MCP server with an authorization server like `https://foo.com/oauth` produces discovery URL `https://foo.com/.well-known/oauth-authorization-server/oauth` (not `https://foo.com/oauth/.well-known/oauth-authorization-server`)
- [ ] Verify that an MCP server with a pathless authorization server like `https://example.com` still produces `https://example.com/.well-known/oauth-authorization-server`
- [ ] Verify the OAuth 2.1 verification endpoint (`/tool_servers/verify`) completes without `TypeError`

contributor license agreement