### PR TITLE
fix: handle already-deserialized JSON values from PostgreSQL

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -36,8 +36,11 @@ class JSONField(types.TypeDecorator):
         return json.dumps(value)
 
     def process_result_value(self, value: Optional[_T], dialect: Dialect) -> Any:
-        if value is not None:
-            return json.loads(value)
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return value
+        return json.loads(value)
 
     def copy(self, **kw: Any) -> Self:
         return JSONField(self.impl.length)


### PR DESCRIPTION
## Summary

- `JSONField.process_result_value` unconditionally calls `json.loads()` on column values, but PostgreSQL's `psycopg2` driver with native JSON handling returns Python dicts/lists directly from JSONB columns
- This causes `TypeError: the JSON object must be str, bytes or bytearray, not dict` on PostgreSQL deployments
- Fix adds a type check to skip deserialization when the value is already a `dict` or `list`

## Test plan

- [ ] Verify on PostgreSQL deployment that JSONB columns load without TypeError
- [ ] Verify on SQLite deployment that string-serialized JSON values still deserialize correctly
- [ ] Confirm no regression in chat history, user settings, or other JSONField-backed models

🤖 Generated with [Claude Code](https://claude.com/claude-code)