### PR TITLE
fix: support TEI reranker format in ExternalReranker with auto-detection

### DIFF
--- a/backend/open_webui/retrieval/models/external.py
+++ b/backend/open_webui/retrieval/models/external.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+import threading
 from typing import Optional, List, Tuple
 from urllib.parse import quote
 
@@ -12,6 +13,15 @@ log = logging.getLogger(__name__)
 
 
 class ExternalReranker(BaseReranker):
+    # Supported API formats for external reranker endpoints
+    FORMAT_COHERE = 'cohere'  # Cohere/Jina: {"documents": [...], "model": ..., "top_n": N}
+    FORMAT_TEI = 'tei'  # TEI: {"texts": [...], "truncate": true}
+
+    # Class-level cache: survives re-instantiation (e.g. config updates).
+    # Keyed by URL so different endpoints can use different formats.
+    _format_cache: dict = {}
+    _format_lock = threading.Lock()
+
     def __init__(
         self,
         api_key: str,
@@ -24,16 +34,23 @@ class ExternalReranker(BaseReranker):
         self.model = model
         self.timeout = timeout
 
-    def predict(self, sentences: List[Tuple[str, str]], user=None) -> Optional[List[float]]:
-        query = sentences[0][0]
-        docs = [i[1] for i in sentences]
-
-        payload = {
+    def _build_payload(self, query: str, docs: list, api_format: str) -> dict:
+        if api_format == self.FORMAT_TEI:
+            return {
+                'query': query,
+                'texts': docs,
+                'truncate': True,
+            }
+        return {
             'model': self.model,
             'query': query,
             'documents': docs,
             'top_n': len(docs),
         }
+
+    def predict(self, sentences: List[Tuple[str, str]], user=None) -> Optional[List[float]]:
+        query = sentences[0][0]
+        docs = [i[1] for i in sentences]
 
         try:
             log.info(f'ExternalReranker:predict:model {self.model}')
@@ -47,6 +64,15 @@ class ExternalReranker(BaseReranker):
             if ENABLE_FORWARD_USER_INFO_HEADERS and user:
                 headers = include_user_info_headers(headers, user)
 
+            # Detect API format on first call (thread-safe).
+            # The first thread to arrive does the detection; others wait and reuse.
+            if self.url not in self._format_cache:
+                with self._format_lock:
+                    if self.url not in self._format_cache:
+                        self._format_cache[self.url] = self._detect_format(headers, query, docs)
+
+            payload = self._build_payload(query, docs, self._format_cache[self.url])
+
             r = requests.post(
                 f'{self.url}',
                 headers=headers,
@@ -58,13 +84,62 @@ class ExternalReranker(BaseReranker):
             r.raise_for_status()
             data = r.json()
 
-            if 'results' in data:
-                sorted_results = sorted(data['results'], key=lambda x: x['index'])
-                return [result['relevance_score'] for result in sorted_results]
-            else:
-                log.error('No results found in external reranking response')
-                return None
+            return self._parse_response(data)
 
         except Exception as e:
             log.exception(f'Error in external reranking: {e}')
             return None
+
+    def _detect_format(self, headers: dict, query: str, docs: list) -> str:
+        """Detect the API format by trying Cohere first, falling back to TEI.
+
+        Sends a single probe request with Cohere format. If the endpoint
+        returns 422 (validation error), it likely expects TEI format instead.
+        """
+        payload = self._build_payload(query, docs, self.FORMAT_COHERE)
+        try:
+            r = requests.post(
+                f'{self.url}',
+                headers=headers,
+                json=payload,
+                timeout=self.timeout,
+                verify=REQUESTS_VERIFY,
+            )
+        except Exception:
+            # Network error — default to Cohere, let predict() handle the error
+            return self.FORMAT_COHERE
+
+        if r.status_code == 422:
+            log.info(f'ExternalReranker: Cohere format rejected, using TEI format')
+            return self.FORMAT_TEI
+
+        log.info(f'ExternalReranker: detected API format: {self.FORMAT_COHERE}')
+        return self.FORMAT_COHERE
+
+    @staticmethod
+    def _parse_response(data) -> Optional[List[float]]:
+        """Parse reranking response in either Cohere/Jina or TEI format.
+
+        Cohere/Jina: {"results": [{"index": 0, "relevance_score": 0.9}, ...]}
+        TEI:         [{"index": 0, "score": 0.9}, ...]
+        """
+        results = None
+
+        if isinstance(data, list):
+            # TEI format: flat array
+            results = data
+        elif isinstance(data, dict) and 'results' in data:
+            # Cohere/Jina format: wrapped in {"results": [...]}
+            results = data['results']
+
+        if not results:
+            log.error('No results found in external reranking response')
+            return None
+
+        sorted_results = sorted(results, key=lambda x: x['index'])
+
+        # Support both "relevance_score" (Cohere/Jina) and "score" (TEI)
+        return [
+            result.get('relevance_score', result.get('score', 0.0))
+            for result in sorted_results
+        ]


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Targets `dev`
- [x] **Description:** See below
- [x] **Changelog:** See below
- [ ] **Documentation:** No user-facing config changes - TEI format is auto-detected transparently
- [x] **Dependencies:** None
- [x] **Testing:** Manually tested on a live deployment with TEI reranker (bge-reranker-v2-m3 via `ghcr.io/huggingface/text-embeddings-inference:120-1.9.1`). Confirmed format auto-detection, reranking scores returned correctly, thread-safe under 10 parallel rerank calls. Also verified Cohere/Jina format path is unchanged (probe succeeds on first try, cached).
- [x] **Agentic AI Code:** AI-assisted but human-reviewed, manually tested on live deployment
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** No new settings - format is auto-detected via smart default
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

`ExternalReranker` only supports the Cohere/Jina rerank API format (`"documents"` key, `{"results": [{"relevance_score": ...}]}` response). HuggingFace Text Embeddings Inference (TEI) uses a different format (`"texts"` key, flat array response with `"score"` key), causing a silent 422 error that falls back to unreranked results. Users with TEI rerankers configured get no reranking despite the setting being enabled.

~~Additionally, `ChromaClient.search()` silently swallows all exceptions (`except: return None`), making it impossible to diagnose vector search failures.~~

### Added

- Auto-detection of reranker API format (Cohere/Jina vs TEI) on first call, cached for subsequent requests
- Thread-safe format detection via lock (hybrid search dispatches parallel rerank calls across collections)
- Support for TEI response format (flat array with `"score"` key)

### Changed

- `ExternalReranker.predict()` now auto-detects and caches the API format instead of assuming Cohere/Jina
- Response parsing extracted to `_parse_response()` static method, handles both Cohere/Jina and TEI formats
- Payload construction extracted to `_build_payload()` method

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- External reranker now works with TEI endpoints out of the box (no config change needed)
~~- `ChromaClient.search()` now logs exceptions instead of silently returning `None`~~

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- TEI's `/rerank` endpoint expects `{"query": "...", "texts": [...], "truncate": true}` and returns `[{"index": 0, "score": 0.5}, ...]`. Open WebUI sends `{"model": "...", "query": "...", "documents": [...], "top_n": N}` and expects `{"results": [{"index": 0, "relevance_score": 0.5}]}`. The 422 from TEI was caught by the generic exception handler in `predict()`, silently falling back to unreranked results.
- Format detection sends one Cohere-format probe on first call. If the endpoint returns 422, TEI format is used. The result is cached as a class-level dict keyed by URL, surviving `ExternalReranker` re-instantiation (which happens on config updates via the admin UI). A `threading.Lock` prevents concurrent probe requests when hybrid search dispatches parallel rerank calls.
~~- The ChromaDB logging change is included because the silent `except: return None` in `search()` made it very difficult to diagnose a vector search failure encountered during testing of the reranker integration.~~

This is related to my other PR https://github.com/open-webui/open-webui/pull/22892, which enables reranking for query_knowledge_files, which in turn is my use case.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
