### PR TITLE
fix: remove public-read granting write access for notes

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -236,7 +236,6 @@ async def get_note_by_id(
             permission="write",
             db=db,
         )
-        or has_public_read_access_grant(note.access_grants)
     )
 
     return NoteResponse(**note.model_dump(), write_access=write_access)


### PR DESCRIPTION
## Description

Public-read (user:* read) should not grant write access. This fix ensures that notes with public-read permission only allow read access, not write access.

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.