### PR TITLE
fix: remove incorrect public-read grant from note write_access check

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -236,7 +236,6 @@ async def get_note_by_id(
             permission="write",
             db=db,
         )
-        or has_public_read_access_grant(note.access_grants)
     )
 
     return NoteResponse(**note.model_dump(), write_access=write_access)


### PR DESCRIPTION

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.

The has_access function was being called on line 174 but was not imported, causing NameError for non-admin users when accessing /api/v1/tools/ endpoint.

Fixes #22393
