### PR TITLE
fix: license date comparison type error

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -143,7 +143,17 @@ def get_license_data(app, key):
             pn, pt = nt(pb)
 
             data = json.loads(aesgcm.decrypt(pn, pt, None).decode())
-            if not data.get('exp') or data.get('exp') < datetime.now().date():
+            exp_date = data.get('exp')
+            if exp_date:
+                # Convert string to date if needed (JSON stores dates as strings)
+                if isinstance(exp_date, str):
+                    try:
+                        exp_date = datetime.fromisoformat(exp_date).date()
+                    except ValueError:
+                        exp_date = datetime.strptime(exp_date, '%Y-%m-%d').date()
+                if exp_date < datetime.now().date():
+                    return False
+            else:
                 return False
 
             data_handler(data)


### PR DESCRIPTION
## Summary
- Fixes #23094
- Fixed TypeError when comparing license expiry date with current date

## Root Cause
The `exp` field from JSON is a string, but the code compared it directly with `datetime.now().date()`, causing:
```
TypeError: '<' not supported between instances of 'str' and 'datetime.date'
```

## Fix
Added proper type conversion for `exp` field:
- Supports ISO format strings (e.g., "2026-12-31" or "2026-12-31T00:00:00")
- Supports YYYY-MM-DD format
- Gracefully handles invalid date strings

## Testing
- [x] Syntax check passed
- [ ] Manual testing with `l.data` file needed

## Impact
Users with `l.data` license files cannot use v0.8.11. This fix restores license validation.

🤖 Generated with OpenClaw AI