### PR TITLE
fix: prevent event bubbling on memory delete/edit buttons

### DIFF
--- a/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
@@ -110,7 +110,7 @@
 													<Tooltip content="Edit">
 														<button
 															class="self-center w-fit text-sm px-2 py-2 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-															on:click={() => {
+															on:click|stopPropagation={() => {
 																selectedMemory = memory;
 																showEditMemoryModal = true;
 															}}
@@ -135,7 +135,7 @@
 													<Tooltip content="Delete">
 														<button
 															class="self-center w-fit text-sm px-2 py-2 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-															on:click={async () => {
+															on:click|stopPropagation={async () => {
 																const res = await deleteMemoryById(
 																	localStorage.token,
 																	memory.id


### PR DESCRIPTION
## Summary

- Fixes #22783: Clicking the Delete (trash) button in the Memory management modal triggers event bubbling, causing the parent click handler to open the Edit modal for the already-deleted memory.
- Added `|stopPropagation` modifier to both the Edit and Delete button `on:click` handlers in `ManageModal.svelte` to prevent the click event from propagating to parent elements.

## Test plan

- [ ] Open Settings > Personalization > Manage (Memory)
- [ ] Click the Delete (trash) icon on a memory entry
- [ ] Verify the memory is deleted and the Edit modal does NOT open
- [ ] Click the Edit (pencil) icon on a memory entry
- [ ] Verify only the Edit modal opens without any duplicate event issues

Closes #22783

---

### CLA Confirmation
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license and I agree to the Open WebUI Contributor License Agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>