### PR TITLE
fix: close dropdown menu after cloning chat

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -395,6 +395,7 @@
 				class="flex gap-2 items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
 				on:click={() => {
 					cloneChatHandler();
+					show = false;
 				}}
 			>
 				<DocumentDuplicate strokeWidth="1.5" />


### PR DESCRIPTION
Fixes #22784 - Chat Menu Dropdown remains open after clicking Clone

The dropdown menu was not closing after clicking the Clone button,
causing it to remain visible in the sidebar. Added 'show = false'
to close the dropdown after cloneChatHandler() completes.

## Changes
- Added `show = false;` to close the dropdown after cloning