### PR TITLE
fix: prevent preceding character deletion when typing inline code backticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@sveltejs/svelte-virtual-list": "^3.0.1",
 		"@tiptap/core": "^3.0.7",
 		"@tiptap/extension-bubble-menu": "^2.26.1",
+		"@tiptap/extension-code": "^3.0.7",
 		"@tiptap/extension-code-block-lowlight": "^3.0.7",
 		"@tiptap/extension-drag-handle": "^3.4.5",
 		"@tiptap/extension-file-handler": "^3.0.7",

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -114,9 +114,25 @@
 	import { Fragment, DOMParser } from 'prosemirror-model';
 	import { EditorState, Plugin, PluginKey, TextSelection, Selection } from 'prosemirror-state';
 	import { Decoration, DecorationSet } from 'prosemirror-view';
-	import { Editor, Extension, mergeAttributes } from '@tiptap/core';
+	import { Editor, Extension, markInputRule, mergeAttributes } from '@tiptap/core';
+	import { Code } from '@tiptap/extension-code';
 
 	import { AIAutocompletion } from './RichTextInput/AutoCompletion.js';
+
+	// Fix: TipTap's default Code input rule regex captures the character before the
+	// opening backtick, causing markInputRule to delete it. Using a lookbehind avoids
+	// including that character in the match range. See: #20417
+	const codeInputRegex = /(?<=[^`]|^)`([^`]+)`(?!`)$/;
+	const FixedCode = Code.extend({
+		addInputRules() {
+			return [
+				markInputRule({
+					find: codeInputRegex,
+					type: this.type
+				})
+			];
+		}
+	});
 
 	import StarterKit from '@tiptap/starter-kit';
 
@@ -692,12 +708,16 @@
 			extensions: [
 				StarterKit.configure({
 					link: link,
+					// Disable default Code mark; we add FixedCode below with a corrected
+					// input rule that doesn't eat the preceding character (#20417).
+					code: false,
 					// When rich text is off, disable Strike from StarterKit so we can
 					// re-add it below without its Mod-Shift-s shortcut (which conflicts
 					// with the Toggle Sidebar shortcut). When rich text is on, the user
 					// can undo strikethrough via the toolbar, so the shortcut is fine.
 					...(richText ? {} : { strike: false })
 				}),
+				FixedCode,
 				...(dragHandle ? [ListItemDragHandle] : []),
 				Placeholder.configure({ placeholder: () => _placeholder, showOnlyWhenEditable: false }),
 				SelectionDecoration,


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Dependencies:** Added `@tiptap/extension-code` as explicit dependency (already a transitive dep via `@tiptap/starter-kit`, same version `^3.0.7`).
- [x] **Testing:** Manually verified the root cause by tracing TipTap's `markInputRule` logic with the default regex vs the fixed regex. The fix changes only the input rule regex pattern — all other Code mark behavior (keyboard shortcut, paste rules, rendering) remains unchanged.
- [x] **Agentic AI Code:** This PR has been reviewed and the fix has been verified by tracing through the TipTap source code.
- [x] **Code review:** Self-reviewed.
- [x] **Git Hygiene:** Single atomic commit, one logical change.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

When "Rich Text Input for Chat" is enabled and a user types inline code using backticks immediately after text (e.g. `Hello\`123\``), the character preceding the opening backtick is incorrectly deleted, resulting in `Hell` + `123` instead of `Hello` + `123`.

**Root cause:** TipTap's default Code mark input rule uses the regex `/(^|[^\x60])\x60([^\x60]+)\x60(?!\x60)$/`. The first capture group `[^\x60]` captures the character **before** the opening backtick. When `markInputRule` processes the match, it calls `tr.delete(range.from + startSpaces, textStart)` which deletes everything from the match start to the code content — including that captured preceding character.

**Fix:** Override the Code extension from StarterKit with a custom extension (`FixedCode`) that uses a lookbehind assertion `/(?<=[^\x60]|^)\x60([^\x60]+)\x60(?!\x60)$/` instead of a capture group, so the preceding character is never part of the match range.

### Added

- `@tiptap/extension-code` as explicit dependency (was already transitive via starter-kit)
- `FixedCode` extension in `RichTextInput.svelte` that extends TipTap's Code mark with a corrected input rule

### Changed

- StarterKit configured with `code: false` to disable the default (buggy) Code mark
- `FixedCode` added to the editor extensions list

### Fixed

- Preceding character no longer deleted when typing inline code backticks in Rich Text Input mode (e.g. `Hello\`123\`` now correctly produces "Hello" + code("123"))

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Fixes #20417
- Confirmed reproducible by collaborator @silentoplayz on latest `dev` with "Rich Text Input for Chat" toggled on
- The lookbehind `(?<=...)` is supported in all modern browsers (Chrome 62+, Firefox 78+, Safari 16.4+)
- Only the input rule is overridden — keyboard shortcut (Mod+E), paste rules, and rendering remain unchanged from the default Code extension

### Screenshots or Videos

**Before (bug):** Typing `Hello\`123\`` produces "Hell" + code("123") — the "o" is deleted

**After (fix):** Typing `Hello\`123\`` correctly produces "Hello" + code("123")

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.