### PR TITLE
fix: prevent URL double-indexing on # trigger after backspace

### DIFF
--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -138,19 +138,6 @@
 		await tick();
 	});
 
-	const onKeyDown = (e) => {
-		if (e.key === 'Enter') {
-			e.preventDefault();
-			select();
-		}
-	};
-	onMount(() => {
-		window.addEventListener('keydown', onKeyDown);
-	});
-
-	onDestroy(() => {
-		window.removeEventListener('keydown', onKeyDown);
-	});
 </script>
 
 {#if filteredItems.length > 0 || query.startsWith('http')}


### PR DESCRIPTION
## Summary

Fixes #22749

- Removed a redundant global `window.addEventListener('keydown', ...)` in the `Knowledge.svelte` command component that duplicated the Enter key handling already provided by `CommandSuggestionList`'s `_onKeyDown` method (called by TipTap's suggestion renderer plugin)
- When typing `#`, backspacing to remove it, then typing `#` again and selecting a URL, the `select()` function fired twice — once through TipTap's suggestion plugin key handler and once through the redundant global listener — causing the URL to be indexed twice
- The fix removes the duplicate listener, relying solely on the suggestion renderer's existing key event pipeline

## Test plan

- [ ] Type `#` in the chat input, then press Backspace to remove it
- [ ] Type `#` again and enter/select a URL
- [ ] Verify the URL is indexed only once (not duplicated in the files list)
- [ ] Verify that Enter/Tab key selection still works correctly in the `#` knowledge suggestion dropdown
- [ ] Verify that `@`, `/`, and `$` trigger suggestions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)