### PR TITLE
fix(chat): remove unexpected 'db' kwarg from upsert_message function

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1024,7 +1024,6 @@ async def update_chat_message_by_id(
         {
             "content": form_data.content,
         },
-        db=db,
     )
 
     event_emitter = get_event_emitter(


### PR DESCRIPTION
Fixes #22959. The `upsert_message_to_chat_by_id_and_message_id` function in `backend/open_webui/models/chats.py` does not accept a `db` parameter, but a call site in `backend/open_webui/routers/chats.py` was passing `db=db`. This caused a `TypeError: upsert_message_to_chat_by_id_and_message_id() got an unexpected keyword argument 'db'`.

**Fix:** Removed the extraneous `db=db` argument from the call site in `routers/chats.py`.