### PR TITLE
fix : missing edit button and empty save for markdown in terminal file

### DIFF
--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -124,6 +124,8 @@
 	$: isSvg = getFileExt(selectedFile) === 'svg';
 	$: isNotebook = getFileExt(selectedFile) === 'ipynb';
 	$: isCode = isCodeFile(selectedFile);
+	$: isPreviewFormat = isMarkdown || isCsv || isJson || isSvg || isNotebook;
+	$: isCodeEditorFile = isCode && !isPreviewFormat;
 	$: isOfficeFile = OFFICE_EXTS.has(getFileExt(selectedFile));
 	$: isTextFile =
 		fileContent !== null && fileImageUrl === null && filePdfData === null && !isOfficeFile;
@@ -745,7 +747,7 @@
 					</Tooltip>
 				{:else if isHtml}
 					<!-- HTML preview mode: no edit/save buttons -->
-				{:else if isCode}
+				{:else if isCodeEditorFile}
 					<Tooltip content={$i18n.t('Save')}>
 						<button
 							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"


### PR DESCRIPTION
### Description

- Terminal file panel: markdown was treated as a code file for the toolbar, so the Edit button was hidden and Save used `saveCodeFile()` without a mounted CodeMirror editor, which could overwrite the file with empty content. This PR uses `isPreviewFormat` / `isCodeEditorFile` so preview-first types use the textarea edit/save flow.

### Added

- `isPreviewFormat` and `isCodeEditorFile` in `FileNav.svelte`.

### Changed

- Toolbar Save for code files uses `isCodeEditorFile` instead of `isCode`.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Missing Edit control for markdown (and other preview-first types) in the terminal file panel.
- Save overwriting markdown with empty content.

### Security

- N/A

### Breaking Changes

- **BREAKING CHANGE**: N/A

---

### Additional Information

- Fixes issue with terminal file browser when opening `.md` files (pip install / Windows reported in original report).

### Screenshots or Videos

- [Optional: add before/after screenshots]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.