### PR TITLE
fix: handle ollama embedding errors for bge-m3 and similar models

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -747,7 +747,7 @@ def generate_ollama_batch_embeddings(
         log.debug(
             f"generate_ollama_batch_embeddings:model {model} batch size: {len(texts)}"
         )
-        json_data = {"input": texts, "model": model}
+        json_data = {"input": texts, "model": model, "truncate": True}
         if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
             json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
@@ -763,7 +763,17 @@ def generate_ollama_batch_embeddings(
             headers=headers,
             json=json_data,
         )
-        r.raise_for_status()
+        if r.status_code != 200:
+            error_detail = r.text
+            try:
+                error_json = r.json()
+                if "error" in error_json:
+                    error_detail = error_json["error"]
+            except Exception:
+                pass
+            raise Exception(
+                f"Ollama embed error (status {r.status_code}): {error_detail}"
+            )
         data = r.json()
 
         if "embeddings" in data:
@@ -789,7 +799,7 @@ async def agenerate_ollama_batch_embeddings(
         log.debug(
             f"agenerate_ollama_batch_embeddings:model {model} batch size: {len(texts)}"
         )
-        form_data = {"input": texts, "model": model}
+        form_data = {"input": texts, "model": model, "truncate": True}
         if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
             form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
@@ -809,7 +819,17 @@ async def agenerate_ollama_batch_embeddings(
                 json=form_data,
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
-                r.raise_for_status()
+                if r.status != 200:
+                    error_detail = await r.text()
+                    try:
+                        error_json = await r.json()
+                        if "error" in error_json:
+                            error_detail = error_json["error"]
+                    except Exception:
+                        pass
+                    raise Exception(
+                        f"Ollama embed error (status {r.status}): {error_detail}"
+                    )
                 data = await r.json()
                 if "embeddings" in data:
                     return data["embeddings"]
@@ -947,11 +967,15 @@ async def generate_embeddings(
                 "user": user,
             }
         )
+        if embeddings is None:
+            return None
         return embeddings[0] if isinstance(text, str) else embeddings
     elif engine == "openai":
         embeddings = await agenerate_openai_batch_embeddings(
             model, text if isinstance(text, list) else [text], url, key, prefix, user
         )
+        if embeddings is None:
+            return None
         return embeddings[0] if isinstance(text, str) else embeddings
     elif engine == "azure_openai":
         azure_api_version = kwargs.get("azure_api_version", "")
@@ -964,6 +988,8 @@ async def generate_embeddings(
             prefix,
             user,
         )
+        if embeddings is None:
+            return None
         return embeddings[0] if isinstance(text, str) else embeddings
 
 


### PR DESCRIPTION
## Summary
- Explicitly pass `truncate: true` in ollama `/api/embed` requests to ensure input is truncated to fit the model's context length, preventing HTTP 500 errors with models like bge-m3 that have limited context windows (num_ctx=4096)
- Replace `raise_for_status()` with error response body parsing in both sync and async ollama embedding functions, so the actual ollama error message is logged instead of a generic "500 Internal Server Error"
- Add `None` guards in `generate_embeddings` to prevent `TypeError: 'NoneType' object is not subscriptable` when an upstream embedding call fails and returns `None`

## Root cause
When using `RAG_EMBEDDING_ENGINE=ollama` with `RAG_EMBEDDING_MODEL=bge-m3`, ollama can return HTTP 500 if the input text exceeds the model's context length. While ollama's API documents `truncate` as defaulting to `true`, certain model/version combinations (bge-m3 on ollama 0.18.0) fail without it being explicitly set. The error was further obscured because `raise_for_status()` discarded ollama's error response body, and the `None` return from the embedding function caused a cascading `TypeError`.

## Test plan
- [ ] Verify embedding generation works with `RAG_EMBEDDING_ENGINE=ollama` and `RAG_EMBEDDING_MODEL=bge-m3`
- [ ] Verify that when ollama returns an error, the actual error message appears in Open WebUI logs
- [ ] Verify existing embedding functionality (openai, azure_openai, sentence-transformers) is unaffected

Fixes #22671

🤖 Generated with [Claude Code](https://claude.com/claude-code)