### PR TITLE
fix: preserve header metadata in markdown splitter

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1495,7 +1495,7 @@ def save_docs_to_vector_db(
                     [
                         Document(
                             page_content=split_chunk.page_content,
-                            metadata={**doc.metadata},
+                            metadata={**doc.metadata, **split_chunk.metadata},
                         )
                         for split_chunk in markdown_splitter.split_text(
                             doc.page_content


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Changelog:** Provided below
- [x] **Documentation:** No user-facing behavior change, no docs needed
- [x] **Dependencies:** None
- [x] **Testing:** Manually tested with markdown files containing nested H1-H4 headers
- [x] **Agentic AI Code:** This fix was identified through manual code review and tested by the author
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Minimal one-line fix, no new settings
- [x] **Git Hygiene:** Single atomic commit
- [x] **Title Prefix:** fix

# Changelog Entry

### Description

- Fix header metadata being discarded when using `MarkdownHeaderTextSplitter`

### Fixed

- `MarkdownHeaderTextSplitter.split_text()` returns chunks with metadata containing the header hierarchy (e.g. `{"Header 1": "Chapter 1", "Header 2": "1.1 Background"}`), but only the parent document's metadata was preserved via `metadata={**doc.metadata}`, discarding `split_chunk.metadata`. Changed to `metadata={**doc.metadata, **split_chunk.metadata}` to merge both.

---

### Additional Information

- Relates to #21486 (Bug 1)
- One-line change in `backend/open_webui/routers/retrieval.py`

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.