### PR TITLE
perf(utils): convert action/filter lists to sets for O(1) lookup

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -130,11 +130,11 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
             ]
         models = models + arena_models
 
-    global_action_ids = [function.id for function in Functions.get_global_action_functions()]
-    enabled_action_ids = [function.id for function in Functions.get_functions_by_type('action', active_only=True)]
+    global_action_ids = {function.id for function in Functions.get_global_action_functions()}
+    enabled_action_ids = {function.id for function in Functions.get_functions_by_type('action', active_only=True)}
 
-    global_filter_ids = [function.id for function in Functions.get_global_filter_functions()]
-    enabled_filter_ids = [function.id for function in Functions.get_functions_by_type('filter', active_only=True)]
+    global_filter_ids = {function.id for function in Functions.get_global_filter_functions()}
+    enabled_filter_ids = {function.id for function in Functions.get_functions_by_type('filter', active_only=True)}
 
     custom_models = Models.get_all_models()
 

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -328,14 +328,14 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     for model in models:
         action_ids = [
             action_id
-            for action_id in list(set(model.pop('action_ids', []) + global_action_ids))
+            for action_id in list(set(model.pop('action_ids', [])) | global_action_ids)
             if action_id in enabled_action_ids
         ]
         action_ids.sort(key=lambda aid: (get_action_priority(aid), aid))
 
         filter_ids = [
             filter_id
-            for filter_id in list(set(model.pop('filter_ids', []) + global_filter_ids))
+            for filter_id in list(set(model.pop('filter_ids', [])) | global_filter_ids)
             if filter_id in enabled_filter_ids
         ]
 


### PR DESCRIPTION
### Description

Replaced list comprehensions with set comprehensions for action and filter ID collections. This changes lookup complexity from O(n) to O(1) when checking if an action/filter ID is enabled.

### Changed

Optimized action/filter ID lookups in `get_all_models()` by using sets instead of lists

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
