### PR TITLE
feat: Pass RFC 8707 resource parameter in MCP OAuth 2.1 flows

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -363,7 +363,7 @@ async def verify_tool_servers_config(request: Request, form_data: ToolServerConn
     try:
         if form_data.type == 'mcp':
             if form_data.auth_type in ('oauth_2.1', 'oauth_2.1_static'):
-                discovery_urls = await get_discovery_urls(form_data.url)
+                discovery_urls, _ = await get_discovery_urls(form_data.url)
                 for discovery_url in discovery_urls:
                     log.debug(f'Trying to fetch OAuth 2.1 discovery document from {discovery_url}')
                     async with aiohttp.ClientSession(

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -363,7 +363,7 @@ async def verify_tool_servers_config(request: Request, form_data: ToolServerConn
     try:
         if form_data.type == 'mcp':
             if form_data.auth_type in ('oauth_2.1', 'oauth_2.1_static'):
-                discovery_urls, _ = await get_discovery_urls(form_data.url)
+                discovery_urls, _ = await get_discovery_urls(form_data.url)  # resource not needed for verification
                 for discovery_url in discovery_urls:
                     log.debug(f'Trying to fetch OAuth 2.1 discovery document from {discovery_url}')
                     async with aiohttp.ClientSession(

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -106,6 +106,10 @@ class OAuthClientInformationFull(OAuthClientMetadata):
     server_metadata: Optional[OAuthMetadata] = None  # Fetched from the OAuth server
     resource: Optional[str] = None  # RFC 8707 resource indicator for token audience
 
+    def resource_params(self) -> dict[str, str]:
+        """Return ``{'resource': ...}`` if a RFC 8707 resource is set, else ``{}``."""
+        return {'resource': self.resource} if self.resource else {}
+
 
 from open_webui.env import GLOBAL_LOG_LEVEL
 
@@ -266,7 +270,7 @@ async def get_authorization_server_discovery_urls(
     """
 
     authorization_servers = []
-    resource_url = None
+    resource_url: Optional[str] = None
     try:
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
@@ -298,11 +302,10 @@ async def get_authorization_server_discovery_urls(
                                     log.debug(f'Discovered authorization servers: {servers}')
 
                                 # Step 4: Extract resource identifier (RFC 8707)
-                                resource_url = resource_metadata.get('resource')
-                                if resource_url:
-                                    log.debug(
-                                        f'Discovered resource identifier: {resource_url}'
-                                    )
+                                raw_resource = resource_metadata.get('resource')
+                                if isinstance(raw_resource, str) and raw_resource.startswith('http'):
+                                    resource_url = raw_resource
+                                    log.debug(f'Discovered resource identifier: {resource_url}')
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 
@@ -480,7 +483,7 @@ async def get_oauth_client_info_with_static_credentials(
         redirect_uri = f'{redirect_base_url}/oauth/clients/{client_id}/callback'
 
         # Discover server metadata (authorization endpoint, token endpoint, scopes, etc.)
-        discovery_urls = await get_discovery_urls(oauth_server_url)
+        discovery_urls, resource_url = await get_discovery_urls(oauth_server_url)
         for url in discovery_urls:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(url, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
@@ -517,6 +520,7 @@ async def get_oauth_client_info_with_static_credentials(
             token_endpoint_auth_method=token_endpoint_auth_method,
             issuer=oauth_server_metadata_url,
             server_metadata=oauth_server_metadata,
+            **({'resource': resource_url} if resource_url else {}),
         )
 
         log.info(
@@ -819,8 +823,8 @@ class OAuthClientManager:
 
             # Add RFC 8707 resource parameter for correct JWT audience
             client_info = self.get_client_info(client_id)
-            if client_info and client_info.resource:
-                refresh_data['resource'] = client_info.resource
+            if client_info:
+                refresh_data.update(client_info.resource_params())
 
             # Make refresh request
             async with aiohttp.ClientSession(trust_env=True) as session_http:
@@ -873,10 +877,7 @@ class OAuthClientManager:
 
         # Pass RFC 8707 resource parameter so the IDP sets the correct
         # audience in the issued JWT access token.
-        extra_params = {}
-        if client_info.resource:
-            extra_params['resource'] = client_info.resource
-        return await client.authorize_redirect(request, redirect_uri_str, **extra_params)
+        return await client.authorize_redirect(request, redirect_uri_str, **client_info.resource_params())
 
     async def handle_callback(self, request, client_id: str, user_id: str, response):
         client = self.get_client(client_id) or self.ensure_client_from_config(client_id)
@@ -894,9 +895,7 @@ class OAuthClientManager:
 
             # Pass RFC 8707 resource parameter so the IDP sets the correct
             # audience in the issued JWT access token.
-            token_params = {}
-            if client_info and client_info.resource:
-                token_params['resource'] = client_info.resource
+            token_params = client_info.resource_params() if client_info else {}
             token = await client.authorize_access_token(request, **token_params)
 
             # Validate that we received a proper token response

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -104,6 +104,7 @@ class OAuthClientInformationFull(OAuthClientMetadata):
     client_secret_expires_at: int | None = None
 
     server_metadata: Optional[OAuthMetadata] = None  # Fetched from the OAuth server
+    resource: Optional[str] = None  # RFC 8707 resource indicator for token audience
 
 
 from open_webui.env import GLOBAL_LOG_LEVEL
@@ -252,12 +253,20 @@ def get_parsed_and_base_url(server_url) -> tuple[urllib.parse.ParseResult, str]:
     return parsed, base_url
 
 
-async def get_authorization_server_discovery_urls(server_url: str) -> list[str]:
+async def get_authorization_server_discovery_urls(
+    server_url: str,
+) -> tuple[list[str], Optional[str]]:
     """
     https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization
+
+    Returns (discovery_urls, resource_url) where resource_url is the RFC 9728
+    resource identifier that should be passed as the RFC 8707 ``resource``
+    parameter in authorization and token requests so that the IDP sets the
+    correct ``aud`` claim in the issued JWT.
     """
 
     authorization_servers = []
+    resource_url = None
     try:
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
@@ -287,6 +296,13 @@ async def get_authorization_server_discovery_urls(server_url: str) -> list[str]:
                                 if servers:
                                     authorization_servers = servers
                                     log.debug(f'Discovered authorization servers: {servers}')
+
+                                # Step 4: Extract resource identifier (RFC 8707)
+                                resource_url = resource_metadata.get('resource')
+                                if resource_url:
+                                    log.debug(
+                                        f'Discovered resource identifier: {resource_url}'
+                                    )
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 
@@ -300,11 +316,11 @@ async def get_authorization_server_discovery_urls(server_url: str) -> list[str]:
             ]
         )
 
-    return discovery_urls
+    return discovery_urls, resource_url
 
 
-async def get_discovery_urls(server_url) -> list[str]:
-    urls = await get_authorization_server_discovery_urls(server_url)
+async def get_discovery_urls(server_url) -> tuple[list[str], Optional[str]]:
+    urls, resource_url = await get_authorization_server_discovery_urls(server_url)
     parsed, base_url = get_parsed_and_base_url(server_url)
 
     if parsed.path and parsed.path != '/':
@@ -328,7 +344,7 @@ async def get_discovery_urls(server_url) -> list[str]:
         ]
     )
 
-    return urls
+    return urls, resource_url
 
 
 # TODO: Some OAuth providers require Initial Access Tokens (IATs) for dynamic client registration.
@@ -353,7 +369,7 @@ async def get_oauth_client_info_with_dynamic_client_registration(
         )
 
         # Attempt to fetch OAuth server metadata to get registration endpoint & scopes
-        discovery_urls = await get_discovery_urls(oauth_server_url)
+        discovery_urls, resource_url = await get_discovery_urls(oauth_server_url)
         for url in discovery_urls:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(url, ssl=AIOHTTP_CLIENT_SESSION_SSL) as oauth_server_metadata_response:
@@ -415,6 +431,7 @@ async def get_oauth_client_info_with_dynamic_client_registration(
                             **registration_response_json,
                             **{'issuer': oauth_server_metadata_url},
                             **{'server_metadata': oauth_server_metadata},
+                            **({'resource': resource_url} if resource_url else {}),
                         }
                     )
                     log.info(
@@ -800,6 +817,11 @@ class OAuthClientManager:
             ):
                 refresh_data['scope'] = client.client_kwargs['scope']
 
+            # Add RFC 8707 resource parameter for correct JWT audience
+            client_info = self.get_client_info(client_id)
+            if client_info and client_info.resource:
+                refresh_data['resource'] = client_info.resource
+
             # Make refresh request
             async with aiohttp.ClientSession(trust_env=True) as session_http:
                 async with session_http.post(
@@ -848,7 +870,13 @@ class OAuthClientManager:
 
         redirect_uri = client_info.redirect_uris[0] if client_info.redirect_uris else None
         redirect_uri_str = str(redirect_uri) if redirect_uri else None
-        return await client.authorize_redirect(request, redirect_uri_str)
+
+        # Pass RFC 8707 resource parameter so the IDP sets the correct
+        # audience in the issued JWT access token.
+        extra_params = {}
+        if client_info.resource:
+            extra_params['resource'] = client_info.resource
+        return await client.authorize_redirect(request, redirect_uri_str, **extra_params)
 
     async def handle_callback(self, request, client_id: str, user_id: str, response):
         client = self.get_client(client_id) or self.ensure_client_from_config(client_id)
@@ -863,7 +891,13 @@ class OAuthClientManager:
             # The Authlib client already has these configured during add_client().
             # Passing them again causes Authlib to concatenate them (e.g., "ID1,ID1"),
             # which results in 401 errors from the token endpoint. (Fix for #19823)
-            token = await client.authorize_access_token(request)
+
+            # Pass RFC 8707 resource parameter so the IDP sets the correct
+            # audience in the issued JWT access token.
+            token_params = {}
+            if client_info and client_info.resource:
+                token_params['resource'] = client_info.resource
+            token = await client.authorize_access_token(request, **token_params)
 
             # Validate that we received a proper token response
             # If token exchange failed (e.g., 401), we may get an error response instead


### PR DESCRIPTION
Extract the `resource` field from RFC 9728 Protected Resource Metadata and include it as the RFC 8707 `resource` parameter in authorization requests, token exchanges, and token refreshes. This allows the IdP to set the correct `aud` claim in issued JWT access tokens, which MCP servers require for token validation.

Changes:
- `get_authorization_server_discovery_urls` now returns `(urls, resource_url)`
- `OAuthClientInformationFull` stores the discovered `resource`
- `handle_authorize` passes `resource` in the authorization redirect
- `handle_callback` passes `resource` in the token exchange
- `_perform_token_refresh` passes `resource` in refresh requests

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Pass RFC 8707 resource parameter in MCP OAuth 2.1 flows

### Added

- Extract the `resource` field from RFC 9728 Protected Resource Metadata and include it as the RFC 8707 `resource` parameter in authorization requests, token exchanges, and token refreshes.

### Changed

- `get_authorization_server_discovery_urls` now returns `(urls, resource_url)`
- `OAuthClientInformationFull` stores the discovered `resource`
- `handle_authorize` passes `resource` in the authorization redirect
- `handle_callback` passes `resource` in the token exchange
- `_perform_token_refresh` passes `resource` in refresh requests

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
