### PR TITLE
fix: conditionally hide user status emojis based on global enable_user_status feature flag config

### DIFF
--- a/src/lib/components/channel/Messages/Message/UserStatus.svelte
+++ b/src/lib/components/channel/Messages/Message/UserStatus.svelte
@@ -3,7 +3,7 @@
 
 	const i18n = getContext('i18n');
 
-	import { user as _user, channels, socket } from '$lib/stores';
+	import { user as _user, channels, socket, config } from '$lib/stores';
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 	import { getChannels, getDMChannelByUserId } from '$lib/apis/channels';
 
@@ -73,7 +73,7 @@
 			</div>
 		</div>
 
-		{#if user?.status_emoji || user?.status_message}
+		{#if (user?.status_emoji || user?.status_message) && ($config?.features?.enable_user_status ?? true)}
 			<div class="mx-2 mt-2">
 				<Tooltip content={user?.status_message}>
 					<div

--- a/src/lib/components/layout/Sidebar/ChannelItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelItem.svelte
@@ -4,7 +4,7 @@
 	const i18n = getContext('i18n');
 
 	import { page } from '$app/stores';
-	import { channels, mobile, showSidebar, user } from '$lib/stores';
+	import { channels, mobile, showSidebar, user, config } from '$lib/stores';
 	import { getUserActiveStatusById } from '$lib/apis/users';
 	import { updateChannelById, updateChannelMemberActiveStatusById } from '$lib/apis/channels';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
@@ -170,7 +170,7 @@
 					{#if channel?.users?.length === 2}
 						{@const dmUser = channel.users.find((u) => u.id !== $user?.id)}
 
-						{#if dmUser?.status_emoji || dmUser?.status_message}
+						{#if (dmUser?.status_emoji || dmUser?.status_message) && ($config?.features?.enable_user_status ?? true)}
 							<span class="flex gap-1.5 line-clamp-1">
 								{#if dmUser?.status_emoji}
 									<div class=" self-center shrink-0">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed a visual persistence bug where user status emojis would incorrectly remain rendered inside the profile modal hover preview component (`UserStatus.svelte`) even when user statuses were globally disabled via settings or environment variables (`ENABLE_USER_STATUS=false`).

### Added

- Appended `$config?.features?.enable_user_status` conditional wrapping correctly encapsulating the entire emoji container layout explicitly.
- Imported the global `config` user preferences layout store precisely inside `src/lib/components/channel/Messages/Message/UserStatus.svelte` correctly enabling environment variable validation parsing safely.

### Fixed

- Solved the emoji isolation bypass bug internally exposing user status widgets regardless of configuration parameters natively on `UserList.svelte` hover profiles gracefully.

---

### Additional Information

- **Context**: The `UserStatus.svelte` module previously only evaluated the presence of `user?.status_emoji` or `user?.status_message` inside its internal HTML markup conditional branches without cross-referencing `$config?.features?.enable_user_status` explicitly. This resulted in the status payload conditionally hiding text if stripped serverside natively by configurations overriding it internally, yet continuing to generate empty ghost emoji blocks due to the payload conditionally clearing improperly locally when text drops natively. Adding the explicit condition ensures synchronicity indefinitely.

### Screenshots or Videos

### Before

<img width="446" height="278" alt="image" src="https://github.com/user-attachments/assets/b9589a37-d65c-47c4-8235-8ffd5658ccf5" />

<img width="221" height="189" alt="image" src="https://github.com/user-attachments/assets/5dcc53e2-ef0d-47bd-9a44-8592bb7ce41f" />

<img width="1739" height="96" alt="image" src="https://github.com/user-attachments/assets/0ad5f04d-055c-4565-9371-acd6063da5fc" />


### After

<img width="446" height="278" alt="image" src="https://github.com/user-attachments/assets/b3ead4fa-e630-41a3-b87b-a2d0bb649bf6" />

<img width="221" height="189" alt="image" src="https://github.com/user-attachments/assets/f269c29c-6142-4e2c-a393-710ed24e9424" />

<img width="1739" height="96" alt="image" src="https://github.com/user-attachments/assets/f5b5e2c4-f78c-463a-b49d-7b2c951e87e4" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.