### PR TITLE
fix: preserve header metadata in markdown splitter

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1495,7 +1495,7 @@ def save_docs_to_vector_db(
                     [
                         Document(
                             page_content=split_chunk.page_content,
-                            metadata={**doc.metadata},
+                            metadata={**doc.metadata, **split_chunk.metadata},
                         )
                         for split_chunk in markdown_splitter.split_text(
                             doc.page_content


### PR DESCRIPTION
## Summary

Fixes header metadata loss in `MarkdownHeaderTextSplitter` output.

Relates to #21486 (Bug 1).

## Change

`MarkdownHeaderTextSplitter.split_text()` returns chunks with metadata containing the header hierarchy, e.g.:

```python
{"Header 1": "Chapter 1", "Header 2": "1.1 Background"}
```

Currently, only the parent document's metadata is preserved:

```python
metadata={**doc.metadata}  # split_chunk.metadata is discarded
```

This PR merges both:

```python
metadata={**doc.metadata, **split_chunk.metadata}
```

## Impact

- Chunks now carry header context, improving retrieval relevance
- No behavioral change when `ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER` is disabled
- No new config keys or dependencies

## Testing

1. Enable markdown header splitting in Admin → Settings → Documents
2. Upload a markdown file with nested headers (H1-H4)
3. Inspect chunk metadata via ChromaDB or API

**Before:** all chunks have identical metadata (parent doc only)
**After:** each chunk includes `Header 1`, `Header 2`, etc. from its section