### PR TITLE
fix: remove undefined cookie_expires in OAuth session cookie

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1683,7 +1683,7 @@ class OAuthManager:
                     httponly=True,
                     samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
                     secure=WEBUI_AUTH_COOKIE_SECURE,
-                    **({'max_age': cookie_max_age, 'expires': cookie_expires} if cookie_max_age is not None else {}),
+                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
                 )
 
                 log.info(f'Stored OAuth session server-side for user {user.id}, provider {provider}')


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Testing:** Verified the NameError no longer occurs when `cookie_max_age` is set

# Changelog Entry

### Description

The `set_cookie()` call in `handle_callback` references `cookie_expires`, which is never defined in the current scope. When `cookie_max_age` is not `None`, this causes a `NameError` at runtime. Since `max_age` alone is sufficient for cookie expiration (browsers derive `expires` from it per RFC 6265), we can just drop the `expires` kwarg.

### Fixed

- `NameError: name 'cookie_expires' is not defined` when setting OAuth session cookies with a configured max age

---

### Additional Information

- Relates to #23197
- Only the `oauth_session_id` cookie was affected; the auth token cookie above it already uses `max_age` alone

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.