### PR TITLE
perf: Fix O(n²) perf issue

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -93,12 +93,11 @@ def get_message_list(messages_map, message_id):
     message_list = []
 
     while current_message:
-        message_list.insert(
-            0, current_message
-        )  # Insert the message at the beginning of the list
+        message_list.append(current_message)
         parent_id = current_message.get("parentId")  # Use .get() for safety
         current_message = messages_map.get(parent_id) if parent_id else None
 
+    message_list.reverse()
     return message_list
 
 


### PR DESCRIPTION
Co-authored-by: Jordan <CenteredAxis@users.noreply.github.com>

**This PR should greatly improve the performance when sending a message (latency before the model starts responding) and when searching across chats.**

get_message_list is called in middleware.py during message processing (when you send a message). It's used to build the conversation history that gets sent to the LLM. It's also called in routers/chats.py for search (lines 165, 318) and in retrieval/utils.py for RAG context building.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
