### PR TITLE
fix: guard audioQueue access to prevent TypeError in Search Chats preview

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -197,7 +197,7 @@
 	const stopAudio = () => {
 		try {
 			speechSynthesis.cancel();
-			$audioQueue.stop();
+			$audioQueue?.stop();
 		} catch {}
 
 		if (speaking) {
@@ -260,6 +260,12 @@
 				}
 			}, 100);
 		} else {
+			if (!$audioQueue) {
+				toast.error($i18n.t('Audio queue is not available'));
+				speaking = false;
+				return;
+			}
+
 			$audioQueue.setId(`${message.id}`);
 			$audioQueue.setPlaybackRate($settings.audio?.tts?.playbackRate ?? 1);
 			$audioQueue.onStopped = () => {


### PR DESCRIPTION
## Summary
Fixes #22745.

**Root cause:** The `$audioQueue` Svelte store is typed `AudioQueue | null` and initialized to `null`. When "Read Aloud" is clicked in the Search Chats preview modal, `speak()` calls `$audioQueue.setId()` without a null check, causing `TypeError: can't access property "setId", _() is null`.

**Fix:** Added a null guard before accessing `$audioQueue` methods in `speak()`, and used optional chaining (`$audioQueue?.stop()`) in `stopAudio()`.

## Changes
- `src/lib/components/chat/Messages/ResponseMessage.svelte`: Added null check for `$audioQueue` at the start of the TTS engine path in `speak()`, returning early with a toast error if the audio queue is unavailable. Used optional chaining in `stopAudio()` for the same store.

## Testing
- Verified fix addresses the reported scenario (Read Aloud in Search Chats preview)
- Change is minimal and follows existing code patterns (optional chaining + early return with toast)
- No behavioral change when `$audioQueue` is properly initialized

Made with [Cursor](https://cursor.com)