### PR TITLE
fix: respect 'always expand details' setting for collapsible tool groups

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -31,7 +31,7 @@
 
 	export let messageDone = true;
 
-	let open = false;
+	let open = $settings?.expandDetails ?? false;
 
 	function parseJSONString(str: string) {
 		try {

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -381,7 +381,7 @@
 							id={`${id}-${tokenIdx}-${detailIdx}-tc`}
 							attributes={detailToken.attributes}
 							grouped={true}
-							open={false}
+							open={$settings?.expandDetails ?? false}
 							className="w-full space-y-1"
 						/>
 					{:else if textContent.length > 0}
@@ -428,7 +428,7 @@
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
-				open={false}
+				open={$settings?.expandDetails ?? false}
 				className="w-full space-y-1"
 			/>
 		{:else if textContent.length > 0}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manually verified the fix works as intended.
- [x] **Code review:** Self-reviewed the changes.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Fixes #23255

When the **"Always Expand Details"** setting is enabled (Settings → Interface → Chat → Always Expand Details), collapsible tool call groups and standalone tool call details still start collapsed. This is because certain `ToolCallDisplay` components and the `ConsecutiveDetailsGroup` wrapper hardcode `open={false}` instead of reading from the user's settings store.

**`ConsecutiveDetailsGroup.svelte`**
- Changed `let open = false;` to `let open = $settings?.expandDetails ?? false;`
- The `settings` store was already imported — the initial open state now respects the user's preference while still allowing manual toggling.

**`MarkdownTokens.svelte`**
- Changed `open={false}` → `open={$settings?.expandDetails ?? false}` for grouped `ToolCallDisplay` (inside `ConsecutiveDetailsGroup`)
- Changed `open={false}` → `open={$settings?.expandDetails ?? false}` for standalone `ToolCallDisplay` (outside group)

Note: `Collapsible` components for non-tool-call details already correctly read `$settings?.expandDetails` — only `ToolCallDisplay` and the group wrapper were missing this.

### Fixed

- Fixed collapsible tool groups ignoring "Always Expand Details" setting (#23255)

---

### Additional Information

- Related to #21604 (original "expand details" feature)
- The fix is minimal: 3 lines changed across 2 files, each changing `false` to `$settings?.expandDetails ?? false`

### How to Test

1. Enable **Settings → Interface → Chat → Always Expand Details**
2. Send a message that triggers tool calls (e.g., web search)
3. **Before fix**: Tool call groups appear collapsed despite the setting
4. **After fix**: Tool call groups appear expanded, matching the user's preference

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
