### PR TITLE
feat: support arbitrary file output from Jupyter code execution

### DIFF
--- a/backend/open_webui/utils/code_interpreter.py
+++ b/backend/open_webui/utils/code_interpreter.py
@@ -132,6 +132,26 @@ class JupyterCodeExecuter:
             await self.execute_in_jupyter(ws)
 
     async def execute_in_jupyter(self, ws) -> None:
+        # Preamble: ensure a writable data directory exists and track existing
+        # files so we can detect new outputs written by skills.
+        # Try /mnt/data first (ChatGPT/Vercel convention), fall back to /tmp/data.
+        preamble = (
+            "import os as __owui_os, tempfile as __owui_tmp\n"
+            "__owui_data_dir = '/mnt/data'\n"
+            "try:\n"
+            "    __owui_os.makedirs(__owui_data_dir, exist_ok=True)\n"
+            "    # Verify it's writable\n"
+            "    __owui_test = __owui_os.path.join(__owui_data_dir, '.owui_test')\n"
+            "    open(__owui_test, 'w').close()\n"
+            "    __owui_os.remove(__owui_test)\n"
+            "except (PermissionError, OSError):\n"
+            "    __owui_data_dir = __owui_os.path.join(__owui_tmp.gettempdir(), 'data')\n"
+            "    __owui_os.makedirs(__owui_data_dir, exist_ok=True)\n"
+            "__owui_pre_files = set(__owui_os.listdir(__owui_data_dir))\n"
+            "del __owui_tmp\n"
+        )
+        code_with_preamble = preamble + self.code
+
         # send message
         msg_id = uuid.uuid4().hex
         await ws.send(
@@ -148,7 +168,7 @@ class JupyterCodeExecuter:
                     "parent_header": {},
                     "metadata": {},
                     "content": {
-                        "code": self.code,
+                        "code": code_with_preamble,
                         "silent": False,
                         "store_history": True,
                         "user_expressions": {},
@@ -179,9 +199,21 @@ class JupyterCodeExecuter:
                             stderr += message_data["content"]["text"]
                     case "execute_result" | "display_data":
                         data = message_data["content"]["data"]
-                        if "image/png" in data:
-                            result.append(f"data:image/png;base64,{data['image/png']}")
-                        elif "text/plain" in data:
+                        handled = False
+                        for mime_type in data:
+                            if mime_type == "text/plain":
+                                continue
+                            if (
+                                mime_type.startswith("image/")
+                                or mime_type.startswith("application/")
+                                or mime_type.startswith("audio/")
+                            ):
+                                result.append(
+                                    f"data:{mime_type};base64,{data[mime_type]}"
+                                )
+                                handled = True
+                                break
+                        if not handled and "text/plain" in data:
                             result.append(data["text/plain"])
                     case "error":
                         stderr += "\n".join(message_data["content"]["traceback"])
@@ -192,6 +224,94 @@ class JupyterCodeExecuter:
             except asyncio.TimeoutError:
                 stderr += "\nExecution timed out."
                 break
+
+        # Post-execution: scan the data directory for new files and emit as data URIs.
+        # This allows skills that save files to deliver downloadable attachments.
+        # Uses __owui_data_dir set by the preamble (either /mnt/data or /tmp/data).
+        postamble = (
+            "import os as __owui_os, base64 as __owui_b64, mimetypes as __owui_mt\n"
+            "from IPython.display import display as __owui_display\n"
+            "# Register common office MIME types (not always present in minimal containers)\n"
+            "__owui_mt.add_type('application/vnd.openxmlformats-officedocument.presentationml.presentation', '.pptx')\n"
+            "__owui_mt.add_type('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '.xlsx')\n"
+            "__owui_mt.add_type('application/vnd.openxmlformats-officedocument.wordprocessingml.document', '.docx')\n"
+            "__owui_mt.add_type('application/pdf', '.pdf')\n"
+            "__owui_mt.add_type('text/csv', '.csv')\n"
+            "if '__owui_pre_files' in dir() and '__owui_data_dir' in dir():\n"
+            "    __owui_new = sorted(set(__owui_os.listdir(__owui_data_dir)) - __owui_pre_files)\n"
+            "    for __owui_f in __owui_new:\n"
+            "        __owui_p = __owui_os.path.join(__owui_data_dir, __owui_f)\n"
+            "        if __owui_os.path.isfile(__owui_p):\n"
+            "            __owui_ct = __owui_mt.guess_type(__owui_p)[0] or 'application/octet-stream'\n"
+            "            with open(__owui_p, 'rb') as __owui_fh:\n"
+            "                __owui_d = __owui_b64.b64encode(__owui_fh.read()).decode()\n"
+            "            __owui_display({__owui_ct: __owui_d, 'text/plain': __owui_f}, raw=True)\n"
+            "    del __owui_pre_files, __owui_data_dir\n"
+        )
+        post_msg_id = uuid.uuid4().hex
+        await ws.send(
+            json.dumps(
+                {
+                    "header": {
+                        "msg_id": post_msg_id,
+                        "msg_type": "execute_request",
+                        "username": "user",
+                        "session": uuid.uuid4().hex,
+                        "date": "",
+                        "version": "5.3",
+                    },
+                    "parent_header": {},
+                    "metadata": {},
+                    "content": {
+                        "code": postamble,
+                        "silent": False,
+                        "store_history": False,
+                        "user_expressions": {},
+                        "allow_stdin": False,
+                        "stop_on_error": False,
+                    },
+                    "channel": "shell",
+                }
+            )
+        )
+        # Capture only display_data from postamble (file outputs)
+        while True:
+            try:
+                message = await asyncio.wait_for(ws.recv(), self.timeout)
+                message_data = json.loads(message)
+                if message_data.get("parent_header", {}).get("msg_id") != post_msg_id:
+                    continue
+                msg_type = message_data.get("msg_type")
+                match msg_type:
+                    case "display_data":
+                        data = message_data["content"]["data"]
+                        filename = data.get("text/plain", "")
+                        for mime_type in data:
+                            if mime_type == "text/plain":
+                                continue
+                            if (
+                                mime_type.startswith("image/")
+                                or mime_type.startswith("application/")
+                                or mime_type.startswith("audio/")
+                            ):
+                                # Encode original filename into the data URI
+                                # so downstream processors can use it
+                                if filename:
+                                    safe_name = filename.replace(";", "_")
+                                    result.append(
+                                        f"data:{mime_type};filename={safe_name};base64,{data[mime_type]}"
+                                    )
+                                else:
+                                    result.append(
+                                        f"data:{mime_type};base64,{data[mime_type]}"
+                                    )
+                                break
+                    case "status":
+                        if message_data["content"]["execution_state"] == "idle":
+                            break
+            except asyncio.TimeoutError:
+                break
+
         self.result.stdout = stdout.strip()
         self.result.stderr = stderr.strip()
         self.result.result = "\n".join(result).strip() if result else ""

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -649,7 +649,7 @@
 							<StatusHistory statusHistory={message?.statusHistory} />
 						{/if}
 
-						{#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}
+						{#if message?.files && message.files.length > 0}
 							<div
 								class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap"
 								dir={$settings?.chatDirection ?? 'auto'}


### PR DESCRIPTION
## Summary

- The Jupyter code interpreter engine was limited to capturing `image/png` outputs only. Skills that generate documents (PPTX, PDF, XLSX, CSV, etc.) had no way to deliver files to users
- This generalizes the entire output pipeline — from Jupyter kernel capture through backend processing to frontend display — to handle any file type
- Non-image files are delivered as downloadable chat message attachments using the existing `chat:message:files` event pattern (same as `generate_image`)

### Changes across 5 files:

- **`code_interpreter.py`** — Capture any `image/*`, `application/*`, `audio/*` MIME type from Jupyter. Add preamble/postamble that creates a writable data dir, scans for new files after execution, and emits them as `display_data` with correct MIME types and original filenames
- **`files.py`** — Add generic `upload_file_from_base64()` and `get_file_url_from_base64()` that handle any data URI MIME type. Register common office MIME types. Support embedded `filename` parameter in data URIs
- **`builtin.py`** — Replace image-only scanning in `execute_code` with generic data URI detection. Images render inline; non-image files emitted as `chat:message:files` attachments with DB persistence
- **`middleware.py`** — Apply same generic handling to the native (non-tool) code interpreter path
- **`ResponseMessage.svelte`** — Change file display gate from `filter(f => f.type === 'image')` to show all file types (the inner `{#each}` already dispatches to `<Image>` vs `<FileItem>`)

### How it works

1. User code saves a file (e.g., `.pptx`) to `__owui_data_dir` (set by the preamble)
2. Postamble detects the new file, reads it, and emits as `display_data` with the correct MIME type
3. `code_interpreter.py` captures the base64 data with MIME type and original filename
4. `builtin.py` uploads via `get_file_url_from_base64()` and emits as a chat file attachment
5. Frontend renders it as a downloadable `<FileItem>`

## Test plan

- [ ] Set `CODE_INTERPRETER_ENGINE=jupyter` with an external Jupyter server
- [ ] Run a skill/code that generates a `.pptx` file using `python-pptx` — verify it appears as a downloadable attachment in the chat
- [ ] Run existing image generation code (e.g., matplotlib plot) — verify images still render inline as before
- [ ] Test with PDF output (`data:application/pdf;base64,...`) and CSV output
- [ ] Verify the original filename is preserved (not `generated-file.pptx`)
- [ ] Verify the download link works (no 404 or double URL path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)