### PR TITLE
fix: read WEB_SEARCH_DOMAIN_FILTER_LIST from env variable

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3213,15 +3213,17 @@ WEB_SEARCH_RESULT_COUNT = PersistentConfig(
 
 # You can provide a list of your own websites to filter after performing a web search.
 # This ensures the highest level of safety and reliability of the information sources.
+try:
+    web_search_domain_filter_list = json.loads(
+        os.environ.get("WEB_SEARCH_DOMAIN_FILTER_LIST", "[]")
+    )
+except Exception as e:
+    log.exception(f"Error loading WEB_SEARCH_DOMAIN_FILTER_LIST: {e}")
+    web_search_domain_filter_list = []
 WEB_SEARCH_DOMAIN_FILTER_LIST = PersistentConfig(
     "WEB_SEARCH_DOMAIN_FILTER_LIST",
     "rag.web.search.domain.filter_list",
-    [
-        # "wikipedia.com",
-        # "wikimedia.org",
-        # "wikidata.org",
-        # "!stackoverflow.com",
-    ],
+    web_search_domain_filter_list,
 )
 
 WEB_SEARCH_CONCURRENT_REQUESTS = PersistentConfig(


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** N/A - internal code fix, no user-facing API changes.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

WEB_SEARCH_DOMAIN_FILTER_LIST is [currently](https://github.com/open-webui/open-webui/blob/c71beb0a7df1a4e4a3ac7ace757fe67a73e4935a/backend/open_webui/config.py#L3216C1-L3225C2) not being read from the env variables. A default value of `[]` is always applied.

This fix adds the code to read and parse the config value, like it's done with other persistent config variables. 

Steps to reproduce:
```yaml
services:
  open-webui:
    build: .
    image: ghcr.io/open-webui/open-webui:main
    container_name: open-webui
    volumes:
      - open-webui:/app/backend/data
    ports:
      - 3000:8080
    environment:
      - 'WEBUI_SECRET_KEY='
      - 'ENABLE_PERSISTENT_CONFIG=False'
      - 'WEB_SEARCH_DOMAIN_FILTER_LIST=["docs.openwebui.com"]'
volumes:
  open-webui: {}
```
- Expected: Domain filter is set to `docs.openwebui.com`
- Actual behavior: Domain filter is empty

### Fixed

- WEB_SEARCH_DOMAIN_FILTER_LIST is now correctly read from environment variables.

---

### Additional Information

- Fixes #20186

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
