### PR TITLE
fix(a11y): improve modal, dialog, and drawer accessibility

### DIFF
--- a/src/lib/components/common/CodeEditorModal.svelte
+++ b/src/lib/components/common/CodeEditorModal.svelte
@@ -26,12 +26,12 @@
 	});
 </script>
 
-<Drawer bind:show>
+<Drawer bind:show ariaLabelledby="code-editor-modal-title">
 	<div class="flex h-full flex-col">
 		<div
 			class=" sticky top-0 z-30 flex justify-between bg-white px-4.5 pt-3 pb-3 dark:bg-gray-900 dark:text-gray-100"
 		>
-			<div class=" font-primary self-center text-lg font-medium">
+			<div id="code-editor-modal-title" class=" font-primary self-center text-lg font-medium">
 				{$i18n.t('Code Editor')}
 			</div>
 			<button

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -66,7 +66,9 @@
 	$: if (mounted) {
 		if (show && modalElement) {
 			document.body.appendChild(modalElement);
-			focusTrap = FocusTrap.createFocusTrap(modalElement);
+			focusTrap = FocusTrap.createFocusTrap(modalElement, {
+				returnFocusOnDeactivate: true
+			});
 			focusTrap.activate();
 
 			window.addEventListener('keydown', handleKeyDown);
@@ -98,6 +100,9 @@
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={modalElement}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="confirm-dialog-title"
 		class=" fixed top-0 right-0 left-0 bottom-0 bg-black/60 w-full h-screen max-h-[100dvh] flex justify-center z-99999999 overflow-hidden overscroll-contain"
 		in:fade={{ duration: 10 }}
 		on:mousedown={() => {
@@ -112,7 +117,7 @@
 			}}
 		>
 			<div class="px-[1.75rem] py-6 flex flex-col">
-				<div class=" text-lg font-medium dark:text-gray-200 mb-2.5">
+				<div id="confirm-dialog-title" class=" text-lg font-medium dark:text-gray-200 mb-2.5">
 					{#if title !== ''}
 						{title}
 					{:else}
@@ -133,6 +138,7 @@
 							<textarea
 								bind:value={inputValue}
 								placeholder={inputPlaceholder ? inputPlaceholder : $i18n.t('Enter your message')}
+								aria-label={inputPlaceholder ? inputPlaceholder : $i18n.t('Enter your message')}
 								class="w-full mt-2 rounded-lg px-4 py-2 text-sm dark:text-gray-300 dark:bg-gray-900 outline-hidden resize-none"
 								rows="3"
 								required

--- a/src/lib/components/common/InputModal.svelte
+++ b/src/lib/components/common/InputModal.svelte
@@ -22,12 +22,12 @@
 	let inputElement;
 </script>
 
-<Drawer bind:show>
+<Drawer bind:show ariaLabelledby="input-modal-title">
 	<div class="flex h-full min-h-screen flex-col">
 		<div
 			class=" sticky top-0 z-30 flex justify-between bg-white px-4.5 pt-3 pb-3 dark:bg-gray-900 dark:text-gray-100"
 		>
-			<div class=" font-primary self-center text-lg">
+			<div id="input-modal-title" class=" font-primary self-center text-lg">
 				{$i18n.t('Input')}
 			</div>
 			<button

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -8,6 +8,7 @@
 	export let size = 'md';
 	export let containerClassName = 'p-3';
 	export let className = 'bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm rounded-4xl';
+	export let ariaLabelledby = undefined;
 
 	let modalElement = null;
 	let mounted = false;
@@ -63,7 +64,8 @@
 					e.target.closest('[data-sonner-toast]') !== null ||
 					e.target.closest('.modal-content') === null
 				);
-			}
+			},
+			returnFocusOnDeactivate: true
 		});
 		focusTrap.activate();
 		window.addEventListener('keydown', handleKeyDown);
@@ -94,6 +96,7 @@
 		bind:this={modalElement}
 		aria-modal="true"
 		role="dialog"
+		aria-labelledby={ariaLabelledby}
 		class="modal fixed top-0 right-0 left-0 bottom-0 bg-black/30 dark:bg-black/60 w-full h-screen max-h-[100dvh] {containerClassName}  flex justify-center z-9999 overflow-y-auto overscroll-contain"
 		style="scrollbar-gutter: stable;"
 		in:fade={{ duration: 10 }}


### PR DESCRIPTION
- Add aria-labelledby prop to Modal.svelte so consumer components can reference their heading element for screen reader announcement (WCAG 4.1.2 Name, Role, Value).

- Configure focus-trap with returnFocusOnDeactivate: true in Modal.svelte to restore keyboard focus to the trigger element when the modal closes (WCAG 2.4.3 Focus Order).

- Add role='dialog', aria-modal='true', and aria-labelledby to ConfirmDialog.svelte. Previously the confirm dialog container had no ARIA dialog semantics at all.

- Add id='confirm-dialog-title' to the ConfirmDialog title element and reference it via aria-labelledby so screen readers announce the dialog purpose on open.

- Add aria-label to the ConfirmDialog textarea input so screen readers can identify the field.

- Configure ConfirmDialog focus-trap with returnFocusOnDeactivate: true.

- Add full focus-trap implementation to Drawer.svelte using the same focus-trap library already used by Modal and ConfirmDialog. Previously the Drawer had no focus trapping at all, allowing keyboard focus to escape the drawer.

- Add role='dialog', aria-modal='true', and ariaLabelledby prop to Drawer.svelte.

- Wire ariaLabelledby and heading IDs in InputModal.svelte and CodeEditorModal.svelte so their Drawer dialogs are properly labeled for screen readers.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
