### PR TITLE
fix: URL-encode OAuth error message in redirect URL

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1706,7 +1706,7 @@ class OAuthManager:
         redirect_url = f"{redirect_base_url}/auth"
 
         if error_message:
-            redirect_url = f"{redirect_url}?error={error_message}"
+            redirect_url = f"{redirect_url}?error={urllib.parse.quote_plus(error_message)}"
             return RedirectResponse(url=redirect_url, headers=response.headers)
 
         response = RedirectResponse(url=redirect_url, headers=response.headers)


### PR DESCRIPTION
### Description

- In the OAuth error handling flow, the error message was inserted directly into the redirect URL without URL-encoding. When the error message contained special characters (spaces, ampersands, etc.), it produced a malformed redirect URL that could break the redirect or lose parts of the error message.

### Fixed

- URL-encoded the OAuth error message before inserting it into the redirect URL, ensuring the redirect works correctly regardless of special characters in the error message.

### Additional Information

- Tested by reviewing the code path and verifying the fix addresses the issue
- Self-reviewed the code changes

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.