### PR TITLE
perf(notes): reduce list response size and N+1 queries for faster Notes tab

### DIFF
--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -31,7 +31,7 @@
 
 	import { goto } from '$app/navigation';
 	import { WEBUI_NAME, config, prompts as _prompts, user } from '$lib/stores';
-	import { createNewNote, deleteNoteById, getNoteList, searchNotes } from '$lib/apis/notes';
+	import { createNewNote, deleteNoteById, getNoteById, getNoteList, searchNotes } from '$lib/apis/notes';
 	import { capitalizeFirstLetter, copyToClipboard, getTimeRange } from '$lib/utils';
 	import { downloadPdf, createNoteHandler } from './utils';
 
@@ -73,15 +73,21 @@
 	let allItemsLoaded = false;
 
 	const downloadHandler = async (type) => {
+		const fullNote = await getNoteById(localStorage.token, selectedNote.id).catch((err) => {
+			toast.error(`Failed to load note: ${err}`);
+			return null;
+		});
+		if (!fullNote) return;
+
 		if (type === 'txt') {
-			const blob = new Blob([selectedNote.data.content.md], { type: 'text/plain' });
-			saveAs(blob, `${selectedNote.title}.txt`);
+			const blob = new Blob([fullNote.data.content.md], { type: 'text/plain' });
+			saveAs(blob, `${fullNote.title}.txt`);
 		} else if (type === 'md') {
-			const blob = new Blob([selectedNote.data.content.md], { type: 'text/markdown' });
-			saveAs(blob, `${selectedNote.title}.md`);
+			const blob = new Blob([fullNote.data.content.md], { type: 'text/markdown' });
+			saveAs(blob, `${fullNote.title}.md`);
 		} else if (type === 'pdf') {
 			try {
-				await downloadPdf(selectedNote);
+				await downloadPdf(fullNote);
 			} catch (error) {
 				toast.error(`${error}`);
 			}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **perf**: Performance improvement

# Changelog Entry

### Description

The Notes tab becomes very slow when users have many notes. The list/search endpoints (`get_notes`, `search_notes`, `get_notes_by_user_id`) return the full `data` field (markdown, HTML, JSON, files, versions) for every note. For ~60 notes per page this results in a ~167 MB response and ~27 second load time. Additionally, each note triggers a separate DB query for access grants (N+1 problem).

This PR reduces list payload from ~167 MB to ~10 KB and eliminates the N+1 grant queries, making the Notes tab load in seconds instead of tens of seconds.

### Added

- `get_grants_by_resources()` in `AccessGrantsTable` for batch grant loading (single query instead of N separate queries)
- `_to_note_models_batch()` in `NoteTable` for batch note-to-model conversion using the batch grant loader
- `_strip_data_for_list()` in `NoteTable` to keep only a 200-character markdown preview in list/grid responses

### Changed

- `get_notes()`, `search_notes()`, and `get_notes_by_user_id()` now use batch conversion + data stripping for lightweight list responses
- `downloadHandler` in `Notes.svelte` now fetches the full note via `getNoteById()` before generating TXT/MD/PDF files, since the list response no longer contains full content

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Notes tab extremely slow load time with many notes (~27s, ~167 MB payload for 60 notes)
- N+1 query problem where each note in a list triggered a separate DB query for access grants

### Security

- N/A

### Breaking Changes

- N/A — `GET /notes/:id` still returns full `data`; only list endpoints are affected, and the frontend download flow was updated to compensate

---

### Additional Information

- The `GET /notes/:id` endpoint and `update_note_by_id` are **not** modified — they still return full `data` for the note editor
- The 200-character preview is sufficient for the grid view preview line (`line-clamp-3`)
- No new dependencies were added
- No database schema changes
- `getNoteById` already existed in `src/lib/apis/notes/index.ts` — only the import in `Notes.svelte` was added

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
