### PR TITLE
feat: make Action Rich UI (embed) placement configurable per-action

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -841,12 +841,18 @@ def get_event_emitter(request_info, update_db=True):
                 embeds = event_data.get("data", {}).get("embeds", [])
                 embeds.extend(message.get("embeds", []))
 
+                placement = event_data.get("data", {}).get("placement", None)
+
+                update_data = {
+                    "embeds": embeds,
+                }
+                if placement:
+                    update_data["embed_placement"] = placement
+
                 Chats.upsert_message_to_chat_by_id_and_message_id(
                     request_info["chat_id"],
                     request_info["message_id"],
-                    {
-                        "embeds": embeds,
-                    },
+                    update_data,
                 )
 
             if "type" in event_data and event_data["type"] == "files":

--- a/backend/open_webui/utils/actions.py
+++ b/backend/open_webui/utils/actions.py
@@ -126,6 +126,7 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
                         "type": "embeds",
                         "data": {
                             "embeds": action_embeds,
+                            "placement": "bottom",
                         },
                     }
                 )

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -415,6 +415,9 @@
 					message.files = data.files;
 				} else if (type === 'chat:message:embeds' || type === 'embeds') {
 					message.embeds = data.embeds;
+					if (data.placement) {
+						message.embed_placement = data.placement;
+					}
 				} else if (type === 'chat:message:error') {
 					message.error = data.error;
 				} else if (type === 'chat:message:follow_ups') {

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -678,7 +678,7 @@
 							</div>
 						{/if}
 
-						{#if message?.embeds && message.embeds.length > 0}
+						{#if (message?.embed_placement ?? 'bottom') === 'top' && message?.embeds && message.embeds.length > 0}
 							<div class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap">
 								{#each message.embeds as embed, idx}
 									<div class="my-2 w-full" id={`${message.id}-embeds-${idx}`}>
@@ -829,6 +829,22 @@
 
 							{#if message.code_executions}
 								<CodeExecutions codeExecutions={message.code_executions} />
+							{/if}
+
+							{#if (message?.embed_placement ?? 'bottom') === 'bottom' && message?.embeds && message.embeds.length > 0}
+								<div class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap">
+									{#each message.embeds as embed, idx}
+										<div class="my-2 w-full" id={`${message.id}-embeds-${idx}`}>
+											<FullHeightIframe
+												src={embed}
+												allowScripts={true}
+												allowForms={true}
+												allowSameOrigin={$settings?.iframeSandboxAllowSameOrigin ?? false}
+												allowPopups={true}
+											/>
+										</div>
+									{/each}
+								</div>
 							{/if}
 						</div>
 					</div>


### PR DESCRIPTION
### Description

Follow-up to discussion #21482.

Makes Action Rich UI (embed) placement configurable per-action. Actions now default to rendering embeds below the assistant message, near the action button. Developers can override this by specifying placement in the embed event data.

Tool Rich UI is unaffected — it already renders inline at the tool call invocation point.

### Why

As discussed in #21482, the previous fixed "top" placement caused UX issues:

- For long messages, clicking an action button appeared broken because the Rich UI rendered out of view at the top
- The result (Rich UI) should follow its source (the message content), matching natural derivation logic
- Tool Rich UI already renders inline at the invocation point — Action Rich UI should similarly appear near the action button
- Community consensus strongly favored "bottom" as the default

### What changed

**Backend:**
- actions.py: Sends placement alongside embeds in the event data (default: bottom)
- socket/main.py: Persists embed_placement on the message from the event data

**Frontend:**
- Chat.svelte: Reads placement from the embed event and stores it on the message
- ResponseMessage.svelte: Renders embeds above or below content based on the message's embed_placement (defaults to bottom when unset)

### Developer usage

Placement is controlled per-action. The default for actions is bottom. Developers who manually emit embeds via the event emitter can specify placement:

```python
await __event_emitter__({"type": "embeds", "data": {"embeds": [...], "placement": "top"}})

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
