### PR TITLE
fix: add missing redirect_uri to Feishu OAuth provider config

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -801,6 +801,7 @@ def load_oauth_providers():
         OAUTH_PROVIDERS['feishu'] = {
             'register': feishu_oauth_register,
             'sub_claim': 'user_id',
+            'redirect_uri': FEISHU_REDIRECT_URI.value,
         }
 
     configured_providers = []


### PR DESCRIPTION
  Fixes #23128       
  Supersedes #23129                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                  
  - [x] **Target branch:** `dev`                                                                                                                                                                                                                                                                                  
  - [x] **Description:** See below                                                                                                                                                                                                                                                                                
  - [x] **Changelog:** See below                                                                                                                                                                                                                                                                                  
  - [ ] **Documentation:** No doc changes needed — `FEISHU_CLIENT_REDIRECT_URI` env var is already documented                                                                                                                                                                                                     
  - [ ] **Dependencies:** No new dependencies                                                                                                                                                                                                                                                                     
  - [x] **Testing:** Manually tested Feishu OAuth login behind ALB Ingress (Kubernetes), confirmed redirect URI is now `https://`                                                                                                                                                                                 
  - [x] **Agentic AI Code:** This is a one-line fix identified through manual debugging, reviewed and tested by a human                                                                                                                                                                                           
  - [x] **Code review:** Self-reviewed                                                                                                                                                                                                                                                                            
  - [x] **Design & Architecture:** No new settings, just fixing an omission to match existing pattern                                                                                                                                                                                                             
  - [x] **Git Hygiene:** Single atomic commit, rebased on `dev`                                                                                                                                                                                                                                                   
  - [x] **Title Prefix:** `fix:`                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
  # Changelog Entry                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
  ### Description                                                                                                                                                                                                                                                                                                 
   
  - Fix Feishu OAuth login failing with HTTPS behind reverse proxy due to missing `redirect_uri` in `OAUTH_PROVIDERS['feishu']` dict                                                                                                                                                                              
                  
  ### Fixed                                                                                                                                                                                                                                                                                                       
                  
  - Add missing `redirect_uri` key to `OAUTH_PROVIDERS['feishu']` in `config.py`. `FEISHU_REDIRECT_URI` was already defined and passed to `oauth.register()` but was not included in the `OAUTH_PROVIDERS` dict that `handle_login()` reads from. This caused `handle_login()` to fall back to `request.url_for()`
   which generates `http://` redirect URIs behind a reverse proxy. All other providers (Google, Microsoft, GitHub, OIDC) already include this key. This bug may not surface when the proxy correctly forwards `X-Forwarded-Proto: https` (e.g. single-layer Docker + ALB), but breaks in multi-layer proxy setups
  (e.g. Kubernetes with Ingress).                                                                                                                                                                                                                                                                                 
                  
  ---                                                                                                                                                                                                                                                                                                             
   
  ### Additional Information                                                                                                                                                                                                                                                                                      
                  
  - Related env var: `FEISHU_CLIENT_REDIRECT_URI`                                                                                                                                                                                                                                                                 
  - Affected file: `backend/open_webui/config.py`
  - The fix is one line, consistent with how all other OAuth providers are configured                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
  ### Contributor License Agreement                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
  - [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.   