### PR TITLE
fix: TypeScript .ts MIME type misdetection and image URL fetch with wrong headers

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -229,6 +229,24 @@ def upload_file_handler(
 ):
     log.info(f"file.content_type: {file.content_type} {process}")
 
+    # Fix commonly misdetected MIME types based on file extension.
+    # For example, .ts (TypeScript) files are often detected as
+    # video/vnd.dlna.mpeg-tts or video/mp2t by browsers.
+    _MIME_OVERRIDES = {
+        ".ts": "text/plain",
+        ".mts": "text/plain",
+        ".cts": "text/plain",
+        ".tsx": "text/plain",
+    }
+    if file.filename:
+        ext = os.path.splitext(file.filename)[1].lower()
+        if ext in _MIME_OVERRIDES and (
+            file.content_type is None
+            or file.content_type.startswith("video/")
+        ):
+            file.content_type = _MIME_OVERRIDES[ext]
+            log.info(f"Corrected MIME type for {ext} file to {file.content_type}")
+
     if isinstance(metadata, str):
         try:
             metadata = json.loads(metadata)

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -478,10 +478,10 @@ GenerateImageForm = CreateImageForm  # Alias for backward compatibility
 def get_image_data(data: str, headers=None):
     try:
         if data.startswith("http://") or data.startswith("https://"):
-            if headers:
-                r = requests.get(data, headers=headers)
-            else:
-                r = requests.get(data)
+            # Don't forward API-specific headers (Content-Type, Authorization)
+            # when fetching image URLs — the image may be hosted on a different
+            # domain (e.g. cloud storage) that rejects unexpected headers.
+            r = requests.get(data)
 
             r.raise_for_status()
             if r.headers["content-type"].split("/")[0] == "image":


### PR DESCRIPTION
## Fixes

### 1. TypeScript .ts files rejected as video MIME type (fixes #21454)

**Problem:** Browsers detect `.ts` files as `video/vnd.dlna.mpeg-tts` or `video/mp2t`, causing Open WebUI to reject them with 'File type not supported for processing'.

**Fix:** Added MIME type correction in the file upload handler for `.ts`, `.mts`, `.cts`, and `.tsx` extensions.

### 2. Image generation fails with 403 on external image URLs (fixes #21301)

**Problem:** Generated image URLs are fetched with API headers (Content-Type: application/json, Authorization), causing 403 on external hosting.

**Fix:** `get_image_data()` no longer forwards API headers when fetching image URLs.