### PR TITLE
fix: Fallback for missing favicons in web‑search sources

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -178,6 +178,9 @@
 							src="https://www.google.com/s2/favicons?sz=32&domain={citation.source.name}"
 							alt="favicon"
 							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-white dark:bg-gray-900"
+							on:error={(e) => {
+								e.target.src = '/favicon.png';
+							}}
 						/>
 					{/each}
 				</div>


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** No user-facing documentation changes needed.
- [ ] **Dependencies:** No changes on dependencies
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed a failure similar to #21730 in the web‑search-sources where favicons could not be displayed because the search backend runs in an isolated environment. The code now detects missing external icon resources and falls back to a default open-webui favicon.

### Added

- Added `on:error` handler to `<img />` for sources from websearch. Uses the open-webui favicon as fallback in `Citations.svelte`.

### Fixed

- Resolved a problem in Firefox where the `alt` text displayed for a broken image overflow its container.

---

### Additional Information

- its similar to #21730
  - Prevent Firefox from showing overflowing `alt` text when an avatar fails to load by adding an `on:error` handler that swaps in a fallback icon.

### Screenshots or Videos

### before
<img width="1123" height="498" alt="screen2" src="https://github.com/user-attachments/assets/511e2f0e-3e5a-4c0d-aba3-893743219b4f" />

### after
<img width="1138" height="489" alt="screen1" src="https://github.com/user-attachments/assets/424344aa-e909-4d5f-8e50-878771aeb687" />


### Contributor License Agreement


By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.