### PR TITLE
fix: preserve newlines in textarea prompt variables on Windows

### DIFF
--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -21,7 +21,14 @@
 	let variableValues = {};
 
 	const submitHandler = async () => {
-		onSave(variableValues);
+		// Normalize Windows CRLF line endings to LF for consistent handling
+		const normalizedValues = Object.fromEntries(
+			Object.entries(variableValues).map(([key, value]) => [
+				key,
+				typeof value === 'string' ? value.replace(/\r\n/g, '\n') : value
+			])
+		);
+		onSave(normalizedValues);
 		show = false;
 	};
 

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -501,7 +501,23 @@
 
 		// Apply replacements in reverse order to maintain correct positions
 		replacements.reverse().forEach(({ from, to, text }) => {
-			tr = tr.replaceWith(from, to, text !== '' ? state.schema.text(text) : []);
+			if (text === '') {
+				tr = tr.replaceWith(from, to, []);
+			} else {
+				// Normalize Windows line endings and split on newlines
+				// to preserve line breaks as hardBreak nodes in ProseMirror
+				const lines = text.replace(/\r\n/g, '\n').split('\n');
+				const nodes = [];
+				lines.forEach((line, i) => {
+					if (line) {
+						nodes.push(state.schema.text(line));
+					}
+					if (i < lines.length - 1) {
+						nodes.push(state.schema.nodes.hardBreak.create());
+					}
+				});
+				tr = tr.replaceWith(from, to, nodes);
+			}
 		});
 
 		// Only dispatch if there are changes


### PR DESCRIPTION
  ## Summary

  Fixes textarea input variables losing line breaks after message submission on Windows.

  ## Problem

  When users paste or type multi-line text into a textarea prompt variable on Windows:
  1. Text appears correct in the modal
  2. After clicking "Save" and sending the message, all newlines are stripped
  3. Editing the message reveals formatting is lost

  Root cause: two issues working together:
  - Windows uses CRLF (`\r\n`) line endings which were not normalized
  - ProseMirror's `schema.text()` creates plain text nodes that discard newline characters — they need to be represented as `hardBreak` nodes

  ## Solution

  **`InputVariablesModal.svelte`**: Normalize Windows CRLF (`\r\n`) to LF (`\n`) before passing variable values to the editor.

  **`RichTextInput.svelte`**: In `replaceVariables()`, split replacement text on newlines and create proper ProseMirror `hardBreak` nodes between text
  segments instead of inserting raw newline characters.

  Closes #21447

  # Changelog Entry

  ### Description

  - Fix textarea prompt variables losing newlines on Windows in `replaceVariables()` and `InputVariablesModal`

  ### Fixed

  - Textarea prompt variable newlines now preserved on Windows by normalizing CRLF line endings and converting newlines to ProseMirror hardBreak nodes

  ### Contributor License Agreement

  By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement
  (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.