### PR TITLE
fix: Clear selected tools when switching models

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -326,10 +326,9 @@
 						[...(model?.info?.meta?.toolIds ?? [])].filter((id) => $tools.find((t) => t.id === id))
 					)
 				];
-			} else if ($settings?.tools) {
-				selectedToolIds = $settings.tools;
 			} else {
-				selectedToolIds = selectedToolIds.filter((id) => !id.startsWith('direct_server:'));
+				// Clear selected tools when switching to a model without default tools
+				selectedToolIds = [];
 			}
 
 			// Set Default Filters (Toggleable only)


### PR DESCRIPTION
## Summary
When user switches to a model without default toolIds, the previously selected tools should be cleared instead of being retained.

## Changes
- Modified `src/lib/components/chat/Chat.svelte`
- When a model doesn't have default toolIds, selectedToolIds is now set to empty array instead of keeping old tools

## Issue
Fixes #14157 - Switching models does not deselect previously selected tools

## Testing
Manual testing recommended:
1. Select some tools with model A
2. Switch to model B (one without default tools)
3. Verify tools are deselected