### PR TITLE
fix: preserve blank lines in code blocks when submitting messages

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2951,7 +2951,7 @@
 										if (e.detail || files.length > 0) {
 											await tick();
 
-											submitHandler(e.detail.replaceAll('\n\n', '\n'));
+											submitHandler(e.detail);
 										}
 									}}
 								/>
@@ -2994,7 +2994,7 @@
 										clearDraft();
 										if (e.detail || files.length > 0) {
 											await tick();
-											submitHandler(e.detail.replaceAll('\n\n', '\n'));
+											submitHandler(e.detail);
 										}
 									}}
 								/>


### PR DESCRIPTION
## Summary

- Removed `.replaceAll('\n\n', '\n')` from both `on:submit` handlers in `Chat.svelte` that blindly stripped all double newlines from message content before passing it to `submitHandler`
- This was destroying intentional blank lines inside code blocks (and elsewhere), causing pasted/typed code to lose its formatting after submission

## Steps to Reproduce (before fix)

1. Open a chat and type a message containing a code block with blank lines:
   ````
   ```python
   def hello():
       print("hello")

       x = 1

       return x
   ```
   ````
2. Send the message
3. **Bug:** The blank lines inside the code block disappear — the code is collapsed together

## Root Cause

In `src/lib/components/chat/Chat.svelte`, both submit handlers (lines 2954 and 2997) called:
```javascript
submitHandler(e.detail.replaceAll('\n\n', '\n'));
```

This replaced **all** double newlines with single newlines across the entire message — including inside code blocks where blank lines are semantically meaningful.

## Fix

Pass `e.detail` directly to `submitHandler` without stripping newlines:
```javascript
submitHandler(e.detail);
```

## Testing

- Verified code blocks with blank lines are preserved after sending
- Verified normal messages still work correctly
- Tested with Ollama (llama3.2) via Docker Compose

Fixes #20302

---

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.