### PR TITLE
fix: Incorrect hybrid search variable unpacking order

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -292,7 +292,7 @@ async def query_doc_with_hybrid_search(
         # retrieve only min(k, k_reranker) items, sort and cut by distance if k < k_reranker
         if k < k_reranker:
             sorted_items = sorted(
-                zip(distances, metadatas, documents), key=lambda x: x[0], reverse=True
+                zip(distances, documents, metadatas), key=lambda x: x[0], reverse=True
             )
             sorted_items = sorted_items[:k]
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->
# Changelog Entry

### Description

- Fix: Hybrid search returning 0 results due to a mismatch in query result unpacking order.

### Fixed

- Fix: Hybrid search returning 0 results due to a mismatch in query result unpacking order.

---

### Additional Information

Fix: Hybrid search returning 0 results due to a mismatch in query result unpacking order.
The zip order is:
[(distances, metadatas, documents)], but the unpack order is 
[distances, documents, metadatas] — these are mismatched.

After unpacking, what's actually in each variable is:
[distances] ← distances ✅
[documents]← metadatas ❌
[metadatas]← documents ❌

```py
        if k < k_reranker:
            sorted_items = sorted(
                # Ordering here is different to how it is unpacked in the lines below, leading to mismatched values in the variables.
                zip(distances, metadatas, documents ), key=lambda x: x[0], reverse=True 
            )
            sorted_items = sorted_items[:k]

            if sorted_items:
                distances, documents, metadatas = map(list, zip(*sorted_items))
            else:
                distances, documents, metadatas = [], [], []
```

When the results are then processed in merge_and_sort_query_results, the isinstance(document, str) check always fails, leading to 0 results in the combined list.

```py
def merge_and_sort_query_results(query_results: list[dict], k: int) -> dict:
......
        for distance, document, metadata in zip(distances, documents, metadatas):
            if isinstance(document, str):  # <--- the metadata value is accidentally getting unpacked into this variable.
                doc_hash = hashlib.sha256(
                    document.encode()
                ).hexdigest()  # Compute a hash for uniqueness

                if doc_hash not in combined.keys():
                    combined[doc_hash] = (distance, document, metadata)
                    continue  # if doc is new, no further comparison is needed

                # if doc is alredy in, but new distance is better, update
                if distance > combined[doc_hash][0]:
                    combined[doc_hash] = (distance, document, metadata)
```

### Screenshots or Videos

Before change: 
The value in 'document' is a dict with all the document metadata values:
<img width="780" height="445" alt="image" src="https://github.com/user-attachments/assets/a55a9ba9-a32e-4612-9180-e89905b41358" />

After change:
The value in 'document' is a string with the document chunk content:
<img width="842" height="392" alt="image" src="https://github.com/user-attachments/assets/b86e66b8-762e-4857-be27-4fc16023ffc4" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
