### PR TITLE
fix: use static month names in getTimeRange to prevent OS locale leaking into sidebar

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1094,6 +1094,22 @@ export const approximateToHumanReadable = (nanoseconds: number) => {
 	return results.reverse().join(' ');
 };
 
+// Month names used as i18n translation keys — must be English regardless of locale
+const MONTH_NAMES = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December'
+];
+
 export const getTimeRange = (timestamp) => {
 	const now = new Date();
 	const date = new Date(timestamp * 1000); // Convert Unix timestamp to milliseconds
@@ -1119,7 +1135,7 @@ export const getTimeRange = (timestamp) => {
 	} else if (diffDays <= 30) {
 		return 'Previous 30 days';
 	} else if (nowYear === dateYear) {
-		return date.toLocaleString('default', { month: 'long' });
+		return MONTH_NAMES[dateMonth];
 	} else {
 		return date.getFullYear().toString();
 	}


### PR DESCRIPTION
getTimeRange returns month names that are used as i18n translation keys (consumed via \.t(chat.time_range) in the sidebar, search modal, etc.). The keys must be exact English strings like 'January', 'February', etc.

Previously, toLocaleString('default', { month: 'long' }) was used to generate these keys. The 'default' locale defers to the browser's locale resolution, which in Firefox with intl.regional_prefs.use_os_locales=true picks up OS regional settings instead of the browser language. This caused German month names (e.g. 'Februar', 'Januar') to appear in the sidebar for users whose OS region is set to Germany, even when both browser and app language are set to English. Chrome was unaffected because it ignores OS regional settings for the 'default' locale.

Since i18n has no translation key for 'Februar', the German string passed through untranslated. Replace toLocaleString with a static MONTH_NAMES array lookup to make the intent explicit and eliminate any browser/OS locale dependency.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
