### PR TITLE
feat: Add admin-configurable citation format (plain text vs markdown)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1245,6 +1245,12 @@ RESPONSE_WATERMARK = PersistentConfig(
     os.environ.get("RESPONSE_WATERMARK", ""),
 )
 
+CITATION_FORMAT = PersistentConfig(
+    "CITATION_FORMAT",
+    "ui.citation_format",
+    os.environ.get("CITATION_FORMAT", "plain_text"),
+)
+
 
 USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS = (
     os.environ.get("USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS", "False").lower()

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -423,6 +423,7 @@ from open_webui.config import (
     OAUTH_PROVIDERS,
     WEBUI_URL,
     RESPONSE_WATERMARK,
+    CITATION_FORMAT,
     # Admin
     ENABLE_ADMIN_CHAT_ACCESS,
     BYPASS_ADMIN_ACCESS_CONTROL,
@@ -788,6 +789,7 @@ app.state.config.PENDING_USER_OVERLAY_CONTENT = PENDING_USER_OVERLAY_CONTENT
 app.state.config.PENDING_USER_OVERLAY_TITLE = PENDING_USER_OVERLAY_TITLE
 
 app.state.config.RESPONSE_WATERMARK = RESPONSE_WATERMARK
+app.state.config.CITATION_FORMAT = CITATION_FORMAT
 
 app.state.config.USER_PERMISSIONS = USER_PERMISSIONS
 app.state.config.WEBHOOK_URL = WEBHOOK_URL
@@ -2006,6 +2008,7 @@ async def get_app_config(request: Request):
                     "pending_user_overlay_title": app.state.config.PENDING_USER_OVERLAY_TITLE,
                     "pending_user_overlay_content": app.state.config.PENDING_USER_OVERLAY_CONTENT,
                     "response_watermark": app.state.config.RESPONSE_WATERMARK,
+                    "citation_format": app.state.config.CITATION_FORMAT,
                 },
                 "license_metadata": app.state.LICENSE_METADATA,
                 **(

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1024,6 +1024,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,
+        "CITATION_FORMAT": request.app.state.config.CITATION_FORMAT,
     }
 
 
@@ -1050,6 +1051,7 @@ class AdminConfig(BaseModel):
     PENDING_USER_OVERLAY_TITLE: Optional[str] = None
     PENDING_USER_OVERLAY_CONTENT: Optional[str] = None
     RESPONSE_WATERMARK: Optional[str] = None
+    CITATION_FORMAT: Optional[str] = "plain_text"
 
 
 @router.post("/admin/config")
@@ -1104,6 +1106,7 @@ async def update_admin_config(
     )
 
     request.app.state.config.RESPONSE_WATERMARK = form_data.RESPONSE_WATERMARK
+    request.app.state.config.CITATION_FORMAT = form_data.CITATION_FORMAT
 
     return {
         "SHOW_ADMIN_DETAILS": request.app.state.config.SHOW_ADMIN_DETAILS,
@@ -1128,6 +1131,7 @@ async def update_admin_config(
         "PENDING_USER_OVERLAY_TITLE": request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         "PENDING_USER_OVERLAY_CONTENT": request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         "RESPONSE_WATERMARK": request.app.state.config.RESPONSE_WATERMARK,
+        "CITATION_FORMAT": request.app.state.config.CITATION_FORMAT,
     }
 
 

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -775,6 +775,19 @@
 						/>
 					</div>
 
+					<div class="mb-2.5">
+						<div class=" self-center text-xs font-medium mb-2">
+							{$i18n.t('Citation Content Format')}
+						</div>
+						<select
+							class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+							bind:value={adminConfig.CITATION_FORMAT}
+						>
+							<option value="plain_text">{$i18n.t('Plain Text')}</option>
+							<option value="markdown">{$i18n.t('Markdown')}</option>
+						</select>
+					</div>
+
 					<div class="mb-2.5 w-full justify-between">
 						<div class="flex w-full justify-between">
 							<div class=" self-center text-xs font-medium">{$i18n.t('WebUI URL')}</div>

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -3,10 +3,11 @@
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
-	import { settings } from '$lib/stores';
+	import { config, settings } from '$lib/stores';
 
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import Markdown from '$lib/components/chat/Messages/Markdown.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -215,6 +216,13 @@
 									srcdoc={document.document}
 									title={$i18n.t('Content')}
 								></iframe>
+							{:else if $config?.ui?.citation_format === 'markdown'}
+								<div class="text-sm dark:text-gray-400 prose dark:prose-invert max-w-none">
+									<Markdown
+										id={`citation-${documentIdx}`}
+										content={document.document.trim().replace(/\n\n+/g, '\n\n')}
+									/>
+								</div>
 							{:else}
 								<pre class="text-sm dark:text-gray-400 whitespace-pre-line">{document.document
 										.trim()


### PR DESCRIPTION
## Summary
- Adds a **Citation Content Format** setting in Admin > Settings > General
- Admins can toggle between `plain_text` (default) and `markdown` rendering in citation modals
- When markdown is selected, citation content is rendered using the existing Markdown component with full formatting support

## Changes
- **Backend**: Added `CITATION_FORMAT` PersistentConfig in `config.py`, exposed via `/api/config` and admin settings endpoints in `auths.py`
- **Frontend**: Added dropdown in `admin/Settings/General.svelte`, updated `CitationModal.svelte` to conditionally render markdown

## Test plan
- [ ] Set citation format to "markdown" in Admin > Settings > General
- [ ] Open a chat with RAG citations and verify they render with markdown formatting
- [ ] Switch back to "plain_text" and verify citations render as before
- [ ] Verify setting persists across server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)