### PR TITLE
fix: SensitiveInput not capturing password manager autofill values

### DIFF
--- a/src/lib/components/common/SensitiveInput.svelte
+++ b/src/lib/components/common/SensitiveInput.svelte
@@ -8,6 +8,8 @@
 	export let type = 'text';
 	export let required = true;
 	export let readOnly = false;
+	export let autocomplete = 'off';
+	export let name = '';
 	export let outerClassName = 'flex flex-1 bg-transparent';
 	export let inputClassName = 'w-full text-sm py-0.5 bg-transparent';
 	export let showButtonClassName = 'pl-1.5  transition bg-transparent';
@@ -25,13 +27,11 @@
 		class={`${inputClassName} ${show ? '' : 'password'} ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : ' outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-600'}`}
 		{placeholder}
 		type={type === 'password' && !show ? 'password' : 'text'}
-		{value}
+		bind:value
 		required={required && !readOnly}
 		disabled={readOnly}
-		on:change={(e) => {
-			value = e.target.value;
-		}}
-		autocomplete="off"
+		{autocomplete}
+		{name}
 	/>
 	<button
 		class={showButtonClassName}


### PR DESCRIPTION
## Summary

The `SensitiveInput` component used one-way `{value}` binding with an `on:change` event handler. Password managers (e.g. Apple's iCloud Passwords Chrome extension) autofill the input's DOM value directly without triggering the `change` event, causing the Svelte variable to remain empty (`""`) while the field visually appears filled. This results in an empty password being sent to the backend, returning "The email or password provided is incorrect" even though the correct password is displayed in the field.

### Changes

- Replace `{value}` + `on:change` with `bind:value` for proper two-way binding that captures all value changes including password manager autofill
- Add `autocomplete` and `name` as exported props (defaulting to `'off'` and `''`) instead of hardcoding `autocomplete="off"`, so parent components (e.g. the login form) can pass the correct autocomplete hints like `current-password`

### Root Cause

```svelte
<!-- Before: one-way binding + on:change (misses autofill) -->
<input {value} on:change={(e) => { value = e.target.value; }} autocomplete="off" />

<!-- After: two-way binding (captures all value changes) -->
<input bind:value {autocomplete} {name} />
```

The `on:change` event only fires on user-initiated changes with blur. Browser extension-based password managers set `input.value` programmatically without dispatching `change` or `input` events, so the Svelte variable never updates.

## Test Plan

- [ ] Login with password manager autofill in Chrome (iCloud Passwords / 1Password / Bitwarden extension)
- [ ] Login with manually typed password
- [ ] Verify `autocomplete="current-password"` is correctly applied on the login page password field
- [ ] Verify existing SensitiveInput usages (API key fields etc.) still work with default `autocomplete="off"`

Made with [Cursor](https://cursor.com)