### PR TITLE
fix: URL-encode OAuth error message in redirect URL

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1706,7 +1706,7 @@ class OAuthManager:
         redirect_url = f"{redirect_base_url}/auth"
 
         if error_message:
-            redirect_url = f"{redirect_url}?error={error_message}"
+            redirect_url = f"{redirect_url}?error={urllib.parse.quote_plus(error_message)}"
             return RedirectResponse(url=redirect_url, headers=response.headers)
 
         response = RedirectResponse(url=redirect_url, headers=response.headers)


### PR DESCRIPTION
## Summary
- URL-encodes the OAuth error message when constructing the redirect URL in the OIDC callback handler (`backend/open_webui/utils/oauth.py`, line 1709)
- Without encoding, error messages containing spaces, ampersands, or other special characters produce malformed URLs that the frontend cannot parse correctly
- The custom OAuth client callback handler (line 938) already correctly uses `urllib.parse.quote_plus()` for the same purpose; this fix brings the OIDC handler in line with that pattern

## Test plan
- [ ] Trigger an OAuth error (e.g., invalid credentials) and verify the redirect URL is properly encoded
- [ ] Verify the frontend correctly displays the error message after redirect
- [ ] Verify normal OAuth login flow still works without errors