### PR TITLE
fix: consistent conversation bubble sizes with YAML blocks in widescreen

### DIFF
--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -47,7 +47,7 @@
 
 <div
 	role="listitem"
-	class="flex flex-col justify-between px-5 mb-3 w-full {($settings?.widescreenMode ?? null)
+	class="flex flex-col justify-between px-5 mb-3 w-full min-w-0 {($settings?.widescreenMode ?? null)
 		? 'max-w-full'
 		: 'max-w-5xl'} mx-auto rounded-lg group"
 >


### PR DESCRIPTION
## Description
Fixes #5975

Resolves inconsistent conversation bubble sizing when scrolling in widescreen mode with YAML code blocks.

## Changes
- Added `min-w-0` to message container
- Prevents flex overflow that causes size changes during scroll

## Root Cause
In widescreen mode (`max-w-full`), flex containers without `min-w-0` allow child code blocks to overflow, causing the parent bubble to resize inconsistently during scroll.

## Demo

**Before:**
Conversation bubbles change size when scrolling up/down with YAML blocks

**After:**
Bubble sizes remain stable during scroll

## Testing
```bash
1. Open in widescreen mode (viewport width > max-w-5xl)
2. Paste this YAML: https://github.com/ChatLunaLab/chatluna-character/blob/main/resources/presets/default.yml
3. Send message
4. Scroll up and down
5. Verify: bubble size stays consistent
```

Tested in Chrome/Firefox on 1920×1080 display.