### PR TITLE
fix: resolve model aliases in openai proxy, responses, and embeddings endpoints

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1161,10 +1161,18 @@ async def embeddings(request: Request, form_data: dict, user):
         dict: OpenAI-compatible embeddings response.
     """
     idx = 0
-    # Prepare payload/body
-    body = json.dumps(form_data)
     # Find correct backend url/key based on model
     model_id = form_data.get("model")
+
+    # Resolve workspace alias models to their base model
+    if model_id:
+        model_info = Models.get_model_by_id(model_id)
+        if model_info and model_info.base_model_id:
+            model_id = model_info.base_model_id
+            form_data["model"] = model_id
+
+    # Prepare payload/body
+    body = json.dumps(form_data)
     # Check if model is already in app state cache to avoid expensive get_all_models() call
     models = request.app.state.OPENAI_MODELS
     if not models or model_id not in models:
@@ -1268,6 +1276,15 @@ async def responses(
 
     idx = 0
     model_id = form_data.model
+
+    # Resolve workspace alias models to their base model
+    if model_id:
+        model_info = Models.get_model_by_id(model_id)
+        if model_info and model_info.base_model_id:
+            model_id = model_info.base_model_id
+            payload["model"] = model_id
+            body = json.dumps(payload)
+
     if model_id:
         models = request.app.state.OPENAI_MODELS
         if not models or model_id not in models:
@@ -1374,6 +1391,15 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
 
     idx = 0
     model_id = payload.get("model") if isinstance(payload, dict) else None
+
+    # Resolve workspace alias models to their base model
+    if model_id:
+        model_info = Models.get_model_by_id(model_id)
+        if model_info and model_info.base_model_id:
+            model_id = model_info.base_model_id
+            payload["model"] = model_id
+            body = json.dumps(payload).encode()
+
     if model_id:
         models = request.app.state.OPENAI_MODELS
         if not models or model_id not in models:


### PR DESCRIPTION
**REASONING**: https://github.com/open-webui/open-webui/discussions/22230#discussioncomment-16097381

The proxy (catch-all), responses, and embeddings endpoints only looked up models in the OPENAI_MODELS cache, which contains real backend models but not workspace alias models. When an alias model was requested, it was not found and the request either fell back to the wrong backend (idx=0) or the upstream returned 404 for the unrecognized alias name.

Now all three endpoints check the Models DB for workspace aliases and resolve base_model_id before routing, matching the existing behavior in generate_chat_completion.

https://github.com/open-webui/open-webui/discussions/22230

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
