### PR TITLE
feat: add MiniMax as a suggested API provider

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -319,6 +319,7 @@
 											<option value="https://api.anthropic.com/v1" />
 											<option value="https://generativelanguage.googleapis.com/v1beta/openai" />
 											<option value="https://api.mistral.ai/v1" />
+											<option value="https://api.minimax.io/v1" />
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />


### PR DESCRIPTION
## Summary

- Add MiniMax (`https://api.minimax.io/v1`) to the suggested API base URL datalist in the Add Connection modal
- MiniMax provides OpenAI-compatible Chat Completions API, making it work seamlessly with Open WebUI's existing OpenAI-compatible provider system
- This places MiniMax alongside other major providers (OpenAI, Anthropic, Google, Mistral, Groq, OpenRouter, xAI) for easy discoverability

## About MiniMax

[MiniMax](https://www.minimax.io) is an AI company offering powerful large language models including MiniMax-M2.5 (204K context window). Their API is fully OpenAI-compatible, so no additional code changes are needed — users simply select the suggested URL, enter their API key, and start chatting.

## Changes

- `src/lib/components/AddConnectionModal.svelte`: Added `https://api.minimax.io/v1` to the `<datalist>` suggestions

## Test Plan

- [x] Verified the datalist suggestion appears when typing in the URL field
- [x] MiniMax API endpoint follows OpenAI-compatible format (`/chat/completions`, `/models`)
- [x] No breaking changes — purely additive one-line change

🤖 Generated with [Claude Code](https://claude.com/claude-code)