### PR TITLE
refactor: modernize type hints and imports in access_control module

### DIFF
--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -1,15 +1,21 @@
-from typing import Optional, Set, Union, List, Dict, Any
-from open_webui.models.users import Users, UserModel
-from open_webui.models.groups import Groups
-
-
-from open_webui.config import DEFAULT_USER_PERMISSIONS
 import json
+from typing import Any
+
+from open_webui.models.users import UserModel
+from open_webui.models.groups import Groups
+from open_webui.models.access_grants import (
+    has_public_read_access_grant,
+    has_user_access_grant,
+    strip_user_access_grants,
+)
+from open_webui.config import DEFAULT_USER_PERMISSIONS
+
+from sqlalchemy.orm import Session
 
 
 def fill_missing_permissions(
-    permissions: Dict[str, Any], default_permissions: Dict[str, Any]
-) -> Dict[str, Any]:
+    permissions: dict[str, Any], default_permissions: dict[str, Any]
+) -> dict[str, Any]:
     """
     Recursively fills in missing properties in the permissions dictionary
     using the default permissions as a template.
@@ -27,9 +33,9 @@ def fill_missing_permissions(
 
 def get_permissions(
     user_id: str,
-    default_permissions: Dict[str, Any],
-    db: Optional[Any] = None,
-) -> Dict[str, Any]:
+    default_permissions: dict[str, Any],
+    db: Session | None = None,
+) -> dict[str, Any]:
     """
     Get all permissions for a user by combining the permissions of all groups the user is a member of.
     If a permission is defined in multiple groups, the most permissive value is used (True > False).
@@ -37,8 +43,8 @@ def get_permissions(
     """
 
     def combine_permissions(
-        permissions: Dict[str, Any], group_permissions: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        permissions: dict[str, Any], group_permissions: dict[str, Any]
+    ) -> dict[str, Any]:
         """Combine permissions from multiple groups by taking the most permissive value."""
         for key, value in group_permissions.items():
             if isinstance(value, dict):
@@ -72,8 +78,8 @@ def get_permissions(
 def has_permission(
     user_id: str,
     permission_key: str,
-    default_permissions: Dict[str, Any] = {},
-    db: Optional[Any] = None,
+    default_permissions: dict[str, Any] = {},
+    db: Session | None = None,
 ) -> bool:
     """
     Check if a user has a specific permission by checking the group permissions
@@ -82,7 +88,7 @@ def has_permission(
     Permission keys can be hierarchical and separated by dots ('.').
     """
 
-    def get_permission(permissions: Dict[str, Any], keys: List[str]) -> bool:
+    def get_permission(permissions: dict[str, Any], keys: list[str]) -> bool:
         """Traverse permissions dict using a list of keys (from dot-split permission_key)."""
         for key in keys:
             if key not in permissions:
@@ -110,9 +116,9 @@ def has_permission(
 def has_access(
     user_id: str,
     permission: str = "read",
-    access_grants: Optional[list] = None,
-    user_group_ids: Optional[Set[str]] = None,
-    db: Optional[Any] = None,
+    access_grants: list | None = None,
+    user_group_ids: set[str] | None = None,
+    db: Session | None = None,
 ) -> bool:
     """
     Check if a user has the specified permission using an in-memory access_grants list.
@@ -156,7 +162,7 @@ def has_access(
 def has_connection_access(
     user: UserModel,
     connection: dict,
-    user_group_ids: Optional[Set[str]] = None,
+    user_group_ids: set[str] | None = None,
 ) -> bool:
     """
     Check if a user can access a server connection (tool server, terminal, etc.)
@@ -194,7 +200,7 @@ def migrate_access_control(
     if access_control is None and ac_key not in data:
         return
 
-    grants: List[Dict[str, str]] = []
+    grants: list[dict[str, str]] = []
     if access_control and isinstance(access_control, dict):
         for perm in ["read", "write"]:
             perm_data = access_control.get(perm, {})
@@ -221,20 +227,13 @@ def migrate_access_control(
     data.pop(ac_key, None)
 
 
-from open_webui.models.access_grants import (
-    has_public_read_access_grant,
-    has_user_access_grant,
-    strip_user_access_grants,
-)
-
-
 def filter_allowed_access_grants(
-    default_permissions: Dict[str, Any],
+    default_permissions: dict[str, Any],
     user_id: str,
     user_role: str,
     access_grants: list,
     public_permission_key: str,
-    db: Optional[Any] = None,
+    db: Session | None = None,
 ) -> list:
     """
     Checks if the user has the required permissions to grant access to a resource.

--- a/backend/open_webui/utils/access_control/files.py
+++ b/backend/open_webui/utils/access_control/files.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional, Any
 
 from open_webui.models.users import UserModel
 from open_webui.models.files import Files
@@ -10,14 +9,16 @@ from open_webui.models.groups import Groups
 from open_webui.models.models import Models
 from open_webui.models.access_grants import AccessGrants
 
+from sqlalchemy.orm import Session
+
 log = logging.getLogger(__name__)
 
 
 def has_access_to_file(
-    file_id: Optional[str],
+    file_id: str | None,
     access_type: str,
     user: UserModel,
-    db: Optional[Any] = None,
+    db: Session | None = None,
 ) -> bool:
     """
     Check if a user has the specified access to a file through any of:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Changelog:** See below
- [ ] **Documentation:** No user-facing changes, docs update not needed
- [x] **Dependencies:** No new dependencies. `sqlalchemy` already used throughout the project.
- [x] **Testing:** No logic changes — only type annotations and import ordering. Verified no runtime behavior is affected.
- [x] **Agentic AI Code:** Changes reviewed and verified manually.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** No new settings or UX changes.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `refactor`

# Changelog Entry

### Description

- Modernize type annotations in `access_control/__init__.py` and `access_control/files.py` to use built-in generics and PEP 604 union syntax. Replace untyped `db: Optional[Any]` with `db: Session | None` for better static analysis and IDE support.

### Added

- N/A

### Changed

- Replaced `typing.Dict`, `List`, `Set`, `Optional` with built-in `dict`, `list`, `set` and `X | None` syntax (PEP 585 / PEP 604)
- Typed `db` parameter as `Session | None` instead of `Optional[Any]` across all functions in both files
- Moved mid-file import of `access_grants` helpers to top-level imports in `__init__.py`
- Removed unused `Users` import from `__init__.py`
- Unified `Session` import style to `from sqlalchemy.orm import Session` in both files

### Deprecated

- N/A

### Removed

- Unused `Users` import from `open_webui.models.users`
- Redundant `typing` imports (`Dict`, `List`, `Set`, `Optional`, `Union`)

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- No runtime behavior changes — purely type annotation and import cleanup
- Requires Python 3.10+ (project already targets this)

### Screenshots or Videos

- N/A (no UI changes)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.