### PR TITLE
fix: reduce sideOffset on SubContent menus to prevent hover gap

### DIFF
--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -355,7 +355,7 @@
 				<DropdownMenu.SubContent
 					class="select-none w-full rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100  dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 					transition={flyAndScale}
-					sideOffset={8}
+					sideOffset={2}
 				>
 					{#if $user?.role === 'admin' || ($user.permissions?.chat?.export ?? true)}
 						<DropdownMenu.Item
@@ -424,7 +424,7 @@
 						<DropdownMenu.SubContent
 							class="select-none w-full max-w-[200px] rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100  dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 							transition={flyAndScale}
-							sideOffset={8}
+							sideOffset={2}
 						>
 							{#each $folders.sort((a, b) => b.updated_at - a.updated_at) as folder}
 								{#if folder?.id}

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -325,7 +325,7 @@
 				<DropdownMenu.SubContent
 					class="select-none w-full rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg border border-gray-100  dark:border-gray-800"
 					transition={flyAndScale}
-					sideOffset={8}
+					sideOffset={2}
 				>
 					{#if $user?.role === 'admin' || ($user.permissions?.chat?.export ?? true)}
 						<DropdownMenu.Item
@@ -414,7 +414,7 @@
 					<DropdownMenu.SubContent
 						class="select-none w-full max-w-[200px] rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100  dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 						transition={flyAndScale}
-						sideOffset={8}
+						sideOffset={2}
 					>
 						{#each $folders.sort((a, b) => b.updated_at - a.updated_at) as folder}
 							<DropdownMenu.Item

--- a/src/lib/components/notes/Notes/NoteMenu.svelte
+++ b/src/lib/components/notes/Notes/NoteMenu.svelte
@@ -58,7 +58,7 @@
 				<DropdownMenu.SubContent
 					class="w-full rounded-xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg"
 					transition={flyAndScale}
-					sideOffset={8}
+					sideOffset={2}
 					align="end"
 				>
 					<DropdownMenu.Item
@@ -102,7 +102,7 @@
 					<DropdownMenu.SubContent
 						class="w-full rounded-xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg"
 						transition={flyAndScale}
-						sideOffset={8}
+						sideOffset={2}
 						align="end"
 					>
 						{#if onCopyLink}

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -379,7 +379,7 @@
 								<DropdownMenu.SubContent
 									class="w-full rounded-2xl p-1 z-50 bg-white dark:bg-gray-850 dark:text-white border border-gray-100 dark:border-gray-800 shadow-lg max-h-52 overflow-y-auto scrollbar-hidden"
 									transition={flyAndScale}
-									sideOffset={8}
+									sideOffset={2}
 								>
 									<DropdownMenu.Item
 										class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full"


### PR DESCRIPTION
Fixes #22744

## Changes

Reduce `sideOffset` from 8 to 2 on all `DropdownMenu.SubContent` elements. The 8px gap between trigger and submenu causes `mouseleave` to fire before `mouseenter` on the submenu, making it impossible to select submenu items at normal cursor speeds.

Changed files:
- `src/lib/components/layout/Sidebar/ChatMenu.svelte` — Download and Move submenus
- `src/lib/components/layout/Navbar/Menu.svelte` — Download and Move submenus
- `src/lib/components/notes/Notes/NoteMenu.svelte` — Download and Share submenus
- `src/lib/components/playground/Chat.svelte` — Download submenu

7 total `sideOffset={8}` → `sideOffset={2}` changes on SubContent elements. Top-level `DropdownMenu.Content` sideOffset values are unchanged.

## Test Plan

- Hover over Download/Move/Share submenu triggers in sidebar chat menu, navbar menu, notes menu, and playground menu
- Verify submenus stay open during cursor transit from trigger to submenu content