### PR TITLE
fix: resolve unhandled 500 error on unauthenticated api requests

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -771,6 +771,25 @@
 	};
 
 	onMount(async () => {
+		const API_PATHS = ['/api/', '/ollama/', '/openai/', '/ws/'];
+		let handlingAuthRedirect = false;
+		const originalFetch = window.fetch;
+		window.fetch = async (...args) => {
+			const response = await originalFetch(...args);
+			if (response.status === 401 && !handlingAuthRedirect) {
+				const input = args[0];
+				const href = input instanceof Request ? input.url : String(input);
+				const pathname = href.startsWith('/') ? href : new URL(href, location.origin).pathname;
+				if (API_PATHS.some((p) => pathname.startsWith(p))) {
+					handlingAuthRedirect = true;
+					user.set(null);
+					localStorage.removeItem('token');
+					location.reload();
+				}
+			}
+			return response;
+		};
+
 		window.addEventListener('message', windowMessageEventHandler);
 
 		let touchstartY = 0;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [ ] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR resolves the problems outlined in issue #21072 where users sometimes encounter error pages with messages such as "500: Internal Error" or "Open WebUI Backend Required". This happens when using authenticating reverse-proxies which is required for trusted header authentication. As described in the issue, unauthenticated background API requests are redirected to the identity provider for re-authentication, but they're blocked by the browser since this violates CORS policy. This behavior is expected, and redirecting background requests should probably not be supported

Ideally the browser would refresh the user's session token before it expires by reaching out to the identity provider, but there is currently no support for this in Open WebUI. If a refresh doesn't happen in time, it is generally best to deny background API requests by returning a 401 after a user session has expired and let the frontend decide what to do. Open WebUI doesn't handle this case either which results in the same issues that come from CORS violations. This PR implements a fix to handle these cases where 401s occur

### Fixed

- A 401 handler is added to `+layout.svelte` in this PR in order to catch unauthenticated background requests and trigger re-authentication. This is done by catching all 401s returned from internal requests to API paths ("/api/", "/ollama/", "/openai/", "/ws/"). Once caught, the current page is reloaded. This triggers a top-level request allowing redirection to the identity provider which does not violate CORS policy. So the reverse-proxy would need to be configured to deny unauthenticated requests on API paths and redirect unauthenticated requests on all other paths

---

### Additional Information

This fix can be observed by running an openresty nginx reverse-proxy locally using the docker compose and nginx config below. Headers required for trusted header authentication are attached in this nginx container. Requests to API paths are rejected when the reverse-proxy is in an "unauthenticated" state which is reached 15 seconds after the previous 401 was fired. This is to simulate token expiry with a short enough window for observation. This setup is used in the before/after videos in the screenshot/video section

`docker-compose.yml`

```yaml
services:
  loadbalancer:
    image: openresty/openresty:alpine
    container_name: loadbalancer
    ports:
      - 5000:5000
    volumes:
      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
```

`nginx.conf`

```lua
worker_processes 1;

events {
    worker_connections 1024;
}

http {
    lua_shared_dict test_state 1m;

    server {
        listen 5000;

        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header x-user-email "john.smith@gmail.com";
        proxy_set_header x-user-name "John Smith";
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";

        location ~* ^/(api|ollama|openai|ws)/ {
            access_by_lua_block {
                local shared = ngx.shared.test_state
                if not shared:get("authenticated") then
                    shared:set("authenticated", true, 15)
                    ngx.exit(401);
                end
            }
            proxy_pass http://host.docker.internal:5173;
        }

        location / {
            proxy_pass http://host.docker.internal:5173;
        }
    }
}
```

The following changes need to be made in the dev environment to support the reverse-proxy setup described above:

`vite.config.ts`

```typescript
export default defineConfig({
    server: {
        proxy: {
            '/api': 'http://localhost:8080',
            '/ollama': 'http://localhost:8080',
            '/openai': 'http://localhost:8080',
            '/ws': { target: 'ws://localhost:8080', ws: true }
        }
    },
```

`.env`

```bash
WEBUI_AUTH_TRUSTED_EMAIL_HEADER='x-user-email'
WEBUI_AUTH_TRUSTED_NAME_HEADER='x-user-name'
```

`src/lib/constants.ts`

```typescript
export const WEBUI_HOSTNAME = browser ? (dev ? location.host : ``) : '';
export const WEBUI_BASE_URL = browser ? (dev ? `${location.protocol}//${WEBUI_HOSTNAME}` : ``) : ``;
```

`backend/dev.sh`

```bash
export CORS_ALLOW_ORIGIN="http://localhost:5173;http://localhost:8080;http://localhost:5000"
```

### Screenshots or Videos

The videos below demonstrate how the frontend behaves with the reverse-proxy setup described above before and after adding a handler to `+layout.svelte`. In both videos, there's an attempt to navigate to "Workspace". This causes stalling with a loading spinner before the fix, but re-authentication is observed after the fix. An attempt is also made to reload the page in the first video which results in the "Open WebUI Backend Required" page due to a failed background request to /api/config as observed in the originally reported issue. This again triggers re-authentication which resolves the problem as shown in the second video

Before fix:
https://github.com/user-attachments/assets/e4ad3412-638b-4d25-a55a-00ae2798b187

After fix:
https://github.com/user-attachments/assets/2a1b9400-a8a7-4749-a1b3-5cc2c42489c6

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
