### PR TITLE
enh: Set the default executor for asyncio based on THREAD_POOL_SIZE

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 import random
 import re
+from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
 
@@ -641,9 +642,14 @@ async def lifespan(app: FastAPI):
     if app.state.redis is not None:
         app.state.redis_task_command_listener = asyncio.create_task(redis_task_command_listener(app))
 
+    executor = None
+
     if THREAD_POOL_SIZE and THREAD_POOL_SIZE > 0:
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = THREAD_POOL_SIZE
+
+        executor = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE)
+        app.state.main_loop.set_default_executor(executor)
 
     asyncio.create_task(periodic_usage_pool_cleanup())
     asyncio.create_task(periodic_session_pool_cleanup())
@@ -703,6 +709,9 @@ async def lifespan(app: FastAPI):
     app.state.startup_complete = True
 
     yield
+
+    if executor is not None:
+        executor.shutdown()
 
     if hasattr(app.state, 'redis_task_command_listener'):
         app.state.redis_task_command_listener.cancel()


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Changelog Entry

### Description

- This repository heavily utilizes asyncio.to_thread and only has a small amount of anyio.to_thread. Initially, THREAD_POOL_SIZE only increased the thread pool size of anyio. This pull request enables the thread pool executor of asyncio to be configured by this environment variable

### Added

- Set the default executor for asyncio based on THREAD_POOL_SIZE

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
