### PR TITLE
fix: resolve knowledge collection indentation/truncation issue by correcting flex layout

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -186,12 +186,16 @@
 						}}
 						data-selected={idx === selectedIdx}
 					>
-						<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
+						<div class="w-full text-left text-black dark:text-gray-100 flex items-center gap-1">
 							<Tooltip content={$i18n.t('Collection')} placement="top">
 								<Database className="size-4" />
 							</Tooltip>
 
-							<Tooltip content={item.description || decodeString(item?.name)} placement="top-start">
+							<Tooltip
+								content={item.description || decodeString(item?.name)}
+								placement="top-start"
+								className="flex flex-1 min-w-0"
+							>
 								<div class="line-clamp-1 flex-1 text-sm">
 									{decodeString(item?.name)}
 								</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

The "Attach Knowledge" menu items were suffering from a layout issue where long collection names (specifically "Add Web Sources to...") would refuse to shrink, causing the flex container to push the content to the right, creating the appearance of unwanted indentation/tabbing.

This PR fixes the issue by:
1. Removing `shrink-0` from the item wrapper.
2. Adding `w-full` and `text-left` to enforce proper width and alignment.
3. Ensuring the `Tooltip` component behaves as a flex container (`flex`) with `min-w-0` to allow its children (the text) to truncate (`line-clamp-1`) correctly.

### Changed

- Updated `src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte` to improve flexbox layout handling for collection items.

### Fixed

- Fixed a layout issue in the Knowledge integration menu where long collection names caused indentation artifacts due to improper flex shrinking.

---

### Additional Information

This purely CSS/layout fix ensures that the "Attach Knowledge" modal displays long collection names correctly, truncating them with an ellipsis instead of breaking the alignment.

### Screenshots or Videos

### Before

<img width="307" height="231" alt="image" src="https://github.com/user-attachments/assets/8b97593e-8cf6-48a7-ac81-fc4821212ce8" />

<img width="307" height="231" alt="image" src="https://github.com/user-attachments/assets/bf25caa1-89fd-43b6-94ef-fedd1a2cb78a" />

### After
<img width="307" height="231" alt="image" src="https://github.com/user-attachments/assets/de763db4-7155-4c19-af73-d5c229f45d05" />

<img width="307" height="231" alt="image" src="https://github.com/user-attachments/assets/6f7441db-0652-48c6-a228-50c61d3dfa6e" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
