### PR TITLE
fix: remove undefined cookie_expires in OAuth session cookie

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1683,7 +1683,7 @@ class OAuthManager:
                     httponly=True,
                     samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
                     secure=WEBUI_AUTH_COOKIE_SECURE,
-                    **({'max_age': cookie_max_age, 'expires': cookie_expires} if cookie_max_age is not None else {}),
+                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
                 )
 
                 log.info(f'Stored OAuth session server-side for user {user.id}, provider {provider}')


### PR DESCRIPTION
Fixes #23197

`handle_callback` references `cookie_expires` when setting the `oauth_session_id` cookie, but that variable is never defined — only `cookie_max_age` is computed from `JWT_EXPIRES_IN`. This causes a `NameError` on every OAuth login, silently skipping the cookie (caught by the `try/except`).

The other two cookies in the same method (`token`, `oauth_id_token`) already use just `max_age`, so this aligns the third cookie with the same pattern.

One-line change: drop the `expires` kwarg from the `oauth_session_id` `set_cookie` call.