### PR TITLE
fix: correct French typo "Analtique" → "Analytique"

### DIFF
--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -128,7 +128,7 @@
 	"Amazing": "Incroyable",
 	"an assistant": "un assistant",
 	"An error occurred while fetching the explanation": "Une erreur s'est produite lors de la récupération de l'explication",
-	"Analytics": "Analtique",
+	"Analytics": "Analytique",
 	"Analyzed": "Analysé",
 	"Analyzing...": "Analyse en cours",
 	"and {{COUNT}} more": "et {{COUNT}} autres",


### PR DESCRIPTION
# Changelog Entry

### Description

This pull request fixes a typo in the French translation for the Analytics feature: the label `"Analtique"` has been corrected to `"Analytique"`.  
This improves the quality and consistency of the French localization in the user interface.

### Added

- N/A

### Changed

- Updated the French i18n translation string for the Analytics label from `"Analtique"` to `"Analytique"` in the French locale file(s).

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed a French typo where the Analytics label was displayed as `"Analtique"` instead of the correct `"Analytique"`.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Scope of the change is limited to French localization only; no functional or behavioral changes to the Analytics feature itself.
- The fix was applied in the French locale resource file (for example `fr-FR` JSON/TS file under the i18n/locales folder, depending on the current codebase structure).

**Manual testing performed:**

- Switched the UI language to French.
- Navigated to the Analytics section of Open WebUI. [https://docs.openwebui.com/features/](https://docs.openwebui.com/features/
- Verified that the label now displays `"Analytique"` instead of `"Analtique"` everywhere it is used.

### Contributor License Agreement

contributor license agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
