### PR TITLE
feat: log provider errors to console for better insights

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1833,7 +1833,7 @@ async def chat_completion(
             finally:
                 raise  # re-raise to ensure proper task cancellation handling
         except Exception as e:
-            log.exception('Error processing chat payload: %s', e)
+            log.error('Error processing chat payload: %s', e)
             if metadata.get('chat_id') and metadata.get('message_id'):
                 # Update the chat message with the error
                 try:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1833,7 +1833,7 @@ async def chat_completion(
             finally:
                 raise  # re-raise to ensure proper task cancellation handling
         except Exception as e:
-            log.debug(f'Error processing chat payload: {e}')
+            log.exception('Error processing chat payload: %s', e)
             if metadata.get('chat_id') and metadata.get('message_id'):
                 # Update the chat message with the error
                 try:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1192,6 +1192,22 @@ async def generate_chat_completion(
 
         # Check if response is SSE
         if 'text/event-stream' in r.headers.get('Content-Type', ''):
+            # If the provider returned an error status with SSE content-type,
+            # read the body and return a proper error response instead of
+            # streaming the error back (which hides the error from logs).
+            if r.status >= 400:
+                error_body = await r.text()
+                log.error(
+                    'Provider returned HTTP %d with SSE content-type: %s',
+                    r.status,
+                    error_body[:1000],
+                )
+                try:
+                    error_json = json.loads(error_body)
+                    return JSONResponse(status_code=r.status, content=error_json)
+                except json.JSONDecodeError:
+                    return PlainTextResponse(status_code=r.status, content=error_body)
+
             streaming = True
             return StreamingResponse(
                 stream_wrapper(r, session, stream_chunks_handler),

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1206,7 +1206,10 @@ async def generate_chat_completion(
                     error_json = json.loads(error_body)
                     return JSONResponse(status_code=r.status, content=error_json)
                 except json.JSONDecodeError:
-                    return PlainTextResponse(status_code=r.status, content=error_body)
+                    return JSONResponse(
+                        status_code=r.status,
+                        content={"error": {"message": error_body, "code": r.status}},
+                    )
 
             streaming = True
             return StreamingResponse(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3077,6 +3077,8 @@ async def non_streaming_chat_response_handler(response, ctx):
                 else:
                     error = str(error)
 
+                log.error('Provider returned error (non-streaming): %s', error)
+
                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata['chat_id'],
                     metadata['message_id'],
@@ -3645,6 +3647,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     if not choices:
                                         error = data.get('error', {})
                                         if error:
+                                            log.error('Provider returned error (streaming): %s', error)
                                             try:
                                                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                                                     metadata['chat_id'],


### PR DESCRIPTION
Some SSE streamed provider errors like from openrouter.ai are swallowed by open webui and this makes it impossible to see what actually was the error (i.e. context window exceeded)

this raises them and makes them visible to console logging.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
