### PR TITLE
fix: remove undefined cookie_expires from oauth_session_id set_cookie

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1683,7 +1683,7 @@ class OAuthManager:
                     httponly=True,
                     samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
                     secure=WEBUI_AUTH_COOKIE_SECURE,
-                    **({'max_age': cookie_max_age, 'expires': cookie_expires} if cookie_max_age is not None else {}),
+                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
                 )
 
                 log.info(f'Stored OAuth session server-side for user {user.id}, provider {provider}')


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [X] **Target branch:** Verify that the pull request targets the `dev` branch.
- [X] **Description:** Provided below.
- [X] **Changelog:** Included below.
- [X] **Documentation:** No user-facing docs needed — this is an internal bug fix.
- [X] **Dependencies:** No new dependencies.
- [X] **Testing:** Manually tested with Authentik OIDC provider. Before fix: `oauth_session_id` cookie missing, logs show `NameError: name 'cookie_expires' is not defined`. After fix: cookie is set correctly and `system_oauth` auth_type forwards the access token.
- [X] **Agentic AI Code:** This fix was identified through manual debugging and the one-line change was human-reviewed and manually tested.
- [X] **Code review:** Self-reviewed. The fix follows the exact same pattern as the two other `set_cookie` calls in the same function.
- [X] **Design & Architecture:** No design changes — single variable reference removal.
- [X] **Git Hygiene:** Single atomic commit, one logical change.
- [X] **Title Prefix:** `fix:`

## Description

Fixes #23250

The `oauth_session_id` cookie is never set after OIDC login because `cookie_expires` is referenced but never defined in `handle_callback()`. This breaks the `system_oauth` auth_type for OpenAI API connections.

**Root cause:** Line 1686 of `backend/open_webui/utils/oauth.py` passes `'expires': cookie_expires` to `set_cookie()`, but `cookie_expires` is never assigned. The variable `cookie_max_age` IS defined (line 1627), and the other two `set_cookie` calls in the same function (lines 1637, 1648) correctly use only `max_age`.

**Fix:** Remove `'expires': cookie_expires` from the kwargs dict, matching the pattern of the other `set_cookie` calls. Browsers prefer `max_age` over `expires` per RFC 6265 §5.3, so `max_age` alone is sufficient.

**Before:**
```python
**({'max_age': cookie_max_age, 'expires': cookie_expires} if cookie_max_age is not None else {}),
```

**After:**
```python
**({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
```

### Changelog Entry

### Fixed
- Fixed `oauth_session_id` cookie not being set after OIDC login due to undefined `cookie_expires` variable, which broke `system_oauth` auth_type for OpenAI API connections

### Breaking Changes

- None

### Additional Information

- Fixes #23250
- The bug exists on both `main` (v0.8.12) and `dev` branches
- One-line change, zero risk of side effects

### Screenshots or Videos

**Before fix — error on every OIDC login:**
```
ERROR | open_webui.utils.oauth:handle_callback:1693 - Failed to store OAuth session server-side: name 'cookie_expires' is not defined
```

**After fix — session stored successfully:**
```
INFO | open_webui.utils.oauth:handle_callback:1689 - Stored OAuth session server-side for user <uuid>, provider oidc
```

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.