### PR TITLE
feat: use rich text editor for knowledge file editing

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -1217,11 +1217,9 @@
 			} else {
 				if (value !== mdValue) {
 					editor.commands.setContent(
-						preserveBreaks
-							? value
-							: marked.parse(value.replaceAll(`\n<br/>`, `<br/>`), {
-									breaks: false
-								})
+						marked.parse(value.replaceAll(`\n<br/>`, `<br/>`), {
+							breaks: false
+						})
 					);
 
 					selectTemplate();

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -171,14 +171,18 @@
 
 	const fileSelectHandler = async (file) => {
 		try {
-			selectedFile = file;
-			const rawContent = selectedFile?.data?.content || '';
+			const rawContent = file?.data?.content || '';
 
-			// Normalize single newlines to paragraph breaks (double newlines) so the
-			// rich text editor's markdown parser preserves them. Without this, single
-			// newlines get collapsed into spaces during markdown parsing (breaks: false).
-			// Existing double+ newlines (paragraph breaks) are left unchanged.
-			selectedFileContent = rawContent.replace(/(?<!\n)\n(?!\n)/g, '\n\n');
+			// Strip carriage returns and normalize single newlines to paragraph
+			// breaks (double newlines) so the rich text editor's markdown parser
+			// preserves them. This is idempotent — already-doubled newlines are
+			// left unchanged, so re-opening saved content doesn't compound.
+			const normalized = rawContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+			selectedFileContent = normalized.replace(/(?<!\n)\n(?!\n)/g, '\n\n');
+
+			// Set selectedFile AFTER content so the {#key selectedFile.id} block
+			// recreates RichTextInput with the already-normalized value.
+			selectedFile = file;
 		} catch (e) {
 			toast.error($i18n.t('Failed to load file content.'));
 		}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -172,7 +172,13 @@
 	const fileSelectHandler = async (file) => {
 		try {
 			selectedFile = file;
-			selectedFileContent = selectedFile?.data?.content || '';
+			const rawContent = selectedFile?.data?.content || '';
+
+			// Normalize single newlines to paragraph breaks (double newlines) so the
+			// rich text editor's markdown parser preserves them. Without this, single
+			// newlines get collapsed into spaces during markdown parsing (breaks: false).
+			// Existing double+ newlines (paragraph breaks) are left unchanged.
+			selectedFileContent = rawContent.replace(/(?<!\n)\n(?!\n)/g, '\n\n');
 		} catch (e) {
 			toast.error($i18n.t('Failed to load file content.'));
 		}
@@ -1111,7 +1117,7 @@
 									</div>
 
 									{#key selectedFile.id}
-										<div class="flex-1 overflow-y-auto px-3 py-2">
+										<div class="flex-1 overflow-y-auto px-3 py-2" role="textbox" aria-label={$i18n.t('File content')}>
 											<RichTextInput
 												bind:value={selectedFileContent}
 												placeholder={$i18n.t('Add content here')}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -55,6 +55,7 @@
 	import DropdownOptions from '$lib/components/common/DropdownOptions.svelte';
 	import Pagination from '$lib/components/common/Pagination.svelte';
 	import AttachWebpageModal from '$lib/components/chat/MessageInput/AttachWebpageModal.svelte';
+	import RichTextInput from '$lib/components/common/RichTextInput.svelte';
 
 	let largeScreen = true;
 
@@ -1110,13 +1111,14 @@
 									</div>
 
 									{#key selectedFile.id}
-										<textarea
-											class="w-full h-full text-sm outline-none resize-none px-3 py-2"
-											bind:value={selectedFileContent}
-											disabled={!knowledge?.write_access}
-											aria-label={$i18n.t('File content')}
-											placeholder={$i18n.t('Add content here')}
-										/>
+										<div class="flex-1 overflow-y-auto px-3 py-2">
+											<RichTextInput
+												bind:value={selectedFileContent}
+												placeholder={$i18n.t('Add content here')}
+												preserveBreaks={true}
+												editable={knowledge?.write_access ?? false}
+											/>
+										</div>
 									{/key}
 								</div>
 							</div>


### PR DESCRIPTION
## Use Rich Text Editor for Knowledge File Editing

### Problem

There is an inconsistency in the Knowledge workspace: creating new text content via the "Add Text Content" modal offers a full WYSIWYG editing experience (TipTap-based RichTextInput with formatting toolbar, headings, bold, lists, code blocks, etc.), while editing existing files is limited to a plain, unstyled textarea. Since all knowledge file content is stored as text regardless of the original file type, there is no reason for the editing experience to differ from the creation experience.

### Changes

**KnowledgeBase.svelte**
- Replace the plain textarea in the file editor drawer with the same RichTextInput component used by the Add Text Content modal
- Normalize single newlines to paragraph breaks when loading file content, so extracted text from PDFs, DOCXs, and other files preserves its line structure in the rich text editor
- Set selectedFile after selectedFileContent to avoid a timing issue where the {#key} block would recreate the editor before the content was ready
- Retain the original aria-label for accessibility on the wrapper element

**RichTextInput.svelte (bug fix)**
- Fix a bug in onValueChange where the preserveBreaks code path bypassed markdown parsing entirely, passing raw markdown directly to setContent instead of parsed HTML. This caused all editor content to collapse into a single paragraph whenever a reactive value update triggered setContent. The fix ensures content is always parsed through marked regardless of the preserveBreaks setting.

### How it works

- File content is loaded from selectedFile.data.content
- Carriage returns are stripped and single newlines are normalized to double newlines (markdown paragraph breaks) — this is idempotent and does not compound on repeated save/reopen cycles
- The normalized markdown is parsed by RichTextInput's internal marked parser into proper HTML paragraphs
- Users can format content with headings, bold, italic, lists, code blocks, and tables via the floating toolbar
- On save, TipTap HTML is converted back to markdown via Turndown and stored via updateFileDataContentById


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
