### PR TITLE
fix: resolve UnboundLocalError in oracle23ai.py get() method

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -695,27 +695,26 @@ class Oracle23aiClient(VectorDBBase):
         """
         Get all items in a collection.
 
-        Retrieves items from a specified collection up to the limit.
+        Retrieves items from a specified collection up to an internal limit.
 
         Args:
             collection_name (str): Name of the collection to retrieve
-            limit (Optional[int]): Maximum number of items to retrieve
 
         Returns:
             Optional[GetResult]: Result containing ids, documents, and metadata
 
         Example:
             >>> client = Oracle23aiClient()
-            >>> results = client.get("my_collection", limit=50)
+            >>> results = client.get("my_collection")
             >>> if results:
             ...     print(f"Retrieved {len(results.ids[0])} documents from collection")
         """
-        log.info(
-            f"Getting items from collection '{collection_name}' with limit {limit}."
-        )
-
         try:
             limit = 1000  # Hardcoded limit for get operation
+
+            log.info(
+                f"Getting items from collection '{collection_name}' with limit {limit}."
+            )
 
             with self.get_connection() as connection:
                 with connection.cursor() as cursor:


### PR DESCRIPTION
## Summary

- Fix `UnboundLocalError` in `Oracle23aiClient.get()` where the `limit` variable was referenced in a `log.info()` call before being assigned, crashing hybrid search for all Oracle 23ai users.
- Move `limit = 1000` assignment before the log statement that references it.
- Fix incorrect docstring that documented a non-existent `limit` parameter in the method signature.

## Details

In `backend/open_webui/retrieval/vector/dbs/oracle23ai.py`, the `get()` method had:

```python
def get(self, collection_name: str) -> Optional[GetResult]:
    log.info(
        f"Getting items from collection '{collection_name}' with limit {limit}."  # BUG: limit not yet defined
    )

    try:
        limit = 1000  # defined here, but too late
```

Python treats `limit` as a local variable throughout the function because of the assignment on line 718. But the `log.info()` on line 714 references it before the assignment executes, raising:

```
UnboundLocalError: cannot access local variable 'limit' where it is not associated with a value
```

This crashes the entire hybrid search pipeline: `query_collection_with_hybrid_search()` -> `VECTOR_DB_CLIENT.get()` -> crash.

The fix simply reorders the statements so `limit` is assigned before it is used.

Fixes #22664
Related: #22616, #18356

## Test plan

- [ ] Verify `oracle23ai.py` `get()` method no longer raises `UnboundLocalError`
- [ ] Confirm hybrid search works end-to-end with Oracle 23ai as vector DB
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)