### PR TITLE
fix: add missing has_access import in tools.py

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_permission, has_access, filter_allowed_access_grants
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
## Summary
Fixes #22393

The `has_access` function was used in `routers/tools.py` but was not imported from `utils.access_control`. This caused a `NameError: name 'has_access' is not defined` when the tools router was accessed.

## Changes
- Added missing import: `from utils.access_control import has_access` in `backend/open_webui/routers/tools.py`

## Testing
- Verified the import resolves the NameError
- No functional changes, only missing import fix

Fixes #22393