### PR TITLE
fix: correct conflicting output format in follow-up generation prompt template

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1960,7 +1960,7 @@ Suggest 3-5 relevant follow-up questions or prompts that the user might naturall
 - Only suggest follow-ups that make sense given the chat content and do not repeat what was already covered.
 - If the conversation is very short or not specific, suggest more general (but relevant) follow-ups the user might ask.
 - Use the conversation's primary language; default to English if multilingual.
-- Response must be a JSON array of strings, no extra text or formatting.
+- Response must be a JSON object with a "follow_ups" key containing an array of strings, no extra text or formatting.
 ### Output:
 JSON format: { "follow_ups": ["Question 1?", "Question 2?", "Question 3?"] }
 ### Chat History:


### PR DESCRIPTION
## What?

Fixes conflicting output format instructions in `DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE` that caused follow-up suggestions to silently fail.

## Why?

The prompt template contained contradictory instructions:
- **Guidelines** section said: _"Response must be a JSON array of strings"_ (top-level array `[...]`)
- **Output** section said: `{ "follow_ups": ["Question 1?", ...] }` (object with key)

The frontend parser in `src/lib/apis/index.ts` expects a JSON **object** — it searches for `{`/`}` delimiters and extracts `parsed.follow_ups`. When an LLM followed the "array" instruction and returned `["Q1?", "Q2?"]`, the parser found no `{`, returned `[]`, and the UI showed no follow-up suggestions.

## How?

Updated the Guidelines line from:
```
- Response must be a JSON array of strings, no extra text or formatting.
```
to:
```
- Response must be a JSON object with a "follow_ups" key containing an array of strings, no extra text or formatting.
```

This makes Guidelines and Output sections consistent, matching what the frontend parser expects.

## Testing

1. Verified the frontend parser (`src/lib/apis/index.ts:716-730`) expects `{ "follow_ups": [...] }` format
2. Confirmed the updated guideline now matches the Output section example
3. Single-line change, no behavioral changes to parsing logic

## Checklist
- [x] Fix is focused on a single issue (1 line changed)
- [x] No unrelated changes
- [x] Documentation within the template is now self-consistent
- [x] No breaking changes

## Related Issues

Fixes #22187