### PR TITLE
fix: allow tool calls to continue generation for non-admin users

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4552,6 +4552,7 @@ async def streaming_chat_response_handler(response, ctx):
                             request,
                             new_form_data,
                             user,
+                            bypass_filter=True,
                             bypass_system_prompt=True,
                         )
 
@@ -4737,6 +4738,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 request,
                                 new_form_data,
                                 user,
+                                bypass_filter=True,
                                 bypass_system_prompt=True,
                             )
 


### PR DESCRIPTION
## Problem
Fixes #22851

When a tool call is executed by a non-admin user, the generation stops after the tool result is returned. Admin users are unaffected.

## Root Cause
In `streaming_chat_response_handler`, when a tool call completes and the model needs to continue generating the response, the subsequent call to `generate_chat_completion` was missing the `bypass_filter=True` parameter. This caused the model access control check to fail for regular users.

## Solution
Add `bypass_filter=True` to both `generate_chat_completion` calls after tool execution in the streaming handler:
- Line 4551: Tool result continuation
- Line 4737: Code interpreter continuation

## Testing
- Tested with non-admin user making tool calls
- Generation now continues after tool result is returned
- No changes to security model - this only affects the follow-up generation after the user has already been authorized for the initial request

## Files Changed
- `backend/open_webui/utils/middleware.py`: Added `bypass_filter=True` parameter