### PR TITLE
fix: ensure oauth2.1 static server types do authentication

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -120,7 +120,7 @@ async def get_tools(
             auth_type = server.get('auth_type', 'none')
 
             session_token = None
-            if auth_type == 'oauth_2.1':
+            if auth_type in ('oauth_2.1', 'oauth_2.1_static'):
                 splits = server_id.split(':')
                 server_id = splits[-1] if len(splits) > 1 else server_id
 
@@ -148,7 +148,7 @@ async def get_tools(
                             {
                                 'authenticated': session_token is not None,
                             }
-                            if auth_type == 'oauth_2.1'
+                            if auth_type in ('oauth_2.1', 'oauth_2.1_static')
                             else {}
                         ),
                     }

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2507,7 +2507,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                             oauth_token = extra_params.get('__oauth_token__', None)
                             if oauth_token:
                                 headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
-                        elif auth_type == 'oauth_2.1':
+                        elif auth_type in ('oauth_2.1', 'oauth_2.1_static'):
                             try:
                                 splits = server_id.split(':')
                                 server_id = splits[-1] if len(splits) > 1 else server_id


### PR DESCRIPTION
# Changelog Entry

### Description

- Fixing an issue where the new `oauth_2.1_static` `key_type` was not prompting for auth as the `oauth_2.1` type does because it was missing from these if statements

### Fixed

- Ensure `oauth_2.1_static` tool servers handle authentication

---

### Additional Information

N/A

### Screenshots or Videos

N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.