### PR TITLE
fix: skip message data fetch for pending channel messages

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -66,7 +66,7 @@
 	let showDeleteConfirmDialog = false;
 
 	const loadMessageData = async () => {
-		if (message && message?.data) {
+		if (!pending && message && message?.data) {
 			const res = await getMessageData(localStorage.token, channel?.id, message.id);
 			if (res) {
 				message.data = res;
@@ -75,7 +75,7 @@
 	};
 
 	onMount(async () => {
-		if (message && message?.data) {
+		if (!pending && message && message?.data) {
 			await loadMessageData();
 		}
 	});


### PR DESCRIPTION
# Changelog Entry

### Description

- Skip message data fetch for pending channel messages to avoid unnecessary API calls and potential errors.

### Fixed

- Added `!pending` guards in `src/lib/components/channel/Messages/Message.svelte`

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

Made with [Cursor](https://cursor.com)