### PR TITLE
fix: add type guards in citation parser to prevent AttributeError

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -183,6 +183,8 @@ def get_citation_source_from_tool_result(
         if tool_name == "search_web":
             # Parse JSON array: [{"title": "...", "link": "...", "snippet": "..."}]
             results = tool_result
+            if not isinstance(results, list):
+                return []
             documents = []
             metadata = []
 
@@ -210,6 +212,8 @@ def get_citation_source_from_tool_result(
 
         elif tool_name == "view_knowledge_file":
             file_data = tool_result
+            if not isinstance(file_data, dict):
+                return []
             filename = file_data.get("filename", "Unknown File")
             file_id = file_data.get("id", "")
             knowledge_name = file_data.get("knowledge_name", "")
@@ -258,6 +262,8 @@ def get_citation_source_from_tool_result(
 
         elif tool_name == "query_knowledge_files":
             chunks = tool_result
+            if not isinstance(chunks, list):
+                return []
 
             # Group chunks by source for better citation display
             # Each unique source becomes a separate source entry


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Type guards added to citation parser to prevent AttributeError when tools return error strings
- [x] **Testing:** Manually verified that passing a string to each tool branch now returns `[]` instead of crashing
- [x] **Code review:** Self-reviewed, minimal 6-line change

# Changelog Entry

### Description

When a tool (e.g. `search_web`) returns an error string instead of the expected data structure, `get_citation_source_from_tool_result` crashes with `AttributeError: 'str' object has no attribute 'get'`. This happens because the JSON parse failure silently falls through, leaving `tool_result` as a plain string.

### Fixed

- Added `isinstance` type guards in `get_citation_source_from_tool_result` for three tool branches:
  - `search_web`: checks result is a `list` before iterating
  - `view_knowledge_file`: checks result is a `dict` before calling `.get()`
  - `query_knowledge_files`: checks result is a `list` before iterating
- Returns empty source list on type mismatch instead of crashing

Fixes #21070

---

### Additional Information

Previous PRs (#21638, #21209, #21207, #21244, #21250) attempted to fix this but were closed. The root cause is still present in the current codebase — the `isinstance` guards are the minimal defensive fix.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.