### PR TITLE
feat: add "Show Tool Call Output" interface toggle

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -329,6 +329,7 @@
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
+				showToolCallOutput={$settings?.showToolCallOutput ?? true}
 				open={false}
 				className="w-full space-y-1"
 			/>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -70,6 +70,7 @@
 	let chatFadeStreamingText = true;
 	let collapseCodeBlocks = false;
 	let expandDetails = false;
+	let showToolCallOutput = true;
 	let renderMarkdownInPreviews = true;
 	let showChatTitleInTab = true;
 
@@ -233,6 +234,7 @@
 
 		collapseCodeBlocks = $settings?.collapseCodeBlocks ?? false;
 		expandDetails = $settings?.expandDetails ?? false;
+		showToolCallOutput = $settings?.showToolCallOutput ?? true;
 		renderMarkdownInPreviews = $settings?.renderMarkdownInPreviews ?? true;
 
 		landingPageMode = $settings?.landingPageMode ?? '';
@@ -960,6 +962,25 @@
 							bind:state={expandDetails}
 							on:change={() => {
 								saveSettings({ expandDetails });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="show-tool-call-output-label" class=" self-center text-xs">
+						{$i18n.t('Show Tool Call Output')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="show-tool-call-output-label"
+							tooltip={true}
+							bind:state={showToolCallOutput}
+							on:change={() => {
+								saveSettings({ showToolCallOutput });
 							}}
 						/>
 					</div>

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -65,6 +65,19 @@
 			.replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
+	function formatValue(value: any): string {
+		if (value === null || value === undefined) return '—';
+		if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+		if (typeof value === 'string') return value;
+		if (typeof value === 'number') return String(value);
+		if (Array.isArray(value)) return `[${value.length} item${value.length !== 1 ? 's' : ''}]`;
+		if (typeof value === 'object') {
+			const keys = Object.keys(value);
+			return `{${keys.join(', ')}}`;
+		}
+		return String(value);
+	}
+
 	function tryParseArgs(str: string): Record<string, any> | null {
 		try {
 			const parsed = parseJSONString(str);
@@ -185,7 +198,7 @@
 										{#each Object.entries(parsedArgs) as [key, value]}
 											<div class="flex gap-2 text-xs py-0.5">
 												<span class="font-semibold text-gray-600 dark:text-gray-400 shrink-0">{formatKey(key)}</span>
-												<span class="text-gray-800 dark:text-gray-200 break-all">{typeof value === 'object' ? JSON.stringify(value) : String(value)}</span>
+												<span class="text-gray-800 dark:text-gray-200 break-all">{formatValue(value)}</span>
 											</div>
 										{/each}
 									</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -164,6 +164,7 @@ type Settings = {
 	voiceInterruption?: boolean;
 	collapseCodeBlocks?: boolean;
 	expandDetails?: boolean;
+	showToolCallOutput?: boolean;
 	notificationSound?: boolean;
 	notificationSoundAlways?: boolean;
 	stylizedPdfExport?: boolean;


### PR DESCRIPTION
Add a new per-user interface toggle under Settings > Interface that controls how tool calls are displayed when expanded in the chat UI. The toggle defaults to on, preserving the existing behavior. When turned off:
- The Output section (raw JSON result) is completely hidden
- The Input section replaces the JSON code block with a formatted key-value list, converting parameter names from snake_case/camelCase to readable labels (e.g. "search_query" becomes "Search Query")
- Falls back to raw JSON display if arguments cannot be parsed This is a frontend-only change. Tool call data is still sent to models and stored in chat history unchanged — only the visual rendering is affected.
Files changed:
- src/lib/stores/index.ts Added showToolCallOutput to the Settings type definition.
- src/lib/components/chat/Settings/Interface.svelte Added the toggle variable, onMount initialization from saved settings, and the toggle UI row in the Chat section after "Always Expand Details".
- src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte Passes the showToolCallOutput setting as a prop to ToolCallDisplay.
- src/lib/components/common/ToolCallDisplay.svelte Added showToolCallOutput prop, formatKey helper for converting parameter names to human-readable labels, and tryParseArgs helper for safely parsing tool arguments. Conditionally renders either the original JSON code blocks or the formatted key-value display based on the setting.

**1. Would fix: #21440
2. Relates to: https://github.com/open-webui/open-webui/issues/20598
3. Improves: #20878**

<img width="1126" height="40" alt="image" src="https://github.com/user-attachments/assets/dd7105af-d61e-4811-a014-3ba3cc3396be" />

On by default for backwards compatibility

<img width="1075" height="290" alt="image" src="https://github.com/user-attachments/assets/4fe4f0da-f709-440a-b4b3-8f581a794c98" />


If toggled on - all tool output no longer gets shown - and tool input gets shown in a key: value format instead of JSON

<ins>**This should also really help this issue here with hard performance issues with many codeblocks and long response outputs: https://github.com/open-webui/open-webui/discussions/20878**</ins>

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
