### PR TITLE
fix: guard against null user in Shared Chats view (#22742)

### DIFF
--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -133,12 +133,14 @@
 	style="scroll-margin-top: 3rem;"
 >
 	{#if !($settings?.chatBubble ?? true)}
-		<div class={`shrink-0 ltr:mr-3 rtl:ml-3 mt-1`}>
-			<ProfileImage
-				src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
-				className={'size-8 user-message-profile-image'}
-			/>
-		</div>
+		{#if user}
+			<div class={`shrink-0 ltr:mr-3 rtl:ml-3 mt-1`}>
+				<ProfileImage
+					src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
+					className={'size-8 user-message-profile-image'}
+				/>
+			</div>
+		{/if}
 	{/if}
 	<div class="flex-auto w-0 max-w-full pl-1">
 		{#if !($settings?.chatBubble ?? true)}
@@ -147,8 +149,10 @@
 					{#if message.user}
 						{$i18n.t('You')}
 						<span class=" text-gray-500 text-sm font-medium">{message?.user ?? ''}</span>
-					{:else if $settings.showUsername || $_user.name !== user.name}
+					{:else if user && ($settings.showUsername || $_user.name !== user.name)}
 						{user.name}
+					{:else if !user && message?.user}
+						{message.user}
 					{:else}
 						{$i18n.t('You')}
 					{/if}


### PR DESCRIPTION
## Summary

Fixes #22742.

**Root cause:** UserMessage.svelte accesses user.id and user.name without null checks. When viewing a shared chat as an unauthenticated viewer, user is null, causing TypeError.

**Fix:** Wrap ProfileImage in {#if user}, add user && guard to Name condition, add fallback for message.user when user is null.

## Changes

- src/lib/components/chat/Messages/UserMessage.svelte: Added null guards