### PR TITLE
fix(tts): pin datasets below 4 for SpeechT5 embeddings

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -59,6 +59,7 @@ opensearch-py==3.1.0
 transformers==5.1.0
 sentence-transformers==5.2.2
 accelerate
+datasets<4 # fix: SpeechT5 TTS speaker embeddings still rely on a script-based HF dataset (Matthijs/cmu-arctic-xvectors)
 pyarrow==20.0.0 # fix: pin pyarrow version to 20 for rpi compatibility #15897
 einops==0.8.2 
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on it and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** No docs change was added because this is a dependency compatibility fix and does not change user-facing configuration or behavior.
- [x] **Dependencies:** This PR adds a version constraint for `datasets` because the local transformers TTS path currently depends on a script-based Hugging Face dataset (`Matthijs/cmu-arctic-xvectors`), which is no longer supported by `datasets` 4.x. I manually tested the affected TTS path after this change.
- [x] **Testing:** I manually reproduced the issue and verified the fix. Steps are included below.
- [x] **Agentic AI Code:** This change was prepared with AI assistance, and I manually reviewed and tested it before submitting.
- [x] **Code review:** I performed a self-review and kept the PR to a single dependency compatibility change.
- [x] **Design & Architecture:** This PR does not add settings or architectural changes; it only restores compatibility for the existing local TTS implementation.
- [x] **Git Hygiene:** This PR is atomic and contains only the dependency pin needed for this fix.
- [x] **Title Prefix:** This PR uses the `fix` prefix.

# Changelog Entry

### Description

- Pin `datasets` to `<4` in `backend/requirements.txt` to restore compatibility for the local transformers SpeechT5 TTS path.

### Added

- No new features were added.

### Changed

- Added a dependency constraint `datasets<4` in the backend requirements.

### Deprecated

- No deprecated functionality.

### Removed

- No removed functionality.

### Fixed

- Fixed runtime failure in local transformers TTS when loading the SpeechT5 speaker embedding dataset `Matthijs/cmu-arctic-xvectors`.
- Prevents errors such as `RuntimeError: Dataset scripts are no longer supported, but found cmu-arctic-xvectors.py` when `datasets` resolves to 4.x.

### Security

- No security-related changes.

### Breaking Changes

- None.

---

### Additional Information

- Root cause: Open WebUI's local transformers TTS path still uses `load_dataset("Matthijs/cmu-arctic-xvectors", split="validation")`.
- That dataset relies on a legacy dataset script, and `datasets` 4.x removed support for dataset scripts.
- This PR intentionally keeps the fix minimal by pinning the dependency rather than changing TTS behavior.
- A future follow-up could remove the dependency on a script-based dataset entirely.

### How I Tested

- Reproduced the issue in a running Open WebUI deployment with `datasets==4.0.0`.
- Set the TTS engine to `transformers`.
- Triggered a speech request through the Open WebUI audio speech endpoint.
- Confirmed the request failed with `RuntimeError: Dataset scripts are no longer supported, but found cmu-arctic-xvectors.py`.
- Applied the dependency pin and rebuilt the environment so that `datasets==3.6.0` was installed.
- Re-ran the same TTS flow and verified that `Matthijs/cmu-arctic-xvectors` loaded successfully and the speech request completed normally.

### Screenshots or Videos

- Not applicable for this PR because this is a backend dependency compatibility fix. No UI changes were made.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.