### PR TITLE
feat: update admin users and evaluations sidebars to leverage native anchor tags for robust new-tab link capabilities

### DIFF
--- a/src/lib/components/admin/Evaluations.svelte
+++ b/src/lib/components/admin/Evaluations.svelte
@@ -54,15 +54,14 @@
 			id="users-tabs-container"
 			class="tabs mx-[16px] lg:mx-0 lg:px-[16px] flex flex-row overflow-x-auto gap-2.5 max-w-full lg:gap-1 lg:flex-col lg:flex-none lg:w-50 dark:text-gray-200 text-sm font-medium text-left scrollbar-none"
 		>
-			<button
+			<a
 				id="leaderboard"
-				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
+				href="/admin/evaluations/leaderboard"
+				draggable="false"
+				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition select-none {selectedTab ===
 				'leaderboard'
 					? ''
 					: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
-				on:click={() => {
-					goto('/admin/evaluations/leaderboard');
-				}}
 			>
 				<div class=" self-center mr-2">
 					<svg
@@ -79,17 +78,16 @@
 					</svg>
 				</div>
 				<div class=" self-center">{$i18n.t('Leaderboard')}</div>
-			</button>
+			</a>
 
-			<button
+			<a
 				id="feedback"
-				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
+				href="/admin/evaluations/feedback"
+				draggable="false"
+				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition select-none {selectedTab ===
 				'feedback'
 					? ''
 					: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
-				on:click={() => {
-					goto('/admin/evaluations/feedback');
-				}}
 			>
 				<div class=" self-center mr-2">
 					<svg
@@ -106,7 +104,7 @@
 					</svg>
 				</div>
 				<div class=" self-center">{$i18n.t('Feedback')}</div>
-			</button>
+			</a>
 		</div>
 
 		<div class="flex-1 mt-1 lg:mt-0 px-[16px] lg:pr-[16px] lg:pl-0 overflow-y-scroll">

--- a/src/lib/components/admin/Users.svelte
+++ b/src/lib/components/admin/Users.svelte
@@ -60,15 +60,14 @@
 		id="users-tabs-container"
 		class="mx-[16px] lg:mx-0 lg:px-[16px] flex flex-row overflow-x-auto gap-2.5 max-w-full lg:gap-1 lg:flex-col lg:flex-none lg:w-50 dark:text-gray-200 text-sm font-medium text-left scrollbar-none"
 	>
-		<button
+		<a
 			id="overview"
-			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
+			href="/admin/users/overview"
+			draggable="false"
+			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition select-none {selectedTab ===
 			'overview'
 				? ''
 				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
-			on:click={() => {
-				goto('/admin/users/overview');
-			}}
 		>
 			<div class=" self-center mr-2">
 				<svg
@@ -83,17 +82,16 @@
 				</svg>
 			</div>
 			<div class=" self-center">{$i18n.t('Overview')}</div>
-		</button>
+		</a>
 
-		<button
+		<a
 			id="groups"
-			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
+			href="/admin/users/groups"
+			draggable="false"
+			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition select-none {selectedTab ===
 			'groups'
 				? ''
 				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
-			on:click={() => {
-				goto('/admin/users/groups');
-			}}
 		>
 			<div class=" self-center mr-2">
 				<svg
@@ -108,7 +106,7 @@
 				</svg>
 			</div>
 			<div class=" self-center">{$i18n.t('Groups')}</div>
-		</button>
+		</a>
 	</div>
 
 	<div class="flex-1 mt-1 lg:mt-0 px-[16px] lg:pr-[16px] lg:pl-0 overflow-y-scroll">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: New feature

# Changelog Entry

### Description

- Upgraded the `Users` and `Evaluations` sidebar navigation components inside the Administration panel to inherently support native browser new-tab actions securely (such as middle-clicking to open in a background tab natively). 

### Added

- Inserted standard component `<a href...>` navigation mappings correctly tracking `evaluations` and `users` route tabs internally across both elements precisely targeting their respective endpoints.
- Preserved drag safeguards seamlessly mapping `draggable="false"` accompanied by `class="... select-none"` identical to previous iteration templates across the rest of the Admin routes natively.

### Changed

- Converted `<button>` components driving Single-Page-Application routing exclusively via `goto(route)` interactions into robust HTML5 native anchors identically structured identically parsing inside `src/lib/components/admin/Evaluations.svelte` and `src/lib/components/admin/Users.svelte`.

### Removed

- Redundant pure UI `button` overrides previously suppressing local native HTML capabilities.

---

### Additional Information

- **Context**: Just like the `admin/Settings.svelte` navigation pane addressed earlier, the sub-tabs governing the `Users` view (Overview vs Groups) and `Evaluations` views (Leaderboard vs Feedback) were rendering inside `on:click` bound `<button>` nodes blocking normal interaction commands via mouse. Adjusting them to natively route through `<a href...>` standard elements explicitly allows native mechanisms uninterrupted.

- Related PR: https://github.com/open-webui/open-webui/pull/21721

### Screenshots or Videos

### Before

<img width="383" height="559" alt="image" src="https://github.com/user-attachments/assets/59a3e60e-bea8-4050-9e36-8ef6a28241ee" />

<img width="377" height="556" alt="image" src="https://github.com/user-attachments/assets/e016b3c2-27ec-4334-9784-a1dcf83d74b1" />

### After

<img width="383" height="559" alt="image" src="https://github.com/user-attachments/assets/b95c65bf-65d6-4079-933e-d303b691f90c" />

<img width="380" height="561" alt="image" src="https://github.com/user-attachments/assets/288875d5-2657-4ea8-b8cc-b9b576bd9cc2" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.