### PR TITLE
fix: Move embeds rendering below message content

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -693,25 +693,6 @@
 							</div>
 						{/if}
 
-						{#if message?.embeds && message.embeds.length > 0}
-							<div
-								class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap"
-								id={`${message.id}-embeds-container`}
-							>
-								{#each message.embeds as embed, idx}
-									<div class="my-2 w-full" id={`${message.id}-embeds-${idx}`}>
-										<FullHeightIframe
-											src={embed}
-											allowScripts={true}
-											allowForms={true}
-											allowSameOrigin={$settings?.iframeSandboxAllowSameOrigin ?? false}
-											allowPopups={true}
-										/>
-									</div>
-								{/each}
-							</div>
-						{/if}
-
 						{#if edit === true}
 							<div class="w-full bg-gray-50 dark:bg-gray-800 rounded-3xl px-5 py-3 my-2">
 								<textarea
@@ -847,6 +828,25 @@
 
 							{#if message.code_executions}
 								<CodeExecutions codeExecutions={message.code_executions} />
+							{/if}
+
+							{#if message?.embeds && message.embeds.length > 0}
+								<div
+									class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap"
+									id={`${message.id}-embeds-container`}
+								>
+									{#each message.embeds as embed, idx}
+										<div class="my-2 w-full" id={`${message.id}-embeds-${idx}`}>
+											<FullHeightIframe
+												src={embed}
+												allowScripts={true}
+												allowForms={true}
+												allowSameOrigin={$settings?.iframeSandboxAllowSameOrigin ?? false}
+												allowPopups={true}
+											/>
+										</div>
+									{/each}
+								</div>
 							{/if}
 						</div>
 					</div>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets the `dev` branch
- [x] **Description:** Fix embeds rendering order to show below message content
- [x] **Changelog:** Entry added below
- [x] **Testing:** Logic follows documented rendering position
- [x] **Code review:** Self-review completed
- [x] **Git Hygiene:** Single atomic fix, focused on rendering order

# Changelog Entry

### Description

Rich UI embeds now render below message text content, as documented.

### Fixed

- Moved embeds block to render after code_executions
- Ensures correct visual order: message content → code executions → embeds

---

### Additional Information

Fixes #23049

**Root Cause:** Embeds were rendering above message content due to incorrect position in the component.

**Solution:** Moved the embeds rendering block to the correct position after code_executions.

**Testing:**
- Verified the diff matches the expected change
- No new dependencies or breaking changes

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.