### PR TITLE
fix: prevent stale task state blocking input after chat navigation

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1848,12 +1848,18 @@ async def chat_completion(
             except Exception as e:
                 log.debug(f'Error cleaning up: {e}')
                 pass
-            # Emit chat:active=false when task completes
+            # Only emit chat:active=false when this is the last task for the chat
+            # (current task is still registered, hence <= 1)
             try:
-                if metadata.get('chat_id'):
-                    event_emitter = get_event_emitter(metadata, update_db=False)
-                    if event_emitter:
-                        await event_emitter({'type': 'chat:active', 'data': {'active': False}})
+                chat_id = metadata.get('chat_id')
+                if chat_id:
+                    remaining = await list_task_ids_by_item_id(
+                        request.app.state.redis, chat_id
+                    )
+                    if len(remaining) <= 1:
+                        event_emitter = get_event_emitter(metadata, update_db=False)
+                        if event_emitter:
+                            await event_emitter({'type': 'chat:active', 'data': {'active': False}})
             except Exception as e:
                 log.debug(f'Error emitting chat:active: {e}')
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1279,20 +1279,24 @@
 				autoScroll = true;
 				await tick();
 
+				const taskRes = await getTaskIdsByChatId(localStorage.token, $chatId).catch((error) => {
+					return null;
+				});
+
+				// Don't block input for background tasks (follow-ups, title) when the response is done
+				const lastMsg = history.currentId ? history.messages[history.currentId] : null;
+				if (taskRes && taskRes.task_ids.length > 0 && !(lastMsg?.role === 'assistant' && lastMsg?.done)) {
+					taskIds = taskRes.task_ids;
+				} else {
+					taskIds = null;
+				}
+
 				if (history.currentId) {
 					for (const message of Object.values(history.messages)) {
 						if (message && message.role === 'assistant' && message.done !== false) {
 							message.done = true;
 						}
 					}
-				}
-
-				const taskRes = await getTaskIdsByChatId(localStorage.token, $chatId).catch((error) => {
-					return null;
-				});
-
-				if (taskRes) {
-					taskIds = taskRes.task_ids;
 				}
 
 				await tick();


### PR DESCRIPTION
 Two bugs related to background task state (follow-up suggestions, title generation) when navigating between chats.

  **Bug 1: Stop button gets stuck after navigating away and back**

  Steps to reproduce:
  1. Send a message (use a model with thinking/reasoning enabled so follow-up suggestions take longer to generate)
  2. Wait for the response content to finish, but before the follow-up suggestions appear, navigate to a different chat or page
  3. Navigate back to the original chat

  The stop button is now stuck in the message input. Clicking it or reloading the page is the only way to dismiss it. The response was already done, but loadChat picks up the still-running background task IDs from the
  backend and nothing clears them afterwards.

  **Bug 2: Sidebar spinner disappears too early with rapid messages**

  Steps to reproduce:
  1. Send a message
  2. Before the follow-up suggestions from that response arrive, send another message
  3. The sidebar activity spinner disappears when the first task finishes, even though the second task of follow up questions is still running

  Each task independently emits chat:active=false when it finishes without checking if other tasks are still active for the same chat.

  **Fixes:**
  - Check the DB-persisted done state in loadChat before assigning taskIds -- if the response is already done, remaining tasks are background work that shouldn't block input
  - Gate chat:active=false emission on whether other tasks remain for the chat
### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.