### PR TITLE
perf: load chat message map from chat_message rows

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -430,7 +430,54 @@ class ChatTable:
                 return None
             return result[0] or 'New Chat'
 
+    def _messages_map_from_chat_message_rows(self, chat_id: str, rows: list) -> dict:
+        """Build the same shape as `chat.history.messages` from `chat_message` rows."""
+        prefix = f'{chat_id}-'
+        messages_map: dict = {}
+        for row in rows:
+            logical_id = row.id[len(prefix) :] if row.id.startswith(prefix) else row.id
+            msg: dict = {
+                'id': logical_id,
+                'parentId': row.parent_id,
+                'role': row.role,
+                'content': row.content,
+                'output': row.output,
+                # Avoid None: code does `for f in message.get("files", [])` which yields None if key exists
+                'files': row.files if row.files is not None else [],
+            }
+            if row.model_id is not None:
+                msg['model'] = row.model_id
+            if row.created_at is not None:
+                msg['timestamp'] = row.created_at
+            if row.sources is not None:
+                msg['sources'] = row.sources
+            if row.embeds is not None:
+                msg['embeds'] = row.embeds
+            if row.status_history is not None:
+                msg['statusHistory'] = row.status_history
+            if row.error is not None:
+                msg['error'] = row.error
+            if row.usage is not None:
+                msg['usage'] = row.usage
+            if row.done is not None:
+                msg['done'] = row.done
+            messages_map[logical_id] = msg
+        return messages_map
+
     def get_messages_map_by_chat_id(self, id: str) -> Optional[dict]:
+        """
+        Message map for walking history (see `get_message_list`). Prefer `chat_message`
+        rows to avoid loading the large `chat` JSON blob; fall back to embedded history
+        when no rows exist (legacy chats).
+        """
+        with get_db_context() as db:
+            if db.query(Chat.id).filter_by(id=id).first() is None:
+                return None
+
+            rows = db.query(ChatMessage).filter_by(chat_id=id).all()
+            if rows:
+                return self._messages_map_from_chat_message_rows(id, rows)
+
         chat = self.get_chat_by_id(id)
         if chat is None:
             return None
@@ -1111,24 +1158,28 @@ class ChatTable:
                 # Check if there are any tags to filter, it should have all the tags
                 if 'none' in tag_ids:
                     query = query.filter(
-                        text("""
+                        text(
+                            """
                             NOT EXISTS (
                                 SELECT 1
                                 FROM json_each(Chat.meta, '$.tags') AS tag
                             )
-                            """)
+                            """
+                        )
                     )
                 elif tag_ids:
                     query = query.filter(
                         and_(
                             *[
-                                text(f"""
+                                text(
+                                    f"""
                                     EXISTS (
                                         SELECT 1
                                         FROM json_each(Chat.meta, '$.tags') AS tag
                                         WHERE tag.value = :tag_id_{tag_idx}
                                     )
-                                    """).params(**{f'tag_id_{tag_idx}': tag_id})
+                                    """
+                                ).params(**{f'tag_id_{tag_idx}': tag_id})
                                 for tag_idx, tag_id in enumerate(tag_ids)
                             ]
                         )
@@ -1165,24 +1216,28 @@ class ChatTable:
                 # Check if there are any tags to filter, it should have all the tags
                 if 'none' in tag_ids:
                     query = query.filter(
-                        text("""
+                        text(
+                            """
                             NOT EXISTS (
                                 SELECT 1
                                 FROM json_array_elements_text(Chat.meta->'tags') AS tag
                             )
-                            """)
+                            """
+                        )
                     )
                 elif tag_ids:
                     query = query.filter(
                         and_(
                             *[
-                                text(f"""
+                                text(
+                                    f"""
                                     EXISTS (
                                         SELECT 1
                                         FROM json_array_elements_text(Chat.meta->'tags') AS tag
                                         WHERE tag = :tag_id_{tag_idx}
                                     )
-                                    """).params(**{f'tag_id_{tag_idx}': tag_id})
+                                    """
+                                ).params(**{f'tag_id_{tag_idx}': tag_id})
                                 for tag_idx, tag_id in enumerate(tag_ids)
                             ]
                         )


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. *(No user-facing API or env changes; skip unless maintainers want an internal note.)*
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. *(None.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**. *(Steps below; screenshots optional for this backend-only change.)*
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR. *(Confirm per your policy.)*
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **perf** 

---

# Changelog Entry

- ⚡ **Chat history map from `chat_message`.** Loading the message map for middleware now reads normalized `chat_message` rows when present instead of the full `chat` JSON blob, reducing DB I/O and parse cost for large chats; legacy chats without rows still use embedded history.

### Description

- **`get_messages_map_by_chat_id`** now builds `history.messages` from **`chat_message`** rows when any exist for the chat, avoiding loading and parsing the large **`chat` JSON** blob for that hot path. If there are no `chat_message` rows (legacy chats or failed dual-write), behavior falls back to reading embedded history from **`get_chat_by_id`** as before. The goal is to improve performance and reduce memory by not loading and parsing the full json blob.

### Added

- `Chats._messages_map_from_chat_message_rows()` helper to map `ChatMessage` ORM rows into the same shape as embedded `history.messages`.

### Changed

- `Chats.get_messages_map_by_chat_id()`: lightweight chat existence check; prefer `SELECT` from `chat_message` by `chat_id`; fallback to JSON-backed history when no rows.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.