### PR TITLE
fix: use sessionStorage for showControls to prevent cross-tab state leakage

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -346,9 +346,12 @@
 		}
 		// Persist showControls: track open/close state separately from saved size
 		// chatControlsSize always retains the last width for openPane()
-		await showControls.set(!$mobile ? localStorage.showControls === 'true' : false);
+		// Use sessionStorage (per-tab) instead of localStorage to prevent
+		// cross-tab state leakage (e.g. opening Artifacts in one tab
+		// auto-expanding Advanced Settings in another tab). See #23232.
+		await showControls.set(!$mobile ? sessionStorage.getItem('showControls') === 'true' : false);
 		showControls.subscribe((value) => {
-			localStorage.showControls = value ? 'true' : 'false';
+			sessionStorage.setItem('showControls', value ? 'true' : 'false');
 		});
 
 		// Persist selectedTerminalId across page loads


### PR DESCRIPTION
<!--
CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE)
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manually verified the fix works as intended.
- [x] **Code review:** Self-reviewed the changes.

# Changelog Entry

### Description

Opening an Artifacts preview in one browser tab automatically expands the Advanced Settings/Controls panel on the Home page in another tab, without user action. This is caused by `showControls` being persisted via `localStorage` which is shared across all tabs of the same origin.

**Root Cause:**
In `src/routes/(app)/+layout.svelte`, the `showControls` store state is persisted via `localStorage`:
```js
await showControls.set(!$mobile ? localStorage.showControls === 'true' : false);
showControls.subscribe((value) => {
    localStorage.showControls = value ? 'true' : 'false';
});
```

Since `localStorage` is shared across all tabs:
1. **Tab A**: User opens Artifacts preview -> `showControls.set(true)` -> writes `localStorage.showControls = 'true'`
2. **Tab B**: User navigates to Home -> `onMount` reads `localStorage.showControls === 'true'` -> controls panel auto-expands

**Fix:** Switch from `localStorage` to `sessionStorage` for persisting `showControls`. `sessionStorage` is isolated per browser tab/session, so each tab maintains its own independent controls panel state. This preserves within-tab persistence (controls stay open across SPA navigation within the same tab) while eliminating cross-tab leakage.

Note: `chatControlsSize` (the panel width) intentionally remains in `localStorage` so the user's preferred panel width is preserved globally.

### Fixed

- Fixed cross-tab state leakage where opening Artifacts preview in one tab would auto-expand Advanced Settings/Controls panel in another tab (#23232)

### Additional Information

- Only `showControls` is affected. Other `localStorage` items like `chatControlsSize` and `selectedTerminalId` correctly use `localStorage` since they represent user preferences that should persist globally.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
