### PR TITLE
fix: RAG_OPENAI_ env vars fall back to OPENAI_API_ values

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3101,12 +3101,12 @@ RAG_TEMPLATE = PersistentConfig(
 RAG_OPENAI_API_BASE_URL = PersistentConfig(
     "RAG_OPENAI_API_BASE_URL",
     "rag.openai_api_base_url",
-    os.getenv("RAG_OPENAI_API_BASE_URL", OPENAI_API_BASE_URL),
+    os.getenv("RAG_OPENAI_API_BASE_URL", os.environ.get("OPENAI_API_BASE_URL", OPENAI_API_BASE_URL)),
 )
 RAG_OPENAI_API_KEY = PersistentConfig(
     "RAG_OPENAI_API_KEY",
     "rag.openai_api_key",
-    os.getenv("RAG_OPENAI_API_KEY", OPENAI_API_KEY),
+    os.getenv("RAG_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", OPENAI_API_KEY)),
 )
 
 RAG_AZURE_OPENAI_BASE_URL = PersistentConfig(


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** When `RAG_OPENAI_API_KEY` and `RAG_OPENAI_API_BASE_URL` are not explicitly set, they now fall back to `OPENAI_API_KEY` and `OPENAI_API_BASE_URL` respectively.
- [x] **Code review:** Self-reviewed

## Description

Fixes #22084

Users who already configure `OPENAI_API_KEY` and `OPENAI_API_BASE_URL` should not need to duplicate those values for RAG-specific config. This PR adds fallback logic so `RAG_OPENAI_API_KEY` defaults to `OPENAI_API_KEY` (and same for base URL) when not explicitly set.

# Changelog Entry

### Bug Fixes

- `RAG_OPENAI_API_KEY` and `RAG_OPENAI_API_BASE_URL` now fall back to `OPENAI_API_KEY` / `OPENAI_API_BASE_URL` when not explicitly configured (fixes #22084)

---

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.