### PR TITLE
feat: Add ability to not overwrite the whole collection when processing URLs

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -25,7 +25,7 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.concurrency import run_in_threadpool
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import tiktoken
 
 
@@ -252,6 +252,14 @@ class CollectionNameForm(BaseModel):
 
 class ProcessUrlForm(CollectionNameForm):
     url: str
+    overwrite: bool = Field(
+        default=True,
+        description=(
+            "Whether to replace an existing vector collection before saving "
+            "content from the URL. Set to false to preserve existing vectors "
+            "for the collection."
+        ),
+    )
 
 
 class SearchForm(BaseModel):
@@ -1953,7 +1961,7 @@ async def process_web(
                     request,
                     docs,
                     collection_name,
-                    overwrite=True,
+                    overwrite=form_data.overwrite,
                     user=user,
                 )
             else:

--- a/backend/open_webui/test/apps/webui/routers/test_retrieval_process_web.py
+++ b/backend/open_webui/test/apps/webui/routers/test_retrieval_process_web.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.documents import Document
+
+from open_webui.routers import retrieval
+
+
+def _build_request(bypass_embedding_and_retrieval: bool = False):
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                config=SimpleNamespace(
+                    BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=bypass_embedding_and_retrieval
+                )
+            )
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_web_defaults_to_overwrite_true(monkeypatch):
+    calls = []
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        if func is retrieval.get_content_from_url:
+            return ("example content", [Document(page_content="doc", metadata={})])
+        if func is retrieval.save_docs_to_vector_db:
+            return True
+        raise AssertionError(f"Unexpected threadpool function: {func}")
+
+    monkeypatch.setattr(retrieval, "run_in_threadpool", fake_run_in_threadpool)
+
+    response = await retrieval.process_web(
+        request=_build_request(),
+        form_data=retrieval.ProcessUrlForm(
+            url="https://example.com", collection_name="test-collection"
+        ),
+        process=True,
+        user=SimpleNamespace(id="test-user"),
+    )
+
+    assert response["status"] is True
+    save_call = calls[1]
+    assert save_call[0] is retrieval.save_docs_to_vector_db
+    assert save_call[2]["overwrite"] is True
+
+
+@pytest.mark.asyncio
+async def test_process_web_respects_overwrite_false(monkeypatch):
+    calls = []
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        if func is retrieval.get_content_from_url:
+            return ("example content", [Document(page_content="doc", metadata={})])
+        if func is retrieval.save_docs_to_vector_db:
+            return True
+        raise AssertionError(f"Unexpected threadpool function: {func}")
+
+    monkeypatch.setattr(retrieval, "run_in_threadpool", fake_run_in_threadpool)
+
+    response = await retrieval.process_web(
+        request=_build_request(),
+        form_data=retrieval.ProcessUrlForm(
+            url="https://example.com",
+            collection_name="test-collection",
+            overwrite=False,
+        ),
+        process=True,
+        user=SimpleNamespace(id="test-user"),
+    )
+
+    assert response["status"] is True
+    save_call = calls[1]
+    assert save_call[0] is retrieval.save_docs_to_vector_db
+    assert save_call[2]["overwrite"] is False

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -331,7 +331,8 @@ export const processWeb = async (
 	token: string,
 	collection_name: string,
 	url: string,
-	process: boolean = true
+	process: boolean = true,
+	overwrite: boolean = true
 ) => {
 	let error = null;
 
@@ -350,7 +351,8 @@ export const processWeb = async (
 		},
 		body: JSON.stringify({
 			url: url,
-			collection_name: collection_name
+			collection_name: collection_name,
+			overwrite: overwrite
 		})
 	})
 		.then(async (res) => {


### PR DESCRIPTION
Make /process/web overwrite behavior configurable instead of always replacing existing collections. Reasoning behind it: When trying to import all URLs of a website using the API, I want them all to end up in the same knowledge base. Currently that was not possible because every new request would replace the knowledge base (collection) instead of just adding the content of the new URL to the collection.

See https://github.com/open-webui/open-webui/issues/21336


<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps: See https://github.com/open-webui/docs/pull/1094
- [X] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [X] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Make /process/web overwrite behavior configurable instead of always replacing existing collections. Reasoning behind it: When trying to import all URLs of a website using the API, I want them all to end up in the same knowledge base. Currently that was not possible because every new request would replace the knowledge base (collection) instead of just adding the content of the new URL to the collection.

### Changed

- Made POST /api/v1/retrieval/process/web respect a request-body overwrite flag instead of always forcing overwrite.
- Updated frontend retrieval API helper to pass overwrite (default true) so existing behavior remains unchanged unless explicitly set.

### Added

- Added OpenAPI/Swagger documentation for the overwrite field on ProcessUrlForm.
- Added backend tests covering default overwrite=true and explicit overwrite=false behavior.

---


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
