### PR TITLE
feat: add sortable columns to groups admin panel

### DIFF
--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -21,6 +21,8 @@
 	import UserCircleSolid from '$lib/components/icons/UserCircleSolid.svelte';
 	import EditGroupModal from './Groups/EditGroupModal.svelte';
 	import Pencil from '$lib/components/icons/Pencil.svelte';
+	import ChevronUp from '$lib/components/icons/ChevronUp.svelte';
+	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 	import GroupItem from './Groups/GroupItem.svelte';
 	import { createNewGroup, getGroups } from '$lib/apis/groups';
 	import {
@@ -36,15 +38,38 @@
 	let groups = [];
 	let filteredGroups;
 
-	$: filteredGroups = groups.filter((user) => {
-		if (search === '') {
-			return true;
+	let sortBy = '';
+	let sortAsc = true;
+
+	const toggleSort = (column) => {
+		if (sortBy === column) {
+			sortAsc = !sortAsc;
 		} else {
-			let name = user.name.toLowerCase();
-			const query = search.toLowerCase();
-			return name.includes(query);
+			sortBy = column;
+			sortAsc = true;
 		}
-	});
+	};
+
+	$: filteredGroups = groups
+		.filter((group) => {
+			if (search === '') {
+				return true;
+			} else {
+				let name = group.name.toLowerCase();
+				const query = search.toLowerCase();
+				return name.includes(query);
+			}
+		})
+		.sort((a, b) => {
+			if (sortBy === 'name') {
+				const cmp = a.name.localeCompare(b.name);
+				return sortAsc ? cmp : -cmp;
+			} else if (sortBy === 'members') {
+				const cmp = (a.member_count ?? 0) - (b.member_count ?? 0);
+				return sortAsc ? cmp : -cmp;
+			}
+			return 0;
+		});
 
 	let search = '';
 	let defaultPermissions = {};
@@ -171,9 +196,33 @@
 		{:else}
 			<div>
 				<div class=" flex items-center gap-3 justify-between text-xs uppercase px-1 font-medium">
-					<div class="w-full basis-3/5">{$i18n.t('Group')}</div>
+					<button
+						class="w-full basis-3/5 flex items-center gap-1 hover:text-gray-900 dark:hover:text-gray-100 transition cursor-pointer"
+						on:click={() => toggleSort('name')}
+					>
+						{$i18n.t('Group')}
+						{#if sortBy === 'name'}
+							{#if sortAsc}
+								<ChevronUp className="size-3" strokeWidth="2.5" />
+							{:else}
+								<ChevronDown className="size-3" strokeWidth="2.5" />
+							{/if}
+						{/if}
+					</button>
 
-					<div class="w-full basis-2/5 text-right">{$i18n.t('Users')}</div>
+					<button
+						class="w-full basis-2/5 flex items-center gap-1 justify-end hover:text-gray-900 dark:hover:text-gray-100 transition cursor-pointer"
+						on:click={() => toggleSort('members')}
+					>
+						{$i18n.t('Users')}
+						{#if sortBy === 'members'}
+							{#if sortAsc}
+								<ChevronUp className="size-3" strokeWidth="2.5" />
+							{:else}
+								<ChevronDown className="size-3" strokeWidth="2.5" />
+							{/if}
+						{/if}
+					</button>
 				</div>
 
 				<hr class="mt-1.5 border-gray-100/30 dark:border-gray-850/30" />

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -37,36 +37,36 @@
 
 	let groups = [];
 
-	let search = '';
-	let sortBy = '';
-	let sortAsc = true;
+	let query = '';
+	let orderBy = '';
+	let direction = 'asc';
 
-	const toggleSort = (column) => {
-		if (sortBy === column) {
-			sortAsc = !sortAsc;
+	const setSortKey = (key) => {
+		if (orderBy === key) {
+			direction = direction === 'asc' ? 'desc' : 'asc';
 		} else {
-			sortBy = column;
-			sortAsc = true;
+			orderBy = key;
+			direction = 'asc';
 		}
 	};
 
 	$: filteredGroups = groups
 		.filter((group) => {
-			if (search === '') {
+			if (query === '') {
 				return true;
 			} else {
 				let name = group.name.toLowerCase();
-				const query = search.toLowerCase();
-				return name.includes(query);
+				const q = query.toLowerCase();
+				return name.includes(q);
 			}
 		})
 		.sort((a, b) => {
-			if (sortBy === 'name') {
+			if (orderBy === 'name') {
 				const cmp = a.name.localeCompare(b.name);
-				return sortAsc ? cmp : -cmp;
-			} else if (sortBy === 'members') {
+				return direction === 'asc' ? cmp : -cmp;
+			} else if (orderBy === 'members') {
 				const cmp = (a.member_count ?? 0) - (b.member_count ?? 0);
-				return sortAsc ? cmp : -cmp;
+				return direction === 'asc' ? cmp : -cmp;
 			}
 			return 0;
 		});
@@ -149,7 +149,7 @@
 					</div>
 					<input
 						class=" w-full text-sm pr-4 py-1 rounded-r-xl outline-hidden bg-transparent"
-						bind:value={search}
+						bind:value={query}
 						placeholder={$i18n.t('Search')}
 					/>
 				</div>
@@ -198,11 +198,11 @@
 				<div class=" flex items-center gap-3 justify-between text-xs uppercase px-1 font-medium">
 					<button
 						class="w-full basis-3/5 flex items-center gap-1 hover:text-gray-900 dark:hover:text-gray-100 transition cursor-pointer"
-						on:click={() => toggleSort('name')}
+						on:click={() => setSortKey('name')}
 					>
 						{$i18n.t('Group')}
-						{#if sortBy === 'name'}
-							{#if sortAsc}
+						{#if orderBy === 'name'}
+							{#if direction === 'asc'}
 								<ChevronUp className="size-3" strokeWidth="2.5" />
 							{:else}
 								<ChevronDown className="size-3" strokeWidth="2.5" />
@@ -212,11 +212,11 @@
 
 					<button
 						class="w-full basis-2/5 flex items-center gap-1 justify-end hover:text-gray-900 dark:hover:text-gray-100 transition cursor-pointer"
-						on:click={() => toggleSort('members')}
+						on:click={() => setSortKey('members')}
 					>
 						{$i18n.t('Users')}
-						{#if sortBy === 'members'}
-							{#if sortAsc}
+						{#if orderBy === 'members'}
+							{#if direction === 'asc'}
 								<ChevronUp className="size-3" strokeWidth="2.5" />
 							{:else}
 								<ChevronDown className="size-3" strokeWidth="2.5" />

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -36,8 +36,8 @@
 	let loaded = false;
 
 	let groups = [];
-	let filteredGroups;
 
+	let search = '';
 	let sortBy = '';
 	let sortAsc = true;
 
@@ -71,7 +71,7 @@
 			return 0;
 		});
 
-	let search = '';
+
 	let defaultPermissions = {};
 
 	let showAddGroupModal = false;


### PR DESCRIPTION
Make the Group and Users column headers in the admin groups list clickable to sort groups alphabetically by name or numerically by member count. Clicking a column toggles ascending/descending order, indicated by a chevron icon. When no sort is active, the default API order (by updated_at) is preserved.

As discussed in: https://github.com/open-webui/open-webui/discussions/16793

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
