### PR TITLE
Fix:  new Environment variable OAUTH_DEFAULT_GROUP_PERMISSIONS & default Group behavior of {"config": {"share": False}} for sharing when new group created via oAuth

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -339,6 +339,11 @@ ENABLE_OAUTH_SIGNUP = PersistentConfig(
     os.environ.get("ENABLE_OAUTH_SIGNUP", "False").lower() == "true",
 )
 
+OAUTH_DEFAULT_GROUP_PERMISSIONS = PersistentConfig(
+    "OAUTH_DEFAULT_GROUP_PERMISSIONS",
+    "oauth.default_group_permissions",
+    os.environ.get("OAUTH_DEFAULT_GROUP_PERMISSIONS", "members"),
+)
 
 OAUTH_MERGE_ACCOUNTS_BY_EMAIL = PersistentConfig(
     "OAUTH_MERGE_ACCOUNTS_BY_EMAIL",

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -70,6 +70,7 @@ from open_webui.env import (
     ENABLE_OAUTH_ID_TOKEN_COOKIE,
     ENABLE_OAUTH_EMAIL_FALLBACK,
     OAUTH_CLIENT_INFO_ENCRYPTION_KEY,
+    OAUTH_MAX_SESSIONS_PER_USER
 )
 from open_webui.utils.misc import parse_duration
 from open_webui.utils.auth import get_password_hash, create_token


### PR DESCRIPTION
Fix: OAUTH_DEFAULT_GROUP_PERMISSIONS

Add oAuth Group Permission logic for new groups based off of permissions environment model by default . If not set, sets to noone as best form of secops.

OAUTH_DEFAULT_GROUP_PERMISSIONS = 'members' , 'noone' or 'anyone'


```
            group_data_payload = {}
            oauth_default_permission = (
                auth_manager_config.OAUTH_DEFAULT_GROUP_PERMISSIONS
            )

            if oauth_default_permission:
                if oauth_default_permission.lower() == "members":
                    group_data_payload = {"config": {"share": "members"}}
                elif oauth_default_permission.lower() == "noone":
                    group_data_payload = {"config": {"share": False}}
                elif oauth_default_permission.lower() == "anyone":
                    group_data_payload = {"config": {"share": True}}
                else:
                    log.warning(
                        f"Unknown OAUTH_DEFAULT_GROUP_PERMISSIONS value: {oauth_default_permission}. "
                        "Using empty data payload."
                    )
                    group_data_payload = {"config": {"share": False}}

            log.debug(
                f"Group data payload for OAuth group creation: {group_data_payload}"
            )

```

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
