### PR TITLE
fix: race condition in signup allows multiple admin accounts

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -700,8 +700,9 @@ async def signup_handler(
     Returns the newly created UserModel.
     Raises HTTPException on failure.
     """
-    has_users = Users.has_users(db=db)
-    role = "admin" if not has_users else request.app.state.config.DEFAULT_USER_ROLE
+    # Insert with default role first to avoid TOCTOU race on first signup.
+    # If has_users() is checked before insert, concurrent requests during
+    # first-user registration can all see an empty table and each get admin.
     hashed = get_password_hash(password)
 
     user = Auths.insert_new_auth(
@@ -709,11 +710,18 @@ async def signup_handler(
         password=hashed,
         name=name,
         profile_image_url=profile_image_url,
-        role=role,
+        role=request.app.state.config.DEFAULT_USER_ROLE,
         db=db,
     )
     if not user:
         raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+
+    # Atomically check if this is the only user *after* the insert.
+    # Only the single user present at this point should become admin.
+    if Users.get_num_users(db=db) == 1:
+        Users.update_user_role_by_id(user.id, "admin", db=db)
+        user = Users.get_user_by_id(user.id, db=db)
+        request.app.state.config.ENABLE_SIGNUP = False
 
     if request.app.state.config.WEBHOOK_URL:
         await post_webhook(
@@ -726,10 +734,6 @@ async def signup_handler(
                 "user": user.model_dump_json(exclude_none=True),
             },
         )
-
-    if not has_users:
-        # Disable signup after the first user is created
-        request.app.state.config.ENABLE_SIGNUP = False
 
     apply_default_group_assignment(
         request.app.state.config.DEFAULT_GROUP_ID,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** N/A — internal code fix, no user-facing API changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Tested with 4 uvicorn workers and 30 concurrent signup requests. Before fix: 4 admin accounts created. After fix: only 1 admin.
- [x] **Agentic AI Code:** This fix has been human-reviewed and manually tested against a running Open WebUI instance.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** Minimal change — no new settings, no UI changes.
- [x] **Git Hygiene:** Single atomic commit.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Race condition in `signup_handler` allows multiple admin account registrations on fresh deployments when running with multiple uvicorn workers.

### Fixed

- TOCTOU race in `signup_handler` where `has_users()` check is not atomic with `insert_new_auth()`. With multiple workers, concurrent signup requests during first-user registration can all see an empty user table and each receive the admin role.

### Security

- Prevents unauthorized admin privilege escalation during initial setup on multi-worker deployments.

---

### Vulnerable Lines

**File:** [`backend/open_webui/routers/auths.py#L703-L709`](https://github.com/open-webui/open-webui/blob/main/backend/open_webui/routers/auths.py#L703-L709)

```python
has_users = Users.has_users(db=db)                    # CHECK
role = "admin" if not has_users else ...               # DECIDE
hashed = get_password_hash(password)                   # bcrypt ~100ms window
user = Auths.insert_new_auth(..., role=role, db=db)   # USE (stale check)
```

### What could happen

On a fresh Open WebUI deployment with multiple uvicorn workers (`--workers >= 2`), an attacker can send concurrent signup requests during first-user registration. Each worker's `has_users()` returns False before any insert completes, so multiple accounts get the admin role. I tested with 4 workers and 30 concurrent requests — 4 accounts got admin, each with full admin privileges (listing users, reading config, managing the instance).

### How to verify

1. Start Open WebUI with `UVICORN_WORKERS=4` and `ENABLE_SIGNUP=true`
2. On a fresh instance (no existing users), fire 20+ concurrent POST requests to `/api/v1/auths/signup` with different email addresses
3. Check how many responses contain `"role": "admin"` — without this fix, multiple will

### What this PR does

Reverses the signup flow: insert the user with the default role first, then atomically check if the user count is 1 (meaning this is the only user). Only then promote to admin. This closes the race window because after the insert, the count includes the just-inserted row — if two workers insert concurrently, both will see count >= 2 and neither gets promoted.

### Evidence

Full race condition exploit traces: https://gist.github.com/theeggorchicken/455f6c46ea73bd96396400a679c3c207

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.