### PR TITLE
fix/chore: add missing hr separators between section groups in user settings

### DIFF
--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -178,6 +178,7 @@
 	<div class=" space-y-3 overflow-y-scroll max-h-[28rem] md:max-h-full">
 		<div>
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('STT Settings')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			{#if $config.audio.stt.engine !== 'web'}
 				<div class=" py-0.5 flex w-full justify-between">
@@ -242,6 +243,7 @@
 
 		<div>
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('TTS Settings')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div class=" py-0.5 flex w-full justify-between">
 				<div class=" self-center text-xs font-medium">{$i18n.t('Text-to-Speech Engine')}</div>
@@ -315,12 +317,11 @@
 			</div>
 		</div>
 
-		<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
 		{#if TTSEngine === 'browser-kokoro'}
 			{#if TTSModel}
 				<div>
 					<div class=" mb-2.5 text-sm font-medium">{$i18n.t('Set Voice')}</div>
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 					<div class="flex w-full">
 						<div class="flex-1">
 							<input
@@ -360,6 +361,7 @@
 		{:else if $config.audio.tts.engine === ''}
 			<div>
 				<div class=" mb-2.5 text-sm font-medium">{$i18n.t('Set Voice')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 				<div class="flex w-full">
 					<div class="flex-1">
 						<select
@@ -391,6 +393,7 @@
 		{:else if $config.audio.tts.engine !== ''}
 			<div>
 				<div class=" mb-2.5 text-sm font-medium">{$i18n.t('Set Voice')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 				<div class="flex w-full">
 					<div class="flex-1">
 						<input

--- a/src/lib/components/chat/Settings/DataControls.svelte
+++ b/src/lib/components/chat/Settings/DataControls.svelte
@@ -176,6 +176,7 @@
 
 		<div>
 			<div class="mb-1 text-sm font-medium">{$i18n.t('Chats')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class="py-0.5 flex w-full justify-between">
@@ -272,6 +273,7 @@
 
 		<div>
 			<div class="mb-1 text-sm font-medium">{$i18n.t('Files')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class="py-0.5 flex w-full justify-between">

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -198,6 +198,7 @@
 	<div class="  overflow-y-scroll max-h-[28rem] md:max-h-full">
 		<div class="">
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div class="flex w-full justify-between">
 				<div class=" self-center text-xs font-medium">{$i18n.t('Theme')}</div>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -332,6 +332,7 @@
 	<div class=" space-y-3 overflow-y-scroll max-h-[28rem] md:max-h-full">
 		<div>
 			<h1 class=" mb-2 text-sm font-medium">{$i18n.t('UI')}</h1>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class="py-0.5 flex w-full justify-between">
@@ -586,7 +587,8 @@
 				</div>
 			{/if}
 
-			<div class=" my-2 text-sm font-medium">{$i18n.t('Chat')}</div>
+		<div class=" my-2 text-sm font-medium">{$i18n.t('Chat')}</div>
+			<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">
@@ -1096,6 +1098,7 @@
 			</div>
 
 			<div class=" my-2 text-sm font-medium">{$i18n.t('Input')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">
@@ -1220,6 +1223,7 @@
 			</div>
 
 			<div class=" my-2 text-sm font-medium">{$i18n.t('Artifacts')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">
@@ -1279,6 +1283,7 @@
 			</div>
 
 			<div class=" my-2 text-sm font-medium">{$i18n.t('Voice')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">
@@ -1319,6 +1324,7 @@
 			</div>
 
 			<div class=" my-2 text-sm font-medium">{$i18n.t('File')}</div>
+				<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. *(No new dependencies.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes. *(UI-only change, no architecture impact.)*
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** `style: add missing section separator lines in user settings panels`

# Changelog Entry

### Description

Several user-facing settings panels were missing `<hr>` separator lines beneath their top-level section headers, making it harder to visually distinguish setting categories at a glance. This is a pure visual consistency fix — no settings logic or behavior is changed.

The canonical separator pattern already in use throughout the codebase (e.g. `General.svelte`, admin `Documents.svelte`, `Connections.svelte`) was applied uniformly to the affected tabs.

### Changed

- `Interface.svelte` — added `<hr>` beneath the **UI**, **Chat**, **Input**, **Artifacts**, **Voice**, and **File** section headers (6 separators added; none previously existed)
- `Audio.svelte` — added `<hr>` beneath the **STT Settings**, **TTS Settings**, and **Set Voice** section headers (moved the pre-existing Set Voice separator from above the header to below it to match the established pattern)
- `DataControls.svelte` — added `<hr>` beneath the **Chats** and **Files** section headers
- `General.svelte` — added `<hr>` beneath the **WebUI Settings** section header

---

### Additional Information

- The separator element used throughout is `<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />`, consistent with the rest of the codebase.
- The `About.svelte` tab was intentionally left untouched — its layout is informational rather than settings-based, and its existing upstream separator placement was already appropriate.
- No admin settings files were modified; those panels already use separators consistently throughout.

### Screenshots or Videos

### Before

`General.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/14f03b36-0cfd-41a6-a4d3-7f3179b97065" />

`Interface.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/f855db88-d524-47a0-9e49-bcce74fccb70" />

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/6a4348d3-14c3-47e4-821c-6c5ef0c167e7" />

 `Audio.svelte` 

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/1f802830-d74f-4429-a16a-abab48ac1fd6" />

`DataControls.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/1f1e7913-d956-4ee8-922b-30442a6a1f19" />

### After

`General.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/8919570f-6b51-4828-82d1-778e9a1b8e47" />

`Interface.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/723d61c3-559d-4d02-a722-54b8dd92bdb0" />

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/ac5a6c11-c2ed-417f-be96-e7adf08d9e1a" />

 `Audio.svelte` 

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/00416556-13d6-44d4-b9d5-e1edfc38c559" />

`DataControls.svelte`

<img width="1374" height="770" alt="image" src="https://github.com/user-attachments/assets/deed3120-ef04-4446-b770-dcfef3e25ab2" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.