### PR TITLE
fix: apply folder prompt to temporary chats

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1707,6 +1707,7 @@ async def chat_completion(
         metadata = {
             'user_id': user.id,
             'chat_id': form_data.pop('chat_id', None),
+            'folder_id': form_data.pop('folder_id', None),
             'message_id': form_data.pop('id', None),
             'parent_message': form_data.pop('parent_message', None),
             'parent_message_id': form_data.pop('parent_id', None),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2148,6 +2148,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     chat_id = metadata.get('chat_id', None)
     if chat_id and user:
         folder_id = Chats.get_chat_folder_id(chat_id, user.id)
+        if not folder_id and metadata.get('folder_id'):
+            folder_id = metadata.get('folder_id')
         if folder_id:
             folder = Folders.get_folder_by_id_and_user_id(folder_id, user.id)
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2221,6 +2221,7 @@
 
 				session_id: $socket?.id,
 				chat_id: $chatId,
+				folder_id: $temporaryChatEnabled && $selectedFolder?.id ? $selectedFolder.id : undefined,
 
 				id: responseMessageId,
 				parent_id: userMessage?.id ?? null,


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixed folder prompts not being applied to temporary chats. When a user creates a temporary chat in a folder with a system prompt, the prompt is now correctly applied.

### Fixed

- Folder system prompts are now applied to temporary chats by passing `folder_id` explicitly from the frontend when the chat is temporary, and using it in the backend middleware when the chat record lookup returns nothing.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

Made with [Cursor](https://cursor.com)