### PR TITLE
feat: add OpenTelemetry system metrics instrumentation

### DIFF
--- a/backend/open_webui/utils/telemetry/instrumentors.py
+++ b/backend/open_webui/utils/telemetry/instrumentors.py
@@ -20,6 +20,7 @@ from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 from opentelemetry.trace import Span, StatusCode
 from redis import Redis
 from redis.cluster import RedisCluster
@@ -204,6 +205,7 @@ class Instrumentor(BaseInstrumentor):
             request_hook=aiohttp_request_hook,
             response_hook=aiohttp_response_hook,
         )
+        SystemMetricsInstrumentor().instrument()
 
     def _uninstrument(self, **kwargs):
         if getattr(self, "instrumentors", None) is None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -155,3 +155,4 @@ opentelemetry-instrumentation-requests==0.60b1
 opentelemetry-instrumentation-logging==0.60b1
 opentelemetry-instrumentation-httpx==0.60b1
 opentelemetry-instrumentation-aiohttp-client==0.60b1
+opentelemetry-instrumentation-system-metrics==0.60b1


### PR DESCRIPTION
### Description

- Add Python runtime and system metrics via `opentelemetry-instrumentation-system-metrics` (CPU, memory, GC, threads)

### Added

- `opentelemetry-instrumentation-system-metrics==0.60b1` dependency
- `SystemMetricsInstrumentor` in telemetry instrumentors

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Exposes `process.runtime.cpython.memory`, `process.runtime.cpython.cpu_time`, `process.runtime.cpython.gc_count`, `process.runtime.cpython.thread_count`, `system.cpu.utilization`, `system.memory.usage` etc. via existing OTLP exporter
- No configuration changes needed — works with existing `ENABLE_OTEL` setup

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.