### PR TITLE
perf: remove per-word fade transitions from TextToken during streaming

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
@@ -1,19 +1,7 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
-
 	export let token;
 	export let done = true;
-
-	let texts = [];
-	$: texts = (token?.raw ?? '').split(' ');
 </script>
 
-{#if done}
-	{token?.raw}
-{:else}
-	{#each texts as text}
-		<span class="" transition:fade={{ duration: 100 }}>
-			{text}{' '}
-		</span>
-	{/each}
-{/if}
+{token?.raw}
+


### PR DESCRIPTION
During streaming, TextToken split text by spaces and wrapped each word in a span with a 100ms CSS fade transition. This created O(words) DOM elements with active transitions that were all destroyed and recreated on every content update. Replace with direct raw text rendering, eliminating unnecessary DOM overhead during streaming.

<ins>**In other words: this removes the subtle per-word fade effect when streaming in the words
@tjbck alternative: refactor to fade in per token or per batched token to at least have minor perf improvement**</ins>

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
