### PR TITLE
fix: honor ENABLE_AUDIT_STDOUT for stdout audit logging

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -133,7 +133,7 @@ def start_logger():
         level=GLOBAL_LOG_LEVEL,
         format=stdout_format,
         filter=lambda record: (
-            "auditable" not in record["extra"] if ENABLE_AUDIT_STDOUT else True
+            True if ENABLE_AUDIT_STDOUT else "auditable" not in record["extra"]
         ),
     )
     if AUDIT_LOG_LEVEL != "NONE" and ENABLE_AUDIT_LOGS_FILE:


### PR DESCRIPTION
ENABLE_AUDIT_STDOUT was effectively inverted in the stdout logger filter.

Expected: true should include audit logs on stdout.
Actual: true excluded auditable entries.

This change flips the condition so stdout behavior matches the changelog note about routing audit logs to container logs.

Reference: CHANGELOG.md entry about ENABLE_AUDIT_STDOUT and ENABLE_AUDIT_LOGS_FILE.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.