### PR TITLE
fix: close thread sidebar when parent message is deleted

### DIFF
--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -141,6 +141,9 @@
 					messages[idx] = data;
 				}
 			} else if (type === 'message:delete') {
+				if (threadId !== null && data.id === threadId) {
+					threadId = null;
+				}
 				messages = messages.filter((message) => message.id !== data.id);
 			} else if (type === 'message:reply') {
 				const idx = messages.findIndex((message) => message.id === data.id);


### PR DESCRIPTION
## Summary

- Fixes #22781: When a parent message is deleted in a channel, the thread sidebar now automatically closes instead of remaining open with an orphaned thread.
- Adds a check in the `message:delete` event handler in `Channel.svelte` to reset `threadId` to `null` when the deleted message matches the currently open thread's parent ID.

## Test plan

- [ ] Open any channel (public, group, or DM)
- [ ] Send a message and open a thread on it via "Reply in Thread"
- [ ] Delete the parent message while the thread sidebar is open
- [ ] Verify the thread sidebar closes automatically
- [ ] Verify normal message deletion (non-thread-parent) still works correctly
- [ ] Verify closing thread sidebar manually still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>