### PR TITLE
fix: make prompt optional in /api/generate for Ollama model unload

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1176,7 +1176,7 @@ async def embeddings(
 
 class GenerateCompletionForm(BaseModel):
     model: str
-    prompt: str
+    prompt: Optional[str] = None
     suffix: Optional[str] = None
     images: Optional[list[str]] = None
     format: Optional[Union[dict, str]] = None


### PR DESCRIPTION
## Problem

Sending `keep_alive: 0` to `/ollama/api/generate` through the Open WebUI proxy fails with:

```json
{"detail":[{"type":"missing","loc":["body","prompt"],"msg":"Field required"}]}
```

The same request works when sent directly to Ollama.

## Root Cause

`GenerateCompletionForm` defines `prompt: str` as required, but Ollama's `/api/generate` API allows omitting `prompt` for model management operations (load/unload via `keep_alive`).

## Fix

One-line change: `prompt: str` → `prompt: Optional[str] = None`

Fixes #22260