### PR TITLE
feat: add EUrouter to connection URL suggestions

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -323,6 +323,7 @@
 											<option value="https://api.mistral.ai/v1" />
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
+											<option value="https://api.eurouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />
 										</datalist>
 									{/if}


### PR DESCRIPTION
## Summary

- Add EUrouter (https://www.eurouter.ai) API base URL to the connection URL suggestions datalist
- EUrouter is a European AI Gateway providing a single OpenAI-compatible API endpoint to EU-hosted, GDPR-friendly AI models (DeepSeek R1, Kimi K2.5, Mistral Large 3, MiniMax M2.5, and more)
- No backend changes needed as EUrouter is fully OpenAI-compatible with standard Bearer token authentication

### Changelog

### Added
- EUrouter (`https://api.eurouter.ai/api/v1`) to OpenAI-compatible connection URL suggestions