### PR TITLE
feat: improve chat scroll readability

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1262,13 +1262,19 @@
 		}
 	};
 
+	const isAtContentBottom = (): boolean => {
+		const marker = document.getElementById('messages-bottom');
+		if (!marker || !messagesContainerElement) return true;
+		const markerRect = marker.getBoundingClientRect();
+		const containerRect = messagesContainerElement.getBoundingClientRect();
+		return markerRect.top <= containerRect.bottom + 5;
+	};
+
 	const scrollToBottom = async (behavior = 'auto') => {
 		await tick();
-		if (messagesContainerElement) {
-			messagesContainerElement.scrollTo({
-				top: messagesContainerElement.scrollHeight,
-				behavior
-			});
+		const marker = document.getElementById('messages-bottom');
+		if (marker && messagesContainerElement) {
+			marker.scrollIntoView({ behavior, block: 'end' });
 		}
 	};
 
@@ -1840,6 +1846,14 @@
 
 		saveSessionSelectedModels();
 
+		// Scroll user message to top of viewport
+		autoScroll = false;
+		await tick();
+		const userMsgEl = document.getElementById(`message-${userMessageId}`);
+		if (userMsgEl) {
+			userMsgEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
+
 		await sendMessage(history, userMessageId, { newChat: true });
 	};
 
@@ -1950,7 +1964,9 @@
 						responseMessageIds[`${modelId}-${modelIdx ? modelIdx : _modelIdx}`];
 					const chatEventEmitter = await getChatEventEmitter(model.id, _chatId);
 
-					scrollToBottom();
+					if (autoScroll) {
+						scrollToBottom();
+					}
 					await sendMessageSocket(
 						model,
 						messages && messages.length > 0
@@ -2052,7 +2068,9 @@
 				array.findIndex((i) => JSON.stringify(i) === JSON.stringify(item)) === index
 		);
 
-		scrollToBottom();
+		if (autoScroll) {
+			scrollToBottom();
+		}
 		eventTarget.dispatchEvent(
 			new CustomEvent('chat:start', {
 				detail: {
@@ -2282,7 +2300,9 @@
 		}
 
 		await tick();
-		scrollToBottom();
+		if (autoScroll) {
+			scrollToBottom();
+		}
 	};
 
 	const handleOpenAIError = async (error, responseMessage) => {
@@ -2384,10 +2404,12 @@
 		history.messages[userMessageId] = userMessage;
 		history.currentId = userMessageId;
 
+		// Scroll user message to top of viewport
+		autoScroll = false;
 		await tick();
-
-		if (autoScroll) {
-			scrollToBottom();
+		const askUserMsgEl = document.getElementById(`message-${userMessageId}`);
+		if (askUserMsgEl) {
+			askUserMsgEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 		}
 
 		await sendMessage(history, userMessageId);
@@ -2404,8 +2426,12 @@
 				return;
 			}
 
-			if (autoScroll) {
-				scrollToBottom();
+			// Scroll user message to top of viewport
+			autoScroll = false;
+			await tick();
+			const userMsgEl = document.getElementById(`message-${userMessage.id}`);
+			if (userMsgEl) {
+				userMsgEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 			}
 
 			await sendMessage(history, userMessage.id, {
@@ -2762,9 +2788,7 @@
 								id="messages-container"
 								bind:this={messagesContainerElement}
 								on:scroll={(e) => {
-									autoScroll =
-										messagesContainerElement.scrollHeight - messagesContainerElement.scrollTop <=
-										messagesContainerElement.clientHeight + 5;
+									autoScroll = isAtContentBottom();
 								}}
 							>
 								<div class=" h-full w-full flex flex-col">

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -11,7 +11,7 @@
 	dayjs.extend(duration);
 	dayjs.extend(relativeTime);
 
-	import { onMount, tick, getContext, createEventDispatcher } from 'svelte';
+	import { onMount, onDestroy, tick, getContext, createEventDispatcher } from 'svelte';
 
 	import { createPicker, getAuthToken } from '$lib/utils/google-drive-picker';
 	import { pickAndDownloadFile } from '$lib/utils/onedrive-file-picker';
@@ -520,12 +520,36 @@
 	}
 
 	const scrollToBottom = () => {
-		const element = document.getElementById('messages-container');
-		element.scrollTo({
-			top: element.scrollHeight,
-			behavior: 'smooth'
-		});
+		const marker = document.getElementById('messages-bottom');
+		if (marker) {
+			marker.scrollIntoView({ behavior: 'smooth', block: 'end' });
+		}
 	};
+
+	// Show scroll button only when content-end marker is actually below viewport
+	let showScrollButton = false;
+	let scrollButtonRAF: number | null = null;
+
+	const updateScrollButton = () => {
+		const marker = document.getElementById('messages-bottom');
+		const container = document.getElementById('messages-container');
+		if (marker && container) {
+			const markerRect = marker.getBoundingClientRect();
+			const containerRect = container.getBoundingClientRect();
+			showScrollButton = markerRect.top > containerRect.bottom + 5;
+		} else {
+			showScrollButton = false;
+		}
+		scrollButtonRAF = requestAnimationFrame(updateScrollButton);
+	};
+
+	onMount(() => {
+		scrollButtonRAF = requestAnimationFrame(updateScrollButton);
+	});
+
+	onDestroy(() => {
+		if (scrollButtonRAF) cancelAnimationFrame(scrollButtonRAF);
+	});
 
 	const screenCaptureHandler = async () => {
 		try {
@@ -1085,7 +1109,7 @@
 					: 'max-w-6xl'} w-full"
 			>
 				<div class="relative">
-					{#if autoScroll === false && history?.currentId}
+					{#if showScrollButton && history?.currentId}
 						<div
 							class=" absolute -top-12 left-0 right-0 flex justify-center z-30 pointer-events-none"
 						>

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -134,8 +134,10 @@
 	}
 
 	const scrollToBottom = () => {
-		const element = document.getElementById('messages-container');
-		element.scrollTop = element.scrollHeight;
+		const marker = document.getElementById('messages-bottom');
+		if (marker) {
+			marker.scrollIntoView({ behavior: 'auto', block: 'end' });
+		}
 	};
 
 	const updateChat = async () => {
@@ -184,8 +186,13 @@
 
 		// Optional auto-scroll
 		if ($settings?.scrollOnBranchChange ?? true) {
+			const marker = document.getElementById('messages-bottom');
 			const element = document.getElementById('messages-container');
-			autoScroll = element.scrollHeight - element.scrollTop <= element.clientHeight + 50;
+			if (marker && element) {
+				const markerRect = marker.getBoundingClientRect();
+				const containerRect = element.getBoundingClientRect();
+				autoScroll = markerRect.top <= containerRect.bottom + 50;
+			}
 
 			setTimeout(() => {
 				scrollToBottom();
@@ -231,8 +238,13 @@
 		await tick();
 
 		if ($settings?.scrollOnBranchChange ?? true) {
+			const marker = document.getElementById('messages-bottom');
 			const element = document.getElementById('messages-container');
-			autoScroll = element.scrollHeight - element.scrollTop <= element.clientHeight + 50;
+			if (marker && element) {
+				const markerRect = marker.getBoundingClientRect();
+				const containerRect = element.getBoundingClientRect();
+				autoScroll = markerRect.top <= containerRect.bottom + 50;
+			}
 
 			setTimeout(() => {
 				scrollToBottom();
@@ -282,8 +294,13 @@
 		await tick();
 
 		if ($settings?.scrollOnBranchChange ?? true) {
+			const marker = document.getElementById('messages-bottom');
 			const element = document.getElementById('messages-container');
-			autoScroll = element.scrollHeight - element.scrollTop <= element.clientHeight + 50;
+			if (marker && element) {
+				const markerRect = marker.getBoundingClientRect();
+				const containerRect = element.getBoundingClientRect();
+				autoScroll = markerRect.top <= containerRect.bottom + 50;
+			}
 
 			setTimeout(() => {
 				scrollToBottom();
@@ -432,8 +449,13 @@
 
 	const triggerScroll = () => {
 		if (autoScroll) {
+			const marker = document.getElementById('messages-bottom');
 			const element = document.getElementById('messages-container');
-			autoScroll = element.scrollHeight - element.scrollTop <= element.clientHeight + 50;
+			if (marker && element) {
+				const markerRect = marker.getBoundingClientRect();
+				const containerRect = element.getBoundingClientRect();
+				autoScroll = markerRect.top <= containerRect.bottom + 50;
+			}
 			setTimeout(() => {
 				scrollToBottom();
 			}, 100);
@@ -496,9 +518,10 @@
 						{/each}
 					</ul>
 				</section>
-				<div class="pb-18" />
+				<div id="messages-bottom" />
+				<div style="min-height: calc(100vh - 12rem);" />
 				{#if bottomPadding}
-					<div class="  pb-6" />
+					<div class="pb-6" />
 				{/if}
 			{/key}
 		</div>


### PR DESCRIPTION
Two changes to how scrolling works during chat:

**Scroll user message to top on send** - when you send a message, the user message gets scrolled to the top of the viewport and stays there while the response streams in below. Makes it easier to keep track of what you asked, especially with longer prompts. Same thing happens on regenerate.

**Smarter scroll-to-bottom button** - the button now checks if content has actually grown past the bottom of the viewport before showing up. Previously it would appear right away after sending even though everything was still visible.

Under the hood this adds a `#messages-bottom` marker after the message list with a permanent spacer below it. All scroll-to-bottom and at-bottom detection logic uses this marker instead of `scrollHeight`, so "end of messages" and "end of scrollable area" are properly separated.

### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.