### PR TITLE
fix: prevent code blocks from causing message bubble width inconsistency

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -629,7 +629,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
@@ -657,7 +657,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -196,7 +196,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div
@@ -363,8 +363,8 @@
 					</div>
 				</div>
 			{:else if message.content !== ''}
-				<div class="w-full">
-					<div class="flex {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
+				<div class="w-full min-w-0">
+					<div class="flex min-w-0 {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
 						<div
 							class="rounded-3xl {($settings?.chatBubble ?? true)
 								? `max-w-[90%] px-4 py-1.5  bg-gray-50 dark:bg-gray-850 ${


### PR DESCRIPTION
## Description

While testing the chat interface in widescreen mode, I noticed that message bubbles containing code blocks (particularly YAML) would change width inconsistently when scrolling. The bubbles would appear to resize as different messages came into view, creating a jarring visual effect.

## Root Cause

The issue was caused by missing `min-w-0` on flex containers in the message components. In CSS flexbox, without `min-w-0`, flex children refuse to shrink below their intrinsic content width. When code blocks rendered wide content, they would force their parent containers to expand beyond the intended max-width, causing the layout reflow.

Additionally, some containers used `min-w-full` which explicitly prevented proper flex shrinking behavior.

## Changes

**UserMessage.svelte:**
- Changed `min-w-full` to `min-w-0` on the `.chat-user` container
- Added `min-w-0` to parent flex containers wrapping message content

**ResponseMessage.svelte:**
- Added `min-w-0` to the `flex-auto` container that wraps assistant messages
- Changed `min-w-full` to `min-w-0` on the `.chat-assistant` container

## Testing

Tested in widescreen mode with various code block types (YAML, JSON, Python) containing long lines. Message bubble widths now remain consistent when scrolling up and down through the conversation.

Fixes #5975