### PR TITLE
fix: prefilled input value resets when sending input event call

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2652,6 +2652,7 @@
 	inputPlaceholder={eventConfirmationInputPlaceholder}
 	inputValue={eventConfirmationInputValue}
 	inputType={eventConfirmationInputType}
+	prefilled={!!eventConfirmationInputValue}
 	on:confirm={(e) => {
 		if (e.detail) {
 			eventCallback(e.detail);

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -26,8 +26,9 @@
 	export let inputType = '';
 
 	export let show = false;
+	export let prefilled = false;
 
-	$: if (show) {
+	$: if (show && !prefilled) {
 		init();
 	}
 


### PR DESCRIPTION
## Summary

Fixes #23019

## Problem
When sending an event call of type `input` with a prefilled `value`, the prefilled value is reset and sent empty on subsequent calls.

## Root Cause
Commit fb26be7 introduced a reset in `init()` that clears `inputValue` every time the dialog shows, even when the value is intentionally prefilled.

## Solution
- Added `prefilled` prop to `ConfirmDialog.svelte`
- Only reset `inputValue` when `!prefilled`
- Pass `prefilled={!!eventConfirmationInputValue}` from `Chat.svelte`

## Testing
1. Create a filter function that sends an input event with prefilled value
2. Trigger multiple prompts
3. Verify prefilled value persists on subsequent calls

## Files Changed
- `src/lib/components/common/ConfirmDialog.svelte`: Added `prefilled` prop and conditional reset
- `src/lib/components/chat/Chat.svelte`: Pass `prefilled` prop based on inputValue existence