### PR TITLE
fix: race condition in signup allows multiple admin accounts

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -700,8 +700,9 @@ async def signup_handler(
     Returns the newly created UserModel.
     Raises HTTPException on failure.
     """
-    has_users = Users.has_users(db=db)
-    role = "admin" if not has_users else request.app.state.config.DEFAULT_USER_ROLE
+    # Insert with default role first to avoid TOCTOU race on first signup.
+    # If has_users() is checked before insert, concurrent requests during
+    # first-user registration can all see an empty table and each get admin.
     hashed = get_password_hash(password)
 
     user = Auths.insert_new_auth(
@@ -709,11 +710,18 @@ async def signup_handler(
         password=hashed,
         name=name,
         profile_image_url=profile_image_url,
-        role=role,
+        role=request.app.state.config.DEFAULT_USER_ROLE,
         db=db,
     )
     if not user:
         raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+
+    # Atomically check if this is the only user *after* the insert.
+    # Only the single user present at this point should become admin.
+    if Users.get_num_users(db=db) == 1:
+        Users.update_user_role_by_id(user.id, "admin", db=db)
+        user = Users.get_user_by_id(user.id, db=db)
+        request.app.state.config.ENABLE_SIGNUP = False
 
     if request.app.state.config.WEBHOOK_URL:
         await post_webhook(
@@ -726,10 +734,6 @@ async def signup_handler(
                 "user": user.model_dump_json(exclude_none=True),
             },
         )
-
-    if not has_users:
-        # Disable signup after the first user is created
-        request.app.state.config.ENABLE_SIGNUP = False
 
     apply_default_group_assignment(
         request.app.state.config.DEFAULT_GROUP_ID,


### PR DESCRIPTION
## Security Fix: TOCTOU Race in Signup Allows Multiple Admin Registrations

### Vulnerable Lines

**File:** [`backend/open_webui/routers/auths.py#L703-L709`](https://github.com/open-webui/open-webui/blob/main/backend/open_webui/routers/auths.py#L703-L709)

```python
has_users = Users.has_users(db=db)                    # CHECK
role = "admin" if not has_users else ...               # DECIDE  
hashed = get_password_hash(password)                   # bcrypt ~100ms window
user = Auths.insert_new_auth(..., role=role, db=db)   # USE (stale check)
```

### What could happen

On a fresh Open WebUI deployment with multiple uvicorn workers, an attacker can send concurrent signup requests during first-user registration. Each worker's `has_users()` check returns False before any insert completes, so multiple accounts receive the admin role. I tested this with 4 workers and 30 concurrent requests — 4 accounts got admin. Each had full admin privileges: listing users, reading config, managing the instance.

### How to verify

1. Start Open WebUI with `UVICORN_WORKERS=4` and `ENABLE_SIGNUP=true`
2. On a fresh instance (no existing users), fire 20+ concurrent POST requests to `/api/v1/auths/signup` with different email addresses
3. Check how many responses contain `"role": "admin"` — without this fix, multiple will

Full HTTP traces and race condition results: [evidence gist](https://gist.github.com/theeggorchicken/455f6c46ea73bd96396400a679c3c207)

### What this PR does

Eliminates the TOCTOU (time-of-check-to-time-of-use) race window in `signup_handler` by reversing the order of operations:

1. **Before (vulnerable):** Check `has_users()` → decide role → hash password (~100ms) → insert with pre-decided role
2. **After (fixed):** Hash password → insert with default role → check `get_num_users()` after insert → promote to admin only if user count is exactly 1

The key insight is that `get_num_users()` after the insert is a point-in-time read that includes the just-inserted row. If two concurrent requests both insert, both will see count >= 2, so neither gets promoted. Only the truly first user (count == 1) becomes admin.

The fix also moves the `ENABLE_SIGNUP = False` guard into the same conditional block, so signup is disabled atomically with the admin promotion.

### Evidence

https://gist.github.com/theeggorchicken/455f6c46ea73bd96396400a679c3c207