### PR TITLE
fix: add support for scope in OAuth refresh token request

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -787,6 +787,12 @@ class OAuthClientManager:
             if hasattr(client, "client_secret") and client.client_secret:
                 refresh_data["client_secret"] = client.client_secret
 
+            # Add scope if available in client kwargs (some providers require it on refresh)
+            if hasattr(client, "client_kwargs") and client.client_kwargs.get(
+                "scope", ""
+            ):
+                refresh_data["scope"] = client.client_kwargs["scope"]
+
             # Make refresh request
             async with aiohttp.ClientSession(trust_env=True) as session_http:
                 async with session_http.post(
@@ -1080,6 +1086,12 @@ class OAuthManager:
             # Add client_secret if available (some providers require it)
             if hasattr(client, "client_secret") and client.client_secret:
                 refresh_data["client_secret"] = client.client_secret
+
+            # Add scope if available in client kwargs (some providers require it on refresh)
+            if hasattr(client, "client_kwargs") and client.client_kwargs.get(
+                "scope", ""
+            ):
+                refresh_data["scope"] = client.client_kwargs["scope"]
 
             # Make refresh request
             async with aiohttp.ClientSession(trust_env=True) as session_http:


### PR DESCRIPTION
### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CLA.md), and I am providing my contributions under its terms.

> **Note**
> 
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

---
## Description
This PR fixes an issue where the refresh token request for Microsoft OAuth was failing with error `AADSTS90009`. Previously, the refresh payload only included the `grant_type`, `refresh_token`, `client_id`, and optionally `client_secret`.

Azure AD requires the **scope (or resource)** to be explicitly provided when refreshing a token. Without it, Azure interprets the request as “the application is requesting a token for itself,” which triggers the 400 error:

```
AADSTS90009: Application '[APPLICATION_ID]' is requesting a token for itself.
```

### Changes
- Added support for including a **custom scope** in the refresh token request.
- The scope is read from the environment variable `MICROSOFT_OAUTH_SCOPE`.
- Example format for the scope:

```
openid email profile offline_access api://<Application ID URI>/<custom_scope>
```

- Updated `_perform_token_refresh` to include this scope when refreshing tokens.

### Root Cause
- Azure AD v2.0 requires **explicit scopes** in refresh token requests to determine which resource the new access token should target.
- Omitting `scope` caused Azure to treat the request as self-targeted, resulting in `AADSTS90009`.
- Including the custom scope resolves this and allows token refreshes to succeed.

### Logs Before Fix
```
Token refresh failed for provider microsoft: 400 - {"error":"invalid_request","error_description":"AADSTS90009: Application '[APPLICATION_ID]' is requesting a token for itself."}
```

### Logs After Fix
- Refresh token requests now succeed, and new access tokens are issued without errors.

### Environment Variables
- `MICROSOFT_OAUTH_SCOPE` (required) – the custom scope for token requests.

