### PR TITLE
fix: dismiss mobile soft keyboard after sending message

### DIFF
--- a/src/lib/components/channel/MessageInput.svelte
+++ b/src/lib/components/channel/MessageInput.svelte
@@ -559,7 +559,13 @@
 
 			await tick();
 
-			chatInputElement.focus();
+			// On mobile, dismiss the soft keyboard after send.
+			// On desktop, keep focus in the input for rapid follow-up messages.
+			if ('ontouchstart' in window) {
+				document.activeElement?.blur();
+			} else {
+				chatInputElement.focus();
+			}
 		}
 	};
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1161,6 +1161,10 @@
 
 								if ($settings?.speechAutoSend ?? false) {
 									dispatch('submit', prompt);
+									// Dismiss mobile soft keyboard after speech auto-send
+									if ('ontouchstart' in window) {
+										document.activeElement?.blur();
+									}
 								}
 							}}
 						/>
@@ -1170,6 +1174,10 @@
 						on:submit|preventDefault={() => {
 							// check if selectedModels support image input
 							dispatch('submit', prompt);
+							// Dismiss mobile soft keyboard after send
+							if ('ontouchstart' in window) {
+								document.activeElement?.blur();
+							}
 						}}
 					>
 						<button
@@ -1462,6 +1470,10 @@
 																	e.preventDefault();
 																	if (prompt !== '' || files.length > 0) {
 																		dispatch('submit', prompt);
+																		// Dismiss mobile soft keyboard after send
+																		if ('ontouchstart' in window) {
+																			document.activeElement?.blur();
+																		}
 																	}
 																}
 															}


### PR DESCRIPTION
## Summary

On iOS Safari (both browser and PWA), the soft keyboard remains visible after sending a message. Users must manually tap the chat area to dismiss it. This degrades the mobile experience — the keyboard covers half the screen and obscures the AI response.

## Root Cause

After dispatching the submit event, no `blur()` is called on the textarea/contenteditable input. On desktop this is invisible (physical keyboard), but on mobile the soft keyboard stays open because the input retains focus.

## Fix

Call `document.activeElement?.blur()` after submit, gated behind `'ontouchstart' in window` so desktop behavior (keeping focus for rapid follow-up messages) is unchanged.

Applied to:
- **Chat `MessageInput.svelte`** — all 3 submit paths: form submit, Enter key, speech auto-send
- **Channel `MessageInput.svelte`** — replaced unconditional `chatInputElement.focus()` with mobile-aware blur/focus

## Testing

- **iOS Safari (PWA)**: Send message → keyboard dismisses → response visible immediately
- **iOS Safari (browser)**: Same behavior
- **Desktop Chrome/Firefox/Safari**: No change — input retains focus after send
- **Android Chrome**: Keyboard dismisses after send (same improvement)

## Related Issues

- #16851 — Hiding keyboard in Web App mode in iOS
- #20722 — Mobile viewport doesn't resize when keyboard appears
- #18966 — Responsive iOS PWA suggestions (maintainer said "Open to reviewing PRs!")