### PR TITLE
fix: add missing group_id filter to analytics token usage query

### DIFF
--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -418,11 +418,13 @@ class ChatMessageTable:
         self,
         start_date: Optional[int] = None,
         end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
         db: Optional[Session] = None,
     ) -> dict[str, dict]:
         """Aggregate token usage by user using database-level aggregation."""
         with get_db_context(db) as db:
             from sqlalchemy import func, cast, Integer
+            from open_webui.models.groups import GroupMember
 
             dialect = db.bind.dialect.name
 
@@ -462,6 +464,13 @@ class ChatMessageTable:
                 query = query.filter(ChatMessage.created_at >= start_date)
             if end_date:
                 query = query.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = (
+                    db.query(GroupMember.user_id)
+                    .filter(GroupMember.group_id == group_id)
+                    .subquery()
+                )
+                query = query.filter(ChatMessage.user_id.in_(group_users))
 
             results = query.group_by(ChatMessage.user_id).all()
 

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -86,7 +86,7 @@ async def get_user_analytics(
         start_date=start_date, end_date=end_date, group_id=group_id, db=db
     )
     token_usage = ChatMessages.get_token_usage_by_user(
-        start_date=start_date, end_date=end_date, db=db
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
     )
 
     # Get user info for top users


### PR DESCRIPTION
The get_token_usage_by_user query lacked group_id filtering, while the companion get_message_count_by_user query already supported it. When an admin filtered analytics by user group, message counts were correctly scoped to the group but token usage totals included data from all users.

Add the group_id parameter and subquery filter to get_token_usage_by_user, matching the pattern used by get_message_count_by_user and other analytics queries, and pass group_id through from the analytics endpoint.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
