### PR TITLE
fix(users): return 403 for blocked primary admin deletion

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -677,6 +677,8 @@ async def delete_user_by_id(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ERROR_MESSAGES.ACTION_PROHIBITED,
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.error(f"Error checking primary admin status: {e}")
         raise HTTPException(

--- a/backend/open_webui/test/apps/webui/routers/test_users.py
+++ b/backend/open_webui/test/apps/webui/routers/test_users.py
@@ -153,6 +153,11 @@ class TestUsers(AbstractPostgresTest):
             profile_image_url=f"/api/v1/users/2/profile/image",
         )
 
+        # Prevent primary admin deletion
+        with mock_webui_user(id="1"):
+            response = self.fast_api_client.delete(self.create_url("/1"))
+        assert response.status_code == 403
+
         # Delete user by id
         with mock_webui_user(id="1"):
             response = self.fast_api_client.delete(self.create_url("/2"))


### PR DESCRIPTION
## Summary
- preserve HTTPException raised by the primary-admin guard in `/{user_id}` DELETE
- avoid converting intentional 403 responses into 500 errors
- add a regression assertion in `test_users.py` for primary-admin deletion attempts

## Why
The delete endpoint intentionally blocks deleting the first admin, but the broad exception handler catches that HTTPException and rethrows a 500. This patch keeps the intended 403 status code.

## Testing
- not run in this environment: existing backend test package references missing `test.util.abstract_integration_test` module
