### PR TITLE
fix: harden file preview components against crashes and stale state

### DIFF
--- a/src/lib/components/chat/FileNav/FilePreview.svelte
+++ b/src/lib/components/chat/FileNav/FilePreview.svelte
@@ -68,9 +68,12 @@
 	export const saveEdit = async () => {
 		if (!onSave) return;
 		saving = true;
-		await onSave(editContent);
-		saving = false;
-		editing = false;
+		try {
+			await onSave(editContent);
+			editing = false;
+		} finally {
+			saving = false;
+		}
 	};
 
 	export const cancelEdit = () => {
@@ -82,9 +85,12 @@
 	export const saveCodeFile = async () => {
 		if (!onSave) return;
 		saving = true;
-		const content = fileCodeEditorRef?.getValue() ?? '';
-		await onSave(content);
-		saving = false;
+		try {
+			const content = fileCodeEditorRef?.getValue() ?? '';
+			await onSave(content);
+		} finally {
+			saving = false;
+		}
 	};
 
 	$: isTextFile = fileContent !== null && fileImageUrl === null && filePdfData === null;
@@ -186,30 +192,7 @@
 	$: csvHeader = csvRows.length > 0 ? csvRows[0] : [];
 	$: csvBody = csvRows.length > 1 ? csvRows.slice(1) : [];
 
-	// ── Shiki code highlighting (SVG only) ──────────────────────────────
-	let highlightedHtml: string | null = null;
-	let highlightingFile: string | null = null;
 
-	$: if (isSvg && fileContent !== null && selectedFile) {
-		const currentFile = selectedFile;
-		highlightingFile = currentFile;
-		import('shiki')
-			.then(({ codeToHtml }) =>
-				codeToHtml(fileContent!, {
-					lang: 'xml',
-					themes: { light: 'github-light', dark: 'github-dark' },
-					defaultColor: 'light'
-				})
-			)
-			.then((html) => {
-				if (highlightingFile === currentFile) highlightedHtml = html;
-			})
-			.catch(() => {
-				if (highlightingFile === currentFile) highlightedHtml = null;
-			});
-	} else {
-		highlightedHtml = null;
-	}
 
 	// ── JSON parsing ────────────────────────────────────────────────────
 	let parsedJson: unknown = undefined;
@@ -487,7 +470,7 @@
 					ADD_TAGS: ['use']
 				})}
 			</div>
-		{:else if isCode && !showRaw}
+		{:else if isSvg && showRaw}
 			<div class="absolute inset-0">
 				<FileCodeEditor
 					bind:this={fileCodeEditorRef}
@@ -496,9 +479,14 @@
 					{onSave}
 				/>
 			</div>
-		{:else if isSvg && highlightedHtml && !showRaw}
-			<div class="shiki-preview overflow-auto h-full text-xs">
-				{@html highlightedHtml}
+		{:else if isCode && !showRaw}
+			<div class="absolute inset-0">
+				<FileCodeEditor
+					bind:this={fileCodeEditorRef}
+					value={fileContent ?? ''}
+					filePath={selectedFile}
+					{onSave}
+				/>
 			</div>
 		{:else if editing}
 			<textarea
@@ -696,45 +684,5 @@
 		padding-left: 1.5em;
 		margin: 0.5em 0;
 	}
-	/* ── Shiki code highlighting ─────────────────────────────────── */
-	.shiki-preview :global(pre.shiki) {
-		margin: 0;
-		padding: 0.75rem 1rem;
-		font-size: 0.75rem;
-		line-height: 1.6;
-		border-radius: 0;
-		overflow-x: auto;
-		min-height: 100%;
-	}
-	.shiki-preview :global(pre.shiki code) {
-		counter-reset: line;
-	}
-	.shiki-preview :global(pre.shiki code > .line) {
-		counter-increment: line;
-		display: inline-block;
-		width: 100%;
-		white-space: pre;
-	}
-	.shiki-preview :global(pre.shiki code > .line::before) {
-		content: counter(line);
-		display: inline-block;
-		width: 2.5em;
-		text-align: right;
-		margin-right: 1em;
-		color: #9ca3af;
-		user-select: none;
-		font-size: 0.65rem;
-	}
-	:global(.dark) .shiki-preview :global(pre.shiki code > .line::before) {
-		color: #4b5563;
-	}
-	/* Shiki dual-theme: swap CSS variables in dark mode */
-	:global(.dark) .shiki-preview :global(.shiki),
-	:global(.dark) .shiki-preview :global(.shiki span) {
-		color: var(--shiki-dark) !important;
-		background-color: var(--shiki-dark-bg) !important;
-		font-style: var(--shiki-dark-font-style) !important;
-		font-weight: var(--shiki-dark-font-weight) !important;
-		text-decoration: var(--shiki-dark-text-decoration) !important;
-	}
+
 </style>

--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -5,6 +5,7 @@
 	import { getContext, onMount, tick } from 'svelte';
 
 	import { formatFileSize, getLineCount } from '$lib/utils';
+	import { isCodeFile } from '$lib/utils/codeHighlight';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import { settings } from '$lib/stores';
 	import { getKnowledgeById } from '$lib/apis/knowledge';
@@ -85,28 +86,7 @@
 		item?.meta?.content_type === 'text/markdown' ||
 		(item?.name && item?.name.toLowerCase().endsWith('.md'));
 
-	$: isCode =
-		item?.name &&
-		(item.name.toLowerCase().endsWith('.py') ||
-			item.name.toLowerCase().endsWith('.js') ||
-			item.name.toLowerCase().endsWith('.ts') ||
-			item.name.toLowerCase().endsWith('.java') ||
-			item.name.toLowerCase().endsWith('.html') ||
-			item.name.toLowerCase().endsWith('.css') ||
-			item.name.toLowerCase().endsWith('.json') ||
-			item.name.toLowerCase().endsWith('.cpp') ||
-			item.name.toLowerCase().endsWith('.c') ||
-			item.name.toLowerCase().endsWith('.h') ||
-			item.name.toLowerCase().endsWith('.sh') ||
-			item.name.toLowerCase().endsWith('.bash') ||
-			item.name.toLowerCase().endsWith('.yaml') ||
-			item.name.toLowerCase().endsWith('.yml') ||
-			item.name.toLowerCase().endsWith('.xml') ||
-			item.name.toLowerCase().endsWith('.sql') ||
-			item.name.toLowerCase().endsWith('.go') ||
-			item.name.toLowerCase().endsWith('.rs') ||
-			item.name.toLowerCase().endsWith('.php') ||
-			item.name.toLowerCase().endsWith('.rb'));
+	$: isCode = isCodeFile(item?.name ?? null) && !isMarkdown;
 
 	$: isAudio =
 		(item?.meta?.content_type ?? '').startsWith('audio/') ||
@@ -213,9 +193,27 @@
 		}
 	};
 
+	let loadGeneration = 0;
+
 	const loadContent = async () => {
+		const currentGeneration = ++loadGeneration;
+
 		selectedTab = '';
 		expandedContent = false;
+
+		// Reset office state from previous item
+		excelWorkbook = null;
+		excelSheetNames = [];
+		selectedSheet = '';
+		excelHtml = '';
+		excelError = '';
+		rowCount = 0;
+		docxHtml = '';
+		docxError = '';
+		pptxSlides = [];
+		pptxCurrentSlide = 0;
+		pptxError = '';
+
 		if (item?.type === 'collection') {
 			loading = true;
 
@@ -223,6 +221,8 @@
 				console.error('Error fetching knowledge base:', e);
 				return null;
 			});
+
+			if (currentGeneration !== loadGeneration) return;
 
 			if (knowledge) {
 				item.files = knowledge.files || [];
@@ -236,20 +236,26 @@
 				return null;
 			});
 
+			if (currentGeneration !== loadGeneration) return;
+
 			if (file) {
-				item.file = file || {};
+				item.file = file;
 			}
 
-			// Load Excel content if it's an Excel file
 			if (isExcel) {
 				await loadExcelContent();
 			}
+			if (currentGeneration !== loadGeneration) return;
+
 			if (isDocx) {
 				await loadDocxContent();
 			}
+			if (currentGeneration !== loadGeneration) return;
+
 			if (isPptx) {
 				await loadPptxContent();
 			}
+			if (currentGeneration !== loadGeneration) return;
 
 			loading = false;
 		}
@@ -262,7 +268,6 @@
 	}
 
 	onMount(() => {
-		console.log(item);
 		if (item?.context === 'full') {
 			enableFullContent = true;
 		}
@@ -569,8 +574,8 @@
 					{:else if isCode}
 						<div class="max-h-[60vh] overflow-scroll scrollbar-hidden text-sm relative">
 							<CodeBlock
-								code={item.file.data.content}
-								lang={item.name.split('.').pop()}
+								code={item?.file?.data?.content ?? ''}
+								lang={item?.name?.split('.').pop()}
 								token={null}
 								edit={false}
 								run={false}
@@ -581,7 +586,7 @@
 						<div
 							class="max-h-[60vh] overflow-scroll scrollbar-hidden text-sm prose dark:prose-invert max-w-full"
 						>
-							<Markdown content={item.file.data.content} id="markdown-viewer" />
+							<Markdown content={item?.file?.data?.content ?? ''} id="markdown-viewer" />
 						</div>
 					{:else if isDocx}
 						{#if docxError}

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, onMount, getContext } from 'svelte';
+	import { onDestroy, getContext } from 'svelte';
 	import panzoom, { type PanZoom } from 'panzoom';
 
 	import fileSaver from 'file-saver';
@@ -13,13 +13,9 @@
 
 	const i18n = getContext('i18n');
 
-	let mounted = false;
-
 	let previewElement = null;
 
 	let instance: PanZoom;
-
-	let sceneParentElement: HTMLElement;
 	let sceneElement: HTMLElement;
 
 	$: if (sceneElement) {
@@ -33,19 +29,44 @@
 	const resetPanZoomViewport = () => {
 		instance.moveTo(0, 0);
 		instance.zoomAbs(0, 0, 1);
-		console.log(instance.getTransform());
 	};
 
 	const handleKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Escape') {
-			console.log('Escape');
 			show = false;
 		}
 	};
 
-	onMount(() => {
-		mounted = true;
-	});
+	const downloadImage = async () => {
+		if (src.startsWith('data:image/')) {
+			const base64Data = src.split(',')[1];
+			const blob = new Blob([Uint8Array.from(atob(base64Data), (c) => c.charCodeAt(0))], {
+				type: 'image/png'
+			});
+			const mimeType = blob.type || 'image/png';
+			const fileName = `${$i18n
+				.t('Generated Image')
+				.toLowerCase()
+				.replace(/ /g, '_')}.${mimeType.split('/')[1]}`;
+			saveAs(blob, fileName);
+		} else {
+			try {
+				const response = await fetch(src);
+				const blob = await response.blob();
+				const mimeType = blob.type || 'image/png';
+				const blobWithType = new Blob([blob], { type: mimeType });
+				const fileName = `${$i18n
+					.t('Generated Image')
+					.toLowerCase()
+					.replace(/ /g, '_')}.${mimeType.split('/')[1]}`;
+				saveAs(blobWithType, fileName);
+			} catch (error) {
+				console.error('Error downloading image:', error);
+			}
+		}
+	};
+
+
 
 	$: if (show && previewElement) {
 		document.body.appendChild(previewElement);
@@ -93,77 +114,7 @@
 			<div>
 				<button
 					class=" p-5 z-999"
-					on:click={() => {
-						if (src.startsWith('data:image/')) {
-							const base64Data = src.split(',')[1];
-							const blob = new Blob([Uint8Array.from(atob(base64Data), (c) => c.charCodeAt(0))], {
-								type: 'image/png'
-							});
-
-							const mimeType = blob.type || 'image/png';
-							// create file name based on the MIME type, alt should be a valid file name with extension
-							const fileName = `${$i18n
-								.t('Generated Image')
-								.toLowerCase()
-								.replace(/ /g, '_')}.${mimeType.split('/')[1]}`;
-
-							// Use FileSaver to save the blob
-							saveAs(blob, fileName);
-							return;
-						} else if (src.startsWith('blob:')) {
-							// Handle blob URLs
-							fetch(src)
-								.then((response) => response.blob())
-								.then((blob) => {
-									// detect the MIME type from the blob
-									const mimeType = blob.type || 'image/png';
-
-									// Create a new Blob with the correct MIME type
-									const blobWithType = new Blob([blob], { type: mimeType });
-
-									// create file name based on the MIME type, alt should be a valid file name with extension
-									const fileName = `${$i18n
-										.t('Generated Image')
-										.toLowerCase()
-										.replace(/ /g, '_')}.${mimeType.split('/')[1]}`;
-
-									// Use FileSaver to save the blob
-									saveAs(blobWithType, fileName);
-								})
-								.catch((error) => {
-									console.error('Error downloading blob:', error);
-								});
-							return;
-						} else if (
-							src.startsWith('/') ||
-							src.startsWith('http://') ||
-							src.startsWith('https://')
-						) {
-							// Handle remote URLs
-							fetch(src)
-								.then((response) => response.blob())
-								.then((blob) => {
-									// detect the MIME type from the blob
-									const mimeType = blob.type || 'image/png';
-
-									// Create a new Blob with the correct MIME type
-									const blobWithType = new Blob([blob], { type: mimeType });
-
-									// create file name based on the MIME type, alt should be a valid file name with extension
-									const fileName = `${$i18n
-										.t('Generated Image')
-										.toLowerCase()
-										.replace(/ /g, '_')}.${mimeType.split('/')[1]}`;
-
-									// Use FileSaver to save the blob
-									saveAs(blobWithType, fileName);
-								})
-								.catch((error) => {
-									console.error('Error downloading remote image:', error);
-								});
-							return;
-						}
-					}}
+					on:click={downloadImage}
 				>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/common/SVGPanZoom.svelte
+++ b/src/lib/components/common/SVGPanZoom.svelte
@@ -38,7 +38,6 @@
 	const resetPanZoomViewport = () => {
 		instance.moveTo(0, 0);
 		instance.zoomAbs(0, 0, 1);
-		console.log(instance.getTransform());
 	};
 
 	const downloadAsSVG = () => {
@@ -57,7 +56,6 @@
 				'class',
 				'style',
 				'id',
-				'data-*',
 				'viewBox',
 				'preserveAspectRatio',
 				// markers / arrows
@@ -86,6 +84,7 @@
 				'aria-hidden',
 				'tabindex'
 			],
+			ALLOW_DATA_ATTR: true,
 			SANITIZE_DOM: true
 		})}
 	</div>


### PR DESCRIPTION
## fix: harden file preview components against crashes and stale state

Fixes multiple crash paths, race conditions, dead code, and maintainability issues across the file preview components.

### Crash fixes

- **FileItemModal TypeError on failed file fetch** — When getFileById fails (network error, missing file), the modal template accessed item.file.data.content without optional chaining, throwing a TypeError and breaking the entire modal. Added proper optional chaining on all unguarded access paths.

- **FilePreview save button stuck forever** — If onSave rejected in saveEdit or saveCodeFile, the saving flag was never reset. The save button became permanently disabled with no way to retry or cancel. Wrapped both functions in try/finally so the flag always resets.

### Race condition fix

- **FileItemModal content mismatch on rapid switching** — Opening file A then quickly switching to file B could render file A's Excel/DOCX/PPTX data under file B's name if the first async fetch completed after the second. Added a generation counter to loadContent so stale responses are discarded.

### Functional fixes

- **Unreachable SVG source view in FilePreview** — The Shiki syntax-highlighted SVG source branch was unreachable because the inline SVG preview branch always matched first (both checked isSvg && !showRaw). Removed the dead Shiki computation (which was wasting CPU on every SVG load) and replaced it with a proper isSvg && showRaw branch using FileCodeEditor, matching the pattern used by HTML and Markdown.

- **DOMPurify data-* attributes silently stripped in SVGPanZoom** — The ADD_ATTR config used "data-*" as a glob pattern, but DOMPurify treats it as a literal attribute name. Data attributes on SVG content (common in Mermaid diagrams) were silently removed. Replaced with ALLOW_DATA_ATTR: true, which is the correct API.

- **isCode detection divergence between FileItemModal and FilePreview** — FileItemModal hardcoded ~20 extensions while FilePreview used the shared isCodeFile utility. Files recognized as code in one context weren't in the other. Replaced the hardcoded list with the shared utility.

### Cleanup

- **Stale office state between items** — Excel/DOCX/PPTX state variables (excelHtml, docxHtml, pptxSlides, etc.) were not reset when switching items. Currently gated by template conditionals but would surface stale data if those conditionals ever changed. Now explicitly reset at the start of loadContent.

- **Triplicated download logic in ImagePreview** — The blob URL and remote URL download branches were identical copy-paste. Consolidated into a single downloadImage function.

- **Dead variables and console.log statements** — Removed unused mounted and sceneParentElement variables from ImagePreview, and removed stray console.log calls from FileItemModal, ImagePreview, and SVGPanZoom.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
