### PR TITLE
fix: preserve prefilled input value in input event dialog

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -131,6 +131,7 @@
 	let eventConfirmationInputPlaceholder = '';
 	let eventConfirmationInputValue = '';
 	let eventConfirmationInputType = '';
+	let eventConfirmationPrefilled = false;
 	let eventCallback = null;
 
 	let selectedModels = [''];
@@ -549,6 +550,7 @@
 					eventConfirmationInputPlaceholder = data.placeholder;
 					eventConfirmationInputValue = data?.value ?? '';
 					eventConfirmationInputType = data?.type ?? '';
+					eventConfirmationPrefilled = !!data?.value;
 				} else if (type.startsWith('terminal:')) {
 					terminalEventHandler(type, data);
 				} else {
@@ -2714,6 +2716,7 @@
 	inputPlaceholder={eventConfirmationInputPlaceholder}
 	inputValue={eventConfirmationInputValue}
 	inputType={eventConfirmationInputType}
+	prefilled={eventConfirmationPrefilled}
 	on:confirm={(e) => {
 		if (e.detail) {
 			eventCallback(e.detail);

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -24,10 +24,11 @@
 	export let inputPlaceholder = '';
 	export let inputValue = '';
 	export let inputType = '';
+	export let prefilled = false;
 
 	export let show = false;
 
-	$: if (show) {
+	$: if (show && !prefilled) {
 		init();
 	}
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** PR targets the `dev` branch
- [x] **Description:** Concise description provided below
- [x] **Changelog:** Entry added
- [x] **Testing:** Manually tested - the fix works as intended

# Changelog Entry

### Description

Fixes #23019 - When sending an input event call with a prefilled value, the value was being reset to empty on subsequent calls.

### Fixed

- Added `prefilled` prop to `ConfirmDialog.svelte` to preserve intentionally prefilled input values
- Modified reset logic to skip when `prefilled=true`
- Added `eventConfirmationPrefilled` state in `Chat.svelte` to track prefilled state

### Screenshots or Videos

- N/A (logic fix, no visual changes)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.