### PR TITLE
perf: Query title column directly in get_chat_title_by_id instead of loading full chat

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -456,11 +456,11 @@ class ChatTable:
             return ChatModel.model_validate(chat)
 
     def get_chat_title_by_id(self, id: str) -> Optional[str]:
-        chat = self.get_chat_by_id(id)
-        if chat is None:
-            return None
-
-        return chat.chat.get("title", "New Chat")
+        with get_db_context() as db:
+            result = db.query(Chat.title).filter_by(id=id).first()
+            if result is None:
+                return None
+            return result[0] or "New Chat"
 
     def get_messages_map_by_chat_id(self, id: str) -> Optional[dict]:
         chat = self.get_chat_by_id(id)


### PR DESCRIPTION
Previously loaded the entire ChatModel (including the full conversation JSON blob) just to extract the title string. Now queries only the Chat.title column directly, which is already a top-level DB column.

get_chat_title_by_id: 2 call sites, both in middleware.py (lines 2927 and 4432). It's called to grab the title for notification/logging purposes after a response completes. Low frequency, but saves transmitting the full blob over the wire for something that's just a column read.

**Makes the database query MUCH faster as only the title has to be grabbed and also saves network latency and network bandwidth!**

For a chat with hundreds of messages, the difference between `SELECT title FROM chat WHERE id = ?` and` SELECT * FROM chat WHERE id = ?` is significant at every layer: disk I/O, DB CPU, network, and application memory.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
