### PR TITLE
enh.: Move citation-only RAG prompt to system prompt to prevent tool call hallucination

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -430,7 +430,7 @@ ENABLE_REALTIME_CHAT_SAVE = (
 
 ENABLE_QUERIES_CACHE = os.environ.get("ENABLE_QUERIES_CACHE", "False").lower() == "true"
 
-RAG_SYSTEM_CONTEXT = os.environ.get("RAG_SYSTEM_CONTEXT", "True").lower() == "true"
+RAG_SYSTEM_CONTEXT = os.environ.get("RAG_SYSTEM_CONTEXT", "False").lower() == "true"
 
 ####################################
 # REDIS

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -430,7 +430,7 @@ ENABLE_REALTIME_CHAT_SAVE = (
 
 ENABLE_QUERIES_CACHE = os.environ.get("ENABLE_QUERIES_CACHE", "False").lower() == "true"
 
-RAG_SYSTEM_CONTEXT = os.environ.get("RAG_SYSTEM_CONTEXT", "False").lower() == "true"
+RAG_SYSTEM_CONTEXT = os.environ.get("RAG_SYSTEM_CONTEXT", "True").lower() == "true"
 
 ####################################
 # REDIS

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -128,7 +128,6 @@ from open_webui.env import (
     BYPASS_MODEL_ACCESS_CONTROL,
     ENABLE_REALTIME_CHAT_SAVE,
     ENABLE_QUERIES_CACHE,
-    RAG_SYSTEM_CONTEXT,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     FORWARD_SESSION_INFO_HEADER_CHAT_ID,
     FORWARD_SESSION_INFO_HEADER_MESSAGE_ID,
@@ -862,22 +861,13 @@ def apply_source_context_to_messages(
     if not context_string:
         return messages
 
-    if RAG_SYSTEM_CONTEXT:
-        return add_or_update_system_message(
-            rag_template(
-                request.app.state.config.RAG_TEMPLATE, context_string, user_message
-            ),
-            messages,
-            append=True,
-        )
-    else:
-        return add_or_update_user_message(
-            rag_template(
-                request.app.state.config.RAG_TEMPLATE, context_string, user_message
-            ),
-            messages,
-            append=False,
-        )
+    return add_or_update_system_message(
+        rag_template(
+            request.app.state.config.RAG_TEMPLATE, context_string, user_message
+        ),
+        messages,
+        append=True,
+    )
 
 
 def process_tool_result(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -128,6 +128,7 @@ from open_webui.env import (
     BYPASS_MODEL_ACCESS_CONTROL,
     ENABLE_REALTIME_CHAT_SAVE,
     ENABLE_QUERIES_CACHE,
+    RAG_SYSTEM_CONTEXT,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     FORWARD_SESSION_INFO_HEADER_CHAT_ID,
     FORWARD_SESSION_INFO_HEADER_MESSAGE_ID,
@@ -861,13 +862,22 @@ def apply_source_context_to_messages(
     if not context_string:
         return messages
 
-    return add_or_update_system_message(
-        rag_template(
-            request.app.state.config.RAG_TEMPLATE, context_string, user_message
-        ),
-        messages,
-        append=True,
-    )
+    if RAG_SYSTEM_CONTEXT:
+        return add_or_update_system_message(
+            rag_template(
+                request.app.state.config.RAG_TEMPLATE, context_string, user_message
+            ),
+            messages,
+            append=True,
+        )
+    else:
+        return add_or_update_user_message(
+            rag_template(
+                request.app.state.config.RAG_TEMPLATE, context_string, user_message
+            ),
+            messages,
+            append=False,
+        )
 
 
 def process_tool_result(


### PR DESCRIPTION
apply_source_context_to_messages: When include_content=False (citation-only context from native tool calls like search_web, fetch_url), always append the RAG template to the system prompt instead of the user message. This prevents models from hallucinating the RAG template text into tool call arguments — a problem observed across multiple models (GLM-5, Kimi 2.5, Qwen 3.5, etc.) during native tool calling. Full document context (uploaded files, include_content=True) still respects the RAG_SYSTEM_CONTEXT env var as before.

Tool call loop: Save and restore the original system message content before each re-apply of apply_source_context_to_messages, mirroring the existing user message save/restore. Without this, the RAG template would accumulate in the system message on each tool call iteration — the same class of double-injection bug reported in #21780.

Fixes #21780

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
