### PR TITLE
perf: remove unnecessary {#key id} block in Markdown.svelte

### DIFF
--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -80,21 +80,20 @@
 	});
 </script>
 
-{#key id}
-	<MarkdownTokens
-		{tokens}
-		{id}
-		{done}
-		{save}
-		{preview}
-		{paragraphTag}
-		{editCodeBlock}
-		{sourceIds}
-		{topPadding}
-		{onTaskClick}
-		{onSourceClick}
-		{onSave}
-		{onUpdate}
-		{onPreview}
-	/>
-{/key}
+<MarkdownTokens
+	{tokens}
+	{id}
+	{done}
+	{save}
+	{preview}
+	{paragraphTag}
+	{editCodeBlock}
+	{sourceIds}
+	{topPadding}
+	{onTaskClick}
+	{onSourceClick}
+	{onSave}
+	{onUpdate}
+	{onPreview}
+/>
+


### PR DESCRIPTION
The {#key id} wrapper around MarkdownTokens forced Svelte to destroy and recreate the entire token component tree whenever id changed. Since id is derived from chatId + messageId and is stable during streaming, this mainly prevented Svelte from reusing components across re-renders and forced all child components like KatexRenderer and CodeBlock to remount. The tokens prop already drives reactivity, making the key block redundant.

<ins>**this is a completely invisible change - free lunch**</ins>

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
