### PR TITLE
fix(users): return 403 for blocked primary admin role downgrade

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -607,6 +607,8 @@ async def update_user_by_id(
                         detail=ERROR_MESSAGES.ACTION_PROHIBITED,
                     )
 
+    except HTTPException:
+        raise
     except Exception as e:
         log.error(f"Error checking primary admin status: {e}")
         raise HTTPException(

--- a/backend/open_webui/test/apps/webui/routers/test_users.py
+++ b/backend/open_webui/test/apps/webui/routers/test_users.py
@@ -137,6 +137,19 @@ class TestUsers(AbstractPostgresTest):
             )
         assert response.status_code == 200
 
+        # Prevent primary admin role downgrade
+        with mock_webui_user(id="1"):
+            response = self.fast_api_client.post(
+                self.create_url("/1/update"),
+                json={
+                    "name": "user 1",
+                    "email": "user1@openwebui.com",
+                    "profile_image_url": "/user1.png",
+                    "role": "user",
+                },
+            )
+        assert response.status_code == 403
+
         # Get all users
         with mock_webui_user(id="3"):
             response = self.fast_api_client.get(self.create_url(""))


### PR DESCRIPTION
## Summary
- preserve HTTPException raised by the primary-admin guard in `/{user_id}/update`
- avoid converting intentional 403 responses into 500 errors
- add a regression assertion in `test_users.py` for primary-admin role downgrade attempts

## Why
The endpoint intentionally blocks changing the first admin's role away from `admin`, but the broad exception handler catches that HTTPException and rethrows a 500. This patch keeps the intended 403 status code.

## Testing
- not run in this environment: existing backend test package references missing `test.util.abstract_integration_test` module
