### PR TITLE
fix: show model avatars in chat search preview modal

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -427,7 +427,7 @@
 			</div>
 			<div
 				id="chat-preview"
-				class="hidden md:flex md:flex-1 w-full overflow-y-auto h-96 md:h-[40rem] scrollbar-hidden"
+				class="hidden md:flex md:flex-1 w-full overflow-y-auto h-96 md:h-[40rem] scrollbar-hidden @container"
 			>
 				{#if messages === null}
 					<div


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Are there any new or upgraded dependencies?
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**.
- [x] **Code review:** Have you performed a self-review of your code?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change).
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following: **fix**

# Changelog Entry

### Description

Fixed an issue where assistant profile images (avatars) were not displayed in the chat preview pane within the Search Modal. This was resolved by adding the `@container` class to the chat-preview container, which correctly enables container-based responsive styles for the assistant's profile image.

### Changed

- Added `@container` class to the chat-preview div in `SearchModal.svelte` to enable container queries.

### Fixed

- Assistant profile image display in the chat preview pane of the Search Modal.

### Screenshots or Videos

#### Before

<img width="1144" height="734" alt="image" src="https://github.com/user-attachments/assets/ed17a9d4-d03d-48e8-a0e4-c654e4282a3a" />

#### After

<img width="1144" height="734" alt="image" src="https://github.com/user-attachments/assets/81378c33-6f23-4d3b-a5c8-0d6c0c69dfbf" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.