### PR TITLE
fix: prevent TypeError in Teams webhook when user data is missing

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -26,9 +26,14 @@ async def post_webhook(name: str, url: str, message: str, event_data: dict) -> b
         # Microsoft Teams Webhooks
         elif "webhook.office.com" in url:
             action = event_data.get("action", "undefined")
+            user_data = event_data.get("user", "{}")
+            if isinstance(user_data, dict):
+                user_dict = user_data
+            else:
+                user_dict = json.loads(user_data)
             facts = [
                 {"name": name, "value": value}
-                for name, value in json.loads(event_data.get("user", {})).items()
+                for name, value in user_dict.items()
             ]
             payload = {
                 "@type": "MessageCard",


### PR DESCRIPTION
### Description

- Fixed `TypeError` crash in Teams webhook handler. `json.loads(event_data.get("user", {}))` passes a dict `{}` as default to `json.loads()` which expects a string. When the `"user"` key is absent from `event_data`, this crashes with `TypeError: the JSON object must be str, bytes or bytearray, not dict`.

### Fixed

- Teams webhook handler no longer crashes when `"user"` key is missing from event data

### Additional Information

- Tested by reviewing the code path and confirming the fix handles the missing key case
- Self-reviewed the code changes
- Rebased onto dev (replaces #22433)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.