### PR TITLE
fix: handle non-dict history/messages in chat_message migration

### DIFF
--- a/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
+++ b/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
@@ -151,7 +151,12 @@ def upgrade() -> None:
                 continue
 
         history = chat_data.get("history", {})
+        if not isinstance(history, dict):
+            continue
+
         messages = history.get("messages", {})
+        if not isinstance(messages, dict):
+            continue
 
         for message_id, message in messages.items():
             if not isinstance(message, dict):


### PR DESCRIPTION
Some databases contain chat records where 'history' or 'messages' are stored as lists instead of dicts. This causes an AttributeError ('list' object has no attribute 'items') during the 8452d01d26d7_add_chat_message_table migration.

Add isinstance checks to skip chat records with unexpected data shapes gracefully, matching the existing pattern used for individual message validation.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
