### PR TITLE
fix: trigger title generation when chat title is still empty after cancelled first response

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2231,10 +2231,11 @@
 
 				background_tasks: {
 					...(!$temporaryChatEnabled &&
-					(messages.length == 1 ||
+					((messages.length == 1 ||
 						(messages.length == 2 &&
 							messages.at(0)?.role === 'system' &&
-							messages.at(1)?.role === 'user')) &&
+							messages.at(1)?.role === 'user')) ||
+						!$chatTitle) &&
 					(selectedModels[0] === model.id || atSelectedModel !== undefined)
 						? {
 								title_generation: $settings?.title?.auto ?? true,


### PR DESCRIPTION
he background_tasks.title_generation flag was only sent when the message array had exactly 1 entry (or 2 with a system prompt) i.e., the very first user message. If the user cancelled that first response, the cancelled assistant message remained in the history, so on any subsequent message messages.length > 2 and the title generation condition was never met again. The chat stayed as "New Chat" forever.

https://github.com/open-webui/open-webui/issues/21961


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
