### PR TITLE
fix: query_knowledge_files uses knowledge_ids param when provided

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1808,12 +1808,16 @@ async def query_knowledge_files(
 
         # If model has attached knowledge, use those
         if __model_knowledge__:
+            knowledge_ids_set = set(knowledge_ids) if knowledge_ids else None
+
             for item in __model_knowledge__:
                 item_type = item.get("type")
                 item_id = item.get("id")
 
                 if item_type == "collection":
-                    # Knowledge base - use KB ID as collection name
+                    if knowledge_ids_set and item_id not in knowledge_ids_set:
+                        continue
+
                     knowledge = Knowledges.get_knowledge_by_id(item_id)
                     if knowledge and (
                         user_role == "admin"
@@ -1829,13 +1833,17 @@ async def query_knowledge_files(
                         collection_names.append(item_id)
 
                 elif item_type == "file":
-                    # Individual file - use file-{id} as collection name
+                    if knowledge_ids_set:
+                        continue
+
                     file = Files.get_file_by_id(item_id)
                     if file:
                         collection_names.append(f"file-{item_id}")
 
                 elif item_type == "note":
-                    # Note - always return full content as context
+                    if knowledge_ids_set:
+                        continue
+
                     note = Notes.get_note_by_id(item_id)
                     if note and (
                         user_role == "admin"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixes bug where `query_knowledge_files` optional parameter `knowledge_ids` is ignored. When KBs are attached to a model in `Workspace`, all of the attached KBs will be searched even if `knowledge_ids` is populated. 
- This parameter might be provided in order to limit the model from searching all attached KBs - this fix allows that to happen. 

### Added

- Added a check to see if the optional `knowledge_ids` parameter is populated before looping through attached knowledge and using it if it is. 

### Changed

- Use optional `knowledge_ids` for knowledge search. 

### Deprecated

- None

### Removed

- None

### Fixed

- Use optional `knowledge_ids` for knowledge search. 

### Security

- None

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

- Tested using the following steps:
1. Create 2 KBs, insert a duplicate file in each (KB_1 and KB_2)
2. Attach KBs to a Workspace Model, in system prompt, note KB_1 and KB_2 actual hash ID.
3. Ask question about KB_1, see that `query_knowledge_files` returns files from both KB_1 and KB_2 even with the `knowledge_ids` populated in the call.
4. Make code update
5. Ask question about KB_1, see that `query_knowledge_files` returns **only** files from KB_1. 
6. Ask question about files stored in KBs and request that `knowledge_ids` not be provided to tool, see that `query_knowledge_files` returns files from both KB_1 and KB_2 as expected. 

### Screenshots or Videos

- None

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
