### PR TITLE
fix: redirect to home when active chat is deleted or archived

### DIFF
--- a/src/lib/components/layout/ChatsModal.svelte
+++ b/src/lib/components/layout/ChatsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
-	import { getContext } from 'svelte';
+	import { getContext, tick } from 'svelte';
+	import { goto } from '$app/navigation';
 
 	import dayjs from 'dayjs';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
@@ -10,6 +11,7 @@
 	dayjs.extend(calendar);
 
 	import { deleteChatById } from '$lib/apis/chats';
+	import { chatId } from '$lib/stores';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import Modal from '$lib/components/common/Modal.svelte';
@@ -64,12 +66,22 @@
 		}
 	};
 
-	const deleteHandler = async (chatId) => {
-		const res = await deleteChatById(localStorage.token, chatId).catch((error) => {
+	const deleteHandler = async (id) => {
+		const res = await deleteChatById(localStorage.token, id).catch((error) => {
 			toast.error(`${error}`);
+			return null;
 		});
 
-		onUpdate();
+		if (res) {
+			if ($chatId === id) {
+				await goto('/');
+
+				await chatId.set('');
+				await tick();
+			}
+
+			onUpdate();
+		}
 	};
 </script>
 

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -155,6 +155,14 @@
 	const archiveChatHandler = async (id) => {
 		try {
 			await archiveChatById(localStorage.token, id);
+
+			if ($chatId === id) {
+				await goto('/');
+
+				await chatId.set('');
+				await tick();
+			}
+
 			dispatch('change');
 			toast.success($i18n.t('Chat archived.'));
 		} catch (error) {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

This PR fixes two critical UI redirection bugs that allowed users to interact with "zombie" chat states; chats that were ostensibly deleted or archived but remained interactive in the UI. 

The core issue was a lack of reactive redirection in the `ChatsModal` and inconsistent redirection logic when archiving from the sidebar. By synchronizing the `$chatId` store and triggering client-side navigation via SvelteKit's `goto`, this PR ensures a clean UI reset whenever the active chat is removed or hidden.

### Fixed

- **Archive Redirection**: Fixed the behavior where archiving a chat from the sidebar or page navbar would incorrectly leave the user on the now-archived chat's page.
- **Store Synchronization**: Ensured the `$chatId` store is explicitly reset to an empty string upon deletion/archival to trigger complete component re-renders and show the default placeholder.

---

### Additional Information

#### Bug 1: Interaction in Deleted Chats (The "Zombie Chat" issue)
**Issue**: Users could continue a conversation in a chat that was already deleted.
**Reproduction**: 
1. Open the **Archived Chats** modal.
2. Click on an archived chat to view it.
3. Re-open the **Archived Chats** modal.
4. Delete that specific chat from within the modal.
5. Close the modal and click the **Continue Response** button on the now-deleted chat.
**Fix**: Updated `ChatsModal.svelte` to check if the deleted ID matches the current `$chatId`. If so, it now redirects to `/` and resets the chat state.

#### Bug 2: Sticky URL after Archiving
**Issue**: Archiving a chat from the sidebar left the user on `/c/[id]` instead of navigating home.
**Fix**: Implemented explicit navigation home in both `ChatItem.svelte` (sidebar) and `Chat.svelte` (navbar/page) handlers to ensure the URL and UI state remain consistent with the chat's availability.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.