### PR TITLE
fix: implement server-side pagination for chats/files/memories (#22206)

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1013,8 +1013,10 @@ class ChatTable:
         with get_db_context(db) as db:
             all_chats = (
                 db.query(Chat)
-                # .limit(limit).offset(skip)
                 .order_by(Chat.updated_at.desc())
+                .offset(skip)
+                .limit(limit)
+                .all()
             )
             return [ChatModel.model_validate(chat) for chat in all_chats]
 
@@ -1065,7 +1067,11 @@ class ChatTable:
             )
 
     def get_pinned_chats_by_user_id(
-        self, user_id: str, db: Optional[Session] = None
+        self,
+        user_id: str,
+        skip: int = 0,
+        limit: int = 200,
+        db: Optional[Session] = None,
     ) -> list[ChatTitleIdResponse]:
         with get_db_context(db) as db:
             all_chats = (
@@ -1073,6 +1079,9 @@ class ChatTable:
                 .filter_by(user_id=user_id, pinned=True, archived=False)
                 .order_by(Chat.updated_at.desc())
                 .with_entities(Chat.id, Chat.title, Chat.updated_at, Chat.created_at)
+                .offset(skip)
+                .limit(limit)
+                .all()
             )
             return [
                 ChatTitleIdResponse.model_validate(
@@ -1087,13 +1096,20 @@ class ChatTable:
             ]
 
     def get_archived_chats_by_user_id(
-        self, user_id: str, db: Optional[Session] = None
+        self,
+        user_id: str,
+        skip: int = 0,
+        limit: int = 50,
+        db: Optional[Session] = None,
     ) -> list[ChatModel]:
         with get_db_context(db) as db:
             all_chats = (
                 db.query(Chat)
                 .filter_by(user_id=user_id, archived=True)
                 .order_by(Chat.updated_at.desc())
+                .offset(skip)
+                .limit(limit)
+                .all()
             )
             return [ChatModel.model_validate(chat) for chat in all_chats]
 
@@ -1320,7 +1336,12 @@ class ChatTable:
             return [ChatModel.model_validate(chat) for chat in all_chats]
 
     def get_chats_by_folder_ids_and_user_id(
-        self, folder_ids: list[str], user_id: str, db: Optional[Session] = None
+        self,
+        folder_ids: list[str],
+        user_id: str,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
     ) -> list[ChatModel]:
         with get_db_context(db) as db:
             query = db.query(Chat).filter(
@@ -1330,6 +1351,11 @@ class ChatTable:
             query = query.filter_by(archived=False)
 
             query = query.order_by(Chat.updated_at.desc())
+
+            if skip:
+                query = query.offset(skip)
+            if limit:
+                query = query.limit(limit)
 
             all_chats = query.all()
             return [ChatModel.model_validate(chat) for chat in all_chats]
@@ -1388,6 +1414,13 @@ class ChatTable:
                 raise NotImplementedError(
                     f"Unsupported dialect: {db.bind.dialect.name}"
                 )
+
+            query = query.order_by(Chat.updated_at.desc())
+
+            if skip:
+                query = query.offset(skip)
+            if limit:
+                query = query.limit(limit)
 
             all_chats = query.all()
             log.debug(f"all_chats: {all_chats}")
@@ -1597,21 +1630,36 @@ class ChatTable:
     ) -> bool:
         try:
             with get_db_context(db) as db:
-                chats_by_user = db.query(Chat).filter_by(user_id=user_id).all()
-                shared_chat_ids = [f"shared-{chat.id}" for chat in chats_by_user]
+                # Build the set of shared user_id values server-side using a
+                # correlated subquery – avoids loading all chat rows into Python.
+                owned_chat_ids_subq = (
+                    db.query(Chat.id).filter_by(user_id=user_id).subquery()
+                )
 
-                # Use subquery to delete chat_messages for shared chats
-                shared_id_subq = (
+                # Shared rows are stored with user_id = 'shared-<original_chat_id>'
+                # We match by checking that the suffix after 'shared-' exists in
+                # the owner's chat ids.
+                shared_chats_subq = (
                     db.query(Chat.id)
-                    .filter(Chat.user_id.in_(shared_chat_ids))
+                    .filter(
+                        Chat.user_id.like("shared-%"),
+                        func.substr(Chat.user_id, 8).in_(owned_chat_ids_subq),
+                    )
                     .subquery()
                 )
-                db.query(ChatMessage).filter(
-                    ChatMessage.chat_id.in_(shared_id_subq)
-                ).delete(synchronize_session=False)
-                db.query(Chat).filter(Chat.user_id.in_(shared_chat_ids)).delete()
-                db.commit()
 
+                # Delete chat_messages that belong to shared chats
+                db.query(ChatMessage).filter(
+                    ChatMessage.chat_id.in_(shared_chats_subq)
+                ).delete(synchronize_session=False)
+
+                # Delete the shared chat rows themselves
+                db.query(Chat).filter(
+                    Chat.user_id.like("shared-%"),
+                    func.substr(Chat.user_id, 8).in_(owned_chat_ids_subq),
+                ).delete(synchronize_session=False)
+
+                db.commit()
                 return True
         except Exception:
             return False

--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -276,12 +276,19 @@ class FeedbackTable:
 
             return FeedbackListResponse(items=feedbacks, total=total)
 
-    def get_all_feedbacks(self, db: Optional[Session] = None) -> list[FeedbackModel]:
+    def get_all_feedbacks(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
+    ) -> list[FeedbackModel]:
         with get_db_context(db) as db:
             return [
                 FeedbackModel.model_validate(feedback)
                 for feedback in db.query(Feedback)
                 .order_by(Feedback.updated_at.desc())
+                .offset(skip)
+                .limit(limit)
                 .all()
             ]
 
@@ -386,7 +393,11 @@ class FeedbackTable:
         return result
 
     def get_feedbacks_by_type(
-        self, type: str, db: Optional[Session] = None
+        self,
+        type: str,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
     ) -> list[FeedbackModel]:
         with get_db_context(db) as db:
             return [
@@ -394,11 +405,17 @@ class FeedbackTable:
                 for feedback in db.query(Feedback)
                 .filter_by(type=type)
                 .order_by(Feedback.updated_at.desc())
+                .offset(skip)
+                .limit(limit)
                 .all()
             ]
 
     def get_feedbacks_by_user_id(
-        self, user_id: str, db: Optional[Session] = None
+        self,
+        user_id: str,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
     ) -> list[FeedbackModel]:
         with get_db_context(db) as db:
             return [
@@ -406,6 +423,8 @@ class FeedbackTable:
                 for feedback in db.query(Feedback)
                 .filter_by(user_id=user_id)
                 .order_by(Feedback.updated_at.desc())
+                .offset(skip)
+                .limit(limit)
                 .all()
             ]
 

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -87,20 +87,42 @@ class MemoriesTable:
             except Exception:
                 return None
 
-    def get_memories(self, db: Optional[Session] = None) -> list[MemoryModel]:
+    def get_memories(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
+    ) -> list[MemoryModel]:
         with get_db_context(db) as db:
             try:
-                memories = db.query(Memory).all()
+                memories = (
+                    db.query(Memory)
+                    .order_by(Memory.updated_at.desc())
+                    .offset(skip)
+                    .limit(limit)
+                    .all()
+                )
                 return [MemoryModel.model_validate(memory) for memory in memories]
             except Exception:
                 return None
 
     def get_memories_by_user_id(
-        self, user_id: str, db: Optional[Session] = None
+        self,
+        user_id: str,
+        skip: int = 0,
+        limit: int = 100,
+        db: Optional[Session] = None,
     ) -> list[MemoryModel]:
         with get_db_context(db) as db:
             try:
-                memories = db.query(Memory).filter_by(user_id=user_id).all()
+                memories = (
+                    db.query(Memory)
+                    .filter_by(user_id=user_id)
+                    .order_by(Memory.updated_at.desc())
+                    .offset(skip)
+                    .limit(limit)
+                    .all()
+                )
                 return [MemoryModel.model_validate(memory) for memory in memories]
             except Exception:
                 return None

--- a/backend/open_webui/models/messages.py
+++ b/backend/open_webui/models/messages.py
@@ -237,13 +237,14 @@ class MessageTable:
             )
 
     def get_thread_replies_by_message_id(
-        self, id: str, db: Optional[Session] = None
+        self, id: str, limit: int = 200, db: Optional[Session] = None
     ) -> list[MessageReplyToResponse]:
         with get_db_context(db) as db:
             all_messages = (
                 db.query(Message)
                 .filter_by(parent_id=id)
                 .order_by(Message.created_at.desc())
+                .limit(limit)
                 .all()
             )
 
@@ -293,9 +294,10 @@ class MessageTable:
         self, id: str, db: Optional[Session] = None
     ) -> list[str]:
         with get_db_context(db) as db:
+            # Query only the user_id column to avoid loading full Message rows.
             return [
-                message.user_id
-                for message in db.query(Message).filter_by(parent_id=id).all()
+                row[0]
+                for row in db.query(Message.user_id).filter_by(parent_id=id).all()
             ]
 
     def get_messages_by_channel_id(


### PR DESCRIPTION
**Summary**: Fixes critical OOM crashes (#22206) by implementing server-side pagination and optimizing memory-intensive database queries.

**The Problem**: 
High-volume endpoints like `/api/v1/chats/all`, `/api/v1/memories/`, and `/api/v1/evaluations/` load entire datasets into memory at once, causing OOM crashes on enterprise-scale instances.

**The Fix**:
* **Atomic Commit**: Rebased against `upstream/dev` and squashed into a single commit.
* **Server-side Pagination**: Added `skip` and `limit` to SQLAlchemy queries in `chats.py`, `feedbacks.py`, `memories.py`, and `messages.py`.
* **Optimized Deletion**: Replaced Python-side materialization in `delete_shared_chats_by_user_id` with a correlated subquery.
* **Omitted Tests**: Test files removed per maintainer request.

**Testing & Validation**:
* ✅ **Personal Testing**: I have personally tested ALL changes in this PR.
* ✅ **Methodology**: Verified pagination by seeding a local PostgreSQL database with 5,000+ chat and memory records.
* ✅ **Result**: Confirmed that memory usage remains stable (O(1) relative to total record count) during high-offset fetches.

**Contributor License Agreement**
I certify that this contribution is my own original work and that I have the right to submit it under the project's license.

**contributor license agreement**
I agree to the terms of the contributor license agreement.

Fixes #22206