### PR TITLE
fix: folder prompt ignored in temporary chats

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1779,6 +1779,7 @@ async def chat_completion(
             "parent_message": form_data.pop("parent_message", None),
             "parent_message_id": form_data.pop("parent_id", None),
             "session_id": form_data.pop("session_id", None),
+            "folder_id": form_data.pop("folder_id", None),
             "filter_ids": form_data.pop("filter_ids", []),
             "tool_ids": form_data.get("tool_ids", None),
             "tool_servers": form_data.pop("tool_servers", None),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2238,26 +2238,30 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Check if the request has chat_id and is inside of a folder
     # Uses lightweight column query — only fetches folder_id, not the full chat JSON blob
     chat_id = metadata.get("chat_id", None)
+    folder_id = None
     if chat_id and user:
         folder_id = Chats.get_chat_folder_id(chat_id, user.id)
-        if folder_id:
-            folder = Folders.get_folder_by_id_and_user_id(folder_id, user.id)
+    # For temporary chats, fall back to the folder_id sent by the frontend
+    if not folder_id:
+        folder_id = metadata.get("folder_id", None)
+    if folder_id and user:
+        folder = Folders.get_folder_by_id_and_user_id(folder_id, user.id)
 
-            if folder and folder.data:
-                if "system_prompt" in folder.data:
-                    form_data = apply_system_prompt_to_body(
-                        folder.data["system_prompt"], form_data, metadata, user
-                    )
-                if "files" in folder.data:
-                    if metadata.get("params", {}).get("function_calling") != "native":
-                        form_data["files"] = [
-                            *folder.data["files"],
-                            *form_data.get("files", []),
-                        ]
-                    else:
-                        # Native FC: skip RAG injection, builtin tools
-                        # will read folder knowledge from metadata.
-                        metadata["folder_knowledge"] = folder.data["files"]
+        if folder and folder.data:
+            if "system_prompt" in folder.data:
+                form_data = apply_system_prompt_to_body(
+                    folder.data["system_prompt"], form_data, metadata, user
+                )
+            if "files" in folder.data:
+                if metadata.get("params", {}).get("function_calling") != "native":
+                    form_data["files"] = [
+                        *folder.data["files"],
+                        *form_data.get("files", []),
+                    ]
+                else:
+                    # Native FC: skip RAG injection, builtin tools
+                    # will read folder knowledge from metadata.
+                    metadata["folder_knowledge"] = folder.data["files"]
 
     # Model "Knowledge" handling
     user_message = get_last_user_message(form_data["messages"])

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -169,6 +169,7 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let temporaryChatFolderId: string | null = null;
 
 	// Message queue for storing messages while generating
 	let messageQueue: { id: string; prompt: string; files: any[] }[] = [];
@@ -1129,6 +1130,7 @@
 
 		chatFiles = [];
 		params = {};
+		temporaryChatFolderId = null;
 		taskIds = null;
 		messageQueue = [];
 
@@ -2213,6 +2215,7 @@
 
 				session_id: $socket?.id,
 				chat_id: $chatId,
+				...(temporaryChatFolderId ? { folder_id: temporaryChatFolderId } : {}),
 
 				id: responseMessageId,
 				parent_id: userMessage?.id ?? null,
@@ -2544,6 +2547,9 @@
 		} else {
 			_chatId = `local:${$socket?.id}`; // Use socket id for temporary chat
 			await chatId.set(_chatId);
+
+			// Capture folder id so temporary chats can still use folder prompts
+			temporaryChatFolderId = $selectedFolder?.id ?? null;
 		}
 		await tick();
 


### PR DESCRIPTION
## Summary
- Fixes #22772: When a folder has a custom system prompt, creating a "Temporary Chat" in that folder now correctly applies the folder's prompt.
- The root cause was that temporary chats are not persisted to the database, so the backend's folder lookup by `chat_id` returned nothing. The fix captures the `folder_id` on the frontend when a temporary chat starts and passes it in the request payload. The backend falls back to this client-supplied `folder_id` when the DB lookup finds no result.
- This also ensures folder knowledge files are attached to temporary chats, not just the system prompt.

## Changes
- **`src/lib/components/chat/Chat.svelte`**: Store `temporaryChatFolderId` when initializing a temporary chat inside a folder; send it as `folder_id` in the chat completion request.
- **`backend/open_webui/main.py`**: Extract `folder_id` from the request payload into metadata.
- **`backend/open_webui/utils/middleware.py`**: Fall back to `metadata["folder_id"]` when `Chats.get_chat_folder_id()` returns nothing (as happens with temporary chats).

## Test plan
- [ ] Create a folder with a custom system prompt (e.g., "Always respond in pirate speak")
- [ ] Create a regular chat in that folder — verify the prompt is applied
- [ ] Create a temporary chat in that folder — verify the prompt is now also applied
- [ ] Create a temporary chat outside any folder — verify no regression (no folder prompt injected)
- [ ] Create a folder with knowledge files — verify temporary chats in that folder receive the files

🤖 Generated with [Claude Code](https://claude.com/claude-code)