### PR TITLE
fix: pass background parameter to OpenAI Image Edit API

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -849,6 +849,7 @@ class EditImageForm(BaseModel):
     size: Optional[str] = None
     n: Optional[int] = None
     negative_prompt: Optional[str] = None
+    background: Optional[str] = None  # "transparent", "opaque", or "auto"
 
 
 @router.post("/edit")
@@ -961,6 +962,7 @@ async def image_edits(
                     )
                     else {"response_format": "b64_json"}
                 ),
+                **({"background": form_data.background} if form_data.background else {}),
             }
 
             files = []

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -283,6 +283,7 @@ async def generate_image(
 async def edit_image(
     prompt: str,
     image_urls: list[str],
+    background: str = None,
     __request__: Request = None,
     __user__: dict = None,
     __event_emitter__: callable = None,
@@ -294,6 +295,7 @@ async def edit_image(
 
     :param prompt: A description of the changes to make to the images
     :param image_urls: A list of URLs of the images to edit
+    :param background: Background type - "transparent", "opaque", or "auto" (default: None, uses API default)
     :return: Confirmation that the images were edited, or an error message
     """
     if __request__ is None:
@@ -304,7 +306,7 @@ async def edit_image(
 
         images = await image_edits(
             request=__request__,
-            form_data=EditImageForm(prompt=prompt, image=image_urls),
+            form_data=EditImageForm(prompt=prompt, image=image_urls, background=background),
             user=user,
         )
 


### PR DESCRIPTION
 # Pull Request Checklist

  - [x] **Target branch:** `dev`
  - [x] **Description:** Provided below.
  - [x] **Changelog:** Provided below.
  - [ ] **Documentation:** No user-facing behavior changes requiring docs update.
  - [ ] **Dependencies:** No new dependencies.
  - [x] **Testing:** Manually tested with gpt-image-1 model using transparent/opaque/auto background options.
  - [x] **Agentic AI Code:** This PR has been manually reviewed and tested by a human.
  - [x] **Code review:** Self-reviewed.
  - [x] **Design & Architecture:** Minimal change, follows existing pattern for optional API parameters.
  - [x] **Git Hygiene:** Single atomic commit.
  - [x] **Title Prefix:** `fix:`

  # Changelog Entry

  ### Description

  The OpenAI Image Edit API (`gpt-image-1`) supports a `background` parameter with values `"transparent"`, `"opaque"`, or `"auto"`, but Open WebUI does not pass this parameter through. This means users cannot
  control background transparency when editing images via the built-in tool.

  ### Added

  - `background` field to `EditImageForm` model (`"transparent"`, `"opaque"`, or `"auto"`)
  - `background` parameter to `edit_image` built-in tool function with docstring

  ### Changed

  - N/A

  ### Deprecated

  - N/A

  ### Removed

  - N/A

  ### Fixed

  - `background` parameter is now passed to the OpenAI Image Edit API when provided

  ### Security

  - N/A

  ### Breaking Changes

  - N/A

  ---

  ### Additional Information

  - Follows existing pattern: `**({"background": form_data.background} if form_data.background else {})` same as other optional parameters like `size`, `n`
  - Parameter is optional with default `None`, so no breaking change to existing behavior
  - Reference: [OpenAI Image Edit API docs](https://platform.openai.com/docs/api-reference/images/createEdit)

  ### Screenshots or Videos

  - N/A (API parameter passthrough, no UI change)

  ### Contributor License Agreement

  By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and
  I am providing my contributions under its terms.