### PR TITLE
fix(terminals): proxy admin terminal verification through backend

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -1,5 +1,7 @@
 import logging
 import copy
+import json
+from urllib.parse import quote
 from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel, ConfigDict
 import aiohttp
@@ -245,6 +247,77 @@ class TerminalServersConfigForm(BaseModel):
     TERMINAL_SERVER_CONNECTIONS: list[TerminalServerConnection]
 
 
+class TerminalServerPolicyForm(BaseModel):
+    url: str
+    key: Optional[str] = ''
+    auth_type: Optional[str] = 'bearer'
+    policy: dict
+
+
+def _build_terminal_request_auth(request: Request, auth_type: str, key: str):
+    headers: dict[str, str] = {}
+    cookies = {}
+
+    if auth_type == 'bearer':
+        if key:
+            headers['Authorization'] = f'Bearer {key}'
+    elif auth_type == 'session':
+        cookies = request.cookies
+        token = getattr(getattr(request.state, 'token', None), 'credentials', '')
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+    elif auth_type == 'system_oauth':
+        cookies = request.cookies
+        oauth_token = request.headers.get('x-oauth-access-token', '')
+        if oauth_token:
+            headers['Authorization'] = f'Bearer {oauth_token}'
+
+    return headers, cookies
+
+
+async def _detect_terminal_server_type(
+    request: Request,
+    form_data: TerminalServerConnection,
+) -> Optional[str]:
+    base_url = form_data.url.rstrip('/')
+    if not base_url:
+        return None
+
+    headers, cookies = _build_terminal_request_auth(
+        request,
+        form_data.auth_type or 'bearer',
+        form_data.key or '',
+    )
+
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        for path, server_type in (
+            ('/api/v1/policies', 'orchestrator'),
+            ('/api/config', 'terminal'),
+        ):
+            try:
+                async with session.get(f'{base_url}{path}', headers=headers, cookies=cookies) as response:
+                    if response.status == 200:
+                        return server_type
+            except Exception as e:
+                log.debug(f'Failed to probe terminal server endpoint {path}: {e}')
+
+    return None
+
+
+async def _load_json_response(response: aiohttp.ClientResponse):
+    body = await response.text()
+    if not body:
+        return None, body
+
+    try:
+        return json.loads(body), body
+    except json.JSONDecodeError:
+        return None, body
+
+
 @router.get('/terminal_servers')
 async def get_terminal_servers_config(request: Request, user=Depends(get_admin_user)):
     return {
@@ -267,6 +340,79 @@ async def set_terminal_servers_config(
     return {
         'TERMINAL_SERVER_CONNECTIONS': request.app.state.config.TERMINAL_SERVER_CONNECTIONS,
     }
+
+
+@router.post('/terminal_servers/verify')
+async def verify_terminal_servers_config(
+    request: Request,
+    form_data: TerminalServerConnection,
+    user=Depends(get_admin_user),
+):
+    """
+    Verify the connection to a terminal server without exposing credentials to the browser.
+    """
+    server_type = await _detect_terminal_server_type(request, form_data)
+
+    if server_type is None:
+        raise HTTPException(status_code=400, detail='Server connection failed')
+
+    return {
+        'status': True,
+        'server_type': server_type,
+    }
+
+
+@router.put('/terminal_servers/policies/{policy_id}')
+async def put_terminal_server_policy(
+    policy_id: str,
+    request: Request,
+    form_data: TerminalServerPolicyForm,
+    user=Depends(get_admin_user),
+):
+    """
+    Create or update an orchestrator policy through the backend so the terminal API key
+    never leaves Open WebUI.
+    """
+    base_url = form_data.url.rstrip('/')
+    if not base_url:
+        raise HTTPException(status_code=400, detail='Please enter a valid URL')
+
+    headers, cookies = _build_terminal_request_auth(
+        request,
+        form_data.auth_type or 'bearer',
+        form_data.key or '',
+    )
+    headers['Content-Type'] = 'application/json'
+
+    target_url = f'{base_url}/api/v1/policies/{quote(policy_id, safe="")}'
+
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        try:
+            async with session.put(
+                target_url,
+                headers=headers,
+                cookies=cookies,
+                json=form_data.policy,
+            ) as response:
+                response_json, response_text = await _load_json_response(response)
+
+                if response.status >= 400:
+                    detail = (
+                        response_json.get('detail')
+                        if isinstance(response_json, dict) and response_json.get('detail')
+                        else response_text
+                    ) or 'Failed to save policy'
+                    raise HTTPException(status_code=response.status, detail=detail)
+
+                return response_json if response_json is not None else {'status': True}
+        except HTTPException:
+            raise
+        except Exception as e:
+            log.exception(f'Failed to update terminal server policy {policy_id}: {e}')
+            raise HTTPException(status_code=502, detail='Failed to save policy')
 
 
 @router.post('/tool_servers/verify')

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -238,32 +238,40 @@ export const setTerminalServerConnections = async (token: string, connections: o
  * - Neither                         → null
  */
 export const detectTerminalServerType = async (
-	url: string,
-	key: string
+	token: string,
+	connection: {
+		url: string;
+		key?: string;
+		auth_type?: string;
+	}
 ): Promise<'orchestrator' | 'terminal' | null> => {
-	const baseUrl = url.replace(/\/$/, '');
-	const headers: Record<string, string> = {};
-	if (key) {
-		headers['Authorization'] = `Bearer ${key}`;
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/terminal_servers/verify`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			...connection
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
 	}
 
-	// Orchestrators expose a policies API; plain terminals don't.
-	try {
-		const res = await fetch(`${baseUrl}/api/v1/policies`, { headers });
-		if (res.ok) return 'orchestrator';
-	} catch {
-		// ignore
-	}
-
-	// Fall back to open-terminal config endpoint.
-	try {
-		const res = await fetch(`${baseUrl}/api/config`, { headers });
-		if (res.ok) return 'terminal';
-	} catch {
-		// ignore
-	}
-
-	return null;
+	return res?.server_type ?? null;
 };
 
 /**
@@ -271,25 +279,30 @@ export const detectTerminalServerType = async (
  * PUT {url}/api/v1/policies/{policyId}
  */
 export const putOrchestratorPolicy = async (
-	url: string,
-	key: string,
+	token: string,
+	connection: {
+		url: string;
+		key?: string;
+		auth_type?: string;
+	},
 	policyId: string,
 	policyData: object
 ): Promise<object | null> => {
 	let error = null;
 
-	const baseUrl = url.replace(/\/$/, '');
-	const headers: Record<string, string> = {
-		'Content-Type': 'application/json'
-	};
-	if (key) {
-		headers['Authorization'] = `Bearer ${key}`;
-	}
-
-	const res = await fetch(`${baseUrl}/api/v1/policies/${encodeURIComponent(policyId)}`, {
-		method: 'PUT',
-		headers,
-		body: JSON.stringify(policyData)
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/configs/terminal_servers/policies/${encodeURIComponent(policyId)}`,
+		{
+			method: 'PUT',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({
+				...connection,
+				policy: policyData
+			})
+		}
 	})
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -112,7 +112,11 @@
 		try {
 			if (admin) {
 				// Admin: detect orchestrator vs terminal
-				const type = await detectTerminalServerType(_url, key);
+				const type = await detectTerminalServerType(localStorage.token, {
+					url: _url,
+					key,
+					auth_type
+				});
 
 				if (type) {
 					serverType = type;
@@ -194,7 +198,16 @@
 		// Save policy to orchestrator if applicable
 		if (serverType === 'orchestrator' && admin && policyId) {
 			try {
-				await putOrchestratorPolicy(url, key, policyId, buildPolicyData());
+				await putOrchestratorPolicy(
+					localStorage.token,
+					{
+						url,
+						key,
+						auth_type
+					},
+					policyId,
+					buildPolicyData()
+				);
 			} catch (err) {
 				toast.error($i18n.t('Failed to save policy: {{error}}', { error: err }));
 				return;


### PR DESCRIPTION
## Summary
- add backend config endpoints for admin terminal-server verification and orchestrator policy updates
- route the admin Add Terminal Server modal through those endpoints instead of probing external terminal URLs directly from the browser
- keep credentials on the Open WebUI backend while preserving the existing direct-user terminal flow

## Testing
- python -m compileall backend/open_webui/routers/configs.py

Fixes #23048.