### PR TITLE
feat: add human-in-the-loop tool approval system

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -116,7 +116,9 @@ if os.path.exists(f"{DATA_DIR}/config.json"):
 
 DEFAULT_CONFIG = {
     "version": 0,
-    "ui": {},
+    "ui": {
+        "enable_tool_approval": True,
+    },
 }
 
 
@@ -251,6 +253,7 @@ class AppConfig:
             )
 
         super().__setattr__("_state", {})
+        self._state["ENABLE_TOOL_APPROVAL"] = ENABLE_TOOL_APPROVAL
 
     def __setattr__(self, key, value):
         if isinstance(value, PersistentConfig):
@@ -1676,6 +1679,12 @@ BYPASS_ADMIN_ACCESS_CONTROL = (
 
 ENABLE_ADMIN_CHAT_ACCESS = (
     os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "True").lower() == "true"
+)
+
+ENABLE_TOOL_APPROVAL = PersistentConfig(
+    "ENABLE_TOOL_APPROVAL",
+    "ui.enable_tool_approval",
+    os.environ.get("ENABLE_TOOL_APPROVAL", "true").lower() == "true",
 )
 
 ENABLE_COMMUNITY_SHARING = PersistentConfig(

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1067,7 +1067,7 @@ async def update_admin_config(
     # Check if the input string matches the pattern
     if re.match(pattern, form_data.JWT_EXPIRES_IN):
         request.app.state.config.JWT_EXPIRES_IN = form_data.JWT_EXPIRES_IN
-    
+
     request.app.state.config.ENABLE_TOOL_APPROVAL = form_data.ENABLE_TOOL_APPROVAL
 
     request.app.state.config.ENABLE_COMMUNITY_SHARING = (

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -990,6 +990,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         "DEFAULT_USER_ROLE": request.app.state.config.DEFAULT_USER_ROLE,
         "DEFAULT_GROUP_ID": request.app.state.config.DEFAULT_GROUP_ID,
         "JWT_EXPIRES_IN": request.app.state.config.JWT_EXPIRES_IN,
+        "ENABLE_TOOL_APPROVAL": request.app.state.config.ENABLE_TOOL_APPROVAL,
         "ENABLE_COMMUNITY_SHARING": request.app.state.config.ENABLE_COMMUNITY_SHARING,
         "ENABLE_MESSAGE_RATING": request.app.state.config.ENABLE_MESSAGE_RATING,
         "ENABLE_FOLDERS": request.app.state.config.ENABLE_FOLDERS,
@@ -1016,6 +1017,7 @@ class AdminConfig(BaseModel):
     DEFAULT_USER_ROLE: str
     DEFAULT_GROUP_ID: str
     JWT_EXPIRES_IN: str
+    ENABLE_TOOL_APPROVAL: bool
     ENABLE_COMMUNITY_SHARING: bool
     ENABLE_MESSAGE_RATING: bool
     ENABLE_FOLDERS: bool
@@ -1065,6 +1067,8 @@ async def update_admin_config(
     # Check if the input string matches the pattern
     if re.match(pattern, form_data.JWT_EXPIRES_IN):
         request.app.state.config.JWT_EXPIRES_IN = form_data.JWT_EXPIRES_IN
+    
+    request.app.state.config.ENABLE_TOOL_APPROVAL = form_data.ENABLE_TOOL_APPROVAL
 
     request.app.state.config.ENABLE_COMMUNITY_SHARING = (
         form_data.ENABLE_COMMUNITY_SHARING

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -28,7 +28,7 @@ from open_webui.utils.plugin import (
     get_tool_module_from_cache,
     resolve_valves_schema_options,
 )
-from open_webui.utils.tools import get_tool_specs
+from open_webui.utils.tools import get_tool_specs, BUILTIN_TOOL_CATEGORIES
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_access, has_permission
 from open_webui.utils.tools import get_tool_servers
@@ -48,6 +48,16 @@ def get_tool_module(request, tool_id, load_from_db=True):
     """
     tool_module, _ = get_tool_module_from_cache(request, tool_id, load_from_db)
     return tool_module
+
+
+############################
+# GetBuiltinToolCategories
+############################
+
+
+@router.get("/builtin/categories")
+async def get_builtin_tool_categories(user=Depends(get_verified_user)):
+    return BUILTIN_TOOL_CATEGORIES
 
 
 ############################

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -894,6 +894,7 @@ def get_event_emitter(request_info, update_db=True):
     else:
         return None
 
+
 @sio.on("tool:check_pending")
 async def handle_check_pending_approvals(sid, data):
     """Check if there are pending approvals for a chat."""
@@ -913,13 +914,12 @@ async def handle_check_pending_approvals(sid, data):
     pending_approvals = approval_manager.get_pending_approvals_for_chat(chat_id)
 
     if pending_approvals:
-        await sio.emit('tool:pending_found', pending_approvals, room=sid)
+        await sio.emit("tool:pending_found", pending_approvals, room=sid)
 
 
 @sio.on("tool:approval_response")
 async def handle_tool_approval_response(sid, data):
     """Handle tool approval response from frontend."""
-
 
     session_data = SESSION_POOL.get(sid)
     if not session_data:
@@ -944,11 +944,8 @@ async def handle_tool_approval_response(sid, data):
     from open_webui.utils.tool_approval import approval_manager
 
     await approval_manager.handle_approval_response(
-        chat_id=chat_id,
-        approval_id=approval_id,
-        decision=decision
+        chat_id=chat_id, approval_id=approval_id, decision=decision
     )
-
 
     return {"status": "success", "message": f"Approval {decision}"}
 
@@ -973,13 +970,15 @@ async def handle_add_always_approved(sid, data):
     if level == "parent" and parent_tool_id:
         approval_manager.add_always_approved_parent(chat_id, parent_tool_id)
     elif level == "function" and parent_tool_id and function_name:
-        approval_manager.add_always_approved_function(chat_id, parent_tool_id, function_name)
+        approval_manager.add_always_approved_function(
+            chat_id, parent_tool_id, function_name
+        )
     else:
         return {"status": "error", "message": "Missing required fields"}
 
     return {
         "status": "success",
-        "always_approved": approval_manager.get_always_approved(chat_id)
+        "always_approved": approval_manager.get_always_approved(chat_id),
     }
 
 
@@ -1003,13 +1002,15 @@ async def handle_remove_always_approved(sid, data):
     if level == "parent" and parent_tool_id:
         approval_manager.remove_always_approved_parent(chat_id, parent_tool_id)
     elif level == "function" and parent_tool_id and function_name:
-        approval_manager.remove_always_approved_function(chat_id, parent_tool_id, function_name)
+        approval_manager.remove_always_approved_function(
+            chat_id, parent_tool_id, function_name
+        )
     else:
         return {"status": "error", "message": "Missing required fields"}
 
     return {
         "status": "success",
-        "always_approved": approval_manager.get_always_approved(chat_id)
+        "always_approved": approval_manager.get_always_approved(chat_id),
     }
 
 
@@ -1028,7 +1029,7 @@ async def handle_get_always_approved(sid, data):
 
     return {
         "status": "success",
-        "always_approved": approval_manager.get_always_approved(chat_id)
+        "always_approved": approval_manager.get_always_approved(chat_id),
     }
 
 
@@ -1073,14 +1074,13 @@ async def handle_set_yolo(sid, data):
     elif level == "parent" and parent_tool_id:
         approval_manager.set_yolo_parent(chat_id, parent_tool_id, enabled)
     elif level == "function" and parent_tool_id and function_name:
-        approval_manager.set_yolo_function(chat_id, parent_tool_id, function_name, enabled)
+        approval_manager.set_yolo_function(
+            chat_id, parent_tool_id, function_name, enabled
+        )
     else:
         return {"status": "error", "message": "Missing required fields"}
 
-    return {
-        "status": "success",
-        "yolo": approval_manager.get_yolo_status(chat_id)
-    }
+    return {"status": "success", "yolo": approval_manager.get_yolo_status(chat_id)}
 
 
 @sio.on("tool:get_yolo")
@@ -1096,10 +1096,7 @@ async def handle_get_yolo(sid, data):
 
     from open_webui.utils.tool_approval import approval_manager
 
-    return {
-        "status": "success",
-        "yolo": approval_manager.get_yolo_status(chat_id)
-    }
+    return {"status": "success", "yolo": approval_manager.get_yolo_status(chat_id)}
 
 
 @sio.on("tool:clear_yolo")
@@ -1117,10 +1114,7 @@ async def handle_clear_yolo(sid, data):
 
     approval_manager.clear_yolo(chat_id)
 
-    return {
-        "status": "success",
-        "yolo": {"yolo_all": False, "yolo_functions": {}}
-    }
+    return {"status": "success", "yolo": {"yolo_all": False, "yolo_functions": {}}}
 
 
 def get_event_call(request_info):

--- a/backend/open_webui/utils/tool_approval.py
+++ b/backend/open_webui/utils/tool_approval.py
@@ -1,0 +1,208 @@
+import asyncio
+import json
+import time
+import logging
+from typing import Dict, Set, Union, Optional, Any
+from uuid import uuid4
+
+log = logging.getLogger(__name__)
+
+PARENT_WILDCARD = "*"
+
+
+class ToolApprovalManager:
+
+    def __init__(self):
+        self.pending_approvals: Dict[str, asyncio.Event] = {}
+        self.approval_results: Dict[str, str] = {}
+        self.approval_data: Dict[str, Dict[str, Any]] = {}
+
+        # Nested dict: chat_id -> { parent_tool_id -> set of child function names }
+        # A set containing PARENT_WILDCARD ("*") means the entire parent is approved.
+        self.always_approved: Dict[str, Dict[str, Set[str]]] = {}
+
+        # YOLO mode: chat_id -> set of function names, or PARENT_WILDCARD for all
+        # Same nested structure as always_approved for per-tool YOLO,
+        # plus a top-level "all" flag via yolo_all_chats.
+        self.yolo_functions: Dict[str, Dict[str, Set[str]]] = {}
+        self.yolo_all_chats: Set[str] = set()
+
+    # ---- Approval wait/response (unchanged logic) ----
+
+    async def wait_for_approval(
+        self,
+        chat_id: str,
+        approval_id: str,
+        tool_data: Dict[str, Any] = None
+    ) -> str:
+        event_key = f"{chat_id}:{approval_id}"
+
+        if tool_data:
+            self.approval_data[event_key] = tool_data
+
+        event = asyncio.Event()
+        self.pending_approvals[event_key] = event
+
+        try:
+            await event.wait()
+            result = self.approval_results.get(event_key, "denied")
+            return result
+        finally:
+            self.pending_approvals.pop(event_key, None)
+            self.approval_results.pop(event_key, None)
+            self.approval_data.pop(event_key, None)
+
+    async def handle_approval_response(
+        self,
+        chat_id: str,
+        approval_id: str,
+        decision: str
+    ):
+        event_key = f"{chat_id}:{approval_id}"
+        self.approval_results[event_key] = decision
+
+        if event_key in self.pending_approvals:
+            self.pending_approvals[event_key].set()
+        else:
+            log.warning(f"No pending approval found for {event_key}")
+
+    def get_pending_approvals_for_chat(self, chat_id: str) -> Dict[str, Any] | None:
+        tools = []
+
+        for event_key in self.pending_approvals.keys():
+            if event_key.startswith(f"{chat_id}:"):
+                approval_id = event_key.split(":", 1)[1]
+                tool_data = self.approval_data.get(event_key, {})
+
+                tools.append({
+                    "approval_id": approval_id,
+                    "tool_id": tool_data.get("tool_id", "unknown"),
+                    "tool_name": tool_data.get("tool_name", "Unknown Tool"),
+                    "tool_params": tool_data.get("tool_params", {}),
+                    "parent_tool_id": tool_data.get("parent_tool_id", "unknown"),
+                })
+
+        if not tools:
+            return None
+
+        return {
+            "chat_id": chat_id,
+            "message_id": "restored",
+            "tools": tools,
+            "timestamp": int(time.time() * 1000)
+        }
+
+    # ---- Auto-approve checks (YOLO first, then always-approved) ----
+
+    def should_auto_approve(self, chat_id: str, function_name: str, parent_tool_id: str) -> bool:
+        # YOLO all trumps everything
+        if chat_id in self.yolo_all_chats:
+            return True
+
+        # Per-tool YOLO (same nested structure as always_approved)
+        yolo = self.yolo_functions.get(chat_id)
+        if yolo is not None:
+            parent_yolo = yolo.get(parent_tool_id)
+            if parent_yolo is not None:
+                if PARENT_WILDCARD in parent_yolo or function_name in parent_yolo:
+                    return True
+
+        # Always-approved
+        chat_approvals = self.always_approved.get(chat_id)
+        if chat_approvals is not None:
+            parent = chat_approvals.get(parent_tool_id)
+            if parent is not None:
+                if PARENT_WILDCARD in parent or function_name in parent:
+                    return True
+
+        return False
+
+    def add_always_approved_function(self, chat_id: str, parent_tool_id: str, function_name: str):
+        chat_approvals = self.always_approved.setdefault(chat_id, {})
+        children = chat_approvals.setdefault(parent_tool_id, set())
+        children.add(function_name)
+
+    def add_always_approved_parent(self, chat_id: str, parent_tool_id: str):
+        chat_approvals = self.always_approved.setdefault(chat_id, {})
+        chat_approvals[parent_tool_id] = {PARENT_WILDCARD}
+
+    def remove_always_approved_function(self, chat_id: str, parent_tool_id: str, function_name: str):
+        chat_approvals = self.always_approved.get(chat_id)
+        if chat_approvals is None:
+            return
+        children = chat_approvals.get(parent_tool_id)
+        if children is None:
+            return
+        children.discard(function_name)
+        if not children:
+            del chat_approvals[parent_tool_id]
+            if not chat_approvals:
+                del self.always_approved[chat_id]
+
+    def remove_always_approved_parent(self, chat_id: str, parent_tool_id: str):
+        chat_approvals = self.always_approved.get(chat_id)
+        if chat_approvals is None:
+            return
+        chat_approvals.pop(parent_tool_id, None)
+        if not chat_approvals:
+            del self.always_approved[chat_id]
+
+    def clear_always_approved(self, chat_id: str):
+        self.always_approved.pop(chat_id, None)
+
+    def get_always_approved(self, chat_id: str) -> Dict[str, list]:
+        """Return always-approved data for a chat as JSON-serializable dict.
+        Format: { parent_tool_id: [child_names...] } where ["*"] means parent-level.
+        """
+        chat_approvals = self.always_approved.get(chat_id, {})
+        return {parent: sorted(children) for parent, children in chat_approvals.items()}
+
+
+    # ---- YOLO mode ----
+
+    def set_yolo_all(self, chat_id: str, enabled: bool):
+        if enabled:
+            self.yolo_all_chats.add(chat_id)
+        else:
+            self.yolo_all_chats.discard(chat_id)
+
+    def is_yolo_all(self, chat_id: str) -> bool:
+        return chat_id in self.yolo_all_chats
+
+    def set_yolo_function(self, chat_id: str, parent_tool_id: str, function_name: str, enabled: bool):
+        chat_yolo = self.yolo_functions.setdefault(chat_id, {})
+        children = chat_yolo.setdefault(parent_tool_id, set())
+        if enabled:
+            children.add(function_name)
+        else:
+            children.discard(function_name)
+            if not children:
+                del chat_yolo[parent_tool_id]
+                if not chat_yolo:
+                    del self.yolo_functions[chat_id]
+
+    def set_yolo_parent(self, chat_id: str, parent_tool_id: str, enabled: bool):
+        chat_yolo = self.yolo_functions.setdefault(chat_id, {})
+        if enabled:
+            chat_yolo[parent_tool_id] = {PARENT_WILDCARD}
+        else:
+            chat_yolo.pop(parent_tool_id, None)
+            if not chat_yolo:
+                del self.yolo_functions[chat_id]
+
+    def clear_yolo(self, chat_id: str):
+        self.yolo_all_chats.discard(chat_id)
+        self.yolo_functions.pop(chat_id, None)
+
+    def get_yolo_status(self, chat_id: str) -> Dict[str, Any]:
+        """Return YOLO status for a chat as JSON-serializable dict."""
+        return {
+            "yolo_all": chat_id in self.yolo_all_chats,
+            "yolo_functions": {
+                parent: sorted(children)
+                for parent, children in self.yolo_functions.get(chat_id, {}).items()
+            }
+        }
+
+
+approval_manager = ToolApprovalManager()

--- a/backend/open_webui/utils/tool_approval.py
+++ b/backend/open_webui/utils/tool_approval.py
@@ -30,10 +30,7 @@ class ToolApprovalManager:
     # ---- Approval wait/response (unchanged logic) ----
 
     async def wait_for_approval(
-        self,
-        chat_id: str,
-        approval_id: str,
-        tool_data: Dict[str, Any] = None
+        self, chat_id: str, approval_id: str, tool_data: Dict[str, Any] = None
     ) -> str:
         event_key = f"{chat_id}:{approval_id}"
 
@@ -53,10 +50,7 @@ class ToolApprovalManager:
             self.approval_data.pop(event_key, None)
 
     async def handle_approval_response(
-        self,
-        chat_id: str,
-        approval_id: str,
-        decision: str
+        self, chat_id: str, approval_id: str, decision: str
     ):
         event_key = f"{chat_id}:{approval_id}"
         self.approval_results[event_key] = decision
@@ -74,13 +68,15 @@ class ToolApprovalManager:
                 approval_id = event_key.split(":", 1)[1]
                 tool_data = self.approval_data.get(event_key, {})
 
-                tools.append({
-                    "approval_id": approval_id,
-                    "tool_id": tool_data.get("tool_id", "unknown"),
-                    "tool_name": tool_data.get("tool_name", "Unknown Tool"),
-                    "tool_params": tool_data.get("tool_params", {}),
-                    "parent_tool_id": tool_data.get("parent_tool_id", "unknown"),
-                })
+                tools.append(
+                    {
+                        "approval_id": approval_id,
+                        "tool_id": tool_data.get("tool_id", "unknown"),
+                        "tool_name": tool_data.get("tool_name", "Unknown Tool"),
+                        "tool_params": tool_data.get("tool_params", {}),
+                        "parent_tool_id": tool_data.get("parent_tool_id", "unknown"),
+                    }
+                )
 
         if not tools:
             return None
@@ -89,12 +85,14 @@ class ToolApprovalManager:
             "chat_id": chat_id,
             "message_id": "restored",
             "tools": tools,
-            "timestamp": int(time.time() * 1000)
+            "timestamp": int(time.time() * 1000),
         }
 
     # ---- Auto-approve checks (YOLO first, then always-approved) ----
 
-    def should_auto_approve(self, chat_id: str, function_name: str, parent_tool_id: str) -> bool:
+    def should_auto_approve(
+        self, chat_id: str, function_name: str, parent_tool_id: str
+    ) -> bool:
         # YOLO all trumps everything
         if chat_id in self.yolo_all_chats:
             return True
@@ -117,7 +115,9 @@ class ToolApprovalManager:
 
         return False
 
-    def add_always_approved_function(self, chat_id: str, parent_tool_id: str, function_name: str):
+    def add_always_approved_function(
+        self, chat_id: str, parent_tool_id: str, function_name: str
+    ):
         chat_approvals = self.always_approved.setdefault(chat_id, {})
         children = chat_approvals.setdefault(parent_tool_id, set())
         children.add(function_name)
@@ -126,7 +126,9 @@ class ToolApprovalManager:
         chat_approvals = self.always_approved.setdefault(chat_id, {})
         chat_approvals[parent_tool_id] = {PARENT_WILDCARD}
 
-    def remove_always_approved_function(self, chat_id: str, parent_tool_id: str, function_name: str):
+    def remove_always_approved_function(
+        self, chat_id: str, parent_tool_id: str, function_name: str
+    ):
         chat_approvals = self.always_approved.get(chat_id)
         if chat_approvals is None:
             return
@@ -157,7 +159,6 @@ class ToolApprovalManager:
         chat_approvals = self.always_approved.get(chat_id, {})
         return {parent: sorted(children) for parent, children in chat_approvals.items()}
 
-
     # ---- YOLO mode ----
 
     def set_yolo_all(self, chat_id: str, enabled: bool):
@@ -169,7 +170,9 @@ class ToolApprovalManager:
     def is_yolo_all(self, chat_id: str) -> bool:
         return chat_id in self.yolo_all_chats
 
-    def set_yolo_function(self, chat_id: str, parent_tool_id: str, function_name: str, enabled: bool):
+    def set_yolo_function(
+        self, chat_id: str, parent_tool_id: str, function_name: str, enabled: bool
+    ):
         chat_yolo = self.yolo_functions.setdefault(chat_id, {})
         children = chat_yolo.setdefault(parent_tool_id, set())
         if enabled:
@@ -201,7 +204,7 @@ class ToolApprovalManager:
             "yolo_functions": {
                 parent: sorted(children)
                 for parent, children in self.yolo_functions.get(chat_id, {}).items()
-            }
+            },
         }
 
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -104,7 +104,13 @@ BUILTIN_TOOL_CATEGORIES: dict[str, dict] = {
     "memory": {
         "name": "Memory",
         "description": "Search and manage user memories",
-        "functions": ["search_memories", "add_memory", "replace_memory_content", "delete_memory", "list_memories"],
+        "functions": [
+            "search_memories",
+            "add_memory",
+            "replace_memory_content",
+            "delete_memory",
+            "list_memories",
+        ],
         "feature": False,
     },
     "chats": {
@@ -116,22 +122,37 @@ BUILTIN_TOOL_CATEGORIES: dict[str, dict] = {
     "notes": {
         "name": "Notes",
         "description": "Search, view, and manage user notes",
-        "functions": ["search_notes", "view_note", "write_note", "replace_note_content"],
+        "functions": [
+            "search_notes",
+            "view_note",
+            "write_note",
+            "replace_note_content",
+        ],
         "feature": False,
     },
     "knowledge": {
         "name": "Knowledge Base",
         "description": "Browse and query knowledge bases",
         "functions": [
-            "list_knowledge_bases", "search_knowledge_bases", "query_knowledge_bases",
-            "search_knowledge_files", "query_knowledge_files", "view_knowledge_file", "view_file",
+            "list_knowledge_bases",
+            "search_knowledge_bases",
+            "query_knowledge_bases",
+            "search_knowledge_files",
+            "query_knowledge_files",
+            "view_knowledge_file",
+            "view_file",
         ],
         "feature": False,
     },
     "channels": {
         "name": "Channels",
         "description": "Search channels and channel messages",
-        "functions": ["search_channels", "search_channel_messages", "view_channel_thread", "view_channel_message"],
+        "functions": [
+            "search_channels",
+            "search_channel_messages",
+            "view_channel_thread",
+            "view_channel_message",
+        ],
         "feature": False,
     },
     "web_search": {
@@ -539,7 +560,15 @@ def get_builtin_tools(
 
     # Add memory tools if builtin category enabled AND enabled for this chat
     if is_builtin_tool_enabled("memory") and features.get("memory"):
-        builtin_functions.extend([search_memories, add_memory, replace_memory_content, delete_memory, list_memories])
+        builtin_functions.extend(
+            [
+                search_memories,
+                add_memory,
+                replace_memory_content,
+                delete_memory,
+                list_memories,
+            ]
+        )
 
     # Add web search tools if builtin category enabled AND enabled globally AND model has web_search capability
     if (

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -88,6 +88,72 @@ import copy
 
 log = logging.getLogger(__name__)
 
+# Canonical mapping of builtin tool categories to their function names.
+# Used by the frontend for YOLO mode and the admin builtin-tools panel.
+#
+# "feature" categories (web_search, image_generation, code_interpreter) have
+# dedicated global config flags, model capabilities, and UI toggles.
+# Non-feature categories are pure builtin tools without that special treatment.
+BUILTIN_TOOL_CATEGORIES: dict[str, dict] = {
+    "time": {
+        "name": "Time & Calculation",
+        "description": "Get current time and perform date/time calculations",
+        "functions": ["get_current_timestamp", "calculate_timestamp"],
+        "feature": False,
+    },
+    "memory": {
+        "name": "Memory",
+        "description": "Search and manage user memories",
+        "functions": ["search_memories", "add_memory", "replace_memory_content", "delete_memory", "list_memories"],
+        "feature": False,
+    },
+    "chats": {
+        "name": "Chat History",
+        "description": "Search and view user chat history",
+        "functions": ["search_chats", "view_chat"],
+        "feature": False,
+    },
+    "notes": {
+        "name": "Notes",
+        "description": "Search, view, and manage user notes",
+        "functions": ["search_notes", "view_note", "write_note", "replace_note_content"],
+        "feature": False,
+    },
+    "knowledge": {
+        "name": "Knowledge Base",
+        "description": "Browse and query knowledge bases",
+        "functions": [
+            "list_knowledge_bases", "search_knowledge_bases", "query_knowledge_bases",
+            "search_knowledge_files", "query_knowledge_files", "view_knowledge_file", "view_file",
+        ],
+        "feature": False,
+    },
+    "channels": {
+        "name": "Channels",
+        "description": "Search channels and channel messages",
+        "functions": ["search_channels", "search_channel_messages", "view_channel_thread", "view_channel_message"],
+        "feature": False,
+    },
+    "web_search": {
+        "name": "Web Search",
+        "description": "Search the web and fetch URLs",
+        "functions": ["search_web", "fetch_url"],
+        "feature": True,
+    },
+    "image_generation": {
+        "name": "Image Generation",
+        "description": "Generate and edit images",
+        "functions": ["generate_image", "edit_image"],
+        "feature": True,
+    },
+    "code_interpreter": {
+        "name": "Code Interpreter",
+        "description": "Execute code",
+        "functions": ["execute_code"],
+        "feature": True,
+    },
+}
+
 
 def get_async_tool_function_and_apply_extra_params(
     function: Callable, extra_params: dict

--- a/src/lib/apis/tools/index.ts
+++ b/src/lib/apis/tools/index.ts
@@ -65,6 +65,38 @@ export const loadToolByUrl = async (token: string = '', url: string) => {
 	return res;
 };
 
+export const getBuiltinToolCategories = async (
+	token: string = ''
+): Promise<
+	Record<string, { name: string; description: string; functions: string[]; feature: boolean }>
+> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/tools/builtin/categories`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getTools = async (token: string = '') => {
 	let error = null;
 

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -681,6 +681,14 @@
 
 					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
 						<div class=" self-center text-xs font-medium">
+							{$i18n.t('Global Tool Approval')}
+						</div>
+
+						<Switch bind:state={adminConfig.ENABLE_TOOL_APPROVAL} />
+					</div>
+
+					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
+						<div class=" self-center text-xs font-medium">
 							{$i18n.t('Enable Community Sharing')}
 						</div>
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -97,6 +97,7 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import Sidebar from '../icons/Sidebar.svelte';
 	import Image from '../common/Image.svelte';
+	import { checkPendingApprovals, flushPendingYolo } from '$lib/stores/toolApproval';
 
 	export let chatIdProp = '';
 
@@ -167,6 +168,11 @@
 		navigateHandler();
 	}
 
+	// Check for pending approvals when socket reconnects
+	$: if ($socket && chatIdProp) {
+		checkPendingApprovals(chatIdProp);
+	}
+
 	const navigateHandler = async () => {
 		loading = true;
 
@@ -191,6 +197,8 @@
 
 		if (chatIdProp && (await loadChat())) {
 			await tick();
+			// Check for pending approvals when navigating to a chat
+			checkPendingApprovals(chatIdProp);
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
 
@@ -2429,6 +2437,8 @@
 		}
 		await tick();
 
+		await flushPendingYolo(_chatId);
+
 		return _chatId;
 	};
 
@@ -2656,6 +2666,7 @@
 							<div class=" pb-2 z-10">
 								<MessageInput
 									bind:this={messageInput}
+									bind:chatId={$chatId}
 									{history}
 									{taskIds}
 									{selectedModels}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -109,6 +109,8 @@
 	let selectedModelIds = [];
 	$: selectedModelIds = atSelectedModel !== undefined ? [atSelectedModel.id] : selectedModels;
 
+	export let chatId = '';
+
 	export let history;
 	export let taskIds = null;
 
@@ -1552,6 +1554,7 @@
 										/>
 
 										<IntegrationsMenu
+											{chatId}
 											selectedModels={atSelectedModel ? [atSelectedModel.id] : selectedModels}
 											{toggleFilters}
 											{showWebSearchButton}

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -177,14 +177,15 @@
 	}
 
 	// Feature tools are gated by their existing show* flags
-	$: visibleFeatureTools = featureTools.filter(t =>
-		(t.id === 'web_search' && showWebSearchButton) ||
-		(t.id === 'image_generation' && showImageGenerationButton) ||
-		(t.id === 'code_interpreter' && showCodeInterpreterButton)
+	$: visibleFeatureTools = featureTools.filter(
+		(t) =>
+			(t.id === 'web_search' && showWebSearchButton) ||
+			(t.id === 'image_generation' && showImageGenerationButton) ||
+			(t.id === 'code_interpreter' && showCodeInterpreterButton)
 	);
 
 	function isBuiltinToolYolo(tool: BuiltinTool): boolean {
-		return tool.parentIds.every(pid => {
+		return tool.parentIds.every((pid) => {
 			const funcs = yoloStatus.yolo_functions[pid];
 			return funcs && (funcs.includes('*') || funcs.length > 0);
 		});
@@ -237,7 +238,10 @@
 	}
 
 	// Helper: count always-approved entries
-	$: alwaysApprovedCount = Object.values(alwaysApproved).reduce((sum, children) => sum + children.length, 0);
+	$: alwaysApprovedCount = Object.values(alwaysApproved).reduce(
+		(sum, children) => sum + children.length,
+		0
+	);
 </script>
 
 <Dropdown
@@ -292,8 +296,16 @@
 									tab = 'yolo';
 								}}
 							>
-								<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-									<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+								<svg
+									class="size-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
 								</svg>
 								<div class="flex items-center w-full justify-between">
 									<div class="line-clamp-1">
@@ -309,28 +321,36 @@
 							</button>
 
 							<!-- Always Allowed -->
-								<button
-									class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-									on:click={async () => {
-										if (chatId) await loadAlwaysApproved();
-										tab = 'always-allowed';
-									}}
+							<button
+								class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+								on:click={async () => {
+									if (chatId) await loadAlwaysApproved();
+									tab = 'always-allowed';
+								}}
+							>
+								<svg
+									class="size-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
 								>
-									<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-										<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-									</svg>
-									<div class="flex items-center w-full justify-between">
-										<div class="line-clamp-1">
-											{$i18n.t('Always Allowed')}
-											{#if alwaysApprovedCount > 0}
-												<span class="ml-0.5 text-gray-500">{alwaysApprovedCount}</span>
-											{/if}
-										</div>
-										<div class="text-gray-500">
-											<ChevronRight />
-										</div>
+									<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+								</svg>
+								<div class="flex items-center w-full justify-between">
+									<div class="line-clamp-1">
+										{$i18n.t('Always Allowed')}
+										{#if alwaysApprovedCount > 0}
+											<span class="ml-0.5 text-gray-500">{alwaysApprovedCount}</span>
+										{/if}
 									</div>
-								</button>
+									<div class="text-gray-500">
+										<ChevronRight />
+									</div>
+								</div>
+							</button>
 						{/if}
 					{:else}
 						<div class="py-4">
@@ -503,7 +523,6 @@
 						</Tooltip>
 					{/if}
 				</div>
-
 			{:else if tab === 'tools' && tools}
 				<!-- Tools sub-menu (existing) -->
 				<div in:fly={{ x: 20, duration: 150 }}>
@@ -587,141 +606,156 @@
 						</button>
 					{/each}
 				</div>
-
-		{:else if tab === 'yolo' && tools}
-			<!-- YOLO Mode sub-menu -->
-			<div in:fly={{ x: 20, duration: 150 }}>
-				<button
-					class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-					on:click={() => {
-						tab = '';
-					}}
-				>
-					<ChevronLeft />
-					<div class="flex items-center w-full justify-between">
-						<div>{$i18n.t('YOLO Mode')}</div>
-					</div>
-				</button>
-
-				<!-- YOLO All toggle -->
-				<button
-					class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-					on:click={toggleYoloAll}
-				>
-					<div class="flex-1 truncate">
-						<div class="flex flex-1 gap-2 items-center">
-							<svg class="size-4 text-amber-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-								<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
-							</svg>
-							<div class="truncate font-medium">{$i18n.t('YOLO All Tools')}</div>
+			{:else if tab === 'yolo' && tools}
+				<!-- YOLO Mode sub-menu -->
+				<div in:fly={{ x: 20, duration: 150 }}>
+					<button
+						class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+						on:click={() => {
+							tab = '';
+						}}
+					>
+						<ChevronLeft />
+						<div class="flex items-center w-full justify-between">
+							<div>{$i18n.t('YOLO Mode')}</div>
 						</div>
-					</div>
-					<div class="shrink-0">
-						<Switch state={yoloStatus.yolo_all} />
-					</div>
-				</button>
+					</button>
 
-				{#if !yoloStatus.yolo_all}
-					<!-- Default Features YOLO toggles (gated by existing show* flags) -->
-					{#if visibleFeatureTools.length > 0}
-						<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
-						<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">{$i18n.t('Default Features')}</div>
-						{#each visibleFeatureTools as featureTool (featureTool.id)}
-							<button
-								class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-								on:click={() => toggleBuiltinToolYolo(featureTool)}
-							>
-								<div class="flex-1 truncate">
-									<div class="flex flex-1 gap-2 items-center">
-										<div class="shrink-0">
-											{#if featureTool.id === 'web_search'}
-												<GlobeAlt />
-											{:else if featureTool.id === 'image_generation'}
-												<Photo className="size-4" strokeWidth="1.5" />
-											{:else if featureTool.id === 'code_interpreter'}
-												<Terminal className="size-3.5" strokeWidth="1.75" />
-											{/if}
+					<!-- YOLO All toggle -->
+					<button
+						class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+						on:click={toggleYoloAll}
+					>
+						<div class="flex-1 truncate">
+							<div class="flex flex-1 gap-2 items-center">
+								<svg
+									class="size-4 text-amber-500"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+								</svg>
+								<div class="truncate font-medium">{$i18n.t('YOLO All Tools')}</div>
+							</div>
+						</div>
+						<div class="shrink-0">
+							<Switch state={yoloStatus.yolo_all} />
+						</div>
+					</button>
+
+					{#if !yoloStatus.yolo_all}
+						<!-- Default Features YOLO toggles (gated by existing show* flags) -->
+						{#if visibleFeatureTools.length > 0}
+							<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
+							<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">
+								{$i18n.t('Default Features')}
+							</div>
+							{#each visibleFeatureTools as featureTool (featureTool.id)}
+								<button
+									class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+									on:click={() => toggleBuiltinToolYolo(featureTool)}
+								>
+									<div class="flex-1 truncate">
+										<div class="flex flex-1 gap-2 items-center">
+											<div class="shrink-0">
+												{#if featureTool.id === 'web_search'}
+													<GlobeAlt />
+												{:else if featureTool.id === 'image_generation'}
+													<Photo className="size-4" strokeWidth="1.5" />
+												{:else if featureTool.id === 'code_interpreter'}
+													<Terminal className="size-3.5" strokeWidth="1.75" />
+												{/if}
+											</div>
+											<div class="truncate">{$i18n.t(featureTool.name)}</div>
 										</div>
-										<div class="truncate">{$i18n.t(featureTool.name)}</div>
 									</div>
-								</div>
-								<div class="shrink-0">
-									<Switch state={isBuiltinToolYolo(featureTool)} />
-								</div>
-							</button>
-						{/each}
-					{/if}
-
-					<!-- Builtin Tools YOLO toggles (loaded dynamically from backend) -->
-					{#if builtinTools.length > 0}
-						<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
-						<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">{$i18n.t('Builtin Tools')}</div>
-						{#each builtinTools as builtinTool (builtinTool.id)}
-							<button
-								class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-								on:click={() => toggleBuiltinToolYolo(builtinTool)}
-							>
-								<div class="flex-1 truncate">
-									<div class="flex flex-1 gap-2 items-center">
-										<div class="shrink-0">
-											{#if builtinTool.id === 'time'}
-												<Calendar className="size-4" strokeWidth="1.5" />
-											{:else if builtinTool.id === 'memory'}
-												<Database className="size-4" strokeWidth="1.5" />
-											{:else if builtinTool.id === 'chats'}
-												<ChatBubble className="size-4" strokeWidth="1.5" />
-											{:else if builtinTool.id === 'notes'}
-												<Note className="size-4" strokeWidth="1.5" />
-											{:else if builtinTool.id === 'knowledge'}
-												<BookOpen className="size-4" strokeWidth="1.5" />
-											{:else if builtinTool.id === 'channels'}
-												<Hashtag className="size-4" strokeWidth="1.5" />
-											{:else}
-												<Wrench />
-											{/if}
-										</div>
-										<div class="truncate">{$i18n.t(builtinTool.name)}</div>
-									</div>
-								</div>
-								<div class="shrink-0">
-									<Switch state={isBuiltinToolYolo(builtinTool)} />
-								</div>
-							</button>
-						{/each}
-					{/if}
-
-					{#if (visibleFeatureTools.length > 0 || builtinTools.length > 0) && Object.keys(tools).length > 0}
-						<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
-						<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">{$i18n.t('Workspace Tools')}</div>
-					{/if}
-
-					<!-- Per-tool YOLO toggles -->
-					{#each Object.keys(tools) as toolId}
-						<button
-							class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
-							on:click={() => toggleToolYolo(toolId)}
-						>
-							<div class="flex-1 truncate">
-								<div class="flex flex-1 gap-2 items-center">
 									<div class="shrink-0">
-										<Wrench />
+										<Switch state={isBuiltinToolYolo(featureTool)} />
 									</div>
-									<div class="truncate">{tools[toolId].name}</div>
-								</div>
-							</div>
-							<div class="shrink-0">
-								<Switch state={
-									(() => {
-										const parentFuncs = yoloStatus.yolo_functions[toolId];
-										return !!(parentFuncs && (parentFuncs.includes('*') || parentFuncs.length > 0));
-									})()
-								} />
-							</div>
-						</button>
-					{/each}
-				{/if}
-			</div>
+								</button>
+							{/each}
+						{/if}
 
+						<!-- Builtin Tools YOLO toggles (loaded dynamically from backend) -->
+						{#if builtinTools.length > 0}
+							<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
+							<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">
+								{$i18n.t('Builtin Tools')}
+							</div>
+							{#each builtinTools as builtinTool (builtinTool.id)}
+								<button
+									class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+									on:click={() => toggleBuiltinToolYolo(builtinTool)}
+								>
+									<div class="flex-1 truncate">
+										<div class="flex flex-1 gap-2 items-center">
+											<div class="shrink-0">
+												{#if builtinTool.id === 'time'}
+													<Calendar className="size-4" strokeWidth="1.5" />
+												{:else if builtinTool.id === 'memory'}
+													<Database className="size-4" strokeWidth="1.5" />
+												{:else if builtinTool.id === 'chats'}
+													<ChatBubble className="size-4" strokeWidth="1.5" />
+												{:else if builtinTool.id === 'notes'}
+													<Note className="size-4" strokeWidth="1.5" />
+												{:else if builtinTool.id === 'knowledge'}
+													<BookOpen className="size-4" strokeWidth="1.5" />
+												{:else if builtinTool.id === 'channels'}
+													<Hashtag className="size-4" strokeWidth="1.5" />
+												{:else}
+													<Wrench />
+												{/if}
+											</div>
+											<div class="truncate">{$i18n.t(builtinTool.name)}</div>
+										</div>
+									</div>
+									<div class="shrink-0">
+										<Switch state={isBuiltinToolYolo(builtinTool)} />
+									</div>
+								</button>
+							{/each}
+						{/if}
+
+						{#if (visibleFeatureTools.length > 0 || builtinTools.length > 0) && Object.keys(tools).length > 0}
+							<div class="border-t border-gray-100 dark:border-gray-800 my-1" />
+							<div class="px-3 py-1 text-xs font-medium text-gray-400 dark:text-gray-500">
+								{$i18n.t('Workspace Tools')}
+							</div>
+						{/if}
+
+						<!-- Per-tool YOLO toggles -->
+						{#each Object.keys(tools) as toolId}
+							<button
+								class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+								on:click={() => toggleToolYolo(toolId)}
+							>
+								<div class="flex-1 truncate">
+									<div class="flex flex-1 gap-2 items-center">
+										<div class="shrink-0">
+											<Wrench />
+										</div>
+										<div class="truncate">{tools[toolId].name}</div>
+									</div>
+								</div>
+								<div class="shrink-0">
+									<Switch
+										state={(() => {
+											const parentFuncs = yoloStatus.yolo_functions[toolId];
+											return !!(
+												parentFuncs &&
+												(parentFuncs.includes('*') || parentFuncs.length > 0)
+											);
+										})()}
+									/>
+								</div>
+							</button>
+						{/each}
+					{/if}
+				</div>
 			{:else if tab === 'always-allowed'}
 				<!-- Always Allowed sub-menu -->
 				<div in:fly={{ x: 20, duration: 150 }}>
@@ -747,7 +781,15 @@
 							}}
 						>
 							<div class="flex flex-1 gap-2 items-center">
-								<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<svg
+									class="size-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
 									<line x1="18" y1="6" x2="6" y2="18" />
 									<line x1="6" y1="6" x2="18" y2="18" />
 								</svg>
@@ -764,7 +806,9 @@
 							{/if}
 
 							<!-- Parent header row -->
-							<div class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50">
+							<div
+								class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+							>
 								<div class="flex-1 truncate">
 									<div class="flex flex-1 gap-2 items-center">
 										<div class="shrink-0">
@@ -781,7 +825,15 @@
 										alwaysApproved = await getAlwaysApproved(chatId);
 									}}
 								>
-									<svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+									<svg
+										class="size-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
 										<line x1="18" y1="6" x2="6" y2="18" />
 										<line x1="6" y1="6" x2="18" y2="18" />
 									</svg>
@@ -790,12 +842,16 @@
 
 							<!-- Children -->
 							{#if children.includes('*')}
-								<div class="flex w-full items-center pl-9 pr-3 py-1 text-xs text-gray-500 dark:text-gray-400 italic">
+								<div
+									class="flex w-full items-center pl-9 pr-3 py-1 text-xs text-gray-500 dark:text-gray-400 italic"
+								>
 									{$i18n.t('All functions approved')}
 								</div>
 							{:else}
 								{#each children as funcName}
-									<div class="flex w-full justify-between gap-2 items-center pl-9 pr-3 py-1 text-sm rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50">
+									<div
+										class="flex w-full justify-between gap-2 items-center pl-9 pr-3 py-1 text-sm rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+									>
 										<div class="flex-1 truncate text-gray-700 dark:text-gray-300">
 											{funcName}
 										</div>
@@ -807,7 +863,15 @@
 												alwaysApproved = await getAlwaysApproved(chatId);
 											}}
 										>
-											<svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+											<svg
+												class="size-3.5"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="2"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											>
 												<line x1="18" y1="6" x2="6" y2="18" />
 												<line x1="6" y1="6" x2="18" y2="18" />
 											</svg>

--- a/src/lib/components/chat/ToolApprovalModal.svelte
+++ b/src/lib/components/chat/ToolApprovalModal.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+    import { onDestroy, getContext } from 'svelte';
+    import { fade, fly } from 'svelte/transition';
+    import { socket } from '$lib/stores';
+    import { 
+        pendingApprovals, 
+        removeToolFromPending,
+        clearApprovals,
+        showApprovalModal,
+        addAlwaysApproved
+    } from '$lib/stores/toolApproval';
+    import { approvalCoordinator } from '$lib/utils/toolApprovalChannel';
+    import { toast } from 'svelte-sonner';
+    
+    const i18n = getContext('i18n');
+    
+    
+    $: if ($showApprovalModal && $pendingApprovals) {
+        claimApproval();
+    }
+    
+    function claimApproval() {
+        if (!$pendingApprovals) return;
+        
+        if (!approvalCoordinator.claimApproval()) {
+            showApprovalModal.set(false);
+            return;
+        }
+    }
+    
+    
+    function sendApprovalResponse(approvalId: string, decision: 'approved' | 'denied') {
+        if (!$pendingApprovals || !$socket) return;
+        
+        $socket.emit('tool:approval_response', {
+            chat_id: $pendingApprovals.chat_id,
+            approval_id: approvalId,
+            decision: decision
+        });
+        
+        removeToolFromPending(approvalId);
+        
+        if ($pendingApprovals?.tools.length === 0) {
+            clearApprovals();
+            approvalCoordinator.releaseApproval();
+        }
+    }
+    
+    function approveAllOnce() {
+        if (!$pendingApprovals) return;
+        
+        const tools = [...$pendingApprovals.tools];
+        tools.forEach(tool => {
+            sendApprovalResponse(tool.approval_id, 'approved');
+        });
+    }
+    
+    function denyAll() {
+        if (!$pendingApprovals) return;
+        
+        const tools = [...$pendingApprovals.tools];
+        tools.forEach(tool => {
+            sendApprovalResponse(tool.approval_id, 'denied');
+        });
+    }
+    
+    async function alwaysAllowFunctions() {
+        if (!$pendingApprovals) return;
+        
+        const chatId = $pendingApprovals.chat_id;
+        if (!chatId) {
+            toast.error('Chat ID not found');
+            return;
+        }
+        
+        const tools = [...$pendingApprovals.tools];
+        const uniqueFunctions = new Map<string, string>();
+        for (const tool of tools) {
+            uniqueFunctions.set(tool.tool_name, tool.parent_tool_id);
+        }
+        
+        for (const [functionName, parentToolId] of uniqueFunctions) {
+            await addAlwaysApproved(chatId, parentToolId, functionName, 'function');
+        }
+        
+        toast.success($i18n.t('Functions always allowed for this chat'));
+        
+        tools.forEach(tool => {
+            sendApprovalResponse(tool.approval_id, 'approved');
+        });
+    }
+    
+    async function alwaysAllowParents() {
+        if (!$pendingApprovals) return;
+        
+        const chatId = $pendingApprovals.chat_id;
+        if (!chatId) {
+            toast.error('Chat ID not found');
+            return;
+        }
+        
+        const tools = [...$pendingApprovals.tools];
+        const uniqueParents = new Set(tools.map(t => t.parent_tool_id));
+        
+        for (const parentToolId of uniqueParents) {
+            await addAlwaysApproved(chatId, parentToolId, '', 'parent');
+        }
+        
+        toast.success($i18n.t('Tools always allowed for this chat'));
+        
+        tools.forEach(tool => {
+            sendApprovalResponse(tool.approval_id, 'approved');
+        });
+    }
+    
+    
+    $: uniqueFunctionNames = $pendingApprovals
+        ? [...new Set($pendingApprovals.tools.map(t => t.tool_name))].filter(Boolean)
+        : [];
+    
+    $: uniqueParentNames = $pendingApprovals
+        ? [...new Set($pendingApprovals.tools.map(t => t.parent_tool_id))].filter(id => id && id !== 'unknown')
+        : [];
+    
+    onDestroy(() => {
+        if ($pendingApprovals) {
+            approvalCoordinator.notifyTabClosing(true);
+        }
+    });
+</script>
+
+
+{#if $showApprovalModal && $pendingApprovals}
+    <div 
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+        transition:fade={{ duration: 200 }}
+        on:click|self|preventDefault|stopPropagation
+        on:keydown|preventDefault|stopPropagation
+    >
+        <div 
+            class="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
+            transition:fly={{ y: 20, duration: 300 }}
+            on:click|stopPropagation
+        >
+            <!-- Header -->
+            <div class="px-6 py-5">
+                <h2 class="text-xl font-semibold text-gray-900 dark:text-white text-center">
+                    {$i18n.t('Tool Approval Required')}
+                </h2>
+            </div>
+
+            <!-- Content -->
+            <div class="px-6 py-4 max-h-[60vh] overflow-y-auto">
+                <div class="space-y-4">
+                    {#each $pendingApprovals.tools as tool (tool.approval_id)}
+                        <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-4">
+                            <div class="flex items-center justify-between mb-3">
+                                <div class="flex items-center gap-3">
+                                    <div class="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+                                        <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                                        </svg>
+                                    </div>
+
+                                    <div>
+                                        <h3 class="font-medium text-gray-900 dark:text-white text-lg">
+                                            {tool.tool_name}
+                                        </h3>
+                                        {#if tool.parent_tool_id && tool.parent_tool_id !== 'unknown'}
+                                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                {tool.parent_tool_id}
+                                            </p>
+                                        {/if}
+                                    </div>
+                                </div>
+                            </div>
+
+                            {#if !tool.parent_tool_id || tool.parent_tool_id === 'unknown'}
+                                <div class="flex items-center gap-2 mb-3 px-3 py-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400 text-xs">
+                                    <svg class="size-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                                        <line x1="12" y1="9" x2="12" y2="13"/>
+                                        <line x1="12" y1="17" x2="12.01" y2="17"/>
+                                    </svg>
+                                    <span>{$i18n.t('Unrecognized tool call — this may fail')}</span>
+                                </div>
+                            {/if}
+
+                            {#if Object.keys(tool.tool_params).length > 0}
+                                <div class="bg-white dark:bg-gray-800 rounded-lg p-3 mb-4 border border-gray-100 dark:border-gray-600">
+                                    <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+                                        {$i18n.t('Parameters:')}
+                                    </p>
+                                    <pre class="text-sm text-gray-700 dark:text-gray-300 font-mono overflow-x-auto whitespace-pre-wrap">{JSON.stringify(tool.tool_params, null, 2)}</pre>
+                                </div>
+                            {/if}
+                        </div>
+                    {/each}
+                </div>
+
+                <div class="mt-6 px-6">
+                    <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
+                        {$i18n.t('Review each action carefully before approving')}
+                    </p>
+                </div>
+            </div>
+
+            <!-- Footer Actions -->
+            <div class="px-6 py-4">
+                <div class="flex flex-col gap-2">
+                    <!-- Always Approve row -->
+                    <div class="flex gap-2 justify-center">
+                        <button
+                            on:click={alwaysAllowFunctions}
+                            class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
+                        >
+                            <span class="font-medium">{$i18n.t('Always Approve')}</span>
+                            <br />
+                            <span class="text-xs text-gray-500 dark:text-gray-400">({uniqueFunctionNames.join(', ')})</span>
+                        </button>
+                        {#if uniqueParentNames.length > 0}
+                            <button
+                                on:click={alwaysAllowParents}
+                                class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
+                            >
+                                <span class="font-medium">{$i18n.t('Always Approve')}</span>
+                                <br />
+                                <span class="text-xs text-gray-500 dark:text-gray-400">({uniqueParentNames.join(', ')})</span>
+                            </button>
+                        {/if}
+                    </div>
+                    <!-- Allow Once / Decline row -->
+                    <div class="flex gap-2 justify-center">
+                        <button
+                            on:click={approveAllOnce}
+                            class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors font-medium text-sm"
+                        >
+                            {$i18n.t('Allow Once')}
+                        </button>
+                        <button
+                            on:click={denyAll}
+                            class="flex-1 max-w-xs px-4 py-2.5 bg-gray-800 dark:bg-gray-600 text-white rounded-lg hover:bg-gray-900 dark:hover:bg-gray-500 transition-colors font-medium text-sm"
+                        >
+                            {$i18n.t('Decline')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/src/lib/components/chat/ToolApprovalModal.svelte
+++ b/src/lib/components/chat/ToolApprovalModal.svelte
@@ -1,252 +1,290 @@
 <script lang="ts">
-    import { onDestroy, getContext } from 'svelte';
-    import { fade, fly } from 'svelte/transition';
-    import { socket } from '$lib/stores';
-    import { 
-        pendingApprovals, 
-        removeToolFromPending,
-        clearApprovals,
-        showApprovalModal,
-        addAlwaysApproved
-    } from '$lib/stores/toolApproval';
-    import { approvalCoordinator } from '$lib/utils/toolApprovalChannel';
-    import { toast } from 'svelte-sonner';
-    
-    const i18n = getContext('i18n');
-    
-    
-    $: if ($showApprovalModal && $pendingApprovals) {
-        claimApproval();
-    }
-    
-    function claimApproval() {
-        if (!$pendingApprovals) return;
-        
-        if (!approvalCoordinator.claimApproval()) {
-            showApprovalModal.set(false);
-            return;
-        }
-    }
-    
-    
-    function sendApprovalResponse(approvalId: string, decision: 'approved' | 'denied') {
-        if (!$pendingApprovals || !$socket) return;
-        
-        $socket.emit('tool:approval_response', {
-            chat_id: $pendingApprovals.chat_id,
-            approval_id: approvalId,
-            decision: decision
-        });
-        
-        removeToolFromPending(approvalId);
-        
-        if ($pendingApprovals?.tools.length === 0) {
-            clearApprovals();
-            approvalCoordinator.releaseApproval();
-        }
-    }
-    
-    function approveAllOnce() {
-        if (!$pendingApprovals) return;
-        
-        const tools = [...$pendingApprovals.tools];
-        tools.forEach(tool => {
-            sendApprovalResponse(tool.approval_id, 'approved');
-        });
-    }
-    
-    function denyAll() {
-        if (!$pendingApprovals) return;
-        
-        const tools = [...$pendingApprovals.tools];
-        tools.forEach(tool => {
-            sendApprovalResponse(tool.approval_id, 'denied');
-        });
-    }
-    
-    async function alwaysAllowFunctions() {
-        if (!$pendingApprovals) return;
-        
-        const chatId = $pendingApprovals.chat_id;
-        if (!chatId) {
-            toast.error('Chat ID not found');
-            return;
-        }
-        
-        const tools = [...$pendingApprovals.tools];
-        const uniqueFunctions = new Map<string, string>();
-        for (const tool of tools) {
-            uniqueFunctions.set(tool.tool_name, tool.parent_tool_id);
-        }
-        
-        for (const [functionName, parentToolId] of uniqueFunctions) {
-            await addAlwaysApproved(chatId, parentToolId, functionName, 'function');
-        }
-        
-        toast.success($i18n.t('Functions always allowed for this chat'));
-        
-        tools.forEach(tool => {
-            sendApprovalResponse(tool.approval_id, 'approved');
-        });
-    }
-    
-    async function alwaysAllowParents() {
-        if (!$pendingApprovals) return;
-        
-        const chatId = $pendingApprovals.chat_id;
-        if (!chatId) {
-            toast.error('Chat ID not found');
-            return;
-        }
-        
-        const tools = [...$pendingApprovals.tools];
-        const uniqueParents = new Set(tools.map(t => t.parent_tool_id));
-        
-        for (const parentToolId of uniqueParents) {
-            await addAlwaysApproved(chatId, parentToolId, '', 'parent');
-        }
-        
-        toast.success($i18n.t('Tools always allowed for this chat'));
-        
-        tools.forEach(tool => {
-            sendApprovalResponse(tool.approval_id, 'approved');
-        });
-    }
-    
-    
-    $: uniqueFunctionNames = $pendingApprovals
-        ? [...new Set($pendingApprovals.tools.map(t => t.tool_name))].filter(Boolean)
-        : [];
-    
-    $: uniqueParentNames = $pendingApprovals
-        ? [...new Set($pendingApprovals.tools.map(t => t.parent_tool_id))].filter(id => id && id !== 'unknown')
-        : [];
-    
-    onDestroy(() => {
-        if ($pendingApprovals) {
-            approvalCoordinator.notifyTabClosing(true);
-        }
-    });
+	import { onDestroy, getContext } from 'svelte';
+	import { fade, fly } from 'svelte/transition';
+	import { socket } from '$lib/stores';
+	import {
+		pendingApprovals,
+		removeToolFromPending,
+		clearApprovals,
+		showApprovalModal,
+		addAlwaysApproved
+	} from '$lib/stores/toolApproval';
+	import { approvalCoordinator } from '$lib/utils/toolApprovalChannel';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext('i18n');
+
+	$: if ($showApprovalModal && $pendingApprovals) {
+		claimApproval();
+	}
+
+	function claimApproval() {
+		if (!$pendingApprovals) return;
+
+		if (!approvalCoordinator.claimApproval()) {
+			showApprovalModal.set(false);
+			return;
+		}
+	}
+
+	function sendApprovalResponse(approvalId: string, decision: 'approved' | 'denied') {
+		if (!$pendingApprovals || !$socket) return;
+
+		$socket.emit('tool:approval_response', {
+			chat_id: $pendingApprovals.chat_id,
+			approval_id: approvalId,
+			decision: decision
+		});
+
+		removeToolFromPending(approvalId);
+
+		if ($pendingApprovals?.tools.length === 0) {
+			clearApprovals();
+			approvalCoordinator.releaseApproval();
+		}
+	}
+
+	function approveAllOnce() {
+		if (!$pendingApprovals) return;
+
+		const tools = [...$pendingApprovals.tools];
+		tools.forEach((tool) => {
+			sendApprovalResponse(tool.approval_id, 'approved');
+		});
+	}
+
+	function denyAll() {
+		if (!$pendingApprovals) return;
+
+		const tools = [...$pendingApprovals.tools];
+		tools.forEach((tool) => {
+			sendApprovalResponse(tool.approval_id, 'denied');
+		});
+	}
+
+	async function alwaysAllowFunctions() {
+		if (!$pendingApprovals) return;
+
+		const chatId = $pendingApprovals.chat_id;
+		if (!chatId) {
+			toast.error('Chat ID not found');
+			return;
+		}
+
+		const tools = [...$pendingApprovals.tools];
+		const uniqueFunctions = new Map<string, string>();
+		for (const tool of tools) {
+			uniqueFunctions.set(tool.tool_name, tool.parent_tool_id);
+		}
+
+		for (const [functionName, parentToolId] of uniqueFunctions) {
+			await addAlwaysApproved(chatId, parentToolId, functionName, 'function');
+		}
+
+		toast.success($i18n.t('Functions always allowed for this chat'));
+
+		tools.forEach((tool) => {
+			sendApprovalResponse(tool.approval_id, 'approved');
+		});
+	}
+
+	async function alwaysAllowParents() {
+		if (!$pendingApprovals) return;
+
+		const chatId = $pendingApprovals.chat_id;
+		if (!chatId) {
+			toast.error('Chat ID not found');
+			return;
+		}
+
+		const tools = [...$pendingApprovals.tools];
+		const uniqueParents = new Set(tools.map((t) => t.parent_tool_id));
+
+		for (const parentToolId of uniqueParents) {
+			await addAlwaysApproved(chatId, parentToolId, '', 'parent');
+		}
+
+		toast.success($i18n.t('Tools always allowed for this chat'));
+
+		tools.forEach((tool) => {
+			sendApprovalResponse(tool.approval_id, 'approved');
+		});
+	}
+
+	$: uniqueFunctionNames = $pendingApprovals
+		? [...new Set($pendingApprovals.tools.map((t) => t.tool_name))].filter(Boolean)
+		: [];
+
+	$: uniqueParentNames = $pendingApprovals
+		? [...new Set($pendingApprovals.tools.map((t) => t.parent_tool_id))].filter(
+				(id) => id && id !== 'unknown'
+			)
+		: [];
+
+	onDestroy(() => {
+		if ($pendingApprovals) {
+			approvalCoordinator.notifyTabClosing(true);
+		}
+	});
 </script>
 
-
 {#if $showApprovalModal && $pendingApprovals}
-    <div 
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
-        transition:fade={{ duration: 200 }}
-        on:click|self|preventDefault|stopPropagation
-        on:keydown|preventDefault|stopPropagation
-    >
-        <div 
-            class="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
-            transition:fly={{ y: 20, duration: 300 }}
-            on:click|stopPropagation
-        >
-            <!-- Header -->
-            <div class="px-6 py-5">
-                <h2 class="text-xl font-semibold text-gray-900 dark:text-white text-center">
-                    {$i18n.t('Tool Approval Required')}
-                </h2>
-            </div>
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+		transition:fade={{ duration: 200 }}
+		on:click|self|preventDefault|stopPropagation
+		on:keydown|preventDefault|stopPropagation
+	>
+		<div
+			class="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
+			transition:fly={{ y: 20, duration: 300 }}
+			on:click|stopPropagation
+		>
+			<!-- Header -->
+			<div class="px-6 py-5">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-white text-center">
+					{$i18n.t('Tool Approval Required')}
+				</h2>
+			</div>
 
-            <!-- Content -->
-            <div class="px-6 py-4 max-h-[60vh] overflow-y-auto">
-                <div class="space-y-4">
-                    {#each $pendingApprovals.tools as tool (tool.approval_id)}
-                        <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-4">
-                            <div class="flex items-center justify-between mb-3">
-                                <div class="flex items-center gap-3">
-                                    <div class="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-                                        <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                                        </svg>
-                                    </div>
+			<!-- Content -->
+			<div class="px-6 py-4 max-h-[60vh] overflow-y-auto">
+				<div class="space-y-4">
+					{#each $pendingApprovals.tools as tool (tool.approval_id)}
+						<div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-4">
+							<div class="flex items-center justify-between mb-3">
+								<div class="flex items-center gap-3">
+									<div
+										class="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center"
+									>
+										<svg
+											class="w-5 h-5 text-blue-600 dark:text-blue-400"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+											/>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+											/>
+										</svg>
+									</div>
 
-                                    <div>
-                                        <h3 class="font-medium text-gray-900 dark:text-white text-lg">
-                                            {tool.tool_name}
-                                        </h3>
-                                        {#if tool.parent_tool_id && tool.parent_tool_id !== 'unknown'}
-                                            <p class="text-xs text-gray-500 dark:text-gray-400">
-                                                {tool.parent_tool_id}
-                                            </p>
-                                        {/if}
-                                    </div>
-                                </div>
-                            </div>
+									<div>
+										<h3 class="font-medium text-gray-900 dark:text-white text-lg">
+											{tool.tool_name}
+										</h3>
+										{#if tool.parent_tool_id && tool.parent_tool_id !== 'unknown'}
+											<p class="text-xs text-gray-500 dark:text-gray-400">
+												{tool.parent_tool_id}
+											</p>
+										{/if}
+									</div>
+								</div>
+							</div>
 
-                            {#if !tool.parent_tool_id || tool.parent_tool_id === 'unknown'}
-                                <div class="flex items-center gap-2 mb-3 px-3 py-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400 text-xs">
-                                    <svg class="size-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-                                        <line x1="12" y1="9" x2="12" y2="13"/>
-                                        <line x1="12" y1="17" x2="12.01" y2="17"/>
-                                    </svg>
-                                    <span>{$i18n.t('Unrecognized tool call — this may fail')}</span>
-                                </div>
-                            {/if}
+							{#if !tool.parent_tool_id || tool.parent_tool_id === 'unknown'}
+								<div
+									class="flex items-center gap-2 mb-3 px-3 py-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-amber-700 dark:text-amber-400 text-xs"
+								>
+									<svg
+										class="size-4 shrink-0"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path
+											d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+										/>
+										<line x1="12" y1="9" x2="12" y2="13" />
+										<line x1="12" y1="17" x2="12.01" y2="17" />
+									</svg>
+									<span>{$i18n.t('Unrecognized tool call — this may fail')}</span>
+								</div>
+							{/if}
 
-                            {#if Object.keys(tool.tool_params).length > 0}
-                                <div class="bg-white dark:bg-gray-800 rounded-lg p-3 mb-4 border border-gray-100 dark:border-gray-600">
-                                    <p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
-                                        {$i18n.t('Parameters:')}
-                                    </p>
-                                    <pre class="text-sm text-gray-700 dark:text-gray-300 font-mono overflow-x-auto whitespace-pre-wrap">{JSON.stringify(tool.tool_params, null, 2)}</pre>
-                                </div>
-                            {/if}
-                        </div>
-                    {/each}
-                </div>
+							{#if Object.keys(tool.tool_params).length > 0}
+								<div
+									class="bg-white dark:bg-gray-800 rounded-lg p-3 mb-4 border border-gray-100 dark:border-gray-600"
+								>
+									<p class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+										{$i18n.t('Parameters:')}
+									</p>
+									<pre
+										class="text-sm text-gray-700 dark:text-gray-300 font-mono overflow-x-auto whitespace-pre-wrap">{JSON.stringify(
+											tool.tool_params,
+											null,
+											2
+										)}</pre>
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
 
-                <div class="mt-6 px-6">
-                    <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
-                        {$i18n.t('Review each action carefully before approving')}
-                    </p>
-                </div>
-            </div>
+				<div class="mt-6 px-6">
+					<p class="text-sm text-gray-500 dark:text-gray-400 text-center">
+						{$i18n.t('Review each action carefully before approving')}
+					</p>
+				</div>
+			</div>
 
-            <!-- Footer Actions -->
-            <div class="px-6 py-4">
-                <div class="flex flex-col gap-2">
-                    <!-- Always Approve row -->
-                    <div class="flex gap-2 justify-center">
-                        <button
-                            on:click={alwaysAllowFunctions}
-                            class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
-                        >
-                            <span class="font-medium">{$i18n.t('Always Approve')}</span>
-                            <br />
-                            <span class="text-xs text-gray-500 dark:text-gray-400">({uniqueFunctionNames.join(', ')})</span>
-                        </button>
-                        {#if uniqueParentNames.length > 0}
-                            <button
-                                on:click={alwaysAllowParents}
-                                class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
-                            >
-                                <span class="font-medium">{$i18n.t('Always Approve')}</span>
-                                <br />
-                                <span class="text-xs text-gray-500 dark:text-gray-400">({uniqueParentNames.join(', ')})</span>
-                            </button>
-                        {/if}
-                    </div>
-                    <!-- Allow Once / Decline row -->
-                    <div class="flex gap-2 justify-center">
-                        <button
-                            on:click={approveAllOnce}
-                            class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors font-medium text-sm"
-                        >
-                            {$i18n.t('Allow Once')}
-                        </button>
-                        <button
-                            on:click={denyAll}
-                            class="flex-1 max-w-xs px-4 py-2.5 bg-gray-800 dark:bg-gray-600 text-white rounded-lg hover:bg-gray-900 dark:hover:bg-gray-500 transition-colors font-medium text-sm"
-                        >
-                            {$i18n.t('Decline')}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+			<!-- Footer Actions -->
+			<div class="px-6 py-4">
+				<div class="flex flex-col gap-2">
+					<!-- Always Approve row -->
+					<div class="flex gap-2 justify-center">
+						<button
+							on:click={alwaysAllowFunctions}
+							class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
+						>
+							<span class="font-medium">{$i18n.t('Always Approve')}</span>
+							<br />
+							<span class="text-xs text-gray-500 dark:text-gray-400"
+								>({uniqueFunctionNames.join(', ')})</span
+							>
+						</button>
+						{#if uniqueParentNames.length > 0}
+							<button
+								on:click={alwaysAllowParents}
+								class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors text-sm text-center"
+							>
+								<span class="font-medium">{$i18n.t('Always Approve')}</span>
+								<br />
+								<span class="text-xs text-gray-500 dark:text-gray-400"
+									>({uniqueParentNames.join(', ')})</span
+								>
+							</button>
+						{/if}
+					</div>
+					<!-- Allow Once / Decline row -->
+					<div class="flex gap-2 justify-center">
+						<button
+							on:click={approveAllOnce}
+							class="flex-1 max-w-xs px-4 py-2.5 bg-white dark:bg-gray-700 text-gray-900 dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors font-medium text-sm"
+						>
+							{$i18n.t('Allow Once')}
+						</button>
+						<button
+							on:click={denyAll}
+							class="flex-1 max-w-xs px-4 py-2.5 bg-gray-800 dark:bg-gray-600 text-white rounded-lg hover:bg-gray-900 dark:hover:bg-gray-500 transition-colors font-medium text-sm"
+						>
+							{$i18n.t('Decline')}
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
 {/if}

--- a/src/lib/components/workspace/Models/BuiltinTools.svelte
+++ b/src/lib/components/workspace/Models/BuiltinTools.svelte
@@ -1,62 +1,30 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { onMount, getContext } from 'svelte';
 	import Checkbox from '$lib/components/common/Checkbox.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { getBuiltinToolCategories } from '$lib/apis/tools';
 	import { marked } from 'marked';
 
 	const i18n = getContext('i18n');
 
-	const toolLabels = {
-		time: {
-			label: $i18n.t('Time & Calculation'),
-			description: $i18n.t('Get current time and perform date/time calculations')
-		},
-		memory: {
-			label: $i18n.t('Memory'),
-			description: $i18n.t('Search and manage user memories')
-		},
-		chats: {
-			label: $i18n.t('Chat History'),
-			description: $i18n.t('Search and view user chat history')
-		},
-		notes: {
-			label: $i18n.t('Notes'),
-			description: $i18n.t('Search, view, and manage user notes')
-		},
-		knowledge: {
-			label: $i18n.t('Knowledge Base'),
-			description: $i18n.t('Browse and query knowledge bases')
-		},
-		channels: {
-			label: $i18n.t('Channels'),
-			description: $i18n.t('Search channels and channel messages')
-		},
-		web_search: {
-			label: $i18n.t('Web Search'),
-			description: $i18n.t('Search the web and fetch URLs')
-		},
-		image_generation: {
-			label: $i18n.t('Image Generation'),
-			description: $i18n.t('Generate and edit images')
-		},
-		code_interpreter: {
-			label: $i18n.t('Code Interpreter'),
-			description: $i18n.t('Execute code')
-		}
-	};
-
-	const allTools = Object.keys(toolLabels);
+	let categories: Record<string, { name: string; description: string; functions: string[] }> = {};
+	let allTools: string[] = [];
 
 	export let builtinTools: Record<string, boolean> = {};
 
-	// Initialize missing keys to true (default enabled)
-	$: {
-		for (const tool of allTools) {
-			if (!(tool in builtinTools)) {
-				builtinTools[tool] = true;
+	onMount(async () => {
+		try {
+			categories = await getBuiltinToolCategories(localStorage.token);
+			allTools = Object.keys(categories);
+			for (const tool of allTools) {
+				if (!(tool in builtinTools)) {
+					builtinTools[tool] = true;
+				}
 			}
+		} catch (e) {
+			console.error('Failed to load builtin tool categories:', e);
 		}
-	}
+	});
 </script>
 
 <div>
@@ -77,8 +45,8 @@
 				/>
 
 				<div class="py-0.5 text-sm">
-					<Tooltip content={marked.parse(toolLabels[tool].description)}>
-						{$i18n.t(toolLabels[tool].label)}
+					<Tooltip content={marked.parse(categories[tool]?.description ?? '')}>
+						{$i18n.t(categories[tool]?.name ?? tool)}
 					</Tooltip>
 				</div>
 			</div>

--- a/src/lib/stores/toolApproval.ts
+++ b/src/lib/stores/toolApproval.ts
@@ -1,131 +1,125 @@
 import { writable, derived, get } from 'svelte/store';
 import type { Writable } from 'svelte/store';
 
-
 export interface ToolApprovalRequest {
-    approval_id: string;
-    tool_id: string;
-    tool_name: string;
-    tool_params: Record<string, any>;
-    parent_tool_id: string;
+	approval_id: string;
+	tool_id: string;
+	tool_name: string;
+	tool_params: Record<string, any>;
+	parent_tool_id: string;
 }
 
-
 export interface ToolApprovalData {
-    chat_id: string;
-    message_id: string;
-    tools: ToolApprovalRequest[];
-    timestamp: number;
+	chat_id: string;
+	message_id: string;
+	tools: ToolApprovalRequest[];
+	timestamp: number;
 }
 
 // { parent_tool_id: [function_names...] } where ["*"] means parent-level approval
 export type AlwaysApprovedMap = Record<string, string[]>;
 
-
 export const pendingApprovals: Writable<ToolApprovalData | null> = writable(null);
 export const showApprovalModal = writable(false);
 
 export const remainingTools = derived(
-    pendingApprovals,
-    $pendingApprovals => $pendingApprovals?.tools.length || 0
+	pendingApprovals,
+	($pendingApprovals) => $pendingApprovals?.tools.length || 0
 );
-
 
 // ---- Helpers to get a socket ref ----
 
 async function getSocket() {
-    const { socket } = await import('$lib/stores');
-    return get(socket);
+	const { socket } = await import('$lib/stores');
+	return get(socket);
 }
-
 
 // ---- Always-approved CRUD via socket ----
 
 export async function addAlwaysApproved(
-    chatId: string,
-    parentToolId: string,
-    functionName: string,
-    level: 'function' | 'parent' = 'function'
+	chatId: string,
+	parentToolId: string,
+	functionName: string,
+	level: 'function' | 'parent' = 'function'
 ): Promise<AlwaysApprovedMap | null> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return null;
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return null;
 
-        const response = await $socket.emitWithAck('tool:add_always_approved', {
-            chat_id: chatId,
-            parent_tool_id: parentToolId,
-            function_name: functionName,
-            level
-        });
+		const response = await $socket.emitWithAck('tool:add_always_approved', {
+			chat_id: chatId,
+			parent_tool_id: parentToolId,
+			function_name: functionName,
+			level
+		});
 
-        if (response.status === 'success') {
-            return response.always_approved;
-        }
-        return null;
-    } catch {
-        return null;
-    }
+		if (response.status === 'success') {
+			return response.always_approved;
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export async function removeAlwaysApproved(
-    chatId: string,
-    parentToolId: string,
-    functionName: string,
-    level: 'function' | 'parent' = 'function'
+	chatId: string,
+	parentToolId: string,
+	functionName: string,
+	level: 'function' | 'parent' = 'function'
 ): Promise<AlwaysApprovedMap | null> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return null;
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return null;
 
-        const response = await $socket.emitWithAck('tool:remove_always_approved', {
-            chat_id: chatId,
-            parent_tool_id: parentToolId,
-            function_name: functionName,
-            level
-        });
+		const response = await $socket.emitWithAck('tool:remove_always_approved', {
+			chat_id: chatId,
+			parent_tool_id: parentToolId,
+			function_name: functionName,
+			level
+		});
 
-        if (response.status === 'success') {
-            return response.always_approved;
-        }
-        return null;
-    } catch {
-        return null;
-    }
+		if (response.status === 'success') {
+			return response.always_approved;
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export async function getAlwaysApproved(chatId: string): Promise<AlwaysApprovedMap> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return {};
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return {};
 
-        const response = await $socket.emitWithAck('tool:get_always_approved', {
-            chat_id: chatId
-        });
+		const response = await $socket.emitWithAck('tool:get_always_approved', {
+			chat_id: chatId
+		});
 
-        if (response.status === 'success') {
-            return response.always_approved;
-        }
-        return {};
-    } catch {
-        return {};
-    }
+		if (response.status === 'success') {
+			return response.always_approved;
+		}
+		return {};
+	} catch {
+		return {};
+	}
 }
 
 export async function clearAllAlwaysApproved(chatId: string): Promise<boolean> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return false;
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return false;
 
-        const response = await $socket.emitWithAck('tool:clear_always_approved', {
-            chat_id: chatId
-        });
+		const response = await $socket.emitWithAck('tool:clear_always_approved', {
+			chat_id: chatId
+		});
 
-        return response.status === 'success';
-    } catch {
-        return false;
-    }
+		return response.status === 'success';
+	} catch {
+		return false;
+	}
 }
-
 
 // ---- Approval request handling ----
 
@@ -135,194 +129,194 @@ export async function clearAllAlwaysApproved(chatId: string): Promise<boolean> {
  * so they genuinely need user approval. Just show the modal.
  */
 export async function setApprovalRequest(data: ToolApprovalData) {
-    if (!data.tools || data.tools.length === 0) return;
+	if (!data.tools || data.tools.length === 0) return;
 
-    pendingApprovals.set({
-        ...data,
-        timestamp: Date.now()
-    });
-    showApprovalModal.set(true);
+	pendingApprovals.set({
+		...data,
+		timestamp: Date.now()
+	});
+	showApprovalModal.set(true);
 }
-
 
 export function removeToolFromPending(approval_id: string) {
-    pendingApprovals.update(data => {
-        if (!data) return null;
+	pendingApprovals.update((data) => {
+		if (!data) return null;
 
-        const filteredTools = data.tools.filter(t => t.approval_id !== approval_id);
+		const filteredTools = data.tools.filter((t) => t.approval_id !== approval_id);
 
-        if (filteredTools.length === 0) {
-            showApprovalModal.set(false);
-            return null;
-        }
+		if (filteredTools.length === 0) {
+			showApprovalModal.set(false);
+			return null;
+		}
 
-        return {
-            ...data,
-            tools: filteredTools
-        };
-    });
+		return {
+			...data,
+			tools: filteredTools
+		};
+	});
 }
-
 
 export function clearApprovals() {
-    pendingApprovals.set(null);
-    showApprovalModal.set(false);
+	pendingApprovals.set(null);
+	showApprovalModal.set(false);
 }
-
 
 export function checkPendingApprovals(chatId: string) {
-    if (!chatId) return;
+	if (!chatId) return;
 
-    import('$lib/stores').then(({ socket }) => {
-        const $socket = get(socket);
-        if ($socket) {
-            $socket.emit('tool:check_pending', {
-                chat_id: chatId
-            });
-        }
-    });
+	import('$lib/stores').then(({ socket }) => {
+		const $socket = get(socket);
+		if ($socket) {
+			$socket.emit('tool:check_pending', {
+				chat_id: chatId
+			});
+		}
+	});
 }
-
 
 export async function handlePendingFound(data: ToolApprovalData) {
-    if (!data.tools || data.tools.length === 0) return;
+	if (!data.tools || data.tools.length === 0) return;
 
-    pendingApprovals.set({
-        ...data,
-        timestamp: Date.now()
-    });
-    showApprovalModal.set(true);
+	pendingApprovals.set({
+		...data,
+		timestamp: Date.now()
+	});
+	showApprovalModal.set(true);
 }
-
 
 // ---- YOLO mode via socket ----
 
 export interface YoloStatus {
-    yolo_all: boolean;
-    yolo_functions: Record<string, string[]>;
+	yolo_all: boolean;
+	yolo_functions: Record<string, string[]>;
 }
 
 export async function setYolo(
-    chatId: string,
-    level: 'all' | 'parent' | 'function',
-    enabled: boolean,
-    parentToolId: string = '',
-    functionName: string = ''
+	chatId: string,
+	level: 'all' | 'parent' | 'function',
+	enabled: boolean,
+	parentToolId: string = '',
+	functionName: string = ''
 ): Promise<YoloStatus | null> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return null;
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return null;
 
-        const response = await $socket.emitWithAck('tool:set_yolo', {
-            chat_id: chatId,
-            level,
-            enabled,
-            parent_tool_id: parentToolId,
-            function_name: functionName
-        });
+		const response = await $socket.emitWithAck('tool:set_yolo', {
+			chat_id: chatId,
+			level,
+			enabled,
+			parent_tool_id: parentToolId,
+			function_name: functionName
+		});
 
-        if (response.status === 'success') {
-            return response.yolo;
-        }
-        return null;
-    } catch {
-        return null;
-    }
+		if (response.status === 'success') {
+			return response.yolo;
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export async function getYoloStatus(chatId: string): Promise<YoloStatus> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return { yolo_all: false, yolo_functions: {} };
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return { yolo_all: false, yolo_functions: {} };
 
-        const response = await $socket.emitWithAck('tool:get_yolo', {
-            chat_id: chatId
-        });
+		const response = await $socket.emitWithAck('tool:get_yolo', {
+			chat_id: chatId
+		});
 
-        if (response.status === 'success') {
-            return response.yolo;
-        }
-        return { yolo_all: false, yolo_functions: {} };
-    } catch {
-        return { yolo_all: false, yolo_functions: {} };
-    }
+		if (response.status === 'success') {
+			return response.yolo;
+		}
+		return { yolo_all: false, yolo_functions: {} };
+	} catch {
+		return { yolo_all: false, yolo_functions: {} };
+	}
 }
 
 export async function clearYolo(chatId: string): Promise<boolean> {
-    try {
-        const $socket = await getSocket();
-        if (!$socket) return false;
+	try {
+		const $socket = await getSocket();
+		if (!$socket) return false;
 
-        const response = await $socket.emitWithAck('tool:clear_yolo', {
-            chat_id: chatId
-        });
+		const response = await $socket.emitWithAck('tool:clear_yolo', {
+			chat_id: chatId
+		});
 
-        return response.status === 'success';
-    } catch {
-        return false;
-    }
+		return response.status === 'success';
+	} catch {
+		return false;
+	}
 }
-
 
 // ---- Pending YOLO for new chats (no chatId yet) ----
 
 export interface PendingYoloState {
-    yolo_all: boolean;
-    yolo_parents: string[];
+	yolo_all: boolean;
+	yolo_parents: string[];
 }
 
-export const pendingYolo: Writable<PendingYoloState> = writable({ yolo_all: false, yolo_parents: [] });
+export const pendingYolo: Writable<PendingYoloState> = writable({
+	yolo_all: false,
+	yolo_parents: []
+});
 
-export function setPendingYolo(level: 'all' | 'parent', enabled: boolean, parentToolId: string = '') {
-    pendingYolo.update(state => {
-        if (level === 'all') {
-            return { ...state, yolo_all: enabled };
-        } else {
-            const parents = new Set(state.yolo_parents);
-            if (enabled) {
-                parents.add(parentToolId);
-            } else {
-                parents.delete(parentToolId);
-            }
-            return { ...state, yolo_parents: [...parents] };
-        }
-    });
+export function setPendingYolo(
+	level: 'all' | 'parent',
+	enabled: boolean,
+	parentToolId: string = ''
+) {
+	pendingYolo.update((state) => {
+		if (level === 'all') {
+			return { ...state, yolo_all: enabled };
+		} else {
+			const parents = new Set(state.yolo_parents);
+			if (enabled) {
+				parents.add(parentToolId);
+			} else {
+				parents.delete(parentToolId);
+			}
+			return { ...state, yolo_parents: [...parents] };
+		}
+	});
 }
 
 export function getPendingYoloAsStatus(): YoloStatus {
-    const state = get(pendingYolo);
-    const yolo_functions: Record<string, string[]> = {};
-    for (const parentId of state.yolo_parents) {
-        yolo_functions[parentId] = ['*'];
-    }
-    return { yolo_all: state.yolo_all, yolo_functions };
+	const state = get(pendingYolo);
+	const yolo_functions: Record<string, string[]> = {};
+	for (const parentId of state.yolo_parents) {
+		yolo_functions[parentId] = ['*'];
+	}
+	return { yolo_all: state.yolo_all, yolo_functions };
 }
 
 export async function flushPendingYolo(chatId: string): Promise<void> {
-    const state = get(pendingYolo);
-    if (!state.yolo_all && state.yolo_parents.length === 0) return;
+	const state = get(pendingYolo);
+	if (!state.yolo_all && state.yolo_parents.length === 0) return;
 
-    if (state.yolo_all) {
-        await setYolo(chatId, 'all', true);
-    } else {
-        for (const parentId of state.yolo_parents) {
-            await setYolo(chatId, 'parent', true, parentId);
-        }
-    }
+	if (state.yolo_all) {
+		await setYolo(chatId, 'all', true);
+	} else {
+		for (const parentId of state.yolo_parents) {
+			await setYolo(chatId, 'parent', true, parentId);
+		}
+	}
 
-    pendingYolo.set({ yolo_all: false, yolo_parents: [] });
+	pendingYolo.set({ yolo_all: false, yolo_parents: [] });
 }
-
 
 // ---- Socket listener for pending_found ----
 
 if (typeof window !== 'undefined') {
-    import('$lib/stores').then(({ socket }) => {
-        socket.subscribe(($socket) => {
-            if ($socket) {
-                $socket.off('tool:pending_found');
-                $socket.on('tool:pending_found', handlePendingFound);
-            }
-        });
-    });
+	import('$lib/stores').then(({ socket }) => {
+		socket.subscribe(($socket) => {
+			if ($socket) {
+				$socket.off('tool:pending_found');
+				$socket.on('tool:pending_found', handlePendingFound);
+			}
+		});
+	});
 }

--- a/src/lib/stores/toolApproval.ts
+++ b/src/lib/stores/toolApproval.ts
@@ -1,0 +1,328 @@
+import { writable, derived, get } from 'svelte/store';
+import type { Writable } from 'svelte/store';
+
+
+export interface ToolApprovalRequest {
+    approval_id: string;
+    tool_id: string;
+    tool_name: string;
+    tool_params: Record<string, any>;
+    parent_tool_id: string;
+}
+
+
+export interface ToolApprovalData {
+    chat_id: string;
+    message_id: string;
+    tools: ToolApprovalRequest[];
+    timestamp: number;
+}
+
+// { parent_tool_id: [function_names...] } where ["*"] means parent-level approval
+export type AlwaysApprovedMap = Record<string, string[]>;
+
+
+export const pendingApprovals: Writable<ToolApprovalData | null> = writable(null);
+export const showApprovalModal = writable(false);
+
+export const remainingTools = derived(
+    pendingApprovals,
+    $pendingApprovals => $pendingApprovals?.tools.length || 0
+);
+
+
+// ---- Helpers to get a socket ref ----
+
+async function getSocket() {
+    const { socket } = await import('$lib/stores');
+    return get(socket);
+}
+
+
+// ---- Always-approved CRUD via socket ----
+
+export async function addAlwaysApproved(
+    chatId: string,
+    parentToolId: string,
+    functionName: string,
+    level: 'function' | 'parent' = 'function'
+): Promise<AlwaysApprovedMap | null> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return null;
+
+        const response = await $socket.emitWithAck('tool:add_always_approved', {
+            chat_id: chatId,
+            parent_tool_id: parentToolId,
+            function_name: functionName,
+            level
+        });
+
+        if (response.status === 'success') {
+            return response.always_approved;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export async function removeAlwaysApproved(
+    chatId: string,
+    parentToolId: string,
+    functionName: string,
+    level: 'function' | 'parent' = 'function'
+): Promise<AlwaysApprovedMap | null> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return null;
+
+        const response = await $socket.emitWithAck('tool:remove_always_approved', {
+            chat_id: chatId,
+            parent_tool_id: parentToolId,
+            function_name: functionName,
+            level
+        });
+
+        if (response.status === 'success') {
+            return response.always_approved;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export async function getAlwaysApproved(chatId: string): Promise<AlwaysApprovedMap> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return {};
+
+        const response = await $socket.emitWithAck('tool:get_always_approved', {
+            chat_id: chatId
+        });
+
+        if (response.status === 'success') {
+            return response.always_approved;
+        }
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+export async function clearAllAlwaysApproved(chatId: string): Promise<boolean> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return false;
+
+        const response = await $socket.emitWithAck('tool:clear_always_approved', {
+            chat_id: chatId
+        });
+
+        return response.status === 'success';
+    } catch {
+        return false;
+    }
+}
+
+
+// ---- Approval request handling ----
+
+/**
+ * The backend now handles auto-approval checks server-side via should_auto_approve().
+ * Tools that arrive here have already passed through the backend filter,
+ * so they genuinely need user approval. Just show the modal.
+ */
+export async function setApprovalRequest(data: ToolApprovalData) {
+    if (!data.tools || data.tools.length === 0) return;
+
+    pendingApprovals.set({
+        ...data,
+        timestamp: Date.now()
+    });
+    showApprovalModal.set(true);
+}
+
+
+export function removeToolFromPending(approval_id: string) {
+    pendingApprovals.update(data => {
+        if (!data) return null;
+
+        const filteredTools = data.tools.filter(t => t.approval_id !== approval_id);
+
+        if (filteredTools.length === 0) {
+            showApprovalModal.set(false);
+            return null;
+        }
+
+        return {
+            ...data,
+            tools: filteredTools
+        };
+    });
+}
+
+
+export function clearApprovals() {
+    pendingApprovals.set(null);
+    showApprovalModal.set(false);
+}
+
+
+export function checkPendingApprovals(chatId: string) {
+    if (!chatId) return;
+
+    import('$lib/stores').then(({ socket }) => {
+        const $socket = get(socket);
+        if ($socket) {
+            $socket.emit('tool:check_pending', {
+                chat_id: chatId
+            });
+        }
+    });
+}
+
+
+export async function handlePendingFound(data: ToolApprovalData) {
+    if (!data.tools || data.tools.length === 0) return;
+
+    pendingApprovals.set({
+        ...data,
+        timestamp: Date.now()
+    });
+    showApprovalModal.set(true);
+}
+
+
+// ---- YOLO mode via socket ----
+
+export interface YoloStatus {
+    yolo_all: boolean;
+    yolo_functions: Record<string, string[]>;
+}
+
+export async function setYolo(
+    chatId: string,
+    level: 'all' | 'parent' | 'function',
+    enabled: boolean,
+    parentToolId: string = '',
+    functionName: string = ''
+): Promise<YoloStatus | null> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return null;
+
+        const response = await $socket.emitWithAck('tool:set_yolo', {
+            chat_id: chatId,
+            level,
+            enabled,
+            parent_tool_id: parentToolId,
+            function_name: functionName
+        });
+
+        if (response.status === 'success') {
+            return response.yolo;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export async function getYoloStatus(chatId: string): Promise<YoloStatus> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return { yolo_all: false, yolo_functions: {} };
+
+        const response = await $socket.emitWithAck('tool:get_yolo', {
+            chat_id: chatId
+        });
+
+        if (response.status === 'success') {
+            return response.yolo;
+        }
+        return { yolo_all: false, yolo_functions: {} };
+    } catch {
+        return { yolo_all: false, yolo_functions: {} };
+    }
+}
+
+export async function clearYolo(chatId: string): Promise<boolean> {
+    try {
+        const $socket = await getSocket();
+        if (!$socket) return false;
+
+        const response = await $socket.emitWithAck('tool:clear_yolo', {
+            chat_id: chatId
+        });
+
+        return response.status === 'success';
+    } catch {
+        return false;
+    }
+}
+
+
+// ---- Pending YOLO for new chats (no chatId yet) ----
+
+export interface PendingYoloState {
+    yolo_all: boolean;
+    yolo_parents: string[];
+}
+
+export const pendingYolo: Writable<PendingYoloState> = writable({ yolo_all: false, yolo_parents: [] });
+
+export function setPendingYolo(level: 'all' | 'parent', enabled: boolean, parentToolId: string = '') {
+    pendingYolo.update(state => {
+        if (level === 'all') {
+            return { ...state, yolo_all: enabled };
+        } else {
+            const parents = new Set(state.yolo_parents);
+            if (enabled) {
+                parents.add(parentToolId);
+            } else {
+                parents.delete(parentToolId);
+            }
+            return { ...state, yolo_parents: [...parents] };
+        }
+    });
+}
+
+export function getPendingYoloAsStatus(): YoloStatus {
+    const state = get(pendingYolo);
+    const yolo_functions: Record<string, string[]> = {};
+    for (const parentId of state.yolo_parents) {
+        yolo_functions[parentId] = ['*'];
+    }
+    return { yolo_all: state.yolo_all, yolo_functions };
+}
+
+export async function flushPendingYolo(chatId: string): Promise<void> {
+    const state = get(pendingYolo);
+    if (!state.yolo_all && state.yolo_parents.length === 0) return;
+
+    if (state.yolo_all) {
+        await setYolo(chatId, 'all', true);
+    } else {
+        for (const parentId of state.yolo_parents) {
+            await setYolo(chatId, 'parent', true, parentId);
+        }
+    }
+
+    pendingYolo.set({ yolo_all: false, yolo_parents: [] });
+}
+
+
+// ---- Socket listener for pending_found ----
+
+if (typeof window !== 'undefined') {
+    import('$lib/stores').then(({ socket }) => {
+        socket.subscribe(($socket) => {
+            if ($socket) {
+                $socket.off('tool:pending_found');
+                $socket.on('tool:pending_found', handlePendingFound);
+            }
+        });
+    });
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,3 +13,33 @@ export enum TTS_RESPONSE_SPLIT {
 	PARAGRAPHS = 'paragraphs',
 	NONE = 'none'
 }
+
+// Add these interfaces to your existing types
+
+export interface ToolApprovalRequest {
+    approval_id: string;
+    tool_id: string;
+    tool_name: string;
+    tool_params: Record<string, any>;
+    risk_level: 'high' | 'medium' | 'low';
+}
+
+export interface ToolApprovalData {
+    session_id: string;
+    chat_id: string;
+    message_id: string;
+    tools: ToolApprovalRequest[];
+    timestamp?: number;
+}
+
+export interface ToolApprovalResponse {
+    session_id: string;
+    approval_id: string;
+    decision: 'approved' | 'denied';
+}
+
+export interface ToolApprovalStatusEvent {
+    tool_id: string;
+    tool_name: string;
+    status: 'approved' | 'denied';
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -17,29 +17,29 @@ export enum TTS_RESPONSE_SPLIT {
 // Add these interfaces to your existing types
 
 export interface ToolApprovalRequest {
-    approval_id: string;
-    tool_id: string;
-    tool_name: string;
-    tool_params: Record<string, any>;
-    risk_level: 'high' | 'medium' | 'low';
+	approval_id: string;
+	tool_id: string;
+	tool_name: string;
+	tool_params: Record<string, any>;
+	risk_level: 'high' | 'medium' | 'low';
 }
 
 export interface ToolApprovalData {
-    session_id: string;
-    chat_id: string;
-    message_id: string;
-    tools: ToolApprovalRequest[];
-    timestamp?: number;
+	session_id: string;
+	chat_id: string;
+	message_id: string;
+	tools: ToolApprovalRequest[];
+	timestamp?: number;
 }
 
 export interface ToolApprovalResponse {
-    session_id: string;
-    approval_id: string;
-    decision: 'approved' | 'denied';
+	session_id: string;
+	approval_id: string;
+	decision: 'approved' | 'denied';
 }
 
 export interface ToolApprovalStatusEvent {
-    tool_id: string;
-    tool_name: string;
-    status: 'approved' | 'denied';
+	tool_id: string;
+	tool_name: string;
+	status: 'approved' | 'denied';
 }

--- a/src/lib/utils/toolApprovalChannel.ts
+++ b/src/lib/utils/toolApprovalChannel.ts
@@ -1,0 +1,80 @@
+export class ToolApprovalCoordinator {
+    private channel: BroadcastChannel;
+    private isHandlingApproval = false;
+    private tabId: string;
+
+    constructor() {
+        this.tabId = Math.random().toString(36).substring(7);
+        this.channel = new BroadcastChannel('tool-approval-channel');
+
+        this.channel.onmessage = (event) => {
+            this.handleMessage(event.data);
+        };
+    }
+
+    private handleMessage(data: unknown) {
+        if (!data || typeof data !== 'object' || !('type' in data)) return;
+
+        const msg = data as { type: string; tabId?: string; hasApprovals?: boolean };
+
+        switch (msg.type) {
+            case 'APPROVAL_CLAIMED':
+                if (msg.tabId !== this.tabId) {
+                    // Another tab is handling it
+                    this.isHandlingApproval = false;
+                }
+                break;
+
+            case 'APPROVAL_COMPLETED':
+                // Clear any pending state
+                this.isHandlingApproval = false;
+                break;
+
+            case 'TAB_CLOSING':
+                // Tab is closing with pending approvals
+                if (msg.hasApprovals && !this.isHandlingApproval) {
+                    // Could take over, but we'll let it timeout per requirements
+                }
+                break;
+        }
+    }
+
+    claimApproval(): boolean {
+        if (this.isHandlingApproval) return true;
+
+        // Try to claim the approval handling
+        this.channel.postMessage({
+            type: 'APPROVAL_CLAIMED',
+            tabId: this.tabId,
+            timestamp: Date.now()
+        });
+
+        this.isHandlingApproval = true;
+        return true;
+    }
+
+    releaseApproval() {
+        this.isHandlingApproval = false;
+        this.channel.postMessage({
+            type: 'APPROVAL_COMPLETED',
+            tabId: this.tabId,
+            timestamp: Date.now()
+        });
+    }
+
+    notifyTabClosing(hasApprovals: boolean) {
+        this.channel.postMessage({
+            type: 'TAB_CLOSING',
+            tabId: this.tabId,
+            hasApprovals,
+            timestamp: Date.now()
+        });
+    }
+
+    destroy() {
+        this.channel.close();
+    }
+}
+
+// Export singleton instance
+export const approvalCoordinator = new ToolApprovalCoordinator();

--- a/src/lib/utils/toolApprovalChannel.ts
+++ b/src/lib/utils/toolApprovalChannel.ts
@@ -1,79 +1,79 @@
 export class ToolApprovalCoordinator {
-    private channel: BroadcastChannel;
-    private isHandlingApproval = false;
-    private tabId: string;
+	private channel: BroadcastChannel;
+	private isHandlingApproval = false;
+	private tabId: string;
 
-    constructor() {
-        this.tabId = Math.random().toString(36).substring(7);
-        this.channel = new BroadcastChannel('tool-approval-channel');
+	constructor() {
+		this.tabId = Math.random().toString(36).substring(7);
+		this.channel = new BroadcastChannel('tool-approval-channel');
 
-        this.channel.onmessage = (event) => {
-            this.handleMessage(event.data);
-        };
-    }
+		this.channel.onmessage = (event) => {
+			this.handleMessage(event.data);
+		};
+	}
 
-    private handleMessage(data: unknown) {
-        if (!data || typeof data !== 'object' || !('type' in data)) return;
+	private handleMessage(data: unknown) {
+		if (!data || typeof data !== 'object' || !('type' in data)) return;
 
-        const msg = data as { type: string; tabId?: string; hasApprovals?: boolean };
+		const msg = data as { type: string; tabId?: string; hasApprovals?: boolean };
 
-        switch (msg.type) {
-            case 'APPROVAL_CLAIMED':
-                if (msg.tabId !== this.tabId) {
-                    // Another tab is handling it
-                    this.isHandlingApproval = false;
-                }
-                break;
+		switch (msg.type) {
+			case 'APPROVAL_CLAIMED':
+				if (msg.tabId !== this.tabId) {
+					// Another tab is handling it
+					this.isHandlingApproval = false;
+				}
+				break;
 
-            case 'APPROVAL_COMPLETED':
-                // Clear any pending state
-                this.isHandlingApproval = false;
-                break;
+			case 'APPROVAL_COMPLETED':
+				// Clear any pending state
+				this.isHandlingApproval = false;
+				break;
 
-            case 'TAB_CLOSING':
-                // Tab is closing with pending approvals
-                if (msg.hasApprovals && !this.isHandlingApproval) {
-                    // Could take over, but we'll let it timeout per requirements
-                }
-                break;
-        }
-    }
+			case 'TAB_CLOSING':
+				// Tab is closing with pending approvals
+				if (msg.hasApprovals && !this.isHandlingApproval) {
+					// Could take over, but we'll let it timeout per requirements
+				}
+				break;
+		}
+	}
 
-    claimApproval(): boolean {
-        if (this.isHandlingApproval) return true;
+	claimApproval(): boolean {
+		if (this.isHandlingApproval) return true;
 
-        // Try to claim the approval handling
-        this.channel.postMessage({
-            type: 'APPROVAL_CLAIMED',
-            tabId: this.tabId,
-            timestamp: Date.now()
-        });
+		// Try to claim the approval handling
+		this.channel.postMessage({
+			type: 'APPROVAL_CLAIMED',
+			tabId: this.tabId,
+			timestamp: Date.now()
+		});
 
-        this.isHandlingApproval = true;
-        return true;
-    }
+		this.isHandlingApproval = true;
+		return true;
+	}
 
-    releaseApproval() {
-        this.isHandlingApproval = false;
-        this.channel.postMessage({
-            type: 'APPROVAL_COMPLETED',
-            tabId: this.tabId,
-            timestamp: Date.now()
-        });
-    }
+	releaseApproval() {
+		this.isHandlingApproval = false;
+		this.channel.postMessage({
+			type: 'APPROVAL_COMPLETED',
+			tabId: this.tabId,
+			timestamp: Date.now()
+		});
+	}
 
-    notifyTabClosing(hasApprovals: boolean) {
-        this.channel.postMessage({
-            type: 'TAB_CLOSING',
-            tabId: this.tabId,
-            hasApprovals,
-            timestamp: Date.now()
-        });
-    }
+	notifyTabClosing(hasApprovals: boolean) {
+		this.channel.postMessage({
+			type: 'TAB_CLOSING',
+			tabId: this.tabId,
+			hasApprovals,
+			timestamp: Date.now()
+		});
+	}
 
-    destroy() {
-        this.channel.close();
-    }
+	destroy() {
+		this.channel.close();
+	}
 }
 
 // Export singleton instance

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -356,26 +356,25 @@
 
 		// Always handle tool approval events immediately
 		if (type === 'tool:approval_required') {
-
 			// Only show modal if this tab is viewing the relevant chat
 			const approvalChatId = data.chat_id || event.chat_id || '';
 			const currentChatId = $chatId;
-			
+
 			if (approvalChatId && currentChatId && approvalChatId === currentChatId) {
 				setApprovalRequest({
 					chat_id: data.chat_id || event.chat_id || '',
 					message_id: data.message_id || event.message_id || '',
 					tools: data.tools || [],
 					timestamp: Date.now()
-					});
+				});
 			} else {
 			}
 			return; // stop here so it doesn't go into other branches
 		}
 		if (type === 'tool:approval_status') {
-			// Handle approval status updates		
+			// Handle approval status updates
 			const { tool_name, status } = data;
-			
+
 			// Show toast based on status
 			if (status === 'approved') {
 				toast.success(`Executing ${tool_name}...`);


### PR DESCRIPTION
Add a comprehensive tool approval system that requires explicit user consent before AI agents execute tools, with granular control at both the parent tool and child function level.

Backend:
- Add ENABLE_TOOL_APPROVAL config setting (env var + admin toggle)
- Add ToolApprovalManager with in-memory state for pending approvals, always-approved permissions, and YOLO mode tracking
- Integrate approval checks into middleware for both streaming and non-streaming tool calls, with per-function granularity
- Add Socket.IO handlers for approval responses, always-approved CRUD, and YOLO mode management
- Add `BUILTIN_TOOL_CATEGORIES` canonical mapping and `GET /tools/builtin/categories` endpoint for dynamic builtin tool category metadata

Frontend:
- Add ToolApprovalModal with Allow Once, Always Approve (per-function and per-tool), and Decline actions
- Add YOLO Mode and Always Allowed sub-menus to IntegrationsMenu with per-tool toggles and tree-view revocation UI
- Add toolApproval Svelte store for socket-based state management
- Add cross-tab coordination via BroadcastChannel
- Show inline warning for unrecognized tool calls in approval modal

**Contribution Note**:

This feature was initially developed by @Barbaronno and extended with granular per-function/per-tool permissions, YOLO mode, an always-allowed revocation UI, and unrecognized tool call warnings.

This submitted commit adds @Barbaronno as a co-author.

See the original PR at: https://github.com/open-webui/open-webui/pull/16913

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

#### First-time Contributor Acknowledgement

See the discussion at: https://github.com/open-webui/open-webui/discussions/16701

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
  - [x] Documentation PR: https://github.com/open-webui/docs/pull/1095
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
  - [x] Both the description and code were heavily helped by cursor with Opus 4.6 as my favored model, but I am responsible for reviewing and testing it. It made a fair number of odd decisions along the way that I corrected. For instance the backend storage data structure was a mess, but it cleaned things up nicely when I recommended the nested dictionary and tree-view structures.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
  - [x] **Refactor Notice:** Minor refactor included. built-in tools for models in the admin panel were hard-coded before. Moved this to a dictionary with an endpoint for the backend so they can be shared with the new features. I kept this in a separate commit in case you'd like a separate PR.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Adds a human-in-the-loop (HITL) tool approval system that requires explicit user consent before AI agents execute tools during chat. When enabled, every tool call pauses and presents a modal asking the user to **Allow Once**, **Always Approve**, or **Decline**. Approval granularity operates at both the individual function level (e.g. `read_file`) and the parent tool level (e.g. `mcp:desktop_commander`). A **YOLO Mode** option is available for users who want to auto-approve all tool calls without prompts. All approval state is per-chat and in-memory — nothing is persisted to disk or database.

### Added

- `ENABLE_TOOL_APPROVAL` configuration setting — toggleable via environment variable or Admin Settings > General. Defaults to `true`.
- `ToolApprovalManager` backend class (`backend/open_webui/utils/tool_approval.py`) managing pending approvals, always-approved permissions, and YOLO mode state, all in-memory and per-chat.
- Middleware integration for both streaming and non-streaming tool calls that checks approval status before execution, with per-function granularity.
- Socket.IO handlers (`backend/open_webui/socket/main.py`) for real-time approval responses, always-approved CRUD, YOLO mode management, and pending approval recovery.
- `ToolApprovalModal` frontend component with four actions: Allow Once, Always Approve (per-function), Always Approve (per-tool), and Decline.
- YOLO Mode sub-menu in IntegrationsMenu with a master "YOLO All Tools" toggle and per-category toggles organized into Default Features (gated by model capabilities), Builtin Tools (loaded dynamically from backend), and Workspace Tools sections.
- Always Allowed sub-menu in IntegrationsMenu with a tree-view display of approved parent tools and their child functions, with individual and bulk revocation.
- `toolApproval` Svelte store (`src/lib/stores/toolApproval.ts`) for socket-based frontend state management.
- Cross-tab coordination via `BroadcastChannel` (`src/lib/utils/toolApprovalChannel.ts`) to prevent duplicate approval modals across browser tabs.
- TypeScript interfaces for tool approval data structures (`src/lib/types/index.ts`).
- Inline warning banner in approval modal when a tool call has an unrecognized parent tool ID.
- `BUILTIN_TOOL_CATEGORIES` dict in `tools.py` as single source of truth for builtin tool category names, descriptions, and function mappings.
- `GET /tools/builtin/categories` API endpoint serving builtin tool metadata to authenticated users.

### Changed

- **Refactor Notice:** built-in tools for models in the admin panel were hard-coded before. Moved this to a dictionary with an endpoint for the backend.
  - `BuiltinTools.svelte` admin component fetches categories from backend API instead of hardcoding.
- `IntegrationsMenu` now accepts a `chatId` prop and displays YOLO Mode and Always Allowed entries when a chat is active.
- `MessageInput` passes `chatId` down to `IntegrationsMenu`.
- `Chat.svelte` passes `chatId` to the message input component.
- `+layout.svelte` handles `tool:approval_request` and `tool:approval_status` socket events globally.
- Admin config endpoints (`routers/auths.py`) expose and accept `ENABLE_TOOL_APPROVAL`.
- MCP tools and direct server tools in middleware now carry a `tool_id` field for parent tool resolution.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- **Contribution Note**: This feature was initially developed by @Barbaronno and extended with granular per-function/per-tool permissions, YOLO mode, an always-allowed revocation UI, and unrecognized tool call warnings.
  - This submitted commit adds @Barbaronno as a co-author.
  - See the original PR at: https://github.com/open-webui/open-webui/pull/16913
- **Documentation PR**: https://github.com/open-webui/docs/pull/1095
- All approval state lives in-memory on the backend (`ToolApprovalManager` singleton) and resets on server restart. No database migrations or schema changes.
- The `ENABLE_TOOL_APPROVAL` env var can be set to `false` to disable the feature entirely, bypassing all approval checks.
- Approval granularity: functions are identified by their callable name (e.g. `read_file`), parent tools by their registered ID (e.g. `mcp:desktop_commander`, `direct_server:http://...`).
- YOLO Mode and Always Approved are scoped per-chat, so enabling YOLO in one conversation does not affect others.

### Screenshots or Videos

**Scenario 1.a** — YOLO a single tool in a new chat
- YOLO "Web Search" in a new chat, then 
- Prompt: `Find documentation for aws strands.`
**Result:** No permission was asked to use web search tool.
<img width="500" height="489" alt="image" src="https://github.com/user-attachments/assets/24fbc7b7-5625-4666-b7e4-55adc502fa10" />

**Scenario 1.b** — Disable YOLO in the same chat
- In the same chat, turn YOLO off for "Web Search". 
- Prompt: `Great! Now find documentation for dynamodb.`
**Result:** Approval modal prompts for `search_web` / `builtin:search_web`.
<img width="1271" height="1107" alt="image" src="https://github.com/user-attachments/assets/50dffaa7-b422-468f-816f-334cc3a130d6" />

**Scenario 1.c** —  Always allow function
- Click always allow for the function
**Result:** Search completed and function added to always allow list.
<img width="365" height="236" alt="image" src="https://github.com/user-attachments/assets/673cada3-41eb-46d1-a327-e3e6d5d889cf" />

**Scenario 1.d** — Always allow tool
- Prompt: `Great! Now generate an image of a cat riding a donkey.`
- Click always allow at tool level
**Result:** Result: Always allow menu now shows the always allowed function as well as the tool. `All functions approved` displayed for tool-level approval
<img width="1203" height="1097" alt="image" src="https://github.com/user-attachments/assets/7ed76644-f184-46fe-8aa7-bd5c4c52eb06" />

**Scenario 1.e** — Revoke function access
- Click the red x to revoke access for a web search
- Prompt: Now search for documentation for vLLM
**Result:** Modal prompt for allowing a web search.
<img width="1260" height="1100" alt="image" src="https://github.com/user-attachments/assets/327b4677-a219-43d0-9e02-daa2e9895421" />

**Scenario 1.f** — Cross-tab coordination
- Open the existing chat from Scenario 1.2 in a new browser window. How about my phone!
- **Result:** Approval modal prompts in the new device for web search.
<img width="1344" height="2609" alt="Screenshot_20260220-200859" src="https://github.com/user-attachments/assets/5e088cfa-90aa-45aa-b955-9261ec8a2584" />

Note: These aren't the only test I preformed, but it became tedious to document it all in this format. 

I have tested allow once.

I have tested decline. It suggests to the tool that the user declined it. I have seen this redirect the llm mid stream. For instance it tried to access the knowledge base and I declined it and it did a web search instead.

<img width="1258" height="1102" alt="image" src="https://github.com/user-attachments/assets/81e53d44-136d-4fb8-8ed3-4b12e06ad72e" />

I have tested with several functions under one tool and confirmed that the allow always ones allow, but not the individual functions for the same tool that aren't in the always allow list. 

I have tested it with the subagents tool. Note, this isn't supported at this time. It seemed to ignore permissions.

Error found during testing: Sometimes opening the menu to observe a recently changed setting wouldn't show the change until closing the menu and opening again. Fixed by awaiting the async operation. Updated existing feature commit and pushed. Re-tested.

Bonus screenshot:
![Screenshot_20260216-172805~2](https://github.com/user-attachments/assets/2e416666-fcf7-44a9-b673-f3bc28783e26)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
