### PR TITLE
fix: allow tool calls to continue generation for non-admin users

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4394,6 +4394,7 @@ async def streaming_chat_response_handler(response, ctx):
                             request,
                             new_form_data,
                             user,
+                            bypass_filter=True,
                             bypass_system_prompt=True,
                         )
 
@@ -4580,6 +4581,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 request,
                                 new_form_data,
                                 user,
+                                bypass_filter=True,
                                 bypass_system_prompt=True,
                             )
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** This PR targets the \`dev\` branch
- [x] **Description:** Fix for Issue #22851 - Tool calls fail for non-admin users
- [x] **Testing:** Manually tested by a user in the issue (TheoSlater confirmed the fix works)

## Changelog Entry

### Description

When a tool call is executed by a non-admin user, the generation stops after the tool result is returned. Admin users are unaffected due to \`BYPASS_ADMIN_ACCESS_CONTROL\`.

### Fixed

- Added \`bypass_filter=True\` to \`generate_chat_completion\` calls after tool execution in the streaming handler
- This ensures the model access check is skipped for follow-up generations after the user has already been authorized for the initial request

### Root Cause

In \`streaming_chat_response_handler\`, when a tool call completes and the model needs to continue generating the response, the subsequent call to \`generate_chat_completion\` was missing the \`bypass_filter=True\` parameter. This caused the model access control check to fail for regular users.

### Files Changed

- \`backend/open_webui/utils/middleware.py\`: Added \`bypass_filter=True\` parameter (2 locations)

### Testing Evidence

User @TheoSlater in Issue #22851 confirmed this fix resolves the problem:
> "This fix works for me"

### Related Issues

Fixes #22851

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.