### PR TITLE
fix: correct document/metadata swap in hybrid search sort

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -292,7 +292,7 @@ async def query_doc_with_hybrid_search(
         # retrieve only min(k, k_reranker) items, sort and cut by distance if k < k_reranker
         if k < k_reranker:
             sorted_items = sorted(
-                zip(distances, metadatas, documents), key=lambda x: x[0], reverse=True
+                zip(distances, documents, metadatas), key=lambda x: x[0], reverse=True
             )
             sorted_items = sorted_items[:k]
 


### PR DESCRIPTION
## Summary

- Fix swapped `documents` and `metadatas` variables in `query_doc_with_hybrid_search` when `k < k_reranker`

## Problem

In `backend/open_webui/retrieval/utils.py`, line 295, the `zip()` call used the order `(distances, metadatas, documents)`:

```python
sorted_items = sorted(
    zip(distances, metadatas, documents), key=lambda x: x[0], reverse=True
)
```

But the subsequent unpacking at line 300 expected `(distances, documents, metadatas)`:

```python
distances, documents, metadatas = map(list, zip(*sorted_items))
```

This caused `documents` to contain metadata dicts and `metadatas` to contain document strings whenever `k < k_reranker` (the default config: `TOP_K=8`, `TOP_K_RERANKER=20`).

Downstream, `merge_and_sort_query_results` checks `isinstance(document, str)` which returned `False` for the dict objects, silently discarding **all** hybrid search results.

## Impact

**All hybrid search + reranking results are silently dropped** when `TOP_K < TOP_K_RERANKER` (the default configuration). The RAG pipeline appears to work (Qdrant returns results, reranker scores them) but no documents reach the model context.

## Fix

One-character fix: change `zip(distances, metadatas, documents)` to `zip(distances, documents, metadatas)` to match the unpacking order.

## Test plan

- [x] Verified with direct API call to `/api/v1/retrieval/query/collection` — returns documents with correct types
- [x] Confirmed `merge_and_sort_query_results` receives strings in documents field (not dicts)
- [x] Tested end-to-end with knowledge base containing PDF invoices