### PR TITLE
feat: enable Terminals K8s Orchestrator policy management in Open WebUI

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -255,6 +255,130 @@ async def set_terminal_servers_config(
     }
 
 
+@router.post('/terminal_servers/verify')
+async def verify_terminal_servers_config(
+    request: Request,
+    form_data: TerminalServerConnection,
+    user=Depends(get_admin_user),
+):
+    """
+    Verify the connection to a terminal server and detect its type.
+
+    Returns {"status": True, "server_type": "orchestrator" | "terminal"}
+    """
+    base_url = form_data.url.rstrip('/')
+    headers = {'X-User-Id': user.id}
+
+    if form_data.auth_type == 'bearer' and form_data.key:
+        headers['Authorization'] = f'Bearer {form_data.key}'
+    elif form_data.auth_type == 'session':
+        headers['Authorization'] = f'Bearer {request.state.token.credentials}'
+    elif form_data.auth_type == 'system_oauth':
+        try:
+            if request.cookies.get('oauth_session_id', None):
+                oauth_token = await request.app.state.oauth_manager.get_oauth_token(
+                    user.id,
+                    request.cookies.get('oauth_session_id', None),
+                )
+                if oauth_token:
+                    headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+        except Exception:
+            pass
+
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        # Orchestrators expose a policies API; plain terminals don't.
+        try:
+            async with session.get(f'{base_url}/api/v1/policies', headers=headers) as resp:
+                if resp.ok:
+                    return {'status': True, 'server_type': 'orchestrator'}
+        except Exception:
+            pass
+
+        # Fall back to open-terminal config endpoint.
+        try:
+            async with session.get(f'{base_url}/api/config', headers=headers) as resp:
+                if resp.ok:
+                    return {'status': True, 'server_type': 'terminal'}
+        except Exception:
+            pass
+
+    raise HTTPException(
+        status_code=400,
+        detail='Failed to connect to the terminal server',
+    )
+
+
+class TerminalServerPolicyForm(BaseModel):
+    url: str
+    key: Optional[str] = ''
+    auth_type: Optional[str] = 'bearer'
+    policy_id: str
+    policy_data: dict
+
+
+@router.post('/terminal_servers/policy')
+async def put_terminal_server_policy(
+    request: Request,
+    form_data: TerminalServerPolicyForm,
+    user=Depends(get_admin_user),
+):
+    """
+    Create or update a policy on an orchestrator.
+    """
+    base_url = form_data.url.rstrip('/')
+    headers = {'Content-Type': 'application/json', 'X-User-Id': user.id}
+
+    if form_data.auth_type == 'bearer' and form_data.key:
+        headers['Authorization'] = f'Bearer {form_data.key}'
+    elif form_data.auth_type == 'session':
+        headers['Authorization'] = f'Bearer {request.state.token.credentials}'
+    elif form_data.auth_type == 'system_oauth':
+        try:
+            if request.cookies.get('oauth_session_id', None):
+                oauth_token = await request.app.state.oauth_manager.get_oauth_token(
+                    user.id,
+                    request.cookies.get('oauth_session_id', None),
+                )
+                if oauth_token:
+                    headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+        except Exception:
+            pass
+
+    import json
+
+    policy_url = f'{base_url}/api/v1/policies/{form_data.policy_id}'
+
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        try:
+            async with session.put(
+                policy_url,
+                headers=headers,
+                data=json.dumps(form_data.policy_data),
+            ) as resp:
+                if resp.ok:
+                    return await resp.json()
+
+                error_body = await resp.text()
+                raise HTTPException(
+                    status_code=resp.status,
+                    detail=f'Orchestrator returned {resp.status}: {error_body}',
+                )
+        except HTTPException:
+            raise
+        except Exception as e:
+            log.debug(f'Failed to save policy to orchestrator: {e}')
+            raise HTTPException(
+                status_code=400,
+                detail='Failed to connect to the orchestrator',
+            )
+
+
 @router.post('/tool_servers/verify')
 async def verify_tool_servers_config(request: Request, form_data: ToolServerConnection, user=Depends(get_admin_user)):
     """

--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -1,10 +1,21 @@
 """Reverse proxy for admin-configured terminal servers.
 
 Routes:
-  GET  /                         — list terminals the user has access to
-  *    /{server_id}/{path:path}  — proxy request to terminal server
+  GET  /                                   — list terminals the user has access to
+  *    /{server_id}/{path:path}            — proxy request to terminal server
+
+  Admin API (policy CRUD, instance management, server info):
+  GET    /{server_id}/api/v1/policies          — list policies
+  POST   /{server_id}/api/v1/policies          — create policy
+  GET    /{server_id}/api/v1/policies/{pid}    — get policy
+  PUT    /{server_id}/api/v1/policies/{pid}    — upsert policy
+  DELETE /{server_id}/api/v1/policies/{pid}    — delete policy
+  GET    /{server_id}/api/v1/instances         — list terminal instances
+  DELETE /{server_id}/api/v1/instances/{iid}   — teardown instance
+  GET    /{server_id}/api/v1/info              — server info
 """
 
+import json as _json
 import logging
 import posixpath
 from urllib.parse import unquote
@@ -14,7 +25,7 @@ from fastapi import APIRouter, Depends, Request, Response, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask
 
-from open_webui.utils.auth import get_verified_user
+from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_connection_access
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
@@ -58,6 +69,163 @@ async def list_terminal_servers(request: Request, user=Depends(get_verified_user
         if connection.get('enabled', True) and has_connection_access(user, connection, user_group_ids)
     ]
 
+
+# ---------------------------------------------------------------------------
+# Admin API helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_admin_connection(request: Request, server_id: str) -> dict | None:
+    """Look up a terminal server connection by ID."""
+    connections = request.app.state.config.TERMINAL_SERVER_CONNECTIONS or []
+    return next((c for c in connections if c.get('id') == server_id), None)
+
+
+def _build_admin_headers(connection: dict) -> dict[str, str]:
+    """Build authentication headers for proxying to a terminal server."""
+    headers: dict[str, str] = {'Content-Type': 'application/json'}
+    auth_type = connection.get('auth_type', 'bearer')
+    if auth_type == 'bearer':
+        key = connection.get('key', '')
+        if key:
+            headers['Authorization'] = f'Bearer {key}'
+    return headers
+
+
+async def _admin_proxy_json(
+    connection: dict,
+    method: str,
+    path: str,
+    body: dict | None = None,
+) -> Response:
+    """Proxy a JSON request to a terminal server's API and return the response."""
+    base_url = (connection.get('url') or '').rstrip('/')
+    if not base_url:
+        return JSONResponse({'error': 'Terminal server URL not configured'}, status_code=503)
+
+    url = f'{base_url}/{path}'
+    headers = _build_admin_headers(connection)
+
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=30, connect=10),
+    ) as session:
+        try:
+            kwargs: dict = {'headers': headers}
+            if body is not None:
+                kwargs['data'] = _json.dumps(body)
+
+            async with session.request(method, url, **kwargs) as resp:
+                response_body = await resp.read()
+                filtered_headers = {
+                    key: value
+                    for key, value in resp.headers.items()
+                    if key.lower() not in STRIPPED_RESPONSE_HEADERS
+                }
+                return Response(
+                    content=response_body,
+                    status_code=resp.status,
+                    headers=filtered_headers,
+                )
+        except Exception as e:
+            log.exception('Admin proxy error: %s', e)
+            return JSONResponse({'error': f'Terminal server unreachable: {e}'}, status_code=502)
+
+
+# ---------------------------------------------------------------------------
+# Policy CRUD proxy
+# ---------------------------------------------------------------------------
+
+
+@router.get('/{server_id}/api/v1/policies')
+async def list_policies(server_id: str, request: Request, user=Depends(get_admin_user)):
+    """List all policies on a terminal orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'GET', 'api/v1/policies')
+
+
+@router.post('/{server_id}/api/v1/policies')
+async def create_policy(server_id: str, request: Request, user=Depends(get_admin_user)):
+    """Create a new policy on a terminal orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    body = await request.json()
+    return await _admin_proxy_json(connection, 'POST', 'api/v1/policies', body)
+
+
+@router.get('/{server_id}/api/v1/policies/{policy_id}')
+async def get_policy(server_id: str, policy_id: str, request: Request, user=Depends(get_admin_user)):
+    """Get a single policy from a terminal orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'GET', f'api/v1/policies/{policy_id}')
+
+
+@router.put('/{server_id}/api/v1/policies/{policy_id}')
+async def upsert_policy(server_id: str, policy_id: str, request: Request, user=Depends(get_admin_user)):
+    """Create or update a policy on a terminal orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    body = await request.json()
+    return await _admin_proxy_json(connection, 'PUT', f'api/v1/policies/{policy_id}', body)
+
+
+@router.delete('/{server_id}/api/v1/policies/{policy_id}')
+async def delete_policy(server_id: str, policy_id: str, request: Request, user=Depends(get_admin_user)):
+    """Delete a policy from a terminal orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'DELETE', f'api/v1/policies/{policy_id}')
+
+
+# ---------------------------------------------------------------------------
+# Instance management proxy
+# ---------------------------------------------------------------------------
+
+
+@router.get('/{server_id}/api/v1/instances')
+async def list_instances(server_id: str, request: Request, user=Depends(get_admin_user)):
+    """List all active terminal instances on an orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'GET', 'api/v1/instances')
+
+
+@router.delete('/{server_id}/api/v1/instances/{instance_id}')
+async def teardown_instance(
+    server_id: str, instance_id: str, request: Request, user=Depends(get_admin_user),
+):
+    """Force-teardown a terminal instance on an orchestrator."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'DELETE', f'api/v1/instances/{instance_id}')
+
+
+# ---------------------------------------------------------------------------
+# Server info proxy
+# ---------------------------------------------------------------------------
+
+
+@router.get('/{server_id}/api/v1/info')
+async def get_server_info(server_id: str, request: Request, user=Depends(get_admin_user)):
+    """Get info about a terminal server (backend type, resource caps, etc.)."""
+    connection = _resolve_admin_connection(request, server_id)
+    if connection is None:
+        return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
+    return await _admin_proxy_json(connection, 'GET', 'api/v1/info')
+
+
+# ---------------------------------------------------------------------------
+# Catch-all proxy
+# ---------------------------------------------------------------------------
 
 PROXY_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
 

--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -191,11 +191,36 @@ async def delete_policy(server_id: str, policy_id: str, request: Request, user=D
 
 @router.get('/{server_id}/api/v1/instances')
 async def list_instances(server_id: str, request: Request, user=Depends(get_admin_user)):
-    """List all active terminal instances on an orchestrator."""
+    """List all active terminal instances on an orchestrator.
+
+    Enriches each instance with ``user_name`` resolved from the Open WebUI
+    users table so the admin UI can show human-readable names.
+    """
     connection = _resolve_admin_connection(request, server_id)
     if connection is None:
         return JSONResponse({'error': 'Terminal server not found'}, status_code=404)
-    return await _admin_proxy_json(connection, 'GET', 'api/v1/instances')
+
+    resp = await _admin_proxy_json(connection, 'GET', 'api/v1/instances')
+
+    # Enrich with user names when we successfully got a JSON list back.
+    if resp.status_code == 200:
+        try:
+            instances = _json.loads(resp.body)
+            if isinstance(instances, list):
+                user_ids = {inst.get('user_id') for inst in instances if inst.get('user_id')}
+                user_map = {}
+                for uid in user_ids:
+                    u = Users.get_user_by_id(uid)
+                    if u:
+                        user_map[uid] = u.name
+                for inst in instances:
+                    uid = inst.get('user_id', '')
+                    inst['user_name'] = user_map.get(uid, '')
+                return JSONResponse(instances)
+        except Exception:
+            pass  # Return the original response on any parse error
+
+    return resp
 
 
 @router.delete('/{server_id}/api/v1/instances/{instance_id}')

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -231,65 +231,67 @@ export const setTerminalServerConnections = async (token: string, connections: o
 
 /**
  * Detect whether a terminal server URL points to an Orchestrator or a direct
- * Open Terminal instance.
- *
- * - GET {url}/api/v1/policies → 200 → "orchestrator"
- * - GET {url}/api/config      → 200 → "terminal"
- * - Neither                         → null
+ * Open Terminal instance.  Proxied through the backend so cluster-internal
+ * URLs are reachable.
  */
 export const detectTerminalServerType = async (
-	url: string,
-	key: string
+	token: string,
+	connection: object
 ): Promise<'orchestrator' | 'terminal' | null> => {
-	const baseUrl = url.replace(/\/$/, '');
-	const headers: Record<string, string> = {};
-	if (key) {
-		headers['Authorization'] = `Bearer ${key}`;
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/terminal_servers/verify`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ ...connection })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
 	}
 
-	// Orchestrators expose a policies API; plain terminals don't.
-	try {
-		const res = await fetch(`${baseUrl}/api/v1/policies`, { headers });
-		if (res.ok) return 'orchestrator';
-	} catch {
-		// ignore
-	}
-
-	// Fall back to open-terminal config endpoint.
-	try {
-		const res = await fetch(`${baseUrl}/api/config`, { headers });
-		if (res.ok) return 'terminal';
-	} catch {
-		// ignore
-	}
-
-	return null;
+	return res?.server_type ?? null;
 };
 
 /**
- * Create or update a policy on the orchestrator.
- * PUT {url}/api/v1/policies/{policyId}
+ * Create or update a policy on the orchestrator, proxied through the backend
+ * so cluster-internal URLs are reachable.
  */
 export const putOrchestratorPolicy = async (
+	token: string,
 	url: string,
 	key: string,
+	authType: string,
 	policyId: string,
 	policyData: object
 ): Promise<object | null> => {
 	let error = null;
 
-	const baseUrl = url.replace(/\/$/, '');
-	const headers: Record<string, string> = {
-		'Content-Type': 'application/json'
-	};
-	if (key) {
-		headers['Authorization'] = `Bearer ${key}`;
-	}
-
-	const res = await fetch(`${baseUrl}/api/v1/policies/${encodeURIComponent(policyId)}`, {
-		method: 'PUT',
-		headers,
-		body: JSON.stringify(policyData)
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/terminal_servers/policy`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			url,
+			key,
+			auth_type: authType,
+			policy_id: policyId,
+			policy_data: policyData
+		})
 	})
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();

--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -336,3 +336,177 @@ export const stopNotebookSession = async (
 	}).catch(() => null);
 	return res?.ok ?? false;
 };
+
+// ---------------------------------------------------------------------------
+// Admin API — Policy CRUD (proxied through Open WebUI backend)
+// ---------------------------------------------------------------------------
+
+export type PolicyData = {
+	image?: string;
+	env?: Record<string, string>;
+	cpu_limit?: string;
+	memory_limit?: string;
+	storage?: string;
+	storage_mode?: string;
+	idle_timeout_minutes?: number;
+};
+
+export type PolicyResponse = {
+	id: string;
+	data: PolicyData;
+	created_at?: string;
+	updated_at?: string;
+};
+
+export const listPolicies = async (
+	token: string,
+	serverId: string
+): Promise<PolicyResponse[]> => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/policies`, {
+		headers: { Authorization: `Bearer ${token}` }
+	}).catch(() => null);
+	if (!res || !res.ok) return [];
+	return res.json().catch(() => []);
+};
+
+export const createPolicy = async (
+	token: string,
+	serverId: string,
+	policyId: string,
+	data: PolicyData
+): Promise<PolicyResponse | null> => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/policies`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ id: policyId, data })
+	}).catch(() => null);
+	if (!res || !res.ok) return null;
+	return res.json().catch(() => null);
+};
+
+export const getPolicy = async (
+	token: string,
+	serverId: string,
+	policyId: string
+): Promise<PolicyResponse | null> => {
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/policies/${encodeURIComponent(policyId)}`,
+		{
+			headers: { Authorization: `Bearer ${token}` }
+		}
+	).catch(() => null);
+	if (!res || !res.ok) return null;
+	return res.json().catch(() => null);
+};
+
+export const updatePolicy = async (
+	token: string,
+	serverId: string,
+	policyId: string,
+	data: PolicyData
+): Promise<PolicyResponse | null> => {
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/policies/${encodeURIComponent(policyId)}`,
+		{
+			method: 'PUT',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify(data)
+		}
+	).catch(() => null);
+	if (!res || !res.ok) return null;
+	return res.json().catch(() => null);
+};
+
+export const deletePolicy = async (
+	token: string,
+	serverId: string,
+	policyId: string
+): Promise<boolean> => {
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/policies/${encodeURIComponent(policyId)}`,
+		{
+			method: 'DELETE',
+			headers: { Authorization: `Bearer ${token}` }
+		}
+	).catch(() => null);
+	return res?.ok ?? false;
+};
+
+// ---------------------------------------------------------------------------
+// Admin API — Terminal Instances
+// ---------------------------------------------------------------------------
+
+export type TerminalInstance = {
+	user_id: string;
+	policy_id: string;
+	instance_id: string;
+	instance_name: string;
+	status: string;
+	host: string;
+	port: number;
+	image: string;
+	cpu_limit: string;
+	memory_limit: string;
+	storage: string;
+	idle_timeout_minutes: number;
+	last_activity: string;
+	created_at: string;
+	message: string;
+};
+
+export const listTerminalInstances = async (
+	token: string,
+	serverId: string
+): Promise<TerminalInstance[]> => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/instances`, {
+		headers: { Authorization: `Bearer ${token}` }
+	}).catch(() => null);
+	if (!res || !res.ok) return [];
+	return res.json().catch(() => []);
+};
+
+export const teardownTerminalInstance = async (
+	token: string,
+	serverId: string,
+	instanceId: string
+): Promise<boolean> => {
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/instances/${encodeURIComponent(instanceId)}`,
+		{
+			method: 'DELETE',
+			headers: { Authorization: `Bearer ${token}` }
+		}
+	).catch(() => null);
+	return res?.ok ?? false;
+};
+
+// ---------------------------------------------------------------------------
+// Admin API — Server Info
+// ---------------------------------------------------------------------------
+
+export type TerminalServerInfo = {
+	backend: string;
+	version: string;
+	max_cpu: string;
+	max_memory: string;
+	max_storage: string;
+	allowed_images: string;
+	idle_timeout_minutes: number;
+};
+
+export const getTerminalServerInfo = async (
+	token: string,
+	serverId: string
+): Promise<TerminalServerInfo | null> => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/terminals/${serverId}/api/v1/info`, {
+		headers: { Authorization: `Bearer ${token}` }
+	}).catch(() => null);
+	if (!res || !res.ok) return null;
+	return res.json().catch(() => null);
+};

--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -444,6 +444,7 @@ export const deletePolicy = async (
 
 export type TerminalInstance = {
 	user_id: string;
+	user_name: string;
 	policy_id: string;
 	instance_id: string;
 	instance_name: string;

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -13,6 +13,8 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import { detectTerminalServerType, putOrchestratorPolicy } from '$lib/apis/configs';
+	import { listPolicies, type PolicyResponse } from '$lib/apis/terminal';
+	import PolicyEditor from '$lib/components/chat/Settings/Integrations/Terminals/PolicyEditor.svelte';
 
 	export let show = false;
 	export let edit = false;
@@ -38,6 +40,15 @@
 	let serverType: 'orchestrator' | 'terminal' | null = null;
 	let verifying = false;
 	let policyId = '';
+
+	// Policy selector state
+	let availablePolicies: PolicyResponse[] = [];
+	let loadingPolicies = false;
+	let showPolicyEditor = false;
+	let editingPolicy: { id: string; data: import('$lib/apis/terminal').PolicyData } | null = null;
+	let policySelection: 'existing' | 'new' = 'existing';
+
+	// Legacy inline policy fields (kept for backward compat with existing connections)
 	let policyImage = '';
 	let policyEnvPairs: { key: string; value: string }[] = [];
 	let policyCpu = '1';
@@ -74,6 +85,8 @@
 			// Restore resources
 			policyCpu = p.cpu_limit ?? '1';
 			policyMemory = p.memory_limit ?? '1Gi';
+
+			policySelection = policyId ? 'existing' : 'new';
 		} else {
 			id = '';
 			url = '';
@@ -93,12 +106,37 @@
 			policyStorage = 'ephemeral';
 			policyStorageSize = '5Gi';
 			policyIdleTimeout = 30;
+			policySelection = 'existing';
 		}
+		availablePolicies = [];
 	};
 
 	$: if (show) {
 		init();
+		// Auto-fetch policies for existing orchestrator connections
+		if (connection?.server_type === 'orchestrator' && connection?.id) {
+			fetchPolicies();
+		}
 	}
+
+	const fetchPolicies = async () => {
+		if (!id) return;
+		loadingPolicies = true;
+		try {
+			availablePolicies = await listPolicies(localStorage.token, id);
+			// Auto-select first policy if current selection doesn't match any
+			if (availablePolicies.length > 0 && !availablePolicies.find((p) => p.id === policyId)) {
+				policyId = availablePolicies[0].id;
+			}
+			if (availablePolicies.length > 0 && policyId) {
+				policySelection = 'existing';
+			}
+		} catch {
+			availablePolicies = [];
+		} finally {
+			loadingPolicies = false;
+		}
+	};
 
 	const verifyHandler = async () => {
 		const _url = url.replace(/\/$/, '');
@@ -132,6 +170,10 @@
 							.replace(/-+/g, '-')
 							.replace(/^-|-$/g, '') ||
 						'default';
+				}
+				// Fetch available policies for orchestrators
+				if (type === 'orchestrator' && id) {
+					await fetchPolicies();
 				}
 			} else {
 				serverType = null;
@@ -183,8 +225,8 @@
 		// Remove trailing slash
 		url = url.replace(/\/$/, '');
 
-		// Save policy to orchestrator if applicable
-		if (serverType === 'orchestrator' && admin && policyId) {
+		// Save inline policy to orchestrator if user chose "new" policy
+		if (serverType === 'orchestrator' && admin && policyId && policySelection === 'new') {
 			try {
 				await putOrchestratorPolicy(localStorage.token, url, key, auth_type, policyId, buildPolicyData());
 			} catch (err) {
@@ -207,7 +249,9 @@
 			// Policy fields
 			...(serverType ? { server_type: serverType } : {}),
 			...(serverType === 'orchestrator' && policyId ? { policy_id: policyId } : {}),
-			...(serverType === 'orchestrator' ? { policy: buildPolicyData() } : {})
+			...(serverType === 'orchestrator' && policySelection === 'new'
+				? { policy: buildPolicyData() }
+				: {})
 		};
 
 		onSubmit(result);
@@ -363,190 +407,110 @@
 						{#if serverType === 'orchestrator' && admin}
 							<div class="flex gap-2 mt-2">
 								<div class="flex flex-col w-full">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('Policy ID')}
-										</div>
-									</div>
-									<div class="flex flex-1 items-center">
-										<input
-											id="policy-id"
-											class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											type="text"
-											bind:value={policyId}
-											placeholder="python-ds"
-											autocomplete="off"
-											disabled={edit && !!connection?.policy_id}
-										/>
-									</div>
-								</div>
-							</div>
-
-							<div class="flex gap-2 mt-2">
-								<div class="flex flex-col w-full">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('Image')}
-											<span class="opacity-50">({$i18n.t('optional')})</span>
-										</div>
-									</div>
-									<div class="flex flex-1 items-center">
-										<input
-											id="policy-image"
-											class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											type="text"
-											bind:value={policyImage}
-											placeholder="ghcr.io/open-webui/open-terminal:latest"
-											autocomplete="off"
-										/>
-									</div>
-								</div>
-							</div>
-
-							<div class="flex gap-2 mt-2">
-								<div class="flex flex-col flex-1">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('CPU')}
-										</div>
-									</div>
-									<div class="flex flex-1 items-center">
-										<input
-											id="policy-cpu"
-											class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											type="text"
-											bind:value={policyCpu}
-											placeholder="1"
-											autocomplete="off"
-										/>
-									</div>
-								</div>
-								<div class="flex flex-col flex-1">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('Memory')}
-										</div>
-									</div>
-									<div class="flex flex-1 items-center">
-										<input
-											id="policy-memory"
-											class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											type="text"
-											bind:value={policyMemory}
-											placeholder="1Gi"
-											autocomplete="off"
-										/>
-									</div>
-								</div>
-							</div>
-
-							<div class="flex gap-2 mt-2">
-								<div class="flex flex-col flex-1">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('Storage')}
-										</div>
-									</div>
-									<div class="flex gap-2">
-										<div class="flex-shrink-0 self-start">
-											<select
-												class={`dark:bg-gray-900 w-full text-sm bg-transparent pr-5 ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-												bind:value={policyStorage}
-											>
-												<option value="ephemeral">{$i18n.t('Ephemeral')}</option>
-												<option value="persistent">{$i18n.t('Persistent')}</option>
-											</select>
-										</div>
-										{#if policyStorage === 'persistent'}
-											<div class="flex flex-1 items-center">
-												<input
-													id="policy-storage-size"
-													class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-													type="text"
-													bind:value={policyStorageSize}
-													placeholder="5Gi"
-													autocomplete="off"
-												/>
-											</div>
-										{/if}
-									</div>
-								</div>
-
-								<div class="flex flex-col flex-1">
-									<div class="flex justify-between mb-0.5">
-										<div
-											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
-										>
-											{$i18n.t('Idle Timeout')}
-											<span class="opacity-50">({$i18n.t('min')})</span>
-										</div>
-									</div>
-									<div class="flex flex-1 items-center">
-										<input
-											id="idle-timeout"
-											class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											type="number"
-											min="0"
-											bind:value={policyIdleTimeout}
-											placeholder="30"
-											autocomplete="off"
-										/>
-									</div>
-								</div>
-							</div>
-
-							<!-- Env Vars -->
-							<div class="flex gap-2 mt-2">
-								<div class="flex flex-col w-full">
 									<div class="flex justify-between items-center mb-0.5">
 										<div
 											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
 										>
-											{$i18n.t('Environment Variables')}
+											{$i18n.t('Policy')}
 										</div>
-										<button
-											type="button"
-											class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
-											on:click={() =>
-												(policyEnvPairs = [...policyEnvPairs, { key: '', value: '' }])}
-										>
-											+ {$i18n.t('Add')}
-										</button>
-									</div>
-									{#each policyEnvPairs as pair, idx}
-										<div class="flex gap-1.5 mb-1">
-											<input
-												class={`flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-												type="text"
-												bind:value={pair.key}
-												placeholder="KEY"
-											/>
-											<input
-												class={`flex-[2] text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-												type="text"
-												bind:value={pair.value}
-												placeholder="value"
-											/>
+										{#if id}
 											<button
 												type="button"
-												class="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition px-1"
-												on:click={() =>
-													(policyEnvPairs = policyEnvPairs.filter((_, i) => i !== idx))}
+												class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+												on:click={fetchPolicies}
+												disabled={loadingPolicies}
 											>
-												<XMark className={'size-3'} />
+												{loadingPolicies ? $i18n.t('Loading...') : $i18n.t('Refresh')}
+											</button>
+										{/if}
+									</div>
+
+									{#if availablePolicies.length > 0}
+										<div class="flex gap-2 items-center">
+											<select
+												class={`dark:bg-gray-900 w-full text-sm bg-transparent pr-5 ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+												bind:value={policyId}
+												on:change={() => { policySelection = 'existing'; }}
+											>
+												{#each availablePolicies as p}
+													<option value={p.id}>{p.id}</option>
+												{/each}
+											</select>
+											<button
+												type="button"
+												class="text-xs whitespace-nowrap text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+												on:click={() => {
+													const sel = availablePolicies.find((p) => p.id === policyId);
+													if (sel) {
+														editingPolicy = { id: sel.id, data: sel.data ?? {} };
+													} else {
+														editingPolicy = null;
+													}
+													showPolicyEditor = true;
+												}}
+											>
+												{$i18n.t('Edit')}
+											</button>
+											<button
+												type="button"
+												class="text-xs whitespace-nowrap text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+												on:click={() => { editingPolicy = null; showPolicyEditor = true; }}
+											>
+												+ {$i18n.t('New')}
 											</button>
 										</div>
-									{/each}
+										{#if policyId}
+											{@const selected = availablePolicies.find((p) => p.id === policyId)}
+											{#if selected && (selected.data?.image || selected.data?.cpu_limit || selected.data?.memory_limit)}
+												<div
+													class={`text-xs mt-1 ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
+												>
+													{#if selected.data?.image}{selected.data.image}{/if}
+													{#if selected.data?.cpu_limit}{selected.data.image ? ' · ' : ''}{selected.data.cpu_limit} CPU{/if}
+													{#if selected.data?.memory_limit}{selected.data?.image || selected.data?.cpu_limit ? ' · ' : ''}{selected.data.memory_limit} RAM{/if}
+													{#if selected.data?.storage} · {selected.data.storage} storage{/if}
+												</div>
+											{/if}
+										{/if}
+									{:else if !id}
+										<div
+											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
+										>
+											{$i18n.t('Save the connection first to select policies.')}
+										</div>
+									{:else if loadingPolicies}
+										<div
+											class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
+										>
+											{$i18n.t('Loading policies...')}
+										</div>
+									{:else}
+										<div class="flex items-center gap-2">
+											<div
+												class={`text-xs ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
+											>
+												{$i18n.t('No policies found.')}
+											</div>
+											<button
+												type="button"
+												class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+												on:click={() => { editingPolicy = null; showPolicyEditor = true; }}
+											>
+												+ {$i18n.t('Create')}
+											</button>
+										</div>
+										<!-- Fallback: manual policy ID entry -->
+										<div class="flex flex-1 items-center mt-1">
+											<input
+												id="policy-id"
+												class={`w-full flex-1 text-sm bg-transparent font-mono ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+												type="text"
+												bind:value={policyId}
+												placeholder={$i18n.t('Policy ID (e.g. default)')}
+												autocomplete="off"
+											/>
+										</div>
+									{/if}
 								</div>
 							</div>
 						{/if}
@@ -732,3 +696,24 @@
 		show = false;
 	}}
 />
+
+{#if id}
+	<PolicyEditor
+		bind:show={showPolicyEditor}
+		edit={editingPolicy !== null}
+		serverId={id}
+		policy={editingPolicy}
+		onSave={async () => {
+			showPolicyEditor = false;
+			const prevId = editingPolicy?.id;
+			editingPolicy = null;
+			await fetchPolicies();
+			if (prevId && availablePolicies.find((p) => p.id === prevId)) {
+				policyId = prevId;
+			} else if (availablePolicies.length > 0) {
+				policyId = availablePolicies[availablePolicies.length - 1].id;
+			}
+			policySelection = 'existing';
+		}}
+	/>
+{/if}

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -13,7 +13,6 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import { detectTerminalServerType, putOrchestratorPolicy } from '$lib/apis/configs';
-	import { getTerminalConfig } from '$lib/apis/terminal';
 
 	export let show = false;
 	export let edit = false;
@@ -110,40 +109,33 @@
 
 		verifying = true;
 		try {
-			if (admin) {
-				// Admin: detect orchestrator vs terminal
-				const type = await detectTerminalServerType(_url, key);
+			const type = await detectTerminalServerType(localStorage.token, {
+				url: _url,
+				key,
+				auth_type
+			});
 
-				if (type) {
-					serverType = type;
-					toast.success(
-						$i18n.t('Connected ({{type}})', {
-							type: type === 'orchestrator' ? 'Orchestrator' : 'Terminal'
-						})
-					);
-					// Default policy_id to connection id when orchestrator detected
-					if (type === 'orchestrator' && !policyId) {
-						policyId =
-							id ||
-							name
-								.toLowerCase()
-								.replace(/[^a-z0-9-]/g, '-')
-								.replace(/-+/g, '-')
-								.replace(/^-|-$/g, '') ||
-							'default';
-					}
-				} else {
-					serverType = null;
-					toast.error($i18n.t('Server connection failed'));
+			if (type) {
+				serverType = type;
+				toast.success(
+					$i18n.t('Connected ({{type}})', {
+						type: type === 'orchestrator' ? 'Orchestrator' : 'Terminal'
+					})
+				);
+				// Default policy_id to connection id when orchestrator detected
+				if (type === 'orchestrator' && !policyId) {
+					policyId =
+						id ||
+						name
+							.toLowerCase()
+							.replace(/[^a-z0-9-]/g, '-')
+							.replace(/-+/g, '-')
+							.replace(/^-|-$/g, '') ||
+						'default';
 				}
 			} else {
-				// Non-admin: simple terminal verification
-				const res = await getTerminalConfig(_url, key);
-				if (res) {
-					toast.success($i18n.t('Server connection verified'));
-				} else {
-					toast.error($i18n.t('Server connection failed'));
-				}
+				serverType = null;
+				toast.error($i18n.t('Server connection failed'));
 			}
 		} catch {
 			serverType = null;
@@ -194,7 +186,7 @@
 		// Save policy to orchestrator if applicable
 		if (serverType === 'orchestrator' && admin && policyId) {
 			try {
-				await putOrchestratorPolicy(url, key, policyId, buildPolicyData());
+				await putOrchestratorPolicy(localStorage.token, url, key, auth_type, policyId, buildPolicyData());
 			} catch (err) {
 				toast.error($i18n.t('Failed to save policy: {{error}}', { error: err }));
 				return;

--- a/src/lib/components/admin/Settings/Integrations.svelte
+++ b/src/lib/components/admin/Settings/Integrations.svelte
@@ -15,14 +15,12 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Plus from '$lib/components/icons/Plus.svelte';
-	import Cog6 from '$lib/components/icons/Cog6.svelte';
-	import Cloud from '$lib/components/icons/Cloud.svelte';
 	import Connection from '$lib/components/chat/Settings/Tools/Connection.svelte';
 	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 
 	import AddToolServerModal from '$lib/components/AddToolServerModal.svelte';
-	import AddTerminalServerModal from '$lib/components/AddTerminalServerModal.svelte';
-	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+	import Terminals from '$lib/components/chat/Settings/Integrations/Terminals.svelte';
 
 	import {
 		getToolServerConnections,
@@ -38,10 +36,6 @@
 
 	// Terminal server admin connections
 	let terminalConnections = [];
-	let showAddTerminalModal = false;
-	let editTerminalIdx: number | null = null;
-	let showDeleteTerminalConfirm = false;
-	let deleteTerminalIdx: number | null = null;
 
 	const addConnectionHandler = async (server) => {
 		servers = [...servers, server];
@@ -86,23 +80,6 @@
 		}
 	};
 
-	const addTerminalConnection = (server) => {
-		terminalConnections = [...terminalConnections, { ...server, id: server.id ?? uuidv4() }];
-		saveTerminalServers();
-	};
-
-	const updateTerminalConnection = (idx: number, updated) => {
-		terminalConnections = terminalConnections.map((c, i) =>
-			i === idx ? { ...c, ...updated, id: updated.id ?? c.id } : c
-		);
-		saveTerminalServers();
-	};
-
-	const removeTerminalConnection = (idx: number) => {
-		terminalConnections = terminalConnections.filter((_, i) => i !== idx);
-		saveTerminalServers();
-	};
-
 	onMount(async () => {
 		const res = await getToolServerConnections(localStorage.token);
 		servers = res.TOOL_SERVER_CONNECTIONS;
@@ -120,38 +97,6 @@
 </script>
 
 <AddToolServerModal bind:show={showConnectionModal} onSubmit={addConnectionHandler} />
-
-<AddTerminalServerModal
-	admin
-	bind:show={showAddTerminalModal}
-	edit={editTerminalIdx !== null}
-	connection={editTerminalIdx !== null ? terminalConnections[editTerminalIdx] : null}
-	onSubmit={(c) => {
-		if (editTerminalIdx !== null) {
-			updateTerminalConnection(editTerminalIdx, c);
-			editTerminalIdx = null;
-		} else {
-			addTerminalConnection(c);
-		}
-	}}
-	onDelete={() => {
-		if (editTerminalIdx !== null) {
-			deleteTerminalIdx = editTerminalIdx;
-			showDeleteTerminalConfirm = true;
-			editTerminalIdx = null;
-		}
-	}}
-/>
-
-<ConfirmDialog
-	bind:show={showDeleteTerminalConfirm}
-	on:confirm={() => {
-		if (deleteTerminalIdx !== null) {
-			removeTerminalConnection(deleteTerminalIdx);
-			deleteTerminalIdx = null;
-		}
-	}}
-/>
 
 <form
 	class="flex flex-col h-full justify-between text-sm"
@@ -215,90 +160,7 @@
 					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-4" />
 
 					<div class="mb-2.5 flex flex-col w-full">
-						<div class="flex justify-between items-center mb-1">
-							<div class="flex items-center gap-2">
-								<div class="font-medium">{$i18n.t('Open Terminal')}</div>
-								<span
-									class="text-[0.65rem] font-medium uppercase px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-									>{$i18n.t('Experimental')}</span
-								>
-							</div>
-
-							<Tooltip content={$i18n.t('Add Connection')}>
-								<button
-									class="px-1"
-									on:click={() => {
-										editTerminalIdx = null;
-										showAddTerminalModal = true;
-									}}
-									type="button"
-								>
-									<Plus />
-								</button>
-							</Tooltip>
-						</div>
-
-						<div class="flex flex-col gap-1.5">
-							{#each terminalConnections as connection, idx}
-								<div class="flex w-full gap-2 items-center">
-									<Tooltip className="w-full relative" content={''} placement="top-start">
-										<div class="flex w-full">
-											<div
-												class="flex-1 relative flex gap-1.5 items-center {connection?.enabled ===
-												false
-													? 'opacity-50'
-													: ''}"
-											>
-												<Tooltip content={$i18n.t('Terminal')}>
-													<Cloud className="size-4" strokeWidth="1.5" />
-												</Tooltip>
-
-												<div class="outline-hidden w-full bg-transparent text-sm">
-													{connection.name || connection.url || $i18n.t('New Terminal')}
-												</div>
-											</div>
-										</div>
-									</Tooltip>
-
-									<div class="flex gap-1 items-center">
-										<Tooltip content={$i18n.t('Configure')}>
-											<button
-												class="self-center p-1 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
-												on:click={() => {
-													editTerminalIdx = idx;
-													showAddTerminalModal = true;
-												}}
-												type="button"
-											>
-												<Cog6 />
-											</button>
-										</Tooltip>
-
-										<Tooltip
-											content={connection?.enabled !== false
-												? $i18n.t('Enabled')
-												: $i18n.t('Disabled')}
-										>
-											<Switch
-												state={connection?.enabled !== false}
-												on:change={() => {
-													terminalConnections = terminalConnections.map((c, i) =>
-														i === idx ? { ...c, enabled: !(c?.enabled !== false) } : c
-													);
-													saveTerminalServers();
-												}}
-											/>
-										</Tooltip>
-									</div>
-								</div>
-							{/each}
-						</div>
-
-						{#if terminalConnections.length === 0}
-							<div class="text-xs text-gray-400 dark:text-gray-500">
-								{$i18n.t('No terminal connections configured.')}
-							</div>
-						{/if}
+						<Terminals admin bind:servers={terminalConnections} onChange={() => saveTerminalServers()} />
 
 						<div class="mt-1.5">
 							<div class="text-xs text-gray-500">

--- a/src/lib/components/chat/Settings/Integrations/Terminals.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	const i18n = getContext('i18n');
 
 	import Plus from '$lib/components/icons/Plus.svelte';
@@ -8,7 +8,11 @@
 	import Policies from './Terminals/Policies.svelte';
 	import Instances from './Terminals/Instances.svelte';
 	import AddTerminalServerModal from '$lib/components/AddTerminalServerModal.svelte';
+	import { detectTerminalServerType } from '$lib/apis/configs';
 
+	import { v4 as uuidv4 } from 'uuid';
+
+	export let admin = false;
 	export let servers = [];
 	export let onChange: (servers: typeof servers) => void = () => {};
 
@@ -18,8 +22,39 @@
 	// Show policy/instance tabs only if there's at least one orchestrator server
 	$: hasOrchestrator = servers.some((s) => s.server_type === 'orchestrator' && s.id);
 
+	// On mount, detect server_type for connections that don't have it set yet.
+	// This handles connections created via API or before the server_type field existed.
+	const detectServerTypes = async () => {
+		let changed = false;
+		for (let i = 0; i < servers.length; i++) {
+			const s = servers[i];
+			if (s.server_type || !s.url) continue;
+			try {
+				const type = await detectTerminalServerType(localStorage.token, {
+					url: s.url,
+					key: s.key ?? '',
+					auth_type: s.auth_type ?? 'bearer'
+				});
+				if (type) {
+					servers[i] = { ...servers[i], server_type: type };
+					changed = true;
+				}
+			} catch {
+				// Server unreachable — leave server_type unset
+			}
+		}
+		if (changed) {
+			servers = [...servers]; // trigger reactivity
+			onChange(servers);
+		}
+	};
+
+	onMount(() => {
+		detectServerTypes();
+	});
+
 	const addServer = (server: (typeof servers)[0]) => {
-		servers = [...servers, server];
+		servers = [...servers, { ...server, id: server.id ?? uuidv4() }];
 		onChange(servers);
 	};
 
@@ -44,7 +79,7 @@
 	};
 </script>
 
-<AddTerminalServerModal bind:show={showAddModal} onSubmit={(server) => addServer(server)} />
+<AddTerminalServerModal {admin} bind:show={showAddModal} onSubmit={(server) => addServer(server)} />
 
 <div>
 	<div class="flex justify-between items-center mb-1">
@@ -107,6 +142,7 @@
 		<div class="flex flex-col gap-1.5">
 			{#each servers as server, idx}
 				<Connection
+					{admin}
 					bind:connection={server}
 					onSubmit={(updated) => updateServer(idx, updated)}
 					onDelete={() => deleteServer(idx)}

--- a/src/lib/components/chat/Settings/Integrations/Terminals.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals.svelte
@@ -5,12 +5,18 @@
 	import Plus from '$lib/components/icons/Plus.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Connection from './Terminals/Connection.svelte';
+	import Policies from './Terminals/Policies.svelte';
+	import Instances from './Terminals/Instances.svelte';
 	import AddTerminalServerModal from '$lib/components/AddTerminalServerModal.svelte';
 
 	export let servers = [];
 	export let onChange: (servers: typeof servers) => void = () => {};
 
 	let showAddModal = false;
+	let activeTab: 'connections' | 'policies' | 'instances' = 'connections';
+
+	// Show policy/instance tabs only if there's at least one orchestrator server
+	$: hasOrchestrator = servers.some((s) => s.server_type === 'orchestrator' && s.id);
 
 	const addServer = (server: (typeof servers)[0]) => {
 		servers = [...servers, server];
@@ -49,41 +55,83 @@
 				>{$i18n.t('Experimental')}</span
 			>
 		</div>
-		<Tooltip content={$i18n.t('Add Connection')}>
+		{#if activeTab === 'connections'}
+			<Tooltip content={$i18n.t('Add Connection')}>
+				<button
+					class="px-1"
+					on:click={() => (showAddModal = true)}
+					type="button"
+					aria-label={$i18n.t('Add Connection')}
+				>
+					<Plus />
+				</button>
+			</Tooltip>
+		{/if}
+	</div>
+
+	<!-- Tabs -->
+	{#if hasOrchestrator}
+		<div class="flex gap-1 mb-3 border-b border-gray-100 dark:border-gray-850">
 			<button
-				class="px-1"
-				on:click={() => (showAddModal = true)}
+				class="px-3 py-1.5 text-xs font-medium transition {activeTab === 'connections'
+					? 'border-b-2 border-black dark:border-white text-black dark:text-white'
+					: 'text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}"
 				type="button"
-				aria-label={$i18n.t('Add Connection')}
+				on:click={() => (activeTab = 'connections')}
 			>
-				<Plus />
+				{$i18n.t('Connections')}
 			</button>
-		</Tooltip>
-	</div>
-
-	<div class="flex flex-col gap-1.5">
-		{#each servers as server, idx}
-			<Connection
-				bind:connection={server}
-				onSubmit={(updated) => updateServer(idx, updated)}
-				onDelete={() => deleteServer(idx)}
-				onEnable={() => enableServer(idx)}
-				onDisable={() => disableServer(idx)}
-			/>
-		{/each}
-	</div>
-
-	{#if servers.length === 0}
-		<div class="text-xs text-gray-400 dark:text-gray-500">
-			{$i18n.t('No terminal connections configured.')}
-			<a
-				href="https://github.com/open-webui/open-terminal"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="underline hover:text-gray-700 dark:hover:text-gray-200"
+			<button
+				class="px-3 py-1.5 text-xs font-medium transition {activeTab === 'policies'
+					? 'border-b-2 border-black dark:border-white text-black dark:text-white'
+					: 'text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}"
+				type="button"
+				on:click={() => (activeTab = 'policies')}
 			>
-				{$i18n.t('Learn more')} ↗
-			</a>
+				{$i18n.t('Policies')}
+			</button>
+			<button
+				class="px-3 py-1.5 text-xs font-medium transition {activeTab === 'instances'
+					? 'border-b-2 border-black dark:border-white text-black dark:text-white'
+					: 'text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}"
+				type="button"
+				on:click={() => (activeTab = 'instances')}
+			>
+				{$i18n.t('Active Terminals')}
+			</button>
 		</div>
+	{/if}
+
+	<!-- Tab content -->
+	{#if activeTab === 'connections'}
+		<div class="flex flex-col gap-1.5">
+			{#each servers as server, idx}
+				<Connection
+					bind:connection={server}
+					onSubmit={(updated) => updateServer(idx, updated)}
+					onDelete={() => deleteServer(idx)}
+					onEnable={() => enableServer(idx)}
+					onDisable={() => disableServer(idx)}
+				/>
+			{/each}
+		</div>
+
+		{#if servers.length === 0}
+			<div class="text-xs text-gray-400 dark:text-gray-500">
+				{$i18n.t('No terminal connections configured.')}
+				<a
+					href="https://github.com/open-webui/open-terminal"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="underline hover:text-gray-700 dark:hover:text-gray-200"
+				>
+					{$i18n.t('Learn more')} ↗
+				</a>
+			</div>
+		{/if}
+	{:else if activeTab === 'policies'}
+		<Policies {servers} />
+	{:else if activeTab === 'instances'}
+		<Instances {servers} />
 	{/if}
 </div>

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Connection.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Connection.svelte
@@ -9,6 +9,7 @@
 	import AddTerminalServerModal from '$lib/components/AddTerminalServerModal.svelte';
 	import Cloud from '$lib/components/icons/Cloud.svelte';
 
+	export let admin = false;
 	export let connection = { url: '', key: '', name: '', path: '/openapi.json', enabled: false };
 	export let onSubmit: (c: typeof connection) => void = () => {};
 	export let onDelete: () => void = () => {};
@@ -20,6 +21,7 @@
 </script>
 
 <AddTerminalServerModal
+	{admin}
 	edit
 	bind:show={showConfigModal}
 	{connection}

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Instances.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Instances.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+	import { toast } from 'svelte-sonner';
+	import { getContext, onMount, onDestroy } from 'svelte';
+	const i18n = getContext('i18n');
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+	import type { TerminalInstance } from '$lib/apis/terminal';
+	import { listTerminalInstances, teardownTerminalInstance } from '$lib/apis/terminal';
+
+	export let servers: any[] = [];
+
+	let selectedServerId = '';
+	let instances: TerminalInstance[] = [];
+	let loading = false;
+	let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+	let showTeardownConfirm = false;
+	let teardownTarget: TerminalInstance | null = null;
+
+	$: orchestratorServers = servers.filter(
+		(s) => s.server_type === 'orchestrator' && s.id
+	);
+
+	$: if (orchestratorServers.length > 0 && !selectedServerId) {
+		selectedServerId = orchestratorServers[0]?.id ?? '';
+	}
+
+	const loadInstances = async () => {
+		if (!selectedServerId) return;
+		loading = true;
+		try {
+			instances = await listTerminalInstances(localStorage.token, selectedServerId);
+		} catch {
+			instances = [];
+		} finally {
+			loading = false;
+		}
+	};
+
+	$: if (selectedServerId) {
+		loadInstances();
+	}
+
+	onMount(() => {
+		refreshInterval = setInterval(loadInstances, 30_000);
+	});
+
+	onDestroy(() => {
+		if (refreshInterval) clearInterval(refreshInterval);
+	});
+
+	const handleTeardown = async () => {
+		if (!teardownTarget) return;
+		const ok = await teardownTerminalInstance(
+			localStorage.token,
+			selectedServerId,
+			teardownTarget.instance_id
+		);
+		if (ok) {
+			toast.success($i18n.t('Terminal terminated'));
+			await loadInstances();
+		} else {
+			toast.error($i18n.t('Failed to terminate terminal'));
+		}
+		teardownTarget = null;
+	};
+
+	const statusColor = (status: string) => {
+		switch (status) {
+			case 'running':
+				return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400';
+			case 'pending':
+			case 'provisioning':
+				return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400';
+			case 'idle':
+				return 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400';
+			case 'error':
+				return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400';
+			default:
+				return 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400';
+		}
+	};
+
+	const relativeTime = (iso: string) => {
+		if (!iso) return '—';
+		const diff = Date.now() - new Date(iso).getTime();
+		const mins = Math.floor(diff / 60_000);
+		if (mins < 1) return 'just now';
+		if (mins < 60) return `${mins}m ago`;
+		const hrs = Math.floor(mins / 60);
+		if (hrs < 24) return `${hrs}h ago`;
+		return `${Math.floor(hrs / 24)}d ago`;
+	};
+</script>
+
+<ConfirmDialog
+	bind:show={showTeardownConfirm}
+	message={$i18n.t('Are you sure you want to terminate this terminal? The user will lose any unsaved work.')}
+	confirmLabel={$i18n.t('Terminate')}
+	on:confirm={handleTeardown}
+/>
+
+<div>
+	{#if orchestratorServers.length === 0}
+		<div class="text-xs text-gray-400 dark:text-gray-500 py-4">
+			{$i18n.t('No orchestrator connections configured.')}
+		</div>
+	{:else}
+		<!-- Server selector + refresh -->
+		<div class="flex items-center justify-between mb-2 gap-2">
+			<select
+				class="dark:bg-gray-900 text-sm bg-transparent pr-5 outline-hidden max-w-[200px]"
+				bind:value={selectedServerId}
+			>
+				{#each orchestratorServers as server}
+					<option value={server.id}>{server.name || server.id}</option>
+				{/each}
+			</select>
+
+			<div class="flex items-center gap-2">
+				<span class="text-xs text-gray-400 dark:text-gray-500">
+					{instances.length} {$i18n.t('active')}
+				</span>
+				<Tooltip content={$i18n.t('Refresh')}>
+					<button
+						class="p-1 hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
+						type="button"
+						on:click={loadInstances}
+						aria-label={$i18n.t('Refresh')}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+							<path fill-rule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.243a.75.75 0 00.53-.219z" clip-rule="evenodd" />
+						</svg>
+					</button>
+				</Tooltip>
+			</div>
+		</div>
+
+		<!-- Instance list -->
+		{#if loading && instances.length === 0}
+			<div class="text-xs text-gray-400 dark:text-gray-500 py-4 text-center">
+				{$i18n.t('Loading...')}
+			</div>
+		{:else if instances.length === 0}
+			<div class="text-xs text-gray-400 dark:text-gray-500 py-4 text-center">
+				{$i18n.t('No active terminal instances.')}
+			</div>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="text-xs text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-850">
+							<th class="text-left py-1.5 pr-3 font-medium">{$i18n.t('User')}</th>
+							<th class="text-left py-1.5 pr-3 font-medium">{$i18n.t('Policy')}</th>
+							<th class="text-left py-1.5 pr-3 font-medium">{$i18n.t('Status')}</th>
+							<th class="text-left py-1.5 pr-3 font-medium">{$i18n.t('Last Activity')}</th>
+							<th class="text-left py-1.5 pr-3 font-medium">{$i18n.t('Created')}</th>
+							<th class="text-right py-1.5 font-medium"></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each instances as inst (inst.instance_id)}
+							<tr class="border-b border-gray-50 dark:border-gray-900 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
+								<td class="py-1.5 pr-3">
+									<span class="font-mono text-xs truncate max-w-[120px] inline-block" title={inst.user_id}>
+										{inst.user_id.slice(0, 8)}…
+									</span>
+								</td>
+								<td class="py-1.5 pr-3">
+									<span class="font-mono text-xs">{inst.policy_id}</span>
+								</td>
+								<td class="py-1.5 pr-3">
+									<span class="text-[0.6rem] font-medium uppercase px-1.5 py-0.5 rounded-full {statusColor(inst.status)}">
+										{inst.status}
+									</span>
+								</td>
+								<td class="py-1.5 pr-3 text-xs text-gray-400 dark:text-gray-500">
+									{relativeTime(inst.last_activity)}
+								</td>
+								<td class="py-1.5 pr-3 text-xs text-gray-400 dark:text-gray-500">
+									{relativeTime(inst.created_at)}
+								</td>
+								<td class="py-1.5 text-right">
+									<Tooltip content={$i18n.t('Terminate')}>
+										<button
+											class="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 rounded transition"
+											type="button"
+											on:click={() => {
+												teardownTarget = inst;
+												showTeardownConfirm = true;
+											}}
+											aria-label={$i18n.t('Terminate')}
+										>
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
+												<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+											</svg>
+										</button>
+									</Tooltip>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Instances.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Instances.svelte
@@ -5,6 +5,7 @@
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 
 	import type { TerminalInstance } from '$lib/apis/terminal';
 	import { listTerminalInstances, teardownTerminalInstance } from '$lib/apis/terminal';
@@ -97,8 +98,8 @@
 
 <ConfirmDialog
 	bind:show={showTeardownConfirm}
-	message={$i18n.t('Are you sure you want to terminate this terminal? The user will lose any unsaved work.')}
-	confirmLabel={$i18n.t('Terminate')}
+	message={$i18n.t('Are you sure you want to delete this terminal? The user will lose any unsaved work.')}
+	confirmLabel={$i18n.t('Delete')}
 	on:confirm={handleTeardown}
 />
 
@@ -164,8 +165,8 @@
 						{#each instances as inst (inst.instance_id)}
 							<tr class="border-b border-gray-50 dark:border-gray-900 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
 								<td class="py-1.5 pr-3">
-									<span class="font-mono text-xs truncate max-w-[120px] inline-block" title={inst.user_id}>
-										{inst.user_id.slice(0, 8)}…
+								<span class="text-xs truncate max-w-[150px] inline-block" title={inst.user_id}>
+									{inst.user_name || inst.user_id.slice(0, 8) + '…'}
 									</span>
 								</td>
 								<td class="py-1.5 pr-3">
@@ -183,19 +184,17 @@
 									{relativeTime(inst.created_at)}
 								</td>
 								<td class="py-1.5 text-right">
-									<Tooltip content={$i18n.t('Terminate')}>
-										<button
-											class="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 rounded transition"
-											type="button"
-											on:click={() => {
-												teardownTarget = inst;
-												showTeardownConfirm = true;
-											}}
-											aria-label={$i18n.t('Terminate')}
-										>
-											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
-												<path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
-											</svg>
+								<Tooltip content={$i18n.t('Delete')}>
+									<button
+										class="self-center p-1 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
+										type="button"
+										on:click={() => {
+											teardownTarget = inst;
+											showTeardownConfirm = true;
+										}}
+										aria-label={$i18n.t('Delete')}
+									>
+										<GarbageBin className="w-3.5 h-3.5" />
 										</button>
 									</Tooltip>
 								</td>

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Policies.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Policies.svelte
@@ -4,6 +4,7 @@
 	const i18n = getContext('i18n');
 
 	import Plus from '$lib/components/icons/Plus.svelte';
+	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import PolicyEditor from './PolicyEditor.svelte';
@@ -213,7 +214,7 @@
 							</Tooltip>
 							<Tooltip content={$i18n.t('Delete')}>
 								<button
-									class="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 rounded transition"
+									class="self-center p-1 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
 									type="button"
 									on:click={() => {
 										deletingPolicyId = policy.id;
@@ -221,9 +222,7 @@
 									}}
 									aria-label={$i18n.t('Delete')}
 								>
-									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
-										<path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.519.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
-									</svg>
+									<GarbageBin className="w-3.5 h-3.5" />
 								</button>
 							</Tooltip>
 						</div>

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Policies.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Policies.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+	import { toast } from 'svelte-sonner';
+	import { getContext } from 'svelte';
+	const i18n = getContext('i18n');
+
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import PolicyEditor from './PolicyEditor.svelte';
+
+	import type { PolicyResponse } from '$lib/apis/terminal';
+	import { listPolicies, deletePolicy } from '$lib/apis/terminal';
+
+	export let servers: any[] = [];
+
+	let selectedServerId = '';
+	let policies: PolicyResponse[] = [];
+	let loading = false;
+	let searchQuery = '';
+
+	let showEditor = false;
+	let editingPolicy: PolicyResponse | null = null;
+
+	let showDeleteConfirm = false;
+	let deletingPolicyId = '';
+
+	// Filter to orchestrator-type servers only
+	$: orchestratorServers = servers.filter(
+		(s) => s.server_type === 'orchestrator' && s.id
+	);
+
+	$: if (orchestratorServers.length > 0 && !selectedServerId) {
+		selectedServerId = orchestratorServers[0]?.id ?? '';
+	}
+
+	$: filteredPolicies = searchQuery
+		? policies.filter(
+				(p) =>
+					p.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+					(p.data?.image ?? '').toLowerCase().includes(searchQuery.toLowerCase())
+			)
+		: policies;
+
+	const loadPolicies = async () => {
+		if (!selectedServerId) return;
+		loading = true;
+		try {
+			policies = await listPolicies(localStorage.token, selectedServerId);
+		} catch {
+			toast.error($i18n.t('Failed to load policies'));
+			policies = [];
+		} finally {
+			loading = false;
+		}
+	};
+
+	$: if (selectedServerId) {
+		loadPolicies();
+	}
+
+	const handleDelete = async () => {
+		if (!deletingPolicyId) return;
+		const ok = await deletePolicy(localStorage.token, selectedServerId, deletingPolicyId);
+		if (ok) {
+			toast.success($i18n.t('Policy deleted'));
+			await loadPolicies();
+		} else {
+			toast.error($i18n.t('Failed to delete policy'));
+		}
+		deletingPolicyId = '';
+	};
+
+	const openCreate = () => {
+		editingPolicy = null;
+		showEditor = true;
+	};
+
+	const openEdit = (p: PolicyResponse) => {
+		editingPolicy = p;
+		showEditor = true;
+	};
+
+	const openClone = (p: PolicyResponse) => {
+		editingPolicy = { id: `${p.id}-copy`, data: { ...p.data } };
+		showEditor = true;
+	};
+
+	const statusBadge = (p: PolicyResponse) => {
+		const d = p.data ?? {};
+		const parts: string[] = [];
+		if (d.image) parts.push(d.image.split('/').pop()?.split(':')[0] ?? '');
+		if (d.cpu_limit) parts.push(`${d.cpu_limit} CPU`);
+		if (d.memory_limit) parts.push(d.memory_limit);
+		if (d.storage) parts.push(`💾 ${d.storage}`);
+		else parts.push('ephemeral');
+		return parts.filter(Boolean).join(' · ');
+	};
+</script>
+
+<PolicyEditor
+	bind:show={showEditor}
+	edit={editingPolicy !== null && !editingPolicy.id.endsWith('-copy')}
+	serverId={selectedServerId}
+	policy={editingPolicy}
+	onSave={loadPolicies}
+/>
+
+<ConfirmDialog
+	bind:show={showDeleteConfirm}
+	message={$i18n.t('Are you sure you want to delete this policy? This action cannot be undone.')}
+	confirmLabel={$i18n.t('Delete')}
+	on:confirm={handleDelete}
+/>
+
+<div>
+	{#if orchestratorServers.length === 0}
+		<div class="text-xs text-gray-400 dark:text-gray-500 py-4">
+			{$i18n.t('No orchestrator connections configured. Add a terminal server connection with an orchestrator type to manage policies.')}
+		</div>
+	{:else}
+		<!-- Server selector + actions -->
+		<div class="flex items-center justify-between mb-2 gap-2">
+			<div class="flex items-center gap-2 flex-1 min-w-0">
+				<select
+					class="dark:bg-gray-900 text-sm bg-transparent pr-5 outline-hidden max-w-[200px]"
+					bind:value={selectedServerId}
+				>
+					{#each orchestratorServers as server}
+						<option value={server.id}>{server.name || server.id}</option>
+					{/each}
+				</select>
+
+				<input
+					type="text"
+					class="flex-1 text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700 min-w-0"
+					placeholder={$i18n.t('Search policies...')}
+					bind:value={searchQuery}
+				/>
+			</div>
+
+			<div class="flex items-center gap-1">
+				<Tooltip content={$i18n.t('Refresh')}>
+					<button
+						class="p-1 hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
+						type="button"
+						on:click={loadPolicies}
+						aria-label={$i18n.t('Refresh')}
+					>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+							<path fill-rule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.243a.75.75 0 00.53-.219z" clip-rule="evenodd" />
+						</svg>
+					</button>
+				</Tooltip>
+				<Tooltip content={$i18n.t('Create Policy')}>
+					<button
+						class="p-1 hover:bg-gray-100 dark:hover:bg-gray-850 rounded-lg transition"
+						type="button"
+						on:click={openCreate}
+						aria-label={$i18n.t('Create Policy')}
+					>
+						<Plus />
+					</button>
+				</Tooltip>
+			</div>
+		</div>
+
+		<!-- Policy list -->
+		{#if loading}
+			<div class="text-xs text-gray-400 dark:text-gray-500 py-4 text-center">
+				{$i18n.t('Loading...')}
+			</div>
+		{:else if filteredPolicies.length === 0}
+			<div class="text-xs text-gray-400 dark:text-gray-500 py-4 text-center">
+				{searchQuery ? $i18n.t('No policies match your search.') : $i18n.t('No policies configured yet.')}
+			</div>
+		{:else}
+			<div class="flex flex-col gap-1.5">
+				{#each filteredPolicies as policy (policy.id)}
+					<div
+						class="flex items-center justify-between rounded-lg border border-gray-100 dark:border-gray-850 px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-900 transition group"
+					>
+						<button
+							class="flex-1 min-w-0 text-left"
+							type="button"
+							on:click={() => openEdit(policy)}
+						>
+							<div class="flex items-center gap-2">
+								<span class="text-sm font-medium font-mono truncate">{policy.id}</span>
+								{#if policy.data?.idle_timeout_minutes}
+									<span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 shrink-0">
+										{policy.data.idle_timeout_minutes}m idle
+									</span>
+								{/if}
+							</div>
+							<div class="text-xs text-gray-400 dark:text-gray-500 truncate mt-0.5">
+								{statusBadge(policy)}
+							</div>
+						</button>
+
+						<div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition shrink-0">
+							<Tooltip content={$i18n.t('Clone')}>
+								<button
+									class="p-1 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition"
+									type="button"
+									on:click={() => openClone(policy)}
+									aria-label={$i18n.t('Clone')}
+								>
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
+										<path d="M7 3.5A1.5 1.5 0 018.5 2h3.879a1.5 1.5 0 011.06.44l3.122 3.12A1.5 1.5 0 0117 6.622V12.5a1.5 1.5 0 01-1.5 1.5h-1v-3.379a3 3 0 00-.879-2.121L10.5 5.379A3 3 0 008.379 4.5H7v-1z" />
+										<path d="M4.5 6A1.5 1.5 0 003 7.5v9A1.5 1.5 0 004.5 18h7a1.5 1.5 0 001.5-1.5v-5.879a1.5 1.5 0 00-.44-1.06L9.44 6.439A1.5 1.5 0 008.378 6H4.5z" />
+									</svg>
+								</button>
+							</Tooltip>
+							<Tooltip content={$i18n.t('Delete')}>
+								<button
+									class="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 rounded transition"
+									type="button"
+									on:click={() => {
+										deletingPolicyId = policy.id;
+										showDeleteConfirm = true;
+									}}
+									aria-label={$i18n.t('Delete')}
+								>
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3.5 h-3.5">
+										<path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.519.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
+									</svg>
+								</button>
+							</Tooltip>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/src/lib/components/chat/Settings/Integrations/Terminals/PolicyEditor.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/PolicyEditor.svelte
@@ -1,0 +1,313 @@
+<script lang="ts">
+	import { toast } from 'svelte-sonner';
+	import { getContext } from 'svelte';
+	const i18n = getContext('i18n');
+
+	import { settings } from '$lib/stores';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+
+	import type { PolicyData } from '$lib/apis/terminal';
+	import { createPolicy, updatePolicy } from '$lib/apis/terminal';
+
+	export let show = false;
+	export let edit = false;
+	export let serverId = '';
+	export let policy: { id: string; data: PolicyData } | null = null;
+	export let onSave: () => void = () => {};
+
+	let policyId = '';
+	let image = '';
+	let cpuLimit = '1';
+	let memoryLimit = '1Gi';
+	let storageType: 'ephemeral' | 'persistent' = 'ephemeral';
+	let storageSize = '5Gi';
+	let storageMode = 'per-user';
+	let idleTimeoutMinutes = 30;
+	let envPairs: { key: string; value: string }[] = [];
+
+	let saving = false;
+
+	const init = () => {
+		if (policy) {
+			policyId = policy.id;
+			const d = policy.data ?? {};
+			image = d.image ?? '';
+			cpuLimit = d.cpu_limit ?? '1';
+			memoryLimit = d.memory_limit ?? '1Gi';
+			storageType = d.storage ? 'persistent' : 'ephemeral';
+			storageSize = d.storage ?? '5Gi';
+			storageMode = d.storage_mode ?? 'per-user';
+			idleTimeoutMinutes = d.idle_timeout_minutes ?? 30;
+			const env = d.env ?? {};
+			envPairs = Object.entries(env).map(([k, v]) => ({ key: k, value: v }));
+		} else {
+			policyId = '';
+			image = '';
+			cpuLimit = '1';
+			memoryLimit = '1Gi';
+			storageType = 'ephemeral';
+			storageSize = '5Gi';
+			storageMode = 'per-user';
+			idleTimeoutMinutes = 30;
+			envPairs = [];
+		}
+	};
+
+	$: if (show) {
+		init();
+	}
+
+	const buildData = (): PolicyData => {
+		const data: PolicyData = {};
+		if (image) data.image = image;
+		if (cpuLimit) data.cpu_limit = cpuLimit;
+		if (memoryLimit) data.memory_limit = memoryLimit;
+		if (storageType === 'persistent') {
+			data.storage = storageSize;
+			data.storage_mode = storageMode;
+		}
+		if (idleTimeoutMinutes > 0) data.idle_timeout_minutes = idleTimeoutMinutes;
+
+		const env: Record<string, string> = {};
+		for (const pair of envPairs) {
+			if (pair.key.trim()) env[pair.key.trim()] = pair.value;
+		}
+		if (Object.keys(env).length > 0) data.env = env;
+		return data;
+	};
+
+	const submitHandler = async () => {
+		if (!policyId.trim()) {
+			toast.error($i18n.t('Please enter a Policy ID'));
+			return;
+		}
+
+		saving = true;
+		try {
+			const data = buildData();
+			let result;
+			if (edit) {
+				result = await updatePolicy(localStorage.token, serverId, policyId, data);
+			} else {
+				result = await createPolicy(localStorage.token, serverId, policyId, data);
+			}
+
+			if (result) {
+				toast.success($i18n.t('Policy saved'));
+				onSave();
+				show = false;
+			} else {
+				toast.error($i18n.t('Failed to save policy'));
+			}
+		} catch (err) {
+			toast.error($i18n.t('Failed to save policy: {{error}}', { error: String(err) }));
+		} finally {
+			saving = false;
+		}
+	};
+
+	const inputClass = (hc: boolean) =>
+		`w-full flex-1 text-sm bg-transparent font-mono ${hc ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`;
+	const labelClass = (hc: boolean) =>
+		`text-xs ${hc ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`;
+
+	$: hc = $settings?.highContrastMode ?? false;
+</script>
+
+<Modal size="sm" bind:show>
+	<div>
+		<div class="flex justify-between dark:text-gray-100 px-5 pt-4 pb-2">
+			<h1 class="text-lg font-medium self-center font-primary">
+				{#if edit}
+					{$i18n.t('Edit Policy')}
+				{:else}
+					{$i18n.t('Create Policy')}
+				{/if}
+			</h1>
+			<button class="self-center" aria-label={$i18n.t('Close')} on:click={() => (show = false)}>
+				<XMark className="size-5" />
+			</button>
+		</div>
+
+		<div class="flex flex-col w-full px-4 pb-4 dark:text-gray-200">
+			<form class="flex flex-col w-full" on:submit|preventDefault={submitHandler}>
+				<div class="px-1">
+					<!-- Policy ID -->
+					<div class="flex flex-col">
+						<div class="flex justify-between mb-0.5">
+							<label for="pe-policy-id" class={labelClass(hc)}>{$i18n.t('Policy ID')}</label>
+						</div>
+						<input
+							id="pe-policy-id"
+							class={inputClass(hc)}
+							type="text"
+							bind:value={policyId}
+							placeholder="python-ds"
+							autocomplete="off"
+							disabled={edit}
+						/>
+					</div>
+
+					<!-- Image -->
+					<div class="flex flex-col mt-2">
+						<div class="flex justify-between mb-0.5">
+							<label for="pe-image" class={labelClass(hc)}>
+								{$i18n.t('Image')}
+								<span class="opacity-50">({$i18n.t('optional')})</span>
+							</label>
+						</div>
+						<input
+							id="pe-image"
+							class={inputClass(hc)}
+							type="text"
+							bind:value={image}
+							placeholder="ghcr.io/open-webui/open-terminal:latest"
+							autocomplete="off"
+						/>
+					</div>
+
+					<!-- CPU / Memory -->
+					<div class="flex gap-2 mt-2">
+						<div class="flex flex-col flex-1">
+							<div class="flex justify-between mb-0.5">
+								<label for="pe-cpu" class={labelClass(hc)}>{$i18n.t('CPU')}</label>
+							</div>
+							<input
+								id="pe-cpu"
+								class={inputClass(hc)}
+								type="text"
+								bind:value={cpuLimit}
+								placeholder="1"
+								autocomplete="off"
+							/>
+						</div>
+						<div class="flex flex-col flex-1">
+							<div class="flex justify-between mb-0.5">
+								<label for="pe-memory" class={labelClass(hc)}>{$i18n.t('Memory')}</label>
+							</div>
+							<input
+								id="pe-memory"
+								class={inputClass(hc)}
+								type="text"
+								bind:value={memoryLimit}
+								placeholder="1Gi"
+								autocomplete="off"
+							/>
+						</div>
+					</div>
+
+					<!-- Storage -->
+					<div class="flex gap-2 mt-2">
+						<div class="flex flex-col flex-1">
+							<div class="flex justify-between mb-0.5">
+								<label class={labelClass(hc)}>{$i18n.t('Storage')}</label>
+							</div>
+							<div class="flex gap-2">
+								<select
+									class={`dark:bg-gray-900 w-auto text-sm bg-transparent pr-5 ${hc ? '' : 'outline-hidden'}`}
+									bind:value={storageType}
+								>
+									<option value="ephemeral">{$i18n.t('Ephemeral')}</option>
+									<option value="persistent">{$i18n.t('Persistent')}</option>
+								</select>
+								{#if storageType === 'persistent'}
+									<input
+										class={inputClass(hc)}
+										type="text"
+										bind:value={storageSize}
+										placeholder="5Gi"
+										autocomplete="off"
+									/>
+								{/if}
+							</div>
+						</div>
+
+						{#if storageType === 'persistent'}
+							<div class="flex flex-col flex-1">
+								<div class="flex justify-between mb-0.5">
+									<label class={labelClass(hc)}>{$i18n.t('Storage Mode')}</label>
+								</div>
+								<select
+									class={`dark:bg-gray-900 w-full text-sm bg-transparent pr-5 ${hc ? '' : 'outline-hidden'}`}
+									bind:value={storageMode}
+								>
+									<option value="per-user">{$i18n.t('Per User')}</option>
+									<option value="shared">{$i18n.t('Shared (RWX)')}</option>
+									<option value="shared-rwo">{$i18n.t('Shared (RWO)')}</option>
+								</select>
+							</div>
+						{/if}
+					</div>
+
+					<!-- Idle Timeout -->
+					<div class="flex flex-col mt-2">
+						<div class="flex justify-between mb-0.5">
+							<label for="pe-idle" class={labelClass(hc)}>
+								{$i18n.t('Idle Timeout')}
+								<span class="opacity-50">({$i18n.t('min')})</span>
+							</label>
+						</div>
+						<input
+							id="pe-idle"
+							class={inputClass(hc)}
+							type="number"
+							min="0"
+							bind:value={idleTimeoutMinutes}
+							placeholder="30"
+							autocomplete="off"
+						/>
+					</div>
+
+					<!-- Env Vars -->
+					<div class="flex flex-col mt-2">
+						<div class="flex justify-between items-center mb-0.5">
+							<span class={labelClass(hc)}>{$i18n.t('Environment Variables')}</span>
+							<button
+								type="button"
+								class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+								on:click={() => (envPairs = [...envPairs, { key: '', value: '' }])}
+							>
+								+ {$i18n.t('Add')}
+							</button>
+						</div>
+						{#each envPairs as pair, idx}
+							<div class="flex gap-1.5 mb-1">
+								<input
+									class={`flex-1 text-sm bg-transparent font-mono ${hc ? '' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+									type="text"
+									bind:value={pair.key}
+									placeholder="KEY"
+								/>
+								<input
+									class={`flex-[2] text-sm bg-transparent font-mono ${hc ? '' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+									type="text"
+									bind:value={pair.value}
+									placeholder="value"
+								/>
+								<button
+									type="button"
+									class="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition px-1"
+									on:click={() => (envPairs = envPairs.filter((_, i) => i !== idx))}
+								>
+									<XMark className="size-3" />
+								</button>
+							</div>
+						{/each}
+					</div>
+
+					<!-- Submit -->
+					<div class="flex justify-end pt-3">
+						<button
+							class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+							type="submit"
+							disabled={saving}
+						>
+							{saving ? $i18n.t('Saving...') : $i18n.t('Save')}
+						</button>
+					</div>
+				</div>
+			</form>
+		</div>
+	</div>
+</Modal>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

Adds admin-facing UI and backend proxy routes for managing Terminals Kubernetes Operator policies, monitoring active terminal instances, and inspecting server configuration, all from within Admin Settings → Integrations → Open Terminal.

When a terminal server connection is detected as an orchestrator type, the Open Terminal section gains three tabs: **Connections** (existing), **Policies** (new), and **Active Terminals** (new). Plain terminal server setups are unaffected — the tabs only appear when an orchestrator connection is present.

This is the Open WebUI-side companion to a Terminals repo PR that adds the instance listing and server info API endpoints consumed here. That PR is found here: https://github.com/open-webui/terminals/pull/6

**Why this matters:** The Terminals orchestrator provisions isolated terminal instances per user based on policies (named resource templates). Until now, policies could only be managed via direct API calls, admins had no visibility into running instances, and the connection modal had no way to select from existing policies. This PR solves all three.

### Added

- Admin-only proxy routes in `terminals.py` for policy CRUD, instance listing/teardown, and server info, forwarding requests to the in-cluster orchestrator so its API key never reaches the browser
- Server type detection endpoint (`POST /terminal_servers/verify`) that probes a terminal server and identifies it as `orchestrator` or `terminal`
- Direct policy creation endpoint (`POST /terminal_servers/policy`) for use during initial connection setup before a server ID exists
- User name enrichment on the instance list — resolves user IDs to display names from the Open WebUI users table
- TypeScript API client types and functions (`PolicyData`, `PolicyResponse`, `TerminalInstance`, `TerminalServerInfo`) with corresponding fetch helpers
- `PolicyEditor.svelte` — modal for creating/editing policies (image, CPU, memory, storage, storage mode, idle timeout, environment variables)
- `Policies.svelte` — policy list with server selector, search, create/edit/clone/delete actions
- `Instances.svelte` — active terminal instance table with status badges, auto-refresh, relative timestamps, and delete action with confirmation
- Tabbed interface in `Terminals.svelte` (Connections / Policies / Active Terminals) that appears when an orchestrator connection is detected
- Automatic `server_type` detection on mount — connections without a stored type are probed and the result is persisted

### Changed

- `AddTerminalServerModal.svelte` — replaced inline policy fields with a policy selector dropdown; adds New/Edit buttons to manage policies in-place; stores `policy_id` on the connection instead of `policy_data`
- `Terminals.svelte` — accepts an `admin` prop so it can be embedded in both admin and user settings pages
- `Connection.svelte` — passes `admin` prop through to `AddTerminalServerModal`
- Admin `Integrations.svelte` — replaced inline terminal HTML with the shared `<Terminals admin>` component so admin and user settings use the same tabbed UI

### Deprecated

- N/A

### Removed

- Inline policy editing fields from `AddTerminalServerModal` (replaced by policy selector + PolicyEditor)

### Fixed

- N/A

### Security

- All admin proxy routes require `get_admin_user` — regular users cannot access policy or instance management
- Orchestrator API keys remain server-side; proxied through Open WebUI backend, never sent to the browser

### Breaking Changes

- N/A — existing plain terminal server connections continue to work unchanged. The new tabs only appear when an orchestrator-type connection is detected.

---

### Additional Information

- **Companion PR (Terminals repo):** Adds `/api/v1/instances`, `/api/v1/instances/{id}`, and `/api/v1/info` endpoints that this PR's proxy routes and frontend consume. The policy CRUD endpoints (`/api/v1/policies/*`) already exist in the Terminals main branch.
- **Multi-tenant pattern:** Multiple connections can point at the same orchestrator URL with different `policy_id` values, each granted to a different user group via Open WebUI's existing group-based access control. This enables per-group terminal configurations (e.g., Developers → lightweight Python image, Data Scientists → GPU-capable image with 16 GB RAM).
- **No new dependencies.**

### Testing

Tested end-to-end on a local `kind` cluster with the Terminals orchestrator, Kopf operator, and Open WebUI.

**Automated E2E tests:**
- Policy CRUD — create, read, update, list, delete via proxy routes
- Instance listing — instances appear with correct user/policy/status
- Instance teardown — DELETE removes the Terminal CR
- Server info — backend type, resource caps, version
- Auth — 401 for unauthenticated, 403 for non-admin

**Manual multi-user testing:**

| User | Group | Connection | Policy |
|---|---|---|---|
| Alice | Developers | Dev Terminal | test-python |
| Bob | Data Scientists | Data Terminal | data-science-v2 |

- Alice sees only Dev Terminal, provisions with `test-python` policy
- Bob sees only Data Terminal, provisions with `data-science-v2` policy
- Cross-access denied (Alice→Data Terminal returns 403)
- Admin sees all connections, policies, and instances across tabs

### Screenshots or Videos

New tabs for Open Terminal when Orchestrator is detected:
<img width="1273" height="224" alt="image" src="https://github.com/user-attachments/assets/ee9cd2f3-992e-4dc6-a3ca-71131215a3c8" />

Policies tab with hover actions shown on top policy:
<img width="1270" height="467" alt="image" src="https://github.com/user-attachments/assets/e8d59b57-efc1-477f-b148-541a4aca1261" />

Active Terminals tab:
<img width="1272" height="340" alt="image" src="https://github.com/user-attachments/assets/f8a9546f-d0c6-42da-a4db-8efd3e5830a1" />

Delete Terminal confirmation window:
<img width="1264" height="338" alt="image" src="https://github.com/user-attachments/assets/3e395d1a-b197-4f6c-a3e9-b716c22ee74a" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
