### PR TITLE
fix: don't show stop button if assistant response is done

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2797,7 +2797,6 @@
 								<MessageInput
 									bind:this={messageInput}
 									{history}
-									{taskIds}
 									{selectedModels}
 									bind:files
 									bind:prompt

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -120,7 +120,6 @@
 	$: selectedModelIds = atSelectedModel !== undefined ? [atSelectedModel.id] : selectedModels;
 
 	export let history;
-	export let taskIds = null;
 
 	export let prompt = '';
 	export let files = [];
@@ -138,6 +137,10 @@
 	export let onQueueSendNow: (id: string) => void = () => {};
 	export let onQueueEdit: (id: string) => void = () => {};
 	export let onQueueDelete: (id: string) => void = () => {};
+
+	$: currentMessage = history?.currentId ? history?.messages?.[history.currentId] : null;
+	$: isAssistantGenerating = currentMessage?.role === 'assistant' && currentMessage?.done !== true;
+	$: showStopButton = generating || isAssistantGenerating;
 
 	let inputContent = null;
 
@@ -1768,7 +1771,7 @@
 								</div>
 
 								<div class="self-end flex space-x-1 mr-1 shrink-0 gap-[0.5px]">
-									{#if (taskIds && taskIds.length > 0) || (history.currentId && history.messages[history.currentId]?.done != true) || generating}
+									{#if showStopButton}
 										<div class=" flex items-center">
 											<Tooltip content={$i18n.t('Stop')}>
 												<button


### PR DESCRIPTION
In some cases, the task model tasks will be stuck forever.
When that happens, the stop button never disappears despite the assistant response being done.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
