### PR TITLE
fix: deduplicate RAG content injection when builtin tools execute

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -347,7 +347,7 @@ def make_reference_sources(sources: list) -> list:
         reference_sources.append({
             **source,
             "document": [
-                "(Content provided in tool response above)"
+                "The full content of this source is provided in the tool call response."
                 for _ in source.get("document", [""])
             ],
         })


### PR DESCRIPTION
Fixes: https://github.com/open-webui/open-webui/issues/21726

fix: deduplicate RAG content injection when builtin tools execute

When builtin tools (view_knowledge_file, query_knowledge_files, search_web, fetch_url) execute during a chat, the model receives the same content multiple times:

- With file context OFF: content appears 2x (post-tool RAG source injection into the user/system message + tool result message)
- With file context ON: content appears up to 3x (initial RAG injection + post-tool RAG injection + tool result message)

The fix addresses duplication via two mechanisms while preserving both citation functionality and agentic tool compatibility:

1. Reference-only RAG injection: After a tool call, the post-tool RAG source tags carry only the source ID and name for citation mapping, not the full content (which is already in the tool result message). This preserves the [1], [2] citation format while avoiding content duplication.

2. Source deduplication: After the initial RAG pass (when file context is enabled), all injected source/file IDs are tracked. When tools return citation sources already present from the initial pass, they are filtered out before post-tool RAG injection. Newly injected sources are tracked for subsequent tool call rounds.

Additionally, the repeated inline list of citation tool names is extracted into a module-level CITATION_TOOL_NAMES constant, and the repeated source ID collection logic is extracted into a collect_source_ids helper function.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
