### PR TITLE
fix: prevent scroll jumping when deleting message pair after stopping generation

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -403,12 +403,12 @@
 			newCurrentId = rootIds.length > 0 ? rootIds[rootIds.length - 1] : null;
 		}
 		// Walk to deepest child
+		const getDeepestChildId = (id) => {
+			const childIds = history.messages[id]?.childrenIds ?? [];
+			return childIds.length > 0 ? getDeepestChildId(childIds.at(-1)) : id;
+		};
 		if (newCurrentId !== null) {
-			let childIds = history.messages[newCurrentId]?.childrenIds ?? [];
-			while (childIds.length > 0) {
-				newCurrentId = childIds[childIds.length - 1];
-				childIds = history.messages[newCurrentId]?.childrenIds ?? [];
-			}
+			newCurrentId = getDeepestChildId(newCurrentId);
 		}
 		history.currentId = newCurrentId;
 


### PR DESCRIPTION
fix: prevent scroll jumping when deleting message pair after stopping generation

Replaced the showMessage call in deleteMessage with inline computation of the new currentId. The showMessage function was triggering scrollIntoView and a redundant saveChatHandler call, which caused competing scroll operations and wild visual jumping when deleting a message pair — especially after stopping generation.

**TESTED LOCALLY**

**WORKED**

**This bug existed for at least 1 year.**

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
