### PR TITLE
feat: convert admin settings menu tabs to native anchor tags for new-tab support

### DIFF
--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -321,15 +321,14 @@
 		<!-- {$i18n.t('Pipelines')} -->
 		<!-- {$i18n.t('Database')} -->
 		{#each filteredSettings as tab (tab.id)}
-			<button
+			<a
 				id={tab.id}
-				class="px-0.5 py-1 min-w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+				href={tab.route}
+				draggable="false"
+				class="px-0.5 py-1 min-w-fit rounded-lg flex-1 lg:flex-none flex text-right transition select-none {selectedTab ===
 				tab.id
 					? ''
 					: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
-				on:click={() => {
-					goto(tab.route);
-				}}
 			>
 				<div class=" self-center mr-2">
 					{#if tab.id === 'general'}
@@ -500,7 +499,7 @@
 					{/if}
 				</div>
 				<div class=" self-center">{$i18n.t(tab.title)}</div>
-			</button>
+			</a>
 		{/each}
 	</div>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: New feature

# Changelog Entry

### Description

- Re-engineered the left-hand navigation sidebar logic within the Admin Settings modal to support fully native browser tab branching configurations when prompted directly natively (e.g., Middle-Clicking to open in a new Tab).

### Added

- Added `href={tab.route}` native web navigation mapping specifically tied onto each independent Settings configuration tab module identically mapped.
- Safely applied identical `draggable="false"` configuration natively across each menu parameter parallel to all previous layout updates specifically preventing ghost-image extraction behaviors flawlessly.

### Changed

- Converted the default Svelte `<button on:click={() => goto(tab.route)}>` side-menu tabs into standard generic `<a href={...}>` anchor components internally tracking dynamically inside `src/lib/components/admin/Settings.svelte`.

### Removed

- Hardcoded click-based route switching overriding native browser tab functions inside of the Settings sidebar routing components exclusively.

---

### Additional Information

- **Context**: Relying exclusively on Svelte `goto(route)` inside a native `<button>` element locks specific navigation components out of core native browser actions like opening in a new tab strictly via middle-click or right-click options. Modifying these structural components natively inside `Settings.svelte` to standard HTML anchor tags equipped gracefully with identical layout protections globally resolves this inherently effectively mapping identical parity safely upstream locally.

### Screenshots or Videos

### Before

<img width="381" height="513" alt="image" src="https://github.com/user-attachments/assets/318e2a13-5ecf-4e22-bba5-0d9ddee8e30b" />

### After

<img width="379" height="603" alt="image" src="https://github.com/user-attachments/assets/e3cc0934-ce33-41df-8ade-905639cd95e2" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.