### PR TITLE
fix: Include meta fields in pipe model responses

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -104,6 +104,17 @@ async def get_function_models(request):
 
                 log.debug(f"get_function_models: function '{pipe.id}' is a manifold of {sub_pipes}")
 
+                # Extract meta fields from pipe description/profile
+                pipe_meta = {}
+                if pipe.meta:
+                    _pm = pipe.meta if isinstance(pipe.meta, dict) else {}
+                    pipe_meta = {
+                        'meta': {
+                            k: v for k, v in _pm.items()
+                            if k in ('description', 'profile_image_url', 'capabilities')
+                        }
+                    }
+
                 for p in sub_pipes:
                     sub_pipe_id = f'{pipe.id}.{p["id"]}'
                     sub_pipe_name = p['name']
@@ -113,17 +124,20 @@ async def get_function_models(request):
 
                     pipe_flag = {'type': pipe.type}
 
-                    pipe_models.append(
-                        {
-                            'id': sub_pipe_id,
-                            'name': sub_pipe_name,
-                            'object': 'model',
-                            'created': pipe.created_at,
-                            'owned_by': 'openai',
-                            'pipe': pipe_flag,
-                            'has_user_valves': has_user_valves,
-                        }
-                    )
+                    pipe_model = {
+                        'id': sub_pipe_id,
+                        'name': sub_pipe_name,
+                        'object': 'model',
+                        'created': pipe.created_at,
+                        'owned_by': 'openai',
+                        'pipe': pipe_flag,
+                        'has_user_valves': has_user_valves,
+                    }
+                    # Add meta fields if available
+                    if pipe_meta:
+                        pipe_model.update(pipe_meta)
+
+                    pipe_models.append(pipe_model)
             else:
                 pipe_flag = {'type': 'pipe'}
 
@@ -131,17 +145,31 @@ async def get_function_models(request):
                     f"get_function_models: function '{pipe.id}' is a single pipe {{ 'id': {pipe.id}, 'name': {pipe.name} }}"
                 )
 
-                pipe_models.append(
-                    {
-                        'id': pipe.id,
-                        'name': pipe.name,
-                        'object': 'model',
-                        'created': pipe.created_at,
-                        'owned_by': 'openai',
-                        'pipe': pipe_flag,
-                        'has_user_valves': has_user_valves,
+                # Extract meta fields from pipe description/profile
+                pipe_meta = {}
+                if pipe.meta:
+                    _pm = pipe.meta if isinstance(pipe.meta, dict) else {}
+                    pipe_meta = {
+                        'meta': {
+                            k: v for k, v in _pm.items()
+                            if k in ('description', 'profile_image_url', 'capabilities')
+                        }
                     }
-                )
+
+                pipe_model = {
+                    'id': pipe.id,
+                    'name': pipe.name,
+                    'object': 'model',
+                    'created': pipe.created_at,
+                    'owned_by': 'openai',
+                    'pipe': pipe_flag,
+                    'has_user_valves': has_user_valves,
+                }
+                # Add meta fields if available
+                if pipe_meta:
+                    pipe_model.update(pipe_meta)
+
+                pipe_models.append(pipe_model)
         except Exception as e:
             log.exception(e)
             continue


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Targets the `dev` branch
- [x] **Description:** Include meta fields in pipe model responses for Admin editor
- [x] **Changelog:** Entry added below
- [x] **Testing:** Syntax validation passed
- [x] **Code review:** Self-review completed
- [x] **Git Hygiene:** Single atomic fix

# Changelog Entry

### Description

Pipe models (functions) now include meta fields in their model response.

### Fixed

- Added meta fields (description, profile_image_url, capabilities) to pipe model dicts
- Admin model editor now properly displays these fields instead of empty values

---

### Additional Information

Fixes #23047

**Root Cause:** The `get_function_models()` function was not including the `meta` field from pipe objects when constructing model dictionaries, causing the Admin model editor to show empty fields.

**Solution:** Extract meta fields from `pipe.meta` and include them in both manifold and single pipe model dictionaries.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.