### PR TITLE
fix: OAuth/OIDC session cookie missing max_age causes users to be logged out on every browser close

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1535,9 +1535,11 @@ class OAuthManager:
 
         # Set the cookie token
         # Redirect back to the frontend with the JWT token
+        expires_delta = parse_duration(auth_manager_config.JWT_EXPIRES_IN)
         response.set_cookie(
             key='token',
             value=jwt_token,
+            max_age=int(expires_delta.total_seconds()) if expires_delta else None,
             httponly=False,  # Required for frontend access
             samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
             secure=WEBUI_AUTH_COOKIE_SECURE,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Concise description of the changes is provided below.
- [x] **Changelog:** Changelog entry added below.
- [ ] **Documentation:** No user-facing env vars or public APIs are changed by this fix — existing `JWT_EXPIRES_IN` documentation covers the behaviour.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manually verified on a deployment using Okta OIDC as the sole login provider (`ENABLE_LOGIN_FORM=false`). Before the fix, closing and reopening the browser required users to re-authenticate despite holding a valid JWT. After the fix, the session persists across browser restarts for the full `JWT_EXPIRES_IN` duration.
- [x] **Agentic AI Code:** This PR was written and manually tested by a human contributor.
- [x] **Code review:** Self-reviewed. The change is minimal (2 lines) and mirrors the existing pattern in `routers/auths.py`.
- [x] **Design & Architecture:** No new settings introduced. Reuses existing `JWT_EXPIRES_IN` config and `parse_duration` helper already in scope at the call site.
- [x] **Git Hygiene:** Single atomic fix, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

---

# Changelog Entry

### Description

When a user logs in via OAuth/OIDC, the `token` cookie is set without `max_age` or `expires`. This makes it a session cookie, which the browser discards as soon as it is closed. The user's JWT is still perfectly valid — they just can't use it because the browser threw the cookie away. Every user who authenticates through an SSO provider ends up having to log back in at the start of each day, even when `JWT_EXPIRES_IN` is set to something long like `4w`.

### Fixed

- **OAuth/OIDC session cookie is now persistent.** The `token` cookie set after an OIDC login now includes `max_age` derived from `auth_manager_config.JWT_EXPIRES_IN`, matching the expiry already embedded in the JWT payload. Users who authenticate via SSO providers (Okta, Google, Microsoft, generic OIDC, etc.) will no longer be logged out every time they close their browser.

### Additional Information

The root cause is an inconsistency between the two login paths:

**Password login** (`routers/auths.py` → `create_session_response`) — already handled correctly:
```python
response.set_cookie(
    key="token",
    value=token,
    expires=datetime_expires_at,  # persistent ✓
    ...
)
```

**OAuth/OIDC callback** (`utils/oauth.py` → `OAuthManager.handle_callback`) — was missing expiry:
```python
# Before
response.set_cookie(
    key="token",
    value=jwt_token,
    httponly=False,
    samesite=..., secure=...,
    # no max_age → session cookie, gone when browser closes ✗
)

# After
expires_delta = parse_duration(auth_manager_config.JWT_EXPIRES_IN)
response.set_cookie(
    key="token",
    value=jwt_token,
    max_age=int(expires_delta.total_seconds()) if expires_delta else None,
    httponly=False,
    samesite=..., secure=...,
)
```

Both `parse_duration` and `auth_manager_config` are already imported and in scope at this call site — no new imports needed. When `JWT_EXPIRES_IN` is unset or zero, `max_age=None` preserves the original session-cookie behaviour.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.