### PR TITLE
fix: make Brave web search failures clearer and safer

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2323,6 +2323,15 @@ async def process_web_search(
         # Set to 1 for sequential execution (rate-limited APIs like Brave free tier)
         concurrent_limit = request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS
 
+        # Brave free tier is strict (1 request/second). When concurrency is left at the
+        # default unlimited setting, query expansion can easily trigger 429 errors.
+        # Keep explicit admin configuration untouched, but make the Brave default safer.
+        if (
+            not concurrent_limit
+            and request.app.state.config.WEB_SEARCH_ENGINE == "brave"
+        ):
+            concurrent_limit = 1
+
         if concurrent_limit:
             # Limited concurrency with semaphore
             semaphore = asyncio.Semaphore(concurrent_limit)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1410,12 +1410,27 @@ async def chat_web_search_handler(
 
     except Exception as e:
         log.exception(e)
+
+        error_detail = str(e).strip() or type(e).__name__
+        if len(error_detail) > 300:
+            error_detail = f"{error_detail[:297]}..."
+
+        form_data["messages"] = add_or_update_system_message(
+            (
+                "Web search failed and no live web results were retrieved. "
+                f"Error: {error_detail}. "
+                "Be transparent that you are answering without fresh web data."
+            ),
+            form_data["messages"],
+            append=True,
+        )
+
         await event_emitter(
             {
                 "type": "status",
                 "data": {
                     "action": "web_search",
-                    "description": "An error occurred while searching the web",
+                    "description": f"Web search failed: {error_detail}",
                     "queries": queries,
                     "done": True,
                     "error": True,


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [ ] **Changelog:** Ensure a changelog entry following Keep a Changelog format is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in the Open WebUI Docs repository.
- [x] **Dependencies:** No new dependencies were added.
- [x] **Testing:** Performed manual and direct verification steps (listed below).
- [x] **Agentic AI Code:** Changes were reviewed and validated by a human with explicit testing before submission.
- [x] **Code review:** Performed self-review and ensured consistency with existing patterns.
- [x] **Design & Architecture:** Change uses safe defaults without introducing new settings.
- [x] **Git Hygiene:** PR is atomic and contains one logical fix commit.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description
- Improve Brave web search resiliency and error transparency when query expansion is enabled.

### Added
- A Brave-specific fallback to sequential web-search execution when concurrency is unset/unlimited.
- Clear error details in web-search status events and a system hint to prevent fabricated "technical difficulties" claims.

### Changed
- Preserve explicit admin-configured concurrency for all engines; only apply fallback for Brave with unset/unlimited concurrency.

### Deprecated
- None.

### Removed
- None.

### Fixed
- Reduced likelihood of Brave free-tier 429 bursts from parallel generated queries.
- Improved observability of web-search failures shown to users.

### Security
- None.

### Breaking Changes
- None.

---

### Additional Information
- Files changed:
  - `backend/open_webui/routers/retrieval.py`
  - `backend/open_webui/utils/middleware.py`

### How I tested
1. Compiled changed backend files with:
   - `python -m py_compile open_webui/routers/retrieval.py open_webui/utils/middleware.py`
2. Verified fallback logic only applies when:
   - engine is `brave`
   - `WEB_SEARCH_CONCURRENT_REQUESTS` is unset/0
3. Verified explicit non-zero concurrency remains unchanged.
4. Verified web-search failure status now includes specific exception detail.

### Screenshots or Videos
- Not applicable (backend-only behavior change).

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.