### PR TITLE
fix: add missing has_access import in tools.py

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_permission, has_access, filter_allowed_access_grants
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Fix for missing import causing NameError.
- [x] **Changelog:** Added below.
- [x] **Testing:** Verified the import resolves the NameError.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

Fixes a NameError caused by a missing import of `has_access` function in the tools router.

### Fixed

- Added missing `from utils.access_control import has_access` import in `backend/open_webui/routers/tools.py`

### Additional Information

Fixes #22393

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.