### PR TITLE
fix: remove null bytes from metadata to prevent PostgreSQL JSONB errors

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -3,9 +3,28 @@ from datetime import datetime
 KEYS_TO_EXCLUDE = ['content', 'pages', 'tables', 'paragraphs', 'sections', 'figures']
 
 
+def _clean_string_value(value: str) -> str:
+    """Remove null bytes and other invalid Unicode characters that cause issues with PostgreSQL JSONB."""
+    if not isinstance(value, str):
+        return value
+    # Remove null bytes and other control characters that are invalid in JSON
+    return ''.join(char for char in value if char >= ' ' or char in '\t\n\r')
+
+
+def _clean_value(value):
+    """Recursively clean strings in nested structures (dict, list)."""
+    if isinstance(value, str):
+        return _clean_string_value(value)
+    elif isinstance(value, dict):
+        return {k: _clean_value(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [_clean_value(item) for item in value]
+    return value
+
+
 def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
-    # Removes large/redundant fields from metadata dict.
-    metadata = {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE}
+    # Removes large/redundant fields from metadata dict and cleans invalid characters.
+    metadata = {key: _clean_value(value) for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE}
     return metadata
 
 
@@ -13,6 +32,7 @@ def process_metadata(
     metadata: dict[str, any],
 ) -> dict[str, any]:
     # Removes large fields and converts non-serializable types (datetime, list, dict) to strings.
+    # Also cleans null bytes and invalid Unicode characters.
     result = {}
     for key, value in metadata.items():
         # Skip large fields
@@ -20,7 +40,7 @@ def process_metadata(
             continue
         # Convert non-serializable fields to strings
         if isinstance(value, (datetime, list, dict)):
-            result[key] = str(value)
-        else:
-            result[key] = value
+            value = str(value)
+        # Clean string values from null bytes and invalid characters
+        result[key] = _clean_value(value)
     return result


### PR DESCRIPTION
## Summary

Fixes #22992

Removes null bytes and invalid control characters from metadata strings before storing in vector database. This prevents PostgreSQL JSONB errors when processing PDFs with malformed metadata.

## Changes

- Added `_clean_string_value()` function to remove null bytes and invalid control characters
- Added `_clean_value()` for recursive cleaning of nested structures (dict, list)
- Updated `filter_metadata()` and `process_metadata()` to clean all string values

## Testing

```python
# Test with null byte in PDF metadata
test_metadata = {'producer': 'Adobe PDF Library 15.0\x00'}
result = filter_metadata(test_metadata)
# result['producer'] == 'Adobe PDF Library 15.0'  # null byte removed
```

All unit tests passed.

## Issue Reference

Closes #22992