### PR TITLE
Fix: redis release lock atomic

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -140,7 +140,7 @@ if WEBSOCKET_MANAGER == 'redis':
         redis_sentinels=redis_sentinels,
         redis_cluster=WEBSOCKET_REDIS_CLUSTER,
     )
-    aquire_func = clean_up_lock.aquire_lock
+    acquire_func = clean_up_lock.acquire_lock
     renew_func = clean_up_lock.renew_lock
     release_func = clean_up_lock.release_lock
 
@@ -151,7 +151,7 @@ if WEBSOCKET_MANAGER == 'redis':
         redis_sentinels=redis_sentinels,
         redis_cluster=WEBSOCKET_REDIS_CLUSTER,
     )
-    session_aquire_func = session_cleanup_lock.aquire_lock
+    session_acquire_func = session_cleanup_lock.acquire_lock
     session_renew_func = session_cleanup_lock.renew_lock
     session_release_func = session_cleanup_lock.release_lock
 else:
@@ -160,8 +160,8 @@ else:
     SESSION_POOL = {}
     USAGE_POOL = {}
 
-    aquire_func = release_func = renew_func = lambda: True
-    session_aquire_func = session_release_func = session_renew_func = lambda: True
+    acquire_func = release_func = renew_func = lambda: True
+    session_acquire_func = session_release_func = session_renew_func = lambda: True
 
 
 YDOC_MANAGER = YdocManager(
@@ -172,8 +172,8 @@ YDOC_MANAGER = YdocManager(
 
 async def periodic_session_pool_cleanup():
     """Reap orphaned SESSION_POOL entries that missed heartbeats (e.g. crashed instance)."""
-    if not session_aquire_func():
-        log.debug('Session cleanup lock held by another node. Skipping.')
+    if not session_acquire_func():
+        log.debug("Session cleanup lock held by another node. Skipping.")
         return
 
     try:
@@ -197,7 +197,7 @@ async def periodic_usage_pool_cleanup():
     max_retries = 2
     retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
     for attempt in range(max_retries + 1):
-        if aquire_func():
+        if acquire_func():
             break
         else:
             if attempt < max_retries:

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -5,6 +5,25 @@ from open_webui.env import REDIS_KEY_PREFIX
 from typing import Optional, List, Tuple
 import pycrdt as Y
 
+# Redis has no single command for compare-and-delete or compare-and-expire; Lua runs atomically.
+_RELEASE_LOCK_IF_OWNER_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+# SET key id XX EX would only verify the key exists, not that we still own it — another
+# holder's token could be overwritten after TTL races. Only extend TTL when value matches.
+_RENEW_LOCK_IF_OWNER_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("expire", KEYS[1], tonumber(ARGV[2]))
+else
+    return 0
+end
+"""
+
 
 class RedisLock:
     def __init__(
@@ -25,20 +44,30 @@ class RedisLock:
             redis_cluster=redis_cluster,
             decode_responses=True,
         )
+        self._release_if_owner = self.redis.register_script(_RELEASE_LOCK_IF_OWNER_SCRIPT)
+        self._renew_if_owner = self.redis.register_script(_RENEW_LOCK_IF_OWNER_SCRIPT)
 
-    def aquire_lock(self):
+    def acquire_lock(self):
         # nx=True will only set this key if it _hasn't_ already been set
         self.lock_obtained = self.redis.set(self.lock_name, self.lock_id, nx=True, ex=self.timeout_secs)
         return self.lock_obtained
 
     def renew_lock(self):
-        # xx=True will only set this key if it _has_ already been set
-        return self.redis.set(self.lock_name, self.lock_id, xx=True, ex=self.timeout_secs)
+        # Must not use SET ... XX alone: that only checks key existence, so a stale renew
+        # could steal the lock from another holder after expiry/reacquisition.
+        result = self._renew_if_owner(
+            keys=[self.lock_name],
+            args=[self.lock_id, str(self.timeout_secs)],
+        )
+        ok = result == 1
+        self.lock_obtained = ok
+        return ok
 
     def release_lock(self):
-        lock_value = self.redis.get(self.lock_name)
-        if lock_value and lock_value == self.lock_id:
-            self.redis.delete(self.lock_name)
+        try:
+            self._release_if_owner(keys=[self.lock_name], args=[self.lock_id])
+        except Exception:
+            pass  # Best-effort; TTL will clear the key if we crash
 
 
 class RedisDict:


### PR DESCRIPTION
# Pull Request Checklist

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. *(N/A: internal lock implementation, no user-facing changes.)*
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. *(None.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

---

# Changelog Entry

### Description

- **fix: Make Redis lock release atomic and fix acquire_lock typo.**  
Redis lock release previously used a non-atomic GET-then-DEL sequence. We could GET our value, decide to delete, then—before our DEL runs—the key could expire and another process could acquire it; our DEL would then remove their lock. This change uses a Lua script so that “delete only if value equals my lock_id” runs atomically on Redis, ensuring we never release another process’s lock. Also renames `aquire_lock` to `acquire_lock` and updates all call sites.

- 🔒 **Redis lock release race.** Releasing a Redis lock after TTL expiry could delete another process's lock because the previous implementation used a non-atomic GET-then-DEL sequence. Release now uses a Lua script so that "delete key only if value equals my lock_id" runs atomically on Redis, ensuring only the owning process can remove the key.

### Added

- Lua script `_RELEASE_LOCK_IF_OWNER_SCRIPT` for atomic “delete key only if value matches lock_id” in `RedisLock`.

### Changed

- `RedisLock.release_lock()` now calls the registered Lua script instead of separate GET/DEL.
- Method name: `aquire_lock` → `acquire_lock` in `backend/open_webui/socket/utils.py` and all references in `backend/open_webui/socket/main.py` (`acquire_func`, `session_acquire_func`, and fallback lambdas).

### Fixed

- **Redis lock release race:** Releasing a lock after TTL expiry could delete another process’s lock; release is now atomic so only the owning process can remove the key.

### Security

- (none; correctness fix reduces risk of mistaken lock release in multi-process/WebSocket cleanup.)

### Breaking Changes

- **BREAKING CHANGE**: The public method `RedisLock.aquire_lock` has been renamed to `acquire_lock`. Any external code calling `aquire_lock` must be updated. Internal call sites in this repo are updated.

---

### Additional Information

- Redis has no built-in “delete if value equals” command; the Lua script runs on the server so the check and delete are a single atomic operation.
- Release remains best-effort (exceptions swallowed); if the script fails, TTL will still clear the key.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
