### PR TITLE
perf: replace O(n²) unshift with O(n) push+reverse in buildMessages

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -90,11 +90,11 @@
 			}
 			visitedMessageIds.add(message.id);
 
-			_messages.unshift(message);
+			_messages.push(message);
 			message = message.parentId !== null ? history.messages[message.parentId] : null;
 		}
 
-		messages = _messages;
+		messages = _messages.reverse();
 	};
 
 	// Throttle message list rebuilds to once per animation frame during streaming.


### PR DESCRIPTION
Array.unshift() is O(n) per call because it shifts all existing elements. In a loop building an n-element array, this makes the total cost O(n²). Replace with push() + reverse() which is O(n) total. Produces the identical message ordering.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
