### PR TITLE
Fix YAML files not recognized as text files

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -86,6 +86,8 @@ known_source_ext = [
     "hs",
     "lhs",
     "json",
+    "yaml",
+    "yml",
 ]
 
 


### PR DESCRIPTION
Fixes #22263. YAML and YML files were not included in known_source_ext, causing them to be incorrectly forwarded to Docling which does not support these formats. This change adds yaml and yml extensions to the list so they are properly handled as text files with TextLoader.