### PR TITLE
fix: keep viewport stable during fallback copy

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -511,16 +511,24 @@ export const copyToClipboard = async (text, html = null, formatted = false) => {
 	} else {
 		let result = false;
 		if (!navigator.clipboard) {
+			const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+			const scrollX = window.scrollX;
+			const scrollY = window.scrollY;
 			const textArea = document.createElement('textarea');
 			textArea.value = text;
 
-			// Avoid scrolling to bottom
+			// Keep the fallback copy target off-screen without stealing the viewport.
 			textArea.style.top = '0';
 			textArea.style.left = '0';
 			textArea.style.position = 'fixed';
+			textArea.style.opacity = '0';
 
 			document.body.appendChild(textArea);
-			textArea.focus();
+			try {
+				textArea.focus({ preventScroll: true });
+			} catch {
+				textArea.focus();
+			}
 			textArea.select();
 
 			try {
@@ -533,6 +541,14 @@ export const copyToClipboard = async (text, html = null, formatted = false) => {
 			}
 
 			document.body.removeChild(textArea);
+			window.scrollTo(scrollX, scrollY);
+			if (activeElement && document.contains(activeElement)) {
+				try {
+					activeElement.focus({ preventScroll: true });
+				} catch {
+					activeElement.focus();
+				}
+			}
 			return result;
 		}
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of Keep a Changelog is added at the bottom of the PR description.
- [ ] **Documentation:** No docs repo change needed for this small bug fix.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** I manually tested the fix in a long chat, verified copy actions no longer jump the viewport, and ran `git diff --check`.
- [x] **Agentic AI Code:** I manually reviewed and tested the final patch before opening this PR.
- [x] **Code review:** I performed a self-review of the code change.
- [x] **Design & Architecture:** The change stays inside the existing shared clipboard fallback path and does not add new settings.
- [x] **Git Hygiene:** This PR is a single logical change rebased onto `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Preserve the current viewport when Open WebUI falls back to the textarea-based clipboard copy path.

### Added

- None.

### Changed

- Restore the prior scroll position and focused element after fallback copy completes.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevent inline code, code block, and response copy actions from jumping long chats back to the top when `navigator.clipboard` is unavailable.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Refs #23363
- Manual test steps:
  1. Open a long chat with enough content to scroll well below the top.
  2. Click copy on a response or code block in an environment that uses the fallback clipboard path.
  3. Confirm the chat stays at the same scroll position after the copy succeeds.

### Screenshots or Videos

- Not included for this small utility fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.