### PR TITLE
fix: prevent recursive RAG template nesting during multi-turn tool calling

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2517,16 +2517,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     # If context is not empty, insert it into the messages
     if sources and prompt:
-        log.warning(
-            f"[DefaultMode] Applying RAG template with {len(sources)} source(s), "
-            f"original user message: {len(prompt)} chars"
-        )
         form_data["messages"] = apply_source_context_to_messages(
             request, form_data["messages"], sources, prompt
-        )
-        injected_msg = get_last_user_message(form_data["messages"])
-        log.warning(
-            f"[DefaultMode] User message now {len(injected_msg or '')} chars"
         )
 
     # If there are citations, add them to the data_items
@@ -3972,10 +3964,6 @@ async def streaming_chat_response_handler(response, ctx):
                 _original_user_msg = get_last_user_message(
                     form_data["messages"]
                 )
-                log.warning(
-                    "[ToolLoop] Saved original user message "
-                    f"({len(_original_user_msg or '')} chars)"
-                )
 
                 while (
                     len(tool_calls) > 0
@@ -4133,10 +4121,6 @@ async def streaming_chat_response_handler(response, ctx):
                                     tool_id=tool.get("tool_id", "") if tool else "",
                                 )
                                 tool_call_sources.extend(citation_sources)
-                                log.warning(
-                                    f"[ToolLoop] Extracted {len(citation_sources)} citation source(s) "
-                                    f"from {tool_function_name}, total accumulated: {len(tool_call_sources)}"
-                                )
                             except Exception as e:
                                 log.exception(f"Error extracting citation source: {e}")
 
@@ -4232,21 +4216,12 @@ async def streaming_chat_response_handler(response, ctx):
                                         break
                             else:
                                 msg_item["content"] = _original_user_msg
-                            log.warning(
-                                f"[ToolLoop] Restored user message to original "
-                                f"({len(_original_user_msg)} chars)"
-                            )
 
                         form_data["messages"] = apply_source_context_to_messages(
                             request,
                             form_data["messages"],
                             tool_call_sources,
                             _original_user_msg,
-                        )
-                        injected_msg = get_last_user_message(form_data["messages"])
-                        log.warning(
-                            f"[ToolLoop] Applied RAG template with {len(tool_call_sources)} source(s), "
-                            f"user message now {len(injected_msg or '')} chars"
                         )
 
                     await event_emitter(


### PR DESCRIPTION
When native tool calling produced multiple sequential tool calls with
citation sources (e.g. repeated search_web or fetch_url), the RAG
template was recursively injected into the user message on each
iteration. This caused the user message to grow exponentially, wasting
context window and potentially confusing models into parroting the RAG
instructions into subsequent tool call arguments.

Fix: save the original user message before the tool-calling loop and
restore it before each re-application. Sources now accumulate across
iterations so the RAG template is applied once with a growing source
list, rather than being recursively nested N times.

Tested locally

Fixes: https://github.com/open-webui/open-webui/issues/21663

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
