### PR TITLE
feat: add native Anthropic provider integration

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1128,6 +1128,44 @@ OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 
 
 ####################################
+# ANTHROPIC_API
+####################################
+
+ENABLE_ANTHROPIC_API = PersistentConfig(
+    "ENABLE_ANTHROPIC_API",
+    "anthropic.enable",
+    os.environ.get("ENABLE_ANTHROPIC_API", "False").lower() == "true",
+)
+
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+
+ANTHROPIC_API_KEYS = os.environ.get("ANTHROPIC_API_KEYS", "")
+ANTHROPIC_API_KEYS = ANTHROPIC_API_KEYS if ANTHROPIC_API_KEYS != "" else ANTHROPIC_API_KEY
+
+ANTHROPIC_API_KEYS = [key.strip() for key in ANTHROPIC_API_KEYS.split(";") if key.strip()]
+ANTHROPIC_API_KEYS = PersistentConfig(
+    "ANTHROPIC_API_KEYS", "anthropic.api_keys", ANTHROPIC_API_KEYS
+)
+
+ANTHROPIC_API_BASE_URLS = os.environ.get(
+    "ANTHROPIC_API_BASE_URLS", "https://api.anthropic.com"
+)
+ANTHROPIC_API_BASE_URLS = [
+    url.strip() if url.strip() != "" else "https://api.anthropic.com"
+    for url in ANTHROPIC_API_BASE_URLS.split(";")
+]
+ANTHROPIC_API_BASE_URLS = PersistentConfig(
+    "ANTHROPIC_API_BASE_URLS", "anthropic.api_base_urls", ANTHROPIC_API_BASE_URLS
+)
+
+ANTHROPIC_API_CONFIGS = PersistentConfig(
+    "ANTHROPIC_API_CONFIGS",
+    "anthropic.api_configs",
+    {},
+)
+
+
+####################################
 # MODELS
 ####################################
 

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1140,9 +1140,13 @@ ENABLE_ANTHROPIC_API = PersistentConfig(
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 
 ANTHROPIC_API_KEYS = os.environ.get("ANTHROPIC_API_KEYS", "")
-ANTHROPIC_API_KEYS = ANTHROPIC_API_KEYS if ANTHROPIC_API_KEYS != "" else ANTHROPIC_API_KEY
+ANTHROPIC_API_KEYS = (
+    ANTHROPIC_API_KEYS if ANTHROPIC_API_KEYS != "" else ANTHROPIC_API_KEY
+)
 
-ANTHROPIC_API_KEYS = [key.strip() for key in ANTHROPIC_API_KEYS.split(";") if key.strip()]
+ANTHROPIC_API_KEYS = [
+    key.strip() for key in ANTHROPIC_API_KEYS.split(";") if key.strip()
+]
 ANTHROPIC_API_KEYS = PersistentConfig(
     "ANTHROPIC_API_KEYS", "anthropic.api_keys", ANTHROPIC_API_KEYS
 )

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -70,6 +70,7 @@ from open_webui.socket.main import (
 )
 from open_webui.routers import (
     analytics,
+    anthropic,
     audio,
     images,
     ollama,
@@ -124,6 +125,11 @@ from open_webui.config import (
     OPENAI_API_BASE_URLS,
     OPENAI_API_KEYS,
     OPENAI_API_CONFIGS,
+    # Anthropic
+    ENABLE_ANTHROPIC_API,
+    ANTHROPIC_API_KEYS,
+    ANTHROPIC_API_BASE_URLS,
+    ANTHROPIC_API_CONFIGS,
     # Direct Connections
     ENABLE_DIRECT_CONNECTIONS,
     # Model list
@@ -758,6 +764,19 @@ app.state.config.OPENAI_API_KEYS = OPENAI_API_KEYS
 app.state.config.OPENAI_API_CONFIGS = OPENAI_API_CONFIGS
 
 app.state.OPENAI_MODELS = {}
+
+########################################
+#
+# ANTHROPIC
+#
+########################################
+
+app.state.config.ENABLE_ANTHROPIC_API = ENABLE_ANTHROPIC_API
+app.state.config.ANTHROPIC_API_KEYS = ANTHROPIC_API_KEYS
+app.state.config.ANTHROPIC_API_BASE_URLS = ANTHROPIC_API_BASE_URLS
+app.state.config.ANTHROPIC_API_CONFIGS = ANTHROPIC_API_CONFIGS
+
+app.state.ANTHROPIC_MODELS = {}
 
 ########################################
 #
@@ -1491,6 +1510,7 @@ app.mount("/ws", socket_app)
 
 app.include_router(ollama.router, prefix="/ollama", tags=["ollama"])
 app.include_router(openai.router, prefix="/openai", tags=["openai"])
+app.include_router(anthropic.router, prefix="/anthropic", tags=["anthropic"])
 
 
 app.include_router(pipelines.router, prefix="/api/v1/pipelines", tags=["pipelines"])

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1985,7 +1985,6 @@ async def generate_messages(
         return response
 
 
-
 @app.post("/api/chat/completed")
 async def chat_completed(
     request: Request, form_data: dict, user=Depends(get_verified_user)

--- a/backend/open_webui/routers/anthropic.py
+++ b/backend/open_webui/routers/anthropic.py
@@ -120,9 +120,7 @@ async def update_config(
                 request.app.state.config.ANTHROPIC_API_KEYS[:num_urls]
             )
         else:
-            request.app.state.config.ANTHROPIC_API_KEYS += [""] * (
-                num_urls - num_keys
-            )
+            request.app.state.config.ANTHROPIC_API_KEYS += [""] * (num_urls - num_keys)
 
     request.app.state.config.ANTHROPIC_API_CONFIGS = form_data.ANTHROPIC_API_CONFIGS
 
@@ -393,7 +391,7 @@ async def generate_chat_completion(
     prefix_id = config.get("prefix_id", None)
     actual_model_id = payload.get("model", model_id)
     if prefix_id and actual_model_id.startswith(f"{prefix_id}."):
-        actual_model_id = actual_model_id[len(f"{prefix_id}."):]
+        actual_model_id = actual_model_id[len(f"{prefix_id}.") :]
     payload["model"] = actual_model_id
 
     # Convert payload from OpenAI format to Anthropic format

--- a/backend/open_webui/routers/anthropic.py
+++ b/backend/open_webui/routers/anthropic.py
@@ -1,0 +1,471 @@
+"""
+Anthropic native provider router.
+
+Provides:
+- Admin config endpoints (GET/POST /anthropic/config)
+- Model discovery (GET /anthropic/models)
+- Chat completion (POST /anthropic/chat/completions)
+
+Uses the Anthropic Python SDK for direct API communication,
+converting all responses to OpenAI-compatible format for the frontend.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+import anthropic
+from fastapi import Depends, HTTPException, Request, APIRouter
+from fastapi.responses import StreamingResponse, JSONResponse, PlainTextResponse
+from pydantic import BaseModel
+
+from open_webui.models.models import Models
+from open_webui.models.access_grants import AccessGrants
+from open_webui.models.groups import Groups
+from open_webui.models.users import UserModel
+
+from open_webui.constants import ERROR_MESSAGES
+
+from open_webui.utils.anthropic_payload import (
+    convert_payload_openai_to_anthropic,
+    apply_model_params_to_body_anthropic,
+)
+from open_webui.utils.anthropic_response import (
+    convert_streaming_response_anthropic_to_openai,
+    convert_response_anthropic_to_openai,
+)
+from open_webui.utils.payload import apply_system_prompt_to_body
+from open_webui.utils.auth import get_admin_user, get_verified_user
+
+from open_webui.env import (
+    BYPASS_MODEL_ACCESS_CONTROL,
+)
+
+log = logging.getLogger(__name__)
+
+
+router = APIRouter()
+
+
+# Known Anthropic models — used as fallback when the API models endpoint
+# is unavailable or the SDK version doesn't support client.models.list()
+ANTHROPIC_KNOWN_MODELS = [
+    {
+        "id": "claude-opus-4-20250514",
+        "name": "Claude Opus 4",
+        "context_window": 200000,
+        "max_output": 32000,
+    },
+    {
+        "id": "claude-sonnet-4-20250514",
+        "name": "Claude Sonnet 4",
+        "context_window": 200000,
+        "max_output": 64000,
+    },
+    {
+        "id": "claude-sonnet-4-5-20250514",
+        "name": "Claude Sonnet 4.5",
+        "context_window": 200000,
+        "max_output": 64000,
+    },
+    {
+        "id": "claude-haiku-3-5-20241022",
+        "name": "Claude 3.5 Haiku",
+        "context_window": 200000,
+        "max_output": 8192,
+    },
+]
+
+
+##########################################
+#
+# Config endpoints
+#
+##########################################
+
+
+@router.get("/config")
+async def get_config(request: Request, user=Depends(get_admin_user)):
+    return {
+        "ENABLE_ANTHROPIC_API": request.app.state.config.ENABLE_ANTHROPIC_API,
+        "ANTHROPIC_API_KEYS": request.app.state.config.ANTHROPIC_API_KEYS,
+        "ANTHROPIC_API_BASE_URLS": request.app.state.config.ANTHROPIC_API_BASE_URLS,
+        "ANTHROPIC_API_CONFIGS": request.app.state.config.ANTHROPIC_API_CONFIGS,
+    }
+
+
+class AnthropicConfigForm(BaseModel):
+    ENABLE_ANTHROPIC_API: Optional[bool] = None
+    ANTHROPIC_API_KEYS: list[str]
+    ANTHROPIC_API_BASE_URLS: list[str]
+    ANTHROPIC_API_CONFIGS: dict
+
+
+@router.post("/config/update")
+async def update_config(
+    request: Request, form_data: AnthropicConfigForm, user=Depends(get_admin_user)
+):
+    request.app.state.config.ENABLE_ANTHROPIC_API = form_data.ENABLE_ANTHROPIC_API
+    request.app.state.config.ANTHROPIC_API_KEYS = form_data.ANTHROPIC_API_KEYS
+    request.app.state.config.ANTHROPIC_API_BASE_URLS = form_data.ANTHROPIC_API_BASE_URLS
+
+    # Ensure keys and URLs lists are the same length
+    num_urls = len(request.app.state.config.ANTHROPIC_API_BASE_URLS)
+    num_keys = len(request.app.state.config.ANTHROPIC_API_KEYS)
+
+    if num_keys != num_urls:
+        if num_keys > num_urls:
+            request.app.state.config.ANTHROPIC_API_KEYS = (
+                request.app.state.config.ANTHROPIC_API_KEYS[:num_urls]
+            )
+        else:
+            request.app.state.config.ANTHROPIC_API_KEYS += [""] * (
+                num_urls - num_keys
+            )
+
+    request.app.state.config.ANTHROPIC_API_CONFIGS = form_data.ANTHROPIC_API_CONFIGS
+
+    # Remove configs not matching a valid URL index
+    keys = list(map(str, range(num_urls)))
+    request.app.state.config.ANTHROPIC_API_CONFIGS = {
+        key: value
+        for key, value in request.app.state.config.ANTHROPIC_API_CONFIGS.items()
+        if key in keys
+    }
+
+    return {
+        "ENABLE_ANTHROPIC_API": request.app.state.config.ENABLE_ANTHROPIC_API,
+        "ANTHROPIC_API_KEYS": request.app.state.config.ANTHROPIC_API_KEYS,
+        "ANTHROPIC_API_BASE_URLS": request.app.state.config.ANTHROPIC_API_BASE_URLS,
+        "ANTHROPIC_API_CONFIGS": request.app.state.config.ANTHROPIC_API_CONFIGS,
+    }
+
+
+##########################################
+#
+# Model discovery
+#
+##########################################
+
+
+def _build_client(api_key: str, base_url: str) -> anthropic.AsyncAnthropic:
+    """Create an Anthropic async client for the given credentials."""
+    kwargs = {"api_key": api_key}
+    if base_url and base_url != "https://api.anthropic.com":
+        kwargs["base_url"] = base_url
+    return anthropic.AsyncAnthropic(**kwargs)
+
+
+async def _fetch_models_for_key(api_key: str, base_url: str, idx: int) -> list[dict]:
+    """
+    Attempt to list models from the Anthropic API for a single key/URL pair.
+    Falls back to the hardcoded known models list on failure.
+    """
+    if not api_key:
+        return []
+
+    try:
+        client = _build_client(api_key, base_url)
+        # The Anthropic SDK models.list() is available in recent versions
+        response = await client.models.list(limit=100)
+        models = []
+        for model_data in response.data:
+            model_id = model_data.id
+            model_name = getattr(model_data, "display_name", model_id)
+            models.append(
+                {
+                    "id": model_id,
+                    "name": model_name,
+                    "object": "model",
+                    "owned_by": "anthropic",
+                    "anthropic": {"id": model_id},
+                    "urlIdx": idx,
+                }
+            )
+        return models
+    except Exception as e:
+        log.warning(
+            f"Could not list Anthropic models for key index {idx} "
+            f"(falling back to known models): {e}"
+        )
+        # Return the known models list as fallback
+        return [
+            {
+                "id": m["id"],
+                "name": m["name"],
+                "object": "model",
+                "owned_by": "anthropic",
+                "anthropic": {
+                    "id": m["id"],
+                    "context_window": m.get("context_window"),
+                    "max_output": m.get("max_output"),
+                },
+                "urlIdx": idx,
+            }
+            for m in ANTHROPIC_KNOWN_MODELS
+        ]
+
+
+async def get_all_models(request: Request, user: UserModel = None) -> dict:
+    """
+    Fetch all available Anthropic models across all configured API keys/URLs.
+    Returns in the standard {"data": [...]} format.
+    """
+    if not request.app.state.config.ENABLE_ANTHROPIC_API:
+        return {"data": []}
+
+    api_keys = list(request.app.state.config.ANTHROPIC_API_KEYS)
+    api_base_urls = list(request.app.state.config.ANTHROPIC_API_BASE_URLS)
+    api_configs = request.app.state.config.ANTHROPIC_API_CONFIGS
+
+    # Ensure lists are the same length
+    num_urls = len(api_base_urls)
+    if len(api_keys) < num_urls:
+        api_keys += [""] * (num_urls - len(api_keys))
+
+    # Fetch models from each configured endpoint in parallel
+    tasks = []
+    for idx in range(num_urls):
+        config = api_configs.get(str(idx), {})
+        if not config.get("enable", True):
+            tasks.append(asyncio.ensure_future(asyncio.sleep(0, result=[])))
+            continue
+
+        model_ids = config.get("model_ids", [])
+        if model_ids:
+            # Use explicitly configured model IDs instead of fetching
+            prefix_id = config.get("prefix_id", None)
+            models = []
+            for mid in model_ids:
+                display_id = f"{prefix_id}.{mid}" if prefix_id else mid
+                models.append(
+                    {
+                        "id": display_id,
+                        "name": display_id,
+                        "object": "model",
+                        "owned_by": "anthropic",
+                        "anthropic": {"id": mid},
+                        "urlIdx": idx,
+                    }
+                )
+            tasks.append(asyncio.ensure_future(asyncio.sleep(0, result=models)))
+        else:
+            tasks.append(_fetch_models_for_key(api_keys[idx], api_base_urls[idx], idx))
+
+    results = await asyncio.gather(*tasks)
+
+    # Apply config-level prefix_id, tags, and connection_type to each model
+    # BEFORE dedup so that prefixed IDs don't collide with un-prefixed ones.
+    for idx, model_list in enumerate(results):
+        if not model_list:
+            continue
+        config = api_configs.get(str(idx), {})
+        prefix_id = config.get("prefix_id", None)
+        config_tags = config.get("tags", [])
+        connection_type = config.get("connection_type", "external")
+
+        for model in model_list:
+            model_id = model.get("id", "")
+            if prefix_id and model_id and not model_id.startswith(f"{prefix_id}."):
+                model["id"] = f"{prefix_id}.{model_id}"
+                model["name"] = model["id"]
+
+            # Use prefix_id as the tag (matching OpenAI behavior), plus any config tags
+            model_tags = []
+            if prefix_id:
+                model_tags.append({"name": prefix_id})
+            if config_tags:
+                existing_names = {t["name"].lower() for t in model_tags}
+                for t in config_tags:
+                    if t.get("name", "").lower() not in existing_names:
+                        model_tags.append(t)
+            if model_tags:
+                model["tags"] = model_tags
+            model["connection_type"] = connection_type
+
+    # Merge models, deduplicating by final ID (first occurrence wins)
+    seen = {}
+    for model_list in results:
+        if model_list:
+            for model in model_list:
+                final_id = model.get("id", "")
+                if final_id and final_id not in seen:
+                    seen[final_id] = model
+
+    request.app.state.ANTHROPIC_MODELS = seen
+    return {"data": list(seen.values())}
+
+
+@router.get("/models")
+async def get_models(request: Request, user=Depends(get_verified_user)):
+    if not request.app.state.config.ENABLE_ANTHROPIC_API:
+        raise HTTPException(status_code=503, detail="Anthropic API is disabled")
+    return await get_all_models(request, user=user)
+
+
+##########################################
+#
+# Chat completion
+#
+##########################################
+
+
+@router.post("/chat/completions")
+async def generate_chat_completion(
+    request: Request,
+    form_data: dict,
+    user=Depends(get_verified_user),
+    bypass_filter: Optional[bool] = False,
+    bypass_system_prompt: bool = False,
+):
+    if BYPASS_MODEL_ACCESS_CONTROL:
+        bypass_filter = True
+
+    payload = {**form_data}
+    metadata = payload.pop("metadata", None)
+
+    model_id = form_data.get("model")
+    model_info = Models.get_model_by_id(model_id)
+
+    # Check model info and apply overrides
+    if model_info:
+        if model_info.base_model_id:
+            base_model_id = model_info.base_model_id
+            payload["model"] = base_model_id
+            model_id = base_model_id
+
+        params = model_info.params.model_dump()
+        if params:
+            system = params.pop("system", None)
+            payload = apply_model_params_to_body_anthropic(params, payload)
+            if not bypass_system_prompt:
+                payload = apply_system_prompt_to_body(system, payload, metadata, user)
+
+        # Access control
+        if not bypass_filter and user.role == "user":
+            user_group_ids = {
+                group.id for group in Groups.get_groups_by_member_id(user.id)
+            }
+            if not (
+                user.id == model_info.user_id
+                or AccessGrants.has_access(
+                    user_id=user.id,
+                    resource_type="model",
+                    resource_id=model_info.id,
+                    permission="read",
+                    user_group_ids=user_group_ids,
+                )
+            ):
+                raise HTTPException(status_code=403, detail="Model not found")
+    elif not bypass_filter:
+        if user.role != "admin":
+            raise HTTPException(status_code=403, detail="Model not found")
+
+    # Resolve model to find the correct API key index
+    models = request.app.state.ANTHROPIC_MODELS
+    if not models or model_id not in models:
+        await get_all_models(request, user=user)
+        models = request.app.state.ANTHROPIC_MODELS
+    model = models.get(model_id)
+
+    if not model:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    idx = model.get("urlIdx", 0)
+
+    # Get credentials
+    api_keys = list(request.app.state.config.ANTHROPIC_API_KEYS)
+    api_base_urls = list(request.app.state.config.ANTHROPIC_API_BASE_URLS)
+    api_configs = request.app.state.config.ANTHROPIC_API_CONFIGS
+
+    if idx >= len(api_keys) or idx >= len(api_base_urls):
+        raise HTTPException(status_code=500, detail="Invalid API configuration index")
+
+    api_key = api_keys[idx]
+    base_url = api_base_urls[idx]
+    config = api_configs.get(str(idx), {})
+
+    if not api_key:
+        raise HTTPException(status_code=401, detail="Anthropic API key not configured")
+
+    # Strip prefix_id from model name if present
+    prefix_id = config.get("prefix_id", None)
+    actual_model_id = payload.get("model", model_id)
+    if prefix_id and actual_model_id.startswith(f"{prefix_id}."):
+        actual_model_id = actual_model_id[len(f"{prefix_id}."):]
+    payload["model"] = actual_model_id
+
+    # Convert payload from OpenAI format to Anthropic format
+    is_stream = payload.get("stream", False)
+    anthropic_payload = convert_payload_openai_to_anthropic(payload)
+
+    # Remove internal metadata before sending to Anthropic
+    anthropic_payload.pop("metadata", None)
+
+    # Create SDK client
+    client = _build_client(api_key, base_url)
+
+    try:
+        if is_stream:
+            # Streaming — use raw SSE events
+            stream = await client.messages.create(**anthropic_payload)
+
+            return StreamingResponse(
+                convert_streaming_response_anthropic_to_openai(stream),
+                media_type="text/event-stream",
+            )
+        else:
+            # Non-streaming
+            anthropic_payload.pop("stream", None)
+            response = await client.messages.create(**anthropic_payload)
+            return convert_response_anthropic_to_openai(response)
+
+    except anthropic.AuthenticationError as e:
+        log.error(f"Anthropic authentication error: {e}")
+        raise HTTPException(
+            status_code=401,
+            detail=f"Anthropic API authentication failed: {e.message}",
+        )
+    except anthropic.PermissionDeniedError as e:
+        log.error(f"Anthropic permission denied: {e}")
+        raise HTTPException(
+            status_code=403,
+            detail=f"Anthropic API permission denied: {e.message}",
+        )
+    except anthropic.NotFoundError as e:
+        log.error(f"Anthropic not found: {e}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Anthropic API resource not found: {e.message}",
+        )
+    except anthropic.RateLimitError as e:
+        log.error(f"Anthropic rate limit: {e}")
+        raise HTTPException(
+            status_code=429,
+            detail=f"Anthropic API rate limit exceeded: {e.message}",
+        )
+    except anthropic.APIStatusError as e:
+        log.error(f"Anthropic API error (status {e.status_code}): {e}")
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=f"Anthropic API error: {e.message}",
+        )
+    except anthropic.APIConnectionError as e:
+        log.error(f"Anthropic connection error: {e}")
+        raise HTTPException(
+            status_code=502,
+            detail="Could not connect to Anthropic API",
+        )
+    except anthropic.APITimeoutError as e:
+        log.error(f"Anthropic timeout: {e}")
+        raise HTTPException(
+            status_code=504,
+            detail="Anthropic API request timed out",
+        )
+    except Exception as e:
+        log.exception(f"Unexpected error calling Anthropic API: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Open WebUI: Anthropic provider error: {str(e)}",
+        )

--- a/backend/open_webui/utils/anthropic_payload.py
+++ b/backend/open_webui/utils/anthropic_payload.py
@@ -15,7 +15,10 @@ import logging
 import re
 from typing import Optional, Callable
 
-from open_webui.utils.payload import apply_model_params_to_body, remove_open_webui_params
+from open_webui.utils.payload import (
+    apply_model_params_to_body,
+    remove_open_webui_params,
+)
 from open_webui.utils.misc import deep_update
 
 log = logging.getLogger(__name__)
@@ -237,7 +240,9 @@ def _convert_content_blocks(content) -> list[dict]:
 
             else:
                 # Pass through unknown types as text
-                log.debug(f"Unknown content part type '{part_type}', converting to text")
+                log.debug(
+                    f"Unknown content part type '{part_type}', converting to text"
+                )
                 text = part.get("text", part.get("content", str(part)))
                 blocks.append({"type": "text", "text": str(text)})
 

--- a/backend/open_webui/utils/anthropic_payload.py
+++ b/backend/open_webui/utils/anthropic_payload.py
@@ -1,0 +1,370 @@
+"""
+Payload conversion utilities: OpenAI format → Anthropic Messages API format.
+
+Handles the structural differences between the two APIs:
+- System prompt extraction (OpenAI message → Anthropic top-level param)
+- Content block format conversion (image_url → image source)
+- Tool definition format (function wrapper → flat schema)
+- Tool call/result message conversion
+- Parameter name mapping
+"""
+
+import copy
+import json
+import logging
+import re
+from typing import Optional, Callable
+
+from open_webui.utils.payload import apply_model_params_to_body, remove_open_webui_params
+from open_webui.utils.misc import deep_update
+
+log = logging.getLogger(__name__)
+
+
+def convert_payload_openai_to_anthropic(openai_payload: dict) -> dict:
+    """
+    Convert an OpenAI-format chat completion payload to Anthropic Messages API format.
+
+    Returns a dict suitable for passing to anthropic.AsyncAnthropic().messages.create().
+    """
+    # Shallow copy metadata separately (may contain non-picklable objects)
+    metadata = openai_payload.get("metadata")
+    payload = copy.deepcopy(
+        {k: v for k, v in openai_payload.items() if k != "metadata"}
+    )
+    if metadata is not None:
+        payload["metadata"] = dict(metadata)
+
+    anthropic_payload = {}
+
+    # Model
+    anthropic_payload["model"] = payload.get("model")
+
+    # Extract system prompt and convert messages
+    system_prompt, messages = convert_messages_openai_to_anthropic(
+        payload.get("messages", [])
+    )
+    if system_prompt:
+        anthropic_payload["system"] = system_prompt
+    anthropic_payload["messages"] = messages
+
+    # max_tokens is required by Anthropic — default to 4096 if not set
+    anthropic_payload["max_tokens"] = payload.get(
+        "max_tokens", payload.get("max_completion_tokens", 4096)
+    )
+
+    # Stream
+    if "stream" in payload:
+        anthropic_payload["stream"] = payload["stream"]
+
+    # Temperature
+    if "temperature" in payload and payload["temperature"] is not None:
+        anthropic_payload["temperature"] = float(payload["temperature"])
+
+    # Top P
+    if "top_p" in payload and payload["top_p"] is not None:
+        anthropic_payload["top_p"] = float(payload["top_p"])
+
+    # Stop sequences (OpenAI "stop" → Anthropic "stop_sequences")
+    if "stop" in payload and payload["stop"] is not None:
+        stop = payload["stop"]
+        if isinstance(stop, str):
+            stop = [stop]
+        anthropic_payload["stop_sequences"] = stop
+
+    # Tools
+    if "tools" in payload and payload["tools"]:
+        anthropic_payload["tools"] = convert_tools_openai_to_anthropic(payload["tools"])
+
+    # Tool choice
+    if "tool_choice" in payload and payload["tool_choice"] is not None:
+        anthropic_payload["tool_choice"] = convert_tool_choice_openai_to_anthropic(
+            payload["tool_choice"]
+        )
+
+    # Keep internal metadata for downstream processing (not sent to Anthropic)
+    if metadata is not None:
+        anthropic_payload["metadata"] = metadata
+
+    return anthropic_payload
+
+
+def convert_messages_openai_to_anthropic(
+    messages: list[dict],
+) -> tuple[Optional[str], list[dict]]:
+    """
+    Convert OpenAI-format messages to Anthropic format.
+
+    Returns:
+        (system_prompt, anthropic_messages) — system prompt extracted separately.
+    """
+    system_parts = []
+    anthropic_messages = []
+
+    for message in messages:
+        role = message.get("role", "")
+
+        if role == "system":
+            # Extract system messages into top-level system param
+            content = message.get("content", "")
+            if isinstance(content, list):
+                # Content blocks — extract text parts
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        system_parts.append(block.get("text", ""))
+                    elif isinstance(block, str):
+                        system_parts.append(block)
+            elif isinstance(content, str):
+                system_parts.append(content)
+
+        elif role == "assistant":
+            anthropic_msg = _convert_assistant_message(message)
+            anthropic_messages.append(anthropic_msg)
+
+        elif role == "tool":
+            # OpenAI tool result → Anthropic tool_result content block on a user message
+            tool_result_block = {
+                "type": "tool_result",
+                "tool_use_id": message.get("tool_call_id", ""),
+                "content": message.get("content", ""),
+            }
+
+            # Anthropic requires strict user/assistant alternation.
+            # If the last message is already a user message, merge into it.
+            if (
+                anthropic_messages
+                and anthropic_messages[-1]["role"] == "user"
+                and isinstance(anthropic_messages[-1]["content"], list)
+            ):
+                anthropic_messages[-1]["content"].append(tool_result_block)
+            else:
+                anthropic_messages.append(
+                    {"role": "user", "content": [tool_result_block]}
+                )
+
+        elif role == "user":
+            content = _convert_content_blocks(message.get("content", ""))
+            anthropic_msg = {"role": "user", "content": content}
+
+            # Merge consecutive user messages (Anthropic doesn't allow them)
+            if (
+                anthropic_messages
+                and anthropic_messages[-1]["role"] == "user"
+                and isinstance(anthropic_messages[-1]["content"], list)
+            ):
+                if isinstance(content, list):
+                    anthropic_messages[-1]["content"].extend(content)
+                else:
+                    anthropic_messages[-1]["content"].append(
+                        {"type": "text", "text": str(content)}
+                    )
+            else:
+                anthropic_messages.append(anthropic_msg)
+
+        else:
+            # Unknown role — skip with warning
+            log.warning(f"Skipping message with unknown role: {role}")
+
+    system_prompt = "\n\n".join(system_parts) if system_parts else None
+
+    return system_prompt, anthropic_messages
+
+
+def _convert_assistant_message(message: dict) -> dict:
+    """Convert an OpenAI assistant message to Anthropic format."""
+    content_blocks = []
+
+    # Regular content
+    msg_content = message.get("content")
+    if msg_content:
+        if isinstance(msg_content, str):
+            content_blocks.append({"type": "text", "text": msg_content})
+        elif isinstance(msg_content, list):
+            content_blocks.extend(_convert_content_blocks(msg_content))
+
+    # Tool calls → tool_use content blocks
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        for tc in tool_calls:
+            func = tc.get("function", {})
+            arguments = func.get("arguments", "{}")
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tc.get("id", ""),
+                    "name": func.get("name", ""),
+                    "input": arguments,
+                }
+            )
+
+    # If no content at all, use empty text block (Anthropic requires non-empty content)
+    if not content_blocks:
+        content_blocks.append({"type": "text", "text": ""})
+
+    return {"role": "assistant", "content": content_blocks}
+
+
+def _convert_content_blocks(content) -> list[dict]:
+    """
+    Convert OpenAI content (string or list of parts) to Anthropic content blocks.
+    """
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+
+    if not isinstance(content, list):
+        return [{"type": "text", "text": str(content)}]
+
+    blocks = []
+    for part in content:
+        if isinstance(part, str):
+            blocks.append({"type": "text", "text": part})
+        elif isinstance(part, dict):
+            part_type = part.get("type", "")
+
+            if part_type == "text":
+                blocks.append({"type": "text", "text": part.get("text", "")})
+
+            elif part_type == "image_url":
+                image_block = _convert_image_url_to_anthropic(part)
+                if image_block:
+                    blocks.append(image_block)
+
+            else:
+                # Pass through unknown types as text
+                log.debug(f"Unknown content part type '{part_type}', converting to text")
+                text = part.get("text", part.get("content", str(part)))
+                blocks.append({"type": "text", "text": str(text)})
+
+    return blocks if blocks else [{"type": "text", "text": ""}]
+
+
+def _convert_image_url_to_anthropic(part: dict) -> Optional[dict]:
+    """
+    Convert an OpenAI image_url content part to an Anthropic image content block.
+
+    Handles both base64 data URIs and regular URLs.
+    """
+    image_url = part.get("image_url", {})
+    url = image_url.get("url", "") if isinstance(image_url, dict) else str(image_url)
+
+    if not url:
+        return None
+
+    if url.startswith("data:"):
+        # Parse data URI: data:image/png;base64,iVBOR...
+        match = re.match(r"data:(image/[^;]+);base64,(.+)", url, re.DOTALL)
+        if match:
+            media_type = match.group(1)
+            data = match.group(2)
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": data,
+                },
+            }
+        else:
+            log.warning("Could not parse data URI for image content")
+            return None
+    else:
+        # Regular URL
+        return {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": url,
+            },
+        }
+
+
+def convert_tools_openai_to_anthropic(tools: list[dict]) -> list[dict]:
+    """
+    Convert OpenAI tool definitions to Anthropic format.
+
+    OpenAI: {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
+    Anthropic: {"name": "...", "description": "...", "input_schema": {...}}
+    """
+    anthropic_tools = []
+    for tool in tools:
+        if tool.get("type") == "function":
+            func = tool.get("function", {})
+            anthropic_tool = {
+                "name": func.get("name", ""),
+            }
+            if "description" in func:
+                anthropic_tool["description"] = func["description"]
+
+            # parameters → input_schema
+            params = func.get("parameters")
+            if params:
+                anthropic_tool["input_schema"] = params
+            else:
+                # Anthropic requires input_schema even if empty
+                anthropic_tool["input_schema"] = {"type": "object", "properties": {}}
+
+            anthropic_tools.append(anthropic_tool)
+        else:
+            # Non-function tool types — pass through with warning
+            log.warning(f"Skipping non-function tool type: {tool.get('type')}")
+
+    return anthropic_tools
+
+
+def convert_tool_choice_openai_to_anthropic(tool_choice) -> dict:
+    """
+    Convert OpenAI tool_choice to Anthropic format.
+
+    OpenAI: "auto" | "none" | "required" | {"type": "function", "function": {"name": "..."}}
+    Anthropic: {"type": "auto"} | {"type": "any"} | {"type": "tool", "name": "..."}
+    """
+    if isinstance(tool_choice, str):
+        if tool_choice == "none":
+            # Anthropic doesn't have a "none" tool_choice — omit tools instead
+            return {"type": "auto"}
+        elif tool_choice == "required":
+            return {"type": "any"}
+        else:
+            # "auto" or anything else
+            return {"type": "auto"}
+
+    elif isinstance(tool_choice, dict):
+        func = tool_choice.get("function", {})
+        name = func.get("name", "")
+        if name:
+            return {"type": "tool", "name": name}
+        return {"type": "auto"}
+
+    return {"type": "auto"}
+
+
+def apply_model_params_to_body_anthropic(params: dict, form_data: dict) -> dict:
+    """
+    Apply model-level parameter overrides for Anthropic.
+    Called before payload conversion when model_info has custom params.
+    """
+    params = remove_open_webui_params(params)
+
+    custom_params = params.pop("custom_params", {})
+    if custom_params:
+        for key, value in custom_params.items():
+            if isinstance(value, str):
+                try:
+                    custom_params[key] = json.loads(value)
+                except json.JSONDecodeError:
+                    pass
+        params = deep_update(params, custom_params)
+
+    mappings = {
+        "temperature": float,
+        "top_p": float,
+        "max_tokens": int,
+        "stop": lambda x: [bytes(s, "utf-8").decode("unicode_escape") for s in x],
+    }
+    return apply_model_params_to_body(params, form_data, mappings)

--- a/backend/open_webui/utils/anthropic_response.py
+++ b/backend/open_webui/utils/anthropic_response.py
@@ -1,0 +1,326 @@
+"""
+Response conversion utilities: Anthropic Messages API → OpenAI format.
+
+Handles two conversion paths:
+1. Streaming: Anthropic SSE events → OpenAI SSE chunks (data: {...}\n\n lines)
+2. Non-streaming: Anthropic Message dict → OpenAI chat.completion dict
+
+The streaming converter is the core complexity — Anthropic uses a content-block-based
+event protocol (message_start → content_block_start → content_block_delta* →
+content_block_stop → message_delta → message_stop) while OpenAI uses flat delta chunks.
+"""
+
+import json
+import logging
+from uuid import uuid4
+
+from open_webui.utils.misc import (
+    openai_chat_chunk_message_template,
+    openai_chat_completion_message_template,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Anthropic stop_reason → OpenAI finish_reason
+STOP_REASON_MAP = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+}
+
+
+def map_stop_reason(anthropic_stop: str) -> str:
+    """Map an Anthropic stop_reason to OpenAI finish_reason."""
+    return STOP_REASON_MAP.get(anthropic_stop, "stop")
+
+
+def convert_anthropic_usage_to_openai(
+    input_tokens: int = 0, output_tokens: int = 0
+) -> dict:
+    """
+    Build a normalized usage dict from Anthropic token counts.
+
+    Includes both OpenAI-compatible field names and the standardized names
+    used by Open WebUI's normalize_usage().
+    """
+    total_tokens = input_tokens + output_tokens
+    return {
+        # Standardized fields (used by Open WebUI normalize_usage)
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        # OpenAI-compatible fields (for backward compatibility)
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+    }
+
+
+async def convert_streaming_response_anthropic_to_openai(response):
+    """
+    Consume an Anthropic raw SSE streaming response and yield OpenAI-format SSE lines.
+
+    The `response` parameter should be an async iterator of Anthropic SSE events,
+    such as the object returned by `client.messages.create(..., stream=True)`.
+
+    Each Anthropic event has a `.type` attribute and event-specific data fields.
+    We convert these to OpenAI `chat.completion.chunk` format and yield
+    `data: {json}\n\n` lines suitable for a StreamingResponse.
+
+    Yields:
+        str: SSE lines in the format `data: {...}\n\n` or `data: [DONE]\n\n`
+    """
+    model = ""
+    message_id = ""
+    input_tokens = 0
+    output_tokens = 0
+
+    # Track current content block state for tool call streaming
+    current_block_type = None
+    current_block_index = 0
+    tool_call_index = -1  # Incremented for each tool_use block
+
+    try:
+        async for event in response:
+            event_type = event.type
+
+            if event_type == "message_start":
+                # First event: contains message metadata and input token count
+                message = getattr(event, "message", None)
+                if message:
+                    model = getattr(message, "model", "")
+                    message_id = getattr(message, "id", "")
+                    usage = getattr(message, "usage", None)
+                    if usage:
+                        input_tokens = getattr(usage, "input_tokens", 0)
+
+                # Emit initial chunk with role
+                chunk = openai_chat_chunk_message_template(model)
+                chunk["id"] = message_id or f"chatcmpl-{uuid4().hex[:12]}"
+                chunk["choices"][0]["delta"] = {"role": "assistant"}
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            elif event_type == "content_block_start":
+                # A new content block is starting (text, tool_use, or thinking)
+                content_block = getattr(event, "content_block", None)
+                current_block_index = getattr(event, "index", 0)
+
+                if content_block:
+                    block_type = getattr(content_block, "type", "")
+                    current_block_type = block_type
+
+                    if block_type == "tool_use":
+                        # Start of a tool call — emit the initial tool_calls chunk
+                        tool_call_index += 1
+                        tool_id = getattr(content_block, "id", f"call_{uuid4().hex[:8]}")
+                        tool_name = getattr(content_block, "name", "")
+
+                        chunk = openai_chat_chunk_message_template(model)
+                        chunk["id"] = message_id
+                        chunk["choices"][0]["delta"] = {
+                            "tool_calls": [
+                                {
+                                    "index": tool_call_index,
+                                    "id": tool_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tool_name,
+                                        "arguments": "",
+                                    },
+                                }
+                            ]
+                        }
+                        yield f"data: {json.dumps(chunk)}\n\n"
+
+                    # For text and thinking blocks, we just track state and wait for deltas
+
+            elif event_type == "content_block_delta":
+                delta = getattr(event, "delta", None)
+                if not delta:
+                    continue
+
+                delta_type = getattr(delta, "type", "")
+
+                if delta_type == "text_delta":
+                    text = getattr(delta, "text", "")
+                    if text:
+                        chunk = openai_chat_chunk_message_template(model, content=text)
+                        chunk["id"] = message_id
+                        yield f"data: {json.dumps(chunk)}\n\n"
+
+                elif delta_type == "thinking_delta":
+                    thinking = getattr(delta, "thinking", "")
+                    if thinking:
+                        chunk = openai_chat_chunk_message_template(
+                            model, reasoning_content=thinking
+                        )
+                        chunk["id"] = message_id
+                        yield f"data: {json.dumps(chunk)}\n\n"
+
+                elif delta_type == "input_json_delta":
+                    partial_json = getattr(delta, "partial_json", "")
+                    if partial_json:
+                        chunk = openai_chat_chunk_message_template(model)
+                        chunk["id"] = message_id
+                        chunk["choices"][0]["delta"] = {
+                            "tool_calls": [
+                                {
+                                    "index": tool_call_index,
+                                    "function": {
+                                        "arguments": partial_json,
+                                    },
+                                }
+                            ]
+                        }
+                        yield f"data: {json.dumps(chunk)}\n\n"
+
+                elif delta_type == "signature_delta":
+                    # Thinking signature verification — skip, not needed for frontend
+                    pass
+
+                else:
+                    log.debug(f"Unknown content_block_delta type: {delta_type}")
+
+            elif event_type == "content_block_stop":
+                # Content block finished — reset tracking state
+                current_block_type = None
+
+            elif event_type == "message_delta":
+                # Final message metadata: stop_reason and output token count
+                msg_delta = getattr(event, "delta", None)
+                usage = getattr(event, "usage", None)
+
+                stop_reason = None
+                if msg_delta:
+                    stop_reason = getattr(msg_delta, "stop_reason", None)
+
+                if usage:
+                    output_tokens = getattr(usage, "output_tokens", 0)
+
+                # Emit final chunk with finish_reason and usage
+                finish_reason = map_stop_reason(stop_reason) if stop_reason else "stop"
+                combined_usage = convert_anthropic_usage_to_openai(
+                    input_tokens, output_tokens
+                )
+
+                chunk = openai_chat_chunk_message_template(
+                    model, usage=combined_usage
+                )
+                chunk["id"] = message_id
+                chunk["choices"][0]["finish_reason"] = finish_reason
+                chunk["choices"][0]["delta"] = {}
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            elif event_type == "message_stop":
+                # Stream complete
+                yield "data: [DONE]\n\n"
+
+            elif event_type == "ping":
+                # Keep-alive, skip
+                pass
+
+            elif event_type == "error":
+                # Error during streaming
+                error_data = getattr(event, "error", None)
+                if error_data:
+                    error_msg = getattr(error_data, "message", "Unknown error")
+                    error_type = getattr(error_data, "type", "error")
+                    log.error(f"Anthropic streaming error: {error_type}: {error_msg}")
+
+                    error_chunk = {
+                        "error": {
+                            "message": error_msg,
+                            "type": error_type,
+                        }
+                    }
+                    yield f"data: {json.dumps(error_chunk)}\n\n"
+                yield "data: [DONE]\n\n"
+
+            else:
+                log.debug(f"Unknown Anthropic event type: {event_type}")
+
+    except Exception as e:
+        log.exception(f"Error converting Anthropic streaming response: {e}")
+        error_chunk = {
+            "error": {
+                "message": str(e),
+                "type": "server_error",
+            }
+        }
+        yield f"data: {json.dumps(error_chunk)}\n\n"
+        yield "data: [DONE]\n\n"
+
+
+def convert_response_anthropic_to_openai(response: dict) -> dict:
+    """
+    Convert a non-streaming Anthropic Message response to OpenAI chat.completion format.
+
+    Args:
+        response: The Anthropic Message object (or dict representation).
+
+    Returns:
+        dict: OpenAI-compatible chat.completion response.
+    """
+    # Handle both dict and SDK Message object
+    if hasattr(response, "model_dump"):
+        response = response.model_dump()
+
+    model = response.get("model", "")
+    content_blocks = response.get("content", [])
+    stop_reason = response.get("stop_reason", "end_turn")
+    usage_data = response.get("usage", {})
+
+    # Extract text content, reasoning content, and tool calls from content blocks
+    text_parts = []
+    reasoning_parts = []
+    tool_calls = []
+    tool_call_index = 0
+
+    for block in content_blocks:
+        block_type = block.get("type", "")
+
+        if block_type == "text":
+            text_parts.append(block.get("text", ""))
+
+        elif block_type == "thinking":
+            reasoning_parts.append(block.get("thinking", ""))
+
+        elif block_type == "tool_use":
+            tool_calls.append(
+                {
+                    "index": tool_call_index,
+                    "id": block.get("id", f"call_{uuid4().hex[:8]}"),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {})),
+                    },
+                }
+            )
+            tool_call_index += 1
+
+    # Build the response
+    message_content = "\n".join(text_parts) if text_parts else ""
+    reasoning_content = "\n".join(reasoning_parts) if reasoning_parts else None
+
+    input_tokens = usage_data.get("input_tokens", 0)
+    output_tokens = usage_data.get("output_tokens", 0)
+    usage = convert_anthropic_usage_to_openai(input_tokens, output_tokens)
+
+    result = openai_chat_completion_message_template(
+        model=model,
+        message=message_content,
+        reasoning_content=reasoning_content,
+        tool_calls=tool_calls if tool_calls else None,
+        usage=usage,
+    )
+
+    # Override the generated ID with Anthropic's message ID
+    if response.get("id"):
+        result["id"] = response["id"]
+
+    # Set correct finish_reason
+    result["choices"][0]["finish_reason"] = map_stop_reason(stop_reason)
+
+    return result

--- a/backend/open_webui/utils/anthropic_response.py
+++ b/backend/open_webui/utils/anthropic_response.py
@@ -113,7 +113,9 @@ async def convert_streaming_response_anthropic_to_openai(response):
                     if block_type == "tool_use":
                         # Start of a tool call — emit the initial tool_calls chunk
                         tool_call_index += 1
-                        tool_id = getattr(content_block, "id", f"call_{uuid4().hex[:8]}")
+                        tool_id = getattr(
+                            content_block, "id", f"call_{uuid4().hex[:8]}"
+                        )
                         tool_name = getattr(content_block, "name", "")
 
                         chunk = openai_chat_chunk_message_template(model)
@@ -204,9 +206,7 @@ async def convert_streaming_response_anthropic_to_openai(response):
                     input_tokens, output_tokens
                 )
 
-                chunk = openai_chat_chunk_message_template(
-                    model, usage=combined_usage
-                )
+                chunk = openai_chat_chunk_message_template(model, usage=combined_usage)
                 chunk["id"] = message_id
                 chunk["choices"][0]["finish_reason"] = finish_reason
                 chunk["choices"][0]["delta"] = {}

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -31,6 +31,10 @@ from open_webui.routers.ollama import (
     generate_chat_completion as generate_ollama_chat_completion,
 )
 
+from open_webui.routers.anthropic import (
+    generate_chat_completion as generate_anthropic_chat_completion,
+)
+
 from open_webui.routers.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
@@ -281,6 +285,14 @@ async def generate_chat_completion(
                 )
             else:
                 return convert_response_ollama_to_openai(response)
+        elif model.get("owned_by") == "anthropic":
+            return await generate_anthropic_chat_completion(
+                request=request,
+                form_data=form_data,
+                user=user,
+                bypass_filter=bypass_filter,
+                bypass_system_prompt=bypass_system_prompt,
+            )
         else:
             return await generate_openai_chat_completion(
                 request=request,

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -82,15 +82,10 @@ async def get_all_base_models(request: Request, user: UserModel = None):
     function_task = get_function_models(request)
 
     openai_models, ollama_models, anthropic_models, function_models = (
-        await asyncio.gather(
-            openai_task, ollama_task, anthropic_task, function_task
-        )
+        await asyncio.gather(openai_task, ollama_task, anthropic_task, function_task)
     )
 
-    return (
-        function_models + openai_models + ollama_models
-        + anthropic_models
-    )
+    return function_models + openai_models + ollama_models + anthropic_models
 
 
 async def get_all_models(request, refresh: bool = False, user: UserModel = None):

--- a/src/lib/apis/anthropic/index.ts
+++ b/src/lib/apis/anthropic/index.ts
@@ -1,0 +1,107 @@
+import { ANTHROPIC_API_BASE_URL } from '$lib/constants';
+
+export const getAnthropicConfig = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${ANTHROPIC_API_BASE_URL}/config`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			if ('detail' in err) {
+				error = err.detail;
+			} else {
+				error = 'Server connection failed';
+			}
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+type AnthropicConfig = {
+	ENABLE_ANTHROPIC_API: boolean;
+	ANTHROPIC_API_KEYS: string[];
+	ANTHROPIC_API_BASE_URLS: string[];
+	ANTHROPIC_API_CONFIGS: object;
+};
+
+export const updateAnthropicConfig = async (token: string = '', config: AnthropicConfig) => {
+	let error = null;
+
+	const res = await fetch(`${ANTHROPIC_API_BASE_URL}/config/update`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({
+			...config
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			if ('detail' in err) {
+				error = err.detail;
+			} else {
+				error = 'Server connection failed';
+			}
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getAnthropicModels = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${ANTHROPIC_API_BASE_URL}/models`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			if ('detail' in err) {
+				error = err.detail;
+			} else {
+				error = 'Server connection failed';
+			}
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -211,7 +211,9 @@
 			OLLAMA_BASE_URLS = ollamaConfig.OLLAMA_BASE_URLS;
 			OLLAMA_API_CONFIGS = ollamaConfig.OLLAMA_API_CONFIGS;
 
-			ANTHROPIC_API_BASE_URLS = anthropicConfig.ANTHROPIC_API_BASE_URLS ?? ['https://api.anthropic.com'];
+			ANTHROPIC_API_BASE_URLS = anthropicConfig.ANTHROPIC_API_BASE_URLS ?? [
+				'https://api.anthropic.com'
+			];
 			ANTHROPIC_API_KEYS = anthropicConfig.ANTHROPIC_API_KEYS ?? [''];
 			ANTHROPIC_API_CONFIGS = anthropicConfig.ANTHROPIC_API_CONFIGS ?? {};
 
@@ -249,7 +251,6 @@
 					}
 				}
 			}
-
 		}
 	});
 
@@ -412,90 +413,93 @@
 								</div>
 							</div>
 
-						<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-							{$i18n.t('Trouble accessing Ollama?')}
-							<a
-								class=" text-gray-300 font-medium underline"
-								href="https://github.com/open-webui/open-webui#troubleshooting"
-								target="_blank"
-							>
-								{$i18n.t('Click here for help.')}
-							</a>
-						</div>
-					</div>
-				{/if}
-			</div>
-
-			<div class="my-2">
-				<div class="mt-2 space-y-2">
-					<div class="flex justify-between items-center text-sm">
-						<div class="font-medium">{$i18n.t('Anthropic API')}</div>
-
-						<div class="flex items-center">
-							<div class="">
-								<Switch
-									bind:state={ENABLE_ANTHROPIC_API}
-									on:change={async () => {
-										updateAnthropicHandler();
-									}}
-								/>
-							</div>
-						</div>
-					</div>
-
-					{#if ENABLE_ANTHROPIC_API}
-						<div class="">
-							<div class="flex justify-between items-center">
-								<div class="font-medium text-xs">{$i18n.t('Manage Anthropic API Connections')}</div>
-
-								<Tooltip content={$i18n.t(`Add Connection`)}>
-									<button
-										class="px-1"
-										on:click={() => {
-											showAddAnthropicConnectionModal = true;
-										}}
-										type="button"
-									>
-										<Plus />
-									</button>
-								</Tooltip>
-							</div>
-
-							<div class="flex flex-col gap-1.5 mt-1.5">
-								{#each ANTHROPIC_API_BASE_URLS as url, idx}
-									<AnthropicConnection
-										bind:url={ANTHROPIC_API_BASE_URLS[idx]}
-										bind:key={ANTHROPIC_API_KEYS[idx]}
-										bind:config={ANTHROPIC_API_CONFIGS[idx]}
-										onSubmit={() => {
-											updateAnthropicHandler();
-										}}
-										onDelete={() => {
-											ANTHROPIC_API_BASE_URLS = ANTHROPIC_API_BASE_URLS.filter(
-												(url, urlIdx) => idx !== urlIdx
-											);
-											ANTHROPIC_API_KEYS = ANTHROPIC_API_KEYS.filter((key, keyIdx) => idx !== keyIdx);
-
-											let newConfig = {};
-											ANTHROPIC_API_BASE_URLS.forEach((url, newIdx) => {
-												newConfig[newIdx] =
-													ANTHROPIC_API_CONFIGS[newIdx < idx ? newIdx : newIdx + 1];
-											});
-											ANTHROPIC_API_CONFIGS = newConfig;
-											updateAnthropicHandler();
-										}}
-									/>
-								{/each}
+							<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								{$i18n.t('Trouble accessing Ollama?')}
+								<a
+									class=" text-gray-300 font-medium underline"
+									href="https://github.com/open-webui/open-webui#troubleshooting"
+									target="_blank"
+								>
+									{$i18n.t('Click here for help.')}
+								</a>
 							</div>
 						</div>
 					{/if}
 				</div>
-			</div>
 
+				<div class="my-2">
+					<div class="mt-2 space-y-2">
+						<div class="flex justify-between items-center text-sm">
+							<div class="font-medium">{$i18n.t('Anthropic API')}</div>
 
-			<div class="my-2">
-				<div class="flex justify-between items-center text-sm">
-					<div class="  font-medium">{$i18n.t('Direct Connections')}</div>
+							<div class="flex items-center">
+								<div class="">
+									<Switch
+										bind:state={ENABLE_ANTHROPIC_API}
+										on:change={async () => {
+											updateAnthropicHandler();
+										}}
+									/>
+								</div>
+							</div>
+						</div>
+
+						{#if ENABLE_ANTHROPIC_API}
+							<div class="">
+								<div class="flex justify-between items-center">
+									<div class="font-medium text-xs">
+										{$i18n.t('Manage Anthropic API Connections')}
+									</div>
+
+									<Tooltip content={$i18n.t(`Add Connection`)}>
+										<button
+											class="px-1"
+											on:click={() => {
+												showAddAnthropicConnectionModal = true;
+											}}
+											type="button"
+										>
+											<Plus />
+										</button>
+									</Tooltip>
+								</div>
+
+								<div class="flex flex-col gap-1.5 mt-1.5">
+									{#each ANTHROPIC_API_BASE_URLS as url, idx}
+										<AnthropicConnection
+											bind:url={ANTHROPIC_API_BASE_URLS[idx]}
+											bind:key={ANTHROPIC_API_KEYS[idx]}
+											bind:config={ANTHROPIC_API_CONFIGS[idx]}
+											onSubmit={() => {
+												updateAnthropicHandler();
+											}}
+											onDelete={() => {
+												ANTHROPIC_API_BASE_URLS = ANTHROPIC_API_BASE_URLS.filter(
+													(url, urlIdx) => idx !== urlIdx
+												);
+												ANTHROPIC_API_KEYS = ANTHROPIC_API_KEYS.filter(
+													(key, keyIdx) => idx !== keyIdx
+												);
+
+												let newConfig = {};
+												ANTHROPIC_API_BASE_URLS.forEach((url, newIdx) => {
+													newConfig[newIdx] =
+														ANTHROPIC_API_CONFIGS[newIdx < idx ? newIdx : newIdx + 1];
+												});
+												ANTHROPIC_API_CONFIGS = newConfig;
+												updateAnthropicHandler();
+											}}
+										/>
+									{/each}
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
+
+				<div class="my-2">
+					<div class="flex justify-between items-center text-sm">
+						<div class="  font-medium">{$i18n.t('Direct Connections')}</div>
 
 						<div class="flex items-center">
 							<div class="">

--- a/src/lib/components/admin/Settings/Connections/AnthropicConnection.svelte
+++ b/src/lib/components/admin/Settings/Connections/AnthropicConnection.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	const i18n = getContext('i18n');
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import Cog6 from '$lib/components/icons/Cog6.svelte';
+	import AddConnectionModal from '$lib/components/AddConnectionModal.svelte';
+	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+	export let onDelete = () => {};
+	export let onSubmit = () => {};
+
+	export let url = '';
+	export let key = '';
+	export let config = {};
+
+	let showConfigModal = false;
+	let showDeleteConfirmDialog = false;
+</script>
+
+<ConfirmDialog
+	bind:show={showDeleteConfirmDialog}
+	on:confirm={() => {
+		onDelete();
+	}}
+/>
+
+<AddConnectionModal
+	edit
+	bind:show={showConfigModal}
+	connection={{
+		url,
+		key,
+		config
+	}}
+	onDelete={() => {
+		showDeleteConfirmDialog = true;
+	}}
+	onSubmit={(connection) => {
+		url = connection.url;
+		key = connection.key;
+		config = connection.config;
+		onSubmit(connection);
+	}}
+/>
+
+<div class="flex w-full gap-2 items-center">
+	<Tooltip
+		className="w-full relative"
+		content={$i18n.t(`Anthropic API connection: "{{url}}"`, {
+			url
+		})}
+		placement="top-start"
+	>
+		{#if !(config?.enable ?? true)}
+			<div
+				class="absolute top-0 bottom-0 left-0 right-0 opacity-60 bg-white dark:bg-gray-900 z-10"
+			></div>
+		{/if}
+		<div class="flex w-full gap-2">
+			<div class="flex-1 relative">
+				<input
+					class="outline-hidden w-full bg-transparent"
+					placeholder={$i18n.t('API Base URL')}
+					bind:value={url}
+					autocomplete="off"
+					readonly={true}
+				/>
+			</div>
+		</div>
+	</Tooltip>
+
+	<div class="flex gap-1">
+		<Tooltip content={$i18n.t('Configure')} className="self-start">
+			<button
+				class="self-center p-1 bg-transparent hover:bg-gray-100 dark:bg-gray-900 dark:hover:bg-gray-850 rounded-lg transition"
+				on:click={() => {
+					showConfigModal = true;
+				}}
+				type="button"
+			>
+				<Cog6 />
+			</button>
+		</Tooltip>
+	</div>
+</div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,7 @@ export const WEBUI_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1`;
 
 export const OLLAMA_API_BASE_URL = `${WEBUI_BASE_URL}/ollama`;
 export const OPENAI_API_BASE_URL = `${WEBUI_BASE_URL}/openai`;
+export const ANTHROPIC_API_BASE_URL = `${WEBUI_BASE_URL}/anthropic`;
 export const AUDIO_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/audio`;
 export const IMAGES_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/images`;
 export const RETRIEVAL_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/retrieval`;


### PR DESCRIPTION
Add native Anthropic (Claude) API integration bypassing the OpenAI-compatible layer for direct access to Anthropic-specific features including extended thinking, native streaming events, native tool usage, and accurate token usage reports.

Backend: router, payload converter, response/stream converter, SDK-based client. Frontend: admin connection UI, API client, connection component.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
  - [x] Docs PR: https://github.com/open-webui/docs/pull/1096
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
  - [X] Generative ai acknowladgement. I heavily use cursor for understanding of existing architecture, desgin, and implementation. I recognize that I am responsible for code quality, reviews, and testing. I am the final author of my code. 
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Adds a native Anthropic (Claude) provider integration as a first-class connection type alongside OpenAI and Ollama. Rather than routing Claude requests through the OpenAI-compatible shim, this integration communicates directly with the Anthropic Messages API via the official `anthropic` Python SDK, enabling access to Anthropic-specific features that are lost in translation through the OpenAI compatibility layer.

The integration follows the same architectural patterns as the existing OpenAI and Ollama providers: a dedicated FastAPI router handles configuration, model discovery, and chat completions; payload and response converters translate between Open WebUI's internal OpenAI-compatible format and Anthropic's native format; and the frontend provides an admin connection UI consistent with the existing connection management experience.

**Motivation:** Users connecting to Anthropic models through OpenAI-compatible proxies lose access to features like extended thinking (reasoning blocks), accurate token usage reporting, and native tool use. This integration provides direct access to those capabilities while maintaining full compatibility with Open WebUI's middleware pipeline, model management, and access control systems.

### Added

- **Native Anthropic router** (`backend/open_webui/routers/anthropic.py`, ~470 lines) — FastAPI router with endpoints for admin configuration (`GET/POST /anthropic/config`), model discovery (`GET /anthropic/models`), and chat completions (`POST /anthropic/chat/completions`). Supports multiple API keys/URLs with parallel model fetching.
- **Payload converter** (`backend/open_webui/utils/anthropic_payload.py`, ~370 lines) — Converts OpenAI-format chat completion payloads to Anthropic Messages API format, including system prompt extraction, image content conversion (base64 data URIs and URLs), tool/function definition conversion, tool choice mapping, and assistant message tool call formatting.
- **Response/stream converter** (`backend/open_webui/utils/anthropic_response.py`, ~330 lines) — Converts Anthropic's event-based SSE streaming protocol (`message_start` → `content_block_start` → `content_block_delta` → `message_delta` → `message_stop`) into OpenAI-compatible SSE format. Handles text content, tool call deltas, reasoning/thinking blocks, and token usage reporting.
- **Frontend API client** (`src/lib/apis/anthropic/index.ts`, ~110 lines) — TypeScript client for Anthropic admin endpoints (get/update config, fetch models).
- **Connection component** (`src/lib/components/admin/Settings/Connections/AnthropicConnection.svelte`, ~90 lines) — Svelte component for managing individual Anthropic connections with URL display, configuration modal, enable/disable toggle, and delete confirmation.
- **Admin UI** — Anthropic section in the Connections settings page with enable/disable toggle, connection list, and add-connection modal. Follows the same UX patterns as the existing OpenAI connection management.
- **Environment variables** for configuration:
  - `ENABLE_ANTHROPIC_API` — Enable/disable the Anthropic provider (default: `true`)
  - `ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEYS` — API key(s), semicolon-separated for multiple connections
  - `ANTHROPIC_API_BASE_URL` / `ANTHROPIC_API_BASE_URLS` — Base URL(s) (default: `https://api.anthropic.com`)

### Changed

- **Model routing** (`backend/open_webui/utils/chat.py`) — Added routing for models with `owned_by == "anthropic"` to the Anthropic chat completion handler, alongside existing OpenAI and Ollama routes.
- **Model discovery** (`backend/open_webui/utils/models.py`) — Added Anthropic models to the unified model registry fetched by `get_all_base_models()`.
- **Main application** (`backend/open_webui/main.py`) — Registered Anthropic router at `/anthropic` prefix, added config state initialization, and added middleware support for `x-api-key` header authentication (Anthropic Messages API compatibility).
- **Frontend constants** (`src/lib/constants.ts`) — Added `ANTHROPIC_API_BASE_URL` constant.
- **Admin Connections UI** (`src/lib/components/admin/Settings/Connections.svelte`) — Added Anthropic configuration section with state management, handlers, and UI.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- API keys are stored using `PersistentConfig` (same mechanism as OpenAI keys) and are never exposed to non-admin users.
- Model access control is enforced through Open WebUI's existing `AccessGrants` system.

### Breaking Changes

- None. This is a purely additive change. Existing OpenAI, Ollama, and other provider connections are unaffected.

---

### Additional Information

#### Architecture

The integration follows a three-layer conversion pattern:

1. **Inbound**: Open WebUI's middleware processes the request normally (system prompts, tool injection, file handling, etc.) and produces an OpenAI-format payload.
2. **Conversion**: `anthropic_payload.py` converts the OpenAI payload to Anthropic's Messages API format — extracting system prompts, converting content blocks, mapping tool definitions, and handling parameter differences.
3. **Outbound**: `anthropic_response.py` converts the Anthropic streaming response back to OpenAI-compatible SSE events, which flow through the existing middleware pipeline for post-processing (usage extraction, reasoning tag detection, etc.).

This approach means all of Open WebUI's existing features (chat controls, system prompts, tool calling, file attachments, access control, usage tracking) work with Anthropic models without modification.

#### Per-Connection Configuration

Each Anthropic connection supports:
| Option | Description |
|--------|-------------|
| `enable` | Enable/disable the connection |
| `model_ids` | Restrict which models are exposed (empty = all) |
| `prefix_id` | Custom prefix for model IDs and names (e.g., `work.claude-sonnet-4-20250514`) |
| `tags` | Custom tags shown in the model selector |
| `connection_type` | Mark as `"external"` or `"internal"` |

#### Dependencies

- **`anthropic` Python SDK** (latest) — Used for `AsyncAnthropic` client, `models.list()` for discovery, and `messages.create()` for chat completions. The SDK handles authentication, retries, and Anthropic-specific error types.

#### Model Discovery

Models are fetched via the SDK's `models.list()` API with automatic pagination. If the API call fails (e.g., the endpoint doesn't support model listing), the router falls back to a hardcoded list of known models (Claude Opus 4, Sonnet 4, Sonnet 4.5, Haiku 3.5) with accurate context window and max output token metadata.

#### Error Handling

All Anthropic SDK exceptions are caught and mapped to appropriate HTTP status codes:
| Anthropic Exception | HTTP Status |
|---------------------|-------------|
| `AuthenticationError` | 401 |
| `PermissionDeniedError` | 403 |
| `NotFoundError` | 404 |
| `RateLimitError` | 429 |
| `APIStatusError` | Passthrough |
| `APIConnectionError` | 502 |
| `APITimeoutError` | 504 |

#### Testing

Manually tested with:
- Single and multi-turn conversations with Claude Sonnet 4
- Streaming and non-streaming responses
- System prompt propagation from chat controls
- Token usage display via the existing info tooltip
- Model discovery with prefix ID and tagging
- Multiple connections with different configurations
- Admin UI: add, configure, enable/disable, and delete connections

### Screenshots or Videos

Admin Connections page showing Anthropic section

<img width="1055" height="856" alt="image" src="https://github.com/user-attachments/assets/4cb61c80-cd46-48e6-9231-e269d1cc21f5" />
<img width="1068" height="823" alt="image" src="https://github.com/user-attachments/assets/f5fc6f9d-6935-4f8a-99f2-b2853287bce8" />

Model selector showing Anthropic models with prefix/tags

<img width="1643" height="1291" alt="image" src="https://github.com/user-attachments/assets/1b858004-960e-40c9-8856-657884806d56" />

Chat conversation with token usage tooltip

<img width="291" height="265" alt="image" src="https://github.com/user-attachments/assets/62dd4c75-778b-4322-b8fc-df4ca2946462" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
