### PR TITLE
fix: handle missing XML elements in Yandex search results

### DIFF
--- a/backend/open_webui/retrieval/web/yandex.py
+++ b/backend/open_webui/retrieval/web/yandex.py
@@ -19,7 +19,10 @@ from xml.etree.ElementTree import Element
 log = logging.getLogger(__name__)
 
 
-def xml_element_contents_to_string(element: Element) -> str:
+def xml_element_contents_to_string(element: Optional[Element]) -> str:
+    if element is None:
+        return ""
+
     buffer = [element.text if element.text else ""]
 
     for child in element:


### PR DESCRIPTION
## Summary
- Adds a `None` guard to `xml_element_contents_to_string()` in `backend/open_webui/retrieval/web/yandex.py`
- `Element.find()` returns `None` when the XPath does not match (e.g., a search result lacks a `doc/passages/passage` element), and passing `None` to this function causes `AttributeError: 'NoneType' object has no attribute 'text'`
- This crashes the entire Yandex web search for any query where at least one result is missing a passage, title, or URL element

## Test plan
- [ ] Perform a Yandex web search with a query that returns results with and without passage snippets
- [ ] Verify the search completes without errors and results without passages show empty snippets
- [ ] Verify normal Yandex search results still display correctly