### PR TITLE
fix: improve OpenAI reasoning models support and fix reasoning_effort

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -127,11 +127,15 @@ def openai_reasoning_model_handler(payload):
         payload['max_completion_tokens'] = payload['max_tokens']
         del payload['max_tokens']
 
+    # Convert "reasoning.effort" (dot syntax) to "reasoning_effort" for Chat API
+    if 'reasoning.effort' in payload:
+        payload['reasoning_effort'] = payload.pop('reasoning.effort')
+
     # Handle system role conversion based on model type
     if payload['messages'][0]['role'] == 'system':
         model_lower = payload['model'].lower()
         # Legacy models use "user" role instead of "system"
-        if model_lower.startswith('o1-mini') or model_lower.startswith('o1-preview'):
+        if model_lower.startswith('o1-mini') or model_lower.startswith('o1-preview') or '/o1-mini' in model_lower or '/o1-preview' in model_lower:
             payload['messages'][0]['role'] = 'user'
         else:
             payload['messages'][0]['role'] = 'developer'
@@ -762,11 +766,11 @@ def get_azure_allowed_params(api_version: str) -> set[str]:
 def is_openai_new_model(model: str) -> bool:
     model_lower = model.lower()
     # o-series models (o1, o3, o4, o5, ...)
-    if re.match(r'^o\d+', model_lower):
+    if re.search(r'(^|/)o\d+', model_lower):
         return True
     # gpt-N where N >= 5 (gpt-5, gpt-5.2, gpt-6, ...)
-    m = re.match(r'^gpt-(\d+)', model_lower)
-    if m and int(m.group(1)) >= 5:
+    m = re.search(r'(^|/)gpt-(\d+)', model_lower)
+    if m and int(m.group(2)) >= 5:
         return True
     return False
 
@@ -929,7 +933,18 @@ def convert_to_responses_payload(payload: dict) -> dict:
     if 'max_completion_tokens' in responses_payload:
         responses_payload['max_output_tokens'] = responses_payload.pop('max_completion_tokens')
 
-    # Remove Chat Completions-only parameters not supported by the Responses API
+    # Convert "reasoning_effort" or "reasoning.effort" to nested "reasoning" object
+    effort = responses_payload.pop('reasoning_effort', responses_payload.pop('reasoning.effort', None))
+    if effort:
+        if 'reasoning' not in responses_payload:
+            responses_payload['reasoning'] = {}
+
+        if isinstance(responses_payload['reasoning'], dict):
+            responses_payload['reasoning']['effort'] = effort
+        else:
+            responses_payload['reasoning'] = {'effort': effort}
+
+
     for unsupported_key in (
         'stream_options',
         'logit_bias',

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -109,6 +109,7 @@ def apply_model_params_to_body_openai(params: dict, form_data: dict) -> dict:
         'frequency_penalty': float,
         'presence_penalty': float,
         'reasoning_effort': str,
+        'reasoning.effort': str,
         'seed': lambda x: x,
         'stop': lambda x: [bytes(s, 'utf-8').decode('unicode_escape') for s in x],
         'logit_bias': lambda x: x,

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -388,7 +388,7 @@
 	<div class=" py-0.5 w-full justify-between">
 		<Tooltip
 			content={$i18n.t(
-				'Constrains effort on reasoning for reasoning models. Only applicable to reasoning models from specific providers that support reasoning effort.'
+				'Constrains effort on reasoning for reasoning models (reasoning.effort). Only applicable to reasoning models from specific providers that support reasoning effort.'
 			)}
 			placement="top-start"
 			className="inline-tooltip"
@@ -419,7 +419,7 @@
 					<input
 						class="text-sm w-full bg-transparent outline-hidden outline-none"
 						type="text"
-						placeholder={$i18n.t('Enter reasoning effort')}
+						placeholder={$i18n.t('e.g. low, medium, high, xhigh')}
 						bind:value={params.reasoning_effort}
 						autocomplete="off"
 					/>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Note to maintainers: This is a resubmission of PR #23302. I have cleaned up the git history, removed redundant merge commits, and rebased onto the latest dev branch. Sorry for the confusion earlier! :3

- This PR improves support for OpenAI reasoning models (such as o1 and o3). It primarily resolves an issue where models were not correctly identified as reasoning models when using model names with prefixes (such as openai/o3-mini and azure/gpt-5). Additionally, it standardises the conversion of the `reasoning_effort` to `reasoning.effort` parameter format between the Chat Completions API and the Responses API.

### Added

- Added support for the `reasoning.effort` parameter format according to OpenAI's recent API changes for newer models.

### Changed

- The regular expression logic for `is_openai_new_model` has been updated to recognise inference models with provider prefixes.

- The role mapping logic for inference models has been updated to ensure that prefixed `o1-mini` and `o1-preview` models
     are correctly downgraded to the `user` role, whilst other models use the `developer` role.

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Fixed an issue where `reasoning_effort` in the OpenAI Responses API was not correctly nested within the  {‘reasoning’: {“effort”: ‘...’}} object.
- Fixed a bug where prefixed reasoning models were unable to automatically convert `max_tokens` to `max_completion_tokens`.
- Prevents Unsupported parameter errors for non-reasoning models (like gpt-4) by automatically stripping reasoning-related parameters from the payload before sending.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

 - Manual testing and verification: The following scenarios have been verified using a dedicated test_logic.py script:
     - [x] Models with prefixes such as openai/o3-mini are correctly identified.
     - [x] `max_tokens` is correctly converted to `max_completion_tokens`.
     - [x] The `system` role is correctly converted to `developer` or `user` depending on the model version.
     - [x] Parameters under the Responses API are correctly nested.
     - [x] Non-inference models such as `gpt-4` are not affected.

### Screenshots or Videos

<img width="1280" height="661" alt="Screenshot 2026-04-01 at 1 20 30 AM" src="https://github.com/user-attachments/assets/350636f3-4f1d-414f-9d29-8c05c5f53af5" />
<img width="1280" height="659" alt="Screenshot 2026-04-01 at 1 16 05 AM" src="https://github.com/user-attachments/assets/9e1e24c2-a4ea-43e3-b2e3-637e2d7ba40a" />
<img width="1277" height="659" alt="Screenshot 2026-04-01 at 1 15 44 AM" src="https://github.com/user-attachments/assets/7a844ac8-f4bf-4568-a56c-c9e85b31f3fb" />
<img width="1058" height="506" alt="Screenshot 2026-04-01 at 1 33 32 AM" src="https://github.com/user-attachments/assets/bbde524e-0b9d-470b-a071-5a014535a2d5" />

### Contributor
 License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
