### PR TITLE
fix: OAuth resource_metadata parsing for unquoted WWW-Authenticate values

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -273,7 +273,7 @@ async def get_authorization_server_discovery_urls(server_url: str) -> list[str]:
             ) as response:
                 if response.status == 401:
                     match = re.search(
-                        r'resource_metadata="([^"]+)"',
+                        r'resource_metadata="?([^",\s]+)"?',
                         response.headers.get("WWW-Authenticate", ""),
                     )
                     if match:

--- a/backend/tests/util/test_oauth.py
+++ b/backend/tests/util/test_oauth.py
@@ -1,0 +1,188 @@
+"""Tests for OAuth resource_metadata parsing in WWW-Authenticate headers.
+
+Tests get_authorization_server_discovery_urls() which extracts the
+resource_metadata URL from WWW-Authenticate: Bearer headers returned by MCP
+servers during OAuth protected resource discovery.
+"""
+
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from open_webui.utils.oauth import get_authorization_server_discovery_urls
+
+
+class _AsyncContextManager:
+    """Minimal async context manager that yields a fixed value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _make_response(status, headers=None):
+    """Create a mock aiohttp response with the given status and headers."""
+    resp = MagicMock()
+    resp.status = status
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_resource_metadata_response(authorization_servers):
+    """Create a mock 200 response for the resource metadata endpoint."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(
+        return_value={"authorization_servers": authorization_servers}
+    )
+    return resp
+
+
+def _build_mock_session(post_response, get_response=None):
+    """Build a mock aiohttp.ClientSession with canned post/get responses.
+
+    session.post(...) and session.get(...) are regular calls (not awaited)
+    that return async context managers, matching the real aiohttp API.
+    """
+    session = MagicMock()
+    session.post = MagicMock(return_value=_AsyncContextManager(post_response))
+    if get_response is not None:
+        session.get = MagicMock(return_value=_AsyncContextManager(get_response))
+    return session
+
+
+def _patch_aiohttp_session(session):
+    """Return a patch context that makes aiohttp.ClientSession() yield `session`."""
+    mock_cs = MagicMock()
+    mock_cs.return_value = _AsyncContextManager(session)
+    return patch("open_webui.utils.oauth.aiohttp.ClientSession", mock_cs)
+
+
+class TestGetAuthorizationServerDiscoveryUrls:
+    """Tests for get_authorization_server_discovery_urls()."""
+
+    @pytest.mark.asyncio
+    async def test_quoted_resource_metadata(self):
+        """Quoted resource_metadata value (the common form) should be extracted."""
+        resource_metadata_url = "https://auth.example.com/.well-known/oauth-protected-resource"
+        auth_server = "https://auth.example.com"
+
+        init_resp = _make_response(
+            401,
+            {"WWW-Authenticate": f'Bearer resource_metadata="{resource_metadata_url}"'},
+        )
+        meta_resp = _make_resource_metadata_response([auth_server])
+        session = _build_mock_session(init_resp, meta_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert f"{auth_server}/.well-known/oauth-authorization-server" in urls
+        assert f"{auth_server}/.well-known/openid-configuration" in urls
+
+    @pytest.mark.asyncio
+    async def test_unquoted_resource_metadata(self):
+        """Unquoted resource_metadata value should also be extracted.
+
+        Some MCP servers return the header without quotes, e.g.:
+            Bearer resource_metadata=https://auth.example.com/...
+        """
+        resource_metadata_url = "https://auth.example.com/.well-known/oauth-protected-resource"
+        auth_server = "https://auth.example.com"
+
+        init_resp = _make_response(
+            401,
+            {"WWW-Authenticate": f"Bearer resource_metadata={resource_metadata_url}"},
+        )
+        meta_resp = _make_resource_metadata_response([auth_server])
+        session = _build_mock_session(init_resp, meta_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert f"{auth_server}/.well-known/oauth-authorization-server" in urls
+        assert f"{auth_server}/.well-known/openid-configuration" in urls
+
+    @pytest.mark.asyncio
+    async def test_unquoted_resource_metadata_with_additional_params(self):
+        """Unquoted value followed by other Bearer params should parse correctly."""
+        resource_metadata_url = "https://auth.example.com/.well-known/oauth-protected-resource"
+        auth_server = "https://auth.example.com"
+
+        init_resp = _make_response(
+            401,
+            {
+                "WWW-Authenticate": (
+                    f"Bearer resource_metadata={resource_metadata_url},"
+                    f' realm="example"'
+                )
+            },
+        )
+        meta_resp = _make_resource_metadata_response([auth_server])
+        session = _build_mock_session(init_resp, meta_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert f"{auth_server}/.well-known/oauth-authorization-server" in urls
+        assert f"{auth_server}/.well-known/openid-configuration" in urls
+
+    @pytest.mark.asyncio
+    async def test_no_resource_metadata_returns_empty(self):
+        """When WWW-Authenticate has no resource_metadata, return empty list."""
+        init_resp = _make_response(401, {"WWW-Authenticate": "Bearer"})
+        session = _build_mock_session(init_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_non_401_response_returns_empty(self):
+        """When MCP server does not return 401, return empty list."""
+        init_resp = _make_response(200)
+        session = _build_mock_session(init_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_authorization_servers(self):
+        """Multiple authorization_servers in metadata produce discovery URLs for each."""
+        resource_metadata_url = "https://auth.example.com/.well-known/oauth-protected-resource"
+        servers = ["https://auth1.example.com", "https://auth2.example.com"]
+
+        init_resp = _make_response(
+            401,
+            {"WWW-Authenticate": f'Bearer resource_metadata="{resource_metadata_url}"'},
+        )
+        meta_resp = _make_resource_metadata_response(servers)
+        session = _build_mock_session(init_resp, meta_resp)
+
+        with _patch_aiohttp_session(session):
+            urls = await get_authorization_server_discovery_urls(
+                "https://mcp.example.com/v1"
+            )
+
+        assert len(urls) == 4
+        for server in servers:
+            assert f"{server}/.well-known/oauth-authorization-server" in urls
+            assert f"{server}/.well-known/openid-configuration" in urls


### PR DESCRIPTION

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fix OAuth resource_metadata parsing for unquoted WWW-Authenticate values

### Fixed

- Fixes #22646, WWW-Authenticate values may now be either quoted or unquoted.
---

### Additional Information

- The `resource_metadata` regex in `get_authorization_server_discovery_urls()` only matched quoted values (`resource_metadata="https://..."`), but some MCP servers return unquoted values (`resource_metadata=https://...`)
- This caused the entire protected resource discovery chain to be silently skipped, falling back to `{mcp_server_base_url}/register` instead of the actual IDP's registration endpoint
- Updated the regex from `r'resource_metadata="([^"]+)"'` to `r'resource_metadata="?([^",\s]+)"?'` to accept both forms and added tests to verify functionality

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
