### PR TITLE
fix: correct Azure TTS locale extraction for SSML xml:lang

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -492,7 +492,7 @@ async def speech(request: Request, user=Depends(get_verified_user)):
         region = request.app.state.config.TTS_AZURE_SPEECH_REGION or "eastus"
         base_url = request.app.state.config.TTS_AZURE_SPEECH_BASE_URL
         language = request.app.state.config.TTS_VOICE
-        locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:1])
+        locale = "-".join(request.app.state.config.TTS_VOICE.split("-")[:2])
         output_format = request.app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT
 
         try:


### PR DESCRIPTION
### Description

- Fixed incorrect locale extraction in Azure TTS SSML generation. `split("-")[:1]` only takes the first segment (e.g., "en" from "en-US"), producing an invalid SSML `xml:lang` attribute. Changed to `[:2]` to preserve the full locale (e.g., "en-US").

### Fixed

- Azure TTS now correctly uses the full locale (e.g., "en-US") in SSML `xml:lang` attribute instead of just the language code (e.g., "en")

### Additional Information

- The other TTS code paths in the same file already use the full locale correctly
- Tested by reviewing the code path and verifying the SSML output format matches Azure documentation requirements
- Self-reviewed the code changes
- Rebased onto dev (replaces #22432)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.