### PR TITLE
fix: OAuth/OIDC session cookie is not persistent — users logged out on every browser close

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1715,9 +1715,11 @@ class OAuthManager:
 
         # Set the cookie token
         # Redirect back to the frontend with the JWT token
+        expires_delta = parse_duration(auth_manager_config.JWT_EXPIRES_IN)
         response.set_cookie(
             key="token",
             value=jwt_token,
+            max_age=int(expires_delta.total_seconds()) if expires_delta else None,
             httponly=False,  # Required for frontend access
             samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
             secure=WEBUI_AUTH_COOKIE_SECURE,


### PR DESCRIPTION
## What's happening

When a user signs in via OAuth/OIDC, the `token` cookie is set without `max_age` or `expires`, which makes it a **session cookie**. The browser discards session cookies when it's closed, so every user who authenticates through an SSO provider has to log in again the next time they open their browser — even though their JWT is still perfectly valid.

## Why this matters

This affects every deployment that:
- Uses OIDC/OAuth as the only login method (`ENABLE_LOGIN_FORM=false`)
- Has users who close their browser between sessions (i.e., everyone)

The symptom is users reporting that they "keep getting logged out" or have to re-authenticate daily. The root cause is not token expiry — the JWT itself is fine — it's just that the browser throws the cookie away.

## The inconsistency

The password login path already handles this correctly. In `routers/auths.py`, `create_session_response` sets a persistent cookie:

```python
# Password login — persistent cookie ✓
response.set_cookie(
    key="token",
    value=token,
    expires=datetime_expires_at,  # matches JWT_EXPIRES_IN
    ...
)
```

The OAuth callback in `utils/oauth.py` never received the same treatment:

```python
# OAuth login — session cookie ✗
response.set_cookie(
    key="token",
    value=jwt_token,
    httponly=False,
    samesite=...,
    secure=...,
    # no max_age or expires
)
```

## The fix

Compute `expires_delta` from `auth_manager_config.JWT_EXPIRES_IN` (the same value already used when creating the JWT a few lines above) and pass it as `max_age`:

```python
expires_delta = parse_duration(auth_manager_config.JWT_EXPIRES_IN)
response.set_cookie(
    key="token",
    value=jwt_token,
    max_age=int(expires_delta.total_seconds()) if expires_delta else None,
    httponly=False,
    samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
    secure=WEBUI_AUTH_COOKIE_SECURE,
)
```

`parse_duration` and `auth_manager_config` are already imported and in scope at this call site — no new dependencies needed.

## Tested against

- Deployments using Okta OIDC as the sole auth provider
- `JWT_EXPIRES_IN` default of `4w` — cookie correctly persists across browser restarts
- `JWT_EXPIRES_IN=None`/unset — `max_age=None` falls back to session cookie behavior, same as before