### PR TITLE
fix: Continue Response generates additional response instead of continuing

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2024,7 +2024,7 @@
 			.map((token) => decodeURIComponent(JSON.parse(`"${token.replace(/"/g, '\\"')}"`)));
 	};
 
-	const sendMessageSocket = async (model, _messages, _history, responseMessageId, _chatId) => {
+	const sendMessageSocket = async (model, _messages, _history, responseMessageId, _chatId, { continuePrompt = null } = {}) => {
 		const responseMessage = _history.messages[responseMessageId];
 		const userMessage = _history.messages[responseMessage.parentId];
 
@@ -2120,6 +2120,14 @@
 				};
 			})
 			.filter((message) => message?.role === 'user' || message?.content?.trim());
+
+		// Add continue prompt if this is a continuation request
+		if (continuePrompt) {
+			messages.push({
+				role: 'user',
+				content: continuePrompt
+			});
+		}
 
 		const toolIds = [];
 		const toolServerIds = [];
@@ -2450,7 +2458,8 @@
 					createMessagesList(history, responseMessage.id),
 					history,
 					responseMessage.id,
-					_chatId
+					_chatId,
+					{ continuePrompt: 'Continue' }
 				);
 			}
 		}


### PR DESCRIPTION
## Description

Fixes #21564

When clicking 'Continue Response', the LLM was generating a completely new response instead of continuing from where it left off.

### Problem
The 'Continue Response' feature was not working properly because when the button was clicked, the frontend would:
1. Set the current response message's `done` flag to false
2. Re-send the conversation history to the LLM
3. The LLM would generate a completely new response since it had no indication it should continue

### Solution
Modified `sendMessageSocket` to accept an optional `continuePrompt` parameter. When continuing a response, a user message with content 'Continue' is appended to the messages sent to the LLM. This signals the LLM that it should continue from where it left off.

### Changes
- Added optional `continuePrompt` parameter to `sendMessageSocket` function
- When `continuePrompt` is provided, append a user message with that content to the messages array
- Modified `continueResponse` to pass `{ continuePrompt: 'Continue' }` to `sendMessageSocket`

### Testing
- Type-checked the changes with `npm run check`
- Linted the changes with `npm run lint:frontend`

---
*This PR was created with assistance from an AI agent (ClawOSS).*