### PR TITLE
fix(oauth): sync group membership for admin users

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1681,10 +1681,7 @@ class OAuthManager:
                 data={"id": user.id},
                 expires_delta=parse_duration(auth_manager_config.JWT_EXPIRES_IN),
             )
-            if (
-                auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT
-                and user.role != "admin"
-            ):
+            if auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT:
                 self.update_user_groups(
                     user=user,
                     user_data=user_data,


### PR DESCRIPTION
## Summary

- Removes the `user.role != "admin"` guard in `oauth.py` that prevented `update_user_groups` from being called for admin users
- When `ENABLE_OAUTH_GROUP_MANAGEMENT=true`, group membership is now synced from the OAuth provider for **all** users including admins, on every login
- No change in behavior for non-admin users

Fixes #22527

## Root cause

In `OAuthManager.handle_callback`, after the JWT token is created, group sync was conditionally skipped for admin users:

```python
# before
if (
    auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT
    and user.role != "admin"
):
    self.update_user_groups(...)

# after
if auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT:
    self.update_user_groups(...)
```

The `user.role != "admin"` condition has no documented rationale and directly contradicts the expected behavior: admins should also have their OAuth group memberships reflected in Open WebUI.

## Test plan

- [ ] Login as a non-admin user with `ENABLE_OAUTH_GROUP_MANAGEMENT=true` — groups still sync correctly
- [ ] Login as an admin user — groups now sync from the OAuth provider
- [ ] With `ENABLE_OAUTH_GROUP_MANAGEMENT=false` — no group sync for any user (unchanged)
- [ ] Add admin user to a new group in the OAuth provider, log out and back in — group appears in Open WebUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)