### PR TITLE
fix: detect WebGPU availability via requestAdapter() and surface Kokoro.js load errors in UI

### DIFF
--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -125,9 +125,9 @@
 	const onTTSEngineChange = async () => {
 		if (TTSEngine === 'browser-kokoro') {
 			if (!(await isWebGPUAvailable())) {
-				toast.warning(
+				toast.info(
 					$i18n.t(
-						'Kokoro.js (Browser) requires WebGPU, which is not available in your browser. Enable WebGPU support or use a Chromium-based browser.'
+						'WebGPU is not available in your browser. Kokoro.js will use the WASM backend instead, which is slower. Consider enabling WebGPU or using a quantized dtype (q8, q4) for better performance.'
 					)
 				);
 			}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. *(No docs currently needed — this is a bug fix for existing behaviour.)*
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. *(No new dependencies.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes. *(No new settings added. Error state is handled via ephemeral toast.)*
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** `fix(audio): detect WebGPU availability via requestAdapter() and surface Kokoro.js load errors in UI`

# Changelog Entry

### Description

Selecting **Kokoro.js (Browser)** as the Text-to-Speech engine in the Audio settings had two silent failure modes:

1. **False-positive WebGPU detection** — The code checked `!!navigator?.gpu` to decide whether to use `'webgpu'` as the inference device. In Firefox and other browsers with partial WebGPU support, `navigator.gpu` can exist but `requestAdapter()` returns `null`. Kokoro.js then throws `"no available backend found. ERR: [webgpu] Error: Failed to get GPU adapter"` with no feedback to the user.

2. **Stuck loading state** — If `KokoroTTS.from_pretrained` threw for any reason, `TTSModelLoading` was never reset and the loading spinner stayed visible indefinitely with no error message shown.

**Reproduction (before this fix):**
1. Open user settings → Audio tab in Firefox (WebGPU not enabled by default)
2. Set *Text-to-Speech Engine* to *Kokoro.js (Browser)*
3. Select a *Kokoro.js Dtype* — model starts downloading and may complete at 100%
4. The browser console shows `Uncaught (in promise) Error: no available backend found` with no toast or UI update

### Added

- `isWebGPUAvailable()` — async helper that calls `navigator.gpu.requestAdapter()` and returns `false` if the adapter is `null` or the call throws. Used to reliably distinguish browsers where WebGPU is present but non-functional.

### Changed

- `onTTSEngineChange`: when Kokoro.js is selected, `isWebGPUAvailable()` is now awaited before `loadKokoro()`. If it returns `false`, a `toast.warning` fires immediately advising the user to enable WebGPU or switch to a Chromium-based browser.
- `loadKokoro`: device selection now uses the result of `isWebGPUAvailable()` instead of `!!navigator?.gpu`.
- `loadKokoro`: `KokoroTTS.from_pretrained` is now wrapped in try/catch. On failure: `TTSModel`, `TTSModelProgress`, and `TTSModelLoading` are all reset and a `toast.error` shows the error message.
- `{:else if TTSModelLoading}` (template): the loading spinner branch now only renders when `TTSModelLoading` is `true`. Previously the `{:else}` branch would render the spinner whenever `TTSModel` was `null`, including after a failed load.

### Fixed

- Kokoro.js (Browser) no longer silently crashes on Firefox and other browsers where WebGPU is unavailable
- Loading spinner no longer stays visible indefinitely after a failed model load

---

### Additional Information

- The `navigator.gpu` TypeScript type error is a pre-existing issue in the codebase (WebGPU types are not included in the project's `lib.dom.d.ts`). It does not affect runtime behaviour.
- On browsers where WebGPU is fully available (e.g. Chrome/Edge with default settings), behaviour is unchanged — the probe succeeds, no warning is shown, and the model loads as before.

### Screenshots or Videos

### Before: silent spinner.

<img width="1354" height="763" alt="image" src="https://github.com/user-attachments/assets/4bfb0f96-5030-4fe9-ada3-793239e783ad" />

### After: immediate `toast.warning` on engine selection, `toast.error` with the thrown message if load fails regardless of browser.)*

<img width="2331" height="1270" alt="image" src="https://github.com/user-attachments/assets/91ba34e0-8137-491b-bde4-1453f3b88389" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.