### PR TITLE
fix: add missing primary key constraints to legacy Peewee tables

### DIFF
--- a/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
+++ b/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
@@ -33,7 +33,7 @@ def upgrade() -> None:
     inspector = Inspector.from_engine(conn)
 
     for table, column in TABLES:
-        pk = inspector.get_pk_constraint(table)
+        pk = inspector.get_pk_constraint(table) or {}
         if column in (pk.get("constrained_columns") or []):
             continue
 
@@ -46,6 +46,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
     for table, column in TABLES:
+        pk = inspector.get_pk_constraint(table) or {}
+        if column not in (pk.get("constrained_columns") or []):
+            continue
+
         with op.batch_alter_table(table, schema=None) as batch_op:
             batch_op.drop_constraint(f"pk_{column}", type_="primary")

--- a/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
+++ b/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_missing_primary_keys.py
@@ -1,0 +1,51 @@
+"""add missing primary keys to legacy peewee tables
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-03-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLES = [
+    ("chat", "id"),
+    ("chatidtag", "id"),
+    ("file", "id"),
+    ("function", "id"),
+    ("memory", "id"),
+    ("model", "id"),
+    ("tool", "id"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    for table, column in TABLES:
+        pk = inspector.get_pk_constraint(table)
+        if column in (pk.get("constrained_columns") or []):
+            continue
+
+        unique_constraints = inspector.get_unique_constraints(table)
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            for uc in unique_constraints:
+                if uc.get("column_names") == [column]:
+                    batch_op.drop_constraint(uc["name"], type_="unique")
+            batch_op.create_primary_key(f"pk_{column}", [column])
+
+
+def downgrade() -> None:
+    for table, column in TABLES:
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.drop_constraint(f"pk_{column}", type_="primary")


### PR DESCRIPTION
Tables created by the Peewee migration system were created with only UNIQUE constraints on their `id` columns, not PRIMARY KEY constraints. Alembic's init migration skips these tables since they already exist, so the PKs were never added. This migration retroactively promotes the unique constraint to a primary key for: chat, chatidtag, file, function, memory, model, tool.

The upgrade() is idempotent — it inspects the existing PK constraint before acting. The redundant unique constraint on `id` is dropped first.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Tables originally created by the legacy Peewee migration system (`chat`, `chatidtag`,
`file`, `function`, `memory`, `model`, `tool`) were missing `PRIMARY KEY` constraints on
their `id` columns. Peewee only adds a `UNIQUE` constraint; when OpenWebUI migrated to
Alembic, the init migration skipped these pre-existing tables, leaving the PKs absent. A
new Alembic migration retroactively fixes this.

Related discussion: https://github.com/open-webui/open-webui/discussions/22716

### Fixed

- 🗄️ **Missing `PRIMARY KEY` constraints on legacy Peewee tables.** Tables created by the
  legacy Peewee migration system (`chat`, `chatidtag`, `file`, `function`, `memory`,
  `model`, `tool`) were missing `PRIMARY KEY` constraints on their `id` columns. New
  Alembic migration `c3d4e5f6a7b8` retroactively promotes the unique constraint to a
  primary key and drops the now-redundant unique constraint. The migration is idempotent —
  it inspects the existing PK before acting, so it is safe on databases already migrated
  through Alembic.

---

### Additional Information

- Every OpenWebUI instance runs the Peewee migration first (creating tables with a
  `UNIQUE` constraint on `id` but no `PRIMARY KEY`), then Alembic runs on top. This
  migration applies during that second phase on both new and existing installations.
- The `downgrade()` path drops the PK cleanly.
- No schema changes to tables created exclusively via Alembic (they already have PKs).
- No schema changes to tables that have since had PKs added by Alembic.

### Screenshots or Videos

**Scenario A — Fresh install** (`ghcr.io/open-webui/open-webui:dev`, clean volume, migration mounted from start):

INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 7e5b5dc7342b, init
...
INFO  [alembic.runtime.migration] Running upgrade a1b2c3d4e5f6 -> b2c3d4e5f6a7, add scim column to user table
INFO  [alembic.runtime.migration] Running upgrade b2c3d4e5f6a7 -> c3d4e5f6a7b8, add missing primary keys to legacy peewee tables

Schema after migration (`chat` table):
```sql
CREATE TABLE "chat" (
    id VARCHAR(255) NOT NULL,
    user_id VARCHAR(255) NOT NULL,
    title TEXT NOT NULL,
    share_id VARCHAR(255),
    archived INTEGER NOT NULL,
    created_at DATETIME NOT NULL,
    updated_at DATETIME NOT NULL,
    chat JSON,
    pinned BOOLEAN,
    meta JSON DEFAULT '{}' NOT NULL,
    folder_id TEXT,
    CONSTRAINT pk_id PRIMARY KEY (id)
)

**Scenario B — Existing install** (DB already at b2c3d4e5f6a7 head, migration file added, app restarted):

INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade b2c3d4e5f6a7 -> c3d4e5f6a7b8, add missing primary keys to legacy peewee tables
Schema after incremental apply — identical CONSTRAINT pk_id PRIMARY KEY (id) confirmed ✓

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
