### PR TITLE
fix: show current user in access selector

### DIFF
--- a/src/lib/components/workspace/common/AddAccessModal.svelte
+++ b/src/lib/components/workspace/common/AddAccessModal.svelte
@@ -57,6 +57,7 @@
 							bind:groupIds
 							includeGroups={true}
 							includeUsers={shareUsers}
+							includeCurrentUser={true}
 						/>
 					</div>
 

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -7,6 +7,7 @@
 	import { user as _user } from '$lib/stores';
 	import { getUserInfoById, searchUsers } from '$lib/apis/users';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import { shouldShowSelectableUser } from './member-selector';
 
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import Pagination from '$lib/components/common/Pagination.svelte';
@@ -20,6 +21,7 @@
 
 	export let includeGroups = true;
 	export let includeUsers = true;
+	export let includeCurrentUser = false;
 	export let pagination = false;
 
 	export let groupIds = [];
@@ -245,7 +247,7 @@
 
 							<div>
 								{#each users as user, userIdx (user.id)}
-									{#if user?.id !== $_user?.id}
+									{#if shouldShowSelectableUser(user?.id, $_user?.id, includeCurrentUser)}
 										<button
 											class=" dark:border-gray-850 text-xs flex items-center justify-between w-full"
 											type="button"

--- a/src/lib/components/workspace/common/member-selector.test.ts
+++ b/src/lib/components/workspace/common/member-selector.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shouldShowSelectableUser } from './member-selector.ts';
+
+test('hides the current user by default', () => {
+	assert.equal(shouldShowSelectableUser('user-1', 'user-1'), false);
+});
+
+test('shows the current user when explicitly allowed', () => {
+	assert.equal(shouldShowSelectableUser('user-1', 'user-1', true), true);
+});
+
+test('shows other users regardless of the current-user flag', () => {
+	assert.equal(shouldShowSelectableUser('user-2', 'user-1'), true);
+});

--- a/src/lib/components/workspace/common/member-selector.ts
+++ b/src/lib/components/workspace/common/member-selector.ts
@@ -1,0 +1,11 @@
+export const shouldShowSelectableUser = (
+	userId: string | null | undefined,
+	currentUserId: string | null | undefined,
+	includeCurrentUser = false
+): boolean => {
+	if (!userId) {
+		return false;
+	}
+
+	return includeCurrentUser || userId !== currentUserId;
+};


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fix the access user selector so the currently logged-in user is no longer hidden in Add Access dialogs.

### Added

- Add a small selector helper and a regression test for the current-user visibility rule.

### Changed

- Allow access-control flows to opt into showing the currently logged-in user while preserving the existing default behavior for other member pickers.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fix the Add Access user search so duplicate-name matches include the currently logged-in user, matching the `/users/search` response.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Fixes #22491.
- Automated verification: `node --test src/lib/components/workspace/common/member-selector.test.ts`
- Manual verification performed on the PR branch:
  1. Open `Admin Panel -> Integrations -> Open Terminal -> Edit Terminal Connection -> Access -> Add Access`
  2. Search for a name that matches the currently logged-in user and another user with the same display name
  3. Confirm both matching users are shown in the dialog, including the currently logged-in user
  4. Confirm selecting the currently logged-in user still adds the access entry correctly
- No new dependencies were added.

### Screenshots or Videos

- Existing reproduction screenshot is available in #22491.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of the PR and it will not be merged in.

