### PR TITLE
fix: replace bare string raises with proper exception types

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -590,7 +590,7 @@ def generate_openai_batch_embeddings(
         if "data" in data:
             return [elem["embedding"] for elem in data["data"]]
         else:
-            raise "Something went wrong :/"
+            raise ValueError("Unexpected OpenAI embeddings response: missing 'data' key")
     except Exception as e:
         log.exception(f"Error generating openai batch embeddings: {e}")
         return None
@@ -767,7 +767,7 @@ def generate_ollama_batch_embeddings(
         if "embeddings" in data:
             return data["embeddings"]
         else:
-            raise "Something went wrong :/"
+            raise ValueError("Unexpected Ollama embeddings response: missing 'embeddings' key")
     except Exception as e:
         log.exception(f"Error generating ollama batch embeddings: {e}")
         return None

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1747,7 +1747,7 @@ async def download_file_stream(
 
                                 yield f"data: {json.dumps(res)}\n\n"
                             else:
-                                raise "Ollama: Could not create blob, Please try again."
+                                raise RuntimeError("Ollama: Could not create blob, Please try again.")
 
 
 # url = "https://huggingface.co/TheBloke/stablelm-zephyr-3b-GGUF/resolve/main/stablelm-zephyr-3b.Q2_K.gguf"


### PR DESCRIPTION
### Description

- In Python, `raise "some string"` does not raise an exception with that message — it raises a `TypeError: exceptions must derive from BaseException`. This bug exists in three places in the backend where the code intends to signal an error condition but instead raises a confusing `TypeError`, making the actual problem very hard to debug from logs.
- Fixed all three occurrences by replacing `raise "string"` with proper exception types (`ValueError` / `RuntimeError`) that carry the intended error message.

### Affected locations

1. `backend/open_webui/retrieval/utils.py` — `generate_openai_batch_embeddings()`: when API response is missing the `data` key
2. `backend/open_webui/retrieval/utils.py` — `generate_ollama_batch_embeddings()`: when API response is missing the `embeddings` key
3. `backend/open_webui/routers/ollama.py` — `download_file_stream()`: when blob upload to Ollama fails

### Fixed

- Replaced `raise "Something went wrong :/"` with `raise ValueError(...)` with descriptive messages
- Replaced `raise "Ollama: Could not create blob..."` with `raise RuntimeError(...)`
- Error logs now show the actual problem instead of a misleading `TypeError`

### Additional Information

- Tested by reviewing the code path and verifying the fix
- Self-reviewed the code changes
- These are all inside `try/except Exception` blocks, so behavior is preserved — only the error message logged changes from a confusing `TypeError` to the actual descriptive error
- Rebased onto dev (replaces #22435)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
