### PR TITLE
fix: add profile image fallback handlers for model and user avatars in remaining areas

### DIFF
--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -377,6 +377,9 @@
 										class="rounded-full w-6 min-w-6 h-6 object-cover mr-0.5 flex-shrink-0"
 										src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
 										alt="user"
+										on:error={(e) => {
+											e.currentTarget.src = '/favicon.png';
+										}}
 									/>
 								</ProfilePreview>
 

--- a/src/lib/components/channel/MessageInput/MentionList.svelte
+++ b/src/lib/components/channel/MessageInput/MentionList.svelte
@@ -196,12 +196,18 @@
 								src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${item.id}&lang=${$i18n.language}`}
 								alt={item?.data?.name ?? item.id}
 								class="rounded-full size-5 items-center mr-2"
+								on:error={(e) => {
+									e.currentTarget.src = '/favicon.png';
+								}}
 							/>
 						{:else if item.type === 'user'}
 							<img
 								src={`${WEBUI_API_BASE_URL}/users/${item.id}/profile/image`}
 								alt={item?.label ?? item.id}
 								class="rounded-full size-5 items-center mr-2"
+								on:error={(e) => {
+									e.currentTarget.src = '/favicon.png';
+								}}
 							/>
 						{/if}
 

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -242,6 +242,9 @@
 							alt={message.reply_to_message.meta.model_name ??
 								message.reply_to_message.meta.model_id}
 							class="size-4 ml-0.5 rounded-full object-cover"
+							on:error={(e) => {
+								e.currentTarget.src = '/favicon.png';
+							}}
 						/>
 					{:else}
 						<img
@@ -278,6 +281,9 @@
 							src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${message.meta.model_id}`}
 							alt={message.meta.model_name ?? message.meta.model_id}
 							class="size-8 translate-y-1 ml-0.5 object-cover rounded-full"
+							on:error={(e) => {
+								e.currentTarget.src = '/favicon.png';
+							}}
 						/>
 					{:else}
 						<ProfilePreview user={message.user}>

--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -57,6 +57,9 @@
 								class=" size-[2.7rem] rounded-full border-[1px] border-gray-100 dark:border-none"
 								alt="logo"
 								draggable="false"
+								on:error={(e) => {
+									e.currentTarget.src = '/favicon.png';
+								}}
 							/>
 						</Tooltip>
 					</button>

--- a/src/lib/components/chat/MessageInput/Commands/Models.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Models.svelte
@@ -86,6 +86,9 @@
 						src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${model.id}&lang=${$i18n.language}`}
 						alt={model?.name ?? model.id}
 						class="rounded-full size-5 items-center mr-2"
+						on:error={(e) => {
+							e.currentTarget.src = '/favicon.png';
+						}}
 					/>
 					<div class="truncate">
 						{model.name}

--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -82,6 +82,9 @@
 						alt={$i18n.t('{{modelName}} profile image', { modelName: item.label })}
 						class="rounded-full size-5 flex items-center"
 						loading="lazy"
+						on:error={(e) => {
+							e.currentTarget.src = '/favicon.png';
+						}}
 					/>
 				</Tooltip>
 			</div>

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -128,6 +128,9 @@
 											class=" size-9 @sm:size-10 rounded-full border-[1px] border-gray-100 dark:border-none"
 											aria-hidden="true"
 											draggable="false"
+											on:error={(e) => {
+												e.currentTarget.src = '/favicon.png';
+											}}
 										/>
 									</button>
 								</Tooltip>

--- a/src/lib/components/layout/Sidebar/PinnedModelItem.svelte
+++ b/src/lib/components/layout/Sidebar/PinnedModelItem.svelte
@@ -39,6 +39,9 @@
 					src={`${WEBUI_API_BASE_URL}/models/model/profile/image?id=${model.id}&lang=${$i18n.language}`}
 					class=" size-5 rounded-full -translate-x-[0.5px]"
 					alt="logo"
+					on:error={(e) => {
+						e.currentTarget.src = '/favicon.png';
+					}}
 				/>
 			</div>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Added `on:error` fallback handlers to model and user profile images in several UI components to prevent broken icons when images fail to load.
- Components updated: `MentionList`, `Message`, `Commands/Models` (command list), `ModelSelector/ModelItem`, and `PinnedModelItem` in Sidebar.
- Implemented consistent fallback to `/favicon.png` for all model/user profile image tags.

### Fixed

- **UI**: Fixed broken image icons for models and users by adding client-side error handling that triggers a fallback to the default favicon.

---

### Additional Information

- Changes were implemented across:
  - `src/lib/components/channel/MessageInput/MentionList.svelte`
  - `src/lib/components/channel/Messages/Message.svelte`
  - `src/lib/components/chat/MessageInput/Commands/Models.svelte`
  - `src/lib/components/chat/ModelSelector/ModelItem.svelte`
  - `src/lib/components/layout/Sidebar/PinnedModelItem.svelte`
  - `src/lib/components/admin/Users/UserList.svelte`
  - `src/lib/components/chat/ChatPlaceholder.svelte`
  - `src/lib/components/chat/Placeholder.svelte`

- This fix follows the pattern established in PRs #21730, #21897, and #22485.

### Screenshots or Videos

### Before - `src/lib/components/channel/MessageInput/MentionList.svelte`

<img width="335" height="316" alt="image" src="https://github.com/user-attachments/assets/7e7d6522-7598-4690-8999-9a7ad5c17d28" />

### After - `src/lib/components/channel/MessageInput/MentionList.svelte`

<img width="335" height="316" alt="image" src="https://github.com/user-attachments/assets/3aab6ae7-4885-40e3-815e-0fca4bfffc89" />

### Before - `src/lib/components/channel/Messages/Message.svelte`

<img width="335" height="316" alt="image" src="https://github.com/user-attachments/assets/7e337912-e171-4217-860c-96124c1a84a3" />

### After - `src/lib/components/channel/Messages/Message.svelte`

<img width="335" height="316" alt="image" src="https://github.com/user-attachments/assets/fca9ae5b-ebb0-48d7-9668-000e060bb66d" />

### Before - `src/lib/components/chat/MessageInput/Commands/Models.svelte`

<img width="1175" height="506" alt="image" src="https://github.com/user-attachments/assets/8d7fac24-f394-452f-95d1-1b77bbdbbefd" />

### After - `src/lib/components/chat/MessageInput/Commands/Models.svelte`

<img width="1175" height="506" alt="image" src="https://github.com/user-attachments/assets/0041db98-87ae-44ff-9c17-b080e322c69f" />

### Before - `src/lib/components/chat/ModelSelector/ModelItem.svelte`

<img width="546" height="391" alt="image" src="https://github.com/user-attachments/assets/3ed77124-3079-4164-a7f9-08165ebb6ab8" />

### After - `src/lib/components/chat/ModelSelector/ModelItem.svelte`

<img width="546" height="391" alt="image" src="https://github.com/user-attachments/assets/b3ae4ecd-379f-4f3e-bdd7-337a1b69ce97" />

### Before - `src/lib/components/layout/Sidebar/PinnedModelItem.svelte`

<img width="216" height="118" alt="image" src="https://github.com/user-attachments/assets/01fbfb87-f877-44a8-a8fc-ebb1585a9e56" />

### After - `src/lib/components/layout/Sidebar/PinnedModelItem.svelte`

<img width="216" height="118" alt="image" src="https://github.com/user-attachments/assets/4596fa73-34ff-4576-82ab-1e599bedc2f3" />

### Before - `src/lib/components/admin/Users/UserList.svelte`

<img width="271" height="247" alt="image" src="https://github.com/user-attachments/assets/44c564e6-4981-407a-aed0-41ca15b9dfe0" />

### After - `src/lib/components/admin/Users/UserList.svelte`

<img width="271" height="247" alt="image" src="https://github.com/user-attachments/assets/52b448c1-7db1-4f96-a7ac-1701dcf177d7" />

### Before - `src/lib/components/chat/ChatPlaceholder.svelte`

<img width="1459" height="857" alt="image" src="https://github.com/user-attachments/assets/315f39e3-b425-4e0b-bd35-090cbff5431a" />

### After -  `src/lib/components/chat/ChatPlaceholder.svelte`

<img width="1459" height="857" alt="image" src="https://github.com/user-attachments/assets/a8599cf7-2f0d-4ca6-87d9-4565afd7fa10" />


## It's worth mentioning that the 'After' screenshots might not always reflect the fix, since proper image loading can be hit-or-miss. User and model avatars can fail to load properly, and in that case, should default to the favicon image, but this can be very tricky to capture accurately within a screenshot.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.