### PR TITLE
fix: mcp ssl check

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -9,14 +9,27 @@ from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 import httpx
-from mcp.shared._httpx_utils import create_mcp_http_client
 from open_webui.env import AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL
 
 
 def create_insecure_httpx_client(headers=None, timeout=None, auth=None):
-    client = create_mcp_http_client(headers=headers, timeout=timeout, auth=auth)
-    client.verify = False
-    return client
+    """Create an httpx AsyncClient with SSL verification disabled.
+
+    Note: verify=False must be passed at construction time because httpx
+    configures the SSL context during __init__. Setting client.verify = False
+    after construction does not affect the underlying transport's SSL context.
+    """
+    kwargs = {
+        "follow_redirects": True,
+        "verify": False,
+    }
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if headers is not None:
+        kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
+    return httpx.AsyncClient(**kwargs)
 
 
 class MCPClient:


### PR DESCRIPTION
Setting client.verify = False after httpx.AsyncClient construction does not affect the underlying transport's SSL context - the SSL context is configured during __init__ and cannot be changed afterward. This caused MCP tool connections to always verify SSL certificates even when AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL was set to false.

Build the httpx.AsyncClient directly with verify=False in the constructor kwargs to properly disable SSL certificate verification.

Fixes #21481

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
