### PR TITLE
fix: offline model retrieval, re-raise to disable instead of returning useless fallback

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1269,6 +1269,8 @@ def get_model_path(model: str, update_model: bool = False):
         return model_repo_path
     except Exception as e:
         log.exception(f"Cannot determine model snapshot path: {e}")
+        if OFFLINE_MODE:
+            raise
         return model
 
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

In offline mode (`OFFLINE_MODE=True`), `get_model_path` not-so-silently returns the raw model name string as a fallback. This fallback exists such that `SentenceTransformer` can try to download a model, but when `OFFLINE_MODE=True` download is blocked, SentenceTransformer emits `WARNI: No sentence-transformers model found ... Creating a new one with mean pooling`, making retrieval feature appear useful, but not really so.

The fix is re-raise the exception in offline mode. Caller chain already handles this:
- `get_ef()` catches, returns `None`
- `get_rf()` catches, re-raises to `main.py:1072-1074`
-  App starts cleanly with `ef=None`. Retrieval is disabled until a model is pre-cached or `RAG_EMBEDDING_ENGINE` setup.

closes #21405 

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
