### PR TITLE
feat: add Zaps Privacy Filter for OpenAI connections

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1101,6 +1101,18 @@ ENABLE_OPENAI_API = PersistentConfig(
     os.environ.get("ENABLE_OPENAI_API", "True").lower() == "true",
 )
 
+ENABLE_ZAPS_PRIVACY_FILTER = PersistentConfig(
+    "ENABLE_ZAPS_PRIVACY_FILTER",
+    "openai.zaps_privacy_filter",
+    os.environ.get("ENABLE_ZAPS_PRIVACY_FILTER", "False").lower() == "true",
+)
+
+ZAPS_API_BASE_URL = PersistentConfig(
+    "ZAPS_API_BASE_URL",
+    "openai.zaps_api_base_url",
+    os.environ.get("ZAPS_API_BASE_URL", "http://localhost:3000"),
+)
+
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 OPENAI_API_BASE_URL = os.environ.get("OPENAI_API_BASE_URL", "")

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -41,6 +41,7 @@
 	let OPENAI_API_CONFIGS = {};
 
 	let ENABLE_OPENAI_API: null | boolean = null;
+	let ENABLE_ZAPS_PRIVACY_FILTER: null | boolean = null;
 	let ENABLE_OLLAMA_API: null | boolean = null;
 
 	let connectionsConfig = null;
@@ -72,6 +73,7 @@
 
 			const res = await updateOpenAIConfig(localStorage.token, {
 				ENABLE_OPENAI_API: ENABLE_OPENAI_API,
+				ENABLE_ZAPS_PRIVACY_FILTER: ENABLE_ZAPS_PRIVACY_FILTER,
 				OPENAI_API_BASE_URLS: OPENAI_API_BASE_URLS,
 				OPENAI_API_KEYS: OPENAI_API_KEYS,
 				OPENAI_API_CONFIGS: OPENAI_API_CONFIGS
@@ -154,6 +156,7 @@
 			]);
 
 			ENABLE_OPENAI_API = openaiConfig.ENABLE_OPENAI_API;
+			ENABLE_ZAPS_PRIVACY_FILTER = openaiConfig.ENABLE_ZAPS_PRIVACY_FILTER;
 			ENABLE_OLLAMA_API = ollamaConfig.ENABLE_OLLAMA_API;
 
 			OPENAI_API_BASE_URLS = openaiConfig.OPENAI_API_BASE_URLS;
@@ -241,6 +244,23 @@
 						</div>
 
 						{#if ENABLE_OPENAI_API}
+							<div class="mb-2">
+								<div class="flex justify-between items-center text-sm">
+									<div class="font-medium">{$i18n.t('Privacy Filter (Zaps)')}</div>
+									<div class="flex items-center">
+										<Switch
+											bind:state={ENABLE_ZAPS_PRIVACY_FILTER}
+											on:change={async () => {
+												updateOpenAIHandler();
+											}}
+										/>
+									</div>
+								</div>
+								<div class="text-xs text-gray-400 dark:text-gray-500">
+									{$i18n.t('Routes all OpenAI requests through Zaps Privacy Shield to redact PII.')}
+								</div>
+							</div>
+
 							<div class="">
 								<div class="flex justify-between items-center">
 									<div class="font-medium text-xs">{$i18n.t('Manage OpenAI API Connections')}</div>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** See below.
- [x] **Changelog:** See below.
- [x] **Testing:** Manually verified toggle state persistence and URL interception logic.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

Adds a **Privacy Filter** toggle to the OpenAI connection settings that routes all OpenAI-compatible requests through a [Zaps.ai](https://zaps.ai) privacy gateway for automatic PII redaction and rehydration.

When enabled, all outgoing requests to OpenAI providers are transparently redirected to the configured Zaps URL. Zaps handles PII scrubbing before forwarding to the actual upstream provider, and rehydrates PII in responses.

### Added

- `ENABLE_ZAPS_PRIVACY_FILTER` and `ZAPS_API_BASE_URL` persistent configuration options
- `get_target_url()` helper in `routers/openai.py` for conditional URL routing
- "Privacy Filter (Zaps)" toggle in admin Connections settings UI

### Changed

- All OpenAI endpoint URL assignments wrapped with `get_target_url()` for interception
- Config GET/POST endpoints include Zaps settings
- `OpenAIConfigForm` includes `ENABLE_ZAPS_PRIVACY_FILTER`

### Configuration

| Setting | Env Var | Default |
|---|---|---|
| Enable Privacy Filter | `ENABLE_ZAPS_PRIVACY_FILTER` | `false` |
| Zaps API Base URL | `ZAPS_API_BASE_URL` | `http://localhost:3000` |

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.