### PR TITLE
fix: resolve backend execution deadlock when syncing stats with cyclic chat history

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -91,8 +91,17 @@ def get_message_list(messages_map, message_id):
 
     # Reconstruct the chain by following the parentId links
     message_list = []
+    visited_message_ids = set()
 
     while current_message:
+        message_id = current_message.get("id")
+        if message_id in visited_message_ids:
+            # Cycle detected, break to prevent infinite loop
+            break
+        
+        if message_id is not None:
+            visited_message_ids.add(message_id)
+            
         message_list.append(current_message)
         parent_id = current_message.get("parentId")  # Use .get() for safety
         current_message = messages_map.get(parent_id) if parent_id else None


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** `fix: resolve backend execution deadlock when syncing stats with cyclic chat history`

# Changelog Entry

### Description

- Fixed a critical bug in `backend/open_webui/utils/misc.py` where a cyclic reference in a chat history could cause an infinite `while` loop within `get_message_list`, severely deadlocking the backend Python thread. This most frequently presented as a completely frozen/hung browser tab and server instance when users attempted to execute "Sync Usage Stats" and the system tried to read a corrupted chat payload.

### Fixed

- Added loop cycle detection via a `visited_message_ids` set in the `get_message_list` function to safely abort thread traversal if a circular message `parentId` reference is encountered in the database.

### Screenshots

### Before (**FAILURE**)

<img width="682" height="612" alt="image" src="https://github.com/user-attachments/assets/404e44a0-3d25-4e1d-bba2-c93856fef8e5" />

### After (**SUCCESS**)

<img width="713" height="498" alt="image" src="https://github.com/user-attachments/assets/0092d659-53ab-499a-afde-a4ca556ff760" />

<img width="764" height="269" alt="image" src="https://github.com/user-attachments/assets/cb36309a-979a-46a6-b869-d777a0e9db43" />

<img width="772" height="275" alt="image" src="https://github.com/user-attachments/assets/786198c5-3100-469e-ada9-69604bc7791f" />

---

### Additional Information

- Corrupted chat states could unintentionally create cycles in `parentId` mapping. Because `get_message_list` blindly followed `parentId` links backward to compile the chain, any cycle trapped the backend thread indefinitely, locking up Uvicorn pool workers up until a server shutdown/restart.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.