### PR TITLE
fix: respect WEB_SEARCH_RESULT_COUNT in native search_web tool

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -147,7 +147,6 @@ async def calculate_timestamp(
 
 async def search_web(
     query: str,
-    count: int = 5,
     __request__: Request = None,
     __user__: dict = None,
 ) -> str:
@@ -157,7 +156,6 @@ async def search_web(
     consider checking those first for internal information.
 
     :param query: The search query to look up
-    :param count: Number of results to return (default: 5)
     :return: JSON with search results containing title, link, and snippet for each result
     """
     if __request__ is None:
@@ -168,9 +166,6 @@ async def search_web(
         user = UserModel(**__user__) if __user__ else None
 
         results = await asyncio.to_thread(_search_web, __request__, engine, query, user)
-
-        # Limit results
-        results = results[:count] if results else []
 
         return json.dumps(
             [{"title": r.title, "link": r.link, "snippet": r.snippet} for r in results],


### PR DESCRIPTION
## Summary

Fixes #21371

The built-in `search_web` tool was ignoring the admin `WEB_SEARCH_RESULT_COUNT` setting because it had a hardcoded `count=5` default and then re-truncated results.

## Root Cause

```python
async def search_web(
    query: str,
    count: int = 5,  # ← hardcoded default, ignores admin setting
    ...
) -> str:
    ...
    results = results[:count]  # ← re-truncates to 5
```

The backend `_search_web()` function correctly uses `WEB_SEARCH_RESULT_COUNT` from admin settings, but `search_web()` in `builtin.py` was silently discarding extra results.

## Fix

- Removed the `count` parameter from `search_web()` function signature
- Removed the secondary `results[:count]` truncation
- The backend already respects the admin setting, so no additional limiting is needed

## Testing

- [x] Syntax validation via `ast.parse()` - OK
- [x] No other code references the `count` parameter

## Impact

- Users who set `WEB_SEARCH_RESULT_COUNT=10` will now get 10 results instead of 5
- No breaking changes - the tool still returns JSON search results
- Only affects Native Function Calling mode (built-in tools)