### PR TITLE
fix: fix: prevent cascading reasoning item creation from inline think tags

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4116,6 +4116,11 @@ async def streaming_chat_response_handler(response, ctx):
                         )
 
                         if isinstance(res, StreamingResponse):
+                            # Reset content accumulator for the new streaming round.
+                            # The previous round's content (including reasoning) is
+                            # already captured in the output items; keeping it would
+                            # cause tag_output_handler to re-detect old reasoning tags.
+                            content = ""
                             await stream_body_handler(res, new_form_data)
                         else:
                             break
@@ -4300,6 +4305,8 @@ async def streaming_chat_response_handler(response, ctx):
                             )
 
                             if isinstance(res, StreamingResponse):
+                                # Reset content accumulator for the new streaming round
+                                content = ""
                                 await stream_body_handler(res, new_form_data)
                             else:
                                 break


### PR DESCRIPTION
Fix reasoning trace rendering regression in v0.8.0 where inline reasoning tags (e.g. think/thinking) caused one collapsible block per token, freezing the browser.

Root cause: tag_output_handler did not strip the start tag from the content accumulator after detection, causing it to be re-detected on every subsequent token. Additionally, tokens arriving during an active reasoning block were routed to new message items instead of being appended to the reasoning item.

Changes:
- Strip start tag from content accumulator on detection in tag_output_handler to prevent cascading re-detection
- Route streaming tokens directly to in-progress reasoning items from tag detection instead of creating intermediate message items
- Guard message text append to skip when already handled by the reasoning branch
- Add 8 unit tests for tag_output_handler covering single/multiple blocks, tag variants, split tokens, and content deduplication

Only affects providers sending reasoning as inline tags in the content delta (e.g. Google generativelanguage, Minimax, Ollama). Providers using the separate reasoning_content field (OpenAI, LiteLLM/OpenRouter) are unaffected.

Fixes #21348

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
