### PR TITLE
fix: prevent code blocks from causing message bubble width inconsistency in widescreen

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -629,7 +629,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
@@ -657,7 +657,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -196,7 +196,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div
@@ -363,8 +363,8 @@
 					</div>
 				</div>
 			{:else if message.content !== ''}
-				<div class="w-full">
-					<div class="flex {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
+				<div class="w-full min-w-0">
+					<div class="flex min-w-0 {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
 						<div
 							class="rounded-3xl {($settings?.chatBubble ?? true)
 								? `max-w-[90%] px-4 py-1.5  bg-gray-50 dark:bg-gray-850 ${


### PR DESCRIPTION
## Description

When scrolling through a conversation in widescreen mode that contains YAML code blocks, the message bubble widths change inconsistently. This creates a jarring layout shift where bubbles appear to resize as you scroll up and down.

## Root Cause

The message bubble containers were using `min-w-full` which forces the element to be at least as wide as its parent — but in a flex context, this prevented the bubbles from shrinking below their content's intrinsic size. When a YAML (or any wide) code block renders, it pushes the bubble out, causing layout reflow on scroll.

The fix is `min-w-0`, which is the correct Tailwind class for flex children that need to shrink properly. Without it, flexbox children don't shrink below their content width.

## Changes

- `ResponseMessage.svelte`: replaced `min-w-full` with `min-w-0` on the message content container and added `min-w-0` to the flex wrapper
- `UserMessage.svelte`: same fix applied to user bubble containers

## Testing

Reproduced with the YAML preset from the issue:
https://github.com/ChatLunaLab/chatluna-character/blob/main/resources/presets/default.yml

Bubble widths remain consistent while scrolling in widescreen mode after the fix.

Fixes #5975

contributor license agreement