### PR TITLE
perf: fast-path length check in StatusHistory comparison

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage/StatusHistory.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/StatusHistory.svelte
@@ -21,7 +21,8 @@
 		status = history.at(-1);
 	}
 
-	$: if (JSON.stringify(statusHistory) !== JSON.stringify(history)) {
+	$: if (statusHistory.length !== history.length
+		|| JSON.stringify(statusHistory) !== JSON.stringify(history)) {
 		history = statusHistory;
 	}
 </script>


### PR DESCRIPTION
Add O(1) array length check before expensive JSON.stringify comparison. During streaming, status history typically only grows via appends, so a length mismatch catches most updates without serialization.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
