### PR TITLE
feat: Add ModelsLab as image generation engine

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3788,6 +3788,12 @@ IMAGES_GEMINI_ENDPOINT_METHOD = PersistentConfig(
     os.getenv("IMAGES_GEMINI_ENDPOINT_METHOD", ""),
 )
 
+IMAGES_MODELSLAB_API_KEY = PersistentConfig(
+    "IMAGES_MODELSLAB_API_KEY",
+    "image_generation.modelslab.api_key",
+    os.getenv("IMAGES_MODELSLAB_API_KEY", ""),
+)
+
 ENABLE_IMAGE_EDIT = PersistentConfig(
     "ENABLE_IMAGE_EDIT",
     "images.edit.enable",

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -410,6 +410,7 @@
 								<option value="comfyui">{$i18n.t('ComfyUI')}</option>
 								<option value="automatic1111">{$i18n.t('Automatic1111')}</option>
 								<option value="gemini">{$i18n.t('Gemini')}</option>
+								<option value="modelslab">{$i18n.t('ModelsLab')}</option>
 							</select>
 						</div>
 					</div>
@@ -816,6 +817,27 @@
 								</div>
 							</div>
 						{/if}
+					{:else if config?.IMAGE_GENERATION_ENGINE === 'modelslab'}
+						<div class="mb-2.5">
+							<div class="flex w-full justify-between items-center">
+								<div class="text-xs pr-2 shrink-0">
+									<div class="">
+										{$i18n.t('ModelsLab API Key')}
+									</div>
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<SensitiveInput
+											inputClassName="text-right w-full"
+											placeholder={$i18n.t('API Key')}
+											bind:value={config.IMAGES_MODELSLAB_API_KEY}
+											required={true}
+										/>
+									</div>
+								</div>
+							</div>
+						</div>
 					{:else if config?.IMAGE_GENERATION_ENGINE === 'gemini'}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">


### PR DESCRIPTION
contributor license agreement

## Summary

Adds **ModelsLab** (https://modelslab.com) as a new image generation engine in Open WebUI, following the existing Gemini engine pattern.

ModelsLab is an AI generation API providing access to Flux, SDXL, Stable Diffusion 3.5, and 100+ community models.

## Changes

- **backend/open_webui/config.py**: Adds IMAGES_MODELSLAB_API_KEY PersistentConfig (env var support)
- **backend/open_webui/routers/images.py**: get_image_model(), get_models(), ImagesConfig, GET+UPDATE /config, image_generations() with async polling
- **src/lib/components/admin/Settings/Images.svelte**: Engine dropdown + API key config section

## API details

- Auth: key-in-body (IMAGES_MODELSLAB_API_KEY env var)
- Endpoint: POST https://modelslab.com/api/v6/images/text2img
- Async polling: status=processing -> poll /images/fetch/{id} every 5s (up to 300s)
- Models: Flux, Flux Pro, SDXL, SD 3.5, Realistic Vision, JuggernautXL
- Docs: https://docs.modelslab.com

## Setup

1. Admin > Settings > Images
2. Set engine to ModelsLab
3. Enter IMAGES_MODELSLAB_API_KEY
4. Select model and generate