### PR TITLE
fix: variable shadowing in middleware

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -375,9 +375,9 @@ def serialize_output(output: list) -> str:
             result_item = tool_outputs.get(call_id)
             if result_item:
                 result_text = ""
-                for output in result_item.get("output", []):
-                    if "text" in output:
-                        output_text = output.get("text", "")
+                for out in result_item.get("output", []):
+                    if "text" in out:
+                        output_text = out.get("text", "")
                         result_text += (
                             str(output_text)
                             if not isinstance(output_text, str)


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Changelog Entry

### Description

- There is a variable shadowing issue: since a variable with the same name already exists in the function's input, the `reasoning` block incorrectly sets `done` to `true` at the beginning.

### Fixed

- Fixed variable shadowing in middleware

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
