### PR TITLE
fix(chats): remove errant db= kwarg from upsert_message call

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1024,7 +1024,6 @@ async def update_chat_message_by_id(
         {
             "content": form_data.content,
         },
-        db=db,
     )
 
     event_emitter = get_event_emitter(


### PR DESCRIPTION
The `update_chat_message_by_id` endpoint was passing `db=db` to `upsert_message_to_chat_by_id_and_message_id`, which doesn't accept that parameter — causing a TypeError on the `POST /api/v1/chats/{id}/messages/{messageId}` endpoint.

Removed the spurious `db=db` argument. Fixes #22959.