### PR TITLE
fix: add missing primary key constraints to legacy Peewee tables

### DIFF
--- a/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
+++ b/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
@@ -1,0 +1,51 @@
+"""add missing primary keys to legacy peewee tables
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-03-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLES = [
+    ("chat", "id"),
+    ("chatidtag", "id"),
+    ("file", "id"),
+    ("function", "id"),
+    ("memory", "id"),
+    ("model", "id"),
+    ("tool", "id"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    for table, column in TABLES:
+        pk = inspector.get_pk_constraint(table)
+        if column in (pk.get("constrained_columns") or []):
+            continue
+
+        unique_constraints = inspector.get_unique_constraints(table)
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            for uc in unique_constraints:
+                if uc.get("column_names") == [column]:
+                    batch_op.drop_constraint(uc["name"], type_="unique")
+            batch_op.create_primary_key(f"pk_{column}", [column])
+
+
+def downgrade() -> None:
+    for table, column in TABLES:
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_constraint(f"pk_{column}", type_="primary")


### PR DESCRIPTION
Closes / relates to: https://github.com/open-webui/open-webui/discussions/22716

## Description

Tables originally created by the legacy Peewee migration system have only `UNIQUE` constraints on their `id` columns — not `PRIMARY KEY` constraints. When the project migrated to Alembic, the init migration skips tables that already exist, so the PKs were never added.

This PR adds a new Alembic migration (`c3d4e5f6a7b8`) that retroactively promotes the unique constraint to a primary key for all 7 affected tables.

## Changelog

### Fixed
- 🗄️ **Missing primary keys on legacy Peewee tables.** Tables created by
  the legacy Peewee migration system (`chat`, `chatidtag`, `file`,
  `function`, `memory`, `model`, `tool`) were missing `PRIMARY KEY`
  constraints on their `id` columns. A new Alembic migration
  (`c3d4e5f6a7b8`) retroactively adds the primary key and drops the
  now-redundant unique constraint. The migration is idempotent and safe
  to run on databases that were already migrated through Alembic.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTING.md)
- [x] I have opened a GitHub Discussion before submitting this PR: https://github.com/open-webui/open-webui/discussions/22716
- [x] The PR targets the `dev` branch, not `main`
- [x] The migration is idempotent — `upgrade()` checks the existing PK constraint before acting
- [x] `downgrade()` removes the PK cleanly
- [x] Tested against a Peewee-originated DB (`alembic upgrade head` → PKs present, unique constraints removed)
- [x] Verified no-op on a fresh Alembic-only DB
- [x] This PR contains code that was assisted or generated by an AI tool

## 📌 CLA

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that I have the right to submit it.