### PR TITLE
fix: Add pagination support to /chats/all endpoint to prevent OOM

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -669,8 +669,37 @@ async def get_user_pinned_chats(user=Depends(get_verified_user), db: Session = D
 
 
 @router.get('/all', response_model=list[ChatResponse])
-async def get_user_chats(user=Depends(get_verified_user), db: Session = Depends(get_session)):
-    result = Chats.get_chats_by_user_id(user.id, db=db)
+async def get_user_chats(
+    page: Optional[int] = None,
+    limit: Optional[int] = None,
+    user=Depends(get_verified_user),
+    db: Session = Depends(get_session),
+):
+    """
+    Get all chats for the user with optional pagination.
+    
+    Args:
+        page: Page number (1-indexed). If None, returns all chats up to limit.
+        limit: Max number of chats per page. Defaults to 1000 to prevent OOM.
+    
+    Returns:
+        List of ChatResponse objects.
+    
+    Note:
+        To avoid OOM issues, the endpoint now caps results at 1000 by default.
+        Use pagination (page + limit) for users with many chats.
+        For backward compatibility, response is still a list (not paginated response).
+    """
+    # Default limit to prevent OOM for users with many chats
+    effective_limit = limit if limit is not None else 1000
+    skip = None
+    
+    if page is not None:
+        skip = (page - 1) * effective_limit
+    
+    result = Chats.get_chats_by_user_id(
+        user.id, skip=skip, limit=effective_limit, db=db
+    )
     return [ChatResponse(**chat.model_dump()) for chat in result.items]
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets the `dev` branch
- [x] **Description:** Add pagination support to prevent OOM errors when loading all chats
- [x] **Changelog:** Entry added below
- [x] **Testing:** Syntax validation passed, logic follows existing pattern
- [x] **Code review:** Self-review completed
- [x] **Git Hygiene:** Single atomic fix, focused on OOM prevention

# Changelog Entry

### Description

Add pagination support to the `/chats/all` endpoint to prevent Out of Memory (OOM) errors for users with many chats.

### Fixed

- Add optional `page` and `limit` query parameters to `/chats/all` endpoint
- Set default limit of 1000 to prevent memory exhaustion
- Maintain backward compatibility - response is still a list

### Added

- Pagination parameters for chat list retrieval
- Documentation explaining the new parameters

---

### Additional Information

Fixes #22206

**Root Cause:** Users with thousands of chats were experiencing OOM errors when the `/chats/all` endpoint tried to load all chats into memory at once.

**Solution:**
- Add optional `page` and `limit` query parameters
- Default limit of 1000 prevents memory issues
- Backward compatible: response format unchanged

**Testing:**
```python
# Test pagination
GET /chats/all  # Returns max 1000 chats (default limit)
GET /chats/all?page=1&limit=100  # Returns first 100 chats
GET /chats/all?page=2&limit=100  # Returns next 100 chats
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.