### PR TITLE
fix: sanitize generated plugin ids from titles

### DIFF
--- a/src/lib/components/ImportModal.svelte
+++ b/src/lib/components/ImportModal.svelte
@@ -6,7 +6,7 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
-	import { extractFrontmatter } from '$lib/utils';
+	import { extractFrontmatter, toPluginId } from '$lib/utils';
 
 	export let show = false;
 
@@ -42,13 +42,14 @@
 			toast.success(successMessage);
 
 			let func = res;
-			func.id = func.id || func.name.replace(/\s+/g, '_').toLowerCase();
 
 			const frontmatter = extractFrontmatter(res.content); // Ensure frontmatter is extracted
 
 			if (frontmatter?.title) {
 				func.name = frontmatter.title;
 			}
+
+			func.id = toPluginId(func.id || func.name);
 
 			func.meta = {
 				...(func.meta ?? {}),

--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { toast } from 'svelte-sonner';
 	import { getContext, onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -40,9 +39,6 @@
 	$: if (name && !edit && !clone) {
 		id = toPluginId(name);
 	}
-
-	const INVALID_PLUGIN_TITLE_MESSAGE =
-		'Please enter a title with at least one letter, number, or underscore so Open WebUI can generate an id.';
 
 	let codeEditor;
 	let boilerplate = `"""
@@ -262,11 +258,6 @@ class Pipe:
 
 	const saveHandler = async () => {
 		const normalizedId = toPluginId(id || name);
-		if (!normalizedId) {
-			toast.error($i18n.t(INVALID_PLUGIN_TITLE_MESSAGE));
-			return;
-		}
-
 		id = normalizedId;
 		loading = true;
 		onSave({

--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { toast } from 'svelte-sonner';
 	import { getContext, onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -9,6 +10,7 @@
 	import Badge from '$lib/components/common/Badge.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
+	import { toPluginId } from '$lib/utils';
 
 	let formElement = null;
 	let loading = false;
@@ -36,8 +38,11 @@
 	};
 
 	$: if (name && !edit && !clone) {
-		id = name.replace(/\s+/g, '_').toLowerCase();
+		id = toPluginId(name);
 	}
+
+	const INVALID_PLUGIN_TITLE_MESSAGE =
+		'Please enter a title with at least one letter, number, or underscore so Open WebUI can generate an id.';
 
 	let codeEditor;
 	let boilerplate = `"""
@@ -256,9 +261,16 @@ class Pipe:
 `;
 
 	const saveHandler = async () => {
+		const normalizedId = toPluginId(id || name);
+		if (!normalizedId) {
+			toast.error($i18n.t(INVALID_PLUGIN_TITLE_MESSAGE));
+			return;
+		}
+
+		id = normalizedId;
 		loading = true;
 		onSave({
-			id,
+			id: normalizedId,
 			name,
 			meta,
 			content

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -14,6 +14,7 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
+	import { toPluginId } from '$lib/utils';
 
 	let formElement = null;
 	let loading = false;
@@ -45,8 +46,11 @@
 	};
 
 	$: if (name && !edit && !clone) {
-		id = name.replace(/\s+/g, '_').toLowerCase();
+		id = toPluginId(name);
 	}
+
+	const INVALID_PLUGIN_TITLE_MESSAGE =
+		'Please enter a title with at least one letter, number, or underscore so Open WebUI can generate an id.';
 
 	let codeEditor;
 	let boilerplate = `import os
@@ -157,9 +161,16 @@ class Tools:
 `;
 
 	const saveHandler = async () => {
+		const normalizedId = toPluginId(id || name);
+		if (!normalizedId) {
+			toast.error($i18n.t(INVALID_PLUGIN_TITLE_MESSAGE));
+			return;
+		}
+
+		id = normalizedId;
 		loading = true;
 		onSave({
-			id,
+			id: normalizedId,
 			name,
 			meta,
 			content,

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -49,9 +49,6 @@
 		id = toPluginId(name);
 	}
 
-	const INVALID_PLUGIN_TITLE_MESSAGE =
-		'Please enter a title with at least one letter, number, or underscore so Open WebUI can generate an id.';
-
 	let codeEditor;
 	let boilerplate = `import os
 import requests
@@ -162,11 +159,6 @@ class Tools:
 
 	const saveHandler = async () => {
 		const normalizedId = toPluginId(id || name);
-		if (!normalizedId) {
-			toast.error($i18n.t(INVALID_PLUGIN_TITLE_MESSAGE));
-			return;
-		}
-
 		id = normalizedId;
 		loading = true;
 		onSave({

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1401,6 +1401,24 @@ export const slugify = (str: string): string => {
 	);
 };
 
+export const toPluginId = (value: string): string => {
+	let pluginId = value
+		.normalize('NFKC')
+		.trim()
+		.replace(/\s+/gu, '_')
+		.replace(/[^\p{L}\p{N}\p{M}_]/gu, '')
+		.replace(/_+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.toLowerCase();
+
+	// Python identifiers cannot start with a number, so prefix one when needed.
+	if (pluginId !== '' && /^\p{N}/u.test(pluginId)) {
+		pluginId = `_${pluginId}`;
+	}
+
+	return pluginId;
+};
+
 export const extractInputVariables = (text: string): Record<string, any> => {
 	const regex = /{{\s*([^|}\s]+)\s*\|\s*([^}]+)\s*}}/g;
 	const regularRegex = /{{\s*([^|}\s]+)\s*}}/g;


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Sanitize ids derived from plugin titles on the frontend so titles can stay user-friendly while generated ids remain valid.
- [x] **Changelog:** Entry added below.
- [x] **Documentation:** No docs update required. This changes frontend sanitization behavior for existing create/import flows without introducing new user-facing settings or APIs.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified with the reproduction described below. Screenshot placeholders are included and will be replaced with the final images manually.
- [x] **Agentic AI Code:** This PR was prepared by an AI assistant but has been manually reviewed and tested by the user.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** This keeps the existing UX and applies a smarter default when deriving ids from titles instead of adding new settings.
- [x] **Git Hygiene:** This PR only changes the frontend id derivation flow.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

When creating Functions or Tools, the frontend previously derived ids with a very simple `name.replace(/\s+/g, '_').toLowerCase()` rule. Titles like `xxx😄` kept unsupported characters in the generated id, so creation failed later with a misleading backend validation error.

This PR makes the frontend sanitize generated ids before submission while keeping the user-facing title unchanged.

### Changed

- Add a shared `toPluginId` helper for frontend-generated ids.
- Apply the same sanitization flow when creating Functions, creating Tools, and importing plugin content.
- Convert whitespace to underscores, strip emoji and unsupported punctuation, collapse repeated underscores, and prefix ids that would otherwise start with a digit.

### Fixed

- Creating a plugin with a title like `xxx😄` now succeeds because the generated id removes the emoji before submission.
- Other unsupported punctuation such as parentheses is also removed from generated ids instead of being sent to the backend unchanged.
- Frontend-generated ids now better match the actual validation rules instead of surfacing an inaccurate backend error during normal creation flows.

### Additional Information

#### Manual verification

1. Reproduced the old behavior by creating a Tool with the title `xxx😄` and confirmed the previous flow surfaced the backend error.
2. Verified the updated frontend converts the same title into a valid id and allows creation to succeed.
3. Spot-checked additional punctuation and confirmed unsupported characters are removed from generated ids.
4. Verified the import flow also uses the same sanitization logic.
5. Ran `npm run build` successfully on this branch.

### Screenshots or Videos

Old behavior while creating a Tool with title `xxx😄`:

<img width="2174" height="1136" alt="old_create" src="https://github.com/user-attachments/assets/d55bd9a6-3261-485f-8296-0dfc2c22707c" />
<img width="2960" height="638" alt="old_error" src="https://github.com/user-attachments/assets/f10e582f-cab0-4c6a-8225-110ae937a076" />

New behavior with the same title after frontend sanitization:

<img width="2464" height="1336" alt="new_create" src="https://github.com/user-attachments/assets/9295fea8-e558-4b3a-913e-86b5f464677d" />
<img width="2292" height="860" alt="new_success" src="https://github.com/user-attachments/assets/47a493ca-35ee-4072-8663-aceddc412d7a" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
