### PR TITLE
fix: add missing has_access import in tools router

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_access, has_permission, filter_allowed_access_grants
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
## Summary
- Adds the missing `has_access` import from `open_webui.utils.access_control` in `backend/open_webui/routers/tools.py`
- Without this import, the `get_tools` endpoint raises `NameError: name 'has_access' is not defined` for all non-admin users, returning HTTP 500 and hiding all tools
- The function is called on line 174 when filtering tool access for non-admin users with server-type tools

Fixes #22393

## Test plan
- [ ] Log in as a non-admin user and verify GET /api/v1/tools/ returns 200 with the correct tool list
- [ ] Log in as an admin user and verify tools still load correctly
- [ ] Verify server-type tools with access grants are correctly filtered for non-admin users

---

**By submitting this pull request, I agree to the [Contributor License Agreement](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT).**