### PR TITLE
feat: content-aware scroll-to-bottom button

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -11,7 +11,7 @@
 	dayjs.extend(duration);
 	dayjs.extend(relativeTime);
 
-	import { onMount, tick, getContext, createEventDispatcher } from 'svelte';
+	import { onMount, onDestroy, tick, getContext, createEventDispatcher } from 'svelte';
 
 	import { createPicker, getAuthToken } from '$lib/utils/google-drive-picker';
 	import { pickAndDownloadFile } from '$lib/utils/onedrive-file-picker';
@@ -526,6 +526,32 @@
 			behavior: 'smooth'
 		});
 	};
+
+	// Show scroll button only when there's actual content below the viewport.
+	// Uses #messages-bottom marker if present, otherwise falls back to autoScroll flag.
+	let showScrollButton = false;
+	let scrollButtonRAF: number | null = null;
+
+	const updateScrollButton = () => {
+		const marker = document.getElementById('messages-bottom');
+		const container = document.getElementById('messages-container');
+		if (marker && container) {
+			const markerRect = marker.getBoundingClientRect();
+			const containerRect = container.getBoundingClientRect();
+			showScrollButton = markerRect.top > containerRect.bottom + 5;
+		} else {
+			showScrollButton = !autoScroll;
+		}
+		scrollButtonRAF = requestAnimationFrame(updateScrollButton);
+	};
+
+	onMount(() => {
+		scrollButtonRAF = requestAnimationFrame(updateScrollButton);
+	});
+
+	onDestroy(() => {
+		if (scrollButtonRAF) cancelAnimationFrame(scrollButtonRAF);
+	});
 
 	const screenCaptureHandler = async () => {
 		try {
@@ -1085,7 +1111,7 @@
 					: 'max-w-6xl'} w-full"
 			>
 				<div class="relative">
-					{#if autoScroll === false && history?.currentId}
+					{#if showScrollButton && history?.currentId}
 						<div
 							class=" absolute -top-12 left-0 right-0 flex justify-center z-30 pointer-events-none"
 						>


### PR DESCRIPTION
The scroll-to-bottom button currently uses the `autoScroll` flag to decide when to show up. That flag can toggle too early in some cases, making the button flash on when everything is still visible on screen.

This changes it to check the actual DOM position of the content end. If the last message is below the viewport, the button shows. If not, it stays hidden. Falls back to the old `autoScroll` behavior when the `#messages-bottom` marker isn't present.

**Note:** The full benefit of this PR only kicks in when #22535 is also merged, since that PR adds the `#messages-bottom` marker. Without it, this falls back to the existing `autoScroll` flag behavior, which works fine on its own but doesn't give the improved accuracy.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.