### PR TITLE
perf: Eliminate N+1 access grant queries in prompts listing

### DIFF
--- a/backend/open_webui/models/access_grants.py
+++ b/backend/open_webui/models/access_grants.py
@@ -456,6 +456,36 @@ class AccessGrantsTable:
             )
             return [AccessGrantModel.model_validate(g) for g in grants]
 
+    def get_grants_by_resources(
+        self,
+        resource_type: str,
+        resource_ids: list[str],
+        db: Optional[Session] = None,
+    ) -> dict[str, list[AccessGrantModel]]:
+        """Batch-fetch all grants for multiple resources in a single query.
+
+        Returns a dict mapping resource_id -> list of AccessGrantModel.
+        """
+        if not resource_ids:
+            return {}
+
+        with get_db_context(db) as db:
+            grants = (
+                db.query(AccessGrant)
+                .filter(
+                    AccessGrant.resource_type == resource_type,
+                    AccessGrant.resource_id.in_(resource_ids),
+                )
+                .all()
+            )
+
+            result: dict[str, list[AccessGrantModel]] = {
+                rid: [] for rid in resource_ids
+            }
+            for g in grants:
+                result[g.resource_id].append(AccessGrantModel.model_validate(g))
+            return result
+
     def has_access(
         self,
         user_id: str,


### PR DESCRIPTION
The prompts listing endpoints were calling _get_access_grants() per
prompt (N+1 queries) via _to_prompt_model(). Additionally,
get_prompts_by_user_id() called has_access() per prompt for filtering
(another N+1). Now:

- get_prompts() batch-fetches all access grants in one query via new
  get_grants_by_resources() method on AccessGrants
- get_prompts_by_user_id() uses batch get_accessible_resource_ids()
  instead of per-prompt has_access() calls
- search_prompts() batch-fetches grants instead of per-item
  _to_prompt_model() calls

For 30 prompts this reduces ~31 DB queries to ~3.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
