### PR TITLE
fix: replace bare except with except Exception in main.py

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1864,7 +1864,7 @@ async def chat_completion(
                                 "model": model_id,
                             },
                         )
-                except:
+                except Exception:
                     pass
 
             ctx = build_chat_response_context(
@@ -1911,7 +1911,7 @@ async def chat_completion(
                         {"type": "chat:tasks:cancel"},
                     )
 
-                except:
+                except Exception:
                     pass
         finally:
             try:


### PR DESCRIPTION
### Description

- In `main.py`, a bare `except:` clause was used which catches all exceptions including `SystemExit` and `KeyboardInterrupt`. This prevents clean process shutdown and makes debugging harder.

### Fixed

- Replaced bare `except:` with `except Exception:` so that `SystemExit`, `KeyboardInterrupt`, and other `BaseException` subclasses are no longer silently caught.

### Additional Information

- Tested by reviewing the code path and verifying the fix addresses the issue
- Self-reviewed the code changes

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.