### PR TITLE
fix: respect FORWARDED_ALLOW_IPS env var in start.sh

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -50,7 +50,7 @@ if [ -n "$SPACE_ID" ]; then
   echo "Configuring for HuggingFace Space deployment"
   if [ -n "$ADMIN_USER_EMAIL" ] && [ -n "$ADMIN_USER_PASSWORD" ]; then
     echo "Admin user configured, creating"
-    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
+    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}" &
     webui_pid=$!
     echo "Waiting for webui to start..."
     while ! curl -s "http://localhost:${PORT}/health" > /dev/null; do
@@ -83,5 +83,5 @@ fi
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec "$PYTHON_CMD" -m uvicorn open_webui.main:app \
     --host "$HOST" \
     --port "$PORT" \
-    --forwarded-allow-ips '*' \
+    --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}" \
     "${ARGS[@]}"


### PR DESCRIPTION
## Summary

- Replace hardcoded `--forwarded-allow-ips '*'` with `--forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}"` in `backend/start.sh`
- The `FORWARDED_ALLOW_IPS` environment variable is now respected, with `*` as the default for backward compatibility
- Fixes both the main uvicorn launch (line 86) and the HuggingFace Space admin setup launch (line 53)

Fixes #22539

## Test plan

- [ ] Set `FORWARDED_ALLOW_IPS` to a specific IP (e.g., `127.0.0.1`) and verify uvicorn starts with that value
- [ ] Leave `FORWARDED_ALLOW_IPS` unset and verify uvicorn defaults to `*` (backward compatible)

contributor license agreement

🤖 Generated with [Claude Code](https://claude.com/claude-code)