### PR TITLE
fix: align file context injection by user-role messages for native FC

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1669,7 +1669,18 @@ def add_file_context(messages: list, chat_id: str, user) -> list:
             attrs += f' name="{file["name"]}"'
         return f"<file {attrs}/>"
 
-    for message, stored_message in zip(messages, stored_messages):
+    # Pair only user-role messages from both lists to avoid misalignment.
+    # After process_messages_with_output(), assistant messages with tool calls
+    # are expanded into multiple messages (assistant + tool results), making
+    # the payload message list longer than the stored message list. A naive
+    # positional zip() would pair user messages with wrong stored messages,
+    # causing later images to lose their file context (see #21878).
+    user_messages = [m for m in messages if m.get("role") == "user"]
+    stored_user_messages = [
+        m for m in stored_messages if m.get("role") == "user"
+    ]
+
+    for message, stored_message in zip(user_messages, stored_user_messages):
         files_with_urls = [
             file
             for file in stored_message.get("files", [])


### PR DESCRIPTION
The add_file_context function used a positional zip() to pair API payload messages with DB-stored messages. After
process_messages_with_output() expands assistant messages containing tool calls into multiple OpenAI-format messages (assistant + tool results), the payload list becomes longer than the stored list. This caused the zip to misalign, so subsequent user messages never received their attached_files tags -- the model could see uploaded images via vision but had no file URL to pass to edit_image.

Fix: filter both lists to user-role messages only before zipping. User messages maintain the same order in both lists regardless of assistant message expansion, restoring correct file context injection.

Fixes #21878

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
