### PR TITLE
fix(rag): RAG_OPENAI_ env vars fall back to OPENAI_API_ values

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3101,12 +3101,12 @@ RAG_TEMPLATE = PersistentConfig(
 RAG_OPENAI_API_BASE_URL = PersistentConfig(
     "RAG_OPENAI_API_BASE_URL",
     "rag.openai_api_base_url",
-    os.getenv("RAG_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("RAG_OPENAI_API_BASE_URL", os.environ.get("OPENAI_API_BASE_URL", OPENAI_API_BASE_URL)),
 )
 RAG_OPENAI_API_KEY = PersistentConfig(
     "RAG_OPENAI_API_KEY",
     "rag.openai_api_key",
-    os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("RAG_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", OPENAI_API_KEY)),
 )
 
 RAG_AZURE_OPENAI_BASE_URL = PersistentConfig(


### PR DESCRIPTION
Fixes #22084\n\nWhen `RAG_OPENAI_API_KEY` and `RAG_OPENAI_API_BASE_URL` are not explicitly set, they now fall back to `OPENAI_API_KEY` and `OPENAI_API_BASE_URL` respectively.