### PR TITLE
fix: add pagination to chat list endpoints to prevent OOM

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -927,12 +927,12 @@ class ChatTable:
 
     def get_chats(self, skip: int = 0, limit: int = 50, db: Optional[Session] = None) -> list[ChatModel]:
         with get_db_context(db) as db:
-            all_chats = (
-                db.query(Chat)
-                # .limit(limit).offset(skip)
-                .order_by(Chat.updated_at.desc())
-            )
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            query = db.query(Chat).order_by(Chat.updated_at.desc())
+            if skip:
+                query = query.offset(skip)
+            if limit:
+                query = query.limit(limit)
+            return [ChatModel.model_validate(chat) for chat in query.all()]
 
     def get_chats_by_user_id(
         self,
@@ -1000,10 +1000,20 @@ class ChatTable:
                 for chat in all_chats
             ]
 
-    def get_archived_chats_by_user_id(self, user_id: str, db: Optional[Session] = None) -> list[ChatModel]:
+    def get_archived_chats_by_user_id(
+        self, user_id: str, skip: int = 0, limit: int = 50, db: Optional[Session] = None
+    ) -> list[ChatModel]:
         with get_db_context(db) as db:
-            all_chats = db.query(Chat).filter_by(user_id=user_id, archived=True).order_by(Chat.updated_at.desc())
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            query = (
+                db.query(Chat)
+                .filter_by(user_id=user_id, archived=True)
+                .order_by(Chat.updated_at.desc())
+            )
+            if skip:
+                query = query.offset(skip)
+            if limit:
+                query = query.limit(limit)
+            return [ChatModel.model_validate(chat) for chat in query.all()]
 
     def get_chats_by_user_id_and_search_text(
         self,

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -669,8 +669,10 @@ async def get_user_pinned_chats(user=Depends(get_verified_user), db: Session = D
 
 
 @router.get('/all', response_model=list[ChatResponse])
-async def get_user_chats(user=Depends(get_verified_user), db: Session = Depends(get_session)):
-    result = Chats.get_chats_by_user_id(user.id, db=db)
+async def get_user_chats(
+    skip: int = 0, limit: int = 50, user=Depends(get_verified_user), db: Session = Depends(get_session)
+):
+    result = Chats.get_chats_by_user_id(user.id, skip=skip, limit=limit, db=db)
     return [ChatResponse(**chat.model_dump()) for chat in result.items]
 
 
@@ -680,8 +682,13 @@ async def get_user_chats(user=Depends(get_verified_user), db: Session = Depends(
 
 
 @router.get('/all/archived', response_model=list[ChatResponse])
-async def get_user_archived_chats(user=Depends(get_verified_user), db: Session = Depends(get_session)):
-    return [ChatResponse(**chat.model_dump()) for chat in Chats.get_archived_chats_by_user_id(user.id, db=db)]
+async def get_user_archived_chats(
+    skip: int = 0, limit: int = 50, user=Depends(get_verified_user), db: Session = Depends(get_session)
+):
+    return [
+        ChatResponse(**chat.model_dump())
+        for chat in Chats.get_archived_chats_by_user_id(user.id, skip=skip, limit=limit, db=db)
+    ]
 
 
 ############################
@@ -705,13 +712,15 @@ async def get_all_user_tags(user=Depends(get_verified_user), db: Session = Depen
 
 
 @router.get('/all/db', response_model=list[ChatResponse])
-async def get_all_user_chats_in_db(user=Depends(get_admin_user), db: Session = Depends(get_session)):
+async def get_all_user_chats_in_db(
+    skip: int = 0, limit: int = 50, user=Depends(get_admin_user), db: Session = Depends(get_session)
+):
     if not ENABLE_ADMIN_EXPORT:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
-    return [ChatResponse(**chat.model_dump()) for chat in Chats.get_chats(db=db)]
+    return [ChatResponse(**chat.model_dump()) for chat in Chats.get_chats(skip=skip, limit=limit, db=db)]
 
 
 ############################


### PR DESCRIPTION
## Summary

Fixes #22206

Adds pagination to chat list endpoints to prevent Out of Memory (OOM) crashes when users have large numbers of chats.

## Problem

When calling `/api/v1/chats/all` or `/api/v1/chats/all/archived` without pagination, the server loads ALL chats into memory. For users with thousands of chats, this can cause OOM crashes.

## Changes

- **models/chats.py**: Added `skip` and `limit` parameters to `get_chats()` and `get_archived_chats_by_user_id()`
- **routers/chats.py**: Updated `/chats/all`, `/chats/all/archived`, `/chats/all/db` endpoints with pagination parameters
- Default limit of 50 prevents loading unbounded data

## API Changes

```
GET /api/v1/chats/all?skip=0&limit=50
GET /api/v1/chats/all/archived?skip=0&limit=50
GET /api/v1/chats/all/db?skip=0&limit=50
```

## Testing

Tested locally with:
- 1000+ chats in database
- Verified memory usage stays constant
- Verified pagination returns correct subsets

## Related

Based on closed PR #22464 with formatting fixes.

---

### Contributor License Agreement

By submitting this pull request, I confirm that my contributions are made under the Apache 2.0 license.