### PR TITLE
fix: deduplicate notes in pagination to prevent each_key_duplicate error

### DIFF
--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -221,7 +221,9 @@
 			}
 
 			if (items) {
-				items = [...items, ...pageItems];
+				const existingIds = new Set(items.map((n) => n.id));
+				const newItems = (pageItems ?? []).filter((n) => !existingIds.has(n.id));
+				items = [...items, ...newItems];
 			} else {
 				items = pageItems;
 			}


### PR DESCRIPTION
## Summary
Fixes #22740.

**Root cause:** `getItemsPage()` in `Notes.svelte` appends `pageItems` to `items` with `items = [...items, ...pageItems]` without deduplication. When the API returns overlapping notes across pages (e.g., due to concurrent note creation shifting pagination offsets), the same `note.id` appears at multiple array indices. Svelte's keyed `{#each notesList as note, idx (note.id)}` then throws `each_key_duplicate`, breaking infinite scroll.

**Fix:** Before appending, build a `Set` of existing note IDs and filter out any duplicates from the new page.

## Changes
- `src/lib/components/notes/Notes.svelte`: In `getItemsPage()`, deduplicate `pageItems` against existing `items` by `note.id` before concatenation.

## Testing
- Verified fix prevents duplicate key errors when API returns overlapping notes across pages
- Change is minimal (3 lines) and follows existing code patterns
- No behavioral change for non-overlapping pagination responses

Made with [Cursor](https://cursor.com)