### PR TITLE
fix: refresh forwarded system oauth id token for OpenAI proxy

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -177,7 +177,7 @@ async def get_headers_and_cookies(
         cookies = request.cookies
         token = request.state.token.credentials
     elif auth_type == 'system_oauth':
-        cookies = request.cookies
+        cookies = dict(request.cookies)
 
         oauth_token = None
         try:
@@ -190,7 +190,13 @@ async def get_headers_and_cookies(
             log.error(f'Error getting OAuth token: {e}')
 
         if oauth_token:
-            token = f'{oauth_token.get("access_token", "")}'
+            access_token = oauth_token.get('access_token')
+            if access_token:
+                token = f'{access_token}'
+
+            refreshed_id_token = oauth_token.get('id_token')
+            if refreshed_id_token:
+                cookies['oauth_id_token'] = refreshed_id_token
 
     elif auth_type in ('azure_ad', 'microsoft_entra_id'):
         token = get_microsoft_entra_id_access_token()

--- a/backend/open_webui/test/apps/webui/routers/test_openai.py
+++ b/backend/open_webui/test/apps/webui/routers/test_openai.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+from open_webui.routers import openai as openai_router
+
+
+def build_request(*, cookies: dict, oauth_token: dict | None):
+    oauth_manager = SimpleNamespace(get_oauth_token=AsyncMock(return_value=oauth_token))
+    request = SimpleNamespace(
+        cookies=cookies,
+        state=SimpleNamespace(
+            token=HTTPAuthorizationCredentials(scheme='Bearer', credentials='session-token')
+        ),
+        app=SimpleNamespace(state=SimpleNamespace(oauth_manager=oauth_manager)),
+    )
+    return request, oauth_manager
+
+
+class TestOpenAIHeadersAndCookies:
+    @pytest.mark.asyncio
+    async def test_system_oauth_refreshes_forwarded_oauth_id_token(self):
+        request, oauth_manager = build_request(
+            cookies={
+                'oauth_session_id': 'session-1',
+                'oauth_id_token': 'stale-id-token',
+                'other_cookie': 'keep-me',
+            },
+            oauth_token={
+                'access_token': 'fresh-access-token',
+                'id_token': 'fresh-id-token',
+            },
+        )
+
+        headers, cookies = await openai_router.get_headers_and_cookies(
+            request,
+            'https://example.com',
+            config={'auth_type': 'system_oauth'},
+            user=SimpleNamespace(id='user-1'),
+        )
+
+        oauth_manager.get_oauth_token.assert_awaited_once_with('user-1', 'session-1')
+        assert headers['Authorization'] == 'Bearer fresh-access-token'
+        assert cookies['oauth_id_token'] == 'fresh-id-token'
+        assert cookies['other_cookie'] == 'keep-me'
+
+    @pytest.mark.asyncio
+    async def test_system_oauth_keeps_existing_cookie_when_refreshed_token_has_no_id_token(self):
+        request, oauth_manager = build_request(
+            cookies={
+                'oauth_session_id': 'session-1',
+                'oauth_id_token': 'existing-id-token',
+            },
+            oauth_token={
+                'access_token': 'fresh-access-token',
+            },
+        )
+
+        headers, cookies = await openai_router.get_headers_and_cookies(
+            request,
+            'https://example.com',
+            config={'auth_type': 'system_oauth'},
+            user=SimpleNamespace(id='user-1'),
+        )
+
+        oauth_manager.get_oauth_token.assert_awaited_once_with('user-1', 'session-1')
+        assert headers['Authorization'] == 'Bearer fresh-access-token'
+        assert cookies['oauth_id_token'] == 'existing-id-token'


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Refresh the forwarded `oauth_id_token` cookie during `system_oauth` OpenAI proxy requests so custom Responses backends receive the current token instead of a stale browser cookie.

### Added

- Regression tests for `get_headers_and_cookies` covering refreshed and missing `id_token` cases.

### Changed

- `get_headers_and_cookies` now clones forwarded cookies for `system_oauth` requests and replaces `oauth_id_token` with the latest token from the OAuth session when available.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Closes #23074.
- Custom OpenAI-compatible backends that rely on the forwarded `oauth_id_token` cookie now receive the refreshed token during `/responses` and other OpenAI proxy requests.
- Existing cookie values are preserved when the refreshed session does not provide a new `id_token`.

### Security

- Keeps the forwarded OAuth identity cookie aligned with the active OAuth session after refresh instead of continuing to forward an expired value.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- No new dependencies were added to the repository.
- No docs repo change was needed because this corrects internal forwarding for existing `system_oauth` behavior without introducing new settings or APIs.
- Manual validation:
  - `python -m uv run --group dev pytest backend/open_webui/test/apps/webui/routers/test_openai.py`
  - `python -m uv run --group dev ruff check backend/open_webui/test/apps/webui/routers/test_openai.py`
- Screenshots are not applicable for this backend-only token forwarding fix.

### Screenshots or Videos

- N/A (backend-only fix).

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW
Keep the Contributor License Agreement confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.