### PR TITLE
feat: add ability to reset chat folder emoji icons

### DIFF
--- a/src/lib/components/chat/Placeholder/FolderTitle.svelte
+++ b/src/lib/components/chat/Placeholder/FolderTitle.svelte
@@ -166,6 +166,7 @@
 	<div class="mb-3 px-6 @md:max-w-3xl justify-between w-full flex relative group items-center">
 		<div class="text-center flex gap-3.5 items-center">
 			<EmojiPicker
+				showReset={!!folder?.meta?.icon}
 				onClose={() => {}}
 				onSubmit={(name) => {
 					console.log(name);

--- a/src/lib/components/common/EmojiPicker.svelte
+++ b/src/lib/components/common/EmojiPicker.svelte
@@ -19,6 +19,7 @@
 	export let side = 'top';
 	export let align = 'start';
 	export let user = null;
+	export let showReset = false;
 
 	let show = false;
 	let emojis = emojiShortCodes;
@@ -131,6 +132,20 @@
 				bind:value={search}
 			/>
 		</div>
+
+		{#if showReset}
+			<div class="px-4 pb-1">
+				<button
+					class="w-full text-xs font-medium py-1.5 rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 transition"
+					on:click={() => {
+						onSubmit(null);
+						show = false;
+					}}
+				>
+					{$i18n.t('Reset to Default')}
+				</button>
+			</div>
+		{/if}
 		<!-- Virtualized Emoji List -->
 		<div class="w-full flex justify-start h-96 overflow-y-auto px-3 pb-3 text-sm">
 			{#if emojiRows.length === 0}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

Introduces a way to reset the emoji or icon assigned to a chat folder. Previously, once an emoji was chosen, users could only change it to another emoji, with no way to revert to the default non-graphical chevron icon. This PR adds a "Reset to Default" button within the emoji picker, specifically for chat folders. The button only appears when the folder currently has an emoji assigned, ensuring a clean and contextual UI.

### Added

-   `showReset` prop to `EmojiPicker` component to allow conditional display of a reset button.
-   "Reset to Default" button in the `EmojiPicker` that clears the selected emoji when clicked.

### Changed

-   Refined `FolderTitle` component to enable the emoji reset functionality.
-   Updated `EmojiPicker` visibility logic to only show the "Reset to Default" option if the folder already has an assigned icon.

### Fixed

-   User inability to revert a chat folder's emoji to the default non-graphical chevron icon.

---

### Additional Information

-   Relates to UI quality of life improvements for folder management.
-   The "Reset" button uses consistent Tailwind styling and respects dark/high-contrast modes.
-   This PR fulfills the FR in https://github.com/open-webui/open-webui/issues/22488.

### Screenshots or Videos

### Before

<img width="352" height="513" alt="image" src="https://github.com/user-attachments/assets/4a8796ae-f3d6-4d1d-a05d-ce790966d373" />

### After

<img width="352" height="513" alt="image" src="https://github.com/user-attachments/assets/c8d6e56f-e161-49f3-97d9-8ff305124ec5" />

<img width="352" height="513" alt="image" src="https://github.com/user-attachments/assets/4af70f24-28e9-4651-80cc-0f0a31fafaee" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.