### PR TITLE
fix: prevent pipeline filter from corrupting chat payload on HTTP error

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -92,8 +92,8 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
                     json=request_data,
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 ) as response:
-                    payload = await response.json()
                     response.raise_for_status()
+                    payload = await response.json()
             except aiohttp.ClientResponseError as e:
                 res = (
                     await response.json()
@@ -145,8 +145,8 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
                     json=request_data,
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 ) as response:
-                    payload = await response.json()
                     response.raise_for_status()
+                    payload = await response.json()
             except aiohttp.ClientResponseError as e:
                 try:
                     res = (


### PR DESCRIPTION
## Summary

In both the inlet and outlet pipeline filter processing, `response.json()` was called **before** `response.raise_for_status()`. When a filter endpoint returns an HTTP error (4xx/5xx), the user's chat payload gets silently overwritten with the error response body.

### Impact

If a pipeline filter returns an error:
1. The user's chat `payload` (containing messages, model, etc.) is replaced with the error response
2. If the error is swallowed (e.g., by the broad `except Exception` handler that just logs), the corrupted payload propagates to subsequent filters and ultimately to the chat completion endpoint
3. This causes confusing downstream failures with no indication that data corruption occurred

### Fix

Swapped the call order in both `process_pipeline_inlet_filter` and `process_pipeline_outlet_filter`:

```python
# Before (wrong order)
payload = await response.json()     # overwrites payload with error body
response.raise_for_status()         # raises too late

# After (correct order)
response.raise_for_status()         # raises before payload is touched
payload = await response.json()     # only runs on success
```