### PR TITLE
perf: Cache chat object in upsert_message to avoid redundant DB load

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -481,15 +481,17 @@ class ChatTable:
     def upsert_message_to_chat_by_id_and_message_id(
         self, id: str, message_id: str, message: dict
     ) -> Optional[ChatModel]:
-        chat = self.get_chat_by_id(id)
-        if chat is None:
+        chat_obj = self.get_chat_by_id(id)
+        if chat_obj is None:
             return None
+
+        user_id = chat_obj.user_id
 
         # Sanitize message content for null characters before upserting
         if isinstance(message.get("content"), str):
             message["content"] = sanitize_text_for_db(message["content"])
 
-        chat = chat.chat
+        chat = chat_obj.chat
         history = chat.get("history", {})
 
         if message_id in history.get("messages", {}):
@@ -509,7 +511,7 @@ class ChatTable:
             ChatMessages.upsert_message(
                 message_id=message_id,
                 chat_id=id,
-                user_id=self.get_chat_by_id(id).user_id,
+                user_id=user_id,
                 data=history["messages"][message_id],
             )
         except Exception as e:


### PR DESCRIPTION
upsert_message_to_chat_by_id_and_message_id was calling get_chat_by_id
twice: once at the top to load the chat, and again at line 512 just to
get user_id for the dual-write to chat_message table.

<ins>**This function fires many times during streaming responses, so each redundant load deserializes the full conversation JSON blob unnecessarily.**</ins>

upsert_message: Look at that call count: 17 call sites across socket/main.py and middleware.py. This is called during streaming. It's also called when the user's message is first saved, when tool calls happen, when the final response lands. <ins>**So this one fires many times during a single streaming response, and each was doing 2 full chat loads instead of 1.**</ins>

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
