### PR TITLE
fix: close thread sidebar when parent message is deleted

### DIFF
--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -141,6 +141,9 @@
 					messages[idx] = data;
 				}
 			} else if (type === 'message:delete') {
+				if (threadId !== null && data.id === threadId) {
+					threadId = null;
+				}
 				messages = messages.filter((message) => message.id !== data.id);
 			} else if (type === 'message:reply') {
 				const idx = messages.findIndex((message) => message.id === data.id);


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manually verified that deleting a parent message closes the thread sidebar.
- [x] **Code review:** Self-reviewed.

# Changelog Entry

### Description

- Fixes an issue where the thread sidebar remains open after the parent message is deleted, allowing users to send messages into an orphaned thread (#22781).

### Fixed

- Added a check in the `message:delete` event handler in `Channel.svelte` to set `threadId = null` when the deleted message is the parent of the currently open thread sidebar.

---

### Additional Information

- Closes #22781
- The fix is a 3-line check in the existing `channelEventHandler` function.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.