### PR TITLE
fix: handle finish_reason in streaming to prevent infinite loop with tool_calls

### DIFF
--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -82,9 +82,25 @@ async function* openAIStreamToIterator(
 				continue;
 			}
 
+			const delta = parsedData.choices?.[0]?.delta;
+			const finishReason = parsedData.choices?.[0]?.finish_reason;
+
+			// Handle tool_calls finish reason - stop streaming
+			if (finishReason === 'tool_calls') {
+				yield { done: true, value: '' };
+				break;
+			}
+
+			// Handle stop finish reason - stop streaming
+			if (finishReason === 'stop') {
+				yield { done: true, value: '' };
+				break;
+			}
+
+			// Handle regular content or tool_calls (tool_calls are ignored in current implementation)
 			yield {
 				done: false,
-				value: parsedData.choices?.[0]?.delta?.content ?? ''
+				value: delta?.content ?? ''
 			};
 		} catch (e) {
 			console.error('Error extracting delta from SSE event:', e);


### PR DESCRIPTION
## Issue
Fixes #23066

## Problem
When using streaming responses with tool calls, Open WebUI would get stuck in an infinite loop if the server sent `finish_reason: 'tool_calls'`. This is because the streaming parser only checked for `[DONE]` but ignored OpenAI's standard `finish_reason` field.

## Root Cause
In `src/lib/apis/streaming/index.ts`, the `openAIStreamToIterator` function:
- Only yielded `delta.content` for streaming
- Did not check `finish_reason` from `choices[0].finish_reason`
- Did not stop streaming when `finish_reason` was 'tool_calls' or 'stop'

## Solution
1. Extract `delta` and `finish_reason` from parsed data
2. Stop streaming when `finish_reason` equals 'tool_calls'
3. Stop streaming when `finish_reason` equals 'stop'
4. Continue yielding content for all other cases

## Testing
- When a server sends `finish_reason: 'tool_calls'`, the stream now properly terminates
- Prevents infinite loops when using custom OpenAI-compatible servers that stream tool calls
- Maintains backward compatibility with existing content streaming

## Checklist
- [x] I have read and followed all instructions in README.md
- [x] The proposed changes are minimal and targeted
- [x] I have tested the fix (manual testing)