### PR TITLE
fix: ensure RAG and specialized OpenAI configs inherit environment values

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1105,6 +1105,9 @@ ENABLE_OPENAI_API = PersistentConfig(
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 OPENAI_API_BASE_URL = os.environ.get("OPENAI_API_BASE_URL", "")
 
+INITIAL_OPENAI_API_KEY = OPENAI_API_KEY
+INITIAL_OPENAI_API_BASE_URL = OPENAI_API_BASE_URL
+
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
 GEMINI_API_BASE_URL = os.environ.get("GEMINI_API_BASE_URL", "")
 
@@ -3101,12 +3104,12 @@ RAG_TEMPLATE = PersistentConfig(
 RAG_OPENAI_API_BASE_URL = PersistentConfig(
     "RAG_OPENAI_API_BASE_URL",
     "rag.openai_api_base_url",
-    os.getenv("RAG_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("RAG_OPENAI_API_BASE_URL", INITIAL_OPENAI_API_BASE_URL),
 )
 RAG_OPENAI_API_KEY = PersistentConfig(
     "RAG_OPENAI_API_KEY",
     "rag.openai_api_key",
-    os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("RAG_OPENAI_API_KEY", INITIAL_OPENAI_API_KEY),
 )
 
 RAG_AZURE_OPENAI_BASE_URL = PersistentConfig(
@@ -3786,7 +3789,7 @@ COMFYUI_WORKFLOW_NODES = PersistentConfig(
 IMAGES_OPENAI_API_BASE_URL = PersistentConfig(
     "IMAGES_OPENAI_API_BASE_URL",
     "image_generation.openai.api_base_url",
-    os.getenv("IMAGES_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("IMAGES_OPENAI_API_BASE_URL", INITIAL_OPENAI_API_BASE_URL),
 )
 IMAGES_OPENAI_API_VERSION = PersistentConfig(
     "IMAGES_OPENAI_API_VERSION",
@@ -3797,7 +3800,7 @@ IMAGES_OPENAI_API_VERSION = PersistentConfig(
 IMAGES_OPENAI_API_KEY = PersistentConfig(
     "IMAGES_OPENAI_API_KEY",
     "image_generation.openai.api_key",
-    os.getenv("IMAGES_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("IMAGES_OPENAI_API_KEY", INITIAL_OPENAI_API_KEY),
 )
 
 images_openai_params = os.getenv("IMAGES_OPENAI_PARAMS", "")
@@ -3854,7 +3857,7 @@ IMAGE_EDIT_SIZE = PersistentConfig(
 IMAGES_EDIT_OPENAI_API_BASE_URL = PersistentConfig(
     "IMAGES_EDIT_OPENAI_API_BASE_URL",
     "images.edit.openai.api_base_url",
-    os.getenv("IMAGES_EDIT_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("IMAGES_EDIT_OPENAI_API_BASE_URL", INITIAL_OPENAI_API_BASE_URL),
 )
 IMAGES_EDIT_OPENAI_API_VERSION = PersistentConfig(
     "IMAGES_EDIT_OPENAI_API_VERSION",
@@ -3865,7 +3868,7 @@ IMAGES_EDIT_OPENAI_API_VERSION = PersistentConfig(
 IMAGES_EDIT_OPENAI_API_KEY = PersistentConfig(
     "IMAGES_EDIT_OPENAI_API_KEY",
     "images.edit.openai.api_key",
-    os.getenv("IMAGES_EDIT_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("IMAGES_EDIT_OPENAI_API_KEY", INITIAL_OPENAI_API_KEY),
 )
 
 IMAGES_EDIT_GEMINI_API_BASE_URL = PersistentConfig(
@@ -3948,13 +3951,13 @@ ELEVENLABS_API_BASE_URL = os.getenv(
 AUDIO_STT_OPENAI_API_BASE_URL = PersistentConfig(
     "AUDIO_STT_OPENAI_API_BASE_URL",
     "audio.stt.openai.api_base_url",
-    os.getenv("AUDIO_STT_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("AUDIO_STT_OPENAI_API_BASE_URL", INITIAL_OPENAI_API_BASE_URL),
 )
 
 AUDIO_STT_OPENAI_API_KEY = PersistentConfig(
     "AUDIO_STT_OPENAI_API_KEY",
     "audio.stt.openai.api_key",
-    os.getenv("AUDIO_STT_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("AUDIO_STT_OPENAI_API_KEY", INITIAL_OPENAI_API_KEY),
 )
 
 AUDIO_STT_ENGINE = PersistentConfig(
@@ -4032,12 +4035,12 @@ AUDIO_STT_MISTRAL_USE_CHAT_COMPLETIONS = PersistentConfig(
 AUDIO_TTS_OPENAI_API_BASE_URL = PersistentConfig(
     "AUDIO_TTS_OPENAI_API_BASE_URL",
     "audio.tts.openai.api_base_url",
-    os.getenv("AUDIO_TTS_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("AUDIO_TTS_OPENAI_API_BASE_URL", INITIAL_OPENAI_API_BASE_URL),
 )
 AUDIO_TTS_OPENAI_API_KEY = PersistentConfig(
     "AUDIO_TTS_OPENAI_API_KEY",
     "audio.tts.openai.api_key",
-    os.getenv("AUDIO_TTS_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("AUDIO_TTS_OPENAI_API_KEY", INITIAL_OPENAI_API_KEY),
 )
 
 audio_tts_openai_params = os.getenv("AUDIO_TTS_OPENAI_PARAMS", "")


### PR DESCRIPTION
Fixes #22084. 

### Problem
Internal logic in config.py was resetting OPENAI_API_BASE_URL and OPENAI_API_KEY to hardcoded defaults mid-way through initialization. This caused specialized modules (RAG, Image Generation, Audio STT/TTS) to ignore user-provided environment variables and fallback to the hardcoded OpenAI defaults instead of the user's primary OpenAI configuration.

### Solution
- Introduced INITIAL_OPENAI_API_BASE_URL and INITIAL_OPENAI_API_KEY to capture environment values at the very start of initialization.
- Updated all dependent PersistentConfig instances (RAG, IMAGES, AUDIO) to use these captured initial values as their defaults.
- This ensures that if a user sets OPENAI_API_BASE_URL, it correctly flows down to RAG_OPENAI_API_BASE_URL if the latter is not explicitly set.

### Testing Confirmation
I have personally tested these changes by setting the \OPENAI_API_BASE_URL\ and \OPENAI_API_KEY\ environment variables and verifying that the RAG, Image Generation, and Audio modules correctly inherit these values during initialization. I also verified that explicit overrides (e.g. setting \RAG_OPENAI_API_BASE_URL\) still work as expected.

I agree to the contributor license agreement.