### PR TITLE
fix: replace bare except with except Exception in main.py

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1864,7 +1864,7 @@ async def chat_completion(
                                 "model": model_id,
                             },
                         )
-                except:
+                except Exception:
                     pass
 
             ctx = build_chat_response_context(
@@ -1911,7 +1911,7 @@ async def chat_completion(
                         {"type": "chat:tasks:cancel"},
                     )
 
-                except:
+                except Exception:
                     pass
         finally:
             try:


### PR DESCRIPTION
## Description
Replace bare except clauses with `except Exception` in backend/open_webui/main.py to follow Python best practices.

## Changes
- Line 1867 and 1914: bare except replaced with except Exception

## CLA
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.