### PR TITLE
fix: harden distributed lock lifecycle with atomic Lua scripts and resilient retry

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -203,47 +203,54 @@ async def periodic_session_pool_cleanup():
 
 
 async def periodic_usage_pool_cleanup():
-    max_retries = 2
     retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
-    for attempt in range(max_retries + 1):
-        if aquire_func():
-            break
-        else:
-            if attempt < max_retries:
-                log.debug('Cleanup lock already exists. Retry %s after %ss...', attempt + 1, retry_delay)
-                await asyncio.sleep(retry_delay)
-            else:
-                log.warning('Failed to acquire cleanup lock after retries. Skipping cleanup.')
-                return
+    while True:
+        # A Redis error must not kill the task: treat it as "lock not held" and retry.
+        try:
+            acquired = aquire_func()
+        except Exception:
+            log.exception('Cleanup lock acquisition error; will retry')
+            acquired = False
 
-    log.debug('Running periodic_cleanup')
-    try:
-        while True:
-            if not renew_func():
-                log.error('Unable to renew cleanup lock. Exiting usage pool cleanup.')
-                raise Exception('Unable to renew usage pool cleanup lock.')
+        if not acquired:
+            log.debug('Cleanup lock held by another node. Retrying.')
+            await asyncio.sleep(retry_delay)
+            continue
 
-            now = int(time.time())
-            for model_id, connections in list(USAGE_POOL.items()):
-                # Creating a list of sids to remove if they have timed out
-                expired_sids = [
-                    sid for sid, details in connections.items() if now - details['updated_at'] > TIMEOUT_DURATION
-                ]
+        log.debug('Running periodic_cleanup')
+        try:
+            while True:
+                try:
+                    renewed = renew_func()
+                except Exception:
+                    log.exception('Cleanup lock renewal error; will re-acquire')
+                    renewed = False
 
-                if connections and not expired_sids:
-                    continue
+                if not renewed:
+                    log.warning('Unable to renew cleanup lock. Retrying cleanup ownership.')
+                    break
 
-                for sid in expired_sids:
-                    del connections[sid]
+                now = int(time.time())
+                for model_id, connections in list(USAGE_POOL.items()):
+                    # Creating a list of sids to remove if they have timed out
+                    expired_sids = [
+                        sid for sid, details in connections.items() if now - details['updated_at'] > TIMEOUT_DURATION
+                    ]
 
-                if not connections:
-                    log.debug('Cleaning up model %s from usage pool', model_id)
-                    del USAGE_POOL[model_id]
-                else:
-                    USAGE_POOL[model_id] = connections
-            await asyncio.sleep(TIMEOUT_DURATION)
-    finally:
-        release_func()
+                    if connections and not expired_sids:
+                        continue
+
+                    for sid in expired_sids:
+                        del connections[sid]
+
+                    if not connections:
+                        log.debug('Cleaning up model %s from usage pool', model_id)
+                        del USAGE_POOL[model_id]
+                    else:
+                        USAGE_POOL[model_id] = connections
+                await asyncio.sleep(TIMEOUT_DURATION)
+        finally:
+            release_func()
 
 
 app = socketio.ASGIApp(

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -203,47 +203,56 @@ async def periodic_session_pool_cleanup():
 
 
 async def periodic_usage_pool_cleanup():
-    max_retries = 2
     retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
-    for attempt in range(max_retries + 1):
-        if aquire_func():
-            break
-        else:
-            if attempt < max_retries:
-                log.debug(f'Cleanup lock already exists. Retry {attempt + 1} after {retry_delay}s...')
-                await asyncio.sleep(retry_delay)
-            else:
-                log.warning('Failed to acquire cleanup lock after retries. Skipping cleanup.')
-                return
+    while True:
+        # A Redis error must not kill the task: treat it as "lock not held" and retry.
+        try:
+            acquired = aquire_func()
+        except Exception:
+            log.exception('Cleanup lock acquisition error; will retry')
+            acquired = False
 
-    log.debug('Running periodic_cleanup')
-    try:
-        while True:
-            if not renew_func():
-                log.error('Unable to renew cleanup lock. Exiting usage pool cleanup.')
-                raise Exception('Unable to renew usage pool cleanup lock.')
+        if not acquired:
+            log.debug('Cleanup lock held by another node. Retrying.')
+            await asyncio.sleep(retry_delay)
+            continue
 
-            now = int(time.time())
-            for model_id, connections in list(USAGE_POOL.items()):
-                # Creating a list of sids to remove if they have timed out
-                expired_sids = [
-                    sid for sid, details in connections.items() if now - details['updated_at'] > TIMEOUT_DURATION
-                ]
+        log.debug('Running periodic_cleanup')
+        try:
+            while True:
+                try:
+                    renewed = renew_func()
+                except Exception:
+                    log.exception('Cleanup lock renewal error; will re-acquire')
+                    renewed = False
 
-                if connections and not expired_sids:
-                    continue
+                if not renewed:
+                    log.warning('Unable to renew cleanup lock. Retrying cleanup ownership.')
+                    break
 
-                for sid in expired_sids:
-                    del connections[sid]
+                now = int(time.time())
+                for model_id, connections in list(USAGE_POOL.items()):
+                    # Creating a list of sids to remove if they have timed out
+                    expired_sids = [
+                        sid
+                        for sid, details in connections.items()
+                        if now - details['updated_at'] > TIMEOUT_DURATION
+                    ]
 
-                if not connections:
-                    log.debug(f'Cleaning up model {model_id} from usage pool')
-                    del USAGE_POOL[model_id]
-                else:
-                    USAGE_POOL[model_id] = connections
-            await asyncio.sleep(TIMEOUT_DURATION)
-    finally:
-        release_func()
+                    if connections and not expired_sids:
+                        continue
+
+                    for sid in expired_sids:
+                        del connections[sid]
+
+                    if not connections:
+                        log.debug(f'Cleaning up model {model_id} from usage pool')
+                        del USAGE_POOL[model_id]
+                    else:
+                        USAGE_POOL[model_id] = connections
+                await asyncio.sleep(TIMEOUT_DURATION)
+        finally:
+            release_func()
 
 
 app = socketio.ASGIApp(


### PR DESCRIPTION
`periodic_usage_pool_cleanup` in `backend/open_webui/socket/main.py` gives up permanently on any distributed-lock trouble, so on multi-instance Redis deployments the usage pool can stop being reaped for the entire lifetime of a worker process.

Three separate ways it dies:

1. **Acquisition gives up after 3 attempts.** The `for attempt in range(max_retries + 1)` loop `return`s once the lock is held by another node three times in a row. Under startup contention every instance but one can lose the race, and those instances never try again.
2. **Renewal failure is fatal.** `raise Exception('Unable to renew usage pool cleanup lock.')` propagates out of the task instead of releasing and re-acquiring, so a single expired lock ends cleanup permanently.
3. **Redis errors are unguarded.** Neither `aquire_func()` nor `renew_func()` is wrapped, so a connection reset, failover, or idle socket timeout raises rather than returning falsy — killing the task the same way.

The consequence is a silent leak: `USAGE_POOL` entries for disconnected sessions are never expired, models keep reporting phantom active connections, and the only recovery is a process restart.

`periodic_session_pool_cleanup`, directly above it in the same module, already has the correct shape — retry acquisition indefinitely, break out of the work loop and re-acquire on renewal failure. This change brings the usage-pool loop in line with it and additionally treats an exception from either lock call as "lock not held", so transient Redis faults degrade into a retry instead of terminating the task.

Deployments without `REDIS_URL` are unaffected: `aquire_func` / `renew_func` are the `lambda: True` no-ops on that path, so neither the retry ceiling nor the exception path was ever reachable.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
