### PR TITLE
fix: move code interpreter prompt from user turn to system prompt

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2384,7 +2384,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 if engine != "jupyter":
                     prompt += CODE_INTERPRETER_PYODIDE_PROMPT
 
-                form_data["messages"] = add_or_update_user_message(
+                form_data["messages"] = add_or_update_system_message(
                     prompt,
                     form_data["messages"],
                 )
@@ -2392,7 +2392,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 # Native FC: tool docstring can't be dynamic, so inject
                 # filesystem context into messages for pyodide engine
                 if engine != "jupyter":
-                    form_data["messages"] = add_or_update_user_message(
+                    form_data["messages"] = add_or_update_system_message(
                         CODE_INTERPRETER_PYODIDE_PROMPT,
                         form_data["messages"],
                     )


### PR DESCRIPTION
The code interpreter prompt (Pyodide) was being injected into the user turn via add_or_update_user_message, creating a prompt injection vulnerability — a user could override the instructions by modifying their message.

Changed add_or_update_user_message to add_or_update_system_message so the code interpreter prompt is injected as a system message where it cannot be tampered with by the user.

Fixes #22965