### PR TITLE
feat: implement tabbed permissions interface with centered layout and nested hierarchy

### DIFF
--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -1,920 +1,992 @@
 <script lang="ts">
 	import { getContext, onMount } from 'svelte';
-	const i18n = getContext('i18n');
+	const i18n = getContext('i18n') as any;
 
 	import Switch from '$lib/components/common/Switch.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
 	import { DEFAULT_PERMISSIONS } from '$lib/constants/permissions';
 
-	export let permissions = {};
-	export let defaultPermissions = {};
+	export let permissions: any = {};
+	export let defaultPermissions: any = {};
 
 	// Reactive statement to ensure all fields are present in `permissions`
 	$: {
-		permissions = fillMissingProperties(permissions, DEFAULT_PERMISSIONS);
-	}
-
-	function fillMissingProperties(obj: any, defaults: any) {
-		return {
-			...defaults,
-			...obj,
-			workspace: { ...defaults.workspace, ...obj.workspace },
-			sharing: { ...defaults.sharing, ...obj.sharing },
-			access_grants: { ...defaults.access_grants, ...obj.access_grants },
-			chat: { ...defaults.chat, ...obj.chat },
-			features: { ...defaults.features, ...obj.features },
-			settings: { ...defaults.settings, ...obj.settings }
+		permissions = {
+			...DEFAULT_PERMISSIONS,
+			...permissions,
+			workspace: { ...DEFAULT_PERMISSIONS.workspace, ...permissions.workspace },
+			sharing: { ...DEFAULT_PERMISSIONS.sharing, ...permissions.sharing },
+			access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...permissions.access_grants },
+			chat: { ...DEFAULT_PERMISSIONS.chat, ...permissions.chat },
+			features: { ...DEFAULT_PERMISSIONS.features, ...permissions.features },
+			settings: { ...DEFAULT_PERMISSIONS.settings, ...permissions.settings }
 		};
 	}
 
 	onMount(() => {
-		permissions = fillMissingProperties(permissions, DEFAULT_PERMISSIONS);
+		permissions = {
+			...DEFAULT_PERMISSIONS,
+			...permissions,
+			workspace: { ...DEFAULT_PERMISSIONS.workspace, ...permissions.workspace },
+			sharing: { ...DEFAULT_PERMISSIONS.sharing, ...permissions.sharing },
+			access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...permissions.access_grants },
+			chat: { ...DEFAULT_PERMISSIONS.chat, ...permissions.chat },
+			features: { ...DEFAULT_PERMISSIONS.features, ...permissions.features },
+			settings: { ...DEFAULT_PERMISSIONS.settings, ...permissions.settings }
+		};
 	});
+
+	let selectedTab = 'workspace';
 </script>
 
-<div class="space-y-2">
-	<!-- {$i18n.t('Default Model')}
-	{$i18n.t('Model Filtering')}
-	{$i18n.t('Model Permissions')}
-	{$i18n.t('No model IDs')} -->
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Workspace Permissions')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Models Access')}
-				</div>
-				<Switch bind:state={permissions.workspace.models} />
-			</div>
-
-			{#if permissions.workspace.models}
-				<div class="ml-2 flex flex-col gap-2 pt-0.5 pb-1">
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Import Models')}
-						</div>
-						<Switch bind:state={permissions.workspace.models_import} />
-					</div>
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Export Models')}
-						</div>
-						<Switch bind:state={permissions.workspace.models_export} />
-					</div>
-				</div>
-			{:else if defaultPermissions?.workspace?.models}
-				<div class="pb-0.5">
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Knowledge Access')}
-				</div>
-				<Switch bind:state={permissions.workspace.knowledge} />
-			</div>
-			{#if defaultPermissions?.workspace?.knowledge && !permissions.workspace.knowledge}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Prompts Access')}
-				</div>
-				<Switch bind:state={permissions.workspace.prompts} />
-			</div>
-
-			{#if permissions.workspace.prompts}
-				<div class="ml-2 flex flex-col gap-2 pt-0.5 pb-1">
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Import Prompts')}
-						</div>
-						<Switch bind:state={permissions.workspace.prompts_import} />
-					</div>
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Export Prompts')}
-						</div>
-						<Switch bind:state={permissions.workspace.prompts_export} />
-					</div>
-				</div>
-			{:else if defaultPermissions?.workspace?.prompts}
-				<div class="pb-0.5">
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<Tooltip
-				className="flex w-full justify-between my-1"
-				content={$i18n.t(
-					'Warning: Enabling this will allow users to upload arbitrary code on the server.'
-				)}
-				placement="top-start"
-			>
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Tools Access')}
-				</div>
-				<Switch bind:state={permissions.workspace.tools} />
-			</Tooltip>
-
-			{#if permissions.workspace.tools}
-				<div class="ml-2 flex flex-col gap-2 pt-0.5 pb-1">
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Import Tools')}
-						</div>
-						<Switch bind:state={permissions.workspace.tools_import} />
-					</div>
-					<div class="flex w-full justify-between">
-						<div class="self-center text-xs">
-							{$i18n.t('Export Tools')}
-						</div>
-						<Switch bind:state={permissions.workspace.tools_export} />
-					</div>
-				</div>
-			{:else if defaultPermissions?.workspace?.tools}
-				<div class="pb-0.5">
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<Tooltip
-				className="flex w-full justify-between my-1"
-				content={$i18n.t(
-					'Warning: Enabling this will allow users to upload arbitrary code on the server.'
-				)}
-				placement="top-start"
-			>
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Skills Access')}
-				</div>
-				<Switch bind:state={permissions.workspace.skills} />
-			</Tooltip>
-
-			{#if defaultPermissions?.workspace?.skills && !permissions.workspace.skills}
-				<div class="pb-0.5">
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
+<div class="flex flex-col h-full">
+	<div
+		class="flex justify-center overflow-x-auto scrollbar-hidden border-b dark:border-gray-800 mb-3 w-full"
+	>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab === 'workspace'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'workspace')}
+			type="button"
+		>
+			{$i18n.t('Workspace')}
+		</button>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab === 'sharing'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'sharing')}
+			type="button"
+		>
+			{$i18n.t('Sharing')}
+		</button>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab === 'chat'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'chat')}
+			type="button"
+		>
+			{$i18n.t('Chat')}
+		</button>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab === 'features'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'features')}
+			type="button"
+		>
+			{$i18n.t('Features')}
+		</button>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab ===
+			'access_grants'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'access_grants')}
+			type="button"
+		>
+			{$i18n.t('Access')}
+		</button>
+		<button
+			class="flex-1 px-3 py-1.5 text-sm font-medium select-none transition-colors border-b-2 {selectedTab === 'settings'
+				? 'border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100'
+				: 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+			on:click={() => (selectedTab = 'settings')}
+			type="button"
+		>
+			{$i18n.t('Settings')}
+		</button>
 	</div>
 
-	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Sharing Permissions')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Models Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.models} />
-			</div>
-			{#if defaultPermissions?.sharing?.models && !permissions.sharing.models}
+	<div class="flex-1 overflow-y-auto scrollbar-hidden">
+		{#if selectedTab === 'workspace'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.models}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Models Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_models} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_models && !permissions.sharing.public_models}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Models Access')}
+							</div>
+							<Switch bind:state={permissions.workspace.models} />
 						</div>
+
+						{#if permissions.workspace.models}
+							<div class="ml-4 flex flex-col gap-2 pt-0.5 pb-1">
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Import Models')}
+									</div>
+									<Switch bind:state={permissions.workspace.models_import} />
+								</div>
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Export Models')}
+									</div>
+									<Switch bind:state={permissions.workspace.models_export} />
+								</div>
+							</div>
+						{:else if defaultPermissions?.workspace?.models}
+							<div class="pb-0.5">
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Knowledge Access')}
+							</div>
+							<Switch bind:state={permissions.workspace.knowledge} />
+						</div>
+						{#if defaultPermissions?.workspace?.knowledge && !permissions.workspace.knowledge}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Prompts Access')}
+							</div>
+							<Switch bind:state={permissions.workspace.prompts} />
+						</div>
+
+						{#if permissions.workspace.prompts}
+							<div class="ml-4 flex flex-col gap-2 pt-0.5 pb-1">
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Import Prompts')}
+									</div>
+									<Switch bind:state={permissions.workspace.prompts_import} />
+								</div>
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Export Prompts')}
+									</div>
+									<Switch bind:state={permissions.workspace.prompts_export} />
+								</div>
+							</div>
+						{:else if defaultPermissions?.workspace?.prompts}
+							<div class="pb-0.5">
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<Tooltip
+							className="flex w-full justify-between py-1.5"
+							content={$i18n.t(
+								'Warning: Enabling this will allow users to upload arbitrary code on the server.'
+							)}
+							placement="top-start"
+						>
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Tools Access')}
+							</div>
+							<Switch bind:state={permissions.workspace.tools} />
+						</Tooltip>
+
+						{#if permissions.workspace.tools}
+							<div class="ml-4 flex flex-col gap-2 pt-0.5 pb-1">
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Import Tools')}
+									</div>
+									<Switch bind:state={permissions.workspace.tools_import} />
+								</div>
+								<div class="flex w-full justify-between pr-2">
+									<div class="self-center text-xs">
+										{$i18n.t('Export Tools')}
+									</div>
+									<Switch bind:state={permissions.workspace.tools_export} />
+								</div>
+							</div>
+						{:else if defaultPermissions?.workspace?.tools}
+							<div class="pb-0.5">
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<Tooltip
+							className="flex w-full justify-between py-1.5"
+							content={$i18n.t(
+								'Warning: Enabling this will allow users to upload arbitrary code on the server.'
+							)}
+							placement="top-start"
+						>
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Skills Access')}
+							</div>
+							<Switch bind:state={permissions.workspace.skills} />
+						</Tooltip>
+
+						{#if defaultPermissions?.workspace?.skills && !permissions.workspace.skills}
+							<div class="pb-0.5">
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
 			</div>
 		{/if}
 
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Knowledge Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.knowledge} />
-			</div>
-			{#if defaultPermissions?.sharing?.knowledge && !permissions.sharing.knowledge}
+		{#if selectedTab === 'sharing'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.knowledge}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Knowledge Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_knowledge} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_knowledge && !permissions.sharing.public_knowledge}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Models Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.models} />
 						</div>
+						{#if defaultPermissions?.sharing?.models && !permissions.sharing.models}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+
+					{#if permissions.sharing.models}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Models Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_models} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_models && !permissions.sharing.public_models}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Knowledge Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.knowledge} />
+						</div>
+						{#if defaultPermissions?.sharing?.knowledge && !permissions.sharing.knowledge}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.sharing.knowledge}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Knowledge Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_knowledge} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_knowledge && !permissions.sharing.public_knowledge}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Prompts Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.prompts} />
+						</div>
+						{#if defaultPermissions?.sharing?.prompts && !permissions.sharing.prompts}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.sharing.prompts}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Prompts Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_prompts} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_prompts && !permissions.sharing.public_prompts}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Tools Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.tools} />
+						</div>
+						{#if defaultPermissions?.sharing?.tools && !permissions.sharing.tools}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.sharing.tools}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Tools Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_tools} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_tools && !permissions.sharing.public_tools}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Skills Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.skills} />
+						</div>
+						{#if defaultPermissions?.sharing?.skills && !permissions.sharing.skills}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.sharing.skills}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Skills Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_skills} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_skills && !permissions.sharing.public_skills}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Notes Sharing')}
+							</div>
+							<Switch bind:state={permissions.sharing.notes} />
+						</div>
+						{#if defaultPermissions?.sharing?.notes && !permissions.sharing.notes}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.sharing.notes}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Notes Public Sharing')}
+								</div>
+								<Switch bind:state={permissions.sharing.public_notes} />
+							</div>
+							{#if defaultPermissions?.sharing?.public_notes && !permissions.sharing.public_notes}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
 			</div>
 		{/if}
 
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Prompts Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.prompts} />
-			</div>
-			{#if defaultPermissions?.sharing?.prompts && !permissions.sharing.prompts}
+		{#if selectedTab === 'access_grants'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.prompts}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Prompts Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_prompts} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_prompts && !permissions.sharing.public_prompts}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Sharing With Users')}
+							</div>
+							<Switch bind:state={permissions.access_grants.allow_users} />
 						</div>
+						{#if defaultPermissions?.access_grants?.allow_users && !permissions.access_grants.allow_users}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+				</div>
 			</div>
 		{/if}
 
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Tools Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.tools} />
-			</div>
-			{#if defaultPermissions?.sharing?.tools && !permissions.sharing.tools}
+		{#if selectedTab === 'chat'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.tools}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Tools Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_tools} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_tools && !permissions.sharing.public_tools}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow File Upload')}
+							</div>
+							<Switch bind:state={permissions.chat.file_upload} />
 						</div>
+						{#if defaultPermissions?.chat?.file_upload && !permissions.chat.file_upload}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Web Upload')}
+							</div>
+							<Switch bind:state={permissions.chat.web_upload} />
+						</div>
+						{#if defaultPermissions?.chat?.web_upload && !permissions.chat.web_upload}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Chat Controls')}
+							</div>
+							<Switch bind:state={permissions.chat.controls} />
+						</div>
+						{#if defaultPermissions?.chat?.controls && !permissions.chat.controls}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.chat.controls}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Allow Chat Valves')}
+								</div>
+								<Switch bind:state={permissions.chat.valves} />
+							</div>
+							{#if defaultPermissions?.chat?.valves && !permissions.chat.valves}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Allow Chat System Prompt')}
+								</div>
+								<Switch bind:state={permissions.chat.system_prompt} />
+							</div>
+							{#if defaultPermissions?.chat?.system_prompt && !permissions.chat.system_prompt}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Allow Chat Params')}
+								</div>
+								<Switch bind:state={permissions.chat.params} />
+							</div>
+							{#if defaultPermissions?.chat?.params && !permissions.chat.params}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Chat Edit')}
+							</div>
+							<Switch bind:state={permissions.chat.edit} />
+						</div>
+						{#if defaultPermissions?.chat?.edit && !permissions.chat.edit}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Chat Delete')}
+							</div>
+							<Switch bind:state={permissions.chat.delete} />
+						</div>
+						{#if defaultPermissions?.chat?.delete && !permissions.chat.delete}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Delete Messages')}
+							</div>
+							<Switch bind:state={permissions.chat.delete_message} />
+						</div>
+						{#if defaultPermissions?.chat?.delete_message && !permissions.chat.delete_message}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Continue Response')}
+							</div>
+							<Switch bind:state={permissions.chat.continue_response} />
+						</div>
+						{#if defaultPermissions?.chat?.continue_response && !permissions.chat.continue_response}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Regenerate Response')}
+							</div>
+							<Switch bind:state={permissions.chat.regenerate_response} />
+						</div>
+						{#if defaultPermissions?.chat?.regenerate_response && !permissions.chat.regenerate_response}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Rate Response')}
+							</div>
+							<Switch bind:state={permissions.chat.rate_response} />
+						</div>
+						{#if defaultPermissions?.chat?.rate_response && !permissions.chat.rate_response}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Chat Share')}
+							</div>
+							<Switch bind:state={permissions.chat.share} />
+						</div>
+						{#if defaultPermissions?.chat?.share && !permissions.chat.share}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Chat Export')}
+							</div>
+							<Switch bind:state={permissions.chat.export} />
+						</div>
+						{#if defaultPermissions?.chat?.export && !permissions.chat.export}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Speech to Text')}
+							</div>
+							<Switch bind:state={permissions.chat.stt} />
+						</div>
+						{#if defaultPermissions?.chat?.stt && !permissions.chat.stt}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Text to Speech')}
+							</div>
+							<Switch bind:state={permissions.chat.tts} />
+						</div>
+						{#if defaultPermissions?.chat?.tts && !permissions.chat.tts}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Call')}
+							</div>
+							<Switch bind:state={permissions.chat.call} />
+						</div>
+						{#if defaultPermissions?.chat?.call && !permissions.chat.call}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Multiple Models in Chat')}
+							</div>
+							<Switch bind:state={permissions.chat.multiple_models} />
+						</div>
+						{#if defaultPermissions?.chat?.multiple_models && !permissions.chat.multiple_models}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Allow Temporary Chat')}
+							</div>
+							<Switch bind:state={permissions.chat.temporary} />
+						</div>
+						{#if defaultPermissions?.chat?.temporary && !permissions.chat.temporary}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					{#if permissions.chat.temporary}
+						<div class="ml-4 flex flex-col">
+							<div class="flex w-full justify-between py-1.5 pr-2">
+								<div class=" self-center text-xs">
+									{$i18n.t('Enforce Temporary Chat')}
+								</div>
+								<Switch bind:state={permissions.chat.temporary_enforced} />
+							</div>
+							{#if defaultPermissions?.chat?.temporary_enforced && !permissions.chat.temporary_enforced}
+								<div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t('This is a default user permission and will remain enabled.')}
+									</div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
 			</div>
 		{/if}
 
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Skills Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.skills} />
-			</div>
-			{#if defaultPermissions?.sharing?.skills && !permissions.sharing.skills}
+		{#if selectedTab === 'features'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.skills}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Skills Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_skills} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_skills && !permissions.sharing.public_skills}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('API Keys')}
+							</div>
+							<Switch bind:state={permissions.features.api_keys} />
 						</div>
+						{#if defaultPermissions?.features?.api_keys && !permissions.features.api_keys}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Notes')}
+							</div>
+							<Switch bind:state={permissions.features.notes} />
+						</div>
+						{#if defaultPermissions?.features?.notes && !permissions.features.notes}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Channels')}
+							</div>
+							<Switch bind:state={permissions.features.channels} />
+						</div>
+						{#if defaultPermissions?.features?.channels && !permissions.features.channels}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Folders')}
+							</div>
+							<Switch bind:state={permissions.features.folders} />
+						</div>
+						{#if defaultPermissions?.features?.folders && !permissions.features.folders}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Direct Tool Servers')}
+							</div>
+							<Switch bind:state={permissions.features.direct_tool_servers} />
+						</div>
+						{#if defaultPermissions?.features?.direct_tool_servers && !permissions.features.direct_tool_servers}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Web Search')}
+							</div>
+							<Switch bind:state={permissions.features.web_search} />
+						</div>
+						{#if defaultPermissions?.features?.web_search && !permissions.features.web_search}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Image Generation')}
+							</div>
+							<Switch bind:state={permissions.features.image_generation} />
+						</div>
+						{#if defaultPermissions?.features?.image_generation && !permissions.features.image_generation}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Code Interpreter')}
+							</div>
+							<Switch bind:state={permissions.features.code_interpreter} />
+						</div>
+						{#if defaultPermissions?.features?.code_interpreter && !permissions.features.code_interpreter}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Memories')}
+							</div>
+							<Switch bind:state={permissions.features.memories} />
+						</div>
+						{#if defaultPermissions?.features?.memories && !permissions.features.memories}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
+					</div>
+				</div>
 			</div>
 		{/if}
 
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Notes Sharing')}
-				</div>
-				<Switch bind:state={permissions.sharing.notes} />
-			</div>
-			{#if defaultPermissions?.sharing?.notes && !permissions.sharing.notes}
+		{#if selectedTab === 'settings'}
+			<div class="space-y-3 pb-3">
 				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 
-		{#if permissions.sharing.notes}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Notes Public Sharing')}
-					</div>
-					<Switch bind:state={permissions.sharing.public_notes} />
-				</div>
-				{#if defaultPermissions?.sharing?.public_notes && !permissions.sharing.public_notes}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
+					<div class="flex flex-col w-full">
+						<div class="flex w-full justify-between py-1.5">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Interface Settings Access')}
+							</div>
+							<Switch bind:state={permissions.settings.interface} />
 						</div>
+						{#if defaultPermissions?.settings?.interface && !permissions.settings.interface}
+							<div>
+								<div class="text-xs text-gray-500">
+									{$i18n.t('This is a default user permission and will remain enabled.')}
+								</div>
+							</div>
+						{/if}
 					</div>
-				{/if}
+				</div>
 			</div>
 		{/if}
-	</div>
-
-	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Access Grants')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Sharing With Users')}
-				</div>
-				<Switch bind:state={permissions.access_grants.allow_users} />
-			</div>
-			{#if defaultPermissions?.access_grants?.allow_users && !permissions.access_grants.allow_users}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
-
-	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Chat Permissions')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow File Upload')}
-				</div>
-				<Switch bind:state={permissions.chat.file_upload} />
-			</div>
-			{#if defaultPermissions?.chat?.file_upload && !permissions.chat.file_upload}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Web Upload')}
-				</div>
-				<Switch bind:state={permissions.chat.web_upload} />
-			</div>
-			{#if defaultPermissions?.chat?.web_upload && !permissions.chat.web_upload}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Chat Controls')}
-				</div>
-				<Switch bind:state={permissions.chat.controls} />
-			</div>
-			{#if defaultPermissions?.chat?.controls && !permissions.chat.controls}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		{#if permissions.chat.controls}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Allow Chat Valves')}
-					</div>
-					<Switch bind:state={permissions.chat.valves} />
-				</div>
-				{#if defaultPermissions?.chat?.valves && !permissions.chat.valves}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
-						</div>
-					</div>
-				{/if}
-			</div>
-
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Allow Chat System Prompt')}
-					</div>
-					<Switch bind:state={permissions.chat.system_prompt} />
-				</div>
-				{#if defaultPermissions?.chat?.system_prompt && !permissions.chat.system_prompt}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
-						</div>
-					</div>
-				{/if}
-			</div>
-
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Allow Chat Params')}
-					</div>
-					<Switch bind:state={permissions.chat.params} />
-				</div>
-				{#if defaultPermissions?.chat?.params && !permissions.chat.params}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
-						</div>
-					</div>
-				{/if}
-			</div>
-		{/if}
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Chat Edit')}
-				</div>
-				<Switch bind:state={permissions.chat.edit} />
-			</div>
-			{#if defaultPermissions?.chat?.edit && !permissions.chat.edit}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Chat Delete')}
-				</div>
-				<Switch bind:state={permissions.chat.delete} />
-			</div>
-			{#if defaultPermissions?.chat?.delete && !permissions.chat.delete}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Delete Messages')}
-				</div>
-				<Switch bind:state={permissions.chat.delete_message} />
-			</div>
-			{#if defaultPermissions?.chat?.delete_message && !permissions.chat.delete_message}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Continue Response')}
-				</div>
-				<Switch bind:state={permissions.chat.continue_response} />
-			</div>
-			{#if defaultPermissions?.chat?.continue_response && !permissions.chat.continue_response}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Regenerate Response')}
-				</div>
-				<Switch bind:state={permissions.chat.regenerate_response} />
-			</div>
-			{#if defaultPermissions?.chat?.regenerate_response && !permissions.chat.regenerate_response}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Rate Response')}
-				</div>
-				<Switch bind:state={permissions.chat.rate_response} />
-			</div>
-			{#if defaultPermissions?.chat?.rate_response && !permissions.chat.rate_response}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Chat Share')}
-				</div>
-				<Switch bind:state={permissions.chat.share} />
-			</div>
-			{#if defaultPermissions?.chat?.share && !permissions.chat.share}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Chat Export')}
-				</div>
-				<Switch bind:state={permissions.chat.export} />
-			</div>
-			{#if defaultPermissions?.chat?.export && !permissions.chat.export}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Speech to Text')}
-				</div>
-				<Switch bind:state={permissions.chat.stt} />
-			</div>
-			{#if defaultPermissions?.chat?.stt && !permissions.chat.stt}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Text to Speech')}
-				</div>
-				<Switch bind:state={permissions.chat.tts} />
-			</div>
-			{#if defaultPermissions?.chat?.tts && !permissions.chat.tts}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Call')}
-				</div>
-				<Switch bind:state={permissions.chat.call} />
-			</div>
-			{#if defaultPermissions?.chat?.call && !permissions.chat.call}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Multiple Models in Chat')}
-				</div>
-				<Switch bind:state={permissions.chat.multiple_models} />
-			</div>
-			{#if defaultPermissions?.chat?.multiple_models && !permissions.chat.multiple_models}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Allow Temporary Chat')}
-				</div>
-				<Switch bind:state={permissions.chat.temporary} />
-			</div>
-			{#if defaultPermissions?.chat?.temporary && !permissions.chat.temporary}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		{#if permissions.chat.temporary}
-			<div class="flex flex-col w-full">
-				<div class="flex w-full justify-between my-1">
-					<div class=" self-center text-xs font-medium">
-						{$i18n.t('Enforce Temporary Chat')}
-					</div>
-					<Switch bind:state={permissions.chat.temporary_enforced} />
-				</div>
-				{#if defaultPermissions?.chat?.temporary_enforced && !permissions.chat.temporary_enforced}
-					<div>
-						<div class="text-xs text-gray-500">
-							{$i18n.t('This is a default user permission and will remain enabled.')}
-						</div>
-					</div>
-				{/if}
-			</div>
-		{/if}
-	</div>
-
-	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Features Permissions')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('API Keys')}
-				</div>
-				<Switch bind:state={permissions.features.api_keys} />
-			</div>
-			{#if defaultPermissions?.features?.api_keys && !permissions.features.api_keys}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Notes')}
-				</div>
-				<Switch bind:state={permissions.features.notes} />
-			</div>
-			{#if defaultPermissions?.features?.notes && !permissions.features.notes}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Channels')}
-				</div>
-				<Switch bind:state={permissions.features.channels} />
-			</div>
-			{#if defaultPermissions?.features?.channels && !permissions.features.channels}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Folders')}
-				</div>
-				<Switch bind:state={permissions.features.folders} />
-			</div>
-			{#if defaultPermissions?.features?.folders && !permissions.features.folders}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Direct Tool Servers')}
-				</div>
-				<Switch bind:state={permissions.features.direct_tool_servers} />
-			</div>
-			{#if defaultPermissions?.features?.direct_tool_servers && !permissions.features.direct_tool_servers}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Web Search')}
-				</div>
-				<Switch bind:state={permissions.features.web_search} />
-			</div>
-			{#if defaultPermissions?.features?.web_search && !permissions.features.web_search}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Image Generation')}
-				</div>
-				<Switch bind:state={permissions.features.image_generation} />
-			</div>
-			{#if defaultPermissions?.features?.image_generation && !permissions.features.image_generation}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Code Interpreter')}
-				</div>
-				<Switch bind:state={permissions.features.code_interpreter} />
-			</div>
-			{#if defaultPermissions?.features?.code_interpreter && !permissions.features.code_interpreter}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Memories')}
-				</div>
-				<Switch bind:state={permissions.features.memories} />
-			</div>
-			{#if defaultPermissions?.features?.memories && !permissions.features.memories}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
-	</div>
-
-	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
-
-	<div>
-		<div class=" mb-2 text-sm font-medium">{$i18n.t('Settings Permissions')}</div>
-
-		<div class="flex flex-col w-full">
-			<div class="flex w-full justify-between my-1">
-				<div class=" self-center text-xs font-medium">
-					{$i18n.t('Interface Settings Access')}
-				</div>
-				<Switch bind:state={permissions.settings.interface} />
-			</div>
-			{#if defaultPermissions?.settings?.interface && !permissions.settings.interface}
-				<div>
-					<div class="text-xs text-gray-500">
-						{$i18n.t('This is a default user permission and will remain enabled.')}
-					</div>
-				</div>
-			{/if}
-		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Replaced the long, scrollable list of permissions in the Group/Default Permissions modal with a clean, tabbed interface.

### Added

- New tabbed navigation for permissions within `Permissions.svelte`.
- Logical categorization of permissions into six tabs: **Workspace**, **Sharing**, **Chat**, **Features**, **Access**, and **Settings**.
- Visual nesting hierarchy: sub-permission labels are indented, and their corresponding toggles are slightly misaligned (moved left) to sit closer to the text for clearer hierarchical relationships.

### Changed

- Centered and spread the permission tabs evenly across the modal width for a premium and balanced look.
- Integrated `select-none` on tab buttons to prevent accidental text selection during rapid switching.
- Increased vertical spacing between permission options (from `my-1` to `py-1.5`) to improve scannability and interaction ease.
- Refactored internal state management for `permissions` to safely deep-merge with `DEFAULT_PERMISSIONS`, preventing UI crashes.

### Fixed

- Resolved multiple TypeScript and Linting errors in `Permissions.svelte`, including invalid `i18n` store usage and missing prop types.
- Fixed the tab selection logic for the "Access" tab to correctly sync with internal `access_grants` data.

---

### Additional Information

- This change focuses on UI performance and organization, making it significantly easier for admins to manage complex group permission sets without endless scrolling.

### Screenshots or Videos

### Before

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/ec15b55e-3060-4e30-933f-f674c149f922" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/c1e93f83-64bb-4f49-bfdc-8c62b22f1ad0" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/704eba88-7d7e-463d-be10-a447bd0920cf" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/c1652639-f759-465a-ad90-5f89bfaf041b" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/ff39283d-d58d-4c91-90e7-f0d78a9e4da0" />

### After

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/31e179eb-ec35-4491-af62-d9182c090841" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/2e00970a-682b-40a4-8c9a-e1718c784b98" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/07d77457-9199-40ba-997f-0a52c6455374" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/186e5578-295a-470d-9f73-cbcd4259bd41" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/752c70cc-7e9a-448e-9fec-61b1eac1a9a3" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/fc147d2c-55f1-4b16-9ccf-c71fc209483c" />

<img width="912" height="578" alt="image" src="https://github.com/user-attachments/assets/3312b565-972c-45b3-86ac-ca19aa8c784f" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.