### PR TITLE
fix: prevent inconsistent conversation bubble sizes with YAML code bl…

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -411,7 +411,7 @@
 									{/if}
 								</Name>
 
-								<div class="mt-1 markdown-prose w-full min-w-full">
+								<div class="mt-1 markdown-prose w-full min-w-full overflow-hidden">
 									{#if (message?.content ?? '') === ''}
 										<Skeleton />
 									{:else}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -657,7 +657,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-full markdown-prose overflow-hidden">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -196,7 +196,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-full markdown-prose overflow-hidden">
 			{#if edit !== true}
 				{#if message.files}
 					<div


### PR DESCRIPTION
## Summary
Fixes #5975 — Conversation bubbles resize inconsistently when scrolling in widescreen mode with YAML code blocks.

## Root Cause
The `min-w-full` on the markdown-prose container combined with `white-space: pre-wrap` on `pre` elements allowed code block content to push bubble widths beyond the parent's `max-w-5xl` constraint, causing inconsistent resizing during scroll.

## Fix
Added `overflow-hidden` to the markdown-prose container divs in:
- `ResponseMessage.svelte`
- `UserMessage.svelte`  
- `MultiResponseMessages.svelte`

This prevents code block content from expanding the bubble width beyond the parent container's max-width constraint. The code blocks themselves already have `overflow-x-auto` internally for horizontal scrolling of long lines.

## Testing
- Verified the fix addresses the YAML code block scenario described in #5975
- The `overflow-hidden` on the prose container is a standard CSS containment pattern that breaks the intrinsic size feedback loop without affecting normal content rendering