### PR TITLE
feat: add OAUTH_LOGOUT_CUSTOM_REDIRECT_URI for SSO custom logout

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -547,6 +547,10 @@ WEBUI_AUTH_SIGNOUT_REDIRECT_URL = os.environ.get(
     "WEBUI_AUTH_SIGNOUT_REDIRECT_URL", None
 )
 
+OAUTH_LOGOUT_CUSTOM_REDIRECT_URI = os.environ.get(
+    "OAUTH_LOGOUT_CUSTOM_REDIRECT_URI", None
+)
+
 ####################################
 # WEBUI_SECRET_KEY
 ####################################

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -38,6 +38,7 @@ from open_webui.env import (
     WEBUI_AUTH_COOKIE_SAME_SITE,
     WEBUI_AUTH_COOKIE_SECURE,
     WEBUI_AUTH_SIGNOUT_REDIRECT_URL,
+    OAUTH_LOGOUT_CUSTOM_REDIRECT_URI,
     ENABLE_INITIAL_ADMIN_SIGNUP,
     ENABLE_OAUTH_TOKEN_EXCHANGE,
     AIOHTTP_CLIENT_SESSION_SSL,
@@ -840,16 +841,17 @@ async def signout(
                             logout_url = openid_data.get("end_session_endpoint")
 
                             if logout_url:
+                                redirect_url = f"{logout_url}?id_token_hint={oauth_id_token}"
+                                if OAUTH_LOGOUT_CUSTOM_REDIRECT_URI:
+                                    redirect_url = OAUTH_LOGOUT_CUSTOM_REDIRECT_URI
+                                elif WEBUI_AUTH_SIGNOUT_REDIRECT_URL:
+                                    redirect_url += f"&post_logout_redirect_uri={WEBUI_AUTH_SIGNOUT_REDIRECT_URL}"
+
                                 return JSONResponse(
                                     status_code=200,
                                     content={
                                         "status": True,
-                                        "redirect_url": f"{logout_url}?id_token_hint={oauth_id_token}"
-                                        + (
-                                            f"&post_logout_redirect_uri={WEBUI_AUTH_SIGNOUT_REDIRECT_URL}"
-                                            if WEBUI_AUTH_SIGNOUT_REDIRECT_URL
-                                            else ""
-                                        ),
+                                        "redirect_url": redirect_url,
                                     },
                                     headers=response.headers,
                                 )


### PR DESCRIPTION
Fixes #19182.

This PR introduces a new environment variable \OAUTH_LOGOUT_CUSTOM_REDIRECT_URI\ that allows users to specify a complete custom logout URL for OAuth/OIDC providers. 

### Testing Confirmation
I have personally tested these changes by:
1. Setting \OAUTH_LOGOUT_CUSTOM_REDIRECT_URI\ to a test endpoint.
2. Initiating a sign-out flow.
3. Verifying that the application correctly redirects to the custom URI instead of the default OIDC logout URL.
4. Verifying that when the variable is NOT set, the default behavior (OIDC end_session_endpoint) is preserved.

I agree to the contributor license agreement.