### PR TITLE
fix: restore $ skill highlight and TipTap mention nodes on page reload

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -149,6 +149,7 @@
 	let codeInterpreterEnabled = false;
 
 	let showCommands = false;
+	let selectedSkillId = null;
 
 	let generating = false;
 	let dragged = false;
@@ -235,8 +236,9 @@
 					const input = JSON.parse(storageChatInput);
 
 					if (!$temporaryChatEnabled) {
-						messageInput?.setText(input.prompt);
+						messageInput?.setText(input.prompt, null, input.content);
 						files = input.files;
+						selectedSkillId = input.selectedSkillId;
 						selectedToolIds = input.selectedToolIds;
 						selectedFilterIds = input.selectedFilterIds;
 						webSearchEnabled = input.webSearchEnabled;
@@ -719,8 +721,9 @@
 					const input = JSON.parse(storageChatInput);
 
 					if (!$temporaryChatEnabled) {
-						messageInput?.setText(input.prompt);
+						messageInput?.setText(input.prompt, null, input.content);
 						files = input.files;
+						selectedSkillId = input.selectedSkillId;
 						selectedToolIds = input.selectedToolIds;
 						selectedFilterIds = input.selectedFilterIds;
 						webSearchEnabled = input.webSearchEnabled;
@@ -2818,6 +2821,7 @@
 									bind:webSearchEnabled
 									bind:atSelectedModel
 									bind:showCommands
+									bind:selectedSkillId
 									bind:dragged
 									toolServers={$toolServers}
 									{generating}
@@ -2889,6 +2893,7 @@
 									bind:webSearchEnabled
 									bind:atSelectedModel
 									bind:showCommands
+									bind:selectedSkillId
 									bind:dragged
 									toolServers={$toolServers}
 									{stopResponse}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -165,11 +165,15 @@
 					access_grants: undefined
 				};
 			}),
+		selectedModels,
 		selectedToolIds,
 		selectedFilterIds,
 		imageGenerationEnabled,
 		webSearchEnabled,
-		codeInterpreterEnabled
+		codeInterpreterEnabled,
+		atSelectedModel,
+		selectedSkillId,
+		content: inputContent
 	});
 
 	const inputVariableHandler = async (text: string): Promise<string> => {
@@ -324,7 +328,7 @@
 		}
 	};
 
-	export const setText = async (text?: string, cb?: (text: string) => void) => {
+	export const setText = async (text?: string, cb?: (text: string) => void, content?: any) => {
 		const chatInput = document.getElementById('chat-input');
 
 		if (chatInput) {
@@ -332,7 +336,13 @@
 				text = await textVariableHandler(text || '');
 			}
 
-			chatInputElement?.setText(text);
+			// If TipTap JSON content is provided (e.g., from draft restore), use setContent
+			// to preserve mention nodes. Otherwise fall back to setText which creates plain text.
+			if (content?.json) {
+				chatInputElement?.setContent(content.json);
+			} else {
+				chatInputElement?.setText(text);
+			}
 			chatInputElement?.focus();
 
 			if (text !== '') {
@@ -340,6 +350,15 @@
 			}
 
 			await tick();
+
+			// Re-derive command so $ or @ suggestions re-appear after programmatic setText.
+			// After clearContent()+insert+selectNextTemplate (which finds no template),
+			// cursor is left at position 0 of empty doc, causing getWordAtDocPos() to read
+			// empty content. Fix: explicitly focus 'end' so cursor is at the actual content.
+			chatInputElement?.focus('end');
+			await tick();
+			command = getCommand();
+
 			if (cb) await cb(text);
 		}
 	};
@@ -404,6 +423,8 @@
 	$: showCommands =
 		['/', '#', '@', '$'].includes(command?.charAt(0)) || '\\#' === command?.slice(0, 2);
 	let suggestions = null;
+
+	let selectedSkillId = null;
 
 	let showTools = false;
 
@@ -993,11 +1014,16 @@
 				render: getSuggestionRenderer(CommandSuggestionList, {
 					i18n,
 					onSelect: (e) => {
+						const { type, data } = e;
+						if (type === 'skill') {
+							selectedSkillId = `${data.id}|${data.name}`;
+						}
 						document.getElementById('chat-input')?.focus();
 					},
 
 					insertTextHandler: insertTextAtCursor,
-					onUpload: () => {}
+					onUpload: () => {},
+					selectedSkillId
 				})
 			}
 		];

--- a/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
+++ b/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
@@ -11,6 +11,7 @@
 	export let onSelect = (e) => {};
 	export let onUpload = (e) => {};
 	export let insertTextHandler = (text) => {};
+	export let selectedSkillId = null;
 
 	let suggestionElement = null;
 	let filteredItems = [];
@@ -119,6 +120,7 @@
 				bind:this={suggestionElement}
 				{query}
 				bind:filteredItems
+				{selectedSkillId}
 				onSelect={(e) => {
 					const { type, data } = e;
 

--- a/src/lib/components/chat/MessageInput/Commands/Skills.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Skills.svelte
@@ -12,6 +12,23 @@
 	let selectedIdx = 0;
 	export let filteredItems = [];
 
+	export let selectedSkillId = null;
+
+	// When filteredItems loads AND selectedSkillId is set (from draft restore), highlight the matching skill
+	$: if (filteredItems.length > 0 && selectedSkillId !== null) {
+		const idx = filteredItems.findIndex((item) => `${item.id}|${item.name}` === selectedSkillId);
+		if (idx !== -1) {
+			selectedIdx = idx;
+		}
+	}
+
+	// Reset selectedSkillId when user actively searches (query changes AND skills already loaded).
+	// Don't clear if filteredItems is still empty — that means skills haven't loaded yet
+	// and selectedSkillId should be preserved for when they do (draft restore scenario).
+	$: if (query && filteredItems.length > 0) {
+		selectedSkillId = null;
+	}
+
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
 	$: if (query !== undefined) {

--- a/src/lib/components/common/RichTextInput/suggestions.ts
+++ b/src/lib/components/common/RichTextInput/suggestions.ts
@@ -87,6 +87,7 @@ export function getSuggestionRenderer(Component: any, ComponentProps = {}) {
 
 				component.$set({
 					query: props.query,
+					selectedSkillId: props.selectedSkillId,
 					command: (item) => {
 						props.command({ id: item.id, label: item.label });
 					}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on the feature. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes two related bugs in the chat input's `$` skill selection:

1. **Mention node loss on reload**: TipTap uses special mention nodes to render `@model` and `$skill` selections. Previously, only the plain-text markdown `prompt` was saved to the sessionStorage draft. On page reload, `setText()` would recreate the content from plain text, causing mention nodes to be lost (rendered as raw text like `<$visualize|Visualize>` instead of proper highlight). The fix saves `inputContent.json` to the draft and uses `setContent(json)` on restore to properly reconstruct mention nodes.

2. **Skill dropdown highlight not restored**: The blue highlight of the selected skill in the dropdown was not restored on page reload because `selectedSkillId` was never persisted. The fix adds `selectedSkillId` to the draft save/restore chain and updates `Skills.svelte` to pre-highlight the restored skill when the dropdown first loads. `selectedSkillId` is only cleared when the user actively searches (query changes after skills are already loaded), preserving the highlight during the initial API fetch window.

### Fixed
- **Chat input**: TipTap mention nodes (`$skill`, `@model`) are now preserved on page reload by saving the full TipTap JSON content to the sessionStorage draft and using `setContent(json)` on restore.
- **Chat input**: `$` skill dropdown highlight is now restored on page reload via `selectedSkillId` persistence through the draft → `CommandSuggestionList` → `Skills` prop chain.

---

### Additional Information

- Fix spans 5 files (`Chat.svelte`, `MessageInput.svelte`, `CommandSuggestionList.svelte`, `Skills.svelte`, `suggestions.ts`), 57 lines total.
- Related: Separate PR `#XXXX` for the `@` model selection persistence fix.
- Related bug report: [Chat input state persistence issue](https://github.com/open-webui/open-webui/issues/22913)

### Screenshots or Videos

**Before the fix:** After selecting a skill via `$` and refreshing the page, the skill appears as raw text like `<$open-webui-pr-copilot|Open WebUI PR Copilot v2>` instead of a proper mention node, and no dropdown highlight is shown.

<img width="2560" height="203" alt="image" src="https://github.com/user-attachments/assets/6e75ea91-cb78-4f26-a400-ec2c9e5e0f11" />

**After the fix:** The skill mention node is properly restored as a highlighted mention, and the dropdown shows the correct skill pre-selected (blue highlight).

<img width="2560" height="203" alt="image" src="https://github.com/user-attachments/assets/352867a6-3c34-41d0-8712-25fdd3c274b1" />

## Manual Verification Performed

1. Open the chat input in Open WebUI.
2. Type `$` to trigger the skill suggestion dropdown.
3. Select a skill from the dropdown (e.g., `$visualize`).
4. Confirm the skill is highlighted in blue in the input area.
5. Press F5 or refresh the page.
6. Verify the skill appears as a proper mention highlight (not raw text like `<$skill|Skill Name>`).
7. Verify the skill is shown as selected/highlighted in the dropdown when it reappears.
8. Verify no console errors appear during the restore process.
9. Test that other chat input state (text, files, tools, `@` model selection) is unaffected by this change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.