### PR TITLE
fix: restore markdown text editing in Open Terminal

### DIFF
--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -26,7 +26,7 @@
 		setCwd,
 		type FileEntry
 	} from '$lib/apis/terminal';
-	import { isCodeFile } from '$lib/utils/codeHighlight';
+	import { isCodeEditorFile } from '$lib/utils/codeHighlight';
 	import Folder from '../icons/Folder.svelte';
 	import Document from '../icons/Document.svelte';
 	import PenAlt from '../icons/PenAlt.svelte';
@@ -124,7 +124,7 @@
 	$: isJson = ['json', 'jsonc', 'jsonl', 'json5'].includes(getFileExt(selectedFile));
 	$: isSvg = getFileExt(selectedFile) === 'svg';
 	$: isNotebook = getFileExt(selectedFile) === 'ipynb';
-	$: isCode = isCodeFile(selectedFile);
+	$: isCode = isCodeEditorFile(selectedFile);
 	$: isOfficeFile = OFFICE_EXTS.has(getFileExt(selectedFile));
 	$: isTextFile =
 		fileContent !== null && fileImageUrl === null && filePdfData === null && !isOfficeFile;

--- a/src/lib/components/chat/FileNav/FilePreview.svelte
+++ b/src/lib/components/chat/FileNav/FilePreview.svelte
@@ -4,7 +4,7 @@
 	import { marked } from 'marked';
 	import DOMPurify from 'dompurify';
 	import { settings } from '$lib/stores';
-	import { isCodeFile } from '$lib/utils/codeHighlight';
+	import { isCodeEditorFile } from '$lib/utils/codeHighlight';
 	import { initMermaid, renderMermaidDiagram } from '$lib/utils';
 	import Spinner from '../../common/Spinner.svelte';
 	import PDFViewer from '../../common/PDFViewer.svelte';
@@ -101,7 +101,7 @@
 	$: isJson = JSON_EXTS.has(getExt(selectedFile));
 	$: isSvg = getExt(selectedFile) === 'svg';
 	$: isNotebook = getExt(selectedFile) === 'ipynb';
-	$: isCode = isCodeFile(selectedFile);
+	$: isCode = isCodeEditorFile(selectedFile);
 	$: csvDelimiter = getExt(selectedFile) === 'tsv' ? '\t' : ',';
 	$: renderedHtml =
 		isMarkdown && fileContent

--- a/src/lib/utils/codeHighlight.test.ts
+++ b/src/lib/utils/codeHighlight.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCodeEditorFile, isCodeFile } from './codeHighlight';
+
+describe('isCodeEditorFile', () => {
+	it('keeps markdown files on the plain-text editor path', () => {
+		expect(isCodeFile('/notes/readme.md')).toBe(true);
+		expect(isCodeEditorFile('/notes/readme.md')).toBe(false);
+		expect(isCodeEditorFile('/notes/guide.markdown')).toBe(false);
+		expect(isCodeEditorFile('/notes/component.mdx')).toBe(false);
+	});
+
+	it('still treats regular code files as code-editor files', () => {
+		expect(isCodeEditorFile('/src/example.ts')).toBe(true);
+		expect(isCodeEditorFile('/config/docker-compose.yml')).toBe(true);
+	});
+});

--- a/src/lib/utils/codeHighlight.ts
+++ b/src/lib/utils/codeHighlight.ts
@@ -143,6 +143,8 @@ const KNOWN_LANG_IDS = new Set([
 	'zig'
 ]);
 
+const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
+
 /**
  * Resolve a file extension to a Shiki language id, or null if not supported.
  */
@@ -162,6 +164,16 @@ export function isCodeFile(path: string | null): boolean {
 	if (!path) return false;
 	const ext = path.split('.').pop()?.toLowerCase() ?? '';
 	return extToLang(ext) !== null;
+}
+
+/**
+ * Returns true when a file should use the code-editor path in file navigation.
+ * Markdown files keep their preview/plain-text edit flow instead.
+ */
+export function isCodeEditorFile(path: string | null): boolean {
+	if (!path) return false;
+	const ext = path.split('.').pop()?.toLowerCase() ?? '';
+	return !MARKDOWN_EXTENSIONS.has(ext) && isCodeFile(path);
 }
 
 /**


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** I personally tested all changes in this PR and verified the fix and surrounding behavior with the steps listed below.
- [ ] **Agentic AI Code:** This patch was prepared with AI assistance. The author manually tested the change before submission, but I am not claiming additional human code review beyond that.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Restore the plain-text edit/save flow for markdown files in Open Terminal file navigation.

### Added

- A focused regression test for `isCodeEditorFile()` covering markdown and normal code-file extensions.

### Changed

- Markdown files now stay on the preview + text editing path instead of being routed through the code-editor save flow.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Restored the `Edit` action for `.md`, `.markdown`, and `.mdx` files in Open Terminal.
- Prevented markdown preview mode from saving empty content through the code-editor toolbar action.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Root cause: markdown extensions were classified as code-editor files because `isCodeFile()` follows syntax-highlighting support, but FileNav renders markdown via the preview/text-editing path instead of `FileCodeEditor`.
- Manual verification performed by the author:
  - Open a `.md` file in Open Terminal and confirm the `Edit` button appears.
  - Edit and save markdown content and confirm the content persists.
  - Open `.ts` and `.yml` files and confirm they still use the existing code-editor flow.
- Automated verification:
  - `npx -y node@22 node_modules/vitest/vitest.mjs run src/lib/utils/codeHighlight.test.ts --reporter=basic`

Closes #22916

### Screenshots or Videos

- Not included for this small toolbar/edit-flow fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
