### PR TITLE
fix: public-read access grant should not confer write access to notes

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -236,7 +236,6 @@ async def get_note_by_id(
             permission="write",
             db=db,
         )
-        or has_public_read_access_grant(note.access_grants)
     )
 
     return NoteResponse(**note.model_dump(), write_access=write_access)


### PR DESCRIPTION
## Summary

The `get_note_by_id` endpoint incorrectly includes `has_public_read_access_grant(note.access_grants)` in the `write_access` calculation. This means any note shared publicly for **reading** would appear **editable** by all authenticated users.

### Root cause

The `write_access` boolean is computed as:

```python
write_access = (
    user.role == "admin"
    or (user.id == note.user_id)
    or AccessGrants.has_access(..., permission="write", ...)
    or has_public_read_access_grant(note.access_grants)  # BUG
)
```

The last condition checks for **public read** access but uses it to grant **write** access — a privilege escalation bug.

### Fix

Removed `has_public_read_access_grant()` from the `write_access` check. Write access should only be granted to admins, the note owner, or users with an explicit write access grant.