### PR TITLE
fix: preserve trailing slash in MCP server URLs

### DIFF
--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -250,8 +250,10 @@
 	const submitHandler = async () => {
 		loading = true;
 
-		// remove trailing slash from url
-		url = url.replace(/\/$/, '');
+		// remove trailing slash from url (except for MCP servers where it may be significant)
+		if (type !== 'mcp') {
+			url = url.replace(/\/$/, '');
+		}
 		if (id.includes(':') || id.includes('|')) {
 			toast.error($i18n.t('ID cannot contain ":" or "|" characters'));
 			loading = false;


### PR DESCRIPTION
## Summary

When configuring tool servers via the web UI, trailing slashes are stripped from all URLs—including MCP servers. For MCP servers, the trailing slash can be significant: some servers (e.g., Bitrix24) require a specific path format, and removing the slash causes a **301 redirect** that loses authentication headers, resulting in a **400 Bad Request** error.

## Changes

Only strip trailing slashes for `openapi` type tool servers (where path construction appends specific endpoints like `/openapi.json`). MCP server URLs are used as-is by the MCP client and should preserve the user's exact input.

### Before
```
https://api.example.com/mcp/  →  https://api.example.com/mcp  (slash removed)
→ 301 Moved Permanently → loses auth headers → 400 Bad Request
```

### After
```
https://api.example.com/mcp/  →  https://api.example.com/mcp/  (preserved)
→ 200 OK
```

Fixes #21179