### PR TITLE
feat: add OAUTH_LOGOUT_URI for custom OAuth logout endpoints

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -463,6 +463,12 @@ OPENID_PROVIDER_URL = PersistentConfig(
     os.environ.get("OPENID_PROVIDER_URL", ""),
 )
 
+OAUTH_LOGOUT_URI = PersistentConfig(
+    "OAUTH_LOGOUT_URI",
+    "oauth.oidc.logout_uri",
+    os.environ.get("OAUTH_LOGOUT_URI", ""),
+)
+
 OPENID_REDIRECT_URI = PersistentConfig(
     "OPENID_REDIRECT_URI",
     "oauth.oidc.redirect_uri",
@@ -838,7 +844,7 @@ def load_oauth_providers():
     if FEISHU_CLIENT_ID.value:
         configured_providers.append("Feishu")
 
-    if configured_providers and not OPENID_PROVIDER_URL.value:
+    if configured_providers and not OPENID_PROVIDER_URL.value and not OAUTH_LOGOUT_URI.value:
         provider_list = ", ".join(configured_providers)
         log.warning(
             f"⚠️  OAuth providers configured ({provider_list}) but OPENID_PROVIDER_URL not set - logout will not work!"

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -46,6 +46,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from open_webui.config import (
     OPENID_PROVIDER_URL,
+    OAUTH_LOGOUT_URI,
     ENABLE_OAUTH_SIGNUP,
     ENABLE_LDAP,
     ENABLE_PASSWORD_AUTH,
@@ -822,6 +823,16 @@ async def signout(
     oauth_session_id = request.cookies.get("oauth_session_id")
     if oauth_session_id:
         response.delete_cookie("oauth_session_id")
+
+        if OAUTH_LOGOUT_URI.value:
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "status": True,
+                    "redirect_url": OAUTH_LOGOUT_URI.value,
+                },
+                headers=response.headers,
+            )
 
         session = OAuthSessions.get_session_by_id(oauth_session_id, db=db)
         oauth_server_metadata_url = (


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Changelog:** See below
- [x] **Testing:** Manually verified that the new config variable is picked up and the signout handler correctly redirects when `OAUTH_LOGOUT_URI` is set
- [x] **Agentic AI Code:** This PR has been reviewed and tested by a human
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Single atomic commit

# Changelog Entry

### Description

Add a new `OAUTH_LOGOUT_URI` environment variable that allows specifying a full custom logout URI for OAuth providers that do not support the standard OIDC `end_session_endpoint` discovery (e.g. AWS Cognito).

Closes #19182

### Added

- `OAUTH_LOGOUT_URI` PersistentConfig in `config.py` — accepts a full custom logout URL via environment variable
- Early return in the `/signout` handler: when `OAUTH_LOGOUT_URI` is set and an OAuth session exists, redirect to it directly instead of attempting OIDC discovery

### Changed

- Startup warning now also checks `OAUTH_LOGOUT_URI` — the "logout will not work" warning is suppressed when either `OPENID_PROVIDER_URL` or `OAUTH_LOGOUT_URI` is configured

### Fixed

- OAuth logout for providers like AWS Cognito that use a custom logout endpoint with different parameters (e.g. `client_id` + `logout_uri`) instead of the standard OIDC `end_session_endpoint` with `id_token_hint`

---

### Additional Information

- AWS Cognito requires a logout URL like `https://<domain>/logout?client_id=<id>&logout_uri=<uri>` — this cannot be discovered via OIDC metadata
- The new variable is fully opt-in: when unset (default `""`), the existing OIDC discovery flow is used unchanged
- Only 2 files changed, 18 lines added

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.