### PR TITLE
fix: skip Ollama-only Advanced Parameters when forwarding to non-Ollama endpoints

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2038,13 +2038,33 @@ def apply_params_to_form_data(form_data, model):
         # If custom_params are provided, merge them into params
         params = deep_update(params, custom_params)
 
+    # Parameters that are Ollama-specific and must not be forwarded to
+    # OpenAI-compatible endpoints (they cause 400 errors on Bedrock, LiteLLM, etc.)
+    OLLAMA_ONLY_PARAMS = {
+        "mirostat",
+        "mirostat_eta",
+        "mirostat_tau",
+        "num_ctx",
+        "num_batch",
+        "num_keep",
+        "num_predict",
+        "repeat_last_n",
+        "top_k",
+        "min_p",
+        "num_gpu",
+        "use_mmap",
+        "use_mlock",
+        "num_thread",
+        "tfs_z",
+    }
+
     if model.get("owned_by") == "ollama":
         # Ollama specific parameters
         form_data["options"] = params
     else:
         if isinstance(params, dict):
             for key, value in params.items():
-                if value is not None:
+                if value is not None and key not in OLLAMA_ONLY_PARAMS:
                     form_data[key] = value
 
         if "logit_bias" in params and params["logit_bias"] is not None:


### PR DESCRIPTION
## Problem

Advanced Parameters like `num_ctx`, `mirostat`, `mirostat_eta`, `num_batch`, `num_gpu`, etc. are Ollama-specific. When a user sets them for an Ollama model, they are stored in `params`. Later, if any non-Ollama model is used in the same session (or the user has mixed models), these params land directly in the request body of the OpenAI-compatible endpoint, causing errors (fixes #22557):

```
litellm.llms.bedrock.chat.invoke_handler.py: '>' not supported between NoneType and int
```

## Root cause

In `utils/middleware.py`, the `else`-branch for non-Ollama models does:

```python
for key, value in params.items():
    if value is not None:
        form_data[key] = value   # ← no Ollama filter!
```

All params — including Ollama-only ones — are forwarded.

## Fix

Define `OLLAMA_ONLY_PARAMS` (the set of keys only meaningful to Ollama's `/api/chat` `options` field) and skip them in the non-Ollama path:

```python
OLLAMA_ONLY_PARAMS = {"mirostat", "mirostat_eta", "num_ctx", "num_batch", ...}

for key, value in params.items():
    if value is not None and key not in OLLAMA_ONLY_PARAMS:
        form_data[key] = value
```

Ollama models are unaffected — they still receive all params via `form_data['options']`.

Fixes #22557