### PR TITLE
fix: use hybrid search and reranking in builtin query_knowledge_files tool

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1771,7 +1771,7 @@ async def query_knowledge_files(
         from open_webui.models.knowledge import Knowledges
         from open_webui.models.files import Files
         from open_webui.models.notes import Notes
-        from open_webui.retrieval.utils import query_collection
+        from open_webui.retrieval.utils import query_collection, query_collection_with_hybrid_search
         from open_webui.models.access_grants import AccessGrants
 
         user_id = __user__.get('id')
@@ -1873,12 +1873,40 @@ async def query_knowledge_files(
 
         # Query vector collections if any
         if collection_names:
-            query_results = await query_collection(
-                collection_names=collection_names,
-                queries=[query],
-                embedding_function=embedding_function,
-                k=count,
-            )
+            query_results = None
+
+            # Use hybrid search + reranking when enabled (same as middleware RAG pipeline)
+            if __request__.app.state.config.ENABLE_RAG_HYBRID_SEARCH:
+                try:
+                    reranking_function = None
+                    if __request__.app.state.RERANKING_FUNCTION:
+                        reranking_function = lambda q, docs: __request__.app.state.RERANKING_FUNCTION(
+                            q, docs, user=__user__
+                        )
+
+                    query_results = await query_collection_with_hybrid_search(
+                        collection_names=collection_names,
+                        queries=[query],
+                        embedding_function=embedding_function,
+                        k=count,
+                        reranking_function=reranking_function,
+                        k_reranker=__request__.app.state.config.TOP_K_RERANKER,
+                        r=__request__.app.state.config.RELEVANCE_THRESHOLD,
+                        hybrid_bm25_weight=__request__.app.state.config.HYBRID_BM25_WEIGHT,
+                        enable_enriched_texts=__request__.app.state.config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS,
+                    )
+                except Exception as e:
+                    log.debug(f'Hybrid search failed, falling back to vector search: {e}')
+                    query_results = None
+
+            # Fallback to plain vector search
+            if query_results is None:
+                query_results = await query_collection(
+                    collection_names=collection_names,
+                    queries=[query],
+                    embedding_function=embedding_function,
+                    k=count,
+                )
 
             if query_results and 'documents' in query_results:
                 documents = query_results.get('documents', [[]])[0]


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Targets `dev`
- [x] **Description:** See below
- [x] **Changelog:** See below
- [ ] **Documentation:** No user-facing behavior change — hybrid search/reranking now applies to the same admin settings that already exist
- [x] **Dependencies:** None
- [x] **Testing:** Manually tested on a live deployment with native function calling enabled, TEI embeddings (bge-m3), TEI reranker (bge-reranker-v2-m3), and model-attached knowledge (10 epub files). Confirmed hybrid search and reranker are now invoked via container logs. Confirmed fallback to plain vector search works when hybrid search is disabled.
- [x] **Agentic AI Code:** AI-assisted but human-reviewed, manually tested on live deployment, and verified against the existing middleware implementation
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** No new settings — uses existing RAG config values
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

The builtin `query_knowledge_files` tool (used when native function calling is enabled) calls `query_collection()` directly — plain vector search only. The middleware RAG pipeline (`get_sources_from_items`) uses `query_collection_with_hybrid_search()` with BM25 hybrid search, reranking, and relevance threshold filtering.

This means that when a model has attached knowledge and native function calling is enabled, the admin-configured RAG quality settings (hybrid search, reranking, relevance threshold, `TOP_K_RERANKER`) have no effect on knowledge retrieval.

This fix makes `query_knowledge_files` use the same hybrid search + reranking pipeline as the middleware path, controlled by the same existing config flags.

### Added

- N/A

### Changed

- `query_knowledge_files` in `builtin.py` now uses `query_collection_with_hybrid_search()` when `ENABLE_RAG_HYBRID_SEARCH` is enabled, with reranking function, `TOP_K_RERANKER`, `RELEVANCE_THRESHOLD`, `HYBRID_BM25_WEIGHT`, and enriched texts support

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Builtin `query_knowledge_files` tool now respects hybrid search and reranking settings, matching the behavior of the middleware RAG pipeline
- Graceful fallback to plain vector search if hybrid search fails or is disabled (identical to previous behavior)

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- The native function calling builtin tools (`builtin.py`) were introduced in commit 5c1d5223 (Jan 2026) and the knowledge tools added in c8622adc, using `query_collection()` from the start. The hybrid search + reranking infrastructure in `retrieval/utils.py` predates the builtin tools but was never wired in.
- The return format of `query_collection_with_hybrid_search()` is identical to `query_collection()` (both use `merge_and_sort_query_results()`), so no changes to result processing were needed.
- All parameters (`RERANKING_FUNCTION`, `TOP_K_RERANKER`, `RELEVANCE_THRESHOLD`, `HYBRID_BM25_WEIGHT`, `ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS`) are accessed via `__request__.app.state`, which is already available in the tool function.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
