### PR TITLE
a11y: Enhance accessibility of Note, Channel, and Playground components

### DIFF
--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -413,6 +413,7 @@
 			<PaneResizer
 				class="relative flex items-center justify-center group border-l border-gray-50 dark:border-gray-850/30 hover:border-gray-200 dark:hover:border-gray-800  transition z-20"
 				id="controls-resizer"
+				aria-label={$i18n.t('Resize Panel')}
 			>
 				<div
 					class=" absolute -left-1.5 -right-1.5 -top-0 -bottom-0 z-20 cursor-col-resize bg-transparent"

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -696,6 +696,7 @@
 							>
 								<button
 									class=" bg-white border border-gray-100 dark:border-none dark:bg-white/20 p-1.5 rounded-full pointer-events-auto"
+									aria-label={$i18n.t('Scroll to bottom')}
 									on:click={() => {
 										scrollEnd = true;
 										scrollToBottom();
@@ -793,6 +794,7 @@
 										<div>
 											<button
 												class="flex items-center dark:text-gray-500"
+												aria-label={$i18n.t('Cancel reply')}
 												on:click={() => {
 													replyToMessage = null;
 												}}
@@ -824,6 +826,7 @@
 													<button
 														class=" bg-white text-black border border-white rounded-full group-hover:visible invisible transition"
 														type="button"
+														aria-label={$i18n.t('Remove file')}
 														on:click={() => {
 															files.splice(fileIdx, 1);
 															files = files;
@@ -963,7 +966,7 @@
 													id="input-menu-button"
 													class="bg-transparent hover:bg-white/80 text-gray-800 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5 outline-hidden focus:outline-hidden"
 													type="button"
-													aria-label="More"
+													aria-label={$i18n.t('More Options')}
 												>
 													<svg
 														xmlns="http://www.w3.org/2000/svg"
@@ -1013,8 +1016,7 @@
 													} catch {
 														toast.error($i18n.t('Permission denied when accessing microphone'));
 													}
-												}}
-												aria-label="Voice Input"
+												aria-label={$i18n.t('Voice Input')}
 											>
 												<svg
 													xmlns="http://www.w3.org/2000/svg"
@@ -1037,6 +1039,7 @@
 												<Tooltip content={$i18n.t('Stop')}>
 													<button
 														class="bg-white hover:bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5"
+														aria-label={$i18n.t('Stop')}
 														on:click={() => {
 															onStop();
 														}}
@@ -1064,6 +1067,7 @@
 														class="{content !== '' || files.length !== 0
 															? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
 															: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
+														aria-label={$i18n.t('Send Message')}
 														type="submit"
 														disabled={content === '' && files.length === 0}
 													>

--- a/src/lib/components/channel/MessageInput/MentionList.svelte
+++ b/src/lib/components/channel/MessageInput/MentionList.svelte
@@ -154,6 +154,8 @@
 	<div
 		class="mention-list text-black dark:text-white rounded-2xl shadow-lg border border-gray-200 dark:border-gray-800 flex flex-col bg-white dark:bg-gray-850 w-72 p-1"
 		id="suggestions-container"
+		role="listbox"
+		aria-label={$i18n.t('Suggestions')}
 	>
 		<div class="overflow-y-auto scrollbar-thin max-h-60">
 			{#each filteredItems as item, i}
@@ -172,6 +174,8 @@
 				<Tooltip content={item?.id} placement="top-start">
 					<button
 						type="button"
+						role="option"
+						aria-selected={i === selectedIndex}
 						on:click={() => select(i)}
 						on:mousemove={() => {
 							selectedIndex = i;

--- a/src/lib/components/channel/Messages.svelte
+++ b/src/lib/components/channel/Messages.svelte
@@ -56,7 +56,7 @@
 
 {#if messages}
 	{@const messageList = messages.slice().reverse()}
-	<div>
+	<div aria-live="polite">
 		{#if !top}
 			<Loader
 				on:visible={(e) => {

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -108,7 +108,7 @@
 	>
 		{#if !edit && !disabled}
 			<div
-				class=" absolute {showButtons ? '' : 'invisible group-hover:visible'} right-1 -top-2 z-10"
+				class=" absolute {showButtons ? '' : 'opacity-0 focus-within:opacity-100 group-hover:opacity-100'} right-1 -top-2 z-10"
 			>
 				<div
 					class="flex gap-1 rounded-lg bg-white dark:bg-gray-850 shadow-md p-0.5 border border-gray-100/30 dark:border-gray-850/30"
@@ -124,6 +124,7 @@
 							<Tooltip content={$i18n.t('Add Reaction')}>
 								<button
 									class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-1"
+									aria-label={$i18n.t('Add Reaction')}
 									on:click={() => {
 										showButtons = true;
 									}}
@@ -138,6 +139,7 @@
 						<Tooltip content={$i18n.t('Reply')}>
 							<button
 								class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-0.5"
+								aria-label={$i18n.t('Reply')}
 								on:click={() => {
 									onReply(message);
 								}}
@@ -150,6 +152,7 @@
 					<Tooltip content={message?.is_pinned ? $i18n.t('Unpin') : $i18n.t('Pin')}>
 						<button
 							class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-1"
+							aria-label={message?.is_pinned ? $i18n.t('Unpin') : $i18n.t('Pin')}
 							on:click={() => {
 								onPin(message);
 							}}
@@ -166,6 +169,7 @@
 						<Tooltip content={$i18n.t('Reply in Thread')}>
 							<button
 								class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-1"
+								aria-label={$i18n.t('Reply in Thread')}
 								on:click={() => {
 									onThread(message.id);
 								}}
@@ -180,6 +184,7 @@
 							<Tooltip content={$i18n.t('Edit')}>
 								<button
 									class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-1"
+									aria-label={$i18n.t('Edit')}
 									on:click={() => {
 										edit = true;
 										editedContent = message.content;
@@ -194,6 +199,7 @@
 							<Tooltip content={$i18n.t('Delete')}>
 								<button
 									class="hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg p-1"
+									aria-label={$i18n.t('Delete')}
 									on:click={() => (showDeleteConfirmDialog = true)}
 								>
 									<GarbageBin />
@@ -222,6 +228,7 @@
 
 				<button
 					class="ml-12 flex items-center space-x-2 relative z-0"
+					aria-label={$i18n.t('View replied message')}
 					on:click={() => {
 						const messageElement = document.getElementById(
 							`message-${message.reply_to_message.id}`
@@ -499,11 +506,13 @@
 										}}
 									>
 										<Tooltip content={$i18n.t('Add Reaction')}>
-											<div
+											<button
 												class="flex items-center gap-1.5 bg-gray-500/10 hover:outline hover:outline-gray-700/30 dark:hover:outline-gray-300/30 hover:outline-1 transition rounded-xl px-1 py-1 cursor-pointer text-gray-500 dark:text-gray-400"
+												aria-label={$i18n.t('Add Reaction')}
+												type="button"
 											>
 												<FaceSmile />
-											</div>
+											</button>
 										</Tooltip>
 									</EmojiPicker>
 								{/if}

--- a/src/lib/components/channel/Navbar.svelte
+++ b/src/lib/components/channel/Navbar.svelte
@@ -74,6 +74,7 @@
 						<button
 							id="sidebar-toggle-button"
 							class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition cursor-"
+							aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
 							on:click={() => {
 								showSidebar.set(!$showSidebar);
 							}}
@@ -158,7 +159,7 @@
 					<Tooltip content={$i18n.t('Pinned Messages')}>
 						<button
 							class=" flex cursor-pointer py-1.5 px-1.5 border dark:border-gray-850 border-gray-50 rounded-xl text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-850 transition"
-							aria-label="Pinned Messages"
+							aria-label={$i18n.t('Pinned Messages')}
 							type="button"
 							on:click={() => {
 								showChannelPinnedMessagesModal = true;
@@ -174,7 +175,7 @@
 						<Tooltip content={$i18n.t('Users')}>
 							<button
 								class=" flex cursor-pointer py-1 px-1.5 border dark:border-gray-850 border-gray-50 rounded-xl text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-850 transition"
-								aria-label="User Count"
+								aria-label={$i18n.t('Users')}
 								type="button"
 								on:click={() => {
 									showChannelInfoModal = true;
@@ -205,7 +206,7 @@
 					>
 						<button
 							class="select-none flex rounded-xl p-1.5 w-full hover:bg-gray-50 dark:hover:bg-gray-850 transition"
-							aria-label="User Menu"
+							aria-label={$i18n.t('User Menu')}
 						>
 							<div class=" self-center">
 								<img

--- a/src/lib/components/notes/AIMenu.svelte
+++ b/src/lib/components/notes/AIMenu.svelte
@@ -33,8 +33,8 @@
 			align="end"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
-			<button
-				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+			<DropdownMenu.Item
+				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
 				on:click={async () => {
 					onEdit();
 					show = false;
@@ -44,10 +44,10 @@
 					<Sparkles className="size-4" strokeWidth="2" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Enhance')}</div>
-			</button>
+			</DropdownMenu.Item>
 
-			<button
-				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+			<DropdownMenu.Item
+				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
 				on:click={() => {
 					onChat();
 					show = false;
@@ -57,7 +57,7 @@
 					<ChatBubbleOval className="size-4" strokeWidth="2" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Chat')}</div>
-			</button>
+			</DropdownMenu.Item>
 		</DropdownMenu.Content>
 	</slot>
 </DropdownMenu.Root>

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -941,6 +941,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 								type="text"
 								bind:value={note.title}
 								placeholder={titleGenerating ? $i18n.t('Generating...') : $i18n.t('Title')}
+								aria-label={$i18n.t('Note Title')}
 								disabled={(note?.user_id !== $user?.id && $user?.role !== 'admin') ||
 									titleGenerating}
 								required
@@ -967,6 +968,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 										<button
 											class=" self-center dark:hover:text-white transition"
 											id="generate-title-button"
+											aria-label={$i18n.t('Generate Title')}
 											disabled={(note?.user_id !== $user?.id && $user?.role !== 'admin') ||
 												titleGenerating}
 											on:mouseenter={() => {
@@ -994,6 +996,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 											<div class="flex items-center gap-0.5 self-center min-w-fit" dir="ltr">
 												<button
 													class="self-center p-1 hover:enabled:bg-black/5 dark:hover:enabled:bg-white/5 dark:hover:enabled:text-white hover:enabled:text-black rounded-md transition disabled:cursor-not-allowed disabled:text-gray-500 disabled:hover:text-gray-500"
+													aria-label={$i18n.t('Undo')}
 													on:click={() => {
 														editor.chain().focus().undo().run();
 														// versionNavigateHandler('prev');
@@ -1005,6 +1008,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 
 												<button
 													class="self-center p-1 hover:enabled:bg-black/5 dark:hover:enabled:bg-white/5 dark:hover:enabled:text-white hover:enabled:text-black rounded-md transition disabled:cursor-not-allowed disabled:text-gray-500 disabled:hover:text-gray-500"
+													aria-label={$i18n.t('Redo')}
 													on:click={() => {
 														editor.chain().focus().redo().run();
 														// versionNavigateHandler('next');
@@ -1020,6 +1024,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 									<Tooltip placement="top" content={$i18n.t('Chat')} className="cursor-pointer">
 										<button
 											class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg"
+											aria-label={$i18n.t('Chat')}
 											on:click={() => {
 												if (showPanel && selectedPanel === 'chat') {
 													showPanel = false;
@@ -1038,6 +1043,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 									<Tooltip placement="top" content={$i18n.t('Controls')} className="cursor-pointer">
 										<button
 											class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg"
+											aria-label={$i18n.t('Controls')}
 											on:click={() => {
 												if (showPanel && selectedPanel === 'settings') {
 													showPanel = false;
@@ -1086,9 +1092,13 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 										showDeleteConfirm = true;
 									}}
 								>
-									<div class="p-1 bg-transparent hover:bg-white/5 transition rounded-lg">
+									<button
+										class="p-1 bg-transparent hover:bg-white/5 transition rounded-lg"
+										aria-label={$i18n.t('More Options')}
+										type="button"
+									>
 										<EllipsisHorizontal className="size-5" />
-									</div>
+									</button>
 								</NoteMenu>
 
 								{#if note?.write_access}
@@ -1330,11 +1340,13 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 										selectedPanel = 'chat';
 									}}
 								>
-									<div
+									<button
 										class="cursor-pointer p-2.5 flex rounded-full border border-gray-50 bg-white dark:border-none dark:bg-gray-850 hover:bg-gray-50 dark:hover:bg-gray-800 transition shadow-xl"
+										aria-label={$i18n.t('AI Formatting Options')}
+										type="button"
 									>
 										<SparklesSolid />
-									</div>
+									</button>
 								</AiMenu>
 							{/if}
 						</Tooltip>
@@ -1387,11 +1399,13 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 						}}
 					>
 						<Tooltip content={$i18n.t('Record')} placement="top">
-							<div
+							<button
 								class="cursor-pointer p-2.5 flex rounded-full border border-gray-50 bg-white dark:border-none dark:bg-gray-850 hover:bg-gray-50 dark:hover:bg-gray-800 transition shadow-xl"
+								aria-label={$i18n.t('Record Menu')}
+								type="button"
 							>
 								<MicSolid className="size-4.5" />
-							</div>
+							</button>
 						</Tooltip>
 					</RecordMenu>
 				{/if}

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -329,6 +329,7 @@ Based on the user's instruction, update and enhance the existing notes or select
 	<div class="flex items-center mr-1">
 		<button
 			class="p-0.5 bg-transparent transition rounded-lg"
+			aria-label={$i18n.t('Close Chat')}
 			on:click={() => {
 				show = !show;
 			}}
@@ -420,6 +421,7 @@ Based on the user's instruction, update and enhance the existing notes or select
 								<select
 									class=" bg-transparent rounded-lg py-1 px-2 -mx-0.5 text-sm outline-hidden w-full text-right pr-5"
 									bind:value={selectedModelId}
+									aria-label={$i18n.t('Select a model')}
 								>
 									{#each $models.filter((model) => !(model?.info?.meta?.hidden ?? false)) as model}
 										<option value={model.id} class="bg-gray-50 dark:bg-gray-700"

--- a/src/lib/components/notes/NoteEditor/Controls.svelte
+++ b/src/lib/components/notes/NoteEditor/Controls.svelte
@@ -21,6 +21,7 @@
 	<div class=" mr-1 flex items-center">
 		<button
 			class="p-0.5 bg-transparent transition rounded-lg"
+			aria-label={$i18n.t('Close Controls')}
 			on:click={() => {
 				show = !show;
 			}}
@@ -90,7 +91,11 @@
 		<div class=" text-xs font-medium mb-1">{$i18n.t('Model')}</div>
 
 		<div class="w-full">
-			<select class="w-full bg-transparent text-sm outline-hidden" bind:value={selectedModelId}>
+			<select
+				class="w-full bg-transparent text-sm outline-hidden"
+				bind:value={selectedModelId}
+				aria-label={$i18n.t('Select a model')}
+			>
 				<option value="" class="bg-gray-50 dark:bg-gray-700" disabled>
 					{$i18n.t('Select a model')}
 				</option>

--- a/src/lib/components/notes/NotePanel.svelte
+++ b/src/lib/components/notes/NotePanel.svelte
@@ -80,6 +80,7 @@
 	<PaneResizer
 		class="relative flex items-center justify-center group border-l border-gray-50 dark:border-gray-850/30 hover:border-gray-200 dark:hover:border-gray-800  transition z-20"
 		id="controls-resizer"
+		aria-label={$i18n.t('Resize Panel')}
 	>
 		<div
 			class=" absolute -left-1.5 -right-1.5 -top-0 -bottom-0 z-20 cursor-col-resize bg-transparent"

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -379,12 +379,14 @@
 						class=" w-full text-sm py-1 rounded-r-xl outline-hidden bg-transparent"
 						bind:value={query}
 						placeholder={$i18n.t('Search Notes')}
+						aria-label={$i18n.t('Search Notes')}
 					/>
 
 					{#if query}
 						<div class="self-center pl-1.5 translate-y-[0.5px] rounded-l-xl bg-transparent">
 							<button
 								class="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+								aria-label={$i18n.t('Clear Search')}
 								on:click={() => {
 									query = '';
 								}}
@@ -544,6 +546,7 @@
 																		<button
 																			class="self-center w-fit text-sm p-1 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
 																			type="button"
+																			aria-label={$i18n.t('More Options')}
 																		>
 																			<EllipsisHorizontal className="size-5" />
 																		</button>
@@ -606,6 +609,7 @@
 																		<button
 																			class="self-center w-fit text-sm p-1 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
 																			type="button"
+																			aria-label={$i18n.t('More Options')}
 																		>
 																			<EllipsisHorizontal className="size-5" />
 																		</button>

--- a/src/lib/components/notes/RecordMenu.svelte
+++ b/src/lib/components/notes/RecordMenu.svelte
@@ -40,8 +40,8 @@
 			align="start"
 			transition={(e) => fade(e, { duration: 100 })}
 		>
-			<button
-				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+			<DropdownMenu.Item
+				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
 				on:click={async () => {
 					onRecord();
 					show = false;
@@ -51,10 +51,10 @@
 					<Mic className="size-4" strokeWidth="2" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Record')}</div>
-			</button>
+			</DropdownMenu.Item>
 
-			<button
-				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+			<DropdownMenu.Item
+				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
 				on:click={() => {
 					onCaptureAudio();
 					show = false;
@@ -64,10 +64,10 @@
 					<CursorArrowRays className="size-4" strokeWidth="2" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Capture Audio')}</div>
-			</button>
+			</DropdownMenu.Item>
 
-			<button
-				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition"
+			<DropdownMenu.Item
+				class="flex rounded-md py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
 				on:click={() => {
 					onUpload();
 					show = false;
@@ -77,7 +77,7 @@
 					<CloudArrowUp className="size-4" strokeWidth="2" />
 				</div>
 				<div class=" self-center truncate">{$i18n.t('Upload Audio')}</div>
-			</button>
+			</DropdownMenu.Item>
 		</DropdownMenu.Content>
 	</slot>
 </DropdownMenu.Root>

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -327,7 +327,10 @@
 						{/if}
 
 						<div class="shrink-0">
-							<button class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg">
+							<button
+								class="p-1.5 bg-transparent hover:bg-white/5 transition rounded-lg"
+								aria-label={$i18n.t('Toggle System Instructions')}
+							>
 								{#if showSystem}
 									<ChevronUp className="size-3.5" />
 								{:else}
@@ -344,6 +347,7 @@
 								class="w-full h-full bg-transparent resize-none outline-hidden text-sm"
 								bind:value={system}
 								placeholder={$i18n.t("You're a helpful assistant.")}
+								aria-label={$i18n.t('System Instructions')}
 								on:input={() => {
 									resizeSystemTextarea();
 								}}
@@ -476,6 +480,7 @@
 								<select
 									class=" bg-transparent border border-gray-100/30 dark:border-gray-850/30 rounded-lg py-1 px-2 -mx-0.5 text-sm outline-hidden w-full"
 									bind:value={selectedModelId}
+									aria-label={$i18n.t('Select a model')}
 								>
 									{#each $models as model}
 										<option value={model.id} class="bg-gray-50 dark:bg-gray-700"

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -155,6 +155,7 @@
 							class="w-full h-full p-3 bg-transparent border border-gray-100/30 dark:border-gray-850/30 outline-hidden resize-none rounded-lg text-sm"
 							bind:value={text}
 							placeholder={$i18n.t("You're a helpful assistant.")}
+							aria-label={$i18n.t('Text Completion')}
 						/>
 					</div>
 				</div>

--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -136,6 +136,7 @@
 								{#each generatedImages as image, index}
 									<button
 										class="relative group cursor-pointer"
+										aria-label={$i18n.t('Download Generated Image')}
 										on:click={() => downloadImage(image.url, index)}
 									>
 										<img
@@ -190,6 +191,7 @@
 										<button
 											class=" bg-white text-black border border-white rounded-full group-hover:visible invisible transition"
 											type="button"
+											aria-label={$i18n.t('Remove Image')}
 											on:click={() => removeImage(index)}
 										>
 											<svg
@@ -219,6 +221,9 @@
 							placeholder={sourceImages.length > 0
 								? $i18n.t('Describe the edit...')
 								: $i18n.t('Describe the image...')}
+							aria-label={sourceImages.length > 0
+								? $i18n.t('Describe the edit')
+								: $i18n.t('Describe the image')}
 							on:input={resizePromptTextarea}
 							on:focus={resizePromptTextarea}
 							on:keydown={(e) => {


### PR DESCRIPTION
- Added missing aria-labels to buttons, selects, and textareas.
- Fixed ARIA roles in lists and menus.
- Made hover-only action buttons accessible on focus.
- Converted non-semantic divs to buttons in DropdownMenu and resize handles.


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
