### PR TITLE
fix: session cleanup lock

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -757,12 +757,12 @@ WEBSOCKET_REDIS_CLUSTER = (
     os.environ.get("WEBSOCKET_REDIS_CLUSTER", str(REDIS_CLUSTER)).lower() == "true"
 )
 
-websocket_redis_lock_timeout = os.environ.get("WEBSOCKET_REDIS_LOCK_TIMEOUT", "60")
+websocket_redis_lock_timeout = os.environ.get("WEBSOCKET_REDIS_LOCK_TIMEOUT", "15")
 
 try:
     WEBSOCKET_REDIS_LOCK_TIMEOUT = int(websocket_redis_lock_timeout)
 except ValueError:
-    WEBSOCKET_REDIS_LOCK_TIMEOUT = 60
+    WEBSOCKET_REDIS_LOCK_TIMEOUT = 15
 
 WEBSOCKET_SENTINEL_HOSTS = os.environ.get("WEBSOCKET_SENTINEL_HOSTS", "")
 WEBSOCKET_SENTINEL_PORT = os.environ.get("WEBSOCKET_SENTINEL_PORT", "26379")

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -196,7 +196,19 @@ async def periodic_session_pool_cleanup():
                         f"Reaping orphaned session {sid} (user {entry.get('id')})"
                     )
                     del SESSION_POOL[sid]
-            await asyncio.sleep(SESSION_POOL_TIMEOUT)
+            sleep_remaining = SESSION_POOL_TIMEOUT
+            while sleep_remaining > 0:
+                sleep_interval = min(
+                    WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, sleep_remaining
+                )
+                await asyncio.sleep(sleep_interval)
+                sleep_remaining -= sleep_interval
+
+                if sleep_remaining > 0 and not session_renew_func():
+                    log.error(
+                        "Unable to renew session cleanup lock while waiting for the next sweep. Exiting."
+                    )
+                    return
     finally:
         session_release_func()
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fix the session cleanup lock renewal cadence so the Redis lock stays alive throughout the full `SESSION_POOL_TIMEOUT` (120s) wait period. This prevents the session cleanup worker from dropping its lock and exiting early when `WEBSOCKET_REDIS_LOCK_TIMEOUT` is shorter than the session reap interval (which it was by default)
- This also allows to drop the default `WEBSOCKET_REDIS_LOCK_TIMEOUT` to a much shorter value (I opted for 15s), reducing the long startup time of replicas since https://github.com/open-webui/open-webui/pull/15328

### Changed

- Updated the session cleanup loop in `backend/open_webui/socket/main.py` to split the `SESSION_POOL_TIMEOUT` sleep into smaller intervals based on `WEBSOCKET_REDIS_LOCK_TIMEOUT / 2`.
- Reduced the default `WEBSOCKET_REDIS_LOCK_TIMEOUT` to 15 seconds.

### Fixed

- Fixed a bug where the session cleanup Redis lock would expire long before the next cleanup sweep, causing the cleanup worker to exit instead of continuing to reap orphaned sessions. This presented by 1) disappearance of the Redis key `"open-webui:session_cleanup_lock"` and then the log lines `open_webui.socket.main:periodic_session_pool_cleanup:188 - Unable to renew session cleanup lock. Exiting.` on the next cleanup iteration.
- The fixed behavior makes smaller `WEBSOCKET_REDIS_LOCK_TIMEOUT` values compatible with the `SESSION_POOL_TIMEOUT`-based cleanup loop.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
