### PR TITLE
fix: add missing has_public_read_access_grant import in notes.py

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -28,7 +28,7 @@ from open_webui.constants import ERROR_MESSAGES
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
-from open_webui.models.access_grants import AccessGrants
+from open_webui.models.access_grants import AccessGrants, has_public_read_access_grant
 from open_webui.internal.db import get_session
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
## Summary

Adds the missing `has_public_read_access_grant` import to `notes.py`. The function is called at line 239 but was never imported, causing a `NameError` at runtime when notes with public read access grants are accessed.

## Changes

Added `has_public_read_access_grant` to the existing import from `open_webui.models.access_grants` on line 31, matching the pattern used in `channels.py:39`.

## Testing

- Verified the function exists in `models/access_grants.py:193`
- Verified `channels.py` uses the same import pattern successfully

Fixes #22680

This contribution was developed with AI assistance (Claude Code).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.