### PR TITLE
fix: refresh models after saving direct connections

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -535,14 +535,16 @@
 	const saveSettings = async (updated) => {
 		console.log(updated);
 		await settings.set({ ...$settings, ...updated });
-		await models.set(await getModels());
+		await models.set(await getModels('directConnections' in updated));
 		await updateUserSettings(localStorage.token, { ui: $settings });
 	};
 
-	const getModels = async () => {
+	const getModels = async (refresh: boolean = false) => {
 		return await _getModels(
 			localStorage.token,
-			$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
+			$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null),
+			false,
+			refresh
 		);
 	};
 


### PR DESCRIPTION
## Description

When adding or updating a direct connection, the models list was not refreshed, causing new models to not appear until page reload.

## Changes

- Added `refresh` parameter to the local `getModels()` function
- Pass `refresh=true` when `directConnections` is in the updated settings
- Forces backend to re-fetch models from all configured providers

## Test Plan

1. Open Settings > Connections
2. Add a new OpenAI-compatible connection (e.g., OpenRouter, Together AI)
3. Save the connection
4. Verify that models from the new connection appear in the model selector without page reload

Fixes #23060

## Checklist

- [x] My code follows the existing code style
- [x] I have tested my changes locally
- [x] My commit messages follow the [Conventional Commits spec](https://www.conventionalcommits.org/)
- [x] I have signed the CLA: I confirm that my contributions are my own and I have the right to contribute them under the project's license