### PR TITLE
fix: add 10 s AbortController timeout to getToolServerData fetch

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -298,11 +298,15 @@ export const getTaskIdsByChatId = async (token: string, chat_id: string) => {
 	return res;
 };
 
-export const getToolServerData = async (token: string, url: string) => {
+export const getToolServerData = async (token: string, url: string, timeoutMs = 10000) => {
 	let error = null;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
 	const res = await fetch(`${url}`, {
 		method: 'GET',
+		signal: controller.signal,
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
@@ -310,6 +314,7 @@ export const getToolServerData = async (token: string, url: string) => {
 		}
 	})
 		.then(async (res) => {
+			clearTimeout(timeoutId);
 			// Check if URL ends with .yaml or .yml to determine format
 			if (url.toLowerCase().endsWith('.yaml') || url.toLowerCase().endsWith('.yml')) {
 				if (!res.ok) throw await res.text();
@@ -321,8 +326,11 @@ export const getToolServerData = async (token: string, url: string) => {
 			}
 		})
 		.catch((err) => {
+			clearTimeout(timeoutId);
 			console.error(err);
-			if ('detail' in err) {
+			if (err?.name === 'AbortError') {
+				error = `Request timed out after ${timeoutMs / 1000}s — server unreachable: ${url}`;
+			} else if ('detail' in err) {
 				error = err.detail;
 			} else {
 				error = err;


### PR DESCRIPTION
## Problem

When an enabled external tool server is unreachable, the frontend's fetch of `openapi.json` has no timeout, so the page hangs indefinitely with a spinner on every settings / chat load. No error is ever shown to the user (closes #22543).

## Root cause

`getToolServerData()` in `src/lib/apis/index.ts` calls `fetch(url)` without a `signal`, so the browser connection never times out.

## Fix

Add an `AbortController` with a configurable `timeoutMs` (default **10 s**):

```ts
export const getToolServerData = async (token: string, url: string, timeoutMs = 10000) => {
  const controller = new AbortController();
  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);

  const res = await fetch(url, { signal: controller.signal, ... })
    .then(async (res) => { clearTimeout(timeoutId); ... })
    .catch((err) => {
      clearTimeout(timeoutId);
      if (err?.name === 'AbortError') {
        error = `Request timed out after ${timeoutMs / 1000}s — server unreachable: ${url}`;
      } ...
    });
```

- The timeout is cleared on both success and non-abort error paths to avoid memory leaks.
- On abort, a clear human-readable error message is surfaced (instead of the raw `AbortError`).
- The `timeoutMs` parameter defaults to 10 s but callers can override it.

Fixes #22543