### PR TITLE
fix: prevent code blocks from causing message bubble width inconsistency in widescreen

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -629,7 +629,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
@@ -657,7 +657,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -196,7 +196,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div
@@ -363,8 +363,8 @@
 					</div>
 				</div>
 			{:else if message.content !== ''}
-				<div class="w-full">
-					<div class="flex {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
+				<div class="w-full min-w-0">
+					<div class="flex min-w-0 {($settings?.chatBubble ?? true) ? 'justify-end pb-1' : 'w-full'}">
 						<div
 							class="rounded-3xl {($settings?.chatBubble ?? true)
 								? `max-w-[90%] px-4 py-1.5  bg-gray-50 dark:bg-gray-850 ${


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Concise description of changes provided below.
- [x] **Testing:** Manually reproduced the issue using the YAML preset linked in #5975 and verified bubble widths stay consistent while scrolling in widescreen mode.
- [x] **Code review:** Self-reviewed — minimal, focused CSS fix only.
- [x] **Git Hygiene:** Single commit, rebased cleanly on `dev` (1 commit ahead of upstream).

# Changelog Entry

### Description

Fixes inconsistent message bubble widths when scrolling through conversations containing YAML (or other wide) code blocks in widescreen mode.

**Root cause:** `min-w-full` on flex children forces a minimum width equal to the parent container. Without `min-w-0`, flex children cannot shrink below their intrinsic content size — so wide code blocks push the bubble container wider than intended, causing layout reflow on scroll.

### Fixed

- `ResponseMessage.svelte`: replaced `min-w-full` with `min-w-0` on message content containers; added `min-w-0` to flex wrapper
- `UserMessage.svelte`: same fix applied to user bubble and edit containers

---

### Additional Information

- Fixes #5975
- Reproduced with: https://github.com/ChatLunaLab/chatluna-character/blob/main/resources/presets/default.yml
- Both files are part of the same fix — they are the two sides of every conversation (user + response). Fixing only one would leave the UI in a broken half-fixed state.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.