### PR TITLE
fix: use sessionStorage for showControls to prevent cross-tab state leakage

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -346,9 +346,12 @@
 		}
 		// Persist showControls: track open/close state separately from saved size
 		// chatControlsSize always retains the last width for openPane()
-		await showControls.set(!$mobile ? localStorage.showControls === 'true' : false);
+		// Use sessionStorage (per-tab) instead of localStorage to prevent
+		// cross-tab state leakage (e.g. opening Artifacts in one tab
+		// auto-expanding Advanced Settings in another tab).
+		await showControls.set(!$mobile ? sessionStorage.getItem('showControls') === 'true' : false);
 		showControls.subscribe((value) => {
-			localStorage.showControls = value ? 'true' : 'false';
+			sessionStorage.setItem('showControls', value ? 'true' : 'false');
 		});
 
 		// Persist selectedTerminalId across page loads


### PR DESCRIPTION
## Problem

Opening an Artifacts preview in one browser tab automatically expands the Advanced Settings/Controls panel on the Home page in another tab, without user action.

### Root Cause

In `src/routes/(app)/+layout.svelte`, the `showControls` store state is persisted via `localStorage`:

```js
await showControls.set(!$mobile ? localStorage.showControls === 'true' : false);
showControls.subscribe((value) => {
    localStorage.showControls = value ? 'true' : 'false';
});
```

Since `localStorage` is shared across all tabs of the same origin:
1. **Tab A**: User opens Artifacts preview -> `showControls.set(true)` -> subscription writes `localStorage.showControls = 'true'`
2. **Tab B**: User navigates to Home -> `onMount` reads `localStorage.showControls === 'true'` -> controls panel auto-expands

## Fix

Switch from `localStorage` to `sessionStorage` for persisting `showControls`. `sessionStorage` is isolated per browser tab/session, so each tab maintains its own independent controls panel state. This preserves the within-tab persistence (controls stay open across SPA navigation within the same tab) while eliminating cross-tab leakage.

Note: `chatControlsSize` (the panel width) intentionally remains in `localStorage` so the user's preferred panel width is preserved globally.

Fixes #23232
