### PR TITLE
fix: add YAML extensions to known source extensions for Docling

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -86,6 +86,8 @@ known_source_ext = [
     "hs",
     "lhs",
     "json",
+    "yaml",
+    "yml",
 ]
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Enable YAML file processing in Docling.
- [x] **Changelog:** Added below.
- [x] **Testing:** Verified YAML files are now processed correctly.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

Adds YAML file extensions (.yaml, .yml) to the known source extensions list so Docling can process them as text files.

### Fixed

- Added `.yaml` and `.yml` to `KNOWN_SOURCE_EXTENSIONS` in `backend/open_webui/retrieval/utils/youtube_yt_dlp.py`

### Additional Information

Fixes #22263

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.