### PR TITLE
fix(tool-server): add AbortController timeout to openapi.json fetch (fixes #22543)

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -298,11 +298,15 @@ export const getTaskIdsByChatId = async (token: string, chat_id: string) => {
 	return res;
 };
 
-export const getToolServerData = async (token: string, url: string) => {
+export const getToolServerData = async (token: string, url: string, timeout: number = 10000) => {
 	let error = null;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeout);
 
 	const res = await fetch(`${url}`, {
 		method: 'GET',
+		signal: controller.signal,
 		headers: {
 			Accept: 'application/json',
 			'Content-Type': 'application/json',
@@ -321,13 +325,21 @@ export const getToolServerData = async (token: string, url: string) => {
 			}
 		})
 		.catch((err) => {
-			console.error(err);
-			if ('detail' in err) {
-				error = err.detail;
+			if (err?.name === 'AbortError') {
+				console.warn(`Tool server request timed out after ${timeout}ms: ${url}`);
+				error = `Connection timed out after ${timeout / 1000}s`;
 			} else {
-				error = err;
+				console.error(err);
+				if ('detail' in err) {
+					error = err.detail;
+				} else {
+					error = err;
+				}
 			}
 			return null;
+		})
+		.finally(() => {
+			clearTimeout(timeoutId);
 		});
 
 	if (error) {


### PR DESCRIPTION
## Summary

Fixes #22543 — infinite UI hang when an external OpenAPI tool server is unreachable.

- The `fetch()` call in `getToolServerData` (`src/lib/apis/index.ts`) had no timeout or abort signal, causing the browser to keep the request `Pending` forever and blocking page load when a configured tool server is unreachable.
- Added an `AbortController` with a **10-second default timeout** (`timeout` parameter, configurable). The `signal` is passed to `fetch()`.
- On `AbortError`, a descriptive `"Connection timed out after 10s"` error is thrown instead of hanging.
- Existing error handling in `getToolServersData` propagates this as `{ error, url }`, which `setToolServers` (in `src/routes/(app)/+layout.svelte`) already converts into a non-blocking `toast.error()` warning — so page load continues and the user sees a clear message.

## Behaviour change

| Before | After |
|---|---|
| Unreachable tool server causes page to spin indefinitely | Fetch aborts after 10 s; toast shows "Failed to connect to \<URL\> OpenAPI tool server"; rest of the page loads normally |

## Test plan

- [ ] Add an OpenAPI tool server pointing to an unreachable URL (e.g. `http://localhost:2022`)
- [ ] Enable the connection and save
- [ ] Reload Open WebUI — page should load within ~10 s and show a toast error for the unreachable server
- [ ] Verify that reachable tool servers still work correctly
- [ ] Confirm the timeout can be overridden by callers via the optional `timeout` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)