### PR TITLE
feat(config): add environment variable support for DEFAULT_MODEL_PARAMS

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1226,10 +1226,16 @@ DEFAULT_MODEL_METADATA = PersistentConfig(
     {},
 )
 
+try:
+    default_model_params = json.loads(os.environ.get('DEFAULT_MODEL_PARAMS', '{}'))
+except Exception as e:
+    log.exception(f'Error loading DEFAULT_MODEL_PARAMS: {e}')
+    default_model_params = {}
+
 DEFAULT_MODEL_PARAMS = PersistentConfig(
     'DEFAULT_MODEL_PARAMS',
     'models.default_params',
-    {},
+    default_model_params,
 )
 
 DEFAULT_USER_ROLE = PersistentConfig(


### PR DESCRIPTION
## Pull Request Description

**Title:** `fix: DEFAULT_MODEL_PARAMS environment variable ignored`

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Changelog Entry

### Description

The `DEFAULT_MODEL_PARAMS` environment variable was being ignored due to a hardcoded empty dictionary `{}` being passed as the default value to `PersistentConfig`. This fix adds proper JSON parsing of the `DEFAULT_MODEL_PARAMS` environment variable, following the same pattern used by similar configurations like `TOOL_SERVER_CONNECTIONS` and `TERMINAL_SERVER_CONNECTIONS`.

### Fixed

- Fixed `DEFAULT_MODEL_PARAMS` environment variable being ignored - the value is now properly parsed from JSON and passed to `PersistentConfig`

---

### Additional Information
https://github.com/open-webui/open-webui/discussions/21839

**Usage example:**
```bash
export DEFAULT_MODEL_PARAMS='{"temperature": 0.7, "max_tokens": 2048}'
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.