### PR TITLE
fix: add missing has_public_read_access_grant import in notes.py

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -28,7 +28,7 @@ from open_webui.constants import ERROR_MESSAGES
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
-from open_webui.models.access_grants import AccessGrants
+from open_webui.models.access_grants import AccessGrants, has_public_read_access_grant
 from open_webui.internal.db import get_session
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
## Summary

Adds the missing `has_public_read_access_grant` import to `notes.py`. The function is called at line 239 but was never imported, causing a `NameError` at runtime.

## Changes

Added `has_public_read_access_grant` to the existing import from `open_webui.models.access_grants` on line 31. This matches the import pattern already used in `channels.py:39`.

## Testing

- Verified the function exists in `models/access_grants.py:193`
- Verified `channels.py` uses the same import pattern successfully
- The fix is a single import addition with no behavioral change beyond fixing the NameError

Fixes #22680

This contribution was developed with AI assistance (Claude Code).