### PR TITLE
i18n: correct Lithuanian provider placeholder

### DIFF
--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -410,7 +410,7 @@
 	"Content Extraction Engine": "",
 	"Content lengths (character counts only)": "",
 	"Continue Response": "Tęsti atsakymą",
-	"Continue with {{provider}}": "Tęsti su {{tiekėju}}",
+	"Continue with {{provider}}": "Tęsti su {{provider}}",
 	"Continue with Email": "",
 	"Continue with LDAP": "",
 	"Control how message text is split for TTS requests. 'Punctuation' splits into sentences, 'paragraphs' splits into paragraphs, and 'none' keeps the message as a single string.": "",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: This PR is a focused localization fix tied directly to the reported issue and kept intentionally small.

- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [ ] **Documentation:** No docs-repo change was required because this corrects an existing translation placeholder only.
- [x] **Dependencies:** No new or upgraded dependencies were added.
- [x] **Testing:** Manual validation details are included below.
- [x] **Agentic AI Code:** The CLA and testing details have been personally reviewed and accepted by the account owner before resubmission.
- [x] **Code review:** I performed a self-review to keep the change limited to the incorrect translation placeholder.
- [x] **Design & Architecture:** No architectural changes; this is a data-only i18n correction.
- [x] **Git Hygiene:** This PR contains one logical fix and is rebased onto `dev` with no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `i18n` prefix.

# Changelog Entry

### Description

- Correct the Lithuanian auth-provider translation placeholder so provider names render correctly in the "Continue with {{provider}}" string.
- Closes #23070.

### Added

- None.

### Changed

- Updated the Lithuanian translation entry to use the `{{provider}}` placeholder expected by the application.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed the Lithuanian login/auth button text so it interpolates the provider name instead of showing an untranslated placeholder token.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- This supersedes the earlier closed PRs for the same one-line fix and keeps the change targeted to `dev`.
- Manual validation performed:
  - Verified the translation entry now uses `{{provider}}` instead of the incorrect placeholder.
  - Ran `git diff --check` on the branch before submission to confirm a clean patch.
- No dependency or code-path changes were required.

### Screenshots or Videos

- Not included because this change is a one-line localization placeholder correction.

### Contributor License Agreement

<!--
?? DO NOT DELETE THE TEXT BELOW ??
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.