### PR TITLE
fix: use JSON element queries for prompt tag filtering

### DIFF
--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -11,7 +11,7 @@ from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import BigInteger, Boolean, Column, String, Text, JSON, or_, func, cast
+from sqlalchemy import BigInteger, Boolean, Column, String, Text, JSON, or_, func, cast, text
 
 ####################
 # Prompts DB Schema
@@ -284,10 +284,23 @@ class PromptsTable:
 
                 tag = filter.get('tag')
                 if tag:
-                    # Search for tag in JSON array field
-                    like_pattern = f'%"{tag.lower()}"%'
-                    tags_text = func.lower(cast(Prompt.tags, String))
-                    query = query.filter(tags_text.like(like_pattern))
+                    dialect = db.bind.dialect.name
+
+                    if dialect == 'sqlite':
+                        query = query.filter(
+                            text("EXISTS (SELECT 1 FROM json_each(prompt.tags) WHERE json_each.value = :tag)")
+                        ).params(tag=tag)
+                    elif dialect == 'postgresql':
+                        query = query.filter(
+                            text(
+                                "EXISTS (SELECT 1 FROM json_array_elements_text(prompt.tags) AS tag_elem "
+                                "WHERE tag_elem = :tag)"
+                            )
+                        ).params(tag=tag)
+                    else:
+                        like_pattern = f'%"{tag.lower()}"%'
+                        tags_text = func.lower(cast(Prompt.tags, String))
+                        query = query.filter(tags_text.like(like_pattern))
 
                 order_by = filter.get('order_by')
                 direction = filter.get('direction')


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fix prompt tag filtering for non-ASCII tags by querying JSON array elements instead of matching the serialized JSON text.

### Added

- None.

### Changed

- SQLite tag filtering now checks decoded `prompt.tags` values through `json_each(prompt.tags)`.
- PostgreSQL tag filtering now checks decoded tag elements through `json_array_elements_text(prompt.tags)`.
- Fallback behavior for unsupported dialects remains unchanged.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixes the issue where prompt tag filtering can fail for Cyrillic tags on SQLite because the previous implementation matched against serialized JSON text.
- Related issue: https://github.com/open-webui/open-webui/issues/23381

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- This change stays within one backend file: `backend/open_webui/models/prompts.py`.
- It reuses the repo's existing dialect-aware JSON querying approach rather than adding a new query abstraction.

### Screenshots or Videos

- Not applicable for this backend query fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
