### PR TITLE
fix: persist token usage data for non-streaming chat responses

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3082,6 +3082,9 @@ async def non_streaming_chat_response_handler(response, ctx):
                     )
 
                     # Save message in the database
+                    raw_usage = response_data.get("usage", {}) or {}
+                    usage = normalize_usage(raw_usage) if raw_usage else None
+
                     Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata["chat_id"],
                         metadata["message_id"],
@@ -3089,6 +3092,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                             "role": "assistant",
                             "content": content,
                             "output": response_output,
+                            **({"usage": usage} if usage else {}),
                         },
                     )
 


### PR DESCRIPTION
The non-streaming response handler was saving assistant messages without their usage/token data. While the streaming handler correctly extracted and saved usage information, the non-streaming path discarded it entirely.

This caused assistant messages from non-streaming completions to have NULL usage in the chat_message table, making them invisible to the analytics token aggregation queries and contributing to the '0 tokens' display in Admin Panel Analytics.

Extract and normalize the usage data from the API response and include it in the database upsert, matching the pattern already used by the streaming handler.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
