### PR TITLE
fix: banner type dropdown requires two selections to register

### DIFF
--- a/src/lib/components/admin/Settings/Interface/Banners.svelte
+++ b/src/lib/components/admin/Settings/Interface/Banners.svelte
@@ -64,9 +64,7 @@
 					bind:value={banner.type}
 					required
 				>
-					{#if banner.type == ''}
-						<option value="" selected disabled class="text-gray-900">{$i18n.t('Type')}</option>
-					{/if}
+					<option value="" disabled hidden class="text-gray-900">{$i18n.t('Type')}</option>
 					<option value="info" class="text-gray-900">{$i18n.t('Info')}</option>
 					<option value="warning" class="text-gray-900">{$i18n.t('Warning')}</option>
 					<option value="error" class="text-gray-900">{$i18n.t('Error')}</option>


### PR DESCRIPTION


https://github.com/user-attachments/assets/404bbdf7-ffbf-43a2-9c97-ebfda4b1fae2

before

and after

https://github.com/user-attachments/assets/a0667576-ab5a-4027-aa54-7971748b6d48



### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
