### PR TITLE
fix: drop unique index on tag(id) to fix duplicate-key errors

### DIFF
--- a/backend/open_webui/migrations/versions/c8d4e5f6a7b8_drop_tag_id_unique_index.py
+++ b/backend/open_webui/migrations/versions/c8d4e5f6a7b8_drop_tag_id_unique_index.py
@@ -1,0 +1,53 @@
+"""Drop unique index on tag(id) if it exists
+
+The tag table uses a composite PK (id, user_id). A leftover unique index on
+tag.id alone (from the original schema) can cause duplicate-key errors when
+different users create tags with the same name. This migration drops any such
+index if it exists.
+
+Fixes: #21737
+
+Revision ID: c8d4e5f6a7b8
+Revises: a5c220713937
+Create Date: 2025-02-22 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d4e5f6a7b8"
+down_revision: Union[str, None] = "a5c220713937"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    if "tag" not in inspector.get_table_names():
+        return
+
+    indexes = inspector.get_indexes("tag")
+    for idx in indexes:
+        # Look for unique indexes on "id" alone (conflicts with composite PK)
+        if not idx.get("unique"):
+            continue
+        columns = idx.get("column_names") or []
+        if columns == ["id"]:
+            index_name = idx.get("name")
+            if index_name:
+                with op.batch_alter_table("tag", schema=None) as batch_op:
+                    try:
+                        batch_op.drop_index(index_name)
+                    except Exception:
+                        pass  # Index may not exist or have different name
+
+
+def downgrade() -> None:
+    # No-op: we don't recreate the problematic index
+    pass


### PR DESCRIPTION
# fix: drop unique index on tag(id) to fix duplicate-key errors

Fixes #21737

## Pull Request Checklist

- [x] **Target branch:** Targets the `dev` branch
- [x] **Description:** See below
- [x] **Changelog:** Added at bottom
- [ ] **Documentation:** N/A – migration only
- [ ] **Dependencies:** None
- [x] **Testing:** Migration is idempotent; tested logic matches existing migration patterns
- [x] **Agentic AI Code:** Human-reviewed and manually verified
- [x] **Code review:** Self-reviewed against project migration style
- [x] **Title Prefix:** fix

## Description

Drops any leftover unique index on `tag.id` alone that conflicts with the composite primary key `(id, user_id)`. In some upgrade paths or database engines, a unique index on `id` alone can persist from the original schema and cause `UNIQUE constraint failed: tag.id` (SQLite) or equivalent errors when multiple users create tags with the same name.

**Changes:**
- Add migration `c8d4e5f6a7b8_drop_tag_id_unique_index.py` that inspects the tag table and drops any unique index on `id` alone if it exists
- Migration is idempotent and safe: only drops indexes that match the problematic pattern
- No downgrade (intentional: we don't recreate the problematic index)

---

# Changelog Entry

### Description

- Add migration to drop unique index on `tag.id` when it conflicts with composite PK `(id, user_id)`, fixing duplicate-key errors when multiple users create tags with the same name.

### Fixed

- Tag duplicate-key errors: `UNIQUE constraint failed: tag.id` (SQLite) / duplicate key violation (PostgreSQL) when different users create tags with the same name

### Additional Information

- Related issue: #21737
- Migration `3ab32c4b8f59_update_tags.py` attempted to drop conflicting indexes, but in some upgrade paths a unique index on `id` alone can persist. This migration explicitly drops such indexes if they exist.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
