### PR TITLE
fix: consistent bubble sizes with YAML code blocks in widescreen

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -415,7 +415,7 @@
 	});
 </script>
 
-<div>
+<div class="max-w-full overflow-hidden">
 	<div
 		class="relative {className} flex flex-col rounded-2xl border border-gray-100/30 dark:border-gray-850/30 my-0.5"
 		dir="ltr"


### PR DESCRIPTION
## Summary

Fixes #5975

In widescreen mode, conversation bubbles resize inconsistently when messages contain YAML (or other long-line) code blocks. This happens because the code block's outer `<div>` wrapper has no width or overflow constraints, allowing the intrinsic width of long code lines to propagate up and influence the parent bubble's layout during scroll reflows.

## Changes

- Added `max-w-full overflow-hidden` to the outermost `<div>` of `CodeBlock.svelte`
- `max-w-full` ensures the code block never exceeds its parent container's width
- `overflow-hidden` prevents code content from expanding the bubble; the inner `<pre>` element already provides horizontal scrolling via `overflow-x-auto`

## Test Plan

- Open a chat in widescreen mode
- Send or view a message containing a YAML code block with long lines (e.g. from [this file](https://github.com/ChatLunaLab/chatluna-character/blob/main/resources/presets/default.yml))
- Scroll up and down the page
- Verify that conversation bubble widths remain consistent and do not change while scrolling