### PR TITLE
fix: resolve UnboundLocalError for limit in oracle23ai.py get()

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -710,12 +710,11 @@ class Oracle23aiClient(VectorDBBase):
             >>> if results:
             ...     print(f"Retrieved {len(results.ids[0])} documents from collection")
         """
-        log.info(
-            f"Getting items from collection '{collection_name}' with limit {limit}."
-        )
-
         try:
             limit = 1000  # Hardcoded limit for get operation
+            log.info(
+                f"Getting items from collection '{collection_name}' with limit {limit}."
+            )
 
             with self.get_connection() as connection:
                 with connection.cursor() as cursor:


### PR DESCRIPTION
## Summary

Moves the `limit = 1000` assignment before the `log.info()` call that references it in the `get()` method of `oracle23ai.py`.

## Changes

The `get()` method signature is `def get(self, collection_name: str)` with no `limit` parameter. The `log.info()` at line 714 referenced `limit` before it was assigned at line 718, causing an `UnboundLocalError` when Oracle 23ai hybrid search was activated.

## Testing

- Verified the function signature has no `limit` parameter
- Verified the log statement now executes after `limit` is assigned

Fixes #22664
Closes #22616

This contribution was developed with AI assistance (Claude Code).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.