### PR TITLE
fix: add beautifulsoup4 to pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "langchain-text-splitters==1.1.1",
 
     "fake-useragent==2.2.0",
+    "beautifulsoup4==4.14.3",
     "chromadb==1.5.2",
     "opensearch-py==3.1.0",
     "PyMySQL==1.1.2",


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** dev
- [x] **Description:** Fix missing dependency causing ModuleNotFoundError for uvx/pip installs
- [x] **Changelog:** Added below
- [x] **Testing:** Verified beautifulsoup4 is imported in codebase but missing from pyproject.toml

# Changelog Entry

### Description

- Add beautifulsoup4 to pyproject.toml dependencies to fix ModuleNotFoundError for non-Docker installations

### Fixed

- ModuleNotFoundError: No module named 'bs4' when installing via uvx/pip (Issue #23063)

### Root Cause Analysis

BeautifulSoup4 is imported in:
- backend/open_webui/env.py
- backend/open_webui/retrieval/web/utils.py

But was missing from pyproject.toml dependencies (only in backend/requirements.txt which is not used by uvx installs).

### Test Plan

1. Install open-webui via uvx: `uvx open-webui@latest serve`
2. Before fix: ModuleNotFoundError: No module named 'bs4'
3. After fix: Should start successfully

Fixes #23063

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.