### PR TITLE
fix: add missing lang="ts" to ChatControls module script

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script context="module" lang="ts">
 	let savedTab: 'controls' | 'files' | 'overview' = 'controls';
 </script>
 


### PR DESCRIPTION
The `<script context="module">` block in `ChatControls.svelte` uses TypeScript syntax but is missing `lang="ts"`, causing esbuild to fail during `vite dev` dependency scanning:

```
✘ [ERROR] Expected ";" but found ":"

  script:/.../src/lib/components/chat/ChatControls.svelte?id=0:2:13:
    2 │   let savedTab: 'controls' | 'files' | 'overview' = 'controls';
      │               ^
      ╵               ;
```

Fix: `<script context="module">` → `<script context="module" lang="ts">`.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.