### PR TITLE
fix(i18n): correct Lithuanian provider placeholder on auth buttons

### DIFF
--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -410,7 +410,7 @@
 	"Content Extraction Engine": "",
 	"Content lengths (character counts only)": "",
 	"Continue Response": "Tęsti atsakymą",
-	"Continue with {{provider}}": "Tęsti su {{tiekėju}}",
+	"Continue with {{provider}}": "Tęsti su {{provider}}",
 	"Continue with Email": "",
 	"Continue with LDAP": "",
 	"Control how message text is split for TTS requests. 'Punctuation' splits into sentences, 'paragraphs' splits into paragraphs, and 'none' keeps the message as a single string.": "",


### PR DESCRIPTION
## Summary
- replace the Lithuanian `{{tiekeju}}` interpolation token with the `{{provider}}` placeholder used by the auth page
- restore correct provider names on localized sign-in buttons like Microsoft SSO

Fixes #23070.