### PR TITLE
fix: use 'is None' instead of '== None' in socket handler

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -808,7 +808,7 @@ def get_event_emitter(request_info, update_db=True):
 
             if event_data.get("type") in ["source", "citation"]:
                 data = event_data.get("data", {})
-                if data.get("type") == None:
+                if data.get("type") is None:
                     message = Chats.get_message_by_id_and_message_id(
                         request_info["chat_id"],
                         request_info["message_id"],


### PR DESCRIPTION
## Summary
Replace equality comparison with identity check for None value in socket message handler.

## Changes
- `data.get("type") == None` → `data.get("type") is None`

## Why
According to [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations), comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators `==` or `!=`.

This is because:
1. Identity checks (`is`) are faster than equality checks (`==`)
2. `None` is a singleton, so identity comparison is semantically correct
3. Using `==` can lead to unexpected behavior if a class overrides `__eq__`

## Test plan
Existing tests should pass. This is a code quality improvement that maintains identical behavior.