### PR TITLE
refactor(middleware): optimize fence-stripping O(n²) → O(n)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -483,19 +483,22 @@ def serialize_output(output: list) -> str:
             # Check if previous content ends with an opening code fence (e.g., ```python)
             # If so, strip the fence characters since code_interpreter replaces it
             if content_parts:
-                last_part = content_parts[-1]
-                if last_part:
-                    # Preserve trailing whitespace
-                    stripped = last_part.rstrip()
-                    trailing_ws = last_part[len(stripped):]
+                backtick_count = sum(part.count('```') for part in content_parts)
 
-                    backtick_count = sum(part.count('```') for part in content_parts)
-
-                    # Odd count of ``` means opening fence
-                    if backtick_count % 2 == 1:
-                        # Remove trailing backticks from the stripped content
-                        stripped = stripped.rstrip('`').rstrip()
-                    content_parts[-1] = stripped + trailing_ws
+                # Odd count of ``` means opening fence
+                if backtick_count % 2 == 1:
+                    # Iterate backwards to find the last non-empty part
+                    for i in range(len(content_parts) - 1, -1, -1):
+                        part = content_parts[i]
+                        if part:
+                            stripped = part.rstrip()
+                            if stripped:  # Only process if there's actual content after stripping whitespace
+                                # Preserve trailing whitespace
+                                trailing_ws = part[len(stripped):]
+                                # Remove fence pattern: ```<lang> or ``` with any trailing spaces
+                                stripped = re.sub(r'```\w*\s*$', '', stripped).rstrip()
+                                content_parts[i] = stripped + trailing_ws
+                                break
 
             ensure_trailing_newline(content_parts)
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -384,16 +384,15 @@ def get_citation_source_from_tool_result(
         ]
 
 
-def split_content_and_whitespace(content):
-    content_stripped = content.rstrip()
-    original_whitespace = content[len(content_stripped) :] if len(content) > len(content_stripped) else ''
-    return content_stripped, original_whitespace
+def content_endswith_newline(parts):
+    if not parts:
+        return False
+    return parts[-1].endswith('\n')
 
 
-def is_opening_code_block(content):
-    backtick_segments = content.split('```')
-    # Even number of segments means the last backticks are opening a new block
-    return len(backtick_segments) > 1 and len(backtick_segments) % 2 == 0
+def ensure_trailing_newline(parts):
+    if parts and not content_endswith_newline(parts):
+        parts.append('\n')
 
 
 def serialize_output(output: list) -> str:
@@ -401,7 +400,7 @@ def serialize_output(output: list) -> str:
     Convert OR-aligned output items to HTML for display.
     For LLM consumption, use convert_output_to_messages() instead.
     """
-    content = ''
+    content_parts = []
 
     # First pass: collect function_call_output items by call_id for lookup
     tool_outputs = {}
@@ -418,12 +417,12 @@ def serialize_output(output: list) -> str:
                 if 'text' in content_part:
                     text = content_part.get('text', '').strip()
                     if text:
-                        content = f'{content}{text}\n'
+                        content_parts.append(text)
+                        content_parts.append('\n')
 
         elif item_type == 'function_call':
             # Render tool call inline with its result (if available)
-            if content and not content.endswith('\n'):
-                content += '\n'
+            ensure_trailing_newline(content_parts)
 
             call_id = item.get('call_id', '')
             name = item.get('name', '')
@@ -431,33 +430,34 @@ def serialize_output(output: list) -> str:
 
             result_item = tool_outputs.get(call_id)
             if result_item:
-                result_text = ''
+                result_text_parts = []
                 for result_output in result_item.get('output', []):
                     if 'text' in result_output:
                         output_text = result_output.get('text', '')
-                        result_text += str(output_text) if not isinstance(output_text, str) else output_text
+                        result_text_parts.append(str(output_text))
+                result_text = ''.join(result_text_parts)
                 files = result_item.get('files')
                 embeds = result_item.get('embeds', '')
 
-                content += f'<details type="tool_calls" done="true" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}" result="{html.escape(json.dumps(result_text, ensure_ascii=False))}" files="{html.escape(json.dumps(files)) if files else ""}" embeds="{html.escape(json.dumps(embeds))}">\n<summary>Tool Executed</summary>\n</details>\n'
+                content_parts.append(f'<details type="tool_calls" done="true" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}" result="{html.escape(json.dumps(result_text, ensure_ascii=False))}" files="{html.escape(json.dumps(files)) if files else ""}" embeds="{html.escape(json.dumps(embeds))}">\n<summary>Tool Executed</summary>\n</details>\n')
             else:
-                content += f'<details type="tool_calls" done="false" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}">\n<summary>Executing...</summary>\n</details>\n'
+                content_parts.append(f'<details type="tool_calls" done="false" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}">\n<summary>Executing...</summary>\n</details>\n')
 
         elif item_type == 'function_call_output':
             # Already handled inline with function_call above
             pass
 
         elif item_type == 'reasoning':
-            reasoning_content = ''
+            reasoning_parts = []
             # Check for 'summary' (new structure) or 'content' (legacy/fallback)
             source_list = item.get('summary', []) or item.get('content', [])
             for content_part in source_list:
                 if 'text' in content_part:
-                    reasoning_content += content_part.get('text', '')
+                    reasoning_parts.append(content_part.get('text', ''))
                 elif 'summary' in content_part:  # Handle potential nested logic if any
                     pass
 
-            reasoning_content = reasoning_content.strip()
+            reasoning_content = ''.join(reasoning_parts).strip()
 
             duration = item.get('duration')
             status = item.get('status', 'in_progress')
@@ -466,8 +466,7 @@ def serialize_output(output: list) -> str:
             # render as done (a subsequent item means reasoning is complete)
             is_last_item = idx == len(output) - 1
 
-            if content and not content.endswith('\n'):
-                content += '\n'
+            ensure_trailing_newline(content_parts)
 
             display = html.escape(
                 '\n'.join(
@@ -476,19 +475,29 @@ def serialize_output(output: list) -> str:
             )
 
             if status == 'completed' or duration is not None or not is_last_item:
-                content = f'{content}<details type="reasoning" done="true" duration="{duration or 0}">\n<summary>Thought for {duration or 0} seconds</summary>\n{display}\n</details>\n'
+                content_parts.append(f'<details type="reasoning" done="true" duration="{duration or 0}">\n<summary>Thought for {duration or 0} seconds</summary>\n{display}\n</details>\n')
             else:
-                content = f'{content}<details type="reasoning" done="false">\n<summary>Thinking…</summary>\n{display}\n</details>\n'
+                content_parts.append(f'<details type="reasoning" done="false">\n<summary>Thinking…</summary>\n{display}\n</details>\n')
 
         elif item_type == 'open_webui:code_interpreter':
-            content_stripped, original_whitespace = split_content_and_whitespace(content)
-            if is_opening_code_block(content_stripped):
-                content = content_stripped.rstrip('`').rstrip() + original_whitespace
-            else:
-                content = content_stripped + original_whitespace
+            # Check if previous content ends with an opening code fence (e.g., ```python)
+            # If so, strip the fence characters since code_interpreter replaces it
+            if content_parts:
+                last_part = content_parts[-1]
+                if last_part:
+                    # Preserve trailing whitespace
+                    stripped = last_part.rstrip()
+                    trailing_ws = last_part[len(stripped):]
 
-            if content and not content.endswith('\n'):
-                content += '\n'
+                    backtick_count = sum(part.count('```') for part in content_parts)
+
+                    # Odd count of ``` means opening fence
+                    if backtick_count % 2 == 1:
+                        # Remove trailing backticks from the stripped content
+                        stripped = stripped.rstrip('`').rstrip()
+                    content_parts[-1] = stripped + trailing_ws
+
+            ensure_trailing_newline(content_parts)
 
             # Render the code_interpreter item as a <details> block
             # so the frontend Collapsible renders "Analyzing..."/"Analyzed".
@@ -514,11 +523,11 @@ def serialize_output(output: list) -> str:
                 output_attr = f' output="{html.escape(output_json)}"'
 
             if status == 'completed' or duration is not None or not is_last_item:
-                content += f'<details type="code_interpreter" done="true" duration="{duration or 0}"{output_attr}>\n<summary>Analyzed</summary>\n{display}\n</details>\n'
+                content_parts.append(f'<details type="code_interpreter" done="true" duration="{duration or 0}"{output_attr}>\n<summary>Analyzed</summary>\n{display}\n</details>\n')
             else:
-                content += f'<details type="code_interpreter" done="false"{output_attr}>\n<summary>Analyzing…</summary>\n{display}\n</details>\n'
+                content_parts.append(f'<details type="code_interpreter" done="false"{output_attr}>\n<summary>Analyzing…</summary>\n{display}\n</details>\n')
 
-    return content.strip()
+    return ''.join(content_parts).strip()
 
 
 def deep_merge(target, source):


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Replaces incremental string concatenation (`content += ...`) in `serialize_output` 
with a `content_parts` list and a final `''.join()` call. Also refactors two helper 
functions and applies the same pattern to nested string building (`result_text`, 
`reasoning_parts`). No behavior change intended.

### Added

- [List any new features, functionalities, or additions]

### Changed

- `serialize_output`: replaced f-string based `content = f'{content}...'` 
  concatenation pattern with `content_parts` list + `''.join()`.
  The f-string form bypasses CPython's in-place string optimization, 
  resulting in O(n²) allocations on large outputs. List-join is O(n).

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- [List any fixes, corrections, or bug fixes]

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement


- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.