### PR TITLE
feat: Added Readiness probe

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -689,6 +689,9 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             log.warning(f"Failed to initialize tool servers at startup: {e}")
 
+    # Mark application as ready to accept traffic from a startup perspective.
+    app.state.startup_complete = True
+
     yield
 
     if hasattr(app.state, "redis_task_command_listener"):
@@ -702,6 +705,9 @@ app = FastAPI(
     redoc_url=None,
     lifespan=lifespan,
 )
+
+# Used by readiness checks to gate traffic until startup work is done.
+app.state.startup_complete = False
 
 # For Open WebUI OIDC/OAuth2
 oauth_manager = OAuthManager(app)
@@ -2552,6 +2558,47 @@ async def get_opensearch_xml():
 
 @app.get("/health")
 async def healthcheck():
+    return {"status": True}
+
+
+@app.get("/ready")
+async def readiness_check():
+    """
+    Returns 200 only when the application is ready to accept traffic.
+    """
+
+    # Ensure application startup work has completed
+    if not getattr(app.state, "startup_complete", False):
+        log.info("Readiness check failed: startup not complete")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Startup not complete",
+        )
+
+    # Check database connectivity
+    try:
+        ScopedSession.execute(text("SELECT 1;")).all()
+    except Exception as e:
+        log.warning(f"Readiness check DB ping failed: {e!r}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database not ready",
+        )
+
+    # Check Redis connectivity if configured
+    redis = app.state.redis
+    if redis is not None:
+        try:
+            pong = await redis.ping()
+            if pong is False:
+                raise Exception("Redis PING returned False")
+        except Exception as e:
+            log.warning(f"Readiness check Redis ping failed: {e!r}")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Redis not ready",
+            )
+
     return {"status": True}
 
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase
 
# Changelog Entry

- ✅ **Readiness probe for deployments.** Added a `/ready` endpoint that only returns 200 after startup has fully completed and database/Redis are reachable to make Kubernetes deployments more reliable.

### Description

- This pull request introduces a proper readiness probe for Open WebUI, ensuring the application only reports itself ready after startup work has completed and the core dependencies (database and Redis) are healthy. This change is meant to allow for cleaner transitions when using Kubernetes, so traffic isn't sent to a pod that is healthy but not ready for traffic.

### Added

- /ready endpoint that:
Gates readiness on application startup completion via app.state.startup_complete.
Verifies database connectivity with a lightweight SELECT 1;.
Optionally verifies Redis connectivity when configured.

---

### Additional Information

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
