### PR TITLE
fix: make Brave web search failures clearer and safer

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2323,6 +2323,15 @@ async def process_web_search(
         # Set to 1 for sequential execution (rate-limited APIs like Brave free tier)
         concurrent_limit = request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS
 
+        # Brave free tier is strict (1 request/second). When concurrency is left at the
+        # default unlimited setting, query expansion can easily trigger 429 errors.
+        # Keep explicit admin configuration untouched, but make the Brave default safer.
+        if (
+            not concurrent_limit
+            and request.app.state.config.WEB_SEARCH_ENGINE == "brave"
+        ):
+            concurrent_limit = 1
+
         if concurrent_limit:
             # Limited concurrency with semaphore
             semaphore = asyncio.Semaphore(concurrent_limit)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1410,12 +1410,27 @@ async def chat_web_search_handler(
 
     except Exception as e:
         log.exception(e)
+
+        error_detail = str(e).strip() or type(e).__name__
+        if len(error_detail) > 300:
+            error_detail = f"{error_detail[:297]}..."
+
+        form_data["messages"] = add_or_update_system_message(
+            (
+                "Web search failed and no live web results were retrieved. "
+                f"Error: {error_detail}. "
+                "Be transparent that you are answering without fresh web data."
+            ),
+            form_data["messages"],
+            append=True,
+        )
+
         await event_emitter(
             {
                 "type": "status",
                 "data": {
                     "action": "web_search",
-                    "description": "An error occurred while searching the web",
+                    "description": f"Web search failed: {error_detail}",
                     "queries": queries,
                     "done": True,
                     "error": True,


### PR DESCRIPTION
## Summary
- default Brave web-search query fan-out to sequential execution when web search concurrency is left unset/unlimited, reducing free-tier 429 bursts from generated multi-query searches
- preserve explicit admin concurrency settings and only apply the fallback for Brave
- include concrete web-search error details in status events and inject a transparency hint into system context so the model does not fabricate vague 'technical difficulties' claims