### PR TITLE
fix: make fetch_url max_content_length configurable via env var

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 import asyncio
+import os
 from typing import Optional
 
 from fastapi import Request
@@ -203,7 +204,8 @@ async def fetch_url(
         content, _ = await asyncio.to_thread(get_content_from_url, __request__, url)
 
         # Truncate if too long (avoid overwhelming context)
-        max_length = 50000
+        # Make max_length configurable via environment variable
+        max_length = int(os.environ.get("WEBUI_MAX_FETCH_URL_LENGTH", "50000"))
         if len(content) > max_length:
             content = content[:max_length] + "\n\n[Content truncated...]"
 


### PR DESCRIPTION
## Summary
- Add `WEBUI_MAX_FETCH_URL_LENGTH` env var support (default: 50000)
- Allows users to customize the max content length for fetch_url tool
- Fixes issue where max content length is hardcoded

## Changes
- Added `import os` to builtin.py
- Changed hardcoded `max_length = 50000` to `max_length = int(os.environ.get("WEBUI_MAX_FETCH_URL_LENGTH", "50000"))`

## Related Issue
Fixes #22774