### PR TITLE
fix(tools): normalize tool server URLs to prevent double-slash issues

### DIFF
--- a/backend/open_webui/test/util/test_tools.py
+++ b/backend/open_webui/test/util/test_tools.py
@@ -1,0 +1,71 @@
+import pytest
+
+from open_webui.utils.tools import get_tool_server_url
+
+
+class TestGetToolServerUrl:
+    """Test get_tool_server_url which normalizes URLs for both spec
+    fetching (verify) and is the basis for execution URL construction.
+
+    The same rstrip('/') normalization pattern is applied in
+    get_tool_servers_data and execute_tool_server to prevent
+    double-slash issues.
+    """
+
+    # --- Basic path joining ---
+
+    def test_basic_url_and_path(self):
+        result = get_tool_server_url("http://localhost:8080", "openapi.json")
+        assert result == "http://localhost:8080/openapi.json"
+
+    def test_path_starting_with_slash(self):
+        result = get_tool_server_url("http://localhost:8080", "/openapi.json")
+        assert result == "http://localhost:8080/openapi.json"
+
+    def test_nested_path(self):
+        result = get_tool_server_url("http://localhost:8080", "api/v1/openapi.json")
+        assert result == "http://localhost:8080/api/v1/openapi.json"
+
+    def test_full_url_in_path(self):
+        result = get_tool_server_url(
+            "http://localhost:8080", "https://other-host/spec.json"
+        )
+        assert result == "https://other-host/spec.json"
+
+    def test_none_url_with_full_path(self):
+        result = get_tool_server_url(None, "https://other-host/spec.json")
+        assert result == "https://other-host/spec.json"
+
+    # --- Trailing slash normalization (core fix) ---
+
+    def test_url_trailing_slash_stripped(self):
+        result = get_tool_server_url("http://localhost:8080/", "openapi.json")
+        assert result == "http://localhost:8080/openapi.json"
+
+    def test_url_with_path_trailing_slash_stripped(self):
+        result = get_tool_server_url("http://localhost:8080/v1/", "openapi.json")
+        assert result == "http://localhost:8080/v1/openapi.json"
+
+    def test_slash_url_and_slash_path_no_double(self):
+        result = get_tool_server_url("http://localhost:8080/", "/openapi.json")
+        assert result == "http://localhost:8080/openapi.json"
+        assert "//" not in result.split("://", 1)[1]
+
+    def test_multiple_trailing_slashes_stripped(self):
+        result = get_tool_server_url("http://localhost:8080///", "openapi.json")
+        assert result == "http://localhost:8080/openapi.json"
+
+    # --- Subpath / reverse proxy preservation ---
+
+    def test_subpath_preserved(self):
+        result = get_tool_server_url("http://localhost:8080/api/v1", "openapi.json")
+        assert result == "http://localhost:8080/api/v1/openapi.json"
+
+    def test_proxy_prefix_preserved(self):
+        result = get_tool_server_url("http://proxy:8080/gateway/tools", "openapi.json")
+        assert result == "http://proxy:8080/gateway/tools/openapi.json"
+
+    def test_proxy_prefix_trailing_slash_stripped(self):
+        result = get_tool_server_url("http://proxy:8080/gateway/tools/", "openapi.json")
+        assert result == "http://proxy:8080/gateway/tools/openapi.json"
+        assert "//" not in result.split("://", 1)[1]

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1186,7 +1186,7 @@ async def get_tool_servers_data(servers: List[Dict[str, Any]]) -> List[Dict[str,
             {
                 "id": str(id),
                 "idx": idx,
-                "url": server.get("url"),
+                "url": (server.get("url") or "").rstrip("/"),
                 "openapi": openapi_data,
                 "info": response.get("info"),
                 "specs": response.get("specs"),
@@ -1249,7 +1249,7 @@ async def execute_tool_server(
                 elif param_in == "query":
                     query_params[param_name] = params[param_name]
 
-        final_url = f"{url}{route_path}"
+        final_url = f"{url.rstrip('/')}{route_path}"
         for key, value in path_params.items():
             final_url = final_url.replace(f"{{{key}}}", str(value))
 
@@ -1319,6 +1319,8 @@ def get_tool_server_url(url: Optional[str], path: str) -> str:
     if "://" in path:
         # If it contains "://", it's a full URL
         return path
+    if url:
+        url = url.rstrip("/")
     if not path.startswith("/"):
         # Ensure the path starts with a slash
         path = f"/{path}"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Provided below.
- [x] **Testing:** 12 unit tests added; manual ad-hoc verification of all URL normalization scenarios.
- [x] **Code review:** Self-reviewed; Black formatter applied.
- [x] **Git Hygiene:** Atomic PR (single logical change), rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Fixes #21917

When a tool server URL includes a trailing slash (e.g. `http://host:8080/v1/`), joining it with a path like `/openapi.json` or a route like `/search` produces a double-slash URL (`http://host:8080/v1//openapi.json`). Some servers reject or misroute these malformed URLs, causing connection failures.

### Fixed

- Strip trailing slashes from base URLs before path concatenation in three places:
  - `get_tool_server_url` - spec URL construction (verify flow)
  - `get_tool_servers_data` - stored URL normalization
  - `execute_tool_server` - execution URL construction
- Add `None` guard on stored URL to prevent `AttributeError` on malformed configs

### Added

- 12 unit tests for `get_tool_server_url` covering trailing slashes, subpaths, proxy prefixes, and edge cases (`backend/open_webui/test/util/test_tools.py`)

---

### Additional Information

- Only `backend/open_webui/utils/tools.py` modified (4 additions, 2 deletions)
- No new dependencies
- No breaking changes - existing URLs without trailing slashes behave identically

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.