### PR TITLE
fix: correct conflicting output format in follow-up generation prompt template

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1960,7 +1960,7 @@ Suggest 3-5 relevant follow-up questions or prompts that the user might naturall
 - Only suggest follow-ups that make sense given the chat content and do not repeat what was already covered.
 - If the conversation is very short or not specific, suggest more general (but relevant) follow-ups the user might ask.
 - Use the conversation's primary language; default to English if multilingual.
-- Response must be a JSON array of strings, no extra text or formatting.
+- Response must be a JSON object with a "follow_ups" key containing an array of strings, no extra text or formatting.
 ### Output:
 JSON format: { "follow_ups": ["Question 1?", "Question 2?", "Question 3?"] }
 ### Chat History:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Verified the frontend parser expects `{ "follow_ups": [...] }` format and confirmed the updated guideline now matches.
- [x] **Agentic AI Code:** This change has been manually reviewed and verified.
- [x] **Code review:** Self-reviewed.
- [x] **Git Hygiene:** Single atomic commit, one logical change.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

The `DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE` in `backend/open_webui/config.py` contained contradictory output format instructions:
- **Guidelines** section said: *"Response must be a JSON array of strings"* (top-level array `[...]`)
- **Output** section said: `{ "follow_ups": ["Question 1?", ...] }` (object with key)

The frontend parser in `src/lib/apis/index.ts` expects a JSON **object** — it searches for `{`/`}` delimiters and extracts `parsed.follow_ups`. When an LLM followed the "array" instruction and returned `["Q1?", "Q2?"]`, the parser found no `{`, returned `[]`, and the UI showed no follow-up suggestions.

### Fixed

- Corrected the Guidelines instruction from "Response must be a JSON array of strings" to "Response must be a JSON object with a `follow_ups` key containing an array of strings" — now consistent with the Output section and frontend parser expectations.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Fixes #22187
- Single-line change in `backend/open_webui/config.py` (line 1963)
- No behavioral changes to parsing logic — only the prompt template text is updated
- Frontend parser reference: `src/lib/apis/index.ts:716-730`

### Screenshots or Videos

N/A — this is a backend prompt template text fix with no UI changes.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.