### PR TITLE
fix(i18n): correct OpenAPI to OpenAI mistranslation in es-ES

### DIFF
--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -369,7 +369,7 @@
 	"Confirm Your Password": "Confirma Tu Contraseña",
 	"Connect to an AI provider to start chatting": "",
 	"Connect to your own OpenAI compatible API endpoints.": "Conectar a tus propios endpoints compatibles API OpenAI.",
-	"Connect to your own OpenAPI compatible external tool servers.": "Conectar a tus propios endpoints externos de herramientas compatibles API OpenAI.",
+	"Connect to your own OpenAPI compatible external tool servers.": "Conectar a tus propios endpoints externos de herramientas compatibles con OpenAPI.",
 	"Connection failed": "Conexión fallida",
 	"Connection successful": "Conexión realizada",
 	"Connection Type": "Tipo de Conexión",


### PR DESCRIPTION
## Summary

Fixes a translation error in the Spanish (es-ES) locale where "OpenAPI" was incorrectly translated as "OpenAI".

## Changes

- Fixed the translation of "Connect to your own OpenAPI compatible external tool servers." to correctly say "OpenAPI" instead of "OpenAI"

## Before
```
"Conectar a tus propios endpoints externos de herramientas compatibles API OpenAI."
```

## After
```
"Conectar a tus propios endpoints externos de herramientas compatibles con OpenAPI."
```

Fixes #21936