### PR TITLE
feat: Add config to limit the concurrency for async embedding

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2903,6 +2903,12 @@ ENABLE_ASYNC_EMBEDDING = PersistentConfig(
     os.environ.get("ENABLE_ASYNC_EMBEDDING", "True").lower() == "true",
 )
 
+EMBEDDING_MAX_CONCURRENCY = PersistentConfig(
+    "EMBEDDING_MAX_CONCURRENCY",
+    "rag.embedding_max_concurrency",
+    int(os.environ.get("EMBEDDING_MAX_CONCURRENCY", "0")),
+)
+
 RAG_EMBEDDING_QUERY_PREFIX = os.environ.get("RAG_EMBEDDING_QUERY_PREFIX", None)
 
 RAG_EMBEDDING_CONTENT_PREFIX = os.environ.get("RAG_EMBEDDING_CONTENT_PREFIX", None)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -240,6 +240,7 @@ from open_webui.config import (
     RAG_EMBEDDING_ENGINE,
     RAG_EMBEDDING_BATCH_SIZE,
     ENABLE_ASYNC_EMBEDDING,
+    EMBEDDING_MAX_CONCURRENCY,
     RAG_TOP_K,
     RAG_TOP_K_RERANKER,
     RAG_RELEVANCE_THRESHOLD,
@@ -980,6 +981,7 @@ app.state.config.RAG_EMBEDDING_ENGINE = RAG_EMBEDDING_ENGINE
 app.state.config.RAG_EMBEDDING_MODEL = RAG_EMBEDDING_MODEL
 app.state.config.RAG_EMBEDDING_BATCH_SIZE = RAG_EMBEDDING_BATCH_SIZE
 app.state.config.ENABLE_ASYNC_EMBEDDING = ENABLE_ASYNC_EMBEDDING
+app.state.config.EMBEDDING_MAX_CONCURRENCY = EMBEDDING_MAX_CONCURRENCY
 
 app.state.config.RAG_RERANKING_ENGINE = RAG_RERANKING_ENGINE
 app.state.config.RAG_RERANKING_MODEL = RAG_RERANKING_MODEL
@@ -1133,6 +1135,7 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
         else None
     ),
     enable_async=app.state.config.ENABLE_ASYNC_EMBEDDING,
+    embedding_max_concurrency=app.state.config.EMBEDDING_MAX_CONCURRENCY,
 )
 
 app.state.RERANKING_FUNCTION = get_reranking_function(

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -803,6 +803,7 @@ def get_embedding_function(
     embedding_batch_size,
     azure_api_version=None,
     enable_async=True,
+    embedding_max_concurrency=0,
 ) -> Awaitable:
     if embedding_engine == "":
         # Sentence transformers: CPU-bound sync operation
@@ -841,14 +842,28 @@ def get_embedding_function(
                 ]
 
                 if enable_async:
-                    log.debug(
-                        f"generate_multiple_async: Processing {len(batches)} batches in parallel"
-                    )
-                    # Execute all batches in parallel
-                    tasks = [
-                        embedding_function(batch, prefix=prefix, user=user)
-                        for batch in batches
-                    ]
+                    if embedding_max_concurrency > 0:
+                        log.debug(
+                            f"generate_multiple_async: Processing {len(batches)} batches with max concurrency {embedding_max_concurrency}"
+                        )
+                        sem = asyncio.Semaphore(embedding_max_concurrency)
+
+                        async def limited(batch):
+                            async with sem:
+                                return await embedding_function(
+                                    batch, prefix=prefix, user=user
+                                )
+
+                        tasks = [limited(batch) for batch in batches]
+                    else:
+                        log.debug(
+                            f"generate_multiple_async: Processing {len(batches)} batches in parallel"
+                        )
+                        # Execute all batches in parallel (unlimited)
+                        tasks = [
+                            embedding_function(batch, prefix=prefix, user=user)
+                            for batch in batches
+                        ]
                     batch_results = await asyncio.gather(*tasks)
                 else:
                     log.debug(

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -42,6 +42,7 @@
 	let RAG_EMBEDDING_MODEL = '';
 	let RAG_EMBEDDING_BATCH_SIZE = 1;
 	let ENABLE_ASYNC_EMBEDDING = true;
+	let EMBEDDING_MAX_CONCURRENCY = 0;
 
 	let rerankingModel = '';
 
@@ -113,6 +114,7 @@
 			RAG_EMBEDDING_MODEL: RAG_EMBEDDING_MODEL,
 			RAG_EMBEDDING_BATCH_SIZE: RAG_EMBEDDING_BATCH_SIZE,
 			ENABLE_ASYNC_EMBEDDING: ENABLE_ASYNC_EMBEDDING,
+			EMBEDDING_MAX_CONCURRENCY: EMBEDDING_MAX_CONCURRENCY,
 			ollama_config: {
 				key: OllamaKey,
 				url: OllamaUrl
@@ -241,6 +243,7 @@
 			RAG_EMBEDDING_MODEL = embeddingConfig.RAG_EMBEDDING_MODEL;
 			RAG_EMBEDDING_BATCH_SIZE = embeddingConfig.RAG_EMBEDDING_BATCH_SIZE ?? 1;
 			ENABLE_ASYNC_EMBEDDING = embeddingConfig.ENABLE_ASYNC_EMBEDDING ?? true;
+			EMBEDDING_MAX_CONCURRENCY = embeddingConfig.EMBEDDING_MAX_CONCURRENCY ?? 0;
 
 			OpenAIKey = embeddingConfig.openai_config.key;
 			OpenAIUrl = embeddingConfig.openai_config.url;
@@ -1043,6 +1046,31 @@
 									<Switch bind:state={ENABLE_ASYNC_EMBEDDING} />
 								</div>
 							</div>
+
+							{#if ENABLE_ASYNC_EMBEDDING}
+								<div class="  mb-2.5 flex w-full justify-between">
+									<div class="self-center text-xs font-medium">
+										<Tooltip
+											content={$i18n.t(
+												'Limits how many embedding tasks run at once. 0 = unlimited (default).'
+											)
+										}
+										placement="top-start"
+									>
+										{$i18n.t('Embedding Max Concurrency')}
+									</Tooltip>
+									</div>
+									<div class="flex items-center relative">
+										<input
+											bind:value={EMBEDDING_MAX_CONCURRENCY}
+											type="number"
+											class=" bg-transparent text-center w-14 outline-none"
+											min="0"
+											step="1"
+										/>
+									</div>
+								</div>
+							{/if}
 						{/if}
 					</div>
 


### PR DESCRIPTION
Users have asked for this multiple times, so I decided to make a PR for it.

This <ins>**is tested locally**</ins>

Tests made:
- change config, refresh page, check for the persistence of config
- test embedding, if semaphore value is applied correctly (worked perfectly)
- defaults to zero which means unlimited (old existing behaviour)
- only displays in the UI, if async embedding is on at all
- tested OpenAI embedding with 0, 1, 5 and 10 set as the value - speed adjusted accordingly, worked perfectly.
- values persisted

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
