### PR TITLE
feat: show group description preview in admin panel

### DIFF
--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -69,7 +69,7 @@
 	}}
 >
 	<div class="flex items-center gap-1.5 w-full font-medium flex-1 min-w-0">
-		<div class="line-clamp-1">
+		<div class="line-clamp-1 overflow-hidden break-all">
 			{group.name}
 			{#if group.description}
 				<span class="font-normal text-gray-400 dark:text-gray-500"

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -68,9 +68,14 @@
 		showEdit = true;
 	}}
 >
-	<div class="flex items-center gap-1.5 w-full font-medium flex-1">
+	<div class="flex items-center gap-1.5 w-full font-medium flex-1 min-w-0">
 		<div class="line-clamp-1">
 			{group.name}
+			{#if group.description}
+				<span class="font-normal text-gray-400 dark:text-gray-500"
+					>&middot; {group.description}</span
+				>
+			{/if}
 		</div>
 	</div>
 


### PR DESCRIPTION
Display a truncated version of the group description in a lighter color next to the group name in the admin groups list. The description is preceded by a mid-dot separator and clipped to a single line via line-clamp, providing a quick glance at the group purpose without cluttering the UI.

As discussed in: https://github.com/open-webui/open-webui/discussions/16793

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
