### PR TITLE
fix: prevent event bubbling on memory edit/delete buttons

### DIFF
--- a/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
@@ -225,7 +225,7 @@
 											<Tooltip content={$i18n.t('Edit')}>
 												<button
 													class="self-center w-fit text-sm p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-													on:click={() => {
+													on:click|stopPropagation={() => {
 														selectedMemory = memory;
 														showEditMemoryModal = true;
 													}}
@@ -237,7 +237,7 @@
 											<Tooltip content={$i18n.t('Delete')}>
 												<button
 													class="self-center w-fit text-sm p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-													on:click={async () => {
+													on:click|stopPropagation={async () => {
 														const res = await deleteMemoryById(
 															localStorage.token,
 															memory.id


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fix event bubbling issue in Memory ManageModal where clicking the Delete (or Edit) button on a memory entry causes the click event to propagate to the parent row's `on:click` handler, which opens the Edit Memory modal. This results in the memory being deleted while the Edit modal simultaneously opens for the now-deleted entry, leading to a 404 error if the user attempts to update.

### Fixed

- Memory deletion no longer unexpectedly opens the Edit Memory modal due to event bubbling from action buttons to the parent row click handler.
- Memory edit button click no longer fires the parent row's click handler redundantly.

### How it was fixed

Added Svelte's `|stopPropagation` event modifier to both the Edit and Delete button `on:click` handlers in `ManageModal.svelte`. This prevents the click event from bubbling up to the parent `<div>` element that has its own `on:click` handler for opening the edit modal.

This is a minimal, two-line change consistent with the existing pattern used throughout the codebase (e.g., `FileItem.svelte`, `Sidebar/SearchInput.svelte`, `FilesModal.svelte`).

### Steps to reproduce (before fix)

1. Navigate to **Settings > Personalization**
2. Click **Manage** under Memory
3. Click the **Delete** (trash can) icon on any memory entry
4. Observe: memory is deleted, but the Edit Memory modal also opens
5. Click **Update** in the ghost modal
6. Observe: 404 error (`Memory Not found`)

### After fix

Clicking Delete removes the memory and shows the success toast without opening the Edit modal.

Fixes #22783

---

### Additional Information

- No new dependencies
- No documentation changes needed (internal UI behavior fix)
- The `|stopPropagation` modifier is already used extensively across the codebase for similar parent-child click handler patterns

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.