### PR TITLE
 fix: resolve knowledge tooltip z-index issue in model edit page 

### DIFF
--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -170,15 +170,27 @@
 							>
 								<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
 									{#if item.type === 'note'}
-										<Tooltip content={$i18n.t('Note')} placement="top">
+										<Tooltip
+											content={$i18n.t('Note')}
+											placement="top"
+											tippyOptions={{ zIndex: 100000 }}
+										>
 											<PageEdit className="size-4" />
 										</Tooltip>
 									{:else if item.type === 'collection'}
-										<Tooltip content={$i18n.t('Collection')} placement="top">
+										<Tooltip
+											content={$i18n.t('Collection')}
+											placement="top"
+											tippyOptions={{ zIndex: 100000 }}
+										>
 											<Database className="size-4" />
 										</Tooltip>
 									{:else if item.type === 'file'}
-										<Tooltip content={$i18n.t('File')} placement="top">
+										<Tooltip
+											content={$i18n.t('File')}
+											placement="top"
+											tippyOptions={{ zIndex: 100000 }}
+										>
 											<DocumentPage className="size-4" />
 										</Tooltip>
 									{/if}
@@ -186,6 +198,7 @@
 									<Tooltip
 										content={item.description || decodeString(item?.name)}
 										placement="top-start"
+										tippyOptions={{ zIndex: 100000 }}
 									>
 										<div class="line-clamp-1 flex-1 text-sm text-left">
 											{decodeString(item?.name)}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

In the "Select Knowledge" dropdown on the model edit page, tooltips for knowledge items (icons and descriptions) were appearing behind the dropdown menu. This was due to the dropdown having a high z-index (`z-[10000]`) which eclipsed the default z-index of the tooltips.

This PR fixes the issue by explicitly setting the z-index of the tooltips within the `KnowledgeSelector` component to `100000` via `tippyOptions`, ensuring they render on top of the dropdown.

### Changed

- Updated `src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte` to increase the z-index of item tooltips.

### Fixed

- Fixed an issue where tooltips in the "Select Knowledge" dropdown were hidden behind the menu due to z-index stacking.

---

### Additional Information

This fix is specific to the `KnowledgeSelector` component and ensures that users can read the full names/descriptions of knowledge items even when they are truncated or when checking the item type icon.

### Screenshots or Videos

### Before

<img width="304" height="361" alt="image" src="https://github.com/user-attachments/assets/968ef9f8-1add-49f9-9246-2692885803c3" />

<img width="414" height="360" alt="image" src="https://github.com/user-attachments/assets/2d546494-85d7-4f62-802b-e35bbc087658" />

<img width="414" height="360" alt="image" src="https://github.com/user-attachments/assets/5c5c9def-5c79-4bdc-93be-e22575dd3e29" />


### After

<img width="312" height="360" alt="image" src="https://github.com/user-attachments/assets/c0450542-73b5-4bcc-a253-a4150fcb5198" />

<img width="409" height="364" alt="image" src="https://github.com/user-attachments/assets/d1d29f8d-ffa1-4b78-afb1-bbb449a93f51" />

<img width="409" height="364" alt="image" src="https://github.com/user-attachments/assets/26d5322c-37fb-4464-b6b1-ee180880c51c" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
