### PR TITLE
fix: enable follow_redirects in OAuth client manager

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -523,6 +523,7 @@ class OAuthClientManager:
             'client_id': oauth_client_info.client_id,
             'client_secret': oauth_client_info.client_secret,
             'client_kwargs': {
+                'follow_redirects': True,
                 **({'scope': oauth_client_info.scope} if oauth_client_info.scope else {}),
                 **(
                     {'token_endpoint_auth_method': oauth_client_info.token_endpoint_auth_method}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Enable `follow_redirects` in the OAuth client manager to handle providers that redirect on token/userinfo endpoints.
- [x] **Changelog:** Added entry below.
- [ ] **Documentation:** N/A for this internal fix.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified that the change correctly adds the `follow_redirects` flag to the client configuration.
- [x] **Agentic AI Code:** This PR implements a specific fix requested and reviewed.
- [x] **Code review:** Self-reviewed the change.
- [x] **Design & Architecture:** Follows existing patterns in `OAuthClientManager`.
- [x] **Git Hygiene:** Atomic change on a clean branch.

### Description

This PR fixes an issue where OAuth authentication would fail if the provider's token or user information endpoints performed an HTTP redirect. By default, the HTTP client used by Authlib in our `OAuthClientManager` does not follow redirects. Enabling `follow_redirects: True` ensures better compatibility with various OAuth providers.

Fixes #23409

# Changelog Entry

### Fixed
- Fixed OAuth authentication failures when providers use redirects on API endpoints.

---

### Additional Information
- Linked to issue #23409

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.