### PR TITLE
fix: use FORWARDED_ALLOW_IPS env var in start.sh instead of hardcoded wildcard

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -22,6 +22,7 @@ fi
 
 PORT="${PORT:-8080}"
 HOST="${HOST:-0.0.0.0}"
+FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-*}"
 if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   echo "Loading WEBUI_SECRET_KEY from file, not provided as an environment variable."
 
@@ -50,7 +51,7 @@ if [ -n "$SPACE_ID" ]; then
   echo "Configuring for HuggingFace Space deployment"
   if [ -n "$ADMIN_USER_EMAIL" ] && [ -n "$ADMIN_USER_PASSWORD" ]; then
     echo "Admin user configured, creating"
-    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
+    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips "$FORWARDED_ALLOW_IPS" &
     webui_pid=$!
     echo "Waiting for webui to start..."
     while ! curl -s "http://localhost:${PORT}/health" > /dev/null; do
@@ -83,5 +84,5 @@ fi
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec "$PYTHON_CMD" -m uvicorn open_webui.main:app \
     --host "$HOST" \
     --port "$PORT" \
-    --forwarded-allow-ips '*' \
+    --forwarded-allow-ips "$FORWARDED_ALLOW_IPS" \
     "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- `start.sh` hardcodes `--forwarded-allow-ips '*'` in both the HuggingFace Space path (line 53) and the main uvicorn startup (line 86), ignoring the `FORWARDED_ALLOW_IPS` environment variable documented in `.env.example`
- This change reads `FORWARDED_ALLOW_IPS` from the environment with `'*'` as the default fallback, preserving full backward compatibility while allowing users to restrict forwarded IPs as intended

Fixes #22539

## Test plan
- [x] Default behavior unchanged (`*` when env var not set)
- [ ] Set `FORWARDED_ALLOW_IPS=127.0.0.1` and verify uvicorn uses the custom value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

contributor license agreement