### PR TITLE
fix: JSONField double deserialization on PostgreSQL

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -36,8 +36,11 @@ class JSONField(types.TypeDecorator):
         return json.dumps(value)
 
     def process_result_value(self, value: Optional[_T], dialect: Dialect) -> Any:
-        if value is not None:
-            return json.loads(value)
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return value
+        return json.loads(value)
 
     def copy(self, **kw: Any) -> Self:
         return JSONField(self.impl.length)


### PR DESCRIPTION
### Description

- Fix `JSONField.process_result_value` crashing with `TypeError` on PostgreSQL when psycopg2 returns already-deserialized Python dicts/lists from JSONB columns. The bug surfaces most visibly when creating a new skill, as `db.refresh()` triggers deserialization of the `meta` column.

Discussion: https://github.com/open-webui/open-webui/discussions/21397

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `JSONField.process_result_value` now checks whether the value is already a `dict` or `list` before calling `json.loads()`. On PostgreSQL with psycopg2's native JSON type adaptation, JSONB columns return Python objects directly. The previous unconditional `json.loads(value)` raised `TypeError: the JSON object must be str, bytes or bytearray, not dict`.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Single file change: `backend/open_webui/internal/db.py`, 3 lines added, 2 removed
- SQLite is unaffected (always returns JSON as text strings), but the fix is safe for both backends
- The Peewee equivalent `python_value` (same file, lines 51-53) has the same unconditional `json.loads` but is left out of scope to keep this minimal
- Co-authored with AI, manually reviewed and tested on both PostgreSQL and SQLite

### Testing

**PostgreSQL (live deployment, psycopg2 driver):**
- Skill creation works (previously crashed on `db.refresh()`)
- All JSONB column reads return correctly

**SQLite (local Docker, `ghcr.io/open-webui/open-webui:main` with patched file bind-mounted):**

| Test | JSONField columns hit | Result |
|------|----------------------|--------|
| Create skill (with tags in meta) | `skill.meta` | PASS |
| Read skill back | `skill.meta` | PASS |
| List skills (multiple reads) | `skill.meta` | PASS |
| Create chat | `chat.chat` | PASS |
| Read chat back | `chat.chat` | PASS |
| Update chat (nested dicts, lists, child objects) | `chat.chat` | PASS |
| Update user settings | `user.settings` | PASS |
| Read user settings back | `user.settings` | PASS |
| Empty lists, null values, empty dicts | `chat.chat` | PASS |

On SQLite the `isinstance` guard never triggers because values always arrive as strings, so `json.loads()` runs exactly as before. Zero errors in container logs.

### Screenshots or Videos

N/A (backend-only change, no UI impact)

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.