### PR TITLE
fix: use correct attribute file.data instead of file.content in file download

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -770,7 +770,7 @@ async def get_file_content_by_id(
                 )
         else:
             # File path doesn’t exist, return the content as .txt if possible
-            file_content = file.content.get("content", "")
+            file_content = file.data.get("content", "") if file.data else ""
             file_name = file.filename
 
             # Create a generator that encodes the file content


### PR DESCRIPTION
## Summary

In the `GET /{id}/content/{file_name}` endpoint, when a file has no storage path and the code falls back to returning file content inline, it accesses `file.content.get("content", "")`. However, `FileModel` has no `content` attribute — the correct attribute is `data` (which is `Optional[dict]`).

This causes an `AttributeError: 'FileModel' object has no attribute 'content'` crash at runtime whenever this fallback path is hit.

### Fix

- Changed `file.content.get(...)` to `file.data.get(...)`
- Added a `None` guard since `data` is `Optional[dict]`