### PR TITLE
fix: clamp SCIM pagination args instead of rejecting them

### DIFF
--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -523,13 +523,17 @@ async def get_schemas():
 @router.get("/Users", response_model=SCIMListResponse)
 async def get_users(
     request: Request,
-    startIndex: int = Query(1, ge=1),
-    count: int = Query(20, ge=1, le=100),
+    startIndex: int = Query(1),
+    count: int = Query(20),
     filter: Optional[str] = None,
     _: bool = Depends(get_scim_auth),
     db: Session = Depends(get_session),
 ):
     """List SCIM Users"""
+    # Clamp per SCIM 2.0 spec (RFC 7644 §3.4.2.4):
+    # startIndex < 1 SHALL be treated as 1; count < 0 SHALL be treated as 0.
+    startIndex = max(1, startIndex)
+    count = max(0, min(100, count))
     skip = startIndex - 1
     limit = count
 
@@ -794,13 +798,18 @@ async def delete_user(
 @router.get("/Groups", response_model=SCIMListResponse)
 async def get_groups(
     request: Request,
-    startIndex: int = Query(1, ge=1),
-    count: int = Query(20, ge=1, le=100),
+    startIndex: int = Query(1),
+    count: int = Query(20),
     filter: Optional[str] = None,
     _: bool = Depends(get_scim_auth),
     db: Session = Depends(get_session),
 ):
     """List SCIM Groups"""
+    # Clamp per SCIM 2.0 spec (RFC 7644 §3.4.2.4):
+    # startIndex < 1 SHALL be treated as 1; count < 0 SHALL be treated as 0.
+    startIndex = max(1, startIndex)
+    count = max(0, min(100, count))
+
     # Get all groups
     groups_list = Groups.get_all_groups(db=db)
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Changelog:** Provided below
- [x] **Documentation:** No user-facing behaviour or env var changes
- [x] **Dependencies:** None
- [x] **Testing:** Manually verified before/after behaviour — see below
- [x] **Agentic AI Code:** Reviewed and manually tested by human author
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Minimal targeted fix, no new settings
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

The `/Users` and `/Groups` SCIM endpoints used FastAPI `Query` constraints (`ge=1`, `le=100`) to validate `startIndex` and `count`, causing a `422 Unprocessable Entity` for out-of-range values. RFC 7644 §3.4.2.4 is explicit that these values must be **clamped**, not rejected:

> A `startIndex` value less than 1 **SHALL be interpreted as 1.**
> A negative `count` value **SHALL be interpreted as 0.**
> A `count` greater than the server maximum may return fewer results than requested.

### Fixed

- `GET /api/v1/scim/v2/Users` and `GET /api/v1/scim/v2/Groups` now clamp `startIndex` and `count` to valid ranges rather than returning `422` for out-of-range values, in compliance with RFC 7644 §3.4.2.4

---

### Additional Information

**Before** — these all returned `422`:
```
GET /api/v1/scim/v2/Users?startIndex=0
GET /api/v1/scim/v2/Users?count=0
GET /api/v1/scim/v2/Users?count=9999
GET /api/v1/scim/v2/Groups?startIndex=-1
```

**After** — all return `200` with clamped values:
- `startIndex=0` → treated as `1`
- `count=-1` → treated as `0` (returns metadata only, per spec)
- `count=9999` → clamped to server maximum of `100`

### Screenshots or Videos

N/A — backend-only fix, no UI changes.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.