### PR TITLE
fix: throttle mouseenter-triggered API calls in model selector and sidebar

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -45,6 +45,9 @@
 	export let searchEnabled = true;
 	export let searchPlaceholder = $i18n.t('Search a model');
 
+	const MODELS_FETCH_COOLDOWN_MS = 30000;
+	let lastModelsFetchTime = 0;
+
 	export let items: {
 		label: string;
 		value: string;
@@ -413,6 +416,10 @@
 				? 'dark:placeholder-gray-100 placeholder-gray-800'
 				: 'placeholder-gray-400'}"
 			on:mouseenter={async () => {
+				const now = Date.now();
+				if (now - lastModelsFetchTime < MODELS_FETCH_COOLDOWN_MS) return;
+				lastModelsFetchTime = now;
+
 				models.set(
 					await getModels(
 						localStorage.token,

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -79,8 +79,15 @@
 
 	let mouseOver = false;
 	let draggable = false;
+	let loadChatDebounceTimer: ReturnType<typeof setTimeout>;
+
 	$: if (mouseOver) {
-		loadChat();
+		clearTimeout(loadChatDebounceTimer);
+		loadChatDebounceTimer = setTimeout(() => {
+			loadChat();
+		}, 200);
+	} else {
+		clearTimeout(loadChatDebounceTimer);
 	}
 
 	const loadChat = async () => {
@@ -266,6 +273,8 @@
 	});
 
 	onDestroy(() => {
+		clearTimeout(loadChatDebounceTimer);
+
 		if (itemElement) {
 			document.removeEventListener('click', onClickOutside, true);
 


### PR DESCRIPTION
- Add 30s cooldown to model selector mouseenter handler to prevent excessive /api/models calls on hover and tab switches
- Add 200ms debounce to sidebar chat item hover-to-load to prevent rapid-fire getChatById calls when scrolling through the chat list
- Clean up debounce timer on component destroy

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
