### PR TITLE
fix: import missing has_access function in routers/tools.py

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -30,7 +30,7 @@ from open_webui.utils.plugin import (
 )
 from open_webui.utils.tools import get_tool_specs
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control import has_permission, has_access, filter_allowed_access_grants
 from open_webui.utils.tools import get_tool_servers
 
 from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL


### PR DESCRIPTION
### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

---

## Summary

The `has_access` function was being called on line 174 in `routers/tools.py` but was not imported, causing a `NameError` for non-admin users when accessing the `/api/v1/tools/` endpoint.

## Fix

Added `has_access` to the import statement from `open_webui.utils.access_control`.

## Issue

Fixes #22393