### PR TITLE
fix: pass chatId to clearDraft on message submit

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2908,7 +2908,7 @@
 										}
 									}}
 									on:submit={async (e) => {
-										clearDraft();
+										clearDraft($chatId);
 										if (e.detail || files.length > 0) {
 											await tick();
 


### PR DESCRIPTION
## Summary

Fixes #23296

`saveDraft(data, $chatId)` stores the draft under `chat-input-<chatId>`, but `clearDraft()` (called with no arguments on submit) only removes the bare `chat-input` key. This means per-chat drafts are never cleared on send, causing the sent text to reappear after a page refresh.

## Fix

Pass `$chatId` to `clearDraft()` in the `MessageInput` submit handler so it removes the correct `chat-input-<chatId>` key from sessionStorage.

The `Placeholder` submit handler is unchanged since it consistently uses `saveDraft(data)` / `clearDraft()` (both without chatId).

## Test plan

1. Open an existing chat
2. Type some text, wait for debounced draft save
3. Send the message
4. Refresh the page → input should be empty (previously showed the sent text)