### PR TITLE
fix: rewire orphan tool messages to preserve conversation context

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1770,7 +1770,7 @@ async def chat_completion(
         form_data['metadata'] = metadata
 
     except Exception as e:
-        log.debug(f'Error processing chat metadata: {e}')
+        log.error(f'Error processing chat metadata: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -1812,7 +1812,7 @@ async def chat_completion(
             finally:
                 raise  # re-raise to ensure proper task cancellation handling
         except Exception as e:
-            log.debug(f'Error processing chat payload: {e}')
+            log.exception(f'Error processing chat payload: {e}')
             if metadata.get('chat_id') and metadata.get('message_id'):
                 # Update the chat message with the error
                 try:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1155,6 +1155,16 @@ async def generate_chat_completion(
 
         # Check if response is SSE
         if 'text/event-stream' in r.headers.get('Content-Type', ''):
+            if r.status >= 400:
+                error_body = await r.text()
+                log.error(f'Provider returned HTTP {r.status} (streaming): {error_body[:1000]}')
+                await cleanup_response(r, session)
+                try:
+                    error_json = json.loads(error_body)
+                    return JSONResponse(status_code=r.status, content=error_json)
+                except Exception:
+                    return PlainTextResponse(status_code=r.status, content=error_body)
+
             streaming = True
             return StreamingResponse(
                 stream_wrapper(r, session, stream_chunks_handler),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -97,7 +97,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     get_content_from_message,
     convert_output_to_messages,
-    drop_orphan_tool_messages,
+    rewire_orphan_tool_messages,
     strip_empty_content_blocks,
 )
 from open_webui.utils.tools import (
@@ -2090,7 +2090,7 @@ def process_messages_with_output(messages: list[dict]) -> list[dict]:
         clean_message = {k: v for k, v in message.items() if k != 'output'}
         processed.append(clean_message)
 
-    return drop_orphan_tool_messages(processed)
+    return rewire_orphan_tool_messages(processed)
 
 
 async def process_chat_payload(request, form_data, user, metadata, model):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3025,6 +3025,7 @@ async def non_streaming_chat_response_handler(response, ctx):
         try:
             if 'error' in response_data:
                 error = response_data.get('error')
+                log.error(f'Chat completion error from provider: {error}')
 
                 if isinstance(error, dict):
                     error = error.get('detail', error)
@@ -3598,6 +3599,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     if not choices:
                                         error = data.get('error', {})
                                         if error:
+                                            log.error(f'Chat completion stream error from provider: {error}')
                                             await event_emitter(
                                                 {
                                                     'type': 'chat:completion',

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -97,6 +97,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     get_content_from_message,
     convert_output_to_messages,
+    drop_orphan_tool_messages,
     strip_empty_content_blocks,
 )
 from open_webui.utils.tools import (
@@ -2089,7 +2090,7 @@ def process_messages_with_output(messages: list[dict]) -> list[dict]:
         clean_message = {k: v for k, v in message.items() if k != 'output'}
         processed.append(clean_message)
 
-    return processed
+    return drop_orphan_tool_messages(processed)
 
 
 async def process_chat_payload(request, form_data, user, metadata, model):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2076,12 +2076,28 @@ def process_messages_with_output(messages: list[dict]) -> list[dict]:
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
     """
+    # Pre-scan: build call_id -> function name map from ALL outputs so we can
+    # recover tool names for orphan function_call_output items across branches.
+    call_id_to_name: dict[str, str] = {}
+    for message in messages:
+        if message.get('role') == 'assistant' and message.get('output'):
+            for item in message['output']:
+                if (
+                    isinstance(item, dict)
+                    and item.get('type') == 'function_call'
+                    and item.get('call_id')
+                    and item.get('name')
+                ):
+                    call_id_to_name[item['call_id']] = item['name']
+
     processed = []
 
     for message in messages:
         if message.get('role') == 'assistant' and message.get('output'):
             # Use output items for clean OpenAI-format messages
-            output_messages = convert_output_to_messages(message['output'], raw=True)
+            output_messages = convert_output_to_messages(
+                message['output'], raw=True, call_id_to_name=call_id_to_name
+            )
             if output_messages:
                 processed.extend(output_messages)
                 continue
@@ -2090,7 +2106,7 @@ def process_messages_with_output(messages: list[dict]) -> list[dict]:
         clean_message = {k: v for k, v in message.items() if k != 'output'}
         processed.append(clean_message)
 
-    return rewire_orphan_tool_messages(processed)
+    return rewire_orphan_tool_messages(processed, call_id_to_name=call_id_to_name)
 
 
 async def process_chat_payload(request, form_data, user, metadata, model):
@@ -3921,7 +3937,8 @@ async def streaming_chat_response_handler(response, ctx):
                             if done:
                                 pass
                             else:
-                                log.debug(f'Error: {e}')
+                                log.error(f'Error processing stream line: {e}')
+                                log.debug(f'Problematic line: {line}')
                                 continue
                     await flush_pending_delta_data()
 

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -146,6 +146,7 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
         return []
 
     messages = []
+    seen_tool_call_ids = set()
     pending_tool_calls = []
     pending_content = []
 
@@ -178,12 +179,15 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
         elif item_type == 'function_call':
             # Collect tool calls to batch into assistant message
             arguments = item.get('arguments', '{}')
+            call_id = item.get('call_id', '')
+            if call_id:
+                seen_tool_call_ids.add(call_id)
             # Ensure arguments is always a JSON string
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments)
             pending_tool_calls.append(
                 {
-                    'id': item.get('call_id', ''),
+                    'id': call_id,
                     'type': 'function',
                     'function': {
                         'name': item.get('name', ''),
@@ -193,6 +197,12 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
             )
 
         elif item_type == 'function_call_output':
+            call_id = item.get('call_id', '')
+            # Guard: skip orphan tool results with no corresponding tool call
+            # in the reconstructed sequence to avoid invalid provider payloads.
+            if not call_id or call_id not in seen_tool_call_ids:
+                continue
+
             # Flush any pending content/tool_calls before adding tool result
             flush_pending()
 
@@ -214,7 +224,7 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
                 messages.append(
                     {
                         'role': 'tool',
-                        'tool_call_id': item.get('call_id', ''),
+                        'tool_call_id': call_id,
                         'content': [
                             {'type': 'input_text', 'text': content},
                             *[{'type': 'input_image', 'image_url': url} for url in image_urls],
@@ -225,7 +235,7 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
                 messages.append(
                     {
                         'role': 'tool',
-                        'tool_call_id': item.get('call_id', ''),
+                        'tool_call_id': call_id,
                         'content': content,
                     }
                 )
@@ -274,6 +284,42 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
     flush_pending()
 
     return messages
+
+
+def drop_orphan_tool_messages(messages: list[dict]) -> list[dict]:
+    """
+    Drop tool messages that do not have a matching tool call in the previous
+    assistant message.
+
+    This prevents invalid payloads for providers that strictly validate tool
+    message sequencing (e.g. Anthropic/Vertex).
+    """
+    if not messages:
+        return messages
+
+    cleaned = []
+    for message in messages:
+        if message.get('role') != 'tool':
+            cleaned.append(message)
+            continue
+
+        tool_call_id = message.get('tool_call_id', '')
+        if not tool_call_id or not cleaned:
+            continue
+
+        previous_message = cleaned[-1]
+        if previous_message.get('role') != 'assistant':
+            continue
+
+        tool_calls = previous_message.get('tool_calls') or []
+        has_matching_call = any(
+            isinstance(tool_call, dict) and tool_call.get('id') == tool_call_id for tool_call in tool_calls
+        )
+
+        if has_matching_call:
+            cleaned.append(message)
+
+    return cleaned
 
 
 def get_last_user_message(messages: list[dict]) -> Optional[str]:

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -198,10 +198,23 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
 
         elif item_type == 'function_call_output':
             call_id = item.get('call_id', '')
-            # Guard: skip orphan tool results with no corresponding tool call
-            # in the reconstructed sequence to avoid invalid provider payloads.
-            if not call_id or call_id not in seen_tool_call_ids:
+            if not call_id:
                 continue
+
+            # Rewire: if this tool result has no matching tool call,
+            # inject a synthetic function_call so the sequence stays valid.
+            if call_id not in seen_tool_call_ids:
+                seen_tool_call_ids.add(call_id)
+                pending_tool_calls.append(
+                    {
+                        'id': call_id,
+                        'type': 'function',
+                        'function': {
+                            'name': '_unknown',
+                            'arguments': '{}',
+                        },
+                    }
+                )
 
             # Flush any pending content/tool_calls before adding tool result
             flush_pending()
@@ -286,13 +299,13 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
     return messages
 
 
-def drop_orphan_tool_messages(messages: list[dict]) -> list[dict]:
+def rewire_orphan_tool_messages(messages: list[dict]) -> list[dict]:
     """
-    Drop tool messages that do not have a matching tool call in the previous
-    assistant message.
+    Rewire orphan tool messages by injecting a synthetic tool_call into the
+    preceding assistant message when no matching call exists.
 
-    This prevents invalid payloads for providers that strictly validate tool
-    message sequencing (e.g. Anthropic/Vertex).
+    This keeps conversation context intact while producing valid payloads for
+    providers that strictly validate tool message sequencing (e.g. Anthropic/Vertex).
     """
     if not messages:
         return messages
@@ -304,20 +317,43 @@ def drop_orphan_tool_messages(messages: list[dict]) -> list[dict]:
             continue
 
         tool_call_id = message.get('tool_call_id', '')
-        if not tool_call_id or not cleaned:
+        if not tool_call_id:
             continue
 
-        previous_message = cleaned[-1]
-        if previous_message.get('role') != 'assistant':
-            continue
+        # Find or create a preceding assistant message to attach the tool call
+        if not cleaned or cleaned[-1].get('role') not in ('assistant', 'tool'):
+            cleaned.append({'role': 'assistant', 'content': '', 'tool_calls': []})
 
-        tool_calls = previous_message.get('tool_calls') or []
+        # Walk back to find the nearest assistant message
+        assistant_idx = len(cleaned) - 1
+        while assistant_idx >= 0 and cleaned[assistant_idx].get('role') != 'assistant':
+            assistant_idx -= 1
+
+        if assistant_idx < 0:
+            cleaned.insert(0, {'role': 'assistant', 'content': '', 'tool_calls': []})
+            assistant_idx = 0
+
+        assistant_msg = cleaned[assistant_idx]
+        tool_calls = assistant_msg.get('tool_calls') or []
         has_matching_call = any(
-            isinstance(tool_call, dict) and tool_call.get('id') == tool_call_id for tool_call in tool_calls
+            isinstance(tc, dict) and tc.get('id') == tool_call_id for tc in tool_calls
         )
 
-        if has_matching_call:
-            cleaned.append(message)
+        if not has_matching_call:
+            # Inject a synthetic tool call so the result has a valid parent
+            tool_calls.append(
+                {
+                    'id': tool_call_id,
+                    'type': 'function',
+                    'function': {
+                        'name': '_unknown',
+                        'arguments': '{}',
+                    },
+                }
+            )
+            assistant_msg['tool_calls'] = tool_calls
+
+        cleaned.append(message)
 
     return cleaned
 

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -129,7 +129,9 @@ def get_content_from_message(message: dict) -> Optional[str]:
     return None
 
 
-def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
+def convert_output_to_messages(
+    output: list, raw: bool = False, call_id_to_name: Optional[dict] = None
+) -> list[dict]:
     """
     Convert OR-aligned output items to OpenAI Chat Completion-format messages.
 
@@ -141,9 +143,14 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
         output: List of OR-aligned output items (Responses API format).
         raw: If True, include reasoning blocks (with original tags) and code
              interpreter blocks for LLM re-processing follow-ups.
+        call_id_to_name: Optional mapping of call_id -> function name, used to
+             recover tool names for orphan function_call_output items.
     """
     if not output or not isinstance(output, list):
         return []
+
+    if call_id_to_name is None:
+        call_id_to_name = {}
 
     messages = []
     seen_tool_call_ids = set()
@@ -204,13 +211,27 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
             # Rewire: if this tool result has no matching tool call,
             # inject a synthetic function_call so the sequence stays valid.
             if call_id not in seen_tool_call_ids:
+                tool_name = call_id_to_name.get(call_id)
+                if not tool_name:
+                    # Can't recover the tool name — fold result into text context
+                    output_parts = item.get('output', [])
+                    result_text = ''
+                    for part in (output_parts if isinstance(output_parts, list) else []):
+                        if isinstance(part, dict) and part.get('type') == 'input_text':
+                            result_text += part.get('text', '')
+                    if not result_text and isinstance(output_parts, str):
+                        result_text = output_parts
+                    if result_text:
+                        pending_content.append(f'[Tool result: {result_text}]')
+                    continue
+
                 seen_tool_call_ids.add(call_id)
                 pending_tool_calls.append(
                     {
                         'id': call_id,
                         'type': 'function',
                         'function': {
-                            'name': '_unknown',
+                            'name': tool_name,
                             'arguments': '{}',
                         },
                     }
@@ -299,16 +320,26 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
     return messages
 
 
-def rewire_orphan_tool_messages(messages: list[dict]) -> list[dict]:
+def rewire_orphan_tool_messages(
+    messages: list[dict], call_id_to_name: Optional[dict] = None
+) -> list[dict]:
     """
     Rewire orphan tool messages by injecting a synthetic tool_call into the
     preceding assistant message when no matching call exists.
 
     This keeps conversation context intact while producing valid payloads for
     providers that strictly validate tool message sequencing (e.g. Anthropic/Vertex).
+
+    Args:
+        messages: List of OpenAI-format messages.
+        call_id_to_name: Optional mapping of call_id -> function name, used to
+             recover tool names for orphan tool messages.
     """
     if not messages:
         return messages
+
+    if call_id_to_name is None:
+        call_id_to_name = {}
 
     cleaned = []
     for message in messages:
@@ -340,13 +371,28 @@ def rewire_orphan_tool_messages(messages: list[dict]) -> list[dict]:
         )
 
         if not has_matching_call:
-            # Inject a synthetic tool call so the result has a valid parent
+            tool_name = call_id_to_name.get(tool_call_id)
+            if not tool_name:
+                # Can't recover the tool name — fold result into assistant text
+                content = message.get('content', '')
+                if isinstance(content, list):
+                    content = ' '.join(
+                        p.get('text', '') for p in content
+                        if isinstance(p, dict) and p.get('type') in ('text', 'input_text')
+                    )
+                if content:
+                    existing = assistant_msg.get('content', '') or ''
+                    separator = '\n' if existing else ''
+                    assistant_msg['content'] = f'{existing}{separator}[Tool result: {content}]'
+                continue
+
+            # Inject a synthetic tool call with the real name
             tool_calls.append(
                 {
                     'id': tool_call_id,
                     'type': 'function',
                     'function': {
-                        'name': '_unknown',
+                        'name': tool_name,
                         'arguments': '{}',
                     },
                 }


### PR DESCRIPTION
## Summary
- When chat history reconstruction produces `tool_result` messages without a matching `tool_use` (e.g. partial history, retries, edited chains), strict providers like Anthropic/Vertex reject the payload with HTTP 400
- Instead of dropping orphan tool messages (losing context), we now **rewire** them by injecting a synthetic `tool_call` into the preceding assistant message so the sequence stays valid
- Applies at both the output→message conversion layer (`convert_output_to_messages`) and the final message sanitization pass (`rewire_orphan_tool_messages`)


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
