### PR TITLE
fix: enforce public sharing permission checks across all resource types

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -345,6 +345,24 @@ async def update_note_access_by_id(
             status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT()
         )
 
+    # Strip public sharing if user lacks permission
+    if (
+        user.role != "admin"
+        and has_public_read_access_grant(form_data.access_grants)
+        and not has_permission(
+            user.id,
+            "sharing.public_notes",
+            request.app.state.config.USER_PERMISSIONS,
+        )
+    ):
+        form_data.access_grants = [
+            g for g in form_data.access_grants
+            if not (
+                g.get("principal_type") == "user"
+                and g.get("principal_id") == "*"
+            )
+        ]
+
     AccessGrants.set_access_grants("note", id, form_data.access_grants, db=db)
 
     return Notes.get_note_by_id(id, db=db)

--- a/backend/open_webui/routers/skills.py
+++ b/backend/open_webui/routers/skills.py
@@ -17,7 +17,7 @@ from open_webui.models.skills import (
     SkillAccessListResponse,
     Skills,
 )
-from open_webui.models.access_grants import AccessGrants
+from open_webui.models.access_grants import AccessGrants, has_public_read_access_grant
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access, has_permission
 
@@ -312,6 +312,7 @@ class SkillAccessGrantsForm(BaseModel):
 
 @router.post("/id/{id}/access/update", response_model=Optional[SkillModel])
 async def update_skill_access_by_id(
+    request: Request,
     id: str,
     form_data: SkillAccessGrantsForm,
     user=Depends(get_verified_user),
@@ -339,6 +340,24 @@ async def update_skill_access_by_id(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
+
+    # Strip public sharing if user lacks permission
+    if (
+        user.role != "admin"
+        and has_public_read_access_grant(form_data.access_grants)
+        and not has_permission(
+            user.id,
+            "sharing.public_skills",
+            request.app.state.config.USER_PERMISSIONS,
+        )
+    ):
+        form_data.access_grants = [
+            g for g in form_data.access_grants
+            if not (
+                g.get("principal_type") == "user"
+                and g.get("principal_id") == "*"
+            )
+        ]
 
     AccessGrants.set_access_grants("skill", id, form_data.access_grants, db=db)
 

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -21,7 +21,7 @@ from open_webui.models.tools import (
     ToolAccessResponse,
     Tools,
 )
-from open_webui.models.access_grants import AccessGrants
+from open_webui.models.access_grants import AccessGrants, has_public_read_access_grant
 from open_webui.utils.plugin import (
     load_tool_module_by_id,
     replace_imports,
@@ -526,6 +526,7 @@ class ToolAccessGrantsForm(BaseModel):
 
 @router.post("/id/{id}/access/update", response_model=Optional[ToolModel])
 async def update_tool_access_by_id(
+    request: Request,
     id: str,
     form_data: ToolAccessGrantsForm,
     user=Depends(get_verified_user),
@@ -553,6 +554,24 @@ async def update_tool_access_by_id(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
+
+    # Strip public sharing if user lacks permission
+    if (
+        user.role != "admin"
+        and has_public_read_access_grant(form_data.access_grants)
+        and not has_permission(
+            user.id,
+            "sharing.public_tools",
+            request.app.state.config.USER_PERMISSIONS,
+        )
+    ):
+        form_data.access_grants = [
+            g for g in form_data.access_grants
+            if not (
+                g.get("principal_type") == "user"
+                and g.get("principal_id") == "*"
+            )
+        ]
 
     AccessGrants.set_access_grants("tool", id, form_data.access_grants, db=db)
 

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -837,8 +837,7 @@
 			bind:accessGrants={knowledge.access_grants}
 			share={$user?.permissions?.sharing?.knowledge || $user?.role === 'admin'}
 			sharePublic={$user?.permissions?.sharing?.public_knowledge ||
-				$user?.role === 'admin' ||
-				knowledge?.write_access}
+				$user?.role === 'admin'}
 			onChange={async () => {
 				try {
 					await updateKnowledgeAccessGrants(localStorage.token, id, knowledge.access_grants ?? []);

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -342,7 +342,7 @@
 		bind:accessGrants
 		accessRoles={preset ? ['read', 'write'] : ['read']}
 		share={$user?.permissions?.sharing?.models || $user?.role === 'admin'}
-		sharePublic={$user?.permissions?.sharing?.public_models || $user?.role === 'admin' || edit}
+		sharePublic={$user?.permissions?.sharing?.public_models || $user?.role === 'admin'}
 		onChange={async () => {
 			if (edit && model?.id) {
 				try {

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -282,7 +282,7 @@
 	bind:accessGrants
 	accessRoles={['read', 'write']}
 	share={$user?.permissions?.sharing?.prompts || $user?.role === 'admin'}
-	sharePublic={$user?.permissions?.sharing?.public_prompts || $user?.role === 'admin' || edit}
+	sharePublic={$user?.permissions?.sharing?.public_prompts || $user?.role === 'admin'}
 	onChange={async () => {
 		if (edit && prompt?.id) {
 			try {

--- a/src/lib/components/workspace/Skills/SkillEditor.svelte
+++ b/src/lib/components/workspace/Skills/SkillEditor.svelte
@@ -113,7 +113,7 @@
 	bind:accessGrants
 	accessRoles={['read', 'write']}
 	share={$user?.permissions?.sharing?.skills || $user?.role === 'admin'}
-	sharePublic={$user?.permissions?.sharing?.public_skills || $user?.role === 'admin' || edit}
+	sharePublic={$user?.permissions?.sharing?.public_skills || $user?.role === 'admin'}
 	onChange={async () => {
 		if (edit && skill?.id) {
 			try {

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -192,7 +192,7 @@ class Tools:
 	bind:accessGrants
 	accessRoles={['read', 'write']}
 	share={$user?.permissions?.sharing?.tools || $user?.role === 'admin'}
-	sharePublic={$user?.permissions?.sharing?.public_tools || $user?.role === 'admin' || edit}
+	sharePublic={$user?.permissions?.sharing?.public_tools || $user?.role === 'admin'}
 	onChange={async () => {
 		if (edit && id) {
 			try {


### PR DESCRIPTION
The sharePublic prop in editor components (Knowledge, Tools, Skills, Prompts, Models) incorrectly included an "|| edit" / "|| write_access" condition, allowing users with write access to see and use the "Public" sharing option regardless of their actual public sharing permission. Additionally, all backend access/update endpoints only verified write authorization but did not check the corresponding sharing.public_* permission, allowing direct API calls to bypass frontend restrictions entirely.

Frontend: removed the edit/write_access bypass from sharePublic in all five editor components so visibility is gated solely by the user's sharing.public_* permission or admin role.

Backend: added has_public_read_access_grant checks to the access/update endpoints in knowledge.py, tools.py, prompts.py, skills.py, models.py, and notes.py. Public grants are silently stripped when the user lacks the corresponding permission.

Fixes #21356 

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
