### PR TITLE
fix: correct Azure TTS locale extraction for SSML xml:lang

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -492,7 +492,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
         region = request.app.state.config.TTS_AZURE_SPEECH_REGION or "eastus"
         base_url = request.app.state.config.TTS_AZURE_SPEECH_BASE_URL
         language = request.app.state.config.TTS_VOICE
-        locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:1])
+        locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:2])
         output_format = request.app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT
 
         try:


### PR DESCRIPTION
## Summary

The Azure TTS SSML locale was being extracted using `split("-")[:1]`, which only takes the **first** segment of the voice name (e.g., `"en"` from `"en-US"`). The `xml:lang` attribute in SSML requires a proper BCP-47 locale like `"en-US"`, not just a bare language code.

This caused Azure TTS to either fail outright or use incorrect pronunciation/prosody rules because the SSML document had an invalid or overly broad language tag.

### Fix

Changed `[:1]` to `[:2]` so the locale correctly extracts both language and region (e.g., `"en-US"`, `"zh-CN"`, `"fr-FR"`).

### Before
```python
locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:1])
# "en-US-JennyNeural" → "en" (wrong)
```

### After
```python
locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:2])
# "en-US-JennyNeural" → "en-US" (correct)
```