### PR TITLE
fix: reset page to 1 when searching prompts

### DIFF
--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -64,6 +64,7 @@
 		loading = true;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
+			page = 1;
 			getPromptList();
 		}, 300);
 	}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our CI processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- **fix(ui): reset page to 1 when searching prompts** — When a user initiated a search from a paginated page (e.g., page 5), the UI displayed "No prompts found" even though matching results existed. This occurred because the debounced search call used the current page number instead of resetting to page 1. Added `page = 1;` inside the search debounce callback so that search queries always fetch from the first page of results.

### Fixed

- **Prompts search returning "No prompts found" on paginated views** — The search reactive statement now resets `page` to 1 before fetching results, ensuring search queries always start from the first page and correctly display matching prompts regardless of which page the user was viewing when the search was initiated.

---

### Additional Information

- **Root Cause**: In `src/lib/components/workspace/Prompts.svelte`, the query reactive statement (line 63) debounced `getPromptList()` but never reset `page = 1`. When a user searched from page 5, the API was called with `page=5`, returning zero results since search results don't span that many pages.
- **Fix**: Added `page = 1;` inside the debounce callback before calling `getPromptList()`. When `page = 1` is set, Svelte's reactive system also fires the page/filter/tag reactive statement (line 72), which calls `getPromptList()` again with the correct page number. The duplicate call is harmless.
- **File changed**: `src/lib/components/workspace/Prompts.svelte` (1 line added)
- This PR fixes [issue: Prompts Search Results Return "No Prompts Found" on Paginated Views](https://github.com/open-webui/open-webui/issues/22741).

### Screenshots or Videos

**Before fix**: Searching "OWUI" from page 5 shows total count of 1 but displays "No prompts found".

<img width="2340" height="617" alt="image" src="https://github.com/user-attachments/assets/34d6ed13-9880-4b4a-be2c-1bdf8000a28e" />

**After fix**: Searching "OWUI" from any page correctly resets to page 1 and displays the matching prompt.

<img width="2340" height="617" alt="image" src="https://github.com/user-attachments/assets/ca4f0670-d5e0-4a02-b0ff-56348d35255d" />

### Manual Verification Performed

1. Navigate to `/workspace/prompts`
2. Click to a later page (e.g., page 5) in the pagination bar
3. Enter a search query in the search bar (e.g., "OWUI")
4. Confirm the prompt appears and "No prompts found" does not appear
5. Confirm the paginator resets to page 1

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.