### PR TITLE
fix: remove invalid db kwarg from process_files_batch call

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1025,7 +1025,6 @@ async def add_files_to_knowledge_batch(
             request=request,
             form_data=BatchProcessFilesForm(files=files, collection_name=id),
             user=user,
-            db=db,
         )
     except Exception as e:
         log.error(f'add_files_to_knowledge_batch: Exception occurred: {e}', exc_info=True)


### PR DESCRIPTION
## Summary

`process_files_batch()` does not accept a `db` keyword argument, but `add_files_to_knowledge_batch` passes `db=db` when calling it, which raises a `TypeError` at runtime.

**Root cause:** The function signature in `routers/retrieval.py` intentionally omits `db` because it makes long-running external embedding API calls (5–60+ seconds) and manages its own short-lived DB sessions internally.

**Fix:** Remove the `db=db` line from the call in `knowledge.py`.

Fixes #23137

## Change

```python
# Before
result = await process_files_batch(
    request=request,
    form_data=BatchProcessFilesForm(files=files, collection_name=id),
    user=user,
    db=db,   # ← TypeError: unexpected keyword argument
)

# After
result = await process_files_batch(
    request=request,
    form_data=BatchProcessFilesForm(files=files, collection_name=id),
    user=user,
)
```

## Test plan

- [ ] Call `POST /api/v1/knowledge/{id}/files/batch` with a valid collection — should no longer raise `TypeError: process_files_batch() got an unexpected keyword argument 'db'`
- [ ] Verify files are still processed and added to the knowledge collection correctly