### PR TITLE
fix: correct else block indentation in tools_dict handler (middleware.py)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2531,15 +2531,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     for tool in tools_dict.values()
                 ]
 
-        else:
-            # If the function calling is not native, then call the tools function calling handler
-            try:
-                form_data, flags = await chat_completion_tools_handler(
-                    request, form_data, extra_params, user, models, tools_dict
-                )
-                sources.extend(flags.get("sources", []))
-            except Exception as e:
-                log.exception(e)
+            else:
+                # If the function calling is not native, then call the tools function calling handler
+                try:
+                    form_data, flags = await chat_completion_tools_handler(
+                        request, form_data, extra_params, user, models, tools_dict
+                    )
+                    sources.extend(flags.get("sources", []))
+                except Exception as e:
+                    log.exception(e)
 
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (


### PR DESCRIPTION
## Summary

- The `else` block for non-native function calling in `process_chat_payload` was indented at the same level as `if tools_dict:`, incorrectly pairing it with the outer check instead of the inner `if function_calling == "native"` check.

**Before (broken):**
```python
if tools_dict:
    if metadata.get("params", {}).get("function_calling") == "native":
        # native setup...
        ]

else:  # ← paired with 'if tools_dict:' — runs when tools_dict is EMPTY
    # non-native handler never runs when tools are present
    try:
        form_data, flags = await chat_completion_tools_handler(...)
```

**After (fixed):**
```python
if tools_dict:
    if metadata.get("params", {}).get("function_calling") == "native":
        # native setup...
        ]

    else:  # ← correctly paired with inner 'if native:' — runs when tools present and not native
        try:
            form_data, flags = await chat_completion_tools_handler(...)
```

## Impact

- Non-native (default/prompt-based) tool calling was **completely broken** when any tools were present — the handler was never called.
- The non-native handler was incorrectly invoked when `tools_dict` was **empty** (no tools), where it would be a no-op at best.

## Test plan

- [ ] Enable a tool in OpenWebUI with function calling set to default (non-native)
- [ ] Confirm the tool is actually called during a chat completion
- [ ] Enable a tool with function calling set to native — confirm it still works