### PR TITLE
fix: add type guards in citation parser to prevent AttributeError

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -183,6 +183,8 @@ def get_citation_source_from_tool_result(
         if tool_name == "search_web":
             # Parse JSON array: [{"title": "...", "link": "...", "snippet": "..."}]
             results = tool_result
+            if not isinstance(results, list):
+                return []
             documents = []
             metadata = []
 
@@ -210,6 +212,8 @@ def get_citation_source_from_tool_result(
 
         elif tool_name == "view_knowledge_file":
             file_data = tool_result
+            if not isinstance(file_data, dict):
+                return []
             filename = file_data.get("filename", "Unknown File")
             file_id = file_data.get("id", "")
             knowledge_name = file_data.get("knowledge_name", "")
@@ -258,6 +262,8 @@ def get_citation_source_from_tool_result(
 
         elif tool_name == "query_knowledge_files":
             chunks = tool_result
+            if not isinstance(chunks, list):
+                return []
 
             # Group chunks by source for better citation display
             # Each unique source becomes a separate source entry


### PR DESCRIPTION
### Description

When a tool (e.g. `search_web`) returns an error string instead of the expected data structure, `get_citation_source_from_tool_result` crashes with:

```
AttributeError: 'str' object has no attribute 'get'
```

This happens because the JSON parse failure silently falls through (`pass`), leaving `tool_result` as a plain string. The code then tries to iterate over the string and call `.get()` on individual characters.

### Changes

Added `isinstance` type guards before accessing parsed data in three tool branches:

- **`search_web`**: checks `tool_result` is a `list` before iterating
- **`view_knowledge_file`**: checks `tool_result` is a `dict` before calling `.get()`
- **`query_knowledge_files`**: checks `tool_result` is a `list` before iterating

Returns an empty source list on type mismatch instead of crashing.

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Changes are minimal and focused on the reported issue

Fixes #21070