### PR TITLE
perf: cache KaTeX module import as singleton across all renderer instances

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/KatexRenderer.svelte
+++ b/src/lib/components/chat/Messages/Markdown/KatexRenderer.svelte
@@ -2,16 +2,16 @@
 	import type { renderToString as katexRenderToString } from 'katex';
 
 	// Module-level singleton: load katex once, share across all KatexRenderer instances
-	let katexReady: Promise<typeof katexRenderToString> | null = null;
-	function getKatex(): Promise<typeof katexRenderToString> {
-		if (!katexReady) {
-			katexReady = Promise.all([
+	let katexRenderer: Promise<typeof katexRenderToString> | null = null;
+	function getKatexRenderer(): Promise<typeof katexRenderToString> {
+		if (!katexRenderer) {
+			katexRenderer = Promise.all([
 				import('katex'),
 				import('katex/contrib/mhchem'),
 				import('katex/dist/katex.min.css')
 			]).then(([katex]) => katex.renderToString);
 		}
-		return katexReady;
+		return katexRenderer;
 	}
 </script>
 
@@ -24,7 +24,7 @@
 	let renderToString: typeof katexRenderToString | null = null;
 
 	onMount(async () => {
-		renderToString = await getKatex();
+		renderToString = await getKatexRenderer();
 	});
 </script>
 

--- a/src/lib/components/chat/Messages/Markdown/KatexRenderer.svelte
+++ b/src/lib/components/chat/Messages/Markdown/KatexRenderer.svelte
@@ -1,5 +1,21 @@
-<script lang="ts">
+<script lang="ts" context="module">
 	import type { renderToString as katexRenderToString } from 'katex';
+
+	// Module-level singleton: load katex once, share across all KatexRenderer instances
+	let katexReady: Promise<typeof katexRenderToString> | null = null;
+	function getKatex(): Promise<typeof katexRenderToString> {
+		if (!katexReady) {
+			katexReady = Promise.all([
+				import('katex'),
+				import('katex/contrib/mhchem'),
+				import('katex/dist/katex.min.css')
+			]).then(([katex]) => katex.renderToString);
+		}
+		return katexReady;
+	}
+</script>
+
+<script lang="ts">
 	import { onMount } from 'svelte';
 
 	export let content: string;
@@ -8,15 +24,11 @@
 	let renderToString: typeof katexRenderToString | null = null;
 
 	onMount(async () => {
-		const [katex] = await Promise.all([
-			import('katex'),
-			import('katex/contrib/mhchem'),
-			import('katex/dist/katex.min.css')
-		]);
-		renderToString = katex.renderToString;
+		renderToString = await getKatex();
 	});
 </script>
 
 {#if renderToString}
 	{@html renderToString(content, { displayMode, throwOnError: false })}
 {/if}
+


### PR DESCRIPTION
KatexRenderer.svelte dynamically imports katex, mhchem, and the CSS on every component mount. When a message contains multiple math expressions, this triggers redundant module resolution for each one. Move the import promise to a module-level singleton using Svelte's context='module' script block so it loads once and is shared across all KatexRenderer instances.

<ins>**this is a completely invisible change - free lunch**</ins>

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
