### PR TITLE
feat: support upstream model metadata from /v1/models response

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -386,40 +386,52 @@ async def get_model_by_id(
 
 
 @router.get("/model/profile/image")
-def get_model_profile_image(id: str, user=Depends(get_verified_user)):
+def get_model_profile_image(request: Request, id: str, user=Depends(get_verified_user)):
     model = Models.get_model_by_id(id)
+
+    # Resolve profile image URL: DB model takes priority, then in-memory upstream meta
+    profile_image_url: str | None = None
+    etag: str | None = None
 
     if model:
         etag = f'"{model.updated_at}"' if model.updated_at else None
+        profile_image_url = model.meta.profile_image_url
 
-        if model.meta.profile_image_url:
-            if model.meta.profile_image_url.startswith("http"):
-                return Response(
-                    status_code=status.HTTP_302_FOUND,
-                    headers={"Location": model.meta.profile_image_url},
+    if not profile_image_url:
+        # Fall back to upstream model metadata from /v1/models response
+        in_memory = (request.app.state.MODELS or {}).get(id)
+        if in_memory:
+            profile_image_url = (
+                in_memory.get("info", {}).get("meta", {}).get("profile_image_url")
+                or in_memory.get("meta", {}).get("profile_image_url")
+            )
+
+    if profile_image_url:
+        if profile_image_url.startswith("http"):
+            return Response(
+                status_code=status.HTTP_302_FOUND,
+                headers={"Location": profile_image_url},
+            )
+        elif profile_image_url.startswith("data:image"):
+            try:
+                header, base64_data = profile_image_url.split(",", 1)
+                image_data = base64.b64decode(base64_data)
+                image_buffer = io.BytesIO(image_data)
+                media_type = header.split(";")[0].lstrip("data:")
+
+                headers = {"Content-Disposition": "inline"}
+                if etag:
+                    headers["ETag"] = etag
+
+                return StreamingResponse(
+                    image_buffer,
+                    media_type=media_type,
+                    headers=headers,
                 )
-            elif model.meta.profile_image_url.startswith("data:image"):
-                try:
-                    header, base64_data = model.meta.profile_image_url.split(",", 1)
-                    image_data = base64.b64decode(base64_data)
-                    image_buffer = io.BytesIO(image_data)
-                    media_type = header.split(";")[0].lstrip("data:")
+            except Exception as e:
+                pass
 
-                    headers = {"Content-Disposition": "inline"}
-                    if etag:
-                        headers["ETag"] = etag
-
-                    return StreamingResponse(
-                        image_buffer,
-                        media_type=media_type,
-                        headers=headers,
-                    )
-                except Exception as e:
-                    pass
-
-        return FileResponse(f"{STATIC_DIR}/favicon.png")
-    else:
-        return FileResponse(f"{STATIC_DIR}/favicon.png")
+    return FileResponse(f"{STATIC_DIR}/favicon.png")
 
 
 ############################

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -332,6 +332,32 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                 elif meta.get(key) is None:
                     meta[key] = copy.deepcopy(value)
 
+    # Apply upstream model metadata hints from OpenAI-compatible backends.
+    # Upstream meta is model-specific from the provider, so it overrides
+    # global DEFAULT_MODEL_METADATA but is still overridden by DB model overrides.
+    for model in models:
+        # Skip models that have a DB override (custom_models loop already set info)
+        if model.get("info", {}).get("id"):
+            continue
+
+        upstream_meta = model.get("openai", {}).get("meta") or model.get(
+            "ollama", {}
+        ).get("meta")
+        if not upstream_meta:
+            continue
+
+        info = model.setdefault("info", {})
+        meta = info.setdefault("meta", {})
+
+        for key in ("profile_image_url", "description", "capabilities"):
+            value = upstream_meta.get(key)
+            if value is not None:
+                if key == "capabilities" and meta.get("capabilities"):
+                    # Merge: upstream overrides DEFAULT_MODEL_METADATA capabilities
+                    meta["capabilities"] = {**meta["capabilities"], **value}
+                else:
+                    meta[key] = value
+
     # Batch-fetch all function valves in one query to avoid N+1 DB hits
     # inside get_action_priority (previously called per action × per model).
     all_function_valves = Functions.get_function_valves_by_ids(list(all_function_ids))


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Changelog:** See below
- [x] **Testing:** Manual testing with a custom OpenAI-compatible backend returning `meta` in `/v1/models`. Verified: upstream meta populates icons, descriptions, and capabilities in UI; DB overrides take precedence; `DEFAULT_MODEL_METADATA` still applies as base.
- [ ] **Code review:**
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

Allow OpenAI-compatible backends to include an optional `meta` object in their `/v1/models` response entries. OpenWebUI reads `profile_image_url`, `description`, and `capabilities` from it — applying them as model-specific defaults that sit between `DEFAULT_MODEL_METADATA` (global) and DB model overrides (per-model admin config).

This enables managing model presentation (icons, descriptions, capability flags) as infrastructure-as-code on the backend/proxy side, without requiring manual configuration in the OpenWebUI admin UI for each model.

**Precedence (lowest to highest):**
1. `DEFAULT_MODEL_METADATA` config (global blanket defaults for all models)
2. Upstream `meta` from `/v1/models` response (model-specific from the backend)
3. DB model override (admin UI / API)

### Example upstream `/v1/models` response entry

```json
{
  "id": "claude-sonnet-4-20250514",
  "object": "model",
  "owned_by": "anthropic",
  "name": "Claude Sonnet 4",
  "meta": {
    "profile_image_url": "https://example.com/anthropic-icon.png",
    "description": "Anthropic's most capable model",
    "capabilities": { "vision": true }
  }
}
```

All `meta` fields are optional — backends can include any combination of `profile_image_url`, `description`, and `capabilities`.

### Added

- Upstream model metadata support: OpenWebUI now reads `meta.profile_image_url`, `meta.description`, and `meta.capabilities` from `/v1/models` response entries served by OpenAI-compatible backends (including Ollama)

### Changed

- **`backend/open_webui/utils/models.py`** — `get_all_models()`: added a loop after the `DEFAULT_MODEL_METADATA` block that applies upstream `meta` fields, skipping models with DB overrides
- **`backend/open_webui/routers/models.py`** — `get_model_profile_image()`: falls back to in-memory upstream model metadata when no DB model entry exists, so `profile_image_url` from upstream `/v1/models` is served even without a DB override (OpenWebUI strips `profile_image_url` from the `/api/models` payload to reduce size and serves images via this dedicated endpoint instead)

### Why no other files need changes

- **openai.py**: Already preserves all upstream fields via `**model` spread and stores the original in `model["openai"]`
- **Frontend (Svelte)**: Already reads `info.meta` for display and fetches profile images via `/model/profile/image`

---

### Additional Information

- ~65 lines changed across 2 files
- No new dependencies
- No frontend changes required
- No breaking changes — purely additive; backends that don't include `meta` are unaffected

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.