### PR TITLE
fix: remove null bytes from PDF metadata to prevent PostgreSQL JSONB errors

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -21,6 +21,9 @@ def process_metadata(
         # Convert non-serializable fields to strings
         if isinstance(value, (datetime, list, dict)):
             result[key] = str(value)
+        elif isinstance(value, str):
+            # Remove null bytes and other control characters that PostgreSQL JSONB cannot handle
+            result[key] = ''.join(char for char in value if ord(char) >= 32 or char in '\n\r\t')
         else:
             result[key] = value
     return result


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch
- [x] **Description:** Fix for Issue #22992 - PDF upload fails with PostgreSQL backend
- [x] **Testing:** Tested locally with null byte removal logic

## Changelog Entry

### Description

PostgreSQL JSONB cannot handle null bytes (`\x00`) in strings. Some PDF metadata contains null bytes (e.g., `"Adobe PSL 1.3e for Canon\x00"`) which causes `DataError: unsupported Unicode escape sequence` when inserting document chunks.

### Fixed

- Added null byte filtering in `process_metadata` function
- Removes control characters (ord < 32) except newlines (`\n`), carriage returns (`\r`), and tabs (`\t`)
- Ensures metadata is safe for PostgreSQL JSONB storage

### Root Cause

The `process_metadata` function in `backend/open_webui/retrieval/vector/utils.py` converts non-serializable types to strings but does not sanitize string values. When PDF metadata contains null bytes, PostgreSQL raises an error during INSERT.

### Files Changed

- `backend/open_webui/retrieval/vector/utils.py`: Added string sanitization to remove null bytes

### Testing

```python
# Before fix
metadata = {"producer": "Adobe PSL 1.3e for Canon\\x00"}
# INSERT fails with: DataError: unsupported Unicode escape sequence

# After fix
result = process_metadata(metadata)
# result["producer"] = "Adobe PSL 1.3e for Canon" (null byte removed)
# INSERT succeeds
```

### Related Issues

Fixes #22992

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.