### PR TITLE
fix: preserve image files for display in temporary chat mode

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -250,11 +250,13 @@ async def generate_image(
 
         # Persist files to DB if chat context is available
         if __chat_id__ and __message_id__ and images:
-            image_files = Chats.add_message_files_by_id_and_message_id(
+            db_files = Chats.add_message_files_by_id_and_message_id(
                 __chat_id__,
                 __message_id__,
                 image_files,
             )
+            if db_files is not None:
+                image_files = db_files
 
         # Emit the images to the UI if event emitter is available
         if __event_emitter__ and image_files:
@@ -315,11 +317,13 @@ async def edit_image(
 
         # Persist files to DB if chat context is available
         if __chat_id__ and __message_id__ and images:
-            image_files = Chats.add_message_files_by_id_and_message_id(
+            db_files = Chats.add_message_files_by_id_and_message_id(
                 __chat_id__,
                 __message_id__,
                 image_files,
             )
+            if db_files is not None:
+                image_files = db_files
 
         # Emit the images to the UI if event emitter is available
         if __event_emitter__ and image_files:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3777,14 +3777,17 @@ async def streaming_chat_response_handler(response, ctx):
                                         delta.get("images", []), request, metadata, user
                                     )
                                     if image_urls:
+                                        image_file_list = [
+                                            {"type": "image", "url": url}
+                                            for url in image_urls
+                                        ]
                                         message_files = Chats.add_message_files_by_id_and_message_id(
                                             metadata["chat_id"],
                                             metadata["message_id"],
-                                            [
-                                                {"type": "image", "url": url}
-                                                for url in image_urls
-                                            ],
+                                            image_file_list,
                                         )
+                                        if message_files is None:
+                                            message_files = image_file_list
 
                                         await event_emitter(
                                             {


### PR DESCRIPTION
## fix: Preserve image files for display in temporary chat mode

### Description

Fixes image generation not displaying in temporary chat mode when using builtin tools (native function calling).

### Problem

When a model is configured with builtinTools image_generation (native function calling), generated images are never shown in temporary chat mode. The image is generated server-side but the frontend never receives the file event.

The root cause is that Chats.add_message_files_by_id_and_message_id() returns None when the chat doesn't exist in the database — which is always the case for temporary chats (chat IDs starting with "local:"). The code was directly overwriting the correctly-built image_files list with this None return value, causing the event emitter to either never fire (because None is falsy) or emit files: null.

This only affects the builtin tool code path (builtinTools.image_generation: true). The older capability-based path (capabilities.image_generation: true) is unaffected because it constructs and emits the file list directly without a DB round-trip.

### Fix

Store the DB return value in a separate variable and only overwrite the image file list when the DB call returns a non-None result. Applied to three locations:

- generate_image() in builtin.py
- edit_image() in builtin.py
- SSE streaming handler in middleware.py

### Fixes

Fixes #22309

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
