### PR TITLE
perf(models): replace inline base64 icons with URL references in /api/models response

### DIFF
--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import re
 
@@ -23,7 +24,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from pydantic import BaseModel, HttpUrl
 from open_webui.internal.db import get_session
@@ -398,6 +399,61 @@ async def delete_function_by_id(
             del FUNCTIONS[id]
 
     return result
+
+
+############################
+# GetFunctionIcon
+############################
+
+
+@router.get("/id/{id}/icon")
+async def get_function_icon(request: Request, id: str, user=Depends(get_verified_user)):
+    """Serve a function's icon as a binary image response.
+
+    The /api/models endpoint replaces heavy inline base64 icon data with
+    lightweight URL references pointing here.  The response is served with
+    aggressive cache headers so the browser only fetches each icon once.
+    """
+    function_module = request.app.state.FUNCTIONS.get(id)
+    if function_module is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    function = Functions.get_function_by_id(id)
+    raw_icon = (
+        (
+            function.meta.manifest.get("icon_url", None)
+            if function and function.meta
+            else None
+        )
+        or getattr(function_module, "icon_url", None)
+        or getattr(function_module, "icon", None)
+    )
+
+    if not raw_icon or not raw_icon.startswith("data:"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    # Parse data URI: data:[<mediatype>][;base64],<data>
+    try:
+        header, encoded = raw_icon.split(",", 1)
+        media_type = header.split(":")[1].split(";")[0]
+        content = base64.b64decode(encoded)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Invalid icon data URI",
+        )
+
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 ############################

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -242,47 +242,81 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
             models.append(model)
 
+    def _resolve_icon(function_id, raw_icon):
+        """Replace inline base64 data URIs with a lightweight URL reference.
+
+        When the raw icon is a data URI the value is replaced with an
+        endpoint URL so the heavy base64 payload is only fetched on
+        demand rather than duplicated across every model in the
+        /api/models response.
+
+        For SVG icons the URL includes a ``?format=svg`` hint so the
+        frontend can apply dark-mode colour inversion by simply
+        checking whether the icon string contains ``svg``.
+        """
+        if not raw_icon:
+            return None
+
+        if raw_icon.startswith("data:"):
+            url = f"/api/v1/functions/id/{function_id}/icon"
+            if "image/svg" in raw_icon:
+                url += "?format=svg"
+            return url
+
+        return raw_icon
+
+    def _get_raw_icon(function, module, action=None):
+        """Resolve the raw icon value from action / function / module sources."""
+        if action is not None:
+            icon = action.get("icon_url")
+            if icon:
+                return icon
+        return (
+            function.meta.manifest.get("icon_url", None)
+            or getattr(module, "icon_url", None)
+            or getattr(module, "icon", None)
+        )
+
     # Process action_ids to get the actions
     def get_action_items_from_module(function, module):
-        actions = []
         if hasattr(module, "actions"):
-            actions = module.actions
-            return [
-                {
-                    "id": f"{function.id}.{action['id']}",
-                    "name": action.get("name", f"{function.name} ({action['id']})"),
-                    "description": function.meta.description,
-                    "icon": action.get(
-                        "icon_url",
-                        function.meta.manifest.get("icon_url", None)
-                        or getattr(module, "icon_url", None)
-                        or getattr(module, "icon", None),
-                    ),
-                }
-                for action in actions
-            ]
+            items = []
+            for action in module.actions:
+                raw_icon = _get_raw_icon(function, module, action)
+                icon = _resolve_icon(function.id, raw_icon)
+                items.append(
+                    {
+                        "id": f"{function.id}.{action['id']}",
+                        "name": action.get(
+                            "name", f"{function.name} ({action['id']})"
+                        ),
+                        "description": function.meta.description,
+                        "icon": icon,
+                    }
+                )
+            return items
         else:
+            raw_icon = _get_raw_icon(function, module)
+            icon = _resolve_icon(function.id, raw_icon)
             return [
                 {
                     "id": function.id,
                     "name": function.name,
                     "description": function.meta.description,
-                    "icon": function.meta.manifest.get("icon_url", None)
-                    or getattr(module, "icon_url", None)
-                    or getattr(module, "icon", None),
+                    "icon": icon,
                 }
             ]
 
     # Process filter_ids to get the filters
     def get_filter_items_from_module(function, module):
+        raw_icon = _get_raw_icon(function, module)
+        icon = _resolve_icon(function.id, raw_icon)
         return [
             {
                 "id": function.id,
                 "name": function.name,
                 "description": function.meta.description,
-                "icon": function.meta.manifest.get("icon_url", None)
-                or getattr(module, "icon_url", None)
-                or getattr(module, "icon", None),
+                "icon": icon,
                 "has_user_valves": hasattr(module, "UserValves"),
             }
         ]

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1419,7 +1419,7 @@
 													<div class="size-4">
 														<img
 															src={action.icon}
-															class="w-4 h-4 {action.icon.includes('data:image/svg')
+															class="w-4 h-4 {(action.icon ?? '').includes('svg')
 																? 'dark:invert-[80%]'
 																: ''}"
 															style="fill: currentColor;"


### PR DESCRIPTION
The /api/models endpoint previously embedded full base64 icon data inside every action/filter object on every model. With N models sharing M actions, this duplicated each icon blob N times in the JSON payload — easily tens of megabytes in setups with many models and custom actions.

Replace inline base64 data URIs with lightweight URL references to a new GET /api/v1/functions/id/{id}/icon endpoint that serves the icon binary with cache headers. The response shape stays { data: [...] } — fully OpenAI /v1/models compatible.

Changes:

- Backend (models.py): Add _resolve_icon/_get_raw_icon helpers that replace data URIs with endpoint URLs and provide an is_svg flag

- Backend (functions.py): Add GET /id/{id}/icon endpoint serving icon binary with 24h cache headers

- Frontend (ResponseMessage.svelte): Use action.is_svg flag for dark-mode inversion instead of inspecting the data URI string

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
