### PR TITLE
fix: skip message data fetch for pending/optimistic messages

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -66,7 +66,7 @@
 	let showDeleteConfirmDialog = false;
 
 	const loadMessageData = async () => {
-		if (message && message?.data) {
+		if (!pending && message && message?.data) {
 			const res = await getMessageData(localStorage.token, channel?.id, message.id);
 			if (res) {
 				message.data = res;
@@ -75,7 +75,7 @@
 	};
 
 	onMount(async () => {
-		if (message && message?.data) {
+		if (!pending && message && message?.data) {
 			await loadMessageData();
 		}
 	});


### PR DESCRIPTION
## Summary
Fixes #22753.

**Root cause:** `loadMessageData()` in `Message.svelte` runs on mount for any message with truthy `data`, including optimistic messages that use a temporary UUID as their `id`. The backend returns 404 because no DB record exists for the temp ID, causing an unhandled promise rejection.

**Fix:** Added `!pending` guard to both `loadMessageData()` and the `onMount` call, so the API call is only made for messages that have a real server-assigned ID.

## Changes
- `src/lib/components/channel/Messages/Message.svelte`: Added `!pending` check before calling `getMessageData()` in both `loadMessageData()` and `onMount()`.

## Testing
- Verified fix prevents 404 errors for optimistic/pending messages
- No behavioral change for confirmed messages (pending=false)
- Change is minimal (2 lines) and follows existing patterns (pending prop is already used for opacity styling)

Made with [Cursor](https://cursor.com)