### PR TITLE
fix: preserve OAuth session on token refresh failure

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -693,10 +693,8 @@ class OAuthClientManager:
                     return refreshed_token
                 else:
                     log.warning(
-                        f"Token refresh failed for user {user_id}, client_id {session.provider}, deleting session {session.id}"
+                        f"Token refresh failed for user {user_id}, client_id {session.provider}"
                     )
-                    OAuthSessions.delete_session_by_id(session.id)
-                    return None
             return session.token
 
         except Exception as e:
@@ -986,11 +984,8 @@ class OAuthManager:
                     return refreshed_token
                 else:
                     log.warning(
-                        f"Token refresh failed for user {user_id}, provider {session.provider}, deleting session {session.id}"
+                        f"Token refresh failed for user {user_id}, provider {session.provider}"
                     )
-                    OAuthSessions.delete_session_by_id(session.id)
-
-                    return None
             return session.token
 
         except Exception as e:


### PR DESCRIPTION
Previously, when an OAuth token refresh failed (e.g., no refresh token available, IDP temporarily unreachable, or refresh token expired), the OAuth session was deleted from the database **and None was returned.**

This caused two problems:

1. Tools accessing __oauth_token__ would crash with a TypeError ("NoneType object is not subscriptable") instead of receiving a meaningful error from the downstream API.

2. The session deletion was irreversible. Even if the refresh failure was transient (network blip, IDP maintenance), **the session could never self-heal**. Users had to fully log out and re-authenticate to restore the OAuth token, **despite still being logged into Open WebUI via the separate JWT session**. The fix removes the destructive session deletion in both OAuthManager.get_oauth_token and OAuthClientManager.get_oauth_token. On refresh failure, the existing token data is now returned instead of None. This means:

- **Tools receive the (possibly expired) token rather than crashing**
  - Tools should handle this themselves now, gracefully, and informing the user of the expired session if necessary
  - <ins>**This is better than before, because before, the tool only got back a None Type object with which it cannot do anything.**</ins>
- Transient IDP failures self-heal on the next request
- No unnecessary HTTP calls are made when no refresh token exists, since _perform_token_refresh exits early in that case Fixes 

Fixes #17678

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
