### PR TITLE
feat: add LOG_FORMAT=json for structured JSON logging

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -59,7 +59,9 @@ def run_migrations():
         from alembic import command
         from alembic.config import Config
 
-        alembic_cfg = Config(OPEN_WEBUI_DIR / "alembic.ini")
+        alembic_cfg = Config(
+            OPEN_WEBUI_DIR / "alembic.ini", configure_logger=False
+        )
 
         # Set the script location dynamically
         migrations_path = OPEN_WEBUI_DIR / "migrations"

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -5,6 +5,9 @@ import os
 import pkgutil
 import sys
 import shutil
+import traceback
+from datetime import datetime, timezone
+from typing import Any
 from uuid import uuid4
 from pathlib import Path
 from cryptography.hazmat.primitives import serialization
@@ -72,9 +75,51 @@ except Exception:
 # LOGGING
 ####################################
 
+_LEVEL_MAP = {
+    "DEBUG": "debug",
+    "INFO": "info",
+    "WARNING": "warn",
+    "ERROR": "error",
+    "CRITICAL": "fatal",
+}
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as single-line JSON objects for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(
+                timespec="milliseconds"
+            ),
+            "level": _LEVEL_MAP.get(record.levelname, record.levelname.lower()),
+            "msg": record.getMessage(),
+            "caller": record.name,
+        }
+
+        if record.exc_info and record.exc_info[0] is not None:
+            log_entry["error"] = "".join(
+                traceback.format_exception(*record.exc_info)
+            ).rstrip()
+        elif record.exc_text:
+            log_entry["error"] = record.exc_text
+
+        if record.stack_info:
+            log_entry["stacktrace"] = record.stack_info
+
+        return json.dumps(log_entry, ensure_ascii=False, default=str)
+
+
+LOG_FORMAT = os.environ.get("LOG_FORMAT", "").lower()
+
 GLOBAL_LOG_LEVEL = os.environ.get("GLOBAL_LOG_LEVEL", "").upper()
 if GLOBAL_LOG_LEVEL in logging.getLevelNamesMapping():
-    logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL, force=True)
+    if LOG_FORMAT == "json":
+        _handler = logging.StreamHandler(sys.stdout)
+        _handler.setFormatter(JSONFormatter())
+        logging.basicConfig(handlers=[_handler], level=GLOBAL_LOG_LEVEL, force=True)
+    else:
+        logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL, force=True)
 else:
     GLOBAL_LOG_LEVEL = "INFO"
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -498,6 +498,7 @@ from open_webui.env import (
     WEBUI_ADMIN_PASSWORD,
     WEBUI_ADMIN_NAME,
     ENABLE_EASTER_EGGS,
+    LOG_FORMAT,
 )
 
 
@@ -576,7 +577,8 @@ class SPAStaticFiles(StaticFiles):
                 raise ex
 
 
-print(rf"""
+if LOG_FORMAT != "json":
+    print(rf"""
  ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
 ██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
 ██║   ██║██████╔╝█████╗  ██╔██╗ ██║    ██║ █╗ ██║█████╗  ██████╔╝██║   ██║██║

--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -12,13 +12,15 @@ from open_webui.env import (
     AUDIT_LOG_FILE_ROTATION_SIZE,
     AUDIT_LOG_LEVEL,
     GLOBAL_LOG_LEVEL,
+    LOG_FORMAT,
     AUDIT_UVICORN_LOGGER_NAMES,
     ENABLE_OTEL,
     ENABLE_OTEL_LOGS,
+    _LEVEL_MAP,
 )
 
 if TYPE_CHECKING:
-    from loguru import Record
+    from loguru import Message, Record
 
 
 def stdout_format(record: "Record") -> str:
@@ -41,6 +43,31 @@ def stdout_format(record: "Record") -> str:
         "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
         "<level>{message}</level>" + extra_format + "\n{exception}"
     )
+
+
+def _json_sink(message: "Message") -> None:
+    """Write log records as single-line JSON to stdout.
+
+    Used as a Loguru sink when LOG_FORMAT is set to "json".
+    """
+    record = message.record
+    log_entry = {
+        "ts": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "level": _LEVEL_MAP.get(record["level"].name, record["level"].name.lower()),
+        "msg": record["message"],
+        "caller": f"{record['name']}:{record['function']}:{record['line']}",
+    }
+
+    if record["extra"]:
+        log_entry["extra"] = record["extra"]
+
+    if record["exception"] is not None:
+        log_entry["error"] = "".join(
+            record["exception"].format_exception()
+        ).rstrip()
+
+    sys.stdout.write(json.dumps(log_entry, ensure_ascii=False, default=str) + "\n")
+    sys.stdout.flush()
 
 
 class InterceptHandler(logging.Handler):
@@ -127,14 +154,22 @@ def start_logger():
     """
     logger.remove()
 
-    logger.add(
-        sys.stdout,
-        level=GLOBAL_LOG_LEVEL,
-        format=stdout_format,
-        filter=lambda record: (
-            "auditable" not in record["extra"] if ENABLE_AUDIT_STDOUT else True
-        ),
+    audit_filter = lambda record: (
+        "auditable" not in record["extra"] if ENABLE_AUDIT_STDOUT else True
     )
+    if LOG_FORMAT == "json":
+        logger.add(
+            _json_sink,
+            level=GLOBAL_LOG_LEVEL,
+            filter=audit_filter,
+        )
+    else:
+        logger.add(
+            sys.stdout,
+            level=GLOBAL_LOG_LEVEL,
+            format=stdout_format,
+            filter=audit_filter,
+        )
     if AUDIT_LOG_LEVEL != "NONE" and ENABLE_AUDIT_LOGS_FILE:
         try:
             logger.add(


### PR DESCRIPTION
## Summary

- Add `LOG_FORMAT` environment variable — set to `json` to switch all stdout logging to single-line JSON
- Covers both early startup logging (stdlib `basicConfig`) and runtime logging (Loguru sink)
- Prevent alembic from reconfiguring logging during migrations (`configure_logger=False`)
- Suppress ASCII banner when JSON logging is active to keep log stream parseable

## JSON log fields

| Field | Description |
|---|---|
| `ts` | ISO 8601 timestamp with milliseconds (UTC) |
| `level` | `debug`, `info`, `warn`, `error`, `fatal` |
| `msg` | Log message |
| `caller` | Logger name (early) or `module:function:line` (Loguru) |
| `extra` | Loguru extra context (when present) |
| `error` | Exception traceback (when present) |
| `stacktrace` | Stack info (when present) |

## Example output

```json
{"ts": "2026-02-22T19:41:27.285Z", "level": "info", "msg": "GLOBAL_LOG_LEVEL: INFO", "caller": "open_webui.utils.logger:start_logger:160"}
```

## Motivation

Structured JSON logs are essential for log aggregation systems (Loki, Fluentd, CloudWatch, Datadog). Without this, users must resort to fragile regex-based parsing or mount patched files into the container.