### PR TITLE
feat: add SSO custom logout URI support

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -463,6 +463,12 @@ OPENID_PROVIDER_URL = PersistentConfig(
     os.environ.get("OPENID_PROVIDER_URL", ""),
 )
 
+OAUTH_LOGOUT_URI = PersistentConfig(
+    "OAUTH_LOGOUT_URI",
+    "oauth.oidc.logout_uri",
+    os.environ.get("OAUTH_LOGOUT_URI", ""),
+)
+
 OPENID_REDIRECT_URI = PersistentConfig(
     "OPENID_REDIRECT_URI",
     "oauth.oidc.redirect_uri",
@@ -812,7 +818,7 @@ def load_oauth_providers():
     if FEISHU_CLIENT_ID.value:
         configured_providers.append("Feishu")
 
-    if configured_providers and not OPENID_PROVIDER_URL.value:
+    if configured_providers and not OPENID_PROVIDER_URL.value and not OAUTH_LOGOUT_URI.value:
         provider_list = ", ".join(configured_providers)
         log.warning(
             f"⚠️  OAuth providers configured ({provider_list}) but OPENID_PROVIDER_URL not set - logout will not work!"

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -45,6 +45,7 @@ from open_webui.env import (
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from open_webui.config import (
+    OAUTH_LOGOUT_URI,
     OPENID_PROVIDER_URL,
     ENABLE_OAUTH_SIGNUP,
     ENABLE_LDAP,
@@ -818,6 +819,19 @@ async def signout(
     oauth_session_id = request.cookies.get("oauth_session_id")
     if oauth_session_id:
         response.delete_cookie("oauth_session_id")
+
+        # If a custom logout URI is configured, use it directly.
+        # This supports SSO providers (e.g. AWS Cognito) that do not
+        # use the standard OIDC end_session_endpoint flow.
+        if OAUTH_LOGOUT_URI.value:
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "status": True,
+                    "redirect_url": OAUTH_LOGOUT_URI.value,
+                },
+                headers=response.headers,
+            )
 
         session = OAuthSessions.get_session_by_id(oauth_session_id, db=db)
         oauth_server_metadata_url = (


### PR DESCRIPTION
## Summary

Fixes #19182

- Added `OAUTH_LOGOUT_URI` environment variable (PersistentConfig) to allow configuring a custom logout URL for SSO providers
- When `OAUTH_LOGOUT_URI` is set and an OAuth session exists, the signout handler redirects to it directly, bypassing the standard OIDC `end_session_endpoint` discovery flow
- Updated the startup warning to not fire when `OAUTH_LOGOUT_URI` is configured (since logout will work without `OPENID_PROVIDER_URL` in that case)

## Motivation

SSO providers like AWS Cognito do not support the standard OIDC logout flow (`end_session_endpoint` with `id_token_hint` / `post_logout_redirect_uri`). They require provider-specific logout URLs with different parameters. This change allows administrators to set the full logout URI upfront, which is sufficient when all values are known at configuration time.

### Example usage (AWS Cognito)

```
OAUTH_LOGOUT_URI=https://<domain>.auth.<region>.amazoncognito.com/logout?client_id=<client_id>&logout_uri=https://<your-app-url>
```

## Changes

- `backend/open_webui/config.py`: Added `OAUTH_LOGOUT_URI` PersistentConfig; updated startup warning logic
- `backend/open_webui/routers/auths.py`: Imported `OAUTH_LOGOUT_URI`; added early return in signout handler when custom URI is configured

## Test plan

- [x] Verified Python syntax validity of both changed files
- [ ] Set `OAUTH_LOGOUT_URI` to a custom URL and verify signout redirects to it
- [ ] Leave `OAUTH_LOGOUT_URI` unset and verify existing OIDC logout flow still works
- [ ] Set `OAUTH_LOGOUT_URI` without `OPENID_PROVIDER_URL` and verify no startup warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)