### PR TITLE
fix: handle non-numeric timestamp values in chat_message migration

### DIFF
--- a/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
+++ b/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
@@ -127,6 +127,13 @@ def upgrade() -> None:
 
             timestamp = message.get("timestamp", now)
 
+            # Coerce timestamp to numeric — chat data may contain
+            # non-numeric strings from security scanners or corrupted data
+            try:
+                timestamp = int(timestamp)
+            except (TypeError, ValueError):
+                timestamp = now
+
             # Normalize timestamp: convert ms to seconds, validate range
             if timestamp > 10_000_000_000:
                 timestamp = timestamp // 1000


### PR DESCRIPTION
## Summary

The alembic migration `8452d01d26d7_add_chat_message_table` (introduced in v0.8.5) crashes when the `timestamp` field inside chat message JSON data contains a non-numeric string value.

**Root cause:** The migration reads `message.get("timestamp", now)` and immediately compares it with `>` and `<` against integers (lines 131–135). If `timestamp` is a string, Python raises:

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

This rolls back the entire migration transaction. On the next startup, the app finds an incomplete schema and returns 500 on `/api/config`, showing users "Open WebUI Backend Required".

**How string timestamps get into the database:** In our case, an automated security scanner (DAST) injected path-traversal payloads (`/etc/passwd`, `c:/Windows/system.ini`, etc.) into the chat API, which were stored verbatim in the `timestamp` field of 99 chat messages. Any corrupted or manually edited chat data with non-numeric timestamps would trigger the same crash.

## Fix

- Wrap `timestamp` in `int()` with a `try/except (TypeError, ValueError)` before the numeric comparisons
- On failure, fall back to `now` — consistent with the existing fallback for out-of-range timestamps
- This is a 5-line addition with zero impact on valid data paths

## Test plan

- [x] Verified fix locally against a database containing string timestamp values
- [x] Migration completes successfully after the fix
- [x] Valid integer and float timestamps are unaffected (`int(1234567890)` → same value)