### PR TITLE
fix(code-interpreter): inject Pyodide prompt into system message not user turn

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2384,17 +2384,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 if engine != "jupyter":
                     prompt += CODE_INTERPRETER_PYODIDE_PROMPT
 
-                form_data["messages"] = add_or_update_user_message(
+                form_data["messages"] = add_or_update_system_message(
                     prompt,
                     form_data["messages"],
+                    append=True,
                 )
             else:
                 # Native FC: tool docstring can't be dynamic, so inject
                 # filesystem context into messages for pyodide engine
                 if engine != "jupyter":
-                    form_data["messages"] = add_or_update_user_message(
+                    form_data["messages"] = add_or_update_system_message(
                         CODE_INTERPRETER_PYODIDE_PROMPT,
                         form_data["messages"],
+                        append=True,
                     )
 
     tool_ids = form_data.pop("tool_ids", None)


### PR DESCRIPTION
The code interpreter prompt (Pyodide) was injected into the user turn via add_or_update_user_message, creating a prompt injection vulnerability where a user could override the code interpreter instructions.

Changed add_or_update_user_message to add_or_update_system_message so the code interpreter prompt is injected as a system message where it cannot be tampered with by the user.

Fixes #22965