### PR TITLE
fix: correct request header in image generation function

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -641,7 +641,7 @@ async def image_generations(
 
             for image in res["data"]:
                 if image_url := image.get("url", None):
-                    image_data, content_type = get_image_data(image_url, headers)
+                    image_data, content_type = get_image_data(image_url)
                 else:
                     image_data, content_type = get_image_data(image["b64_json"])
 
@@ -993,7 +993,7 @@ async def image_edits(
             images = []
             for image in res["data"]:
                 if image_url := image.get("url", None):
-                    image_data, content_type = get_image_data(image_url, headers)
+                    image_data, content_type = get_image_data(image_url)
                 else:
                     image_data, content_type = get_image_data(image["b64_json"])
 


### PR DESCRIPTION
contributor license agreement

## Summary
- Stop passing API request headers (`Authorization`, `Content-Type: application/json`) when downloading generated image URLs from external CDN/OSS servers
- API headers are only appropriate for the API request itself, not for fetching the resulting image URLs which are on different servers

Closes #21301

## Test plan
- Verified image download from external URLs works without API-specific headers
- ComfyUI paths correctly retain their headers (they serve images directly)