### PR TITLE
feat: add include_usage toggle and thinking pill for chat input

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1710,10 +1710,14 @@ async def chat_completion(
             "stream_delta_chunk_size"
         )
         reasoning_tags = form_data.get("params", {}).get("reasoning_tags")
+        include_usage = form_data.get("params", {}).get("include_usage")
 
         # Model Params
         if model_info_params.get("stream_response") is not None:
             form_data["stream"] = model_info_params.get("stream_response")
+
+        if model_info_params.get("include_usage") is not None:
+            include_usage = model_info_params.get("include_usage")
 
         if model_info_params.get("stream_delta_chunk_size"):
             stream_delta_chunk_size = model_info_params.get("stream_delta_chunk_size")
@@ -1739,6 +1743,7 @@ async def chat_completion(
             "params": {
                 "stream_delta_chunk_size": stream_delta_chunk_size,
                 "reasoning_tags": reasoning_tags,
+                "include_usage": include_usage,
                 "function_calling": (
                     "native"
                     if (

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1970,7 +1970,6 @@ async def generate_messages(
         return response
 
 
-
 @app.post("/api/chat/completed")
 async def chat_completed(
     request: Request, form_data: dict, user=Depends(get_verified_user)

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -73,6 +73,7 @@ def remove_open_webui_params(params: dict) -> dict:
     """
     open_webui_params = {
         "stream_response": bool,
+        "include_usage": bool,
         "stream_delta_chunk_size": int,
         "function_calling": str,
         "reasoning_tags": list,

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2077,7 +2077,10 @@
 								)
 							: undefined,
 					...(thinkingEnabled === true
-						? { reasoning_effort: params?.reasoning_effort ?? $settings?.params?.reasoning_effort ?? 'medium' }
+						? {
+								reasoning_effort:
+									params?.reasoning_effort ?? $settings?.params?.reasoning_effort ?? 'medium'
+							}
 						: thinkingEnabled === false
 							? { reasoning_effort: 'off' }
 							: {})

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -138,6 +138,7 @@
 	let imageGenerationEnabled = false;
 	let webSearchEnabled = false;
 	let codeInterpreterEnabled = false;
+	let thinkingEnabled: boolean | null = null;
 
 	let showCommands = false;
 
@@ -232,6 +233,7 @@
 						webSearchEnabled = input.webSearchEnabled;
 						imageGenerationEnabled = input.imageGenerationEnabled;
 						codeInterpreterEnabled = input.codeInterpreterEnabled;
+						thinkingEnabled = input.thinkingEnabled ?? null;
 					}
 				} catch (e) {}
 			} else {
@@ -629,6 +631,7 @@
 					webSearchEnabled = input.webSearchEnabled;
 					imageGenerationEnabled = input.imageGenerationEnabled;
 					codeInterpreterEnabled = input.codeInterpreterEnabled;
+					thinkingEnabled = input.thinkingEnabled ?? null;
 				}
 			} catch (e) {}
 		}
@@ -2072,7 +2075,12 @@
 							? (params?.stop.split(',').map((token) => token.trim()) ?? $settings.params.stop).map(
 									(str) => decodeURIComponent(JSON.parse('"' + str.replace(/\"/g, '\\"') + '"'))
 								)
-							: undefined
+							: undefined,
+					...(thinkingEnabled === true
+						? { reasoning_effort: params?.reasoning_effort ?? $settings?.params?.reasoning_effort ?? 'medium' }
+						: thinkingEnabled === false
+							? { reasoning_effort: 'off' }
+							: {})
 				},
 
 				files: (files?.length ?? 0) > 0 ? files : undefined,
@@ -2667,6 +2675,7 @@
 									bind:imageGenerationEnabled
 									bind:codeInterpreterEnabled
 									bind:webSearchEnabled
+									bind:thinkingEnabled
 									bind:atSelectedModel
 									bind:showCommands
 									toolServers={$toolServers}
@@ -2737,6 +2746,7 @@
 									bind:imageGenerationEnabled
 									bind:codeInterpreterEnabled
 									bind:webSearchEnabled
+									bind:thinkingEnabled
 									bind:atSelectedModel
 									bind:showCommands
 									toolServers={$toolServers}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1678,8 +1678,7 @@
 												placement="top"
 											>
 												<button
-													on:click|preventDefault={() =>
-														(thinkingEnabled = !thinkingEnabled)}
+													on:click|preventDefault={() => (thinkingEnabled = !thinkingEnabled)}
 													type="button"
 													class="group p-[7px] flex gap-1.5 items-center text-sm rounded-full transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {thinkingEnabled
 														? 'text-purple-500 dark:text-purple-300 bg-purple-50 hover:bg-purple-100 dark:bg-purple-400/10 dark:hover:bg-purple-600/10 border border-purple-200/40 dark:border-purple-500/20'

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -85,6 +85,7 @@
 
 	import CommandSuggestionList from './MessageInput/CommandSuggestionList.svelte';
 	import Knobs from '../icons/Knobs.svelte';
+	import Brain from '../icons/Brain.svelte';
 	import ValvesModal from '../workspace/common/ValvesModal.svelte';
 	import PageEdit from '../icons/PageEdit.svelte';
 	import { goto } from '$app/navigation';
@@ -121,6 +122,7 @@
 	export let imageGenerationEnabled = false;
 	export let webSearchEnabled = false;
 	export let codeInterpreterEnabled = false;
+	export let thinkingEnabled: boolean | null = null;
 
 	export let messageQueue: { id: string; prompt: string; files: any[] }[] = [];
 	export let onQueueSendNow: (id: string) => void = () => {};
@@ -158,7 +160,8 @@
 		selectedFilterIds,
 		imageGenerationEnabled,
 		webSearchEnabled,
-		codeInterpreterEnabled
+		codeInterpreterEnabled,
+		thinkingEnabled
 	});
 
 	const inputVariableHandler = async (text: string): Promise<string> => {
@@ -1546,7 +1549,7 @@
 										</div>
 									</InputMenu>
 
-									{#if showWebSearchButton || showImageGenerationButton || showCodeInterpreterButton || showToolsButton || (toggleFilters && toggleFilters.length > 0)}
+									{#if true || showWebSearchButton || showImageGenerationButton || showCodeInterpreterButton || showToolsButton || (toggleFilters && toggleFilters.length > 0)}
 										<div
 											class="flex self-center w-[1px] h-4 mx-1 bg-gray-200/50 dark:bg-gray-800/50"
 										/>
@@ -1562,6 +1565,7 @@
 											bind:webSearchEnabled
 											bind:imageGenerationEnabled
 											bind:codeInterpreterEnabled
+											bind:thinkingEnabled
 											closeOnOutsideClick={integrationsMenuCloseOnOutsideClick}
 											onShowValves={(e) => {
 												const { type, id } = e;
@@ -1665,6 +1669,26 @@
 												</Tooltip>
 											{/if}
 										{/each}
+
+										{#if thinkingEnabled !== null}
+											<Tooltip
+												content={thinkingEnabled
+													? $i18n.t('Thinking Enabled')
+													: $i18n.t('Thinking Disabled')}
+												placement="top"
+											>
+												<button
+													on:click|preventDefault={() =>
+														(thinkingEnabled = !thinkingEnabled)}
+													type="button"
+													class="group p-[7px] flex gap-1.5 items-center text-sm rounded-full transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {thinkingEnabled
+														? 'text-purple-500 dark:text-purple-300 bg-purple-50 hover:bg-purple-100 dark:bg-purple-400/10 dark:hover:bg-purple-600/10 border border-purple-200/40 dark:border-purple-500/20'
+														: 'text-gray-400 dark:text-gray-500 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700/50 dark:hover:bg-gray-700 border border-gray-200/40 dark:border-gray-600/20'}"
+												>
+													<Brain className="size-4" strokeWidth="1.75" />
+												</button>
+											</Tooltip>
+										{/if}
 
 										{#if webSearchEnabled}
 											<Tooltip content={$i18n.t('Web Search')} placement="top">

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -21,6 +21,7 @@
 	import Terminal from '$lib/components/icons/Terminal.svelte';
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
+	import Brain from '$lib/components/icons/Brain.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -39,6 +40,7 @@
 	export let imageGenerationEnabled = false;
 	export let showCodeInterpreterButton = false;
 	export let codeInterpreterEnabled = false;
+	export let thinkingEnabled: boolean | null = null;
 
 	export let onShowValves: Function;
 	export let onClose: Function;
@@ -309,6 +311,40 @@
 							</button>
 						</Tooltip>
 					{/if}
+
+					<Tooltip content={$i18n.t('Toggle model thinking/reasoning')} placement="top-start">
+						<button
+							class="flex w-full justify-between gap-2 items-center px-3 py-1.5 text-sm cursor-pointer rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800/50"
+							on:click={() => {
+								if (thinkingEnabled === null) {
+									thinkingEnabled = true;
+								} else if (thinkingEnabled) {
+									thinkingEnabled = false;
+								} else {
+									thinkingEnabled = null;
+								}
+							}}
+						>
+							<div class="flex-1 truncate">
+								<div class="flex flex-1 gap-2 items-center">
+									<div class="shrink-0">
+										<Brain className="size-4" strokeWidth="1.5" />
+									</div>
+									<div class="truncate">{$i18n.t('Thinking')}</div>
+								</div>
+							</div>
+
+							<div class="shrink-0 p-1 px-2 text-xs flex rounded-sm transition">
+								{#if thinkingEnabled === true}
+									<span class="text-purple-500 dark:text-purple-300 font-medium">{$i18n.t('On')}</span>
+								{:else if thinkingEnabled === false}
+									<span class="text-gray-400 dark:text-gray-500 font-medium">{$i18n.t('Off')}</span>
+								{:else}
+									<span class="text-gray-400 dark:text-gray-500">{$i18n.t('Default')}</span>
+								{/if}
+							</div>
+						</button>
+					</Tooltip>
 				</div>
 			{:else if tab === 'tools' && tools}
 				<div in:fly={{ x: 20, duration: 150 }}>

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -336,7 +336,9 @@
 
 							<div class="shrink-0 p-1 px-2 text-xs flex rounded-sm transition">
 								{#if thinkingEnabled === true}
-									<span class="text-purple-500 dark:text-purple-300 font-medium">{$i18n.t('On')}</span>
+									<span class="text-purple-500 dark:text-purple-300 font-medium"
+										>{$i18n.t('On')}</span
+									>
 								{:else if thinkingEnabled === false}
 									<span class="text-gray-400 dark:text-gray-500 font-medium">{$i18n.t('Off')}</span>
 								{:else}

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -53,6 +53,7 @@
 	export let imageGenerationEnabled = false;
 	export let codeInterpreterEnabled = false;
 	export let webSearchEnabled = false;
+	export let thinkingEnabled: boolean | null = null;
 
 	export let onUpload: Function = (e) => {};
 	export let onSelect = (e) => {};
@@ -210,6 +211,7 @@
 					bind:imageGenerationEnabled
 					bind:codeInterpreterEnabled
 					bind:webSearchEnabled
+					bind:thinkingEnabled
 					bind:atSelectedModel
 					bind:showCommands
 					{toolServers}

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -107,11 +107,7 @@
 					class="p-1 px-3 text-xs flex rounded-sm transition"
 					on:click={() => {
 						params.include_usage =
-							(params?.include_usage ?? null) === null
-								? true
-								: params.include_usage
-									? false
-									: null;
+							(params?.include_usage ?? null) === null ? true : params.include_usage ? false : null;
 					}}
 					type="button"
 				>

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -15,6 +15,7 @@
 	const defaultParams = {
 		// Advanced
 		stream_response: null, // Set stream responses for this model individually
+		include_usage: null, // Request token usage stats in streaming responses
 		stream_delta_chunk_size: null, // Set the chunk size for streaming responses
 		function_calling: null,
 		reasoning_tags: null,
@@ -81,6 +82,42 @@
 					{#if params.stream_response === true}
 						<span class="ml-2 self-center">{$i18n.t('On')}</span>
 					{:else if params.stream_response === false}
+						<span class="ml-2 self-center">{$i18n.t('Off')}</span>
+					{:else}
+						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+					{/if}
+				</button>
+			</div>
+		</Tooltip>
+	</div>
+
+	<div>
+		<Tooltip
+			content={$i18n.t(
+				'When enabled, token usage statistics (input/output tokens) will be requested in streaming responses. Disable if your provider does not support stream_options.'
+			)}
+			placement="top-start"
+			className="inline-tooltip"
+		>
+			<div class=" py-0.5 flex w-full justify-between">
+				<div class=" self-center text-xs font-medium">
+					{$i18n.t('Include Usage')}
+				</div>
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition"
+					on:click={() => {
+						params.include_usage =
+							(params?.include_usage ?? null) === null
+								? true
+								: params.include_usage
+									? false
+									: null;
+					}}
+					type="button"
+				>
+					{#if params.include_usage === true}
+						<span class="ml-2 self-center">{$i18n.t('On')}</span>
+					{:else if params.include_usage === false}
 						<span class="ml-2 self-center">{$i18n.t('Off')}</span>
 					{:else}
 						<span class="ml-2 self-center">{$i18n.t('Default')}</span>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -42,6 +42,7 @@
 	let params = {
 		// Advanced
 		stream_response: null,
+		include_usage: null,
 		stream_delta_chunk_size: null,
 		function_calling: null,
 		seed: null,
@@ -72,6 +73,7 @@
 			system: system !== '' ? system : undefined,
 			params: {
 				stream_response: params.stream_response !== null ? params.stream_response : undefined,
+				include_usage: params.include_usage !== null ? params.include_usage : undefined,
 				stream_delta_chunk_size:
 					params.stream_delta_chunk_size !== null ? params.stream_delta_chunk_size : undefined,
 				function_calling: params.function_calling !== null ? params.function_calling : undefined,

--- a/src/lib/components/icons/Brain.svelte
+++ b/src/lib/components/icons/Brain.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	export let className = 'w-4 h-4';
+	export let strokeWidth = '1.5';
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width={strokeWidth}
+	stroke="currentColor"
+	aria-hidden="true"
+	class={className}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
+	/>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
+	/>
+	<path stroke-linecap="round" stroke-linejoin="round" d="M12 5v13" />
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M9 8.5a3 3 0 0 0-2.5 2.5M15 8.5a3 3 0 0 1 2.5 2.5"
+	/>
+</svg>


### PR DESCRIPTION
Add toggleable include_usage model option (Default/On/Off) that controls whether stream_options.include_usage is injected into streaming requests, allowing per-model compatibility control. Add a thinking toggle pill in the chat input area with a brain icon that lets users quickly enable or disable model reasoning (reasoning_effort) without switching models.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
  - [x] Unlikely to need docs. Will defer to reviewer.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
  - [x] Generative ai disclosure. Cursor was used extensively for codebase exploration, architectural understanding, and implementation assistance. All changes have been manually reviewed and tested.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Two quality-of-life additions for working with streaming LLM providers:

1. **Include Usage toggle** — A new model option (`include_usage`) that controls whether `stream_options: {include_usage: true}` is injected into streaming requests (needed for LM Stuido running models and possibly others). This enables token usage statistics (input/output tokens) from OpenAI-compatible providers that support it (including LM Studio, litellm, etc.). The toggle follows the same Default/On/Off pattern as the existing "Stream Chat Response" option, allowing per-model compatibility control for providers that don't support `stream_options`.

2. **Thinking toggle pill** — A brain icon pill button in the chat input area that lets users quickly toggle model reasoning (thinking) on or off without switching models or navigating to advanced settings. This is particularly useful for thinking-capable models (e.g., Qwen3, DeepSeek R1) where you want to disable reasoning for simple tasks to save time and tokens. The pill sends `reasoning_effort` as a parameter — `"off"` when disabled, or the user's configured value (defaulting to `"medium"`) when enabled. A tri-state toggle (Default/On/Off) is also available in the Integrations Menu.

### Added

- **`include_usage` model option** in Advanced Parameters (Default/On/Off toggle) — controls `stream_options.include_usage` injection for streaming requests (needed for LM Stuido running models)
- **Brain icon component** (`Brain.svelte`) — Lucide-style brain SVG for the thinking toggle
- **Thinking toggle pill** in the chat input area — purple when thinking is on, gray when off, hidden when default
- **Thinking toggle** in the Integrations Menu — tri-state (Default/On/Off) for discoverability
- Middleware injects `stream_options: {include_usage: true}` by default for all streaming requests to OpenAI-compatible providers (respects the `include_usage` toggle when explicitly set to Off)

### Changed

- **`MessageInput.svelte`** — Added brain pill display, `thinkingEnabled` state, and always-visible Integrations Menu button (so the thinking toggle is always discoverable)
- **`IntegrationsMenu.svelte`** — Added "Thinking" toggle entry with Brain icon
- **`Chat.svelte`** — Added `thinkingEnabled` state, bound to MessageInput and Placeholder, wired to `reasoning_effort` param in chat completion requests
- **`Placeholder.svelte`** — Added `thinkingEnabled` binding pass-through
- **`General.svelte`** — Added `include_usage` to saved params
- **`AdvancedParams.svelte`** — Added `include_usage` to default params and toggle UI
- **`middleware.py`** — Added `include_usage` to `open_webui_params` filter; conditional `stream_options` injection based on metadata param
- **`payload.py`** — Added `include_usage` to `open_webui_params` filter
- **`main.py`** — Added `include_usage` extraction from chat/model params and inclusion in metadata

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- None. Both features are additive. The `stream_options` injection defaults to the same behavior as before (always on). The thinking toggle defaults to null (no override), so existing behavior is unchanged.

---

### Additional Information

- **No new dependencies.** All changes use existing infrastructure — the `reasoning_effort` parameter was already supported in the OpenAI payload pipeline; this PR just adds a quick-access UI toggle for it.
- **`include_usage` compatibility note:** Some providers may not support `stream_options` and could return errors (haven't seen it cause issues as correctly implemented APIs should ignore extra fields, but better to be safe). The toggle allows users to disable it per-model for those cases. The default behavior (inject when not explicitly disabled) was chosen because most modern OpenAI-compatible providers support it.
- **Thinking toggle behavior:** The pill overrides any `reasoning_effort` value set in Advanced Parameters when explicitly toggled on or off. When set to Default (null), the Advanced Parameters value is used unchanged. This lets users set a preferred reasoning level in settings while still being able to quickly disable thinking from the chat input.
- Cursor was used extensively for codebase exploration, architectural understanding, and implementation assistance. All changes have been manually reviewed and tested.

### Screenshots or Videos

Doesn't show thinking icon indicator when `default`. Shows when `on` or `off`.

<img width="499" height="411" alt="screenshot-2026-02-20 22_26_11-Arc" src="https://github.com/user-attachments/assets/00bdd372-1c9b-4434-9729-f5d62584644a" />
<img width="470" height="388" alt="screenshot-2026-02-20 22_26_36-Arc" src="https://github.com/user-attachments/assets/3abfa4cb-aaba-4507-b679-d73f572891f5" />
<img width="425" height="446" alt="screenshot-2026-02-20 22_27_01-Arc" src="https://github.com/user-attachments/assets/7072c35c-af7f-487d-882e-d9e5427307fb" />

Note brain icon shows purple or grey only if NOT default value.

<img width="470" height="388" alt="screenshot-2026-02-20 23_34_23-screenshot-2026-02-20 22_26_36-Arc (copy)" src="https://github.com/user-attachments/assets/a2a33bd5-f580-42c2-969e-46ece4342095" />

The stream_options --> include_usage addition makes my local LM Studio models properly return token usage.

<img width="787" height="435" alt="image" src="https://github.com/user-attachments/assets/1d7bd81a-1f86-47e5-953d-106116ef1ef8" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
