### PR TITLE
feat: add ruff linter & formatter

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,13 +22,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed Python files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- 'backend/**.py' | xargs)
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
 
       - name: Ruff check
+        if: steps.changed.outputs.files != ''
         uses: astral-sh/ruff-action@v3
         with:
-          args: check backend
+          args: check ${{ steps.changed.outputs.files }}
 
       - name: Ruff format
+        if: steps.changed.outputs.files != ''
         uses: astral-sh/ruff-action@v3
         with:
-          args: format --check backend
+          args: format --check ${{ steps.changed.outputs.files }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,34 @@
+name: Ruff
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'backend/**'
+      - 'pyproject.toml'
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'backend/**'
+      - 'pyproject.toml'
+
+jobs:
+  ruff:
+    name: 'Lint & Format Backend'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ruff check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: check backend
+
+      - name: Ruff format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check backend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.5
+    hooks:
+      - id: ruff
+        args: [--fix, backend]
+      - id: ruff-format
+        args: [backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,4 +211,31 @@ ignore-words-list = 'ans'
 [dependency-groups]
 dev = [
     "pytest-asyncio>=1.0.0",
+    "ruff>=0.15.5",
 ]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+quote-style = "single"
+docstring-code-format = false
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle errors
+  "F",    # pyflakes
+  "W",    # pycodestyle warnings
+  "I",    # isort
+  "UP",   # pyupgrade
+  "C90",  # mccabe
+  "Q",    # flake8-quotes
+  "ICN",  # flake8-import-conventions
+]
+
+# Plugin configs:
+flake8-import-conventions.banned-from = [ "ast", "datetime" ]
+flake8-import-conventions.aliases = { datetime = "dt" }
+flake8-quotes.inline-quotes = "single"
+mccabe.max-complexity = 10
+pydocstyle.convention = "google"


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See changelog below
- [x] **Changelog:** See below
- [x] **Documentation:** No user-facing changes — tooling config only
- [x] **Dependencies:** Added `ruff>=0.15.5` as dev dependency. Ruff is the standard Python linter/formatter used by FastAPI, Pydantic, Hugging Face, etc.
- [x] **Testing:** Ran `ruff check backend` and `ruff format --check backend` locally
- [x] **Agentic AI Code:** Not AI-generated code. Config files only.
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** No architectural changes
- [x] **Git Hygiene:** 3 atomic commits, rebased on `dev`
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

- Add Ruff linter & formatter for backend Python code quality. Replaces the disabled `black`-based workflow. Ref: #21641, https://github.com/open-webui/open-webui/discussions/22462

### Added

- `[tool.ruff]` configuration in `pyproject.toml` with base rule set (`E`, `F`, `W`, `I`, `UP`, `C90`, `Q`, `ICN`), single quotes, `line-length = 120`
- `ruff>=0.15.5` dev dependency
- Pre-commit hook (`.pre-commit-config.yaml`) — runs `ruff check --fix` and `ruff format` on `backend/`
- GitHub Actions workflow (`.github/workflows/ruff.yml`) — runs lint & format checks on PRs

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Rule set is intentionally minimal. More rules (`B`, `SIM`, `PERF`, `RUF`, etc.) will be added incrementally in follow-up PRs after fixing existing violations.
- No code was reformatted in this PR — config only.

### Screenshots or Videos

- N/A (no UI changes)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.