### PR TITLE
fix: refresh CONFIG_DATA from DB before saving to prevent stale overwrites in multi-worker environments

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -213,7 +213,12 @@ class PersistentConfig(Generic[T]):
             log.info(f"Updated {self.env_name} to new value {self.value}")
 
     def save(self):
+        global CONFIG_DATA
         log.info(f"Saving '{self.env_name}' to the database")
+        # Re-read the latest config from DB before saving to avoid
+        # overwriting changes made by other workers in multi-worker
+        # environments (e.g. multiple uvicorn workers or k8s replicas).
+        CONFIG_DATA = get_config()
         path_parts = self.config_path.split(".")
         sub_config = CONFIG_DATA
         for key in path_parts[:-1]:


### PR DESCRIPTION


In multi-worker setups (multiple uvicorn workers or Kubernetes replicas), each worker maintains its own in-memory copy of CONFIG_DATA loaded at startup. When any worker saves a config change, PersistentConfig.save() writes the entire CONFIG_DATA blob to the database -- silently overwriting changes made by other workers (e.g. OpenAI connection model IDs).

This adds a get_config() call at the top of save() to re-read the latest state from the database before merging in the new value, ensuring cross-worker changes are preserved.

Fixes #22322

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
