### PR TITLE
Feat: katex render more equations correctly by splitting delimiters into strict and loose types

### DIFF
--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -1,6 +1,13 @@
-const DELIMITER_LIST = [
+// "Loose" delimiters: $ and $$ are ambiguous (could be currency), so they
+// require surrounding-character checks to avoid false positives.
+const LOOSE_DELIMITERS = [
 	{ left: '$$', right: '$$', display: true },
-	{ left: '$', right: '$', display: false },
+	{ left: '$', right: '$', display: false }
+];
+
+// "Strict" delimiters: these are unambiguous LaTeX syntax and can be matched
+// without surrounding-character constraints.
+const STRICT_DELIMITERS = [
 	{ left: '\\pu{', right: '}', display: false },
 	{ left: '\\ce{', right: '}', display: false },
 	{ left: '\\(', right: '\\)', display: false },
@@ -8,7 +15,10 @@ const DELIMITER_LIST = [
 	{ left: '\\begin{equation}', right: '\\end{equation}', display: true }
 ];
 
-// Defines characters that are allowed to immediately precede or follow a math delimiter.
+const ALL_DELIMITERS = [...LOOSE_DELIMITERS, ...STRICT_DELIMITERS];
+
+// Defines characters that are allowed to immediately precede or follow a
+// loose math delimiter ($ and $$). Strict delimiters skip this check.
 const ALLOWED_SURROUNDING_CHARS =
 	'\\s。，、､;；„“‘’“”（）「」『』［］《》【】‹›«»…⋯:：？！～⇒?!-\\/:-@\\[-`{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
 // Modified to fit more formats in different languages. Originally: '\\s?。，、；!-\\/:-@\\[-`{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
@@ -27,44 +37,64 @@ const ALLOWED_SURROUNDING_CHARS_REGEX = new RegExp(`[${ALLOWED_SURROUNDING_CHARS
 // const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\1(?=[\s?!\.,:？！。，：]|$)/;
 // const blockRule = /^(\${1,2})\n((?:\\[^]|[^\\])+?)\n\1(?:\n|$)/;
 
-const inlinePatterns = [];
-const blockPatterns = [];
 
 function escapeRegex(string) {
 	return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-function generateRegexRules(delimiters) {
+function buildPatterns(delimiters) {
+	const inlinePatterns: string[] = [];
+	const blockPatterns: string[] = [];
+
 	delimiters.forEach((delimiter) => {
 		const { left, right, display } = delimiter;
-		// Ensure regex-safe delimiters
 		const escapedLeft = escapeRegex(left);
 		const escapedRight = escapeRegex(right);
 
 		if (!display) {
-			// For inline delimiters, we match everything
-			inlinePatterns.push(`${escapedLeft}((?:\\\\[^]|[^\\\\])+?)${escapedRight}`);
+			// Inline-only delimiters must not span newlines to prevent greedy cross-line matching
+			inlinePatterns.push(`${escapedLeft}((?:\\\\[^\\n]|[^\\\\\\n])+?)${escapedRight}`);
 		} else {
-			// Block delimiters doubles as inline delimiters when not followed by a newline
+			// Block delimiters double as inline delimiters when not followed by a newline
 			inlinePatterns.push(`${escapedLeft}(?!\\n)((?:\\\\[^]|[^\\\\])+?)(?!\\n)${escapedRight}`);
 			blockPatterns.push(`${escapedLeft}\\n((?:\\\\[^]|[^\\\\])+?)\\n${escapedRight}`);
 		}
 	});
 
-	// Math formulas can end in special characters
-	const inlineRule = new RegExp(
-		`^(${inlinePatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`,
-		'u'
-	);
-	const blockRule = new RegExp(
-		`^(${blockPatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`,
-		'u'
-	);
+	return { inlinePatterns, blockPatterns };
+}
+
+function generateRegexRules() {
+	const loose = buildPatterns(LOOSE_DELIMITERS);
+	const strict = buildPatterns(STRICT_DELIMITERS);
+
+	// Loose patterns require the surrounding-char lookahead
+	const looseInline = loose.inlinePatterns.length
+		? `(?:${loose.inlinePatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`
+		: null;
+	const looseBlock = loose.blockPatterns.length
+		? `(?:${loose.blockPatterns.join('|')})(?=[${ALLOWED_SURROUNDING_CHARS}]|$)`
+		: null;
+
+	// Strict patterns match without surrounding-char constraints
+	const strictInline = strict.inlinePatterns.length
+		? `(?:${strict.inlinePatterns.join('|')})`
+		: null;
+	const strictBlock = strict.blockPatterns.length
+		? `(?:${strict.blockPatterns.join('|')})`
+		: null;
+
+	// Combine: try strict first (more specific), then loose
+	const inlineParts = [strictInline, looseInline].filter(Boolean);
+	const blockParts = [strictBlock, looseBlock].filter(Boolean);
+
+	const inlineRule = new RegExp(`^(${inlineParts.join('|')})`, 'u');
+	const blockRule = new RegExp(`^(${blockParts.join('|')})`, 'u');
 
 	return { inlineRule, blockRule };
 }
 
-const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
+const { inlineRule, blockRule } = generateRegexRules();
 
 export default function (options = {}) {
 	return {
@@ -81,6 +111,7 @@ function katexStart(src, displayMode: boolean) {
 			if (displayMode && src.charAt(i + 1) !== '$') {
 				continue;
 			}
+			// $ is a loose delimiter — require surrounding-char check
 			if (i === 0 || ALLOWED_SURROUNDING_CHARS_REGEX.test(src.charAt(i - 1))) {
 				return i;
 			}
@@ -94,9 +125,8 @@ function katexStart(src, displayMode: boolean) {
 				// Inline: \( or \ce{ or \pu{
 				if (next !== '(' && next !== 'c' && next !== 'p') continue;
 			}
-			if (i === 0 || ALLOWED_SURROUNDING_CHARS_REGEX.test(src.charAt(i - 1))) {
-				return i;
-			}
+			// \ delimiters are strict — no surrounding-char check needed
+			return i;
 		}
 	}
 }


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [X] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

seprate the latex delimiters into two groups such that many latex equations could be rendered while still being conservative with the commonly used dollar signs.

### Added

- Split KaTeX delimiters into "strict" (\(, \), \[, \], \ce{}, \pu{}, \begin{equation}) and "loose" ($, $$) groups. Strict delimiters are unambiguous LaTeX syntax and now match without requiring surrounding-character checks.

### Fixed

- Prevented inline KaTeX regex from matching across newlines by changing content patterns from [^] to [^\n], fixing cross-line backtracking that could cause intermediate \(...\) expressions to be consumed by a single greedy $...$ match.

---

### Additional Information

Fix issue #12036  and many other latex/katex equation related discussions.
### Screenshots or Videos

Render
```
and \(10^3\)-\(10^4\) and
 \(10^3\) ——
$10^3$——
 \(\gamma\)and
x——\(10^4\)
 \(x\)—— and \(y\) 
 \(\gamma\)and\(\gamma_c\) 
 \(\gamma\) and\(\gamma_c\) 
d $\cdotp$ b
d $\cdot$ b

The Handshaking Lemma states that $\sum_{v \in V} \deg(v) = 2|E|$.
If all 5 vertices have degree 3, then:

$$\sum_{v \in V} \deg(v) = 15$$

which is odd — contradicting the lemma. QED.
```
Before:
<img width="465" height="415" alt="image" src="https://github.com/user-attachments/assets/8434ae37-c08a-42df-b322-01e988b4f986" />
After:
<img width="457" height="412" alt="image" src="https://github.com/user-attachments/assets/5b916027-bb29-49c3-bd45-cf193264b227" />
Note that the second dollar sign break is intentional.

render:
```
\(\xi = (\xi_1, \dots, \xi_N)\)xx
\(a^2 + b^2 = c^2\)\(e^{i\pi} + 1 = 0\)
```
Before:
<img width="260" height="73" alt="image" src="https://github.com/user-attachments/assets/ca119a3f-35b7-4ec7-ae21-ae74abc61359" />

After:
<img width="221" height="54" alt="image" src="https://github.com/user-attachments/assets/a7537458-1369-4160-bab0-49622b132610" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
