### PR TITLE
fix: drop unique index on tag(id) to fix duplicate-key errors

### DIFF
--- a/backend/open_webui/migrations/versions/c8d4e5f6a7b8_drop_tag_id_unique_index.py
+++ b/backend/open_webui/migrations/versions/c8d4e5f6a7b8_drop_tag_id_unique_index.py
@@ -1,0 +1,53 @@
+"""Drop unique index on tag(id) if it exists
+
+The tag table uses a composite PK (id, user_id). A leftover unique index on
+tag.id alone (from the original schema) can cause duplicate-key errors when
+different users create tags with the same name. This migration drops any such
+index if it exists.
+
+Fixes: #21737
+
+Revision ID: c8d4e5f6a7b8
+Revises: a5c220713937
+Create Date: 2025-02-22 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d4e5f6a7b8"
+down_revision: Union[str, None] = "a5c220713937"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    if "tag" not in inspector.get_table_names():
+        return
+
+    indexes = inspector.get_indexes("tag")
+    for idx in indexes:
+        # Look for unique indexes on "id" alone (conflicts with composite PK)
+        if not idx.get("unique"):
+            continue
+        columns = idx.get("column_names") or []
+        if columns == ["id"]:
+            index_name = idx.get("name")
+            if index_name:
+                with op.batch_alter_table("tag", schema=None) as batch_op:
+                    try:
+                        batch_op.drop_index(index_name)
+                    except Exception:
+                        pass  # Index may not exist or have different name
+
+
+def downgrade() -> None:
+    # No-op: we don't recreate the problematic index
+    pass


### PR DESCRIPTION
# fix: drop unique index on tag(id) to fix duplicate-key errors

## Summary

Fixes #21737

Drops any leftover unique index on `tag.id` alone that conflicts with the composite primary key `(id, user_id)`. In some upgrade paths or database engines, a unique index on `id` alone can persist from the original schema and cause `UNIQUE constraint failed: tag.id` (SQLite) or equivalent errors when multiple users create tags with the same name.

## Changes

- Add migration `c8d4e5f6a7b8_drop_tag_id_unique_index.py` that inspects the tag table and drops any unique index on `id` alone if it exists
- Migration is idempotent and safe: only drops indexes that match the problematic pattern
- No downgrade (intentional: we don't recreate the problematic index)

## Testing

- Migration runs without error on databases that don't have the problematic index
- On affected databases, the unique index on `tag.id` is dropped, resolving duplicate-key errors when different users create tags with the same name

## Checklist

- [x] Follows project coding standards (matches existing migration style)
- [x] References related issue (#21737)
- [x] Clear, descriptive commit message
