### PR TITLE
fix: respect FORWARDED_ALLOW_IPS env var instead of hardcoding '*' in start scripts

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -50,7 +50,7 @@ if [ -n "$SPACE_ID" ]; then
   echo "Configuring for HuggingFace Space deployment"
   if [ -n "$ADMIN_USER_EMAIL" ] && [ -n "$ADMIN_USER_PASSWORD" ]; then
     echo "Admin user configured, creating"
-    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
+    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}" &
     webui_pid=$!
     echo "Waiting for webui to start..."
     while ! curl -s "http://localhost:${PORT}/health" > /dev/null; do
@@ -83,5 +83,5 @@ fi
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec "$PYTHON_CMD" -m uvicorn open_webui.main:app \
     --host "$HOST" \
     --port "$PORT" \
-    --forwarded-allow-ips '*' \
+    --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}" \
     "${ARGS[@]}"

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -46,5 +46,6 @@ IF "%WEBUI_SECRET_KEY% %WEBUI_JWT_SECRET_KEY%" == " " (
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
 IF "%UVICORN_WORKERS%"=="" SET UVICORN_WORKERS=1
-uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --workers %UVICORN_WORKERS% --ws auto
-:: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "cert.pem" --ws auto
+IF "%FORWARDED_ALLOW_IPS%"=="" SET FORWARDED_ALLOW_IPS=*
+uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips "%FORWARDED_ALLOW_IPS%" --workers %UVICORN_WORKERS% --ws auto
+:: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips "%FORWARDED_ALLOW_IPS%" --ssl-keyfile "key.pem" --ssl-certfile "cert.pem" --ws auto


### PR DESCRIPTION
## Problem

`backend/start.sh` and `backend/start_windows.bat` both hardcode `--forwarded-allow-ips '*'`, ignoring the `FORWARDED_ALLOW_IPS` environment variable entirely (closes #22539).

This affects operators running Open WebUI behind a trusted reverse proxy who want to restrict which upstream IPs are allowed to set forwarded headers — e.g.:
```bash
FORWARDED_ALLOW_IPS='10.0.0.1,10.0.0.2'  # internal proxy only
```
With the hardcoded `'*'`, every host is unconditionally trusted regardless of this setting.

## Fix

### `backend/start.sh`
Use shell parameter expansion with default:
```bash
# Before
--forwarded-allow-ips '*'

# After
--forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}"
```

### `backend/start_windows.bat`
Set a default value then reference the variable:
```batch
IF "%FORWARDED_ALLOW_IPS%"=="" SET FORWARDED_ALLOW_IPS=*
uvicorn ... --forwarded-allow-ips "%FORWARDED_ALLOW_IPS%" ...
```

Both changes are **backwards-compatible**: if `FORWARDED_ALLOW_IPS` is not set, `*` is used as the default, preserving the existing behaviour.

Closes #22539