### PR TITLE
fix: prevent event bubbling on memory delete/edit buttons

### DIFF
--- a/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
@@ -110,7 +110,7 @@
 													<Tooltip content="Edit">
 														<button
 															class="self-center w-fit text-sm px-2 py-2 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-															on:click={() => {
+															on:click|stopPropagation={() => {
 																selectedMemory = memory;
 																showEditMemoryModal = true;
 															}}
@@ -135,7 +135,7 @@
 													<Tooltip content="Delete">
 														<button
 															class="self-center w-fit text-sm px-2 py-2 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-															on:click={async () => {
+															on:click|stopPropagation={async () => {
 																const res = await deleteMemoryById(
 																	localStorage.token,
 																	memory.id


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manually verified that clicking Delete no longer opens the Edit modal.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

- Fixes event bubbling issue where clicking Delete or Edit buttons in the Memory management modal triggers the parent div's click handler, causing the Edit modal to open unexpectedly (#22783).

### Fixed

- Added `|stopPropagation` modifier to Edit and Delete button `on:click` handlers in `ManageModal.svelte` to prevent click events from propagating to the parent element.

---

### Additional Information

- Closes #22783
- The fix is minimal: two `|stopPropagation` modifiers on existing click handlers.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.