### PR TITLE
enh: allow iframe postMessage prompts without same-origin (with HITL confirmation)

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -569,10 +569,10 @@
 		const isSameOrigin = event.origin === window.origin;
 		const type = event.data?.type;
 
-		// These message types only submit text to the chat input — functionally
-		// equivalent to the user typing.  They are safe to accept from sandboxed
-		// iframes whose origin is opaque ("null") because they cannot read or
-		// modify any page state.
+		// Prompt-related message types only submit text to the chat input —
+		// functionally equivalent to the user typing.  When same-origin is
+		// enabled they go through immediately.  When it is disabled (opaque
+		// origin) we show a confirmation dialog so the user stays in control.
 		const iframePromptTypes = ['input:prompt', 'input:prompt:submit', 'action:submit'];
 
 		if (!isSameOrigin && !iframePromptTypes.includes(type)) {
@@ -603,8 +603,22 @@
 			console.debug(event.data.text);
 
 			if (event.data.text !== '') {
-				await tick();
-				submitPrompt(event.data.text);
+				if (isSameOrigin) {
+					await tick();
+					submitPrompt(event.data.text);
+				} else {
+					// Cross-origin: ask user to confirm before submitting
+					eventConfirmationInput = false;
+					eventConfirmationTitle = $i18n.t('Confirm Prompt from Embed');
+					eventConfirmationMessage = event.data.text;
+					eventCallback = async (confirmed: boolean) => {
+						if (confirmed) {
+							await tick();
+							submitPrompt(event.data.text);
+						}
+					};
+					showEventConfirmation = true;
+				}
 			}
 		}
 	};

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -566,11 +566,20 @@
 		origin: string;
 		data: { type: string; text: string };
 	}) => {
-		if (event.origin !== window.origin) {
+		const isSameOrigin = event.origin === window.origin;
+		const type = event.data?.type;
+
+		// These message types only submit text to the chat input — functionally
+		// equivalent to the user typing.  They are safe to accept from sandboxed
+		// iframes whose origin is opaque ("null") because they cannot read or
+		// modify any page state.
+		const iframePromptTypes = ['input:prompt', 'input:prompt:submit', 'action:submit'];
+
+		if (!isSameOrigin && !iframePromptTypes.includes(type)) {
 			return;
 		}
 
-		if (event.data.type === 'action:submit') {
+		if (type === 'action:submit') {
 			console.debug(event.data.text);
 
 			if (prompt !== '') {
@@ -579,8 +588,7 @@
 			}
 		}
 
-		// Replace with your iframe's origin
-		if (event.data.type === 'input:prompt') {
+		if (type === 'input:prompt') {
 			console.debug(event.data.text);
 
 			const inputElement = document.getElementById('chat-input');
@@ -591,7 +599,7 @@
 			}
 		}
 
-		if (event.data.type === 'input:prompt:submit') {
+		if (type === 'input:prompt:submit') {
 			console.debug(event.data.text);
 
 			if (event.data.text !== '') {


### PR DESCRIPTION
# allow iframe postMessage prompts without same-origin (with HITL confirmation)

## Problem

The onMessageHandler in Chat.svelte checks event.origin against window.origin and silently drops messages from sandboxed iframes that don't have same-origin access. This means Rich UI tools that use the input:prompt:submit postMessage protocol (e.g. interactive buttons that send prompts back to the chat) only work when "iframe Sandbox Allow Same Origin" is enabled.

Requiring same-origin for this feature is a security tradeoff: it also exposes parent.document, parent.fetch, and parent.localStorage to iframe JavaScript — which is far more access than sendPrompt needs.

## Solution

When same-origin is enabled, prompt messages go through immediately (unchanged behavior).

When same-origin is disabled, cross-origin input:prompt:submit messages now trigger the existing EventConfirmDialog instead of being silently dropped. The user sees the message text and can confirm or cancel before it is submitted. This prevents abuse (spam) while still enabling the feature without requiring same-origin access.

Other cross-origin message types (input:prompt, action:submit) are also allowed through to the handler — input:prompt only fills the input box without submitting, and action:submit uses the existing prompt text.

## Changes

- Chat.svelte: Restructured the origin check in onMessageHandler to allow prompt-related message types from opaque-origin iframes
- For input:prompt:submit from cross-origin: shows a confirmation dialog before submitting
- For input:prompt:submit from same-origin: submits immediately (no behavior change)


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
