### PR TITLE
fix: sharing modal not showing users when access_grants missing from stored config

### DIFF
--- a/backend/open_webui/utils/access_control.py
+++ b/backend/open_webui/utils/access_control.py
@@ -66,6 +66,11 @@ def get_permissions(
     # Ensure all fields from default_permissions are present and filled in
     permissions = fill_missing_permissions(permissions, default_permissions)
 
+    # Also fill from the hardcoded defaults so that newly added permission keys
+    # (e.g. access_grants) are present even when the stored runtime config
+    # predates the code change that introduced them.
+    permissions = fill_missing_permissions(permissions, DEFAULT_USER_PERMISSIONS)
+
     return permissions
 
 

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -64,6 +64,7 @@
 			permissions = {
 				workspace: { ...DEFAULT_PERMISSIONS.workspace, ...loadedPermissions.workspace },
 				sharing: { ...DEFAULT_PERMISSIONS.sharing, ...loadedPermissions.sharing },
+				access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...loadedPermissions.access_grants },
 				chat: { ...DEFAULT_PERMISSIONS.chat, ...loadedPermissions.chat },
 				features: { ...DEFAULT_PERMISSIONS.features, ...loadedPermissions.features },
 				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings }

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -21,6 +21,7 @@
 			...obj,
 			workspace: { ...defaults.workspace, ...obj.workspace },
 			sharing: { ...defaults.sharing, ...obj.sharing },
+			access_grants: { ...defaults.access_grants, ...obj.access_grants },
 			chat: { ...defaults.chat, ...obj.chat },
 			features: { ...defaults.features, ...obj.features },
 			settings: { ...defaults.settings, ...obj.settings }


### PR DESCRIPTION
## Summary
- Fix sharing modal not showing user-to-user sharing options for non-admin users after the `access_grants` permission feature was introduced
- Root cause: the new `access_grants` permission section was missing from three places that enumerate permission keys — backend `get_permissions()` fallback, `EditGroupModal.init()` merge, and `Permissions.svelte` `fillMissingProperties()`
- When `USER_PERMISSIONS` was saved to the DB before `access_grants` existed, the stored config lacked the key, causing `$user.permissions.access_grants` to be `undefined` and `shareUsers` to evaluate to `false`

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
