### PR TITLE
fix: close chat menu dropdown after cloning a chat

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -395,6 +395,7 @@
 				class="flex gap-2 items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl"
 				on:click={() => {
 					cloneChatHandler();
+					show = false;
 				}}
 			>
 				<DocumentDuplicate strokeWidth="1.5" />


### PR DESCRIPTION
## Summary

- Fixes the chat menu dropdown remaining open after clicking "Clone" in the sidebar
- Adds `show = false` after `cloneChatHandler()` to properly close the dropdown menu

Closes #22784

## Test plan

- [ ] Open the sidebar, right-click/three-dots menu on a chat
- [ ] Click "Clone"
- [ ] Verify the dropdown menu closes after the clone operation completes