### PR TITLE
perf: lazy-compute createMessagesList in FloatingButtons

### DIFF
--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -19,7 +19,7 @@
 	export let messageId = '';
 
 	export let model = null;
-	export let messages = [];
+	export let getMessages: () => { role: string; content: string }[] = () => [];
 	export let actions = [];
 	export let onAdd = (e) => {};
 
@@ -123,7 +123,7 @@
 			session_id: $socket?.id,
 			chat_id: $chatId,
 			messages: [
-				...messages,
+				...getMessages(),
 				{
 					role: 'user',
 					content: content

--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -210,7 +210,7 @@
 			: (selectedModels ?? []).length > 0
 				? selectedModels.at(0)
 				: model?.id}
-		messages={createMessagesList(history, messageId)}
+		getMessages={() => createMessagesList(history, messageId)}
 		onAdd={({ modelId, parentId, messages }) => {
 			console.log(modelId, parentId, messages);
 			onAddMessages({ modelId, parentId, messages });


### PR DESCRIPTION
Defer createMessagesList tree walk from render-time to action-time. <ins>**Previously, every rendered message eagerly computed the full message chain on every history change, even though FloatingButtons only uses it when the user selects text and triggers an action.**</ins>

Changed the messages prop to a getMessages getter function that is called lazily only when an action is actually invoked.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
