### PR TITLE
perf: massive 99.982% payload size reduction for functions list (~x5,550 smaller)

### DIFF
--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
-from open_webui.models.users import Users, UserModel
+from open_webui.models.users import Users, UserModel, UserResponse, User
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, Index
 
@@ -75,10 +75,6 @@ class FunctionWithValvesModel(BaseModel):
 ####################
 
 
-class FunctionUserResponse(FunctionModel):
-    user: Optional[UserModel] = None
-
-
 class FunctionResponse(BaseModel):
     id: str
     user_id: str
@@ -89,6 +85,12 @@ class FunctionResponse(BaseModel):
     is_global: bool
     updated_at: int  # timestamp in epoch
     created_at: int  # timestamp in epoch
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FunctionUserResponse(FunctionResponse):
+    user: Optional[UserResponse] = None
 
 
 class FunctionForm(BaseModel):
@@ -227,18 +229,36 @@ class FunctionsTable:
             functions = db.query(Function).order_by(Function.updated_at.desc()).all()
             user_ids = list(set(func.user_id for func in functions))
 
-            users = Users.get_users_by_user_ids(user_ids, db=db) if user_ids else []
+            users = db.query(User).filter(User.id.in_(user_ids)).all()
             users_dict = {user.id: user for user in users}
 
-            return [
-                FunctionUserResponse.model_validate(
+            results = []
+            for func in functions:
+                user = users_dict.get(func.user_id)
+                results.append(
                     {
-                        **FunctionModel.model_validate(func).model_dump(),
-                        'user': (users_dict.get(func.user_id).model_dump() if func.user_id in users_dict else None),
+                        "id": func.id,
+                        "user_id": func.user_id,
+                        "type": func.type,
+                        "name": func.name,
+                        "meta": func.meta,
+                        "is_active": func.is_active,
+                        "is_global": func.is_global,
+                        "updated_at": func.updated_at,
+                        "created_at": func.created_at,
+                        "user": (
+                            {
+                                "id": user.id,
+                                "name": user.name,
+                                "role": user.role,
+                                "email": user.email,
+                            }
+                            if user
+                            else None
+                        ),
                     }
                 )
-                for func in functions
-            ]
+            return results
 
     def get_functions_by_type(self, type: str, active_only=False, db: Optional[Session] = None) -> list[FunctionModel]:
         with get_db_context(db) as db:

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -229,6 +229,8 @@ class UserNameResponse(BaseModel):
     name: str
     role: str
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class UserResponse(UserNameResponse):
     email: str

--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -68,7 +68,7 @@
 	let showDeleteConfirm = false;
 
 	let loaded = false;
-	let functions = null;
+	let functions = [];
 	let filteredItems = [];
 
 	$: if (query !== undefined) {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. (None added).
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **perf**: Performance improvement

# Changelog Entry

### Description

- Optimized the `/api/v1/functions/list` endpoint to significantly reduce payload size. Previously, the endpoint included both the full function source code and the complete user settings object (which can be large) for every function in the list. This optimization removes the `content` field and uses a leaner `UserResponse` model, reducing response sizes by over 99.9% in some cases (e.g., from 323MB to 58KB).

### Fixed (in the process of working on this optimization)

- Fixed a UI crash on the Functions admin page where Svelte 5 would attempt to access `.length` on a `null` value before the function list had loaded.

### Changed

- Modified `FunctionUserResponse` to inherit from `FunctionResponse` (excluding `content`) and use a limited `UserResponse` model.
- Refactored `get_function_list` in `models/functions.py` for efficient, manual field selection to prevent unintended data leakage from the database objects.

---

### Additional Information

By stripping out the redundant function source code and those heavy user settings, we've achieved a **99.982% reduction** in payload size.

To put that in perspective:
- **Original Size**: ~330,000 KB (330 MB)
- **New Size**: ~58.29 KB
- **Difference**: The new payload is about **5,550 times smaller** than the original!

This not only makes the page load instantly but also significantly reduces the memory footprint on your browser and the bandwidth usage on your server.

### Screenshots or Videos

**Before**:

<img width="2559" height="392" alt="image" src="https://github.com/user-attachments/assets/f1ad0bcb-8e2a-4c62-ac7c-ef1fa88ba114" />

**After**:

<img width="2559" height="392" alt="image" src="https://github.com/user-attachments/assets/35b5a68c-376b-4d91-87c1-acb18613cdf9" />

**Before vs After Screen Recordings**:

[Screencast from 2026-03-18 04-06-45.webm](https://github.com/user-attachments/assets/e93725f9-7946-43af-881c-a5457ce6e7da)

[Screencast from 2026-03-18 04-05-12.webm](https://github.com/user-attachments/assets/eeeba7cc-819a-492e-9fb2-8b4c2d9708e4)

[Screencast from 2026-03-18 04-13-40.webm](https://github.com/user-attachments/assets/d3bf0b3c-9d95-4c34-a5a8-24bb96886ab6)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.