### PR TITLE
fix: refresh model list when page becomes visible (fix #22297)

### DIFF
--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -58,6 +58,8 @@
 
 	let selectedModel = null;
 
+import { onMount } from 'svelte';
+
 	let groupIds = [];
 
 	let tags = [];
@@ -230,6 +232,13 @@
 
 		let groups = await getGroups(localStorage.token);
 		groupIds = groups.map((group) => group.id);
+
+		// Refresh model list when page becomes visible (fixes cloned model issue)
+		document.addEventListener('visibilitychange', () => {
+			if (!document.hidden) {
+				getModelList();
+			}
+		});
 
 		await tick();
 		loaded = true;


### PR DESCRIPTION
## Summary
Fixes issue #22297 - cloned models not visible after creation.

## Changes
- Added visibility change listener to refresh model list when user returns to the page
- This ensures cloned models appear immediately after creation

## Testing
- This fix should resolve the issue where cloned models don't show up in the model list

## Related Issue
- Closes #22297