### PR TITLE
fix(ui): use default model for new chat instead of inheriting current model

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1112,9 +1112,11 @@
 		await showCallOverlay.set(false);
 		await showArtifacts.set(false);
 
-		if ($page.url.pathname.includes('/c/')) {
-			window.history.replaceState(history.state, '', `/`);
-		}
+		// Clear model search params so new chat uses configured default instead of inherited model
+		const url = new URL(window.location.href);
+		url.searchParams.delete('models');
+		url.searchParams.delete('model');
+		window.history.replaceState(history.state, '', url.pathname + url.search);
 
 		autoScroll = true;
 


### PR DESCRIPTION
## Description
When clicking 'New Chat' while viewing an active chat with a non-default model, the new chat incorrectly inherits the current model instead of using the configured default model.

### Root Cause
The model selector persists the selected model in the URL search params (?models=...). When navigating to a new chat via 'New Chat', the URL is not cleared of these model search params, causing the Chat component's init() to read the stale model from the URL instead of using the configured default.

### Fix
Clear the 'models' and 'model' URL search params when resetting state for a new chat, ensuring the configured default model is always used.

### Steps to Reproduce (before fix)
1. Configure a default model in Admin/User settings (Model A)
2. Start a chat and switch to a different model (Model B)
3. Click 'New Chat' while Model B is active
4. New chat incorrectly uses Model B instead of Model A

### Steps to Verify (after fix)
1. Configure a default model (Model A)
2. Start a chat and switch to a different model (Model B)
3. Click 'New Chat'
4. New chat now correctly uses Model A

Fixes #22957