### PR TITLE
fix: use is None in socket event type check

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -864,7 +864,7 @@ def get_event_emitter(request_info, update_db=True):
 
             if event_data.get("type") in ["source", "citation"]:
                 data = event_data.get("data", {})
-                if data.get("type") == None:
+                if data.get("type") is None:
                     message = Chats.get_message_by_id_and_message_id(
                         request_info["chat_id"],
                         request_info["message_id"],

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2810,7 +2810,7 @@ async def background_tasks_handler(ctx):
                                 }
                             )
 
-                    if title is None and len(messages) == 2:
+                    if title == None and len(messages) == 2:
                         title = messages[0].get("content", user_message)
 
                         Chats.update_chat_title_by_id(metadata["chat_id"], title)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2810,7 +2810,7 @@ async def background_tasks_handler(ctx):
                                 }
                             )
 
-                    if title == None and len(messages) == 2:
+                    if title is None and len(messages) == 2:
                         title = messages[0].get("content", user_message)
 
                         Chats.update_chat_title_by_id(metadata["chat_id"], title)


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [ ] **Changelog:** Ensure a changelog entry following the format of Keep a Changelog is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in Open WebUI Docs Repository.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Performed manual checks and syntax checks for touched file.
- [x] **Code Review:** Changes were manually reviewed and validated before submission.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** No architecture changes.
- [x] **Git Hygiene:** Atomic fix with only relevant changes.
- [x] **Title Prefix:** Uses `fix:`.

# Changelog Entry

### Description
- Replace `== None` with `is None` in the socket event data type check.
- This avoids equality override edge cases and follows Python singleton comparison best practices.

### Added
- None.

### Changed
- `backend/open_webui/socket/main.py`: `data.get("type") is None`

### Deprecated
- None.

### Removed
- None.

### Fixed
- Uses identity comparison for `None` in socket event fallback logic.

### Security
- None.

### Breaking Changes
- **BREAKING CHANGE**: None.

---

### Additional Information
- Narrowed scope to a single call site for atomic review.

### Screenshots or Videos
- N/A (backend-only conditional check).

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
