### PR TITLE
feat: Add support for using mariadb for the backend database

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -55,8 +55,8 @@ class JSONField(types.TypeDecorator):
 def handle_peewee_migration(DATABASE_URL):
     # db = None
     try:
-        # Replace the postgresql:// with postgres:// to handle the peewee migration
-        db = register_connection(DATABASE_URL.replace('postgresql://', 'postgres://'))
+        # register_connection() normalizes SQLAlchemy URL variants for Peewee.
+        db = register_connection(DATABASE_URL)
         migrate_dir = OPEN_WEBUI_DIR / 'internal' / 'migrations'
         router = Router(db, logger=log, migrate_dir=migrate_dir)
         router.run()

--- a/backend/open_webui/internal/migrations/007_add_user_last_active_at.py
+++ b/backend/open_webui/internal/migrations/007_add_user_last_active_at.py
@@ -33,6 +33,14 @@ with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
 
+def _user_ident(database: pw.Database) -> str:
+    # Postgres: "user" (identifier quoting)
+    # MariaDB/MySQL: `user` (identifier quoting)
+    mod = database.__class__.__module__.lower()
+    name = database.__class__.__name__.lower()
+    return '`user`' if ('mysql' in mod or 'pymysql' in mod or 'mysql' in name or 'mariadb' in name) else '"user"'
+
+
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
     """Write your migrations here."""
 
@@ -45,8 +53,9 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
     )
 
     # Populate the new fields from an existing 'timestamp' field
+    user_tbl = _user_ident(database)
     migrator.sql(
-        'UPDATE "user" SET created_at = timestamp, updated_at = timestamp, last_active_at = timestamp WHERE timestamp IS NOT NULL'
+        f'UPDATE {user_tbl} SET created_at = timestamp, updated_at = timestamp, last_active_at = timestamp WHERE timestamp IS NOT NULL'
     )
 
     # Now that the data has been copied, remove the original 'timestamp' field
@@ -69,7 +78,8 @@ def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
 
     # Copy the earliest created_at date back into the new timestamp field
     # This assumes created_at was originally a copy of timestamp
-    migrator.sql('UPDATE "user" SET timestamp = created_at')
+    user_tbl = _user_ident(database)
+    migrator.sql(f'UPDATE {user_tbl} SET timestamp = created_at')
 
     # Remove the created_at and updated_at fields
     migrator.remove_fields('user', 'created_at', 'updated_at', 'last_active_at')

--- a/backend/open_webui/internal/migrations/009_add_models.py
+++ b/backend/open_webui/internal/migrations/009_add_models.py
@@ -29,6 +29,9 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
+from open_webui.internal.utils import key_text
+
+
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
@@ -38,9 +41,9 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Model(pw.Model):
-        id = pw.TextField(unique=True)
-        user_id = pw.TextField()
-        base_model_id = pw.TextField(null=True)
+        id = key_text(database, unique=True)
+        user_id = key_text(database)
+        base_model_id = key_text(database, null=True)
 
         name = pw.TextField()
 

--- a/backend/open_webui/internal/migrations/012_add_tools.py
+++ b/backend/open_webui/internal/migrations/012_add_tools.py
@@ -29,6 +29,9 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
+from open_webui.internal.utils import key_text
+
+
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
@@ -38,8 +41,8 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Tool(pw.Model):
-        id = pw.TextField(unique=True)
-        user_id = pw.TextField()
+        id = key_text(database, unique=True)
+        user_id = key_text(database)
 
         name = pw.TextField()
         content = pw.TextField()

--- a/backend/open_webui/internal/migrations/014_add_files.py
+++ b/backend/open_webui/internal/migrations/014_add_files.py
@@ -29,6 +29,9 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
+from open_webui.internal.utils import key_text
+
+
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
@@ -38,8 +41,8 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class File(pw.Model):
-        id = pw.TextField(unique=True)
-        user_id = pw.TextField()
+        id = key_text(database, unique=True)
+        user_id = key_text(database)
         filename = pw.TextField()
         meta = pw.TextField()
         created_at = pw.BigIntegerField(null=False)

--- a/backend/open_webui/internal/migrations/015_add_functions.py
+++ b/backend/open_webui/internal/migrations/015_add_functions.py
@@ -29,6 +29,9 @@ from contextlib import suppress
 import peewee as pw
 from peewee_migrate import Migrator
 
+from open_webui.internal.utils import key_text
+
+
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
@@ -38,8 +41,8 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
     @migrator.create_model
     class Function(pw.Model):
-        id = pw.TextField(unique=True)
-        user_id = pw.TextField()
+        id = key_text(database, unique=True)
+        user_id = key_text(database)
 
         name = pw.TextField()
         type = pw.TextField()

--- a/backend/open_webui/internal/utils.py
+++ b/backend/open_webui/internal/utils.py
@@ -1,0 +1,12 @@
+import peewee as pw
+
+
+def key_text(database: pw.Database, *, max_length: int = 255, **kwargs) -> pw.Field:
+    """
+    Dialect-aware "text-like" field for Peewee migrations:
+    - MySQL/MariaDB: use VARCHAR(max_length) so UNIQUE/PK/INDEX works without prefix lengths.
+    - Postgres/SQLite: keep TEXT to preserve existing schema/history.
+    """
+    if isinstance(database, pw.MySQLDatabase):
+        return pw.CharField(max_length=max_length, **kwargs)
+    return pw.TextField(**kwargs)

--- a/backend/open_webui/internal/wrappers.py
+++ b/backend/open_webui/internal/wrappers.py
@@ -32,6 +32,9 @@ class CustomReconnectMixin(ReconnectMixin):
         # psycopg2
         (OperationalError, 'termin'),
         (InterfaceError, 'closed'),
+        # PyMySQL / MySQLdb (MySQL/MariaDB)
+        (OperationalError, 'server has gone away'),
+        (OperationalError, 'lost connection'),
         # peewee
         (PeeWeeInterfaceError, 'closed'),
     )
@@ -41,7 +44,34 @@ class ReconnectingPostgresqlDatabase(CustomReconnectMixin, PostgresqlDatabase):
     pass
 
 
-def register_connection(db_url):
+class ReconnectingMySQLDatabase(CustomReconnectMixin, MySQLDatabase):
+    pass
+
+
+def normalize_db_url_for_peewee(db_url: str) -> str:
+    """
+    Peewee's db_url helper uses slightly different schemes than SQLAlchemy.
+    Normalize the base SQLAlchemy dialect scheme before initializing the
+    Peewee DB, while ignoring any SQLAlchemy driver suffix.
+    """
+    scheme, sep, rest = db_url.partition('://')
+    if not sep:
+        return db_url
+
+    base_dialect, _, _ = scheme.partition('+')
+
+    scheme_map = {
+        'postgresql': 'postgres',
+        'mysql': 'mysql',
+        'mariadb': 'mysql',
+    }
+    normalized_scheme = scheme_map.get(base_dialect, scheme)
+    return f'{normalized_scheme}://{rest}'
+
+
+def register_connection(db_url: str):
+    db_url = normalize_db_url_for_peewee(db_url)
+
     # Check if using SQLCipher protocol
     if db_url.startswith('sqlite+sqlcipher://'):
         database_password = os.environ.get('DATABASE_PASSWORD')
@@ -60,7 +90,7 @@ def register_connection(db_url):
         log.info('Connected to encrypted SQLite database using SQLCipher')
 
     else:
-        # Standard database connection (existing logic)
+        # Standard database connection
         db = connect(db_url, unquote_user=True, unquote_password=True)
         if isinstance(db, PostgresqlDatabase):
             # Enable autoconnect for SQLite databases, managed by Peewee
@@ -73,6 +103,13 @@ def register_connection(db_url):
 
             # Use our custom database class that supports reconnection
             db = ReconnectingPostgresqlDatabase(**connection)
+            db.connect(reuse_if_open=True)
+        elif isinstance(db, MySQLDatabase):
+            log.info('Connected to MySQL/MariaDB database')
+            connection = parse(db_url, unquote_user=True, unquote_password=True)
+            db = ReconnectingMySQLDatabase(**connection)
+            db.autoconnect = True
+            db.reuse_if_open = True
             db.connect(reuse_if_open=True)
         elif isinstance(db, SqliteDatabase):
             # Enable autoconnect for SQLite databases, managed by Peewee

--- a/backend/open_webui/migrations/README
+++ b/backend/open_webui/migrations/README
@@ -2,3 +2,14 @@ Generic single-database configuration.
 
 Create new migrations with
 DATABASE_URL=<replace with actual url> alembic revision --autogenerate -m "a description"
+
+Important notes for new migrations:
+
+- Keep migrations portable across SQLite, PostgreSQL, and MariaDB/MySQL-compatible backends.
+- Do not use `sa.Text()` for identifier-like columns that participate in `PRIMARY KEY`, `UNIQUE`, `INDEX`, or `FOREIGN KEY` paths.
+  Use `open_webui.migrations.util.key_text()` instead for those key-like columns.
+- Prefer explicit lengths for `sa.String(...)` in new migrations, especially for key-like columns.
+- Be careful with table-level `sa.UniqueConstraint(...)` and `op.create_index(...)`: if any participating column is identifier-like, make sure its type is MariaDB-safe.
+- If raw SQL is required, avoid hardcoding identifier quoting that only works on one dialect (for example `"user"`). Use dialect-aware quoting when needed.
+- Treat the compatibility shims in `env.py` as a safety net for historical revisions, not as the primary design pattern for new migrations.
+- Before merging a new migration, test `alembic upgrade head` on at least one fresh MariaDB database in addition to the usual SQLite/PostgreSQL path.

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -4,7 +4,135 @@ from logging.config import fileConfig
 from alembic import context
 from open_webui.models.auths import Auth
 from open_webui.env import DATABASE_URL, DATABASE_PASSWORD, LOG_FORMAT
+import sqlalchemy as sa
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import engine_from_config, pool, create_engine
+
+log = logging.getLogger(__name__)
+
+
+# --- MySQL/MariaDB compatibility shims ---------------------------------------
+# Goal:
+#   Keep existing historical Alembic revisions unchanged while making them
+#   executable on MySQL/MariaDB.
+#
+# Why this is needed:
+#   Open-WebUI has older migrations that were originally written with
+#   SQLite/PostgreSQL-friendly assumptions. In particular:
+#     - some revisions use sa.String() without an explicit length
+#     - some revisions use sa.Text() for identifier-like columns such as ids,
+#       unique keys, indexed columns, or foreign-key columns
+#
+# On MySQL/MariaDB, these patterns can fail during DDL generation because:
+#   - VARCHAR requires a length
+#   - TEXT/BLOB columns cannot be used safely for PRIMARY KEY / UNIQUE / indexed
+#     columns without a key length
+#   - foreign-key columns must be type-compatible with the referenced key
+#
+# Scope:
+#   These shims affect Alembic migration DDL compilation only. They do not change
+#   SQLAlchemy model definitions or runtime query behavior outside migrations.
+#
+# Design note:
+#   sa.String() can be fixed globally because the issue is type-only (missing length).
+#   sa.Text() cannot: TEXT is valid in general, but invalid/problematic only when used
+#   for PK/UNIQUE/index/FK columns, so we must inspect column context during DDL compilation.
+#
+#   This shim is a safety net for historical revisions during CREATE TABLE DDL generation.
+#   New migrations should still use MariaDB-safe types explicitly (for example key_text()),
+#   especially for columns that may later participate in op.create_index(...) or other
+#   for PK/UNIQUE/index/FK columns, so we must inspect column context during DDL compilation.
+#
+# 1) sa.String() without a length:
+#    Triggered when a historical migration emits sa.String() and Alembic compiles
+#    it for the mysql/mariadb dialect. In that case, rewrite it to VARCHAR(255)
+#    so the migration remains valid without editing the historical revision.
+@compiles(sa.String, 'mysql')
+@compiles(sa.String, 'mariadb')
+def _compile_string_mysql(type_, compiler, **kw):
+    if type_.length is None:
+        type_ = sa.String(length=255)
+    return compiler.visit_VARCHAR(type_, **kw)
+
+
+#
+#
+# 2) sa.Text() used for key-like columns:
+#    Triggered when a historical migration defines a TEXT column that is also:
+#      - a PRIMARY KEY
+#      - UNIQUE
+#      - indexed
+#      - or used as a FOREIGN KEY
+#
+#    During MySQL/MariaDB migration DDL compilation only, rewrite those columns
+#    from TEXT to VARCHAR(255). This preserves the intent of the old migration
+#    while satisfying MySQL/MariaDB key and FK requirements.
+#
+#    How it works:
+#      - patch MySQLDDLCompiler.get_column_specification()
+#      - inspect each column as Alembic renders CREATE/ALTER TABLE DDL
+#      - if the column type is sa.Text and it participates in a PK/UNIQUE/index/FK,
+#        make a shallow column copy and replace its type with sa.String(255)
+#      - delegate back to SQLAlchemy's original compiler method
+#
+#    This keeps the compatibility logic centralized in env.py instead of
+#    modifying many already-released migration files.
+try:
+    from sqlalchemy.dialects.mysql.base import MySQLDDLCompiler
+
+    def _is_mysql_key_text_column(column) -> bool:
+        """
+        Return True when a TEXT column participates in a key-like path that is
+        unsafe on MySQL/MariaDB and should be rewritten to VARCHAR(255) during
+        CREATE TABLE DDL compilation.
+
+        This covers both:
+        - column-level flags (primary_key / unique / index / foreign_keys)
+        - table-level constraints/indexes attached before CREATE TABLE compilation
+        """
+        is_fk_col = bool(getattr(column, 'foreign_keys', None))
+        if column.primary_key or column.unique or column.index or is_fk_col:
+            return True
+
+        table = getattr(column, 'table', None)
+        if table is None:
+            return False
+
+        for constraint in getattr(table, 'constraints', ()):
+            if isinstance(constraint, (sa.PrimaryKeyConstraint, sa.UniqueConstraint)):
+                try:
+                    if column in constraint.columns:
+                        return True
+                except Exception:
+                    pass
+
+        for index in getattr(table, 'indexes', ()):
+            try:
+                if column in index.columns:
+                    return True
+            except Exception:
+                pass
+
+        return False
+
+    if not getattr(MySQLDDLCompiler, '_owui_key_text_patch', False):
+        _orig_get_colspec = MySQLDDLCompiler.get_column_specification
+
+        def _patched_get_column_specification(self, column, **kw):
+            # NOTE: For mysql/mariadb, FK columns must be type-compatible with the referenced key.
+            # If historical migrations used TEXT for FK columns, MySQL/MariaDB will reject the FK.
+            if isinstance(column.type, sa.Text) and _is_mysql_key_text_column(column):
+                column = column.copy()
+                column.type = sa.String(length=255)
+            return _orig_get_colspec(self, column, **kw)
+
+        MySQLDDLCompiler.get_column_specification = _patched_get_column_specification
+        MySQLDDLCompiler._owui_key_text_patch = True
+except Exception:
+    if DATABASE_URL.startswith(('mysql', 'mariadb')):
+        log.exception('Failed to install MySQL/MariaDB compatibility shims')
+        raise
+    # If MySQL/MariaDB is not the active dialect, continue without installing the shim.
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/open_webui/migrations/util.py
+++ b/backend/open_webui/migrations/util.py
@@ -1,5 +1,42 @@
-from alembic import op
+import sqlalchemy as sa
+from alembic import context, op
 from sqlalchemy import Inspector
+
+
+def _dialect_name(conn=None) -> str:
+    """
+    Return current dialect name.
+    Prefer a live Alembic bind when available; fall back to Alembic context
+    during offline (`--sql`) runs. If no dialect can be determined, return
+    an empty string so callers can choose a safe default.
+    """
+    if conn is not None:
+        return (conn.dialect.name or '').lower()
+
+    try:
+        conn = op.get_bind()
+    except Exception:
+        conn = None
+
+    if conn is not None:
+        return (conn.dialect.name or '').lower()
+
+    try:
+        return (context.get_context().dialect.name or '').lower()
+    except Exception:
+        return ''
+
+
+def key_text(conn=None, length: int = 255):
+    """
+    Dialect-aware TEXT for identifiers/keys.
+    - MySQL/MariaDB: TEXT cannot be indexed/PK'd without prefix length => use VARCHAR(length).
+    - PostgreSQL/SQLite: keep TEXT (historical behavior).
+    """
+    d = _dialect_name(conn)
+    if d in ('mysql', 'mariadb'):
+        return sa.String(length=length)
+    return sa.Text()
 
 
 def get_existing_tables():

--- a/backend/open_webui/migrations/versions/38d63c18f30f_add_oauth_session_table.py
+++ b/backend/open_webui/migrations/versions/38d63c18f30f_add_oauth_session_table.py
@@ -10,6 +10,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from open_webui.migrations.util import key_text
 
 # revision identifiers, used by Alembic.
 revision: str = '38d63c18f30f'
@@ -52,7 +53,7 @@ def upgrade() -> None:
             sa.ForeignKey('user.id', ondelete='CASCADE'),
             nullable=False,
         ),
-        sa.Column('provider', sa.Text(), nullable=False),
+        sa.Column('provider', key_text(), nullable=False),
         sa.Column('token', sa.Text(), nullable=False),
         sa.Column('expires_at', sa.BigInteger(), nullable=False),
         sa.Column('created_at', sa.BigInteger(), nullable=False),

--- a/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
+++ b/backend/open_webui/migrations/versions/8452d01d26d7_add_chat_message_table.py
@@ -14,6 +14,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
+from open_webui.migrations.util import key_text
+
 log = logging.getLogger(__name__)
 
 revision: str = '8452d01d26d7'
@@ -59,14 +61,14 @@ def upgrade() -> None:
     # Step 1: Create table
     op.create_table(
         'chat_message',
-        sa.Column('id', sa.Text(), primary_key=True),
-        sa.Column('chat_id', sa.Text(), nullable=False, index=True),
-        sa.Column('user_id', sa.Text(), index=True),
+        sa.Column('id', key_text(), primary_key=True),
+        sa.Column('chat_id', key_text(), nullable=False, index=True),
+        sa.Column('user_id', key_text(), index=True),
         sa.Column('role', sa.Text(), nullable=False),
-        sa.Column('parent_id', sa.Text(), nullable=True),
+        sa.Column('parent_id', key_text(), nullable=True),
         sa.Column('content', sa.JSON(), nullable=True),
         sa.Column('output', sa.JSON(), nullable=True),
-        sa.Column('model_id', sa.Text(), nullable=True, index=True),
+        sa.Column('model_id', key_text(), nullable=True, index=True),
         sa.Column('files', sa.JSON(), nullable=True),
         sa.Column('sources', sa.JSON(), nullable=True),
         sa.Column('embeds', sa.JSON(), nullable=True),

--- a/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
+++ b/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
@@ -40,6 +40,11 @@ def _drop_sqlite_indexes_for_column(table_name, column_name, conn):
             conn.execute(sa.text(f'DROP INDEX IF EXISTS {index_name}'))
 
 
+def _quote_table(conn, name: str) -> str:
+    # Postgres uses "name"; MariaDB/MySQL uses `name`
+    return f'`{name}`' if conn.dialect.name in ('mysql', 'mariadb') else f'"{name}"'
+
+
 def _convert_column_to_json(table: str, column: str):
     conn = op.get_bind()
     dialect = conn.dialect.name
@@ -139,7 +144,8 @@ def upgrade() -> None:
     )
 
     conn = op.get_bind()
-    users = conn.execute(sa.text('SELECT id, oauth_sub FROM "user" WHERE oauth_sub IS NOT NULL')).fetchall()
+    q_user = _quote_table(conn, 'user')
+    users = conn.execute(sa.text(f'SELECT id, oauth_sub FROM {q_user} WHERE oauth_sub IS NOT NULL')).fetchall()
 
     for uid, oauth_sub in users:
         if oauth_sub:
@@ -153,11 +159,11 @@ def upgrade() -> None:
 
             oauth_json = json.dumps({provider: {'sub': sub}})
             conn.execute(
-                sa.text('UPDATE "user" SET oauth = :oauth WHERE id = :id'),
+                sa.text(f'UPDATE {q_user} SET oauth = :oauth WHERE id = :id'),
                 {'oauth': oauth_json, 'id': uid},
             )
 
-    users_with_keys = conn.execute(sa.text('SELECT id, api_key FROM "user" WHERE api_key IS NOT NULL')).fetchall()
+    users_with_keys = conn.execute(sa.text(f'SELECT id, api_key FROM {q_user} WHERE api_key IS NOT NULL')).fetchall()
     now = int(time.time())
 
     for uid, api_key in users_with_keys:
@@ -190,7 +196,8 @@ def downgrade() -> None:
     op.add_column('user', sa.Column('oauth_sub', sa.Text(), nullable=True))
 
     conn = op.get_bind()
-    users = conn.execute(sa.text('SELECT id, oauth FROM "user" WHERE oauth IS NOT NULL')).fetchall()
+    q_user = _quote_table(conn, 'user')
+    users = conn.execute(sa.text(f'SELECT id, oauth FROM {q_user} WHERE oauth IS NOT NULL')).fetchall()
 
     for uid, oauth in users:
         try:
@@ -202,7 +209,7 @@ def downgrade() -> None:
             oauth_sub = None
 
         conn.execute(
-            sa.text('UPDATE "user" SET oauth_sub = :oauth_sub WHERE id = :id'),
+            sa.text(f'UPDATE {q_user} SET oauth_sub = :oauth_sub WHERE id = :id'),
             {'oauth_sub': oauth_sub, 'id': uid},
         )
 
@@ -215,7 +222,7 @@ def downgrade() -> None:
     keys = conn.execute(sa.text('SELECT user_id, key FROM api_key')).fetchall()
     for uid, key in keys:
         conn.execute(
-            sa.text('UPDATE "user" SET api_key = :key WHERE id = :id'),
+            sa.text(f'UPDATE {q_user} SET api_key = :key WHERE id = :id'),
             {'key': key, 'id': uid},
         )
 

--- a/backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py
+++ b/backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py
@@ -8,6 +8,7 @@ Create Date: 2024-10-16 02:02:35.241684
 
 from alembic import op
 import sqlalchemy as sa
+from open_webui.migrations.util import key_text
 
 revision = 'c69f45358db4'
 down_revision = '3ab32c4b8f59'
@@ -19,7 +20,7 @@ def upgrade():
     op.create_table(
         'folder',
         sa.Column('id', sa.Text(), nullable=False),
-        sa.Column('parent_id', sa.Text(), nullable=True),
+        sa.Column('parent_id', key_text(), nullable=True),
         sa.Column('user_id', sa.Text(), nullable=False),
         sa.Column('name', sa.Text(), nullable=False),
         sa.Column('items', sa.JSON(), nullable=True),
@@ -38,7 +39,7 @@ def upgrade():
 
     op.add_column(
         'chat',
-        sa.Column('folder_id', sa.Text(), nullable=True),
+        sa.Column('folder_id', key_text(), nullable=True),
     )
 
 

--- a/backend/open_webui/migrations/versions/d4e5f6a7b8c9_add_automation_tables.py
+++ b/backend/open_webui/migrations/versions/d4e5f6a7b8c9_add_automation_tables.py
@@ -10,6 +10,8 @@ from typing import Union
 from alembic import op
 import sqlalchemy as sa
 
+from open_webui.migrations.util import key_text
+
 revision: str = 'd4e5f6a7b8c9'
 down_revision: Union[str, None] = 'a3dd5bedd151'
 branch_labels = None
@@ -19,8 +21,8 @@ depends_on = None
 def upgrade():
     op.create_table(
         'automation',
-        sa.Column('id', sa.Text(), primary_key=True),
-        sa.Column('user_id', sa.Text(), nullable=False),
+        sa.Column('id', key_text(), primary_key=True),
+        sa.Column('user_id', key_text(), nullable=False),
         sa.Column('name', sa.Text(), nullable=False),
         sa.Column('data', sa.JSON(), nullable=False),
         sa.Column('meta', sa.JSON(), nullable=True),
@@ -34,9 +36,9 @@ def upgrade():
 
     op.create_table(
         'automation_run',
-        sa.Column('id', sa.Text(), primary_key=True),
-        sa.Column('automation_id', sa.Text(), nullable=False),
-        sa.Column('chat_id', sa.Text(), nullable=True),
+        sa.Column('id', key_text(), primary_key=True),
+        sa.Column('automation_id', key_text(), nullable=False),
+        sa.Column('chat_id', key_text(), nullable=True),
         sa.Column('status', sa.Text(), nullable=False),
         sa.Column('error', sa.Text(), nullable=True),
         sa.Column('created_at', sa.BigInteger(), nullable=False),

--- a/backend/open_webui/migrations/versions/f1e2d3c4b5a6_add_access_grant_table.py
+++ b/backend/open_webui/migrations/versions/f1e2d3c4b5a6_add_access_grant_table.py
@@ -18,12 +18,63 @@ import uuid
 from alembic import op
 import sqlalchemy as sa
 
-from open_webui.migrations.util import get_existing_tables
+from open_webui.migrations.util import get_existing_tables, key_text
 
 revision: str = 'f1e2d3c4b5a6'
 down_revision: Union[str, None] = '8452d01d26d7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+"""
+Column length limits used for `access_grant` only on MySQL/MariaDB.
+
+Why these values:
+- PostgreSQL and SQLite keep the historical `Text` behavior through `key_text()`.
+- MySQL/MariaDB cannot safely use unbounded `TEXT` columns in `PRIMARY KEY`,
+  `UNIQUE`, `INDEX`, or `FOREIGN KEY` paths.
+- On `utf8mb4`, indexed `VARCHAR` columns must stay within InnoDB key-size
+  limits, so identifier-like fields use a conservative `191` characters.
+- Enum-like fields (`resource_type`, `principal_type`, `permission`) are kept
+  short at `64` characters to reduce composite index width.
+
+Why this is safe for Open-WebUI:
+- Open-WebUI identifiers are normally UUID strings (`str(uuid.uuid4())`),
+  which are only 36 characters long, well below the `191` limit.
+- `resource_type`, `principal_type`, and `permission` store small categorical
+  values such as `knowledge`, `user`, `group`, `read`, and `write`, so `64`
+  characters provides ample headroom.
+
+These limits are therefore applied only for MySQL/MariaDB compatibility,
+while PostgreSQL and SQLite continue using the original unrestricted text
+behavior.
+"""
+RESOURCE_TYPE_LEN = 64
+RESOURCE_ID_LEN = 191
+PRINCIPAL_TYPE_LEN = 64
+PRINCIPAL_ID_LEN = 191
+PERMISSION_LEN = 64
+
+
+def _is_mysql_family(conn) -> bool:
+    return (conn.dialect.name or '').lower() in ('mysql', 'mariadb')
+
+
+def _validate_access_grant_lengths(conn, resource_type, resource_id, principal_type, principal_id, permission) -> None:
+    # Only needed for MySQL/MariaDB, where these columns are narrowed to
+    # VARCHAR(...) for index/key compatibility.
+    if not _is_mysql_family(conn):
+        return
+
+    values = [
+        ('resource_type', resource_type, RESOURCE_TYPE_LEN),
+        ('resource_id', resource_id, RESOURCE_ID_LEN),
+        ('principal_type', principal_type, PRINCIPAL_TYPE_LEN),
+        ('principal_id', principal_id, PRINCIPAL_ID_LEN),
+        ('permission', permission, PERMISSION_LEN),
+    ]
+    for name, value, max_len in values:
+        if value is not None and len(str(value)) > max_len:
+            raise ValueError(f'access_grant.{name} exceeds max length {max_len}: {value!r}')
 
 
 def upgrade() -> None:
@@ -31,14 +82,18 @@ def upgrade() -> None:
 
     # Create access_grant table
     if 'access_grant' not in existing_tables:
+        # Keep composite UNIQUE / secondary index columns tight on MySQL/MariaDB
+        # to avoid oversized utf8mb4 indexes. Use shorter lengths for enum-like
+        # fields and 191 for identifier-like fields as a conservative indexed
+        # string limit.
         op.create_table(
             'access_grant',
-            sa.Column('id', sa.Text(), nullable=False, primary_key=True),
-            sa.Column('resource_type', sa.Text(), nullable=False),
-            sa.Column('resource_id', sa.Text(), nullable=False),
-            sa.Column('principal_type', sa.Text(), nullable=False),
-            sa.Column('principal_id', sa.Text(), nullable=False),
-            sa.Column('permission', sa.Text(), nullable=False),
+            sa.Column('id', key_text(), nullable=False, primary_key=True),
+            sa.Column('resource_type', key_text(length=RESOURCE_TYPE_LEN), nullable=False),
+            sa.Column('resource_id', key_text(length=RESOURCE_ID_LEN), nullable=False),
+            sa.Column('principal_type', key_text(length=PRINCIPAL_TYPE_LEN), nullable=False),
+            sa.Column('principal_id', key_text(length=PRINCIPAL_ID_LEN), nullable=False),
+            sa.Column('permission', key_text(length=PERMISSION_LEN), nullable=False),
             sa.Column('created_at', sa.BigInteger(), nullable=False),
             sa.UniqueConstraint(
                 'resource_type',
@@ -108,6 +163,7 @@ def upgrade() -> None:
 
                 key = (resource_type, resource_id, 'user', '*', 'read')
                 if key not in inserted:
+                    _validate_access_grant_lengths(conn, resource_type, resource_id, 'user', '*', 'read')
                     try:
                         conn.execute(
                             sa.text("""
@@ -164,6 +220,7 @@ def upgrade() -> None:
                     key = (resource_type, resource_id, 'group', group_id, permission)
                     if key in inserted:
                         continue
+                    _validate_access_grant_lengths(conn, resource_type, resource_id, 'group', group_id, permission)
                     try:
                         conn.execute(
                             sa.text("""
@@ -188,6 +245,7 @@ def upgrade() -> None:
                     key = (resource_type, resource_id, 'user', user_id, permission)
                     if key in inserted:
                         continue
+                    _validate_access_grant_lengths(conn, resource_type, resource_id, 'user', user_id, permission)
                     try:
                         conn.execute(
                             sa.text("""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -120,7 +120,7 @@ pgvector==0.4.2
 
 PyMySQL==1.1.2
 boto3==1.42.62
-# mariadb==1.1.14 should be added if you want to support MariaDB
+mariadb==1.1.14  # required for mariadb+mariadbconnector URL support
 
 pymilvus==2.6.9
 qdrant-client==1.17.0


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

---

## Description

Open-WebUI currently supports SQLite and PostgreSQL as primary databases. This PR adds **MariaDB** as a supported primary backend database, allowing Open-WebUI to run with MariaDB for application data, migrations, and runtime persistence.

My main motivation for proposing this change is operational simplicity: Open-WebUI already supports **MariaDB Vector** as a vector database backend, so adding MariaDB as the primary database allows users to deploy both the main application data and vector storage on a single database system instead of operating multiple database technologies side-by-side.

For users who are already committed to MariaDB infrastructure, this means:
- fewer moving parts,
- simpler deployment and backup strategy,
- more consistent operational tooling,
- and a lower barrier to adopting Open-WebUI in environments where PostgreSQL is not already standard.

This PR is designed as an opt-in compatibility expansion rather than a database-layer redesign. Existing SQLite and PostgreSQL users are unaffected.

This work addresses the request to support MariaDB as a main database backend (see discussion #22803).

## Scope of the change

This PR adds MariaDB support for the primary backend database by:

- enabling MariaDB/MySQL-compatible Peewee connection handling,
- normalizing supported SQLAlchemy-style database URLs for Peewee migration/runtime compatibility,
- adding reconnect behavior for MySQL/MariaDB in the same style as PostgreSQL,
- handling migration edge cases that are not directly compatible with MariaDB/MySQL,
- and adding the required MariaDB dependency for runtime and migration flows.

This PR is intentionally limited to MariaDB as the primary backend database.

## Design notes

This change is intended to stay aligned with the current architecture:

- it does **not** introduce a new persistence model,
- it does **not** change any default database choice,
- it does **not** add UI-level complexity,
- it is only activated when users explicitly configure a MariaDB `DATABASE_URL`.

The implementation follows the same overall connection/migration pattern already used for existing primary database backends.

## Dependencies

New dependency added:

- `mariadb` Python driver

Rationale:

MariaDB primary DB support uses the preferred `mariadb+mariadbconnector://...` URL scheme, which requires the official MariaDB Connector/Python driver. `PyMySQL` remains available as a compatibility fallback for `mysql+pymysql://...`.

Compatibility notes:

- MariaDB support is opt-in and only affects deployments configured with a MariaDB `DATABASE_URL`.
- Existing SQLite and PostgreSQL setups should continue to work unchanged.

## Manual tests

Build the Docker image from this branch:

~~~~ {.bash}
$ docker build -f Dockerfile -t open-webui:0.9.0-dev .
~~~~

Both test runs below used a fresh empty database before startup.

### MariaDB primary DB + MariaDB vector test

#### Start Open-WebUI against MariaDB

~~~~ {.bash}
docker run -d \
  --network host \
  -e OLLAMA_BASE_URL="http://ollama-host.com:11434" \
  -e AIOHTTP_CLIENT_TIMEOUT=3600 \
  \
  -e ENABLE_PERSISTENT_CONFIG=False \
  -e DEFAULT_MODEL_PARAMS='{"num_ctx":32768,"temperature":0.1,"top_p":0.9}' \
  \
  -e RAG_EMBEDDING_ENGINE=ollama \
  -e RAG_OLLAMA_BASE_URL="http://ollama-host.com:11434" \
  -e RAG_EMBEDDING_MODEL=nomic-embed-text \
  -e RAG_EMBEDDING_BATCH_SIZE=64 \
  -e RAG_TEXT_SPLITTER=token \
  -e RAG_SYSTEM_CONTEXT=True \
  -e RAG_TOP_K=10 \
  -e RAG_TOP_K_RERANKER=10 \
  \
  -e CHUNK_SIZE=1024 \
  -e CHUNK_OVERLAP=128 \
  -e CHUNK_MIN_SIZE_TARGET=640 \
  -e ENABLE_ASYNC_EMBEDDING=true \
  -e RAG_EMBEDDING_CONCURRENT_REQUESTS=8 \
  -e ENABLE_RAG_HYBRID_SEARCH=true \
  \
  -e DATABASE_URL="mariadb+mariadbconnector://app:app@127.0.0.1:3306/openwebui" \
  -e VECTOR_DB="mariadb-vector" \
  -e MARIADB_VECTOR_DB_URL="mariadb+mariadbconnector://app:app@127.0.0.1:3306/openwebui" \
  -e MARIADB_VECTOR_INITIALIZE_MAX_VECTOR_LENGTH=768 \
  -e MARIADB_VECTOR_DISTANCE_STRATEGY=cosine \
  -e MARIADB_VECTOR_INDEX_M=12 \
  \
  -v open-webui:/app/backend/data \
  --name open-webui \
  --restart always \
  open-webui:0.9.0-dev
~~~~

There are no migration/runtime errors:

~~~~ {.bash}
server@ai:[debug_open-webui] [] $ docker logs -f open-webui
Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.
Generating WEBUI_SECRET_KEY
Loading WEBUI_SECRET_KEY from .webui_secret_key
INFO  [alembic.runtime.migration] Context impl MariaDBImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 7e5b5dc7342b, init
INFO  [alembic.runtime.migration] Running upgrade 7e5b5dc7342b -> ca81bd47c050, Add config table
INFO  [alembic.runtime.migration] Running upgrade ca81bd47c050 -> c0fbf31ca0db, Update file table
INFO  [alembic.runtime.migration] Running upgrade c0fbf31ca0db -> 6a39f3d8e55c, Add knowledge table
Creating knowledge table
Migrating data from document table to knowledge table
INFO  [alembic.runtime.migration] Running upgrade 6a39f3d8e55c -> 242a2047eae0, Update chat table
Converting 'chat' column to JSON
Renaming 'chat' column to 'old_chat'
Adding new 'chat' column of type JSON
Dropping 'old_chat' column
INFO  [alembic.runtime.migration] Running upgrade 242a2047eae0 -> 1af9b942657b, Migrate tags
INFO  [alembic.runtime.migration] Running upgrade 1af9b942657b -> 3ab32c4b8f59, Update tags
Primary Key: {'name': None, 'constrained_columns': []}
Unique Constraints: [{'name': 'tag_id', 'column_names': ['id'], 'duplicates_index': 'tag_id'}, {'name': 'uq_id_user_id', 'column_names': ['id', 'user_id'], 'duplicates_index': 'uq_id_user_id'}]
Indexes: [{'name': 'tag_id', 'column_names': ['id'], 'unique': True, 'type': 'UNIQUE'}, {'name': 'uq_id_user_id', 'column_names': ['id', 'user_id'], 'unique': True, 'type': 'UNIQUE'}]
Creating new primary key with 'id' and 'user_id'.
Dropping unique constraint: uq_id_user_id
INFO  [alembic.runtime.migration] Running upgrade 3ab32c4b8f59 -> c69f45358db4, Add folder table
INFO  [alembic.runtime.migration] Running upgrade c69f45358db4 -> c29facfe716b, Update file table path
INFO  [alembic.runtime.migration] Running upgrade c29facfe716b -> af906e964978, Add feedback table
INFO  [alembic.runtime.migration] Running upgrade af906e964978 -> 4ace53fd72c8, Update folder table and change DateTime to BigInteger for timestamp fields
INFO  [alembic.runtime.migration] Running upgrade 4ace53fd72c8 -> 922e7a387820, Add group table
INFO  [alembic.runtime.migration] Running upgrade 922e7a387820 -> 57c599a3cb57, Add channel table
INFO  [alembic.runtime.migration] Running upgrade 57c599a3cb57 -> 7826ab40b532, Update file table
INFO  [alembic.runtime.migration] Running upgrade 7826ab40b532 -> 3781e22d8b01, Update message & channel tables
INFO  [alembic.runtime.migration] Running upgrade 3781e22d8b01 -> 9f0c9cd09105, Add note table
INFO  [alembic.runtime.migration] Running upgrade 9f0c9cd09105 -> d31026856c01, Update folder table data
INFO  [alembic.runtime.migration] Running upgrade d31026856c01 -> 018012973d35, Add indexes
INFO  [alembic.runtime.migration] Running upgrade 018012973d35 -> 3af16a1c9fb6, update user table
INFO  [alembic.runtime.migration] Running upgrade 3af16a1c9fb6 -> 38d63c18f30f, Add oauth_session table
INFO  [alembic.runtime.migration] Running upgrade 38d63c18f30f -> a5c220713937, Add reply_to_id column to message
INFO  [alembic.runtime.migration] Running upgrade a5c220713937 -> 37f288994c47, add_group_member_table
[]
INFO  [alembic.runtime.migration] Running upgrade 37f288994c47 -> 2f1211949ecc, Update messages and channel member table
INFO  [alembic.runtime.migration] Running upgrade 2f1211949ecc -> b10670c03dd5, Update user table
INFO  [alembic.runtime.migration] Running upgrade b10670c03dd5 -> 90ef40d4714e, Update channel and channel members table
INFO  [alembic.runtime.migration] Running upgrade 90ef40d4714e -> 3e0e00844bb0, Add knowledge_file table
INFO  [alembic.runtime.migration] Running upgrade 3e0e00844bb0 -> 6283dc0e4d8d, Add channel file table
INFO  [alembic.runtime.migration] Running upgrade 6283dc0e4d8d -> 81cc2ce44d79, Update channel file and knowledge table
INFO  [alembic.runtime.migration] Running upgrade 81cc2ce44d79 -> c440947495f3, Add chat_file table
INFO  [alembic.runtime.migration] Running upgrade c440947495f3 -> 374d2f66af06, Add prompt history table
INFO  [alembic.runtime.migration] Running upgrade 374d2f66af06 -> 8452d01d26d7, Add chat_message table
INFO  [alembic.runtime.migration] Running upgrade 8452d01d26d7 -> f1e2d3c4b5a6, Add access_grant table
INFO  [alembic.runtime.migration] Running upgrade f1e2d3c4b5a6 -> a1b2c3d4e5f6, Add skill table
INFO  [alembic.runtime.migration] Running upgrade a1b2c3d4e5f6 -> b2c3d4e5f6a7, add scim column to user table
INFO  [alembic.runtime.migration] Running upgrade b2c3d4e5f6a7 -> a3dd5bedd151, Add tasks and summary columns to chat table
INFO  [alembic.runtime.migration] Running upgrade a3dd5bedd151 -> d4e5f6a7b8c9, add automation tables
INFO  [alembic.runtime.migration] Running upgrade d4e5f6a7b8c9 -> b7c8d9e0f1a2, add last_read_at to chat
WARNI [open_webui.env] 

WARNING: CORS_ALLOW_ORIGIN IS SET TO '*' - NOT RECOMMENDED FOR PRODUCTION DEPLOYMENTS.

WARNI [langchain_community.utils.user_agent] USER_AGENT environment variable not set, consider setting it to identify your requests.

 ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
██║   ██║██████╔╝█████╗  ██╔██╗ ██║    ██║ █╗ ██║█████╗  ██████╔╝██║   ██║██║
██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║    ██║███╗██║██╔══╝  ██╔══██╗██║   ██║██║
╚██████╔╝██║     ███████╗██║ ╚████║    ╚███╔███╔╝███████╗██████╔╝╚██████╔╝██║
 ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝     ╚══╝╚══╝ ╚══════╝╚═════╝  ╚═════╝ ╚═╝


v0.8.12 - building the best AI user interface.

https://github.com/open-webui/open-webui

INFO:     Started server process [1]
INFO:     Waiting for application startup.
2026-04-04 17:47:40.165 | INFO     | open_webui.utils.logger:start_logger:192 - GLOBAL_LOG_LEVEL: INFO
2026-04-04 17:47:40.166 | INFO     | open_webui.main:lifespan:636 - Installing external dependencies of functions and tools...
2026-04-04 17:47:40.187 | INFO     | open_webui.utils.plugin:install_frontmatter_requirements:404 - No requirements found in frontmatter.
2026-04-04 17:47:40.187 | INFO     | open_webui.utils.automations:automation_worker_loop:106 - Automation worker started (poll interval: 10s)
~~~~

#### Verify migration-created tables exist

~~~~ {.bash}
$ mariadb -uapp -papp -D openwebui -e "
SELECT version_num FROM alembic_version;
SHOW TABLES LIKE 'chat_message';
SHOW TABLES LIKE 'access_grant';
SHOW TABLES LIKE 'automation';
SHOW TABLES LIKE 'automation_run';
"

+--------------+
| version_num  |
+--------------+
| b7c8d9e0f1a2 |
+--------------+
+------------------------------------+
| Tables_in_openwebui (chat_message) |
+------------------------------------+
| chat_message                       |
+------------------------------------+
+------------------------------------+
| Tables_in_openwebui (access_grant) |
+------------------------------------+
| access_grant                       |
+------------------------------------+
+----------------------------------+
| Tables_in_openwebui (automation) |
+----------------------------------+
| automation                       |
+----------------------------------+
+--------------------------------------+
| Tables_in_openwebui (automation_run) |
+--------------------------------------+
| automation_run                       |
+--------------------------------------+
~~~~

#### Check important indexes were created

~~~~ {.bash}
$ mariadb -uapp -papp -D openwebui -e "
SHOW INDEX FROM chat_message;
SHOW INDEX FROM access_grant;
SHOW INDEX FROM automation_run;
"

+--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| Table        | Non_unique | Key_name                       | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Ignored |
+--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| chat_message |          0 | PRIMARY                        |            1 | id          | A         |           2 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| chat_message |          1 | ix_chat_message_user_id        |            1 | user_id     | A         |           1 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | ix_chat_message_model_id       |            1 | model_id    | A         |           2 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | ix_chat_message_chat_id        |            1 | chat_id     | A         |           1 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| chat_message |          1 | ix_chat_message_created_at     |            1 | created_at  | A         |           1 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_chat_parent_idx   |            1 | chat_id     | A         |           1 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_chat_parent_idx   |            2 | parent_id   | A         |           2 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_model_created_idx |            1 | model_id    | A         |           2 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_model_created_idx |            2 | created_at  | A         |           2 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_user_created_idx  |            1 | user_id     | A         |           1 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
| chat_message |          1 | chat_message_user_created_idx  |            2 | created_at  | A         |           1 |     NULL | NULL   | YES  | BTREE      |         |               | NO      |
+--------------+------------+--------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
+--------------+------------+----------------------------+--------------+----------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| Table        | Non_unique | Key_name                   | Seq_in_index | Column_name    | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Ignored |
+--------------+------------+----------------------------+--------------+----------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| access_grant |          0 | PRIMARY                    |            1 | id             | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| access_grant |          0 | uq_access_grant_grant      |            1 | resource_type  | A         |           0 |     NULL | NULL   |      | HASH       |         |               | NO      |
| access_grant |          0 | uq_access_grant_grant      |            2 | resource_id    | A         |           0 |     NULL | NULL   |      | HASH       |         |               | NO      |
| access_grant |          0 | uq_access_grant_grant      |            3 | principal_type | A         |           0 |     NULL | NULL   |      | HASH       |         |               | NO      |
| access_grant |          0 | uq_access_grant_grant      |            4 | principal_id   | A         |           0 |     NULL | NULL   |      | HASH       |         |               | NO      |
| access_grant |          0 | uq_access_grant_grant      |            5 | permission     | A         |           0 |     NULL | NULL   |      | HASH       |         |               | NO      |
| access_grant |          1 | idx_access_grant_resource  |            1 | resource_type  | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| access_grant |          1 | idx_access_grant_resource  |            2 | resource_id    | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| access_grant |          1 | idx_access_grant_principal |            1 | principal_type | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| access_grant |          1 | idx_access_grant_principal |            2 | principal_id   | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
+--------------+------------+----------------------------+--------------+----------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
+----------------+------------+---------------------------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| Table          | Non_unique | Key_name                        | Seq_in_index | Column_name   | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Ignored |
+----------------+------------+---------------------------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
| automation_run |          0 | PRIMARY                         |            1 | id            | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
| automation_run |          1 | ix_automation_run_automation_id |            1 | automation_id | A         |           0 |     NULL | NULL   |      | BTREE      |         |               | NO      |
+----------------+------------+---------------------------------+--------------+---------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+
~~~~

#### Verify DB rows after manual actions

~~~~ {.bash}
$ mariadb -uapp -papp -D openwebui -e "
SELECT COUNT(*) AS users_count FROM \`user\`;
SELECT COUNT(*) AS file_count FROM file;
SELECT COUNT(*) AS knowledge_count FROM knowledge;
SELECT COUNT(*) AS knowledge_file_count FROM knowledge_file;
"

+-------------+
| users_count |
+-------------+
|           1 |
+-------------+
+------------+
| file_count |
+------------+
|        216 |
+------------+
+-----------------+
| knowledge_count |
+-----------------+
|               1 |
+-----------------+
+----------------------+
| knowledge_file_count |
+----------------------+
|                  216 |
+----------------------+
~~~~


#### Screenshots

<img width="1837" height="896" alt="image" src="https://github.com/user-attachments/assets/ccfa39dc-3096-4e7c-976e-b4eb7881a6ee" />

### PostgesSQL primary DB + pgvector test

#### Start Open-WebUI against PostgesSQL

~~~~ {.bash}
docker run -d \
  --network host \
  --name open-webui-pg \
  -e PORT=8081 \
  --restart always \
  -e OLLAMA_BASE_URL="http://ollama-host.com:11434" \
  -e AIOHTTP_CLIENT_TIMEOUT=3600 \
  \
  -e ENABLE_PERSISTENT_CONFIG=False \
  -e DEFAULT_MODEL_PARAMS='{"num_ctx":32768,"temperature":0.1,"top_p":0.9}' \
  \
  -e RAG_EMBEDDING_ENGINE=ollama \
  -e RAG_OLLAMA_BASE_URL="http://ollama-host.com:11434" \
  -e RAG_EMBEDDING_MODEL=nomic-embed-text \
  -e RAG_EMBEDDING_BATCH_SIZE=64 \
  -e RAG_TEXT_SPLITTER=token \
  -e RAG_SYSTEM_CONTEXT=True \
  -e RAG_TOP_K=10 \
  -e RAG_TOP_K_RERANKER=10 \
  \
  -e CHUNK_SIZE=1024 \
  -e CHUNK_OVERLAP=128 \
  -e CHUNK_MIN_SIZE_TARGET=640 \
  -e ENABLE_ASYNC_EMBEDDING=true \
  -e RAG_EMBEDDING_CONCURRENT_REQUESTS=8 \
  -e ENABLE_RAG_HYBRID_SEARCH=true \
  \
  -e DATABASE_URL="postgres://app_pg:app_pg@127.0.0.1:5432/openwebui_pg" \
  -e VECTOR_DB="pgvector" \
  -e PGVECTOR_DB_URL="postgresql+psycopg2://app_pg:app_pg@127.0.0.1:5432/openwebui_pg" \
  -e PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH=768 \
  -e PGVECTOR_CREATE_EXTENSION=true \
  -e PGVECTOR_PGCRYPTO=false \
  -v open-webui-pg:/app/backend/data \
  open-webui:0.9.0-dev
~~~~

There are no migration/runtime errors:

~~~~ {.bash}
server@ai:[debug_open-webui] [] $ docker logs -f open-webui-pg
Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.
Generating WEBUI_SECRET_KEY
Loading WEBUI_SECRET_KEY from .webui_secret_key
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 7e5b5dc7342b, init
INFO  [alembic.runtime.migration] Running upgrade 7e5b5dc7342b -> ca81bd47c050, Add config table
INFO  [alembic.runtime.migration] Running upgrade ca81bd47c050 -> c0fbf31ca0db, Update file table
Creating knowledge table
INFO  [alembic.runtime.migration] Running upgrade c0fbf31ca0db -> 6a39f3d8e55c, Add knowledge table
Migrating data from document table to knowledge table
INFO  [alembic.runtime.migration] Running upgrade 6a39f3d8e55c -> 242a2047eae0, Update chat table
Converting 'chat' column to JSON
Renaming 'chat' column to 'old_chat'
Adding new 'chat' column of type JSON
Dropping 'old_chat' column
INFO  [alembic.runtime.migration] Running upgrade 242a2047eae0 -> 1af9b942657b, Migrate tags
INFO  [alembic.runtime.migration] Running upgrade 1af9b942657b -> 3ab32c4b8f59, Update tags
Primary Key: {'name': None, 'constrained_columns': []}
Unique Constraints: [{'column_names': ['id', 'user_id'], 'name': 'uq_id_user_id', 'comment': None, 'dialect_options': {'postgresql_include': [], 'postgresql_nulls_not_distinct': False}}]
Indexes: [{'name': 'tag_id', 'unique': True, 'column_names': ['id'], 'include_columns': [], 'dialect_options': {'postgresql_include': []}}, {'name': 'uq_id_user_id', 'unique': True, 'column_names': ['id', 'user_id'], 'duplicates_constraint': 'uq_id_user_id', 'include_columns': [], 'dialect_options': {'postgresql_include': []}}]
Creating new primary key with 'id' and 'user_id'.
Dropping unique constraint: uq_id_user_id
Dropping unique index: tag_id
INFO  [alembic.runtime.migration] Running upgrade 3ab32c4b8f59 -> c69f45358db4, Add folder table
INFO  [alembic.runtime.migration] Running upgrade c69f45358db4 -> c29facfe716b, Update file table path
INFO  [alembic.runtime.migration] Running upgrade c29facfe716b -> af906e964978, Add feedback table
INFO  [alembic.runtime.migration] Running upgrade af906e964978 -> 4ace53fd72c8, Update folder table and change DateTime to BigInteger for timestamp fields
INFO  [alembic.runtime.migration] Running upgrade 4ace53fd72c8 -> 922e7a387820, Add group table
INFO  [alembic.runtime.migration] Running upgrade 922e7a387820 -> 57c599a3cb57, Add channel table
INFO  [alembic.runtime.migration] Running upgrade 57c599a3cb57 -> 7826ab40b532, Update file table
INFO  [alembic.runtime.migration] Running upgrade 7826ab40b532 -> 3781e22d8b01, Update message & channel tables
INFO  [alembic.runtime.migration] Running upgrade 3781e22d8b01 -> 9f0c9cd09105, Add note table
INFO  [alembic.runtime.migration] Running upgrade 9f0c9cd09105 -> d31026856c01, Update folder table data
INFO  [alembic.runtime.migration] Running upgrade d31026856c01 -> 018012973d35, Add indexes
INFO  [alembic.runtime.migration] Running upgrade 018012973d35 -> 3af16a1c9fb6, update user table
INFO  [alembic.runtime.migration] Running upgrade 3af16a1c9fb6 -> 38d63c18f30f, Add oauth_session table
INFO  [alembic.runtime.migration] Running upgrade 38d63c18f30f -> a5c220713937, Add reply_to_id column to message
INFO  [alembic.runtime.migration] Running upgrade a5c220713937 -> 37f288994c47, add_group_member_table
[]
INFO  [alembic.runtime.migration] Running upgrade 37f288994c47 -> 2f1211949ecc, Update messages and channel member table
INFO  [alembic.runtime.migration] Running upgrade 2f1211949ecc -> b10670c03dd5, Update user table
INFO  [alembic.runtime.migration] Running upgrade b10670c03dd5 -> 90ef40d4714e, Update channel and channel members table
INFO  [alembic.runtime.migration] Running upgrade 90ef40d4714e -> 3e0e00844bb0, Add knowledge_file table
INFO  [alembic.runtime.migration] Running upgrade 3e0e00844bb0 -> 6283dc0e4d8d, Add channel file table
INFO  [alembic.runtime.migration] Running upgrade 6283dc0e4d8d -> 81cc2ce44d79, Update channel file and knowledge table
INFO  [alembic.runtime.migration] Running upgrade 81cc2ce44d79 -> c440947495f3, Add chat_file table
INFO  [alembic.runtime.migration] Running upgrade c440947495f3 -> 374d2f66af06, Add prompt history table
INFO  [alembic.runtime.migration] Running upgrade 374d2f66af06 -> 8452d01d26d7, Add chat_message table
INFO  [alembic.runtime.migration] Running upgrade 8452d01d26d7 -> f1e2d3c4b5a6, Add access_grant table
INFO  [alembic.runtime.migration] Running upgrade f1e2d3c4b5a6 -> a1b2c3d4e5f6, Add skill table
INFO  [alembic.runtime.migration] Running upgrade a1b2c3d4e5f6 -> b2c3d4e5f6a7, add scim column to user table
INFO  [alembic.runtime.migration] Running upgrade b2c3d4e5f6a7 -> a3dd5bedd151, Add tasks and summary columns to chat table
INFO  [alembic.runtime.migration] Running upgrade a3dd5bedd151 -> d4e5f6a7b8c9, add automation tables
INFO  [alembic.runtime.migration] Running upgrade d4e5f6a7b8c9 -> b7c8d9e0f1a2, add last_read_at to chat
WARNI [open_webui.env] 

WARNING: CORS_ALLOW_ORIGIN IS SET TO '*' - NOT RECOMMENDED FOR PRODUCTION DEPLOYMENTS.

WARNI [langchain_community.utils.user_agent] USER_AGENT environment variable not set, consider setting it to identify your requests.

 ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
██║   ██║██████╔╝█████╗  ██╔██╗ ██║    ██║ █╗ ██║█████╗  ██████╔╝██║   ██║██║
██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║    ██║███╗██║██╔══╝  ██╔══██╗██║   ██║██║
╚██████╔╝██║     ███████╗██║ ╚████║    ╚███╔███╔╝███████╗██████╔╝╚██████╔╝██║
 ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝     ╚══╝╚══╝ ╚══════╝╚═════╝  ╚═════╝ ╚═╝


v0.8.12 - building the best AI user interface.

https://github.com/open-webui/open-webui

INFO:     Started server process [1]
INFO:     Waiting for application startup.
2026-04-04 17:55:43.851 | INFO     | open_webui.utils.logger:start_logger:192 - GLOBAL_LOG_LEVEL: INFO
2026-04-04 17:55:43.851 | INFO     | open_webui.main:lifespan:636 - Installing external dependencies of functions and tools...
2026-04-04 17:55:43.873 | INFO     | open_webui.utils.plugin:install_frontmatter_requirements:404 - No requirements found in frontmatter.
2026-04-04 17:55:43.873 | INFO     | open_webui.utils.automations:automation_worker_loop:106 - Automation worker started (poll interval: 10s)
~~~~

#### Verify migration-created tables exist

~~~~ {.bash}
$ PGPASSWORD=app_pg psql -h 127.0.0.1 -U app_pg -d openwebui_pg -c "
SELECT version_num FROM alembic_version;
SELECT tablename FROM pg_tables 
WHERE tablename IN ('chat_message','access_grant','automation','automation_run');
"

 version_num  
--------------
 b7c8d9e0f1a2
(1 row)

   tablename    
----------------
 automation
 automation_run
 chat_message
 access_grant
(4 rows)

~~~~

#### Verify DB rows after manual actions

~~~~ {.bash}
$ PGPASSWORD=app_pg psql -h 127.0.0.1 -U app_pg -d openwebui_pg -c '
SELECT COUNT(*) AS users_count FROM "user";
SELECT COUNT(*) AS file_count FROM file;
SELECT COUNT(*) AS knowledge_count FROM knowledge;
SELECT COUNT(*) AS knowledge_file_count FROM knowledge_file;
'

 users_count 
-------------
           1
(1 row)

 file_count 
------------
        216
(1 row)

 knowledge_count 
-----------------
               1
(1 row)

 knowledge_file_count 
----------------------
                  216
(1 row)
~~~~

#### Screenshots

<img width="1837" height="896" alt="image" src="https://github.com/user-attachments/assets/bd685446-0e60-40d6-9aaa-92aec0c38d47" />

## Observed outcome

- Fresh bootstrap succeeded on MariaDB
- Fresh bootstrap succeeded on PostgreSQL
- alembic_version reached head on both
- chat_message, access_grant, automation, automation_run tables created successfully
- Admin signup/login worked
- Knowledge file upload worked
- Persisted rows verified in DB

## Documentation

- I have already added documentation to https://github.com/open-webui/docs : https://github.com/open-webui/docs/pull/1165

---

## Changelog Entry

### Description

- Add MariaDB as a supported primary database backend so Open-WebUI can run its main application data on MariaDB, including deployments that also use MariaDB Vector for embeddings.

### Added

- Added MariaDB support for the primary backend database.

### Changed

- Updated database connection and migration compatibility logic to support MariaDB-backed deployments.

---

### Additional Information

- Open-WebUI already supports `mariadb-vector` on the vector database side; this PR complements that by enabling MariaDB for the primary database as well.
- The primary value of this change is **single-database-system deployment** for users standardized on MariaDB.
- This PR is intentionally scoped to one logical change: MariaDB as a primary backend database.

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
