### PR TITLE
fix: preserve edited message content when enriching with DB output items

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2081,17 +2081,53 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     form_data = apply_params_to_form_data(form_data, model)
     log.debug(f"form_data: {form_data}")
 
-    # Load messages from DB when available — DB preserves structured 'output' items
-    # which the frontend strips, causing tool calls to be merged into content.
+    # Enrich frontend messages with DB-preserved 'output' items.
+    # The frontend has the authoritative message content (which may have been
+    # edited by the user), but strips structured 'output' items that the DB
+    # preserves for tool call reconstruction.  Instead of fully replacing
+    # frontend messages (which would lose edits), we merge DB-specific fields
+    # (output, files) into the frontend messages.
     chat_id = metadata.get("chat_id")
     parent_message_id = metadata.get("parent_message_id")
 
     if chat_id and parent_message_id and not chat_id.startswith("local:"):
         db_messages = load_messages_from_db(chat_id, parent_message_id)
         if db_messages:
-            system_message = get_system_message(form_data.get("messages", []))
+            # Build the final message list from frontend messages, enriched
+            # with DB fields.  The frontend list is authoritative for content
+            # (it reflects user edits); the DB list is authoritative for
+            # output items and file metadata.
+            frontend_messages = form_data.get("messages", [])
+            system_message = get_system_message(frontend_messages)
+
+            # Non-system frontend messages (the actual conversation)
+            frontend_conv = [
+                m for m in frontend_messages if m.get("role") != "system"
+            ]
+
+            enriched = []
+            for idx, db_msg in enumerate(db_messages):
+                if idx < len(frontend_conv):
+                    # Start from the frontend message (has correct/edited content)
+                    merged = {**frontend_conv[idx]}
+                    # Merge output from DB if frontend doesn't have it
+                    if "output" in db_msg and "output" not in merged:
+                        merged["output"] = db_msg["output"]
+                    # Merge files from DB if frontend doesn't have them
+                    if "files" in db_msg and "files" not in merged:
+                        merged["files"] = db_msg["files"]
+                    enriched.append(merged)
+                else:
+                    # More DB messages than frontend messages — use DB message
+                    enriched.append(db_msg)
+
+            # If frontend has more messages than DB (e.g. system injected
+            # extra), append the remaining frontend messages
+            if len(frontend_conv) > len(db_messages):
+                enriched.extend(frontend_conv[len(db_messages):])
+
             form_data["messages"] = (
-                [system_message, *db_messages] if system_message else db_messages
+                [system_message, *enriched] if system_message else enriched
             )
 
             # Inject image files into content as image_url parts (mirrors frontend logic)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2082,21 +2082,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     log.debug(f"form_data: {form_data}")
 
     # Enrich frontend messages with DB-preserved 'output' items.
-    # The frontend has the authoritative message content (which may have been
-    # edited by the user), but strips structured 'output' items that the DB
-    # preserves for tool call reconstruction.  Instead of fully replacing
-    # frontend messages (which would lose edits), we merge DB-specific fields
-    # (output, files) into the frontend messages.
+    # The frontend messages are authoritative for content (they reflect user
+    # edits).  The DB preserves structured 'output' items that the frontend
+    # strips — these are needed for tool call reconstruction.  We merge only
+    # 'output' and 'files' from DB into frontend messages, never replacing
+    # content.
     chat_id = metadata.get("chat_id")
     parent_message_id = metadata.get("parent_message_id")
 
     if chat_id and parent_message_id and not chat_id.startswith("local:"):
         db_messages = load_messages_from_db(chat_id, parent_message_id)
         if db_messages:
-            # Build the final message list from frontend messages, enriched
-            # with DB fields.  The frontend list is authoritative for content
-            # (it reflects user edits); the DB list is authoritative for
-            # output items and file metadata.
             frontend_messages = form_data.get("messages", [])
             system_message = get_system_message(frontend_messages)
 
@@ -2118,11 +2114,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         merged["files"] = db_msg["files"]
                     enriched.append(merged)
                 else:
-                    # More DB messages than frontend messages — use DB message
+                    # More DB messages than frontend — use DB message as-is
                     enriched.append(db_msg)
 
-            # If frontend has more messages than DB (e.g. system injected
-            # extra), append the remaining frontend messages
+            # Append any extra frontend messages beyond the DB chain
             if len(frontend_conv) > len(db_messages):
                 enriched.extend(frontend_conv[len(db_messages):])
 
@@ -2130,7 +2125,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 [system_message, *enriched] if system_message else enriched
             )
 
-            # Inject image files into content as image_url parts (mirrors frontend logic)
+            # Inject image files into content as image_url parts
             for message in form_data["messages"]:
                 image_files = [
                     f


### PR DESCRIPTION
## fix: preserve edited message content when enriching with DB output items

Fixes #22327

### Problem

When a user edits an assistant's response (e.g., changing "Cerulean" to "Yellow") and then sends a follow-up message, the LLM receives the **original** unedited content instead of the edited version. This causes the AI to reference information the user explicitly corrected.

### Root Cause

In process_chat_payload, the backend loads the message chain from the database and **fully replaces** the frontend-sent messages with the DB-loaded versions. The frontend sends the correct, edited content, but the backend discards it in favor of the (potentially stale) DB content.

This DB-loading feature was introduced to preserve structured output items (for tool call reconstruction) that the frontend strips when building messages. However, its implementation replaced **all** message fields — including content — rather than merging only the DB-specific fields.

### Fix

The frontend messages are now treated as authoritative for content (they reflect user edits). The DB is only used to enrich messages with:
- **output**: structured tool call data needed for proper OpenAI-format message reconstruction
- **files**: image file metadata for content injection

Content from the DB never overwrites the frontend-sent content.

# Testing DONE

1. Start a chat and ask a question that gets a specific answer
2. Edit the assistant's response to say something different
3. Ask a follow-up that references the edited content
4. Verify the AI correctly references the edited version, not the original


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
