### PR TITLE
feat: rendering support for email cards

### DIFF
--- a/src/lib/components/chat/Messages/EmailCard.svelte
+++ b/src/lib/components/chat/Messages/EmailCard.svelte
@@ -26,19 +26,59 @@
 	let isEditing = false;
 	let editBody = '';
 	let editSubject = '';
-	let editTo = '';
 	let textareaEl: HTMLTextAreaElement;
+
+	// Chip-based To field
+	let toChips: string[] = [];
+	let toInput = '';
+	let toInputEl: HTMLInputElement;
 
 	let saveStatus = '';
 	let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
-	// Email block is complete when the closing tag is present or the full message is done
 	$: emailDone = done || (token?.raw ?? '').includes('</email>');
 
-	// Start editing automatically when email block finishes
 	$: if (emailDone && edit && !isEditing) {
 		startEditing();
 	}
+
+	// Serialize chips + pending input back to a flat string
+	const toFieldValue = () => {
+		const all = [...toChips];
+		const pending = toInput.trim();
+		if (pending) all.push(pending);
+		return all.join('; ');
+	};
+
+	// Parse a flat "to" string into chips
+	const parseToChips = (value: string) => {
+		return value
+			.split(/[;,]\s*/)
+			.map((s) => s.trim())
+			.filter(Boolean);
+	};
+
+	const commitChip = () => {
+		// Split on commas, semicolons, or whitespace to handle pasted/typed multi-address input
+		const addresses = toInput
+			.split(/[;,\s]+/)
+			.map((s) => s.trim())
+			.filter(Boolean);
+		if (addresses.length) {
+			toChips = [...toChips, ...addresses];
+			toInput = '';
+			syncToAndSave();
+		}
+	};
+
+	const removeChip = (index: number) => {
+		toChips = toChips.filter((_, i) => i !== index);
+		syncToAndSave();
+	};
+
+	const syncToAndSave = () => {
+		debouncedSave();
+	};
 
 	const resizeTextarea = () => {
 		if (!textareaEl) return;
@@ -49,12 +89,11 @@
 	const saveEmail = () => {
 		saveStatus = 'saving';
 		const oldBody = token.body;
-		const oldSubject = token.subject;
+		const toValue = toFieldValue();
 
-		// Rebuild the raw token with updated values
 		let newRaw = '<email>\n';
 		if (editSubject) newRaw += `<subject>${editSubject}</subject>\n`;
-		if (editTo) newRaw += `<to>${editTo}</to>\n`;
+		if (toValue) newRaw += `<to>${toValue}</to>\n`;
 		newRaw += `\n${editBody}\n</email>`;
 
 		onSave({
@@ -64,10 +103,9 @@
 			newRaw
 		});
 
-		// Update token in place so the card reflects changes
 		token.body = editBody;
 		token.subject = editSubject;
-		token.to = editTo;
+		token.to = toValue;
 		token.raw = newRaw;
 
 		setTimeout(() => {
@@ -89,7 +127,8 @@
 	const startEditing = async () => {
 		editBody = token.body;
 		editSubject = token.subject;
-		editTo = token.to;
+		toChips = parseToChips(token.to);
+		toInput = '';
 		isEditing = true;
 		await tick();
 		resizeTextarea();
@@ -98,11 +137,17 @@
 	const mailtoHref = () => {
 		const subject = isEditing ? editSubject : token.subject;
 		const body = isEditing ? editBody : token.body;
-		const to = isEditing ? editTo : token.to || '';
+		const rawTo = isEditing ? toFieldValue() : token.to || '';
+		// mailto: expects comma-separated addresses in the path, not percent-encoded
+		const to = rawTo
+			.split(/[;,\s]+/)
+			.map((s) => s.trim())
+			.filter(Boolean)
+			.join(',');
 		const params: string[] = [];
 		if (subject) params.push('subject=' + encodeURIComponent(subject));
 		if (body) params.push('body=' + encodeURIComponent(body));
-		return `mailto:${encodeURIComponent(to)}${params.length ? '?' + params.join('&') : ''}`;
+		return `mailto:${to}${params.length ? '?' + params.join('&') : ''}`;
 	};
 
 	const handleCopy = () => {
@@ -189,15 +234,51 @@
 
 		<div class="px-5 pb-4">
 			{#if isEditing}
-				<div class="flex gap-2 text-sm py-2 text-gray-500 dark:text-gray-400">
-					<span class="font-medium shrink-0">{$i18n.t('To')}:</span>
-					<input
-						type="text"
-						class="flex-1 bg-transparent text-gray-700 dark:text-gray-200 outline-none border-none p-0"
-						bind:value={editTo}
-						on:input={debouncedSave}
-						placeholder={$i18n.t('recipient@example.com')}
-					/>
+				<!-- svelte-ignore a11y-click-events-have-key-events -->
+				<!-- svelte-ignore a11y-no-static-element-interactions -->
+				<div
+					class="flex items-center gap-2 text-sm py-2 text-gray-500 dark:text-gray-400 cursor-text"
+					on:click={() => toInputEl?.focus()}
+				>
+					<span class="font-medium shrink-0 self-start mt-0.5">{$i18n.t('To')}:</span>
+					<div class="flex flex-wrap items-center gap-1 flex-1 min-w-0">
+						{#each toChips as chip, i}
+							<span
+								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+							>
+								{chip}
+								<button
+									class="opacity-50 hover:opacity-100 transition"
+									on:click|stopPropagation={() => removeChip(i)}
+								>
+									<svg class="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+									</svg>
+								</button>
+							</span>
+						{/each}
+						<input
+							bind:this={toInputEl}
+							type="text"
+							class="flex-1 min-w-[120px] bg-transparent text-gray-700 dark:text-gray-200 outline-none border-none p-0 text-sm"
+							bind:value={toInput}
+							on:keydown={(e) => {
+								if (e.key === 'Enter' || e.key === ',' || e.key === ';' || e.key === 'Tab') {
+									if (toInput.trim()) {
+										e.preventDefault();
+										commitChip();
+									}
+								} else if (e.key === 'Backspace' && !toInput && toChips.length) {
+									toChips = toChips.slice(0, -1);
+									syncToAndSave();
+								}
+							}}
+							on:blur={() => {
+								if (toInput.trim()) commitChip();
+							}}
+							placeholder={toChips.length ? '' : $i18n.t('recipient@example.com')}
+						/>
+					</div>
 				</div>
 
 				<div class="flex gap-2 text-sm py-2 border-b border-gray-200 dark:border-gray-700">

--- a/src/lib/components/chat/Messages/EmailCard.svelte
+++ b/src/lib/components/chat/Messages/EmailCard.svelte
@@ -93,14 +93,13 @@
 	};
 
 	const mailtoHref = () => {
-		const params = new URLSearchParams();
 		const subject = isEditing ? editSubject : token.subject;
 		const body = isEditing ? editBody : token.body;
-		if (subject) params.set('subject', subject);
-		if (body) params.set('body', body);
-		const paramStr = params.toString();
 		const to = token.to || '';
-		return `mailto:${to}${paramStr ? '?' + paramStr : ''}`;
+		const params: string[] = [];
+		if (subject) params.push('subject=' + encodeURIComponent(subject));
+		if (body) params.push('body=' + encodeURIComponent(body));
+		return `mailto:${encodeURIComponent(to)}${params.length ? '?' + params.join('&') : ''}`;
 	};
 
 	const handleCopy = () => {

--- a/src/lib/components/chat/Messages/EmailCard.svelte
+++ b/src/lib/components/chat/Messages/EmailCard.svelte
@@ -26,6 +26,7 @@
 	let isEditing = false;
 	let editBody = '';
 	let editSubject = '';
+	let editTo = '';
 	let textareaEl: HTMLTextAreaElement;
 
 	let saveStatus = '';
@@ -53,7 +54,7 @@
 		// Rebuild the raw token with updated values
 		let newRaw = '<email>\n';
 		if (editSubject) newRaw += `<subject>${editSubject}</subject>\n`;
-		if (token.to) newRaw += `<to>${token.to}</to>\n`;
+		if (editTo) newRaw += `<to>${editTo}</to>\n`;
 		newRaw += `\n${editBody}\n</email>`;
 
 		onSave({
@@ -66,6 +67,7 @@
 		// Update token in place so the card reflects changes
 		token.body = editBody;
 		token.subject = editSubject;
+		token.to = editTo;
 		token.raw = newRaw;
 
 		setTimeout(() => {
@@ -87,6 +89,7 @@
 	const startEditing = async () => {
 		editBody = token.body;
 		editSubject = token.subject;
+		editTo = token.to;
 		isEditing = true;
 		await tick();
 		resizeTextarea();
@@ -95,7 +98,7 @@
 	const mailtoHref = () => {
 		const subject = isEditing ? editSubject : token.subject;
 		const body = isEditing ? editBody : token.body;
-		const to = token.to || '';
+		const to = isEditing ? editTo : token.to || '';
 		const params: string[] = [];
 		if (subject) params.push('subject=' + encodeURIComponent(subject));
 		if (body) params.push('body=' + encodeURIComponent(body));
@@ -185,14 +188,18 @@
 		</div>
 
 		<div class="px-5 pb-4">
-			{#if token.to}
+			{#if isEditing}
 				<div class="flex gap-2 text-sm py-2 text-gray-500 dark:text-gray-400">
 					<span class="font-medium shrink-0">{$i18n.t('To')}:</span>
-					<span class="text-gray-700 dark:text-gray-200">{token.to}</span>
+					<input
+						type="text"
+						class="flex-1 bg-transparent text-gray-700 dark:text-gray-200 outline-none border-none p-0"
+						bind:value={editTo}
+						on:input={debouncedSave}
+						placeholder={$i18n.t('recipient@example.com')}
+					/>
 				</div>
-			{/if}
 
-			{#if isEditing}
 				<div class="flex gap-2 text-sm py-2 border-b border-gray-200 dark:border-gray-700">
 					<span class="font-medium text-gray-500 dark:text-gray-400 shrink-0"
 						>{$i18n.t('Subject')}:</span
@@ -215,6 +222,13 @@
 					}}
 				></textarea>
 			{:else}
+				{#if token.to}
+					<div class="flex gap-2 text-sm py-2 text-gray-500 dark:text-gray-400">
+						<span class="font-medium shrink-0">{$i18n.t('To')}:</span>
+						<span class="text-gray-700 dark:text-gray-200">{token.to}</span>
+					</div>
+				{/if}
+
 				{#if token.subject}
 					<div class="flex gap-2 text-sm py-2 border-b border-gray-200 dark:border-gray-700">
 						<span class="font-medium text-gray-500 dark:text-gray-400 shrink-0"

--- a/src/lib/components/chat/Messages/EmailCard.svelte
+++ b/src/lib/components/chat/Messages/EmailCard.svelte
@@ -134,7 +134,8 @@
 		resizeTextarea();
 	};
 
-	const mailtoHref = () => {
+	// Reactive so Svelte tracks toChips, editSubject, editBody etc.
+	$: computedMailtoHref = (() => {
 		const subject = isEditing ? editSubject : token.subject;
 		const body = isEditing ? editBody : token.body;
 		const rawTo = isEditing ? toFieldValue() : token.to || '';
@@ -148,7 +149,7 @@
 		if (subject) params.push('subject=' + encodeURIComponent(subject));
 		if (body) params.push('body=' + encodeURIComponent(body));
 		return `mailto:${to}${params.length ? '?' + params.join('&') : ''}`;
-	};
+	})();
 
 	const handleCopy = () => {
 		const body = isEditing ? editBody : token.body;
@@ -222,7 +223,7 @@
 
 					<Tooltip content={$i18n.t('Open in mail app')}>
 						<a
-							href={mailtoHref()}
+							href={computedMailtoHref}
 							class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/10 transition"
 						>
 							<PaperPlane className="size-4" strokeWidth="1.5" />

--- a/src/lib/components/chat/Messages/EmailCard.svelte
+++ b/src/lib/components/chat/Messages/EmailCard.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { tick, afterUpdate, onDestroy } from 'svelte';
+	import { copyToClipboard } from '$lib/utils';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Envelope from '$lib/components/icons/Envelope.svelte';
+	import PaperPlane from '$lib/components/icons/PaperPlane.svelte';
+	import Clipboard from '$lib/components/icons/Clipboard.svelte';
+	import Check from '$lib/components/icons/Check.svelte';
+	const i18n = getContext('i18n');
+
+	export let token: { raw: string; subject: string; to: string; body: string };
+	export let edit = true;
+	export let done = true;
+	export let stickyButtonsClassName = 'top-0';
+
+	export let onSave: Function = () => {};
+
+	let copied = false;
+	let sentinelEl: HTMLElement;
+	let isStuck = false;
+	let observer: IntersectionObserver;
+
+	let isEditing = false;
+	let editBody = '';
+	let editSubject = '';
+	let textareaEl: HTMLTextAreaElement;
+
+	let saveStatus = '';
+	let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Email block is complete when the closing tag is present or the full message is done
+	$: emailDone = done || (token?.raw ?? '').includes('</email>');
+
+	// Start editing automatically when email block finishes
+	$: if (emailDone && edit && !isEditing) {
+		startEditing();
+	}
+
+	const resizeTextarea = () => {
+		if (!textareaEl) return;
+		textareaEl.style.height = 'auto';
+		textareaEl.style.height = textareaEl.scrollHeight + 'px';
+	};
+
+	const saveEmail = () => {
+		saveStatus = 'saving';
+		const oldBody = token.body;
+		const oldSubject = token.subject;
+
+		// Rebuild the raw token with updated values
+		let newRaw = '<email>\n';
+		if (editSubject) newRaw += `<subject>${editSubject}</subject>\n`;
+		if (token.to) newRaw += `<to>${token.to}</to>\n`;
+		newRaw += `\n${editBody}\n</email>`;
+
+		onSave({
+			raw: token.raw,
+			oldContent: oldBody,
+			newContent: editBody,
+			newRaw
+		});
+
+		// Update token in place so the card reflects changes
+		token.body = editBody;
+		token.subject = editSubject;
+		token.raw = newRaw;
+
+		setTimeout(() => {
+			saveStatus = 'saved';
+			setTimeout(() => {
+				saveStatus = '';
+			}, 1500);
+		}, 300);
+	};
+
+	const debouncedSave = () => {
+		if (autoSaveTimer) clearTimeout(autoSaveTimer);
+		saveStatus = '';
+		autoSaveTimer = setTimeout(() => {
+			saveEmail();
+		}, 800);
+	};
+
+	const startEditing = async () => {
+		editBody = token.body;
+		editSubject = token.subject;
+		isEditing = true;
+		await tick();
+		resizeTextarea();
+	};
+
+	const mailtoHref = () => {
+		const params = new URLSearchParams();
+		const subject = isEditing ? editSubject : token.subject;
+		const body = isEditing ? editBody : token.body;
+		if (subject) params.set('subject', subject);
+		if (body) params.set('body', body);
+		const paramStr = params.toString();
+		const to = token.to || '';
+		return `mailto:${to}${paramStr ? '?' + paramStr : ''}`;
+	};
+
+	const handleCopy = () => {
+		const body = isEditing ? editBody : token.body;
+		copyToClipboard(body);
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	};
+
+	afterUpdate(() => {
+		if (sentinelEl && !observer) {
+			observer = new IntersectionObserver(
+				([entry]) => {
+					isStuck = !entry.isIntersecting;
+				},
+				{ threshold: 0 }
+			);
+			observer.observe(sentinelEl);
+		}
+	});
+
+	onDestroy(() => {
+		if (autoSaveTimer) clearTimeout(autoSaveTimer);
+		if (observer) observer.disconnect();
+	});
+</script>
+
+<div>
+	<div
+		class="relative flex flex-col rounded-2xl border border-gray-200 dark:border-gray-800 my-0.5 bg-neutral-50 dark:bg-gray-850 overflow-clip"
+	>
+		<div bind:this={sentinelEl} class="h-0 w-full shrink-0" aria-hidden="true"></div>
+
+		<div
+			class="email-card-header sticky {stickyButtonsClassName} left-0 right-0 z-10 py-2 px-3 gap-2 flex items-center justify-between w-full text-sm text-gray-600 dark:text-gray-300 bg-neutral-50 dark:bg-gray-850 {isStuck
+				? 'border-b border-gray-200/60 dark:border-gray-700/40'
+				: 'rounded-t-2xl'}"
+		>
+			<div class="flex items-center gap-2 truncate">
+				{#if !emailDone}
+					<Spinner className="size-3.5 shrink-0" />
+				{:else}
+					<Envelope className="size-3.5 shrink-0" />
+				{/if}
+				<span class="font-semibold truncate">{$i18n.t('Email')}</span>
+			</div>
+
+			{#if emailDone}
+				<div class="flex items-center gap-0.5 shrink-0">
+					{#if isEditing && saveStatus}
+						<span class="px-2 py-0.5 text-xs text-gray-400 dark:text-gray-500 select-none">
+							{#if saveStatus === 'saving'}
+								{$i18n.t('Saving...')}
+							{:else if saveStatus === 'saved'}
+								{$i18n.t('Saved')}
+							{/if}
+						</span>
+					{/if}
+
+					<Tooltip content={$i18n.t('Copy')}>
+						<button
+							class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/10 transition"
+							on:click={handleCopy}
+						>
+							{#if copied}
+								<Check className="size-4" strokeWidth="2" />
+							{:else}
+								<Clipboard className="size-4" strokeWidth="1.5" />
+							{/if}
+						</button>
+					</Tooltip>
+
+					<Tooltip content={$i18n.t('Open in mail app')}>
+						<a
+							href={mailtoHref()}
+							class="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/10 transition"
+						>
+							<PaperPlane className="size-4" strokeWidth="1.5" />
+						</a>
+					</Tooltip>
+				</div>
+			{/if}
+		</div>
+
+		<div class="px-5 pb-4">
+			{#if token.to}
+				<div class="flex gap-2 text-sm py-2 text-gray-500 dark:text-gray-400">
+					<span class="font-medium shrink-0">{$i18n.t('To')}:</span>
+					<span class="text-gray-700 dark:text-gray-200">{token.to}</span>
+				</div>
+			{/if}
+
+			{#if isEditing}
+				<div class="flex gap-2 text-sm py-2 border-b border-gray-200 dark:border-gray-700">
+					<span class="font-medium text-gray-500 dark:text-gray-400 shrink-0"
+						>{$i18n.t('Subject')}:</span
+					>
+					<input
+						type="text"
+						class="flex-1 bg-transparent font-semibold text-gray-800 dark:text-gray-100 outline-none border-none p-0"
+						bind:value={editSubject}
+						on:input={debouncedSave}
+					/>
+				</div>
+
+				<textarea
+					bind:this={textareaEl}
+					class="w-full bg-transparent whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200 pt-3 outline-none border-none resize-none"
+					bind:value={editBody}
+					on:input={() => {
+						resizeTextarea();
+						debouncedSave();
+					}}
+				></textarea>
+			{:else}
+				{#if token.subject}
+					<div class="flex gap-2 text-sm py-2 border-b border-gray-200 dark:border-gray-700">
+						<span class="font-medium text-gray-500 dark:text-gray-400 shrink-0"
+							>{$i18n.t('Subject')}:</span
+						>
+						<span class="font-semibold text-gray-800 dark:text-gray-100">{token.subject}</span>
+					</div>
+				{/if}
+
+				<div class="whitespace-pre-wrap text-sm text-gray-800 dark:text-gray-200 pt-3">
+					{token.body}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.email-card-header::before {
+		content: '';
+		position: absolute;
+		bottom: 100%;
+		left: 0;
+		right: 0;
+		height: 2.5rem;
+		background: inherit;
+	}
+</style>

--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -5,6 +5,7 @@
 	import { user } from '$lib/stores';
 
 	import markedExtension from '$lib/utils/marked/extension';
+	import emailExtension from '$lib/utils/marked/email-extension';
 	import markedKatexExtension from '$lib/utils/marked/katex-extension';
 	import { disableSingleTilde } from '$lib/utils/marked/strikethrough-extension';
 	import { mentionExtension } from '$lib/utils/marked/mention-extension';
@@ -46,6 +47,7 @@
 
 	marked.use(markedKatexExtension(options));
 	marked.use(markedExtension(options));
+	marked.use(emailExtension(options));
 	marked.use(citationExtension(options));
 	marked.use(footnoteExtension(options));
 	marked.use(disableSingleTilde);

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -13,6 +13,7 @@
 	import { settings } from '$lib/stores';
 
 	import CodeBlock from '$lib/components/chat/Messages/CodeBlock.svelte';
+	import EmailCard from '$lib/components/chat/Messages/EmailCard.svelte';
 	import MarkdownInlineTokens from '$lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte';
 	import KatexRenderer from './KatexRenderer.svelte';
 	import AlertRenderer, { alertComponent } from './AlertRenderer.svelte';
@@ -363,6 +364,21 @@
 				dir="auto"
 			/>
 		{/if}
+	{:else if token.type === 'email'}
+		<EmailCard
+			{token}
+			{done}
+			edit={editCodeBlock}
+			stickyButtonsClassName={topPadding ? 'top-10' : 'top-0'}
+			onSave={(value) => {
+				onSave({
+					raw: token.raw,
+					oldContent: token.body,
+					newContent: value.newContent,
+					newRaw: value.newRaw
+				});
+			}}
+		/>
 	{:else if token.type === 'html'}
 		<HtmlToken {id} {token} {onSourceClick} />
 	{:else if token.type === 'iframe'}

--- a/src/lib/components/icons/Envelope.svelte
+++ b/src/lib/components/icons/Envelope.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let className = 'size-4';
+	export let strokeWidth = '1.5';
+</script>
+
+<svg
+	aria-hidden="true"
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width={strokeWidth}
+	stroke="currentColor"
+	class={className}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"
+	/>
+</svg>

--- a/src/lib/components/icons/PaperPlane.svelte
+++ b/src/lib/components/icons/PaperPlane.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let className = 'size-4';
+	export let strokeWidth = '1.5';
+</script>
+
+<svg
+	aria-hidden="true"
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width={strokeWidth}
+	stroke="currentColor"
+	class={className}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
+	/>
+</svg>

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -890,7 +890,12 @@ export const removeDetails = (content, types) => {
 
 export const removeAllDetails = (content) => {
 	return replaceOutsideCode(content, (segment) => {
-		return segment.replace(/<details[^>]*>.*?<\/details>/gis, '');
+		segment = segment.replace(/<details[^>]*>.*?<\/details>/gis, '');
+		segment = segment.replace(
+			/<email[^>]*>\s*(?:<subject>.*?<\/subject>\s*)?(?:<to>.*?<\/to>\s*)?([\s\S]*?)<\/email>/gis,
+			'$1'
+		);
+		return segment;
 	});
 };
 

--- a/src/lib/utils/marked/email-extension.ts
+++ b/src/lib/utils/marked/email-extension.ts
@@ -1,0 +1,78 @@
+function findMatchingClosingTag(src: string, openTag: string, closeTag: string): number {
+	let depth = 1;
+	let index = openTag.length;
+	while (depth > 0 && index < src.length) {
+		if (src.startsWith(openTag, index)) {
+			depth++;
+		} else if (src.startsWith(closeTag, index)) {
+			depth--;
+		}
+		if (depth > 0) {
+			index++;
+		}
+	}
+	return depth === 0 ? index + closeTag.length : -1;
+}
+
+function emailStart(src: string) {
+	return src.match(/^<email>/) ? 0 : -1;
+}
+
+function emailTokenizer(src: string) {
+	const openRegex = /^<email>\n?/;
+	const openMatch = openRegex.exec(src);
+	if (!openMatch) return;
+
+	const endIndex = findMatchingClosingTag(src, '<email>', '</email>');
+	const closed = endIndex !== -1;
+
+	// If closed, use the matched range. If still streaming, consume all remaining input.
+	const fullMatch = closed ? src.slice(0, endIndex) : src;
+	let content = closed
+		? fullMatch.slice(openMatch[0].length, -'</email>'.length)
+		: fullMatch.slice(openMatch[0].length);
+
+	let subject = '';
+	const subjectMatch = /^<subject>([\s\S]*?)<\/subject>\n?/.exec(content);
+	if (subjectMatch) {
+		subject = subjectMatch[1].trim();
+		content = content.slice(subjectMatch[0].length);
+	}
+
+	let to = '';
+	const toMatch = /^<to>([\s\S]*?)<\/to>\n?/.exec(content);
+	if (toMatch) {
+		to = toMatch[1].trim();
+		content = content.slice(toMatch[0].length);
+	}
+
+	const body = content.replace(/^\n+/, '').replace(/\n+$/, '');
+
+	return {
+		type: 'email',
+		raw: fullMatch,
+		subject,
+		to,
+		body
+	};
+}
+
+function emailRenderer(token: any) {
+	return token.raw;
+}
+
+function emailExtension() {
+	return {
+		name: 'email',
+		level: 'block' as const,
+		start: emailStart,
+		tokenizer: emailTokenizer,
+		renderer: emailRenderer
+	};
+}
+
+export default function (options = {}) {
+	return {
+		extensions: [emailExtension()]
+	};
+}


### PR DESCRIPTION
When a model wraps its response in `<email>` tags, Open WebUI now renders it as a dedicated email card instead of plain markdown.

### What it does

- Marked tokenizer extension (`email-extension.ts`) intercepts `<email>` blocks with optional `<subject>` and `<to>` sub-tags, similar to existing <iframe>, etc.
- `EmailCard.svelte` renders emails in a styled card (same design language as code blocks) with:
  - Sticky header with envelope icon, copy button, and "open in mail app" button (mailto: link) all heroicons
  - Subject and recipient fields
  - Whitespace-preserved body text
  - Inline editing with autosave (enabled by default once streaming completes)
  - Progressive rendering during streaming, spinner until `</email>` closing tag arrives
- `removeAllDetails()` strips `<email>` tags when copying the full message, so clipboard output is clean text

### Video

https://github.com/user-attachments/assets/9a1f9acd-3d45-4b29-acc7-30cbecfa0b21


### How to use

There's no built-in detection - users configure their model's system prompt to use `<email>` tags. Example system prompt:

```
When the user asks you to write an email, wrap it in <email> tags. Use <subject> for the subject line and optionally <to> for the recipient. The body is plain text outside those sub-tags. Example:

<email>
<subject>Meeting follow-up</subject>
<to>jane@example.com</to>

Hi Jane,

thanks for the productive meeting today. I'll send over the proposal by Friday.

Best regards,
[Your Name]
</email>

Only use <email> tags when the user explicitly asks you to write or draft an email. For all other responses, use normal markdown.
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.