### PR TITLE
fix: replace debug print() statements with proper logging

### DIFF
--- a/backend/open_webui/retrieval/web/kagi.py
+++ b/backend/open_webui/retrieval/web/kagi.py
@@ -38,7 +38,7 @@ def search_kagi(
         if result["t"] == 0
     ]
 
-    print(results)
+    log.debug(f"Kagi search results: {results}")
 
     if filter_list:
         results = get_filtered_results(results, filter_list)

--- a/backend/open_webui/retrieval/web/mojeek.py
+++ b/backend/open_webui/retrieval/web/mojeek.py
@@ -26,7 +26,7 @@ def search_mojeek(
     response.raise_for_status()
     json_response = response.json()
     results = json_response.get("response", {}).get("results", [])
-    print(results)
+    log.debug(f"Mojeek search results: {results}")
     if filter_list:
         results = get_filtered_results(results, filter_list)
 

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1065,7 +1065,7 @@ def transcribe(
     # Always produce a list of chunk paths (could be one entry if small)
     try:
         chunk_paths = split_audio(file_path, MAX_FILE_SIZE)
-        print(f"Chunk paths: {chunk_paths}")
+        log.debug(f"Chunk paths: {chunk_paths}")
     except Exception as e:
         log.exception(e)
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Replaces bare `print()` calls with `log.debug()` in three production code files:
  - `backend/open_webui/routers/audio.py` - audio chunk paths printed on every transcription
  - `backend/open_webui/retrieval/web/kagi.py` - full search results printed on every Kagi query
  - `backend/open_webui/retrieval/web/mojeek.py` - full search results printed on every Mojeek query
- These print statements bypass the logging framework, always output to stdout regardless of log level, and can leak search query results to container logs in production

## Test plan
- [ ] Perform a web search using Kagi engine and verify results are not printed to stdout
- [ ] Perform a web search using Mojeek engine and verify results are not printed to stdout  
- [ ] Perform audio transcription and verify chunk paths appear only at DEBUG log level
- [ ] Set log level to DEBUG and verify all three messages appear correctly