### PR TITLE
fix: prevent inconsistent bubble sizes with code blocks in widescreen mode

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -411,7 +411,7 @@
 									{/if}
 								</Name>
 
-								<div class="mt-1 markdown-prose w-full min-w-full">
+								<div class="mt-1 markdown-prose w-full min-w-0">
 									{#if (message?.content ?? '') === ''}
 										<Skeleton />
 									{:else}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -629,7 +629,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
@@ -657,7 +657,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -140,7 +140,7 @@
 			/>
 		</div>
 	{/if}
-	<div class="flex-auto w-0 max-w-full pl-1">
+	<div class="flex-auto w-0 min-w-0 max-w-full pl-1">
 		{#if !($settings?.chatBubble ?? true)}
 			<div>
 				<Name>
@@ -196,7 +196,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div


### PR DESCRIPTION
## Description
Fixes #5975 

This PR fixes the inconsistent conversation bubble sizes when scrolling in widescreen mode with YAML code blocks (or any wide code content).

## Problem
When scrolling the page with code blocks containing wide content (like YAML), the conversation bubble container was changing size inconsistently. This was caused by the browser recalculating flex layout dimensions as `overflow-x: auto` content was measured during scroll.

## Solution
Added `min-w-0` (min-width: 0) to flex containers that hold message content. This is a standard CSS technique to prevent flex items from expanding beyond their flex basis when they contain overflow content.

## Changes
- **ResponseMessage.svelte**: Added `min-w-0` to flex containers
- **UserMessage.svelte**: Added `min-w-0` to flex containers  
- **MultiResponseMessages.svelte**: Changed `min-w-full` to `min-w-0` for proper overflow constraint

## Testing
The fix maintains the intended behavior:
- Normal mode: `max-w-5xl` constraint works correctly
- Widescreen mode: `max-w-full` works correctly
- Scrolling: Bubble sizes remain stable regardless of code block content width

## Technical Details
The `min-w-0` utility prevents flex children from overriding their parent's width constraints when they contain wide scrollable content. Without it, flexbox allows items to grow beyond their container to accommodate content, causing layout shifts during scroll.