### PR TITLE
fix: preserve tool_calls and output fields in temp chat messages

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2099,6 +2099,10 @@
 
 				return {
 					role: message.role,
+					// Preserve tool_calls for assistant messages (needed for proper tool calling)
+					...(message.tool_calls ? { tool_calls: message.tool_calls } : {}),
+					// Preserve output field for temp chats (backend uses it to reconstruct tool messages)
+					...(message.output ? { output: message.output } : {}),
 					...(message.role === 'user' && imageFiles.length > 0
 						? {
 								content: [
@@ -2119,7 +2123,7 @@
 							})
 				};
 			})
-			.filter((message) => message?.role === 'user' || message?.content?.trim());
+			.filter((message) => message?.role === 'user' || message?.content?.trim() || message?.tool_calls);
 
 		const toolIds = [];
 		const toolServerIds = [];

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2123,7 +2123,9 @@
 							})
 				};
 			})
-			.filter((message) => message?.role === 'user' || message?.content?.trim() || message?.tool_calls);
+			.filter(
+				(message) => message?.role === 'user' || message?.content?.trim() || message?.tool_calls
+			);
 
 		const toolIds = [];
 		const toolServerIds = [];


### PR DESCRIPTION
## Description

The issue was that when sending messages to the backend for temp chats, the message mapping function was only preserving 'role' and 'content' fields, stripping out 'tool_calls' and 'output' fields which are essential for proper tool calling behavior.

This caused temp chats to collapse tool-role content into assistant-role content, breaking native tool calling with JSON schema.

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.

Fixes #22470