### PR TITLE
fix: include chat attachment images in OpenAI payload

### DIFF
--- a/backend/open_webui/test/util/test_middleware_images.py
+++ b/backend/open_webui/test/util/test_middleware_images.py
@@ -1,0 +1,124 @@
+import asyncio
+
+from open_webui.utils.chat_image_payload import append_chat_file_images_to_user_messages
+
+
+def test_append_chat_file_images_to_user_messages_injects_image_parts():
+    form_data = {"messages": [{"role": "user", "content": "Describe this image"}]}
+    messages_map = {
+        "msg-1": {
+            "id": "msg-1",
+            "role": "user",
+            "content": "Describe this image",
+            "parentId": None,
+            "files": [
+                {
+                    "id": "file-1",
+                    "url": "file-1",
+                    "content_type": "image/png",
+                    "type": "file",
+                }
+            ],
+        }
+    }
+
+    updated = asyncio.run(
+        append_chat_file_images_to_user_messages(
+            form_data=form_data,
+            messages_map=messages_map,
+            parent_message_id="msg-1",
+            image_loader=lambda _: "data:image/png;base64,abc123",
+        )
+    )
+
+    content = updated["messages"][0]["content"]
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "Describe this image"}
+    assert content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc123"},
+    }
+
+
+def test_append_chat_file_images_to_user_messages_skips_when_content_has_images():
+    existing_content = [
+        {"type": "text", "text": "Already has image"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,existing"},
+        },
+    ]
+    form_data = {"messages": [{"role": "user", "content": list(existing_content)}]}
+    messages_map = {
+        "msg-1": {
+            "id": "msg-1",
+            "role": "user",
+            "content": "Already has image",
+            "parentId": None,
+            "files": [
+                {
+                    "id": "file-1",
+                    "url": "file-1",
+                    "content_type": "image/png",
+                    "type": "file",
+                }
+            ],
+        }
+    }
+
+    updated = asyncio.run(
+        append_chat_file_images_to_user_messages(
+            form_data=form_data,
+            messages_map=messages_map,
+            parent_message_id="msg-1",
+            image_loader=lambda _: "data:image/png;base64,abc123",
+        )
+    )
+
+    assert updated["messages"][0]["content"] == existing_content
+
+
+def test_append_chat_file_images_to_user_messages_ignores_non_image_files():
+    form_data = {"messages": [{"role": "user", "content": "Use this PDF"}]}
+    messages_map = {
+        "msg-1": {
+            "id": "msg-1",
+            "role": "user",
+            "content": "Use this PDF",
+            "parentId": None,
+            "files": [
+                {
+                    "id": "file-1",
+                    "url": "file-1",
+                    "content_type": "application/pdf",
+                    "type": "file",
+                }
+            ],
+        }
+    }
+
+    updated = asyncio.run(
+        append_chat_file_images_to_user_messages(
+            form_data=form_data,
+            messages_map=messages_map,
+            parent_message_id="msg-1",
+            image_loader=lambda _: "data:image/png;base64,abc123",
+        )
+    )
+
+    assert updated["messages"][0]["content"] == "Use this PDF"
+
+
+def test_append_chat_file_images_to_user_messages_no_parent_id_no_changes():
+    form_data = {"messages": [{"role": "user", "content": "Hi"}]}
+
+    updated = asyncio.run(
+        append_chat_file_images_to_user_messages(
+            form_data=form_data,
+            messages_map={},
+            parent_message_id=None,
+            image_loader=lambda _: "data:image/png;base64,abc123",
+        )
+    )
+
+    assert updated == form_data

--- a/backend/open_webui/utils/chat_image_payload.py
+++ b/backend/open_webui/utils/chat_image_payload.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+from typing import Callable, Optional
+
+
+def _get_message_chain(messages_map: dict, message_id: str) -> list[dict]:
+    if not messages_map:
+        return []
+
+    current_message = messages_map.get(message_id)
+    if not current_message:
+        return []
+
+    message_list = []
+    while current_message:
+        message_list.insert(0, current_message)
+        parent_id = current_message.get("parentId")
+        current_message = messages_map.get(parent_id) if parent_id else None
+
+    return message_list
+
+
+def _has_image_part(content: object) -> bool:
+    if not isinstance(content, list):
+        return False
+
+    return any(
+        isinstance(item, dict) and item.get("type") == "image_url" for item in content
+    )
+
+
+async def append_chat_file_images_to_user_messages(
+    form_data: dict,
+    messages_map: dict,
+    parent_message_id: Optional[str],
+    image_loader: Callable[[str], Optional[str]],
+    logger: Optional[logging.Logger] = None,
+) -> dict:
+    if not parent_message_id:
+        return form_data
+
+    db_messages = _get_message_chain(messages_map, parent_message_id)
+    if not db_messages:
+        return form_data
+
+    api_user_messages = [
+        message
+        for message in form_data.get("messages", [])
+        if message.get("role") == "user"
+    ]
+    db_user_messages = [
+        message for message in db_messages if message.get("role") == "user"
+    ]
+
+    for api_message, db_message in zip(api_user_messages, db_user_messages):
+        content = api_message.get("content")
+        if _has_image_part(content):
+            continue
+
+        image_parts = []
+        for file_item in db_message.get("files") or []:
+            content_type = (file_item.get("content_type") or "").lower()
+            if not content_type.startswith("image/"):
+                continue
+
+            image_source = file_item.get("url") or file_item.get("id")
+            if not image_source:
+                continue
+
+            try:
+                image_base64 = await asyncio.to_thread(image_loader, image_source)
+            except Exception as e:
+                if logger:
+                    logger.debug(f"Error converting chat file image to base64: {e}")
+                continue
+
+            if image_base64:
+                image_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": image_base64},
+                    }
+                )
+
+        if not image_parts:
+            continue
+
+        if isinstance(content, str):
+            api_message["content"] = [{"type": "text", "text": content}] + image_parts
+        elif isinstance(content, list):
+            api_message["content"] = content + image_parts
+        else:
+            api_message["content"] = image_parts
+
+    return form_data

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -108,6 +108,9 @@ from open_webui.utils.filter import (
 from open_webui.utils.code_interpreter import execute_code_jupyter
 from open_webui.utils.payload import apply_system_prompt_to_body
 from open_webui.utils.response import normalize_usage
+from open_webui.utils.chat_image_payload import (
+    append_chat_file_images_to_user_messages,
+)
 from open_webui.utils.mcp.client import MCPClient
 
 
@@ -1995,6 +1998,16 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             pass
 
     form_data = await convert_url_images_to_base64(form_data)
+    if chat_id and parent_message_id and not chat_id.startswith("local:"):
+        messages_map = Chats.get_messages_map_by_chat_id(chat_id)
+        if messages_map:
+            form_data = await append_chat_file_images_to_user_messages(
+                form_data=form_data,
+                messages_map=messages_map,
+                parent_message_id=parent_message_id,
+                image_loader=get_image_base64_from_url,
+                logger=log,
+            )
 
     event_emitter = get_event_emitter(metadata)
     event_caller = get_event_call(metadata)


### PR DESCRIPTION
## Summary
- add `append_chat_file_images_to_user_messages` to convert DB-backed chat `files` image attachments into OpenAI `image_url` message parts
- invoke this conversion in `process_chat_payload` after URL->base64 normalization so image attachments survive OpenAI-compatible forwarding
- keep conversion safe by skipping messages that already contain `image_url` parts and ignoring non-image attachments
- add regression tests covering image injection, duplicate-image skip, non-image ignore, and no-parent no-op paths

## Why
OpenWebUI stores pasted/uploaded chat images under message `files`, but the outgoing OpenAI-compatible payload may only include text content when those files are not lifted into `messages[].content` parts. This causes downstream gateways/providers to miss image inputs even though the UI shows an attachment.

## Testing
- `python -m py_compile backend/open_webui/utils/middleware.py backend/open_webui/utils/chat_image_payload.py backend/open_webui/test/util/test_middleware_images.py`
- `python -c \"import sys,pytest; sys.path.insert(0,'backend'); raise SystemExit(pytest.main(['backend/open_webui/test/util/test_middleware_images.py']))\"`