### PR TITLE
fix(a11y): add skip-to-content link, semantic landmarks, and allow viewport zoom

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,128 +1,107 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/png" href="/static/favicon.png" crossorigin="use-credentials" />
-		<link
-			rel="icon"
-			type="image/png"
-			href="/static/favicon-96x96.png"
-			sizes="96x96"
-			crossorigin="use-credentials"
-		/>
-		<link
-			rel="icon"
-			type="image/svg+xml"
-			href="/static/favicon.svg"
-			crossorigin="use-credentials"
-		/>
-		<link rel="shortcut icon" href="/static/favicon.ico" crossorigin="use-credentials" />
-		<link
-			rel="apple-touch-icon"
-			sizes="180x180"
-			href="/static/apple-touch-icon.png"
-			crossorigin="use-credentials"
-		/>
-		<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
-		/>
-		<meta name="theme-color" content="#171717" />
-		<meta name="robots" content="noindex,nofollow" />
 
-		<script src="/static/loader.js" defer crossorigin="use-credentials"></script>
-		<link rel="stylesheet" href="/static/custom.css" crossorigin="use-credentials" />
+<head>
+	<meta charset="utf-8" />
+	<link rel="icon" type="image/png" href="/static/favicon.png" crossorigin="use-credentials" />
+	<link rel="icon" type="image/png" href="/static/favicon-96x96.png" sizes="96x96" crossorigin="use-credentials" />
+	<link rel="icon" type="image/svg+xml" href="/static/favicon.svg" crossorigin="use-credentials" />
+	<link rel="shortcut icon" href="/static/favicon.ico" crossorigin="use-credentials" />
+	<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" crossorigin="use-credentials" />
+	<link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+	<meta name="theme-color" content="#171717" />
+	<meta name="robots" content="noindex,nofollow" />
 
-		<script>
-			function resizeIframe(obj) {
-				obj.style.height = obj.contentWindow.document.documentElement.scrollHeight + 'px';
+	<script src="/static/loader.js" defer crossorigin="use-credentials"></script>
+	<link rel="stylesheet" href="/static/custom.css" crossorigin="use-credentials" />
+
+	<script>
+		function resizeIframe(obj) {
+			obj.style.height = obj.contentWindow.document.documentElement.scrollHeight + 'px';
+		}
+	</script>
+
+	<script>
+		// On page load or when changing themes, best to add inline in `head` to avoid FOUC
+		(() => {
+			const metaThemeColorTag = document.querySelector('meta[name="theme-color"]');
+			const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+			if (!localStorage?.theme) {
+				localStorage.theme = 'system';
 			}
-		</script>
 
-		<script>
-			// On page load or when changing themes, best to add inline in `head` to avoid FOUC
-			(() => {
-				const metaThemeColorTag = document.querySelector('meta[name="theme-color"]');
-				const prefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+			if (localStorage.theme === 'system') {
+				document.documentElement.classList.add(prefersDarkTheme ? 'dark' : 'light');
+				metaThemeColorTag.setAttribute('content', prefersDarkTheme ? '#171717' : '#ffffff');
+			} else if (localStorage.theme === 'oled-dark') {
+				document.documentElement.style.setProperty('--color-gray-800', '#101010');
+				document.documentElement.style.setProperty('--color-gray-850', '#050505');
+				document.documentElement.style.setProperty('--color-gray-900', '#000000');
+				document.documentElement.style.setProperty('--color-gray-950', '#000000');
+				document.documentElement.classList.add('dark');
+				metaThemeColorTag.setAttribute('content', '#000000');
+			} else if (localStorage.theme === 'light') {
+				document.documentElement.classList.add('light');
+				metaThemeColorTag.setAttribute('content', '#ffffff');
+			} else if (localStorage.theme === 'her') {
+				document.documentElement.classList.add('her');
+				metaThemeColorTag.setAttribute('content', '#983724');
+			} else {
+				document.documentElement.classList.add('dark');
+				metaThemeColorTag.setAttribute('content', '#171717');
+			}
 
-				if (!localStorage?.theme) {
-					localStorage.theme = 'system';
-				}
-
+			window.matchMedia('(prefers-color-scheme: dark)').addListener((e) => {
 				if (localStorage.theme === 'system') {
-					document.documentElement.classList.add(prefersDarkTheme ? 'dark' : 'light');
-					metaThemeColorTag.setAttribute('content', prefersDarkTheme ? '#171717' : '#ffffff');
-				} else if (localStorage.theme === 'oled-dark') {
-					document.documentElement.style.setProperty('--color-gray-800', '#101010');
-					document.documentElement.style.setProperty('--color-gray-850', '#050505');
-					document.documentElement.style.setProperty('--color-gray-900', '#000000');
-					document.documentElement.style.setProperty('--color-gray-950', '#000000');
-					document.documentElement.classList.add('dark');
-					metaThemeColorTag.setAttribute('content', '#000000');
-				} else if (localStorage.theme === 'light') {
-					document.documentElement.classList.add('light');
-					metaThemeColorTag.setAttribute('content', '#ffffff');
-				} else if (localStorage.theme === 'her') {
-					document.documentElement.classList.add('her');
-					metaThemeColorTag.setAttribute('content', '#983724');
-				} else {
-					document.documentElement.classList.add('dark');
-					metaThemeColorTag.setAttribute('content', '#171717');
+					if (e.matches) {
+						document.documentElement.classList.add('dark');
+						document.documentElement.classList.remove('light');
+						metaThemeColorTag.setAttribute('content', '#171717');
+					} else {
+						document.documentElement.classList.add('light');
+						document.documentElement.classList.remove('dark');
+						metaThemeColorTag.setAttribute('content', '#ffffff');
+					}
+				}
+			});
+			const isDarkMode = document.documentElement.classList.contains('dark');
+
+			const logo = document.createElement('img');
+			logo.id = 'logo';
+			logo.style =
+				'position: absolute; width: auto; height: 6rem; top: 44%; left: 50%; transform: translateX(-50%); display:block;';
+			logo.src = isDarkMode ? '/static/splash-dark.png' : '/static/splash.png';
+
+			document.addEventListener('DOMContentLoaded', function () {
+				const splash = document.getElementById('splash-screen');
+				if (document.documentElement.classList.contains('her')) {
+					return;
 				}
 
-				window.matchMedia('(prefers-color-scheme: dark)').addListener((e) => {
-					if (localStorage.theme === 'system') {
-						if (e.matches) {
-							document.documentElement.classList.add('dark');
-							document.documentElement.classList.remove('light');
-							metaThemeColorTag.setAttribute('content', '#171717');
-						} else {
-							document.documentElement.classList.add('light');
-							document.documentElement.classList.remove('dark');
-							metaThemeColorTag.setAttribute('content', '#ffffff');
-						}
-					}
-				});
-				const isDarkMode = document.documentElement.classList.contains('dark');
+				if (splash) splash.prepend(logo);
+			});
+		})();
+	</script>
 
-				const logo = document.createElement('img');
-				logo.id = 'logo';
-				logo.style =
-					'position: absolute; width: auto; height: 6rem; top: 44%; left: 50%; transform: translateX(-50%); display:block;';
-				logo.src = isDarkMode ? '/static/splash-dark.png' : '/static/splash.png';
+	<title>Open WebUI</title>
 
-				document.addEventListener('DOMContentLoaded', function () {
-					const splash = document.getElementById('splash-screen');
-					if (document.documentElement.classList.contains('her')) {
-						return;
-					}
+	%sveltekit.head%
+</head>
 
-					if (splash) splash.prepend(logo);
-				});
-			})();
-		</script>
+<body data-sveltekit-preload-data="hover">
+	<a href="#main-content" class="skip-to-content">Skip to main content</a>
+	<div style="display: contents">%sveltekit.body%</div>
 
-		<title>Open WebUI</title>
+	<div id="splash-screen" style="position: fixed; z-index: 100; top: 0; left: 0; width: 100%; height: 100%">
+		<style type="text/css" nonce="">
+			html {
+				overflow-y: scroll !important;
+			}
+		</style>
 
-		%sveltekit.head%
-	</head>
-
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-
-		<div
-			id="splash-screen"
-			style="position: fixed; z-index: 100; top: 0; left: 0; width: 100%; height: 100%"
-		>
-			<style type="text/css" nonce="">
-				html {
-					overflow-y: scroll !important;
-				}
-			</style>
-
-			<div
-				style="
+		<div style="
 					position: absolute;
 					top: 33%;
 					left: 50%;
@@ -133,113 +112,128 @@
 					display: flex;
 					flex-direction: column;
 					align-items: center;
-				"
-			>
-				<img
-					id="logo-her"
-					style="width: auto; height: 13rem"
-					src="/static/splash.png"
-					class="animate-pulse-fast"
-				/>
+				">
+			<img id="logo-her" style="width: auto; height: 13rem" src="/static/splash.png" class="animate-pulse-fast"
+				alt="Open WebUI loading" />
 
-				<div style="position: relative; width: 24rem; margin-top: 0.5rem">
-					<div
-						id="progress-background"
-						style="
+			<div style="position: relative; width: 24rem; margin-top: 0.5rem">
+				<div id="progress-background" style="
 							position: absolute;
 							width: 100%;
 							height: 0.75rem;
 
 							border-radius: 9999px;
 							background-color: #fafafa9a;
-						"
-					></div>
+						"></div>
 
-					<div
-						id="progress-bar"
-						style="
+				<div id="progress-bar" style="
 							position: absolute;
 							width: 0%;
 							height: 0.75rem;
 							border-radius: 9999px;
 							background-color: #fff;
-						"
-						class="bg-white"
-					></div>
-				</div>
+						" class="bg-white"></div>
 			</div>
+		</div>
 
-			<!-- <span style="position: absolute; bottom: 32px; left: 50%; margin: -36px 0 0 -36px">
+		<!-- <span style="position: absolute; bottom: 32px; left: 50%; margin: -36px 0 0 -36px">
 				Footer content
 			</span> -->
-		</div>
-	</body>
+	</div>
+</body>
 
-	<style type="text/css" nonce="">
-		html {
-			overflow-y: hidden !important;
-			overscroll-behavior-y: none;
-		}
+<style type="text/css" nonce="">
+	.skip-to-content {
+		position: absolute;
+		left: -9999px;
+		top: auto;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		z-index: 9999;
+	}
 
-		#splash-screen {
-			background: #fff;
-		}
+	.skip-to-content:focus {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: auto;
+		height: auto;
+		padding: 0.75rem 1.5rem;
+		background: #fff;
+		color: #000;
+		font-size: 1rem;
+		font-weight: 600;
+		text-decoration: none;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+		border-bottom-right-radius: 8px;
+	}
 
-		html.dark #splash-screen {
-			background: #000;
-		}
+	html {
+		overflow-y: hidden !important;
+		overscroll-behavior-y: none;
+	}
 
-		html.her #splash-screen {
-			background: #983724;
-		}
+	#splash-screen {
+		background: #fff;
+	}
 
-		#logo-her {
-			display: none;
-		}
+	html.dark #splash-screen {
+		background: #000;
+	}
 
-		#progress-background {
-			display: none;
-		}
+	html.her #splash-screen {
+		background: #983724;
+	}
 
-		#progress-bar {
-			display: none;
-		}
+	#logo-her {
+		display: none;
+	}
 
-		html.her #logo {
-			display: none;
-		}
+	#progress-background {
+		display: none;
+	}
 
-		html.her #logo-her {
-			display: block;
-			filter: invert(1);
-		}
+	#progress-bar {
+		display: none;
+	}
 
+	html.her #logo {
+		display: none;
+	}
+
+	html.her #logo-her {
+		display: block;
+		filter: invert(1);
+	}
+
+	html.her #progress-background {
+		display: block;
+	}
+
+	html.her #progress-bar {
+		display: block;
+	}
+
+	@media (max-width: 24rem) {
 		html.her #progress-background {
-			display: block;
+			display: none;
 		}
 
 		html.her #progress-bar {
-			display: block;
+			display: none;
 		}
+	}
 
-		@media (max-width: 24rem) {
-			html.her #progress-background {
-				display: none;
-			}
-
-			html.her #progress-bar {
-				display: none;
-			}
+	@keyframes pulse {
+		50% {
+			opacity: 0.65;
 		}
+	}
 
-		@keyframes pulse {
-			50% {
-				opacity: 0.65;
-			}
-		}
+	.animate-pulse-fast {
+		animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+	}
+</style>
 
-		.animate-pulse-fast {
-			animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-		}
-	</style>
 </html>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -383,19 +383,23 @@
 					</div>
 				{/if}
 
-				<Sidebar />
+				<nav aria-label="Chat Sidebar">
+					<Sidebar />
+				</nav>
 
-				{#if loaded}
-					<slot />
-				{:else}
-					<div
-						class="w-full flex-1 h-full flex items-center justify-center {$showSidebar
-							? '  md:max-w-[calc(100%-var(--sidebar-width))]'
-							: ' '}"
-					>
-						<Spinner className="size-5" />
-					</div>
-				{/if}
+				<main id="main-content">
+					{#if loaded}
+						<slot />
+					{:else}
+						<div
+							class="w-full flex-1 h-full flex items-center justify-center {$showSidebar
+								? '  md:max-w-[calc(100%-var(--sidebar-width))]'
+								: ' '}"
+						>
+							<Spinner className="size-5" />
+						</div>
+					{/if}
+				</main>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,10 +2,10 @@
 	import { page } from '$app/stores';
 </script>
 
-<div class=" bg-white dark:bg-gray-800 min-h-screen">
+<main class=" bg-white dark:bg-gray-800 min-h-screen" id="main-content">
 	<div class=" flex h-full">
-		<div class="m-auto my-10 dark:text-gray-300 text-3xl font-medium">
+		<h1 class="m-auto my-10 dark:text-gray-300 text-3xl font-medium">
 			{$page.status}: {$page.error?.message}
-		</div>
+		</h1>
 	</div>
-</div>
+</main>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -896,14 +896,18 @@
 {#if loaded}
 	{#if $isApp}
 		<div class="flex flex-row h-screen">
-			<AppSidebar />
+			<aside aria-label="App Navigation">
+				<AppSidebar />
+			</aside>
 
-			<div class="w-full flex-1 max-w-[calc(100%-4.5rem)]">
+			<main id="main-content" class="w-full flex-1 max-w-[calc(100%-4.5rem)]">
 				<slot />
-			</div>
+			</main>
 		</div>
 	{:else}
-		<slot />
+		<main id="main-content">
+			<slot />
+		</main>
 	{/if}
 {/if}
 

--- a/src/routes/error/+page.svelte
+++ b/src/routes/error/+page.svelte
@@ -17,13 +17,13 @@
 </script>
 
 {#if loaded}
-	<div class="absolute w-full h-full flex z-50">
+	<main class="absolute w-full h-full flex z-50" id="main-content">
 		<div class="absolute rounded-xl w-full h-full backdrop-blur-sm flex justify-center">
 			<div class="m-auto pb-44 flex flex-col justify-center">
 				<div class="max-w-md">
-					<div class="text-center text-2xl font-medium z-50">
+					<h1 class="text-center text-2xl font-medium z-50">
 						{$i18n.t('{{webUIName}} Backend Required', { webUIName: $WEBUI_NAME })}
-					</div>
+					</h1>
 
 					<div class=" mt-4 text-center text-sm w-full">
 						{$i18n.t(
@@ -35,11 +35,15 @@
 						<a
 							class=" font-medium underline"
 							href="https://github.com/open-webui/open-webui#how-to-install-"
-							target="_blank">{$i18n.t('See readme.md for instructions')}</a
+							target="_blank"
+							rel="noopener noreferrer">{$i18n.t('See readme.md for instructions')}</a
 						>
 						{$i18n.t('or')}
-						<a class=" font-medium underline" href="https://discord.gg/5rJgQTnV4s" target="_blank"
-							>{$i18n.t('join our Discord for help.')}</a
+						<a
+							class=" font-medium underline"
+							href="https://discord.gg/5rJgQTnV4s"
+							target="_blank"
+							rel="noopener noreferrer">{$i18n.t('join our Discord for help.')}</a
 						>
 					</div>
 
@@ -56,5 +60,5 @@
 				</div>
 			</div>
 		</div>
-	</div>
+	</main>
 {/if}

--- a/src/routes/watch/+page.svelte
+++ b/src/routes/watch/+page.svelte
@@ -20,3 +20,7 @@
 		}
 	});
 </script>
+
+<main id="main-content" class="sr-only" aria-live="polite">
+	Redirecting…
+</main>


### PR DESCRIPTION
- Remove maximum-scale=1 from viewport meta tag to allow users to zoom (WCAG 1.4.4 Resize Text). The previous value prevented pinch-to-zoom and browser zoom on mobile devices.

- Add a skip-to-content link in app.html that is visually hidden until focused, allowing keyboard and screen reader users to bypass repetitive navigation and jump directly to the main content area (WCAG 2.4.1 Bypass Blocks).

- Wrap AppSidebar in an <aside> landmark and page content in a <main> landmark in the root +layout.svelte, providing proper semantic structure for assistive technologies.

- Wrap Sidebar in a <nav> landmark and page content in a <main> landmark in the (app)/+layout.svelte, ensuring the primary app shell has correct landmark roles for screen reader navigation.

- Replace generic <div> wrappers with <main> landmarks and <div> headings with <h1> elements in +error.svelte and error/+page.svelte for proper heading hierarchy and page structure.

- Add rel='noopener noreferrer' to external links on the error page for security best practices.

- Add alt text to the splash screen loading image for screen reader users.

- Add a visually-hidden loading message on the watch redirect page so screen readers announce the redirect.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
