### PR TITLE
feat: Add ModelsLab as image generation engine

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3788,6 +3788,12 @@ IMAGES_GEMINI_ENDPOINT_METHOD = PersistentConfig(
     os.getenv("IMAGES_GEMINI_ENDPOINT_METHOD", ""),
 )
 
+IMAGES_MODELSLAB_API_KEY = PersistentConfig(
+    "IMAGES_MODELSLAB_API_KEY",
+    "image_generation.modelslab.api_key",
+    os.getenv("IMAGES_MODELSLAB_API_KEY", ""),
+)
+
 ENABLE_IMAGE_EDIT = PersistentConfig(
     "ENABLE_IMAGE_EDIT",
     "images.edit.enable",

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -410,6 +410,7 @@
 								<option value="comfyui">{$i18n.t('ComfyUI')}</option>
 								<option value="automatic1111">{$i18n.t('Automatic1111')}</option>
 								<option value="gemini">{$i18n.t('Gemini')}</option>
+								<option value="modelslab">{$i18n.t('ModelsLab')}</option>
 							</select>
 						</div>
 					</div>
@@ -816,6 +817,27 @@
 								</div>
 							</div>
 						{/if}
+					{:else if config?.IMAGE_GENERATION_ENGINE === 'modelslab'}
+						<div class="mb-2.5">
+							<div class="flex w-full justify-between items-center">
+								<div class="text-xs pr-2 shrink-0">
+									<div class="">
+										{$i18n.t('ModelsLab API Key')}
+									</div>
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<SensitiveInput
+											inputClassName="text-right w-full"
+											placeholder={$i18n.t('API Key')}
+											bind:value={config.IMAGES_MODELSLAB_API_KEY}
+											required={true}
+										/>
+									</div>
+								</div>
+							</div>
+						</div>
 					{:else if config?.IMAGE_GENERATION_ENGINE === 'gemini'}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">


### PR DESCRIPTION
contributor license agreement

## Summary

Adds **ModelsLab** (https://modelslab.com) as a new image generation engine option in Open WebUI, following the existing Gemini engine pattern.

ModelsLab is an AI generation API platform providing access to Flux, SDXL, Stable Diffusion 3.5, and 100+ community models for image, video, and audio generation.

## Changes

### `backend/open_webui/config.py`
- Adds `IMAGES_MODELSLAB_API_KEY` (`PersistentConfig`) — supports `IMAGES_MODELSLAB_API_KEY` env var

### `backend/open_webui/routers/images.py`
- **`get_image_model()`**: Default model is `flux`
- **`get_models()`**: Returns 6 pre-configured models (Flux, Flux Pro, SDXL, SD 3.5, Realistic Vision, JuggernautXL)
- **`ImagesConfig`**: Adds `IMAGES_MODELSLAB_API_KEY: str`
- **GET + UPDATE `/config`**: Read/write the API key
- **`image_generations()`**: Full ModelsLab API call with async polling

### `src/lib/components/admin/Settings/Images.svelte`
- Engine dropdown: adds **ModelsLab** option
- Config section: API key input shown when ModelsLab is selected

## API Details

- **Auth**: Key-in-body (`{"key": "API_KEY"}`) — not Bearer header
- **Endpoint**: `POST https://modelslab.com/api/v6/images/text2img`
- **Async polling**: If `status: processing`, polls `/images/fetch/{request_id}` every 5s (up to 300s)
- **Docs**: https://docs.modelslab.com

## Setup (after merge)

1. Go to **Admin → Settings → Images**
2. Set **Image Generation Engine** to **ModelsLab**
3. Enter your `IMAGES_MODELSLAB_API_KEY`
4. Select a model (Flux, SDXL, etc.)
5. Generate images from any chat

## Checklist
- [x] Follows existing Gemini engine pattern
- [x] Key-in-body auth (matches ModelsLab's API design)
- [x] Async polling for slow generations
- [x] Config persisted via `PersistentConfig`
- [x] Frontend: dropdown option + API key input
- [x] No breaking changes