### PR TITLE
fix: prevent TypeError in Teams webhook when user data is missing

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -26,9 +26,14 @@ async def post_webhook(name: str, url: str, message: str, event_data: dict) -> b
         # Microsoft Teams Webhooks
         elif "webhook.office.com" in url:
             action = event_data.get("action", "undefined")
+            user_data = event_data.get("user", "{}")
+            if isinstance(user_data, dict):
+                user_dict = user_data
+            else:
+                user_dict = json.loads(user_data)
             facts = [
                 {"name": name, "value": value}
-                for name, value in json.loads(event_data.get("user", {})).items()
+                for name, value in user_dict.items()
             ]
             payload = {
                 "@type": "MessageCard",


### PR DESCRIPTION
## Summary

The Microsoft Teams webhook handler crashes with `TypeError: the JSON object must be str, bytes or bytearray, not dict` when the `"user"` key is missing from `event_data`.

### Root cause

```python
json.loads(event_data.get("user", {}))
```

When `"user"` is absent, `dict.get()` returns the default `{}` (a dict), which is then passed to `json.loads()`. But `json.loads()` expects a string or bytes, not a dict — so it raises `TypeError`.

### Fix

- Default to `"{}"` (a JSON string) instead of `{}` (a dict)
- Also handle the case where `"user"` is already a dict (not serialized JSON) for robustness, since callers might pass either form