### PR TITLE
fix: handle orphan messages in chat history to prevent UI deadlock

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -77,10 +77,37 @@
 	let pendingRebuild = null;
 	let lastCurrentId = null;
 
+	const findLastValidMessageId = () => {
+		let lastValidId = null;
+		for (const [id, msg] of Object.entries(history.messages)) {
+			if (!msg.id || !msg.role) continue;
+			if (!lastValidId) {
+				lastValidId = id;
+			} else {
+				const existing = history.messages[lastValidId];
+				if ((msg.timestamp ?? 0) >= (existing.timestamp ?? 0)) {
+					lastValidId = id;
+				}
+			}
+		}
+		return lastValidId;
+	};
+
 	const buildMessages = () => {
 		let _messages = [];
 
 		let message = history.messages[history.currentId];
+
+		// If currentId points to an invalid message, fall back to a valid one
+		if (!message || !message.id || !message.role) {
+			const fallbackId = findLastValidMessageId();
+			if (fallbackId) {
+				console.warn('Invalid currentId, falling back to', fallbackId);
+				history.currentId = fallbackId;
+				message = history.messages[fallbackId];
+			}
+		}
+
 		const visitedMessageIds = new Set();
 
 		while (message && (messagesCount !== null ? _messages.length <= messagesCount : true)) {
@@ -91,7 +118,7 @@
 			visitedMessageIds.add(message.id);
 
 			_messages.push(message);
-			message = message.parentId !== null ? history.messages[message.parentId] : null;
+			message = message.parentId != null ? history.messages[message.parentId] : null;
 		}
 
 		messages = _messages.reverse();
@@ -449,7 +476,7 @@
 			{#key chatId}
 				<section class="w-full" aria-labelledby="chat-conversation">
 					<h2 class="sr-only" id="chat-conversation">{$i18n.t('Chat Conversation')}</h2>
-					{#if messages.at(0)?.parentId !== null}
+					{#if messages.at(0)?.parentId != null}
 						<Loader
 							on:visible={(e) => {
 								console.log('visible');


### PR DESCRIPTION
## Summary

- Orphan messages (missing `id`, `role`, or `parentId`) in `history.messages` cause the UI to hang forever on a loading spinner when opening the chat
- No errors in console, no crash — just a silent deadlock
- The fix makes the frontend resilient to malformed chat data

## Root Cause

Three issues in `src/lib/components/chat/Messages.svelte`:

1. **Infinite spinner** — The "load more" check `messages.at(0)?.parentId !== null` uses strict equality. Orphan messages with missing `parentId` (`undefined`) pass this check (`undefined !== null` is `true`), showing the loader forever.

2. **Broken tree traversal** — Same strict `!== null` check in `buildMessages()` when walking the parent chain.

3. **Blank page** — When `currentId` points to an orphan, `buildMessages()` can only reach the orphan (no parent chain to valid messages), rendering nothing useful.

## Fix

| Change | Line | Description |
|--------|------|-------------|
| Loose null check in template | 481 | `!== null` → `!= null` so `undefined` and `null` both mean "root message" |
| Loose null check in traversal | 94 | Same fix in `buildMessages()` parent chain walk |
| Fallback for invalid `currentId` | 80-112 | New `findLastValidMessageId()` — when `currentId` points to invalid message, scan for the latest valid one and switch to it |

## Steps to Reproduce (before fix)

1. Import a chat with a malformed message (orphan with no `id`/`role`/`parentId` in `history.messages`, and `currentId` pointing to it)
2. Click on the imported chat
3. **Bug:** UI shows loading spinner forever, chat is inaccessible

<details>
<summary>Test JSON for reproduction</summary>

```json
[
  {
    "id": "8a3351f4-79c1-4731-8826-d5783944b0c2",
    "user_id": "fe7bbdce-2468-4ce4-aa02-00edd8c48e76",
    "title": "Malformed Chat Test",
    "chat": {
      "id": "",
      "title": "Malformed Chat Test",
      "models": ["llama3.2:1b"],
      "params": {},
      "history": {
        "messages": {
          "msg-1": {
            "id": "msg-1", "parentId": null, "childrenIds": ["msg-2"],
            "role": "user", "content": "What is Python?", "timestamp": 1750304001
          },
          "msg-2": {
            "id": "msg-2", "parentId": "msg-1", "childrenIds": [],
            "role": "assistant", "content": "Python is a programming language.",
            "model": "llama3.2:1b", "timestamp": 1750304002, "done": true
          },
          "orphan-1": {
            "model": "llama3.2:1b",
            "content": "Orphan message - no id, no role, no parentId"
          }
        },
        "currentId": "orphan-1"
      },
      "messages": [
        { "id": "msg-1", "parentId": null, "childrenIds": ["msg-2"], "role": "user", "content": "What is Python?", "timestamp": 1750304001 },
        { "id": "msg-2", "parentId": "msg-1", "childrenIds": [], "role": "assistant", "content": "Python is a programming language.", "model": "llama3.2:1b", "timestamp": 1750304002, "done": true }
      ],
      "tags": [], "timestamp": 1750304001000, "files": []
    },
    "updated_at": 1750307488, "created_at": 1750304001,
    "share_id": null, "archived": false, "pinned": false, "meta": {}, "folder_id": null
  }
]
```
</details>

## Testing

- Imported malformed chat with 3 orphan messages + 6 valid messages
- Before fix: infinite loading spinner, chat inaccessible
- After fix: orphans skipped, full conversation renders normally
- Verified normal chats still work correctly
- Tested with Ollama (llama3.2:1b) via Docker Compose on macOS

Fixes #15189

---

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.