### PR TITLE
fix: add missing has_access import in tools router

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_access, has_permission, filter_allowed_access_grants
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
### Description

- In the tools router, `has_access` was used but never imported. This caused a `NameError` at runtime when non-admin users attempted to access tools, since the code path invoking `has_access` was only reached for non-admin users.

### Fixed

- Added the missing `has_access` import so the function resolves correctly at runtime for all users.

### Additional Information

- Tested by reviewing the code path and verifying the fix addresses the issue
- Self-reviewed the code changes

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.