### PR TITLE
fix: Persist MCP OAuth client registration and add DCR fallback

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2451,7 +2451,8 @@ async def register_client(request, client_id: str) -> bool:
         return False
 
     try:
-        request.app.state.config.TOOL_SERVER_CONNECTIONS[connection_idx] = {
+        connections = list(request.app.state.config.TOOL_SERVER_CONNECTIONS)
+        connections[connection_idx] = {
             **connection,
             "info": {
                 **connection.get("info", {}),
@@ -2460,6 +2461,7 @@ async def register_client(request, client_id: str) -> bool:
                 ),
             },
         }
+        request.app.state.config.TOOL_SERVER_CONNECTIONS = connections
     except Exception as e:
         log.error(
             f"Failed to persist updated OAuth client info for tool server {client_id}: {e}"
@@ -2482,8 +2484,14 @@ async def oauth_client_authorize(
     # ensure_valid_client_registration
     client = oauth_client_manager.get_client(client_id)
     client_info = oauth_client_manager.get_client_info(client_id)
+
     if client is None or client_info is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND)
+        # Client not in memory or config — attempt dynamic re-registration
+        if await register_client(request, client_id):
+            client = oauth_client_manager.get_client(client_id)
+            client_info = oauth_client_manager.get_client_info(client_id)
+        if client is None or client_info is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND)
 
     if not await oauth_client_manager._preflight_authorization_url(client, client_info):
         log.info(


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

Fixes MCP OAuth 2.1 Dynamic Client Registration (DCR) not being persisted to the database, causing users to get a 404 on `/oauth/clients/mcp:<id>/authorize`.

Discussion: #22756
Related: #20869, #21190

**Root cause:** `register_client()` updates `TOOL_SERVER_CONNECTIONS` via in-place list mutation (`config.TOOL_SERVER_CONNECTIONS[idx] = {...}`). Since `AppConfig.__getattr__` returns the list reference directly, in-place mutation never triggers `AppConfig.__setattr__` → `PersistentConfig.save()`. The `oauth_client_info` only lives in process memory.

**Impact:**
- Multi-instance deployments: only the worker that handled DCR has the client info — requests hitting other workers get 404
- Single instance: any restart loses the client info — all users get 404

### Added

- Fallback DCR re-registration on the authorize route when the OAuth client is not found, before returning 404

### Changed

- `register_client()` now reassigns `TOOL_SERVER_CONNECTIONS` with a new list instead of mutating in-place, triggering `AppConfig.__setattr__` → `PersistentConfig.save()`

### Fixed

- `oauth_client_info` from MCP OAuth 2.1 DCR is now persisted to the database
- Authorize route attempts DCR re-registration before returning 404 when client info is missing

---

### Additional Information

- Two changes in `main.py`, no new dependencies
- Tested on v0.8.10 with a GitLab MCP server (OAuth 2.1 / DCR)
- Verified: admin registers MCP server → different user completes OAuth flow successfully
- Verified: after container restart, OAuth flow still works (client info loaded from DB)
- The same in-place mutation pattern could affect other `AppConfig` attributes that hold mutable values (lists, dicts) — any code that modifies these in-place without reassigning the attribute will silently fail to persist

### Screenshots or Videos

_Before fix:_ Non-admin user gets 404 on `/oauth/clients/mcp:gitlab-mcp/authorize` after admin registers the MCP server.

_After fix:_ Non-admin user completes the full OAuth 2.1 flow and can use the MCP tool.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
