### PR TITLE
fix: email

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2085,7 +2085,7 @@
 				),
 				features: getFeatures(),
 				variables: {
-					...getPromptVariables($user?.name, $settings?.userLocation ? userLocation : undefined)
+					...getPromptVariables($user?.name, $settings?.userLocation ? userLocation : undefined, $user?.email)
 				},
 				model_item: $models.find((m) => m.id === model.id),
 


### PR DESCRIPTION
The getPromptVariables() call in Chat.svelte was missing the $user?.email argument, causing {{USER_EMAIL}} to default to 'Unknown' in the metadata variables sent to the backend. This meant the backend's prompt_variables_template() would replace {{USER_EMAIL}} with 'Unknown' before prompt_template() could substitute the real email from the user object.

Fixes #21465

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
