### PR TITLE
fix: public-read access grant should not confer write access to notes

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -236,7 +236,6 @@ async def get_note_by_id(
             permission="write",
             db=db,
         )
-        or has_public_read_access_grant(note.access_grants)
     )
 
     return NoteResponse(**note.model_dump(), write_access=write_access)


### PR DESCRIPTION
### Description

- The `has_public_read_access_grant()` check was incorrectly included in the write access calculation. This meant that any user with public read access could also gain write access to notes, resulting in a privilege escalation vulnerability.

### Fixed

- Removed `has_public_read_access_grant()` from the write access logic so that public read access no longer confers write access to notes.

### Additional Information

- Tested by reviewing the code path and verifying the fix addresses the issue
- Self-reviewed the code changes

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.