### PR TITLE
fix: use 'is None' instead of '== None' in title check

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2736,7 +2736,7 @@ async def background_tasks_handler(ctx):
                                 }
                             )
 
-                    if title == None and len(messages) == 2:
+                    if title is None and len(messages) == 2:
                         title = messages[0].get("content", user_message)
 
                         Chats.update_chat_title_by_id(metadata["chat_id"], title)


### PR DESCRIPTION
## Summary
Replace equality comparison with identity check for None value in chat title validation middleware.

## Changes
- `title == None` → `title is None`

## Why
According to [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations), comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators `==` or `!=`.

This is because:
1. Identity checks (`is`) are faster than equality checks (`==`)
2. `None` is a singleton, so identity comparison is semantically correct
3. Using `==` can lead to unexpected behavior if a class overrides `__eq__`

## Test plan
Existing tests should pass. This is a code quality improvement that maintains identical behavior.