### PR TITLE
ci: declare explicit least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/deploy-to-hf-spaces.yml
+++ b/.github/workflows/deploy-to-hf-spaces.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-secret:
     runs-on: ubuntu-latest

--- a/.github/workflows/format-backend.yaml
+++ b/.github/workflows/format-backend.yaml
@@ -18,6 +18,9 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 'Format Backend'

--- a/.github/workflows/format-build-frontend.yaml
+++ b/.github/workflows/format-build-frontend.yaml
@@ -18,6 +18,9 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 'Format & Build Frontend'

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -13,6 +13,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/open-webui
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary\n- add explicit top-level `permissions: contents: read` to deploy and CI formatting workflows\n- add `contents: read` to the PyPI release job permissions alongside existing `id-token: write`\n\n## Why\nThese workflows currently rely on implicit/default token scopes in places. Explicitly declaring the minimum required permissions improves security posture and makes workflow intent clear.\n\n## Changed files\n- `.github/workflows/deploy-to-hf-spaces.yml`\n- `.github/workflows/format-backend.yaml`\n- `.github/workflows/format-build-frontend.yaml`\n- `.github/workflows/release-pypi.yml`\n\n## Notes\n- configuration-only change; no build/test logic modified\n