### PR TITLE
perf: skip redundant markdown parsing when content unchanged

### DIFF
--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -55,8 +55,11 @@
 		]
 	});
 
+	let lastParsedContent = '';
+
 	const parseTokens = () => {
 		tokens = marked.lexer(replaceTokens(processResponseContent(content), model?.name, $user?.name));
+		lastParsedContent = content;
 	};
 
 	// Throttle parsing to once per animation frame while streaming
@@ -64,7 +67,9 @@
 		if (done) {
 			cancelAnimationFrame(pendingUpdate);
 			pendingUpdate = null;
-			parseTokens();
+			if (content !== lastParsedContent) {
+				parseTokens();
+			}
 		} else if (!pendingUpdate) {
 			pendingUpdate = requestAnimationFrame(() => {
 				pendingUpdate = null;


### PR DESCRIPTION
Add a content memoization guard to Markdown.svelte that skips marked.lexer() when the content string is identical to what was already parsed. During streaming, content still parses on every animation frame as before. When done, only re-parses if the content string actually changed.

This prevents redundant parsing when a message component re-renders due to non-content changes (e.g. annotation, sources, status) that trigger structuredClone with identical content.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
