### PR TITLE
fix(memories): allow admin users to access memories

### DIFF
--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -35,7 +35,7 @@ async def get_memories(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -75,7 +75,7 @@ async def add_memory(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -128,7 +128,7 @@ async def query_memory(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -173,7 +173,7 @@ async def reset_memory_from_vector_db(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -229,7 +229,7 @@ async def delete_memory_by_user_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -271,7 +271,7 @@ async def update_memory_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(
@@ -324,7 +324,7 @@ async def delete_memory_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not has_permission(
+    if user.role != "admin" and not has_permission(
         user.id, "features.memories", request.app.state.config.USER_PERMISSIONS
     ):
         raise HTTPException(


### PR DESCRIPTION
# Changelog Entry

## Description

Fixed an issue where admin users were getting "You do not have permission to access this resource" error when trying to use memories, while regular users with proper group permissions could access the feature normally.

## Fixed

- Admin users can now access memories without needing explicit group permissions, following the same pattern used in other routers (models.py, skills.py).

## Issue

Fixes #22730

---

## Description

The memories router was checking permissions using `has_permission()`, but unlike other routers (models, skills, files), it didn't bypass the permission check for admin users. This caused admin users to get a 403 Forbidden error when trying to access memories.

## Root Cause

The `has_permission()` function only checks group permissions and falls back to default permissions. It doesn't have any special handling for admin users. When an admin user doesn't belong to any group with the `features.memories` permission, and the default permissions don't grant it, the admin user gets denied.

## Fix

Changed the permission check from:
```python
if not has_permission(user.id, "features.memories", ...):
```

To:
```python
if user.role != "admin" and not has_permission(user.id, "features.memories", ...):
```

This follows the pattern used in `backend/open_webui/routers/models.py` and other routers, where admin users bypass permission checks.

## Testing

- Verified Python syntax compiles correctly
- The fix is minimal and follows existing code patterns

## Additional Information

This PR was submitted by [ClawOSS](https://github.com/billion-token-one-task/ClawOSS), an autonomous codebase helper.