### PR TITLE
perf: replace JSON.stringify with O(1) fingerprint for message change detection

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -61,13 +61,20 @@
 	let selectedModelIdx = null;
 
 	let message = structuredClone(history.messages[messageId]);
+	let lastFingerprint = '';
 	$: if (history.messages) {
 		const source = history.messages[messageId];
 		if (source) {
 			if (message.content !== source.content || message.done !== source.done) {
 				message = structuredClone(source);
-			} else if (JSON.stringify(message) !== JSON.stringify(source)) {
-				message = structuredClone(source);
+				lastFingerprint = '';
+			} else {
+				// O(1) fingerprint instead of O(content_length) JSON.stringify
+				const fp = `${(source.sources ?? []).length}:${(source.code_executions ?? []).length}:${source.annotation?.rating}:${source.error}:${(source.files ?? []).length}:${(source.statusHistory ?? []).length}:${source.timestamp}:${(source.embeds ?? []).length}:${(source.followUps ?? []).length}:${source.favorite}`;
+				if (fp !== lastFingerprint) {
+					lastFingerprint = fp;
+					message = structuredClone(source);
+				}
 			}
 		}
 	}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -120,16 +120,22 @@
 	export let selectedModels = [];
 
 	let message: MessageType = structuredClone(history.messages[messageId]);
+	let lastFingerprint = '';
 	$: if (history.messages) {
 		const source = history.messages[messageId];
 		if (source) {
 			// Fast path: O(1) check on the fields that change most often (content during streaming, done at end)
-			// Avoids 2x O(n) JSON.stringify calls that are always true during streaming anyway
 			if (message.content !== source.content || message.done !== source.done) {
 				message = structuredClone(source);
-			} else if (JSON.stringify(message) !== JSON.stringify(source)) {
-				// Slow path: full comparison for infrequent changes (sources, annotations, status, etc.)
-				message = structuredClone(source);
+				lastFingerprint = '';
+			} else {
+				// O(1) fingerprint covering all fields the event handler can mutate,
+				// instead of O(content_length) JSON.stringify comparison
+				const fp = `${(source.sources ?? []).length}:${(source.code_executions ?? []).length}:${source.annotation?.rating}:${source.error}:${(source.files ?? []).length}:${(source.statusHistory ?? []).length}:${source.timestamp}:${(source.embeds ?? []).length}:${(source.followUps ?? []).length}:${source.favorite}`;
+				if (fp !== lastFingerprint) {
+					lastFingerprint = fp;
+					message = structuredClone(source);
+				}
 			}
 		}
 	}

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -53,13 +53,20 @@
 	let editScrollContainer: HTMLDivElement;
 
 	let message = structuredClone(history.messages[messageId]);
+	let lastFingerprint = '';
 	$: if (history.messages) {
 		const source = history.messages[messageId];
 		if (source) {
 			if (message.content !== source.content) {
 				message = structuredClone(source);
-			} else if (JSON.stringify(message) !== JSON.stringify(source)) {
-				message = structuredClone(source);
+				lastFingerprint = '';
+			} else {
+				// O(1) fingerprint instead of O(content_length) JSON.stringify
+				const fp = `${(source.files ?? []).length}:${source.timestamp}`;
+				if (fp !== lastFingerprint) {
+					lastFingerprint = fp;
+					message = structuredClone(source);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Replace the O(content_length) JSON.stringify fallback comparison in ResponseMessage, UserMessage, and MultiResponseMessages with an O(1) fingerprint check.

Previously, when any part of the history object changed, every rendered message component ran two full JSON.stringify calls to detect changes. With 20 messages containing large content (e.g. thinking blocks), this serialized hundreds of KB synchronously on the main thread per edit.

The fingerprint covers all fields that the WebSocket event handler and user interactions can mutate: sources, code_executions, annotation rating, error, files, statusHistory, timestamp, embeds, followUps, and favorite. The fast-path content/done check remains unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
