### PR TITLE
fix: prevent avatar alt-text overlap on failed image loads in Firefox browser

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -349,6 +349,9 @@
 											src="{WEBUI_API_BASE_URL}/models/model/profile/image?id={model.model_id}"
 											alt={model.name}
 											class="size-5 rounded-full object-cover shrink-0"
+											on:error={(e) => {
+												e.target.src = '/favicon.png';
+											}}
 										/>
 										<span class="truncate max-w-[150px]">{model.name}</span>
 									</div>
@@ -435,6 +438,9 @@
 											src="{WEBUI_API_BASE_URL}/users/{user.user_id}/profile/image"
 											alt={user.name || 'User'}
 											class="size-5 rounded-full object-cover shrink-0"
+											on:error={(e) => {
+												e.target.src = '/user.png';
+											}}
 										/>
 										<span class="truncate max-w-[150px]"
 											>{user.name || user.email || user.user_id.substring(0, 8)}</span

--- a/src/lib/components/admin/Analytics/ModelUsage.svelte
+++ b/src/lib/components/admin/Analytics/ModelUsage.svelte
@@ -130,7 +130,10 @@
 								<img
 									src="{WEBUI_API_BASE_URL}/models/model/profile/image?id={model.model_id}"
 									alt={model.name}
-									class="size-5 rounded-full object-cover"
+									class="size-5 rounded-full object-cover shrink-0"
+									on:error={(e) => {
+										e.target.src = '/favicon.png';
+									}}
 								/>
 								<span class="font-medium text-gray-800 dark:text-gray-200">{model.name}</span>
 							</div>

--- a/src/lib/components/admin/Evaluations/Leaderboard.svelte
+++ b/src/lib/components/admin/Evaluations/Leaderboard.svelte
@@ -180,7 +180,10 @@
 								<img
 									src="{WEBUI_API_BASE_URL}/models/model/profile/image?id={model.id}"
 									alt={model.name}
-									class="size-5 rounded-full object-cover"
+									class="size-5 rounded-full object-cover shrink-0"
+									on:error={(e) => {
+										e.target.src = '/favicon.png';
+									}}
 								/>
 								<Tooltip content={`${model.name} (${model.id})`} placement="top-start">
 									<span class="font-medium text-gray-800 dark:text-gray-200 line-clamp-1"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed a visual bug on Firefox where broken model or user avatar images caused their alt text to awkwardly overflow and overlap adjacent labels on the Analytics and Leaderboard pages.

### Added

- Added `on:error` handlers to `<img />` tags for models and users natively rendering default fallback profile icons whenever avatars fail specifically inside `Dashboard.svelte`, `ModelUsage.svelte` and `Leaderboard.svelte`.

### Fixed

- Fixed an issue where the `alt` text of a failed image load would overflow its container in Firefox.

---

### Additional Information

- **Context**: When an image fails to load, Firefox displays the `alt` text. Because the avatar container is small, this text overflows and overlaps adjacent elements. Adding an `on:error` handler to load a fallback image (the Open WebUI favicon or user icon) prevents this from happening.

### Screenshots or Videos

### Before

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/cc70e531-071e-4445-a85b-c3c5d4c5c3e9" />

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/e9871896-b5d9-4f87-93ce-711ee0df65c0" />

### After

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/77f0e8d4-ad6d-4b36-9557-4e4517f8283c" />

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/59fcc16d-50d6-4b0d-bc4e-babd453d7600" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.