### PR TITLE
fix: model fallback routing for all model types and default model selection

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1705,8 +1705,10 @@ async def chat_completion(
                         default_models[0].strip() if default_models[0] else None
                     )
 
-                    if fallback_model_id:
-                        request.base_model_id = fallback_model_id
+                    if fallback_model_id and fallback_model_id in request.app.state.MODELS:
+                        # Update model and form_data so routing uses the fallback model's type
+                        model = request.app.state.MODELS[fallback_model_id]
+                        form_data["model"] = fallback_model_id
                     else:
                         raise Exception("Model not found")
                 else:

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1032,12 +1032,13 @@
 		if (selectedModels.length === 0 || (selectedModels.length === 1 && selectedModels[0] === '')) {
 			if (availableModels.length > 0) {
 				if (defaultModels && defaultModels.length > 0) {
-					// Set from default models
 					selectedModels = defaultModels.filter((modelId) => availableModels.includes(modelId));
 				}
 
-				// Set to first available model
-				selectedModels = [availableModels?.at(0) ?? ''];
+				if (selectedModels.length === 0 || (selectedModels.length === 1 && selectedModels[0] === '')) {
+					// Only fall back to first available model if default models didn't resolve
+					selectedModels = [availableModels?.at(0) ?? ''];
+				}
 			} else {
 				selectedModels = [''];
 			}


### PR DESCRIPTION
fix: model fallback routing for all model types and default model selection

<ins>**Fixes a bug where you'd get model not found errors despite using the enable custom model fallback, because if the default model to fallback to was configured to be, for example, a pipe - then this pipe would not be found when falling back because it would only check in the connection's available models.**</ins>

Backend: When ENABLE_CUSTOM_MODEL_FALLBACK is active and a custom model's base model is unavailable, the fallback now swaps the model and form data to the configured default model directly. This ensures routing uses the fallback model's type (pipe, Ollama, or OpenAI) instead of the original model's type, which previously caused "Model not found" errors when the fallback was a different backend type.

Frontend: Fixed default model selection in new chat initialization where the admin-configured default models were always overwritten by the first available model. The first-available fallback now only triggers when the configured defaults don't resolve to valid available models.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
