### PR TITLE
fix: remove API headers when downloading generated images from URLs

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -641,7 +641,7 @@ async def image_generations(
 
             for image in res["data"]:
                 if image_url := image.get("url", None):
-                    image_data, content_type = get_image_data(image_url, headers)
+                    image_data, content_type = get_image_data(image_url)
                 else:
                     image_data, content_type = get_image_data(image["b64_json"])
 
@@ -989,7 +989,7 @@ async def image_edits(
             images = []
             for image in res["data"]:
                 if image_url := image.get("url", None):
-                    image_data, content_type = get_image_data(image_url, headers)
+                    image_data, content_type = get_image_data(image_url)
                 else:
                     image_data, content_type = get_image_data(image["b64_json"])
 


### PR DESCRIPTION
## Summary

When the OpenAI-compatible image generation API returns a URL (instead of base64 data), the code was reusing the same API request headers—including `Content-Type: application/json` and `Authorization: Bearer ...`—to download the image from the returned URL.

Since these image URLs typically point to a different server (e.g., cloud storage with pre-signed URLs like Aliyun OSS), sending these inappropriate headers causes **403 Forbidden** errors.

## Changes

Remove the `headers` parameter from `get_image_data()` calls in both `image_generations()` and `image_edits()` for the OpenAI engine path. The returned image URLs are self-contained (pre-signed) and don't need API authentication headers.

**Note:** ComfyUI engine paths are intentionally left unchanged, as they download images from the same ComfyUI server and correctly construct their own minimal headers.

## Root Cause

In `image_generations()` (line 644) and `image_edits()` (line 992), the `headers` dict containing:
```python
{
    "Authorization": "Bearer <API_KEY>",
    "Content-Type": "application/json"
}
```
was passed directly to `get_image_data()`, which uses it for a GET request to the image URL. The `Content-Type: application/json` header is wrong for a GET image download, and the `Authorization` header is rejected by external image hosting servers.

Fixes #21301