### PR TITLE
fix: add configurable access_type and prompt for Google OAuth refresh…

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -379,6 +379,18 @@ GOOGLE_REDIRECT_URI = PersistentConfig(
     os.environ.get("GOOGLE_REDIRECT_URI", ""),
 )
 
+GOOGLE_OAUTH_ACCESS_TYPE = PersistentConfig(
+    "GOOGLE_OAUTH_ACCESS_TYPE",
+    "oauth.google.access_type",
+    os.environ.get("GOOGLE_OAUTH_ACCESS_TYPE", ""),
+)
+
+GOOGLE_OAUTH_PROMPT = PersistentConfig(
+    "GOOGLE_OAUTH_PROMPT",
+    "oauth.google.prompt",
+    os.environ.get("GOOGLE_OAUTH_PROMPT", ""),
+)
+
 MICROSOFT_CLIENT_ID = PersistentConfig(
     "MICROSOFT_CLIENT_ID",
     "oauth.microsoft.client_id",
@@ -683,11 +695,19 @@ def load_oauth_providers():
     if GOOGLE_CLIENT_ID.value and GOOGLE_CLIENT_SECRET.value:
 
         def google_oauth_register(oauth: OAuth):
+            google_authorize_params = {
+                k: v for k, v in {
+                    "access_type": GOOGLE_OAUTH_ACCESS_TYPE.value,
+                    "prompt": GOOGLE_OAUTH_PROMPT.value,
+                }.items() if v
+            }
+
             client = oauth.register(
                 name="google",
                 client_id=GOOGLE_CLIENT_ID.value,
                 client_secret=GOOGLE_CLIENT_SECRET.value,
                 server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+                **({"authorize_params": google_authorize_params} if google_authorize_params else {}),
                 client_kwargs={
                     "scope": GOOGLE_OAUTH_SCOPE.value,
                     **(


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** Environment variables to be documented in Open WebUI Docs.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested on a live deployment — verified refresh token is stored, auto-refresh works after 1 hour, and no behavior change when env vars are unset.
- [x] **Agentic AI Code:** AI-assisted but fully human-reviewed and manually tested on a live Kubernetes deployment.
- [x] **Code review:** Self-reviewed. Follows the same pattern as existing `GOOGLE_OAUTH_SCOPE` and `OAUTH_TIMEOUT` configurations.
- [x] **Design & Architecture:** No new settings in the admin UI — env vars only, consistent with existing OAuth config pattern.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.

# Changelog Entry

### Description

Without `access_type=offline` in the Google OAuth authorization request, Google only returns a short-lived access token (1 hour) with no `refresh_token`. The existing refresh logic in `OAuthManager._perform_token_refresh()` always bails at the `if not token_data.get("refresh_token")` check because no refresh token is ever stored. After ~55 minutes, the OAuth session is silently deleted from the database, breaking any functionality relying on `__oauth_token__` (tools, MCP servers with `system_oauth` auth) while the user's Open WebUI session remains active.

This is a Google-specific issue: Google requires `access_type=offline` (a proprietary parameter not part of the OIDC spec) to issue refresh tokens. The OIDC discovery document gives no hint about this parameter, so authlib cannot add it automatically.

This PR adds two new environment variables that populate `authorize_params` in the Google OAuth client registration, enabling operators to opt in to refresh token support.

### Added

- `GOOGLE_OAUTH_ACCESS_TYPE` environment variable (default: `""`) — set to `"offline"` to request refresh tokens from Google
- `GOOGLE_OAUTH_PROMPT` environment variable (default: `""`) — set to `"consent"` to force re-consent and guarantee a fresh refresh token for users who previously authorized the app

### Changed

- `google_oauth_register()` in `config.py` now conditionally includes `authorize_params` when either env var is set (empty values are filtered out)

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Google OAuth sessions no longer expire and get deleted after 1 hour when `GOOGLE_OAUTH_ACCESS_TYPE=offline` is configured
- The existing token refresh logic (`OAuthManager._perform_token_refresh()`) now functions as intended for Google OAuth

### Security

- Refresh tokens are stored encrypted (Fernet) in the existing `oauth_session` table, consistent with how all other OAuth tokens are stored
- No change to default behavior — both env vars default to empty, preserving existing behavior for all deployments

### Breaking Changes

- None. Both env vars default to empty, so no behavior change for existing deployments.

---

### Additional Information

- **Why not default to `offline`?** To avoid changing behavior for existing deployments. Operators can opt in by setting `GOOGLE_OAUTH_ACCESS_TYPE=offline`.
- **Why is `prompt` separate?** Google only returns a refresh token on the first authorization. For users who previously authorized the app, `prompt=consent` forces re-consent. This can be set temporarily and removed once all users have re-authenticated.
- **Usage example (Helm/K8s):**
  ```yaml
  - name: GOOGLE_OAUTH_ACCESS_TYPE
    value: "offline"
  - name: GOOGLE_OAUTH_PROMPT
    value: "consent"
  ```
- Tested on a live GKE deployment with Google OAuth + BigQuery tools. Verified:
  - `refresh_token` stored in `oauth_session` table after login
  - Token auto-refreshed after >1 hour (log: `"Successfully refreshed token for session ..."`)
  - No behavior change when env vars are unset

### Screenshots or Videos

N/A — backend-only change with no UI impact.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
