### PR TITLE
fix: correct typos in elasticsearch.py and KnowledgeBase.svelte

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -30,8 +30,8 @@ class ElasticsearchClient(VectorDBBase):
     """
     Important:
     in order to reduce the number of indexes and since the embedding vector length is fixed, we avoid creating
-    an index for each file but store it as a text field, while seperating to different index
-    baesd on the embedding length.
+    an index for each file but store it as a text field, while separating to different index
+    based on the embedding length.
     """
 
     def __init__(self):

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -669,7 +669,7 @@
 					continue;
 				}
 
-				// Not sure why you have to call webkitGetAsEntry and isDirectory seperate, but it won't work if you try item.webkitGetAsEntry().isDirectory
+				// Not sure why you have to call webkitGetAsEntry and isDirectory separately, but it won't work if you try item.webkitGetAsEntry().isDirectory
 				const wkentry = item.webkitGetAsEntry();
 				const isDirectory = wkentry.isDirectory;
 				if (isDirectory) {


### PR DESCRIPTION
## Summary
This PR fixes three typos found in code comments:

### Changes
- `seperating` → `separating` in `backend/open_webui/retrieval/vector/dbs/elasticsearch.py`
- `baesd` → `based` in `backend/open_webui/retrieval/vector/dbs/elasticsearch.py`
- `seperate` → `separately` in `src/lib/components/workspace/Knowledge/KnowledgeBase.svelte`

### Type of Change
- [x] Documentation (typo fix in code comments)

These are minor cosmetic changes with no impact on functionality.