### PR TITLE
feat: crash-safe draft persistence using localStorage

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -150,7 +150,8 @@
 			return;
 		}
 
-		clearChatInputStorage();
+		// Note: chat-input localStorage keys are now intentionally used for crash-safe draft persistence.
+		// Stale drafts are cleaned up by cleanupStaleDrafts() in Chat.svelte instead.
 		await Promise.all([
 			checkLocalDBChats(),
 			setBanners(),


### PR DESCRIPTION
feat: crash-safe draft persistence using localStorage

### What

Switches chat input draft storage from sessionStorage to localStorage so unsent messages survive tab crashes, accidental closures, and browser restarts. Adds a beforeunload handler to flush any pending debounced draft on tab close, and a cleanup routine that removes stale drafts older than 7 days.

### Why

With sessionStorage, any unsent text in the chat input was permanently lost if the tab crashed or was closed. This was frustrating for users composing longer messages. localStorage persists across sessions, making drafts recoverable after unexpected closures.

### Changes

**Chat.svelte**
- Replaced all sessionStorage draft reads/writes with localStorage equivalents
- Added a _savedAt timestamp to each draft entry for expiry-based cleanup
- Added a pendingDraft variable and beforeunload handler to flush the latest keystroke synchronously on tab close
- Added a draftInitialized flag to prevent reactive onChange from overwriting a stored draft with an empty prompt during component initialization
- Added cleanupStaleDrafts routine that removes drafts older than 7 days on mount

**(app)/+layout.svelte**
- Removed clearChatInputStorage() call from onMount — this was a legacy cleanup that wiped all chat-input keys from localStorage on every page load, which conflicts with the new persistence approach. Stale draft cleanup is now handled by cleanupStaleDrafts in Chat.svelte instead.

### **Testing done:**

**Verified and tested across four scenarios:**
- Homepage draft survives full page reload
- Draft clears correctly on message submit
- Existing chat draft survives full page reload
- Cross-chat draft isolation (switching chats does not leak drafts)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
