### PR TITLE
fix: enable follow_redirects for OAuth client to support redirect-bas…

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -529,6 +529,7 @@ class OAuthClientManager:
                     if oauth_client_info.token_endpoint_auth_method
                     else {}
                 ),
+                "follow_redirects": True,
             },
             'server_metadata_url': (oauth_client_info.issuer if oauth_client_info.issuer else None),
         }


### PR DESCRIPTION


## Description

This PR enables `follow_redirects=True` in the OAuth client configuration.

Some OAuth providers return HTTP 302 redirect responses during token exchange or user info retrieval. By default, these redirects are not followed, which can cause OAuth authentication to fail.

This change ensures that redirect responses are handled correctly, improving compatibility with providers that rely on redirects.

---

## Fixed

* Enable redirect handling for OAuth client by adding `follow_redirects=True` to `client_kwargs`

---

## Additional Information

* This change is based on analysis of `OAuthClientManager` in the backend
* The issue could not be consistently reproduced using standard providers like GitHub, but aligns with the reported behavior in redirect-based OAuth providers
* No breaking changes expected

---

Open to feedback if this approach aligns with project expectations.

## Contributor License Agreement

* [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
