### PR TITLE
feat: add Show Tool Call Output interface toggle

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -329,6 +329,7 @@
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
+				showToolCallOutput={$settings?.showToolCallOutput ?? true}
 				open={false}
 				className="w-full space-y-1"
 			/>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -70,6 +70,7 @@
 	let chatFadeStreamingText = true;
 	let collapseCodeBlocks = false;
 	let expandDetails = false;
+	let showToolCallOutput = true;
 	let renderMarkdownInPreviews = true;
 	let showChatTitleInTab = true;
 
@@ -233,6 +234,7 @@
 
 		collapseCodeBlocks = $settings?.collapseCodeBlocks ?? false;
 		expandDetails = $settings?.expandDetails ?? false;
+		showToolCallOutput = $settings?.showToolCallOutput ?? true;
 		renderMarkdownInPreviews = $settings?.renderMarkdownInPreviews ?? true;
 
 		landingPageMode = $settings?.landingPageMode ?? '';
@@ -960,6 +962,25 @@
 							bind:state={expandDetails}
 							on:change={() => {
 								saveSettings({ expandDetails });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="show-tool-call-output-label" class=" self-center text-xs">
+						{$i18n.t('Show Tool Call Output')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="show-tool-call-output-label"
+							tooltip={true}
+							bind:state={showToolCallOutput}
+							on:change={() => {
+								saveSettings({ showToolCallOutput });
 							}}
 						/>
 					</div>

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -30,6 +30,7 @@
 	} = {};
 
 	export let open = false;
+	export let showToolCallOutput: boolean = true;
 	export let className = '';
 	export let buttonClassName =
 		'w-fit text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition';
@@ -161,7 +162,7 @@
 					{/if}
 
 					<!-- Output -->
-					{#if isDone && result}
+					{#if showToolCallOutput && isDone && result}
 						<div>
 							<div
 								class="text-[10px] uppercase tracking-wider font-semibold text-gray-400 dark:text-gray-500 mb-1.5 px-1"

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -164,6 +164,7 @@ type Settings = {
 	voiceInterruption?: boolean;
 	collapseCodeBlocks?: boolean;
 	expandDetails?: boolean;
+	showToolCallOutput?: boolean;
 	notificationSound?: boolean;
 	notificationSoundAlways?: boolean;
 	stylizedPdfExport?: boolean;


### PR DESCRIPTION
Adds a new toggle in Settings > Interface that controls whether tool call output (the raw JSON result) is displayed. When off, only the tool name and input are shown, making the AI feel more like a seamless agent.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
