### PR TITLE
fix: register OAUTH_SUB_CLAIM on app.state.config in main.py

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -403,6 +403,7 @@ from open_webui.config import (
     # WebUI (OAuth)
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     OAUTH_ROLES_CLAIM,
+    OAUTH_SUB_CLAIM,
     OAUTH_EMAIL_CLAIM,
     OAUTH_PICTURE_CLAIM,
     OAUTH_USERNAME_CLAIM,
@@ -891,6 +892,7 @@ if any("access_control" in m.get("meta", {}) for m in arena_models):
 app.state.config.OAUTH_USERNAME_CLAIM = OAUTH_USERNAME_CLAIM
 app.state.config.OAUTH_PICTURE_CLAIM = OAUTH_PICTURE_CLAIM
 app.state.config.OAUTH_EMAIL_CLAIM = OAUTH_EMAIL_CLAIM
+app.state.config.OAUTH_SUB_CLAIM = OAUTH_SUB_CLAIM
 
 app.state.config.ENABLE_OAUTH_ROLE_MANAGEMENT = ENABLE_OAUTH_ROLE_MANAGEMENT
 app.state.config.OAUTH_ROLES_CLAIM = OAUTH_ROLES_CLAIM


### PR DESCRIPTION
## Summary

- `OAUTH_SUB_CLAIM` is defined in `config.py` and used in the `token_exchange` endpoint (`routers/auths.py:1349`) via `request.app.state.config.OAUTH_SUB_CLAIM`, but was never imported or assigned in `main.py`
- This causes an `AttributeError: Config key 'OAUTH_SUB_CLAIM' not found` on every token exchange request
- Adds `OAUTH_SUB_CLAIM` to the config import block and registers it on `app.state.config` alongside the other OAuth claim configs (`OAUTH_ROLES_CLAIM`, `OAUTH_EMAIL_CLAIM`, `OAUTH_PICTURE_CLAIM`, `OAUTH_USERNAME_CLAIM`)

## Test plan

- [ ] Configure `OAUTH_SUB_CLAIM` env var and verify token exchange no longer throws `AttributeError`
- [ ] Verify token exchange works without `OAUTH_SUB_CLAIM` set (fallback to default `sub` claim)