### PR TITLE
fix: derive WebSocket protocol from window.location to fix wss:// on HTTPS deployments

### DIFF
--- a/src/lib/components/chat/XTerminal.svelte
+++ b/src/lib/components/chat/XTerminal.svelte
@@ -75,7 +75,11 @@
 				const session = await res.json();
 				sessionId = session.id;
 
-				const wsBase = base.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+				// Use the page's actual protocol so wss:// is used when the page is served over HTTPS,
+				// regardless of how WEBUI_API_BASE_URL was configured.
+				const wsProtocol =
+					typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+				const wsBase = base.replace(/^https?:/, wsProtocol);
 				wsUrl = `${wsBase}/api/terminals/${sessionId}`;
 			} else {
 				// System terminal — proxy through Open WebUI backend
@@ -91,7 +95,11 @@
 				const session = await res.json();
 				sessionId = session.id;
 
-				const wsBase = base.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+				// Use the page's actual protocol so wss:// is used when the page is served over HTTPS,
+				// regardless of how WEBUI_API_BASE_URL was configured.
+				const wsProtocol =
+					typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+				const wsBase = base.replace(/^https?:/, wsProtocol);
 				wsUrl = `${wsBase}/terminals/${info.serverId}/api/terminals/${sessionId}`;
 			}
 


### PR DESCRIPTION
## Problem

When Open WebUI is served over HTTPS but `WEBUI_API_BASE_URL` contains an `http://` URL (e.g. an internal Kubernetes service address), `XTerminal.svelte` derives the WebSocket protocol by replacing the scheme in the API base URL:

```ts
const wsBase = base.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
```

Because `base` starts with `http://`, the replacement produces **`ws://`** instead of **`wss://`**, causing a mixed-content error and a connection failure in the terminal (fixes #22581).

## Fix

Use `window.location.protocol` to determine the correct WebSocket protocol, which always reflects what the browser actually used to load the page:

```ts
const wsProtocol =
  typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
const wsBase = base.replace(/^https?:/, wsProtocol);
```

Applied to both the direct-connect and system (admin connect) terminal paths.

Fixes #22581