### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1864,7 +1864,7 @@ async def chat_completion(
                                 "model": model_id,
                             },
                         )
-                except:
+                except Exception:
                     pass
 
             ctx = build_chat_response_context(
@@ -1911,7 +1911,7 @@ async def chat_completion(
                         {"type": "chat:tasks:cancel"},
                     )
 
-                except:
+                except Exception:
                     pass
         finally:
             try:

--- a/backend/open_webui/retrieval/loaders/external_document.py
+++ b/backend/open_webui/retrieval/loaders/external_document.py
@@ -41,7 +41,7 @@ class ExternalDocumentLoader(BaseLoader):
 
         try:
             headers["X-Filename"] = quote(os.path.basename(self.file_path))
-        except:
+        except Exception:
             pass
 
         if self.user is not None:

--- a/backend/open_webui/retrieval/loaders/mineru.py
+++ b/backend/open_webui/retrieval/loaders/mineru.py
@@ -122,7 +122,7 @@ class MinerULoader:
                 try:
                     error_data = e.response.json()
                     error_detail += f" - {error_data}"
-                except:
+                except Exception:
                     error_detail += f" - {e.response.text}"
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=error_detail)
         except Exception as e:
@@ -252,7 +252,7 @@ class MinerULoader:
                 try:
                     error_data = e.response.json()
                     error_detail += f" - {error_data.get('msg', error_data)}"
-                except:
+                except Exception:
                     error_detail += f" - {e.response.text}"
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=error_detail)
         except Exception as e:
@@ -355,7 +355,7 @@ class MinerULoader:
                     try:
                         error_data = e.response.json()
                         error_detail += f" - {error_data.get('msg', error_data)}"
-                    except:
+                    except Exception:
                         error_detail += f" - {e.response.text}"
                 raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=error_detail)
             except Exception as e:

--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -123,7 +123,7 @@ class ChromaClient(VectorDBBase):
                     }
                 )
             return None
-        except:
+        except Exception:
             return None
 
     def get(self, collection_name: str) -> Optional[GetResult]:

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1095,7 +1095,7 @@ async def send_chat_message_event_by_id(
         else:
             return False
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -179,7 +179,7 @@ async def set_tool_servers_config(
 
             try:
                 request.app.state.oauth_client_manager.remove_client(client_key)
-            except:
+            except Exception:
                 pass
 
     # Set new tool server connections

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -70,7 +70,7 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
 
             try:
                 urlIdx = int(urlIdx)
-            except:
+            except Exception:
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
@@ -123,7 +123,7 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
 
             try:
                 urlIdx = int(urlIdx)
-            except:
+            except Exception:
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1688,7 +1688,7 @@ def process_file(
                     VECTOR_DB_CLIENT.delete_collection(
                         collection_name=f"file-{file.id}"
                     )
-                except:
+                except Exception:
                     # Audio file upload pipeline
                     pass
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -661,7 +661,7 @@ async def yjs_document_update(sid, data):
 
         try:
             await stop_item_tasks(REDIS, document_id)
-        except:
+        except Exception:
             pass
 
         user_id = data.get("user_id", sid)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1926,7 +1926,7 @@ async def chat_completion_files_handler(
                     queries_response = {"queries": [queries_response]}
 
                 queries = queries_response.get("queries", [])
-            except:
+            except Exception:
                 pass
 
             await __event_emitter__(
@@ -2196,7 +2196,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             form_data = apply_system_prompt_to_body(
                 system_message.get("content"), form_data, metadata, user, replace=True
             )  # Required to handle system prompt variables
-        except:
+        except Exception:
             pass
 
     form_data = await convert_url_images_to_base64(form_data)
@@ -3338,7 +3338,7 @@ async def streaming_chat_response_handler(response, ctx):
                         if match:
                             try:
                                 attr_content = match.group(1) if match.group(1) else ""
-                            except:
+                            except Exception:
                                 attr_content = ""
 
                             attributes = extract_attributes(attr_content)

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -620,7 +620,7 @@ class OAuthClientManager:
                             payload = json.loads(response_text)
                             error = payload.get("error")
                             error_description = payload.get("error_description", "")
-                        except:
+                        except Exception:
                             pass
                     else:
                         error_description = response_text


### PR DESCRIPTION
## Summary

- Replace all bare `except:` clauses with `except Exception:` across the backend codebase
- Bare `except:` catches `BaseException`, including `SystemExit` and `KeyboardInterrupt`, which prevents clean shutdown and Ctrl+C signal handling
- This change ensures system signals propagate correctly while still catching all actual errors

## Files Changed

- `backend/open_webui/main.py`
- `backend/open_webui/socket/main.py`
- `backend/open_webui/utils/middleware.py`
- `backend/open_webui/utils/oauth.py`
- `backend/open_webui/routers/configs.py`
- `backend/open_webui/routers/retrieval.py`
- `backend/open_webui/routers/chats.py`
- `backend/open_webui/routers/pipelines.py`
- `backend/open_webui/retrieval/vector/dbs/chroma.py`
- `backend/open_webui/retrieval/loaders/mineru.py`
- `backend/open_webui/retrieval/loaders/external_document.py`

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify Ctrl+C cleanly shuts down the server
- [ ] Verify error handling behavior is unchanged for actual exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)