### PR TITLE
feat: inline ask citation in MessageInput instead of floating modal

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -45,7 +45,8 @@
 		showEmbeds,
 		selectedTerminalId,
 		showFileNavPath,
-		showFileNavDir
+		showFileNavDir,
+		quotedText
 	} from '$lib/stores';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
@@ -2850,10 +2851,20 @@
 									}}
 									on:submit={async (e) => {
 										clearDraft();
-										if (e.detail || files.length > 0) {
-											await tick();
+										let userPrompt = e.detail || '';
 
-											submitPrompt(e.detail.replaceAll('\n\n', '\n'));
+										if ($quotedText) {
+											const quoted = $quotedText
+												.split('\n')
+												.map((l) => `> ${l}`)
+												.join('\n');
+											userPrompt = `${quoted}\n\n\n${userPrompt}`;
+											quotedText.set('');
+										}
+
+										if (userPrompt || files.length > 0) {
+											await tick();
+											submitPrompt(userPrompt.replaceAll('\n\n', '\n'));
 										}
 									}}
 								/>
@@ -2893,9 +2904,20 @@
 									}}
 									on:submit={async (e) => {
 										clearDraft();
-										if (e.detail || files.length > 0) {
+										let userPrompt = e.detail || '';
+
+										if ($quotedText) {
+											const quoted = $quotedText
+												.split('\n')
+												.map((l) => `> ${l}`)
+												.join('\n');
+											userPrompt = `${quoted}\n\n\n${userPrompt}`;
+											quotedText.set('');
+										}
+
+										if (userPrompt || files.length > 0) {
 											await tick();
-											submitPrompt(e.detail.replaceAll('\n\n', '\n'));
+											submitPrompt(userPrompt.replaceAll('\n\n', '\n'));
 										}
 									}}
 								/>

--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 
-	import DOMPurify from 'dompurify';
-	import { marked } from 'marked';
-
 	import { getContext, tick, onDestroy } from 'svelte';
 	const i18n = getContext('i18n');
 
@@ -13,7 +10,7 @@
 	import LightBulb from '$lib/components/icons/LightBulb.svelte';
 	import Markdown from '../Messages/Markdown.svelte';
 	import Skeleton from '../Messages/Skeleton.svelte';
-	import { chatId, models, socket } from '$lib/stores';
+	import { chatId, models, socket, quotedText } from '$lib/stores';
 
 	export let id = '';
 	export let messageId = '';
@@ -22,12 +19,9 @@
 	export let messages = [];
 	export let actions = [];
 	export let onAdd = (e) => {};
-
-	let floatingInput = false;
-	let selectedAction = null;
+	export let onClose = () => {};
 
 	let selectedText = '';
-	let floatingInputValue = '';
 
 	let content = '';
 	let responseContent = null;
@@ -105,11 +99,7 @@
 		// Remove all TOOL placeholders from the prompt
 		prompt = prompt.replace(toolIdPattern, '');
 
-		if (prompt.includes('{{INPUT_CONTENT}}') && floatingInput) {
-			prompt = prompt.replace('{{INPUT_CONTENT}}', floatingInputValue);
-			floatingInputValue = '';
-		}
-
+		prompt = prompt.replace('{{INPUT_CONTENT}}', '');
 		prompt = prompt.replace('{{CONTENT}}', selectedText);
 		prompt = prompt.replace('{{SELECTED_CONTENT}}', selectedContent);
 
@@ -227,12 +217,9 @@
 			controller.abort();
 		}
 
-		selectedAction = null;
 		selectedText = '';
 		responseContent = null;
 		responseDone = false;
-		floatingInput = false;
-		floatingInputValue = '';
 	};
 
 	onDestroy(() => {
@@ -248,85 +235,31 @@
 	style="display: none"
 >
 	{#if responseContent === null}
-		{#if !floatingInput}
-			<div
-				class="flex flex-row shrink-0 p-0.5 bg-white dark:bg-gray-850 dark:text-gray-100 text-medium rounded-xl shadow-xl border border-gray-100 dark:border-gray-800"
-			>
-				{#each actions as action}
-					<button
-						aria-label={action.label}
-						class="px-1.5 py-[1px] hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl flex items-center gap-1 min-w-fit transition"
-						on:click={async () => {
-							selectedText = window.getSelection().toString();
-							selectedAction = action;
+		<div
+			class="flex flex-row shrink-0 p-0.5 bg-white dark:bg-gray-850 dark:text-gray-100 text-medium rounded-xl shadow-xl border border-gray-100 dark:border-gray-800"
+		>
+			{#each actions as action}
+				<button
+					aria-label={action.label}
+					class="px-1.5 py-[1px] hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl flex items-center gap-1 min-w-fit transition"
+					on:click={() => {
+						selectedText = window.getSelection().toString();
 
-							if (action.prompt.includes('{{INPUT_CONTENT}}')) {
-								floatingInput = true;
-								floatingInputValue = '';
-
-								await tick();
-								setTimeout(() => {
-									const input = document.getElementById('floating-message-input');
-									if (input) {
-										input.focus();
-									}
-								}, 0);
-							} else {
-								actionHandler(action.id);
-							}
-						}}
-					>
-						{#if action.icon}
-							<svelte:component this={action.icon} className="size-3 shrink-0" />
-						{/if}
-						<div class="shrink-0">{action.label}</div>
-					</button>
-				{/each}
-			</div>
-		{:else}
-			<div
-				class="py-1 flex dark:text-gray-100 bg-white dark:bg-gray-850 border border-gray-100 dark:border-gray-800 w-72 rounded-full shadow-xl"
-			>
-				<input
-					type="text"
-					id="floating-message-input"
-					class="ml-5 bg-transparent outline-hidden w-full flex-1 text-sm"
-					placeholder={$i18n.t('Ask a question')}
-					aria-label={$i18n.t('Ask a question')}
-					bind:value={floatingInputValue}
-					on:keydown={(e) => {
-						if (e.key === 'Enter') {
-							actionHandler(selectedAction?.id);
+						if (action.input) {
+							quotedText.set(selectedText);
+							onClose();
+						} else {
+							actionHandler(action.id);
 						}
 					}}
-				/>
-
-				<div class="ml-1 mr-1">
-					<button
-						aria-label={$i18n.t('Submit question')}
-						class="{floatingInputValue !== ''
-							? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
-							: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 m-0.5 self-center"
-						on:click={() => {
-							actionHandler(selectedAction?.id);
-						}}
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 16 16"
-							fill="currentColor"
-							class="size-4"
-						>
-							<path
-								fill-rule="evenodd"
-								d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z"
-								clip-rule="evenodd"
-							/>
-						</svg>
-					</button>
-				</div>
-			</div>
-		{/if}
+				>
+					{#if action.icon}
+						<svelte:component this={action.icon} className="size-3 shrink-0" />
+					{/if}
+					<div class="shrink-0">{action.label}</div>
+				</button>
+			{/each}
+		</div>
 	{:else}
 		<div
 			class="bg-white dark:bg-gray-850 dark:text-gray-100 rounded-3xl shadow-xl w-80 max-w-full border border-gray-100 dark:border-gray-800"

--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -34,19 +34,16 @@
 
 	const DEFAULT_ACTIONS = [
 		{
-			id: 'ask',
-			label: $i18n.t('Ask'),
-			icon: ChatBubble,
-			input: true,
-			prompt: `{{SELECTED_CONTENT}}\n\n\n{{INPUT_CONTENT}}`
-		},
-		{
 			id: 'explain',
 			label: $i18n.t('Explain'),
 			icon: LightBulb,
 			prompt: `{{SELECTED_CONTENT}}\n\n\n${$i18n.t('Explain')}`
 		}
 	];
+
+	$: quickActions = actions.filter(
+		(a) => !(a.id === 'ask' && (a.prompt ?? '').trim() === '{{SELECTED_CONTENT}}\n\n\n{{INPUT_CONTENT}}')
+	);
 
 	const autoScroll = async () => {
 		const responseContainer = document.getElementById('response-container');
@@ -238,19 +235,26 @@
 		<div
 			class="flex flex-row shrink-0 p-0.5 bg-white dark:bg-gray-850 dark:text-gray-100 text-medium rounded-xl shadow-xl border border-gray-100 dark:border-gray-800"
 		>
-			{#each actions as action}
+			<button
+				aria-label={$i18n.t('Ask')}
+				class="px-1.5 py-[1px] hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl flex items-center gap-1 min-w-fit transition"
+				on:click={() => {
+					selectedText = window.getSelection().toString();
+					quotedText.set(selectedText);
+					onClose();
+				}}
+			>
+				<ChatBubble className="size-3 shrink-0" />
+				<div class="shrink-0">{$i18n.t('Ask')}</div>
+			</button>
+
+			{#each quickActions as action}
 				<button
 					aria-label={action.label}
 					class="px-1.5 py-[1px] hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl flex items-center gap-1 min-w-fit transition"
 					on:click={() => {
 						selectedText = window.getSelection().toString();
-
-						if (action.input) {
-							quotedText.set(selectedText);
-							onClose();
-						} else {
-							actionHandler(action.id);
-						}
+						actionHandler(action.id);
 					}}
 				>
 					{#if action.icon}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -34,7 +34,8 @@
 		showSettings,
 		selectedTerminalId,
 		TTSWorker,
-		temporaryChatEnabled
+		temporaryChatEnabled,
+		quotedText
 	} from '$lib/stores';
 
 	import {
@@ -75,6 +76,7 @@
 	import Spinner from '../common/Spinner.svelte';
 
 	import XMark from '../icons/XMark.svelte';
+	import ArrowForward from '../icons/ArrowForward.svelte';
 	import GlobeAlt from '../icons/GlobeAlt.svelte';
 	import Photo from '../icons/Photo.svelte';
 	import Wrench from '../icons/Wrench.svelte';
@@ -1203,6 +1205,25 @@
 								: ' border-gray-100/30 dark:border-gray-850/30 hover:border-gray-200 focus-within:border-gray-100 hover:dark:border-gray-800 focus-within:dark:border-gray-800'}  transition px-1 bg-white/5 dark:bg-gray-500/5 backdrop-blur-sm dark:text-gray-100"
 							dir={$settings?.chatDirection ?? 'auto'}
 						>
+							{#if $quotedText}
+								<div
+									class="flex items-center gap-2 mx-2 mt-2 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-xl"
+								>
+									<ArrowForward className="size-3.5 shrink-0 text-gray-500" />
+									<div
+										class="flex-1 text-sm text-gray-600 dark:text-gray-300 line-clamp-1"
+									>
+										"{$quotedText}"
+									</div>
+									<button
+										class="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+										on:click={() => quotedText.set('')}
+									>
+										<XMark />
+									</button>
+								</div>
+							{/if}
+
 							{#if atSelectedModel !== undefined}
 								<div class="px-3 pt-3 text-left w-full flex flex-col z-10">
 									<div class="flex items-center justify-between w-full">

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import DOMPurify from 'dompurify';
+	import { slide } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import { toast } from 'svelte-sonner';
 
 	import { marked } from 'marked';
@@ -1207,6 +1209,7 @@
 						>
 							{#if $quotedText}
 								<div
+									transition:slide={{ duration: 200, easing: cubicOut }}
 									class="flex items-center gap-2 mx-2 mt-2 px-3 py-2 bg-gray-50 dark:bg-gray-800 rounded-xl"
 								>
 									<ArrowForward className="size-3.5 shrink-0 text-gray-500" />

--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -212,5 +212,6 @@
 			onAddMessages({ modelId, parentId, messages });
 			closeFloatingButtons();
 		}}
+		onClose={closeFloatingButtons}
 	/>
 {/if}

--- a/src/lib/components/chat/Settings/Interface/ManageFloatingActionButtonsModal.svelte
+++ b/src/lib/components/chat/Settings/Interface/ManageFloatingActionButtonsModal.svelte
@@ -22,6 +22,11 @@
 	};
 
 	$: if (show) {
+		if (floatingActionButtons !== null) {
+			floatingActionButtons = floatingActionButtons.filter(
+				(a) => !(a.id === 'ask' && (a.prompt ?? '').trim() === '{{SELECTED_CONTENT}}\n\n\n{{INPUT_CONTENT}}')
+			);
+		}
 	}
 
 	onMount(() => {});
@@ -64,15 +69,8 @@
 										if (floatingActionButtons === null) {
 											floatingActionButtons = [
 												{
-													id: 'ask',
-													label: $i18n.t('Ask'),
-													input: true,
-													prompt: `{{SELECTED_CONTENT}}\n\n\n{{INPUT_CONTENT}}`
-												},
-												{
 													id: 'explain',
 													label: $i18n.t('Explain'),
-													input: false,
 													prompt: `{{SELECTED_CONTENT}}\n\n\n${$i18n.t('Explain')}`
 												}
 											];
@@ -106,8 +104,7 @@
 												{
 													id: id,
 													label: `${$i18n.t('New Button')}`,
-													input: true,
-													prompt: `{{CONTENT}}\n\n\n{{INPUT_CONTENT}}`
+													prompt: `{{SELECTED_CONTENT}}\n\n\n`
 												}
 											];
 										}}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -105,6 +105,7 @@ export const artifactContents = writable(null);
 
 export const embed = writable(null);
 
+export const quotedText = writable('');
 export const temporaryChatEnabled = writable(false);
 export const scrollPaginationEnabled = writable(false);
 export const currentChatPage = writable(1);


### PR DESCRIPTION
Text selection + "Ask" now drops a quoted citation bar into the main chat input instead of spawning a separate floating input modal. You type your follow-up question right in the regular input field and the selected text gets prepended as a blockquote on send.

"Explain" is unaffected, still works the same way with the inline streaming response.

<img width="2748" height="820" alt="image" src="https://github.com/user-attachments/assets/ddff3892-5dcf-4aac-9c56-b4cc27ce505f" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.