### PR TITLE
fix: prevent streaming tool call function name duplication

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3716,10 +3716,12 @@ async def streaming_chat_response_handler(response, ctx):
                                                         ).get("arguments")
                                                     )
 
-                                                    if delta_name:
+                                                    if delta_name and not current_response_tool_call[
+                                                        "function"
+                                                    ].get("name"):
                                                         current_response_tool_call[
                                                             "function"
-                                                        ]["name"] += delta_name
+                                                        ]["name"] = delta_name
 
                                                     if delta_arguments:
                                                         current_response_tool_call[

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4118,6 +4118,62 @@ async def streaming_chat_response_handler(response, ctx):
 
                     response_tool_calls = tool_calls.pop(0)
 
+                    # Some models (GPT-5/5.1) concatenate multiple
+                    # complete JSON argument objects under a single
+                    # tool call index.  Expand them into separate
+                    # tool call entries so each is executed.
+                    expanded_tool_calls = []
+                    for tc in response_tool_calls:
+                        raw_args = (
+                            tc.get("function", {}).get("arguments", "") or ""
+                        ).strip()
+                        if not raw_args:
+                            expanded_tool_calls.append(tc)
+                            continue
+
+                        decoder = json.JSONDecoder()
+                        objects = []
+                        idx = 0
+                        try:
+                            while idx < len(raw_args):
+                                obj, end = decoder.raw_decode(raw_args, idx)
+                                objects.append(obj)
+                                # skip whitespace between objects
+                                idx = end
+                                while idx < len(raw_args) and raw_args[idx] in " \t\n\r":
+                                    idx += 1
+                        except (json.JSONDecodeError, ValueError):
+                            # Not valid JSON (possibly ast-style) or
+                            # genuinely malformed — let downstream
+                            # parsing handle it as before.
+                            objects = []
+
+                        if len(objects) > 1:
+                            # Multiple JSON objects found — split into
+                            # separate tool calls.
+                            for i, obj in enumerate(objects):
+                                new_tc = {
+                                    "id": tc.get("id", ""),
+                                    "type": tc.get("type", "function"),
+                                    "function": {
+                                        "name": tc.get("function", {}).get(
+                                            "name", ""
+                                        ),
+                                        "arguments": json.dumps(obj),
+                                    },
+                                }
+                                if "index" in tc:
+                                    new_tc["index"] = tc["index"]
+                                expanded_tool_calls.append(new_tc)
+                            log.debug(
+                                f"Expanded 1 tool call into {len(objects)} "
+                                f"(concatenated JSON arguments detected)"
+                            )
+                        else:
+                            expanded_tool_calls.append(tc)
+                    response_tool_calls = expanded_tool_calls
+
+
                     # Append function_call items for each tool call
                     for tc in response_tool_calls:
                         call_id = tc.get("id", "")


### PR DESCRIPTION
## fix: prevent streaming tool call function name and argument duplication

### Problem

Some models (notably GPT-5, GPT-5.1, and newer OpenAI models) re-send the function name and/or complete arguments in follow-up streaming deltas for the same tool call index. This causes two issues:

1. **Name duplication**: The function name gets doubled (e.g. my_server_search becomes my_server_searchmy_server_search) because the streaming delta handler accumulates names with +=. The doubled name doesn't match any registered tool, so the tool silently fails — the user sees "Tool Executed" but nothing actually ran.

2. **Argument concatenation**: When a model sends multiple complete JSON argument objects under the same tool call index (observed with GPT-5.4 calling search tools with multiple queries), the += accumulation produces concatenated JSON like {"query":"A","count":5}{"query":"B","count":5} which is not valid JSON and fails to parse.

### Fix

**Name deduplication**: Changed the name accumulation to a conditional assignment — the name is only set if it hasn't been set yet. This is safe because:
- Normal case: name arrives in the first delta and is already set via the initial append
- Edge case (empty first delta): the setdefault("name", "") at entry creation sets it to "", which is falsy, so a subsequent delta correctly sets it
- GPT-5/5.1 re-send case: the conditional skips it because the name is already set

**Argument expansion**: Added a pre-processing step before tool call execution that detects concatenated JSON objects in a tool call's arguments using json.JSONDecoder.raw_decode(). If multiple valid JSON objects are found back-to-back, the single tool call entry is expanded into separate entries — one per JSON object — so each gets executed independently. This:
- Doesn't touch the streaming accumulation path, so normal fragmented argument streaming works as before
- Falls through transparently for single-object arguments (the common case)
- Lets downstream ast.literal_eval / json.loads handle non-JSON formats as before

### Affected models

| Model | Name doubled | Args concatenated |
|-------|-------------|-------------------|
| GPT-5.1 | Always | Sometimes |
| GPT-5 | Sometimes | Sometimes |
| GPT-5.2+ | Observed | Observed |
| GPT-4o | Never | Never |
| Claude | Never | Never |

### Related issues

- #22177 — Streaming tool call function name doubled by delta accumulation
- #16138 — Tools names are doubled when calling
- #19656 — Tool call response tokens are duplicated

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
