### PR TITLE
fix: respect FORWARDED_ALLOW_IPS environment variable in start.sh

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -22,6 +22,7 @@ fi
 
 PORT="${PORT:-8080}"
 HOST="${HOST:-0.0.0.0}"
+FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-*}"
 if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   echo "Loading WEBUI_SECRET_KEY from file, not provided as an environment variable."
 
@@ -50,7 +51,7 @@ if [ -n "$SPACE_ID" ]; then
   echo "Configuring for HuggingFace Space deployment"
   if [ -n "$ADMIN_USER_EMAIL" ] && [ -n "$ADMIN_USER_PASSWORD" ]; then
     echo "Admin user configured, creating"
-    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
+    WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips "$FORWARDED_ALLOW_IPS" &
     webui_pid=$!
     echo "Waiting for webui to start..."
     while ! curl -s "http://localhost:${PORT}/health" > /dev/null; do
@@ -83,5 +84,5 @@ fi
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec "$PYTHON_CMD" -m uvicorn open_webui.main:app \
     --host "$HOST" \
     --port "$PORT" \
-    --forwarded-allow-ips '*' \
+    --forwarded-allow-ips "$FORWARDED_ALLOW_IPS" \
     "${ARGS[@]}"


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manually verified default behavior unchanged (`*` when env var not set), and custom value is passed when `FORWARDED_ALLOW_IPS` is set.
- [x] **Code review:** Self-reviewed, minimal 3-line change.

# Changelog Entry

### Description

`start.sh` hardcodes `--forwarded-allow-ips '*'` in both the HuggingFace Space path and the main uvicorn startup, ignoring the `FORWARDED_ALLOW_IPS` environment variable documented in `.env.example`. This change reads `FORWARDED_ALLOW_IPS` from the environment with `'*'` as the default fallback.

### Fixed

- `FORWARDED_ALLOW_IPS` environment variable is now respected in `start.sh` instead of being hardcoded to `'*'` (fixes #22539)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.