### PR TITLE
feat: add Umami analytics integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ FORWARDED_ALLOW_IPS='*'
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Umami analytics (frontend tracking)
+# Script is enabled only when UMAMI_WEBSITE_ID is set.
+# UMAMI_DOMAIN defaults to Umami Cloud if not provided.
+UMAMI_DOMAIN='https://cloud.umami.is'
+UMAMI_WEBSITE_ID=''

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -3,19 +3,19 @@ import json
 import logging
 import os
 import pkgutil
-import sys
+import re
 import shutil
+import sys
 import traceback
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from pathlib import Path
-from cryptography.hazmat.primitives import serialization
-import re
-
 
 import markdown
 from bs4 import BeautifulSoup
+from cryptography.hazmat.primitives import serialization
+
 from open_webui.constants import ERROR_MESSAGES
 
 ####################################
@@ -137,6 +137,9 @@ if WEBUI_NAME != "Open WebUI":
     WEBUI_NAME += " (Open WebUI)"
 
 WEBUI_FAVICON_URL = "https://openwebui.com/favicon.png"
+
+UMAMI_DOMAIN = os.environ.get("UMAMI_DOMAIN", "https://cloud.umami.is")
+UMAMI_WEBSITE_ID = os.environ.get("UMAMI_WEBSITE_ID", "")
 
 TRUSTED_SIGNATURE_KEY = os.environ.get("TRUSTED_SIGNATURE_KEY", "")
 
@@ -646,11 +649,13 @@ LICENSE_PUBLIC_KEY = os.environ.get("LICENSE_PUBLIC_KEY", "")
 
 pk = None
 if LICENSE_PUBLIC_KEY:
-    pk = serialization.load_pem_public_key(f"""
+    pk = serialization.load_pem_public_key(
+        f"""
 -----BEGIN PUBLIC KEY-----
 {LICENSE_PUBLIC_KEY}
 -----END PUBLIC KEY-----
-""".encode("utf-8"))
+""".encode("utf-8")
+    )
 
 
 ####################################

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,16 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
+	interface Window {
+		umami?: {
+			track: (eventName?: string | Record<string, unknown>, data?: Record<string, unknown>) => void;
+			identify: (
+				idOrData: string | Record<string, unknown>,
+				data?: Record<string, unknown>
+			) => void;
+		};
+	}
+
 	namespace App {
 		// interface Error {}
 		// interface Locals {}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -57,6 +57,7 @@
 		isYoutubeUrl
 	} from '$lib/utils';
 	import { AudioQueue } from '$lib/utils/audio';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	import {
 		createNewChat,
@@ -1769,6 +1770,15 @@
 
 		saveSessionSelectedModels();
 
+		trackUmamiEvent('message_sent', {
+			flow: 'chat',
+			surface: 'chat_input',
+			trigger: 'submit',
+			model_count: selectedModels.length,
+			has_files: _files.length > 0,
+			temporary_chat: $temporaryChatEnabled
+		});
+
 		await sendMessage(history, userMessageId, { newChat: true });
 	};
 
@@ -2323,6 +2333,13 @@
 				scrollToBottom();
 			}
 
+			trackUmamiEvent('message_regenerated', {
+				flow: 'chat',
+				surface: 'messages',
+				trigger: 'click',
+				has_suggestion_prompt: Boolean(suggestionPrompt)
+			});
+
 			await sendMessage(history, userMessage.id, {
 				...(suggestionPrompt
 					? {
@@ -2445,6 +2462,15 @@
 				$selectedFolder?.id
 			);
 
+			trackUmamiEvent('chat_created', {
+				flow: 'chat',
+				surface: 'chat_input',
+				trigger: 'submit',
+				model_count: selectedModels.length,
+				has_files: (chatFiles?.length ?? 0) > 0,
+				temporary_chat: false
+			});
+
 			_chatId = chat.id;
 			await chatId.set(_chatId);
 
@@ -2459,6 +2485,13 @@
 		} else {
 			_chatId = `local:${$socket?.id}`; // Use socket id for temporary chat
 			await chatId.set(_chatId);
+			trackUmamiEvent('chat_created', {
+				flow: 'chat',
+				surface: 'chat_input',
+				trigger: 'submit',
+				model_count: selectedModels.length,
+				temporary_chat: true
+			});
 		}
 		await tick();
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -56,6 +56,7 @@
 	import { getTools } from '$lib/apis/tools';
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	import { createNoteHandler } from '../notes/utils';
 	import { getSuggestionRenderer } from '../common/RichTextInput/suggestions';
@@ -616,6 +617,15 @@
 					fileItem.content_type = uploadedFile.meta?.content_type || uploadedFile.content_type;
 					fileItem.url = `${uploadedFile.id}`;
 
+					trackUmamiEvent('file_upload_added', {
+						flow: 'chat',
+						surface: 'message_input',
+						trigger: 'upload_complete',
+						source: 'file_picker',
+						file_type: file.type || 'unknown',
+						temporary_chat: false
+					});
+
 					files = files;
 				} else {
 					files = files.filter((item) => item?.itemId !== tempItemId);
@@ -649,6 +659,15 @@
 				fileItem.type = 'text';
 				fileItem.content = content;
 				fileItem.id = uuidv4(); // Temporary ID for the file
+
+				trackUmamiEvent('file_upload_added', {
+					flow: 'chat',
+					surface: 'message_input',
+					trigger: 'upload_complete',
+					source: 'file_picker',
+					file_type: file.type || 'unknown',
+					temporary_chat: true
+				});
 
 				files = files;
 			}
@@ -752,6 +771,15 @@
 								url: imageUrl
 							}
 						];
+
+						trackUmamiEvent('file_upload_added', {
+							flow: 'chat',
+							surface: 'message_input',
+							trigger: 'upload_complete',
+							source: 'file_picker',
+							file_type: file.type || 'image',
+							temporary_chat: true
+						});
 					} else {
 						const blob = await (await fetch(imageUrl)).blob();
 						const compressedFile = new File([blob], file.name, { type: file.type });

--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -5,6 +5,7 @@
 	import { toast } from 'svelte-sonner';
 	import { deleteSharedChatById, getChatById, shareChatById } from '$lib/apis/chats';
 	import { copyToClipboard } from '$lib/utils';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	import Modal from '../common/Modal.svelte';
 	import Link from '../icons/Link.svelte';
@@ -21,6 +22,11 @@
 
 		const sharedChat = await shareChatById(localStorage.token, chatId);
 		shareUrl = `${window.location.origin}/s/${sharedChat.id}`;
+		trackUmamiEvent('chat_share_link_created', {
+			flow: 'chat',
+			surface: 'share_modal',
+			trigger: 'click'
+		});
 		console.log(shareUrl);
 		chat = await getChatById(localStorage.token, chatId);
 

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -8,6 +8,7 @@
 
 	import { downloadChatAsPDF } from '$lib/apis/utils';
 	import { copyToClipboard, createMessagesList } from '$lib/utils';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	import {
 		showOverview,
@@ -71,6 +72,12 @@
 		});
 
 		saveAs(blob, `chat-${chat.chat.title}.txt`);
+		trackUmamiEvent('chat_exported', {
+			flow: 'chat',
+			surface: 'chat_menu',
+			trigger: 'click',
+			format: 'txt'
+		});
 	};
 
 	const downloadPdf = async () => {
@@ -174,6 +181,12 @@
 					}
 
 					pdf.save(`chat-${chat.chat.title}.pdf`);
+					trackUmamiEvent('chat_exported', {
+						flow: 'chat',
+						surface: 'chat_menu',
+						trigger: 'click',
+						format: 'pdf'
+					});
 
 					showFullMessages = false;
 				} catch (error) {
@@ -226,6 +239,12 @@
 			}
 
 			doc.save(`chat-${chat.chat.title}.pdf`);
+			trackUmamiEvent('chat_exported', {
+				flow: 'chat',
+				surface: 'chat_menu',
+				trigger: 'click',
+				format: 'pdf'
+			});
 		}
 	};
 
@@ -243,6 +262,12 @@
 				type: 'application/json'
 			});
 			saveAs(blob, `chat-export-${Date.now()}.json`);
+			trackUmamiEvent('chat_exported', {
+				flow: 'chat',
+				surface: 'chat_menu',
+				trigger: 'click',
+				format: 'json'
+			});
 		}
 	};
 </script>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -29,6 +29,7 @@
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import { updateUserStatus } from '$lib/apis/users';
 	import { toast } from 'svelte-sonner';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	const i18n = getContext('i18n');
 
@@ -345,6 +346,12 @@
 			<DropdownMenu.Item
 				class="flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer select-none"
 				on:click={async () => {
+					trackUmamiEvent('auth_logout_clicked', {
+						flow: 'auth',
+						surface: 'user_menu',
+						trigger: 'click'
+					});
+
 					const res = await userSignOut();
 					user.set(null);
 					localStorage.removeItem('token');

--- a/src/lib/utils/umami.ts
+++ b/src/lib/utils/umami.ts
@@ -1,0 +1,45 @@
+type UmamiPayload = Record<string, unknown>;
+
+const getUmami = () => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	return window.umami ?? null;
+};
+
+export const identifyUmamiUser = (userId: string, data?: UmamiPayload) => {
+	if (!userId) {
+		return;
+	}
+
+	const umami = getUmami();
+	if (!umami?.identify) {
+		return;
+	}
+
+	if (data) {
+		umami.identify(userId, data);
+		return;
+	}
+
+	umami.identify(userId);
+};
+
+export const trackUmamiEvent = (eventName: string, data?: UmamiPayload) => {
+	if (!eventName) {
+		return;
+	}
+
+	const umami = getUmami();
+	if (!umami?.track) {
+		return;
+	}
+
+	if (data) {
+		umami.track(eventName, data);
+		return;
+	}
+
+	umami.track(eventName);
+};

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -19,6 +19,7 @@
 
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 	import { WEBUI_NAME, config, user, socket } from '$lib/stores';
+	import { trackUmamiEvent } from '$lib/utils/umami';
 
 	import { generateInitialsImage, canvasPixelTest, getUserTimezone } from '$lib/utils';
 
@@ -69,6 +70,13 @@
 	};
 
 	const signInHandler = async () => {
+		trackUmamiEvent('auth_signin_submitted', {
+			flow: 'auth',
+			surface: 'auth_page',
+			trigger: 'submit',
+			method: 'password'
+		});
+
 		const sessionUser = await userSignIn(email, password).catch((error) => {
 			toast.error(`${error}`);
 			return null;
@@ -78,6 +86,13 @@
 	};
 
 	const signUpHandler = async () => {
+		trackUmamiEvent('auth_signup_submitted', {
+			flow: 'auth',
+			surface: 'auth_page',
+			trigger: 'submit',
+			method: 'password'
+		});
+
 		if ($config?.features?.enable_signup_password_confirmation) {
 			if (password !== confirmPassword) {
 				toast.error($i18n.t('Passwords do not match.'));
@@ -96,11 +111,28 @@
 	};
 
 	const ldapSignInHandler = async () => {
+		trackUmamiEvent('auth_signin_submitted', {
+			flow: 'auth',
+			surface: 'auth_page',
+			trigger: 'submit',
+			method: 'ldap'
+		});
+
 		const sessionUser = await ldapUserSignIn(ldapUsername, password).catch((error) => {
 			toast.error(`${error}`);
 			return null;
 		});
 		await setSessionUser(sessionUser);
+	};
+
+	const startOAuthLogin = (provider: string) => {
+		trackUmamiEvent('auth_oauth_started', {
+			flow: 'auth',
+			surface: 'auth_page',
+			trigger: 'click',
+			provider
+		});
+		window.location.href = `${WEBUI_BASE_URL}/oauth/${provider}/login`;
 	};
 
 	const submitHandler = async () => {
@@ -433,7 +465,7 @@
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/google/login`;
+												startOAuthLogin('google');
 											}}
 										>
 											<svg
@@ -463,7 +495,7 @@
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/microsoft/login`;
+												startOAuthLogin('microsoft');
 											}}
 										>
 											<svg
@@ -494,7 +526,7 @@
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/github/login`;
+												startOAuthLogin('github');
 											}}
 										>
 											<svg
@@ -515,7 +547,7 @@
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/oidc/login`;
+												startOAuthLogin('oidc');
 											}}
 										>
 											<svg
@@ -545,7 +577,7 @@
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/feishu/login`;
+												startOAuthLogin('feishu');
 											}}
 										>
 											<span>{$i18n.t('Continue with {{provider}}', { provider: 'Feishu' })}</span>


### PR DESCRIPTION
# Pull Request Checklist

This pull request addresses the feature request in the discussion on post #10203.

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**

- [x] **Description:** Provide a concise description of the changes made in this pull request down below.

- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.

- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.

  - _Not yet submitted in docs repo._

- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.

  - _No new/upgraded project dependencies were introduced by this feature._

- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.

  - _Manual runtime verification completed in Docker demo container with Umami env vars._

- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.

- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.

  - _Implemented with minimal, opt-in env-based defaults and no major architectural churn._

- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.

- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - _Recommended title:_ `feat: add Umami analytics integration with env-gated script and P1 event tracking`

---

# Description

This PR adds Umami analytics integration to Open WebUI with runtime backend configuration and frontend script injection controlled by environment variables. Tracking is enabled only when `UMAMI_WEBSITE_ID` is set; `UMAMI_DOMAIN` defaults to `https://cloud.umami.is` when not provided. If `UMAMI_WEBSITE_ID` is missing/empty, Umami is not loaded.

The implementation includes:

- Backend config exposure (`/api/config`) for Umami runtime values.
- Frontend dynamic script injection in app layout.
- Distinct user identification via `umami.identify(user.id)`.
- P1 product events for authentication and core chat usage.
- Standardized payload keys across P1 events: `flow`, `surface`, `trigger`.

---

# Testing

## Before fix

- No Umami script integration existed.
- No runtime env-gated analytics loading.
- No distinct ID/user-level Umami identification and no P1 event emission.

## After fix (manual)

1. Build and run container.
2. Set Umami env vars.
3. Open app at `http://localhost:3000`.
4. Verify script is injected only when website ID is set.
5. Verify login/session binds distinct id (`user.id`) and P1 events emit for auth/chat actions.

## Commands used

```bash
docker build -t open-webui-umami-demo .
docker run -d --name open-webui-umami-demo-container -p 3000:8080 \
  -e UMAMI_WEBSITE_ID=xxx \
  -e UMAMI_DOMAIN=https://analytics.example.com \
  open-webui-umami-demo
curl -I http://localhost:3000
```

---

# Changelog Entry

### Description

- Added Umami analytics integration with runtime config and env-based enablement.
- Implemented distinct user identification with `user.id`.
- Added standardized analytics events for auth and core chat actions.

### Added

- New env vars:
  - `UMAMI_WEBSITE_ID` (required to enable Umami)
  - `UMAMI_DOMAIN` (optional, defaults to `https://cloud.umami.is`)
- Frontend helper utilities for Umami track/identify.
- Runtime analytics config block in backend `/api/config`.

### Changed

- App layout now conditionally injects Umami script at runtime.
- nalytics events now include standardized payload metadata:
  - `flow`
  - `surface`
  - `trigger`

### Deprecated

- None.

### Removed

- None.

### Fixed

- Enabled proper opt-in analytics behavior: script remains disabled when `UMAMI_WEBSITE_ID` is not configured.
- Added user-level distinct tracking linkage through `user.id`.

### Security

- Analytics remains opt-in and environment-controlled.
- Distinct ID uses internal user ID (not email), reducing PII exposure.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Related request: discussion post #10203.
- Scope intentionally limited to user events only (auth + core chat), no workspace/admin.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
