### PR TITLE
fix: propagate Ollama embedding HTTP errors instead of silently returning None

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -809,7 +809,15 @@ async def agenerate_ollama_batch_embeddings(
                 json=form_data,
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
-                r.raise_for_status()
+                if not r.ok:
+                    body = ""
+                    try:
+                        body = await r.text()
+                    except Exception:
+                        pass
+                    raise Exception(
+                        f"Ollama embedding API returned HTTP {r.status}: {body[:200]}"
+                    )
                 data = await r.json()
                 if "embeddings" in data:
                     return data["embeddings"]
@@ -817,7 +825,7 @@ async def agenerate_ollama_batch_embeddings(
                     raise Exception("Something went wrong :/")
     except Exception as e:
         log.exception(f"Error generating ollama batch embeddings: {e}")
-        return None
+        raise
 
 
 def get_embedding_function(


### PR DESCRIPTION
## Problem

When Ollama returns a non-2xx response (e.g. **503** while the embedding model is reloading after its TTL expires), `agenerate_ollama_batch_embeddings()` catches the exception and **returns `None` silently** (fixes #22571).

The caller then tries `len(None)` or `None[idx]`, raising a confusing `TypeError` / `IndexError` that only appears in server logs. The end user sees the file silently disappear from the Knowledge Collection with no error message.

## Root cause

```python
# Before
except Exception as e:
    log.exception(f"Error generating ollama batch embeddings: {e}")
    return None   # ← swallows the error; caller crashes on None[idx]
```

## Fix

1. Replace implicit `raise_for_status()` with an explicit check that includes the HTTP status and truncated response body in the exception message — making the error actionable (`503 Service Unavailable` vs a generic crash).
2. **Re-raise** the exception instead of returning `None`, so it propagates to `process_file()`, which marks the file as `failed` and returns an informative HTTP 400 to the caller.

```python
if not r.ok:
    body = await r.text()
    raise Exception(f"Ollama embedding API returned HTTP {r.status}: {body[:200]}")
...
except Exception as e:
    log.exception(...)
    raise   # ← propagate so process_file() can mark status=failed
```

Fixes #22571