### PR TITLE
enh: prevent models from always using internal knowledge base search first

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -155,8 +155,7 @@ async def search_web(
 ) -> str:
     """
     Search the public web for information. Best for current events, external references,
-    or topics not covered in internal documents. If knowledge base tools are available,
-    consider checking those first for internal information.
+    or topics not covered in internal documents.
 
     :param query: The search query to look up
     :param count: Number of results to return (default: 5)


### PR DESCRIPTION
Some models always primarily use the internal knowledge base first before deviating to the web search tool

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
