### PR TITLE
fix(oracle23ai): assign limit before use to fix UnboundLocalError (#22664)

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -710,12 +710,12 @@ class Oracle23aiClient(VectorDBBase):
             >>> if results:
             ...     print(f"Retrieved {len(results.ids[0])} documents from collection")
         """
+        limit = 1000  # Hardcoded limit for get operation
         log.info(
             f"Getting items from collection '{collection_name}' with limit {limit}."
         )
 
         try:
-            limit = 1000  # Hardcoded limit for get operation
 
             with self.get_connection() as connection:
                 with connection.cursor() as cursor:


### PR DESCRIPTION
## Summary
Fixes #22664

## Root Cause
In `Oracle23aiClient.get()`, the `limit` variable was referenced in `log.info()` before it was assigned. Python treats `limit` as a local variable throughout the entire function scope (due to the assignment on the next line), causing `UnboundLocalError: cannot access local variable 'limit' where it is not associated with a value` when hybrid search calls `VECTOR_DB_CLIENT.get(collection_name)`.

## Fix
Move `limit = 1000` assignment before the `log.info()` call so the variable is defined when first referenced.

## Impact
- Hybrid search with Oracle 23ai was completely broken
- Users enabling Hybrid Search and performing RAG queries would hit this crash
- Minimal one-line fix, no behavior change

Made with [Cursor](https://cursor.com)