### PR TITLE
fix: handle None meta in FileMeta.sanitize_meta() to prevent API 500 errors

### DIFF
--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -66,8 +66,9 @@ class FileMeta(BaseModel):
     @classmethod
     def sanitize_meta(cls, data):
         """Sanitize metadata fields to handle malformed legacy data."""
+        # Handle None or non-dict input - return empty dict to satisfy required meta field
         if not isinstance(data, dict):
-            return data
+            return {}
 
         # Handle content_type that may be a list like ['application/pdf', None]
         content_type = data.get('content_type')


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** dev
- [x] **Description:** Fix regression in v0.8.11 where /api/v1/files/ returns HTTP 500 when database contains NULL meta values
- [x] **Changelog:** Added below
- [x] **Testing:** Manually verified the fix by analyzing the code path and confirming the root cause

# Changelog Entry

### Description

- Fix regression in v0.8.11 where /api/v1/files/ returns HTTP 500 Internal Server Error

### Fixed

- FileMeta.sanitize_meta() now returns empty dict {} instead of None for non-dict input, preventing Pydantic ValidationError when FileModelResponse.meta is required

### Root Cause Analysis

In v0.8.11, FileListResponse.items changed from list[FileModel] to list[FileModelResponse]. FileModelResponse.meta is a required field (not Optional), but sanitize_meta() was returning None unchanged when the database value was NULL. This caused Pydantic v2 to raise ValidationError → HTTP 500.

### Test Plan

1. Create files with NULL meta in database (legacy data)
2. Call GET /api/v1/files/
3. Expected: 200 with empty meta objects
4. Before fix: 500 Internal Server Error

Fixes #23101

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.