### PR TITLE
fix: reset tool selection when switching models

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -321,15 +321,13 @@
 		if (model) {
 			// Set Default Tools
 			if (model?.info?.meta?.toolIds) {
-				selectedToolIds = [
-					...new Set(
-						[...(model?.info?.meta?.toolIds ?? [])].filter((id) => $tools.find((t) => t.id === id))
-					)
-				];
+				selectedToolIds = (model.info.meta.toolIds ?? []).filter((id) =>
+					$tools.find((t) => t.id === id)
+				);
 			} else if ($settings?.tools) {
 				selectedToolIds = $settings.tools;
 			} else {
-				selectedToolIds = selectedToolIds.filter((id) => !id.startsWith('direct_server:'));
+				selectedToolIds = [];
 			}
 
 			// Set Default Filters (Toggleable only)


### PR DESCRIPTION
## Summary
Fixes #14157

When switching models in chat, previously selected tools were not properly cleared. Two changes in `src/lib/components/chat/Chat.svelte`:

- **Simplified the tool assignment** when a model has configured `toolIds` — removed unnecessary `new Set` wrapping and directly filter by available tools
- **Fixed the else branch** — when a model has no configured tools and no user default tools, clear `selectedToolIds` entirely instead of keeping previous tools (minus `direct_server:` ones)

## Test plan
- [ ] Select a model with configured tools → verify its tools appear
- [ ] Switch to a model with different tools → verify only the new model's tools are shown
- [ ] Switch to a model with no configured tools → verify tools are cleared
- [ ] Verify user default tools (`$settings.tools`) still work as fallback