### PR TITLE
fix: handle non-numeric timestamp values in chat_message migration

### DIFF
--- a/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
+++ b/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
@@ -127,6 +127,13 @@ def upgrade() -> None:
 
             timestamp = message.get("timestamp", now)
 
+            # Coerce timestamp to numeric — chat data may contain
+            # non-numeric strings from security scanners or corrupted data
+            try:
+                timestamp = int(timestamp)
+            except (TypeError, ValueError):
+                timestamp = now
+
             # Normalize timestamp: convert ms to seconds, validate range
             if timestamp > 10_000_000_000:
                 timestamp = timestamp // 1000

--- a/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
+++ b/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
@@ -130,7 +130,7 @@ def upgrade() -> None:
             # Coerce timestamp to numeric — chat data may contain
             # non-numeric strings from security scanners or corrupted data
             try:
-                timestamp = int(timestamp)
+                timestamp = int(float(timestamp))
             except (TypeError, ValueError):
                 timestamp = now
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Changelog:** Included below
- [ ] **Documentation:** No user-facing behavior change — migration internal fix only
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually tested against a database containing string timestamp values (from DAST security scanner injection). Migration completes successfully. Valid integer and float timestamps are unaffected.
- [x] **Agentic AI Code:** This PR was authored and tested by a human
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Minimal 5-line fix, no new settings or architectural changes
- [x] **Git Hygiene:** Single atomic commit on a dedicated branch
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

The alembic migration `8452d01d26d7_add_chat_message_table` (introduced in v0.8.5) crashes when the `timestamp` field inside chat message JSON data contains a non-numeric string value.

**Root cause:** The migration reads `message.get("timestamp", now)` and compares it with `>` and `<` against integers (lines 131–135). If `timestamp` is a string, Python raises:

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

This rolls back the entire migration. On the next startup, the app finds an incomplete schema and returns 500 on `/api/config`, showing "Open WebUI Backend Required".

**How string timestamps get into the database:** In our case, an automated security scanner (DAST) injected path-traversal payloads into the chat API, which were stored verbatim in the `timestamp` field. Any corrupted or manually edited chat data with non-numeric timestamps would trigger the same crash.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Wrap `timestamp` in `int()` with a `try/except (TypeError, ValueError)` before the numeric comparisons in the `8452d01d26d7` migration
- On failure, fall back to `now` — consistent with the existing fallback for out-of-range timestamps
- 5-line addition with zero impact on valid data paths

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Reproduction: any chat row with a non-numeric string in `message.timestamp` will crash the migration
- Previously submitted as #21886, closed due to missing CLA text

### Screenshots or Videos

N/A — this is a backend migration fix with no UI changes.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.