### PR TITLE
fix(config): RAG_OPENAI env vars now correctly inherit OPENAI_API values

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3067,12 +3067,16 @@ RAG_TEMPLATE = PersistentConfig(
 RAG_OPENAI_API_BASE_URL = PersistentConfig(
     "RAG_OPENAI_API_BASE_URL",
     "rag.openai_api_base_url",
-    os.getenv("RAG_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv(
+        "RAG_OPENAI_API_BASE_URL",
+        os.environ.get("OPENAI_API_BASE_URL", "").rstrip("/")
+        or "https://api.openai.com/v1",
+    ),
 )
 RAG_OPENAI_API_KEY = PersistentConfig(
     "RAG_OPENAI_API_KEY",
     "rag.openai_api_key",
-    os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("RAG_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", "")),
 )
 
 RAG_AZURE_OPENAI_BASE_URL = PersistentConfig(


### PR DESCRIPTION
## Summary

Fixes #22084

`RAG_OPENAI_API_BASE_URL` and `RAG_OPENAI_API_KEY` are supposed to fall back to `OPENAI_API_BASE_URL` and `OPENAI_API_KEY` when not explicitly set. However, the fallback references Python variables that have already been **reset to defaults** earlier in `config.py`:

- `OPENAI_API_BASE_URL` is reset to `"https://api.openai.com/v1"` (line 1144)
- `OPENAI_API_KEY` is reset to `""` (line 1134)

By the time the RAG config is defined (~line 3067), both variables contain default/empty values regardless of what the user set via environment variables.

## Root Cause

`config.py` reassigns `OPENAI_API_KEY` and `OPENAI_API_BASE_URL` to extract the "official" OpenAI endpoint from the multi-provider arrays. This means the original user-supplied values are lost from the Python variables, even though they're still available in `os.environ`.

## Fix

Read the original environment variables directly via `os.environ.get()` instead of referencing the already-reset Python variables:

```python
# Before (broken): uses reset Python variables
os.getenv("RAG_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL)
os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY)

# After (fixed): reads original env vars directly
os.getenv("RAG_OPENAI_API_BASE_URL", 
          os.environ.get("OPENAI_API_BASE_URL", "").rstrip("/") or "https://api.openai.com/v1")
os.getenv("RAG_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
```

## Behavior

| Scenario | Before | After |
|---|---|---|
| Only `OPENAI_API_BASE_URL` set | Falls back to `https://api.openai.com/v1` ❌ | Inherits user value ✅ |
| Only `OPENAI_API_KEY` set | Falls back to `""` ❌ | Inherits user value ✅ |
| Both `RAG_OPENAI_*` explicitly set | Uses RAG values ✅ | Uses RAG values ✅ |
| Nothing set | Uses defaults ✅ | Uses defaults ✅ |

## Testing

- Verified Python syntax parses correctly
- The fix is minimal (2 lines changed) and only affects the default value resolution for RAG OpenAI config