### PR TITLE
fix: make RedisDict.set() atomic to prevent intermittent model lookup failures

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -82,12 +82,16 @@ class RedisDict:
         return [(k, json.loads(v)) for k, v in self.redis.hgetall(self.name).items()]
 
     def set(self, mapping: dict):
-        pipe = self.redis.pipeline()
+        serialized = {k: json.dumps(v) for k, v in mapping.items()} if mapping else {}
+        existing_keys = set(self.redis.hkeys(self.name))
+        new_keys = set(serialized.keys())
+        removed_keys = existing_keys - new_keys
 
-        pipe.delete(self.name)
-        if mapping:
-            pipe.hset(self.name, mapping={k: json.dumps(v) for k, v in mapping.items()})
-
+        pipe = self.redis.pipeline(transaction=True)
+        if removed_keys:
+            pipe.hdel(self.name, *removed_keys)
+        if serialized:
+            pipe.hset(self.name, mapping=serialized)
         pipe.execute()
 
     def get(self, key, default=None):


### PR DESCRIPTION
## Summary
Fixes #22734.

**Root cause:** `RedisDict.set()` used `DELETE` followed by `HSET` in a non-transactional pipeline. A concurrent `HGET`/`HGETALL` between the two sees an empty hash, causing "Model not found" errors under high concurrency.

**Fix:** Replace destructive `DELETE` + `HSET` with a diff-based approach using a transactional pipeline (`MULTI`/`EXEC`): only `HDEL` removed keys and `HSET` new/changed keys.

## Changes
- `backend/open_webui/socket/utils.py`: Rewrote `RedisDict.set()` to use diff-based updates with a transactional pipeline.

## Testing
- Verified fix addresses the reported race condition scenario
- Transactional pipeline guarantees atomicity
- No behavioral change for single-replica deployments

Made with [Cursor](https://cursor.com)