### PR TITLE
fix: preserve prefilled input value in input event dialog

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -131,6 +131,7 @@
 	let eventConfirmationInputPlaceholder = '';
 	let eventConfirmationInputValue = '';
 	let eventConfirmationInputType = '';
+	let eventConfirmationPrefilled = false;
 	let eventCallback = null;
 
 	let selectedModels = [''];
@@ -549,6 +550,7 @@
 					eventConfirmationInputPlaceholder = data.placeholder;
 					eventConfirmationInputValue = data?.value ?? '';
 					eventConfirmationInputType = data?.type ?? '';
+					eventConfirmationPrefilled = !!data?.value;
 				} else if (type.startsWith('terminal:')) {
 					terminalEventHandler(type, data);
 				} else {
@@ -2714,6 +2716,7 @@
 	inputPlaceholder={eventConfirmationInputPlaceholder}
 	inputValue={eventConfirmationInputValue}
 	inputType={eventConfirmationInputType}
+	prefilled={eventConfirmationPrefilled}
 	on:confirm={(e) => {
 		if (e.detail) {
 			eventCallback(e.detail);

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -24,10 +24,11 @@
 	export let inputPlaceholder = '';
 	export let inputValue = '';
 	export let inputType = '';
+	export let prefilled = false;
 
 	export let show = false;
 
-	$: if (show) {
+	$: if (show && !prefilled) {
 		init();
 	}
 


### PR DESCRIPTION
## Summary

Fixes #23019

### Problem
When sending an input event call with a prefilled value, the value was being reset to empty on subsequent calls.

### Root Cause
Commit fb26be7 introduced logic to reset the input value when showing the dialog to avoid accidentally sending previous user input. However, this reset was applied unconditionally, even when the value was intentionally prefilled by the event caller.

### Solution
Add a `prefilled` prop to `ConfirmDialog.svelte` that prevents the reset when the value was set by the event caller:

1. Added `prefilled` prop to `ConfirmDialog.svelte`
2. Modified the reset logic to skip when `prefilled=true`
3. Added `eventConfirmationPrefilled` state in `Chat.svelte`
4. Set `prefilled=true` when `data.value` exists

This preserves the intended behavior of clearing stale user input while allowing prefilled values to persist.

### Testing
Manually tested with input event calls containing prefilled values - the value now persists correctly on repeated calls.

### CLA
I have read and agree to the Contributor License Agreement.