### PR TITLE
fix: prevent pipeline filter from corrupting chat payload on HTTP error

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -92,8 +92,8 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
                     json=request_data,
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 ) as response:
-                    payload = await response.json()
                     response.raise_for_status()
+                    payload = await response.json()
             except aiohttp.ClientResponseError as e:
                 res = (
                     await response.json()
@@ -145,8 +145,8 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
                     json=request_data,
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 ) as response:
-                    payload = await response.json()
                     response.raise_for_status()
+                    payload = await response.json()
             except aiohttp.ClientResponseError as e:
                 try:
                     res = (


### PR DESCRIPTION
### Description

- Fixed a bug where pipeline inlet/outlet filters silently corrupt the user's chat payload on HTTP errors. `payload = await response.json()` ran before `response.raise_for_status()`, so on HTTP errors, the user's chat payload was overwritten with the error response body. Moved `raise_for_status()` before `response.json()` in both inlet and outlet filter functions.

### Fixed

- Pipeline filters now properly raise HTTP errors before attempting to parse response, preventing silent chat payload corruption

### Additional Information

- Both `process_pipeline_inlet_filter` and `process_pipeline_outlet_filter` had the same issue
- Tested by reviewing the code path and confirming the fix follows the correct error-handling order
- Self-reviewed the code changes
- Rebased onto dev (replaces #22434)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.