### PR TITLE
Fix: NameError - has_access not defined in tools.py

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_permission, filter_allowed_access_grants, has_access
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
Fixes #22393

## Summary
Add missing has_access import in routers/tools.py - non-admin users were getting 500 error when accessing /api/v1/tools/

## Changes
- Added has_access to the import statement in tools.py

## Testing
- [x] Tested with non-admin user

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.