### PR TITLE
fix: prevent upload process from stalling with Document Intelligence

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1794,6 +1794,10 @@ if THREAD_POOL_SIZE is not None and isinstance(THREAD_POOL_SIZE, str):
         )
         THREAD_POOL_SIZE = None
 
+FILE_UPLOAD_CONCURRENT_PROCESSING = int(
+    os.getenv("FILE_UPLOAD_CONCURRENT_PROCESSING", "2")
+)
+
 
 def validate_cors_origin(origin):
     parsed_url = urlparse(origin)

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -283,6 +283,14 @@ def upload_file_handler(
                     channel.id, file_item.id, user.id, db=db
                 )
 
+        if "knowledge_id" in file_metadata:
+            Knowledges.add_file_to_knowledge_by_id(
+                knowledge_id=file_metadata["knowledge_id"],
+                file_id=file_item.id,
+                user_id=user.id,
+                db=db,
+            )
+
         if process:
             if background_tasks and process_in_background:
                 background_tasks.add_task(

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -2,6 +2,7 @@ import logging
 import os
 import uuid
 import json
+import threading
 from pathlib import Path
 from typing import Optional
 from urllib.parse import quote
@@ -47,7 +48,7 @@ from open_webui.routers.audio import transcribe
 from open_webui.storage.provider import Storage
 
 
-from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
+from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL, FILE_UPLOAD_CONCURRENT_PROCESSING
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
@@ -56,6 +57,8 @@ log = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Limit concurrent file processing to prevent resource exhaustion
+_file_processing_semaphore = threading.Semaphore(FILE_UPLOAD_CONCURRENT_PROCESSING)
 
 from open_webui.utils.access_control.files import has_access_to_file
 
@@ -157,11 +160,12 @@ def process_uploaded_file(
                 db=db_session,
             )
 
-    if db:
-        _process_handler(db)
-    else:
-        with SessionLocal() as db_session:
-            _process_handler(db_session)
+    with _file_processing_semaphore:
+        if db:
+            _process_handler(db)
+        else:
+            with SessionLocal() as db_session:
+                _process_handler(db_session)
 
 
 @router.post("/", response_model=FileModelResponse)

--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -353,7 +353,7 @@
 	};
 
 	const inputFilesHandler = async (inputFiles) => {
-		inputFiles.forEach(async (file) => {
+		for (const file of inputFiles) {
 			console.info('Processing file:', {
 				name: file.name,
 				type: file.type,
@@ -374,7 +374,7 @@
 						maxSize: $config?.file?.max_size
 					})
 				);
-				return;
+				continue;
 			}
 
 			if (file['type'].startsWith('image/')) {
@@ -431,9 +431,9 @@
 
 				reader.readAsDataURL(file['type'] === 'image/heic' ? await convertHeicToJpeg(file) : file);
 			} else {
-				uploadFileHandler(file);
+				await uploadFileHandler(file);
 			}
-		});
+		}
 	};
 
 	const uploadFileHandler = async (file, process = true) => {

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -688,7 +688,7 @@
 			return;
 		}
 
-		inputFiles.forEach(async (file) => {
+		for (const file of inputFiles) {
 			console.log('Processing file:', {
 				name: file.name,
 				type: file.type,
@@ -709,13 +709,13 @@
 						maxSize: $config?.file?.max_size
 					})
 				);
-				return;
+				continue;
 			}
 
 			if (file['type'].startsWith('image/')) {
 				if (visionCapableModels.length === 0) {
 					toast.error($i18n.t('Selected model(s) do not support image inputs'));
-					return;
+					continue;
 				}
 
 				const compressImageHandler = async (imageUrl, settings = {}, config = {}) => {
@@ -780,9 +780,9 @@
 
 				reader.readAsDataURL(file['type'] === 'image/heic' ? await convertHeicToJpeg(file) : file);
 			} else {
-				uploadFileHandler(file);
+				await uploadFileHandler(file);
 			}
-		});
+		}
 	};
 
 	const createNote = async () => {

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -333,9 +333,11 @@
 				}
 			} else {
 				toast.error($i18n.t('Failed to upload file.'));
+				fileItems = fileItems.filter((item) => item.itemId !== fileItem.itemId);
 			}
 		} catch (e) {
 			toast.error(`${e}`);
+			fileItems = fileItems.filter((item) => item.itemId !== fileItem.itemId);
 		}
 	};
 

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -170,6 +170,11 @@
 
 	const fileSelectHandler = async (file) => {
 		try {
+			const status = file?.data?.status;
+			if (status && status !== 'completed' && status !== 'failed') {
+				toast.info($i18n.t('This file is still being processed.'));
+				return;
+			}
 			selectedFile = file;
 			selectedFileContent = selectedFile?.data?.content || '';
 		} catch (e) {


### PR DESCRIPTION
## Summary

When using Document Intelligence (Azure AI) for file processing, uploading multiple files simultaneously could cause the process to stall due to resource exhaustion. This PR addresses several related issues:

- **Add semaphore to limit concurrent file processing** — Prevents backend resource exhaustion by limiting concurrent processing to 2 (configurable via `FILE_UPLOAD_CONCURRENT_PROCESSING` env var)
- **Sequential file upload on frontend** — Changed `forEach(async ...)` to `for...of` with `await` in `inputFilesHandler` to upload files one at a time instead of all concurrently
- **Remove stale upload spinner** — When `uploadFile()` fails, the spinner is now properly removed from the UI
- **Associate file with knowledge base immediately on upload** — Files are added to the KnowledgeFile table at upload time (before background processing begins), so they remain visible after page reload
- **Block selection of files still being processed** — Shows a toast message and prevents selecting files that haven't completed processing

## Test plan

- [ ] Upload multiple files (5+) simultaneously to a Knowledge Base with Document Intelligence enabled and verify they process without stalling
- [ ] Verify the upload spinner disappears when a file upload fails
- [ ] Upload files to a Knowledge Base, reload the page, and verify all files (including those still processing) are visible
- [ ] Click on a file that is still being processed and verify a toast message appears
