### PR TITLE
feat: add Avian to connection provider suggestions

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -322,6 +322,7 @@
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />
+											<option value="https://api.avian.io/v1" />
 										</datalist>
 									{/if}
 								</div>


### PR DESCRIPTION
## Summary

Adds [Avian](https://avian.io) (`https://api.avian.io/v1`) to the connection URL suggestion datalist in the Add Connection modal, alongside existing providers (OpenAI, Anthropic, Google, Mistral, Groq, OpenRouter, xAI).

**About Avian:** Avian is an OpenAI-compatible LLM API provider offering models including DeepSeek V3.2, Kimi K2.5, GLM-5, and MiniMax M2.5. It supports chat completions, streaming, function calling/tools, tool_choice, and response_format.

## Changes

- Added `https://api.avian.io/v1` as a `<option>` entry in the connection URL `<datalist>` in `AddConnectionModal.svelte`

This is a one-line change following the exact same pattern as the existing provider entries.

## Test Plan

- [ ] Open Admin Settings > Connections > Add Connection
- [ ] Verify "https://api.avian.io/v1" appears in the URL dropdown suggestions
- [ ] Add connection with Avian URL and API key, verify it connects and lists models