### PR TITLE
fix: close thread sidebar when parent message is deleted

### DIFF
--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -142,6 +142,11 @@
 				}
 			} else if (type === 'message:delete') {
 				messages = messages.filter((message) => message.id !== data.id);
+
+				// Close thread sidebar if the deleted message is the thread parent
+				if (threadId === data.id) {
+					threadId = null;
+				}
 			} else if (type === 'message:reply') {
 				const idx = messages.findIndex((message) => message.id === data.id);
 


### PR DESCRIPTION
## Summary
- Fixes the thread sidebar remaining open and interactable after the parent message is deleted, creating orphaned threads
- Adds a check in the `message:delete` event handler in `Channel.svelte` to reset `threadId` to `null` when the deleted message matches the currently open thread's parent ID

Fixes #22781

## Test plan
- [ ] Open any channel and create a message with thread replies
- [ ] Open the thread sidebar for that message
- [ ] Delete the parent message
- [ ] Verify the thread sidebar closes automatically
- [ ] Verify deleting a non-thread message does not affect the open thread sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)