### PR TITLE
feat: support additional Anthropic tool_result content types

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1954,7 +1954,10 @@ async def generate_messages(
     # Convert Anthropic payload to OpenAI format
     requested_model = form_data.get('model', '')
 
-    openai_payload = convert_anthropic_to_openai_payload(form_data)
+    try:
+        openai_payload = convert_anthropic_to_openai_payload(form_data)
+    except (ValueError, NotImplementedError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     # Route through the existing chat_completion handler
     response = await chat_completion(request, openai_payload, user)

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1956,7 +1956,7 @@ async def generate_messages(
 
     try:
         openai_payload = convert_anthropic_to_openai_payload(form_data)
-    except Exception as e:
+    except (ValueError, NotImplementedError, TypeError, KeyError, AttributeError) as e:
         log.debug('Anthropic payload conversion failed: %s', e)
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1956,7 +1956,8 @@ async def generate_messages(
 
     try:
         openai_payload = convert_anthropic_to_openai_payload(form_data)
-    except (ValueError, NotImplementedError) as e:
+    except Exception as e:
+        log.debug('Anthropic payload conversion failed: %s', e)
         raise HTTPException(status_code=400, detail=str(e))
 
     # Route through the existing chat_completion handler

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -90,6 +90,17 @@ async def get_anthropic_models(url: str, key: str, user: UserModel = None) -> di
 ##############################
 
 
+def _convert_anthropic_image_source(source: dict) -> str:
+    """Convert an Anthropic image source block to an OpenAI-compatible image URL."""
+    if source.get('type') == 'base64':
+        media_type = source.get('media_type', 'image/png')
+        data = source.get('data', '')
+        return f'data:{media_type};base64,{data}'
+    elif source.get('type') == 'url':
+        return source.get('url', '')
+    return ''
+
+
 def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
     """
     Convert an Anthropic Messages API request to OpenAI Chat Completions format.
@@ -145,23 +156,12 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                         }
                     )
                 elif block_type == 'image':
-                    source = block.get('source', {})
-                    if source.get('type') == 'base64':
-                        media_type = source.get('media_type', 'image/png')
-                        data = source.get('data', '')
+                    url = _convert_anthropic_image_source(block.get('source', {}))
+                    if url:
                         openai_content.append(
                             {
                                 'type': 'image_url',
-                                'image_url': {
-                                    'url': f'data:{media_type};base64,{data}',
-                                },
-                            }
-                        )
-                    elif source.get('type') == 'url':
-                        openai_content.append(
-                            {
-                                'type': 'image_url',
-                                'image_url': {'url': source.get('url', '')},
+                                'image_url': {'url': url},
                             }
                         )
                 elif block_type == 'tool_use':
@@ -181,25 +181,81 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     )
                 elif block_type == 'tool_result':
                     # Tool results become separate tool messages in OpenAI format
+                    # https://docs.anthropic.com/en/api/messages#body-messages
                     tool_content = block.get('content', '')
                     if isinstance(tool_content, list):
                         tool_text_parts = []
+                        image_urls = []
+
                         for tc in tool_content:
-                            if isinstance(tc, dict) and tc.get('type') == 'text':
-                                tool_text_parts.append(tc.get('text', ''))
+                            if isinstance(tc, dict):
+                                tc_type = tc.get('type')
+                                if tc_type == 'text':
+                                    tool_text_parts.append(tc.get('text', ''))
+                                elif tc_type == 'image':
+                                    url = _convert_anthropic_image_source(
+                                        tc.get('source', {})
+                                    )
+                                    if url:
+                                        image_urls.append(url)
+                                elif tc_type in ('search_result', 'document'):
+                                    raise NotImplementedError(
+                                        f'Anthropic tool_result content type '
+                                        f'"{tc_type}" has no OpenAI equivalent'
+                                    )
+                                elif tc_type == 'tool_reference':
+                                    log.debug(
+                                        'Skipping tool_reference in tool_result '
+                                        '(no OpenAI equivalent)'
+                                    )
+                                else:
+                                    raise ValueError(
+                                        f'Unknown tool_result content type: '
+                                        f'{tc_type!r}'
+                                    )
+                            elif isinstance(tc, str):
+                                tool_text_parts.append(tc)
+                            else:
+                                raise ValueError(
+                                    f'Unexpected tool_result content item '
+                                    f'type: {type(tc).__name__}'
+                                )
+
                         tool_content = '\n'.join(tool_text_parts)
+                    elif not isinstance(tool_content, str):
+                        tool_content = str(tool_content) if tool_content else ''
+                        image_urls = []
+                    else:
+                        image_urls = []
 
                     # Propagate error status if present
                     if block.get('is_error'):
                         tool_content = f'Error: {tool_content}'
 
-                    messages.append(
-                        {
-                            'role': 'tool',
-                            'tool_call_id': block.get('tool_use_id', ''),
-                            'content': tool_content,
-                        }
-                    )
+                    # Build tool message, using multimodal format if images
+                    # are present (matches the pattern in utils/misc.py)
+                    if image_urls:
+                        messages.append(
+                            {
+                                'role': 'tool',
+                                'tool_call_id': block.get('tool_use_id', ''),
+                                'content': [
+                                    {'type': 'input_text', 'text': tool_content},
+                                    *[
+                                        {'type': 'input_image', 'image_url': url}
+                                        for url in image_urls
+                                    ],
+                                ],
+                            }
+                        )
+                    else:
+                        messages.append(
+                            {
+                                'role': 'tool',
+                                'tool_call_id': block.get('tool_use_id', ''),
+                                'content': tool_content,
+                            }
+                        )
 
             # Build the message
             if tool_calls:

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -92,13 +92,18 @@ async def get_anthropic_models(url: str, key: str, user: UserModel = None) -> di
 
 def _convert_anthropic_image_source(source: dict) -> str:
     """Convert an Anthropic image source block to an OpenAI-compatible image URL."""
-    if source.get('type') == 'base64':
+    if not isinstance(source, dict):
+        raise ValueError(
+            f'Expected dict for image source, got {type(source).__name__}'
+        )
+    source_type = source.get('type')
+    if source_type == 'base64':
         media_type = source.get('media_type', 'image/png')
         data = source.get('data', '')
         return f'data:{media_type};base64,{data}'
-    elif source.get('type') == 'url':
+    elif source_type == 'url':
         return source.get('url', '')
-    return ''
+    raise ValueError(f'Unsupported image source type: {source_type!r}')
 
 
 def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
@@ -157,13 +162,12 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     )
                 elif block_type == 'image':
                     url = _convert_anthropic_image_source(block.get('source', {}))
-                    if url:
-                        openai_content.append(
-                            {
-                                'type': 'image_url',
-                                'image_url': {'url': url},
-                            }
-                        )
+                    openai_content.append(
+                        {
+                            'type': 'image_url',
+                            'image_url': {'url': url},
+                        }
+                    )
                 elif block_type == 'tool_use':
                     tool_calls.append(
                         {
@@ -196,8 +200,7 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                                     url = _convert_anthropic_image_source(
                                         tc.get('source', {})
                                     )
-                                    if url:
-                                        image_urls.append(url)
+                                    image_urls.append(url)
                                 elif tc_type in ('search_result', 'document'):
                                     raise NotImplementedError(
                                         f'Anthropic tool_result content type '

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -99,10 +99,15 @@ def _convert_anthropic_image_source(source: dict) -> str:
     source_type = source.get('type')
     if source_type == 'base64':
         media_type = source.get('media_type', 'image/png')
-        data = source.get('data', '')
+        data = source.get('data')
+        if not data:
+            raise ValueError('Image source type "base64" is missing required "data" field')
         return f'data:{media_type};base64,{data}'
     elif source_type == 'url':
-        return source.get('url', '')
+        url = source.get('url')
+        if not url:
+            raise ValueError('Image source type "url" is missing required "url" field')
+        return url
     raise ValueError(f'Unsupported image source type: {source_type!r}')
 
 


### PR DESCRIPTION
Adds support for images and string content in Anthropic tool_result blocks, and explicit errors for unsupported types (search_result, document).

Images use the existing input_text/input_image multimodal tool message pattern from utils/misc.py, which the middleware already handles for downstream providers.

Also extracts a _convert_anthropic_image_source helper to DRY up image conversion, and adds HTTP 400 error handling for conversion failures.

Based on the work in #23004 by @regulad.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
