### PR TITLE
fix: honor ENABLE_AUDIT_STDOUT for stdout audit logging

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -153,7 +153,7 @@ def start_logger():
     logger.remove()
 
     audit_filter = lambda record: (
-        "auditable" not in record["extra"] if ENABLE_AUDIT_STDOUT else True
+        True if ENABLE_AUDIT_STDOUT else "auditable" not in record["extra"]
     )
     if LOG_FORMAT == "json":
         logger.add(


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** Added below.
- [x] **Changelog:** Included below in Keep a Changelog style.
- [x] **Testing:** Manually verified the logger behavior for `ENABLE_AUDIT_STDOUT=true/false`.
- [x] **Agentic AI Code:** Changes were reviewed and tested manually.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Fixes inverted stdout filter behavior for audit logs.

### Added

- None.

### Changed

- Adjusted stdout filter logic in `backend/open_webui/utils/logger.py`.

### Deprecated

- None.

### Removed

- None.

### Fixed

- `ENABLE_AUDIT_STDOUT=true` now includes audit logs on stdout as intended.
- `ENABLE_AUDIT_STDOUT=false` continues to keep audit logs off stdout.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- This aligns runtime behavior with the changelog entry about `ENABLE_AUDIT_STDOUT` and `ENABLE_AUDIT_LOGS_FILE` for container log collection.

### Screenshots or Videos

- N/A (backend logger filter fix).

### Contributor License Agreement

contributor license agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
