### PR TITLE
fix(retrieval): append web URL chunks when overwrite is false

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1971,6 +1971,7 @@ async def process_web(
                     docs,
                     collection_name,
                     overwrite=overwrite,
+                    add=(not overwrite),
                     user=user,
                 )
             else:

--- a/backend/open_webui/test/apps/webui/routers/test_retrieval_process_web.py
+++ b/backend/open_webui/test/apps/webui/routers/test_retrieval_process_web.py
@@ -1,0 +1,92 @@
+import types
+
+import pytest
+from langchain_core.documents import Document
+
+from open_webui.routers import retrieval
+
+
+@pytest.mark.asyncio
+async def test_process_web_sets_add_true_when_overwrite_false(monkeypatch):
+    captured = {}
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        if func is retrieval.get_content_from_url:
+            return "content", [Document(page_content="hello", metadata={})]
+
+        if func is retrieval.save_docs_to_vector_db:
+            captured["kwargs"] = kwargs
+            return True
+
+        raise AssertionError(f"Unexpected function passed to run_in_threadpool: {func}")
+
+    monkeypatch.setattr(retrieval, "run_in_threadpool", fake_run_in_threadpool)
+
+    request = types.SimpleNamespace(
+        app=types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                config=types.SimpleNamespace(
+                    BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=False
+                )
+            )
+        )
+    )
+    form_data = retrieval.ProcessUrlForm(
+        url="https://example.com", collection_name="test-collection"
+    )
+    user = types.SimpleNamespace(id="user-1")
+
+    response = await retrieval.process_web(
+        request=request,
+        form_data=form_data,
+        process=True,
+        overwrite=False,
+        user=user,
+    )
+
+    assert response["status"] is True
+    assert captured["kwargs"]["overwrite"] is False
+    assert captured["kwargs"]["add"] is True
+
+
+@pytest.mark.asyncio
+async def test_process_web_keeps_add_false_when_overwrite_true(monkeypatch):
+    captured = {}
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        if func is retrieval.get_content_from_url:
+            return "content", [Document(page_content="hello", metadata={})]
+
+        if func is retrieval.save_docs_to_vector_db:
+            captured["kwargs"] = kwargs
+            return True
+
+        raise AssertionError(f"Unexpected function passed to run_in_threadpool: {func}")
+
+    monkeypatch.setattr(retrieval, "run_in_threadpool", fake_run_in_threadpool)
+
+    request = types.SimpleNamespace(
+        app=types.SimpleNamespace(
+            state=types.SimpleNamespace(
+                config=types.SimpleNamespace(
+                    BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=False
+                )
+            )
+        )
+    )
+    form_data = retrieval.ProcessUrlForm(
+        url="https://example.com", collection_name="test-collection"
+    )
+    user = types.SimpleNamespace(id="user-1")
+
+    response = await retrieval.process_web(
+        request=request,
+        form_data=form_data,
+        process=True,
+        overwrite=True,
+        user=user,
+    )
+
+    assert response["status"] is True
+    assert captured["kwargs"]["overwrite"] is True
+    assert captured["kwargs"]["add"] is False

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -331,7 +331,8 @@ export const processWeb = async (
 	token: string,
 	collection_name: string,
 	url: string,
-	process: boolean = true
+	process: boolean = true,
+	overwrite: boolean = true
 ) => {
 	let error = null;
 
@@ -339,6 +340,9 @@ export const processWeb = async (
 
 	if (!process) {
 		searchParams.append('process', 'false');
+	}
+	if (!overwrite) {
+		searchParams.append('overwrite', 'false');
 	}
 
 	const res = await fetch(`${RETRIEVAL_API_BASE_URL}/process/web?${searchParams.toString()}`, {


### PR DESCRIPTION
The new "overwrite=False" option that was introduced in commit 4bef69c did not adjust the default "add=False" argument for `save_docs_to_vector_db`. That resulted in many log messages of this kind:

"open_webui.routers.retrieval:save_docs_to_vector_db:1570 - collection 5d23d90a-f7fe-4be3-aec4-63139731b251 already exists, overwrite is False and add is False"

Effectively, this caused an early exit from the method and now URL-content actually being added to the knowledge base.

This commit simply sets "add=True" when "overwrite == False". Also adds tests.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [X] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [X] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixes a regression where POST /api/v1/retrieval/process/web with overwrite=false did not append URL content to an existing collection and instead returned early without inserting vectors.
- Exposes the overwrite option in the frontend processWeb API helper so callers can explicitly control overwrite vs append behavior.

### Changed

- Updated backend /process/web flow to pass add=(not overwrite) into save_docs_to_vector_db.
- Updated frontend processWeb(...) helper signature to accept an overwrite parameter (default true) and forward overwrite=false as a query param.

### Fixed

- Fixed incorrect no-op behavior when processing web URLs into an existing collection with overwrite=false.
- Eliminates the "overwrite is False and add is False" path for this API flow when overwrite is intentionally disabled.

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
