### PR TITLE
feat: Forward MCP `initialize` instructions to system prompt and add admin toggle

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -52,6 +52,8 @@ class MCPClient:
     def __init__(self):
         self.session: Optional[ClientSession] = None
         self.exit_stack = None
+        # From InitializeResult.instructions (MCP protocol); forwarded to the model when using this server.
+        self.server_instructions: Optional[str] = None
 
     async def connect(self, url: str, headers: Optional[dict] = None):
         async with AsyncExitStack() as exit_stack:
@@ -71,7 +73,11 @@ class MCPClient:
 
                 self.session = await exit_stack.enter_async_context(self._session_context)
                 with anyio.fail_after(10):
-                    await self.session.initialize()
+                    init_result = await self.session.initialize()
+                instr = getattr(init_result, 'instructions', None)
+                if isinstance(instr, str):
+                    instr = instr.strip()
+                self.server_instructions = instr or None
                 self.exit_stack = exit_stack.pop_all()
             except Exception as e:
                 await asyncio.shield(self.disconnect())
@@ -153,6 +159,7 @@ class MCPClient:
         # Prevent double-close from concurrent callers
         self.exit_stack = None
         self.session = None
+        self.server_instructions = None
 
         try:
             await asyncio.wait_for(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2549,8 +2549,18 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         if mcp_server_connection.get('config', {}).get('forward_mcp_instructions', True):
                             mcp_instr = mcp_clients[server_id].server_instructions
                             if mcp_instr:
+                                mcp_info = mcp_server_connection.get('info', {}) or {}
+                                mcp_attr_id = mcp_info.get('id', '') or server_id
+                                mcp_attr_name = mcp_info.get('name', '') or mcp_attr_id
+                                safe_instr = mcp_instr.replace(']]>', ']]]]><![CDATA[>')
+                                wrapped_instr = (
+                                    f'<mcp_instructions server="{html.escape(mcp_attr_id, quote=True)}"'
+                                    f' name="{html.escape(mcp_attr_name, quote=True)}">'
+                                    f'<![CDATA[{safe_instr}]]>'
+                                    f'</mcp_instructions>'
+                                )
                                 form_data['messages'] = add_or_update_system_message(
-                                    mcp_instr,
+                                    wrapped_instr,
                                     form_data['messages'],
                                     append=True,
                                 )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2546,6 +2546,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                             headers=headers if headers else None,
                         )
 
+                        if mcp_server_connection.get('config', {}).get('forward_mcp_instructions', True):
+                            mcp_instr = mcp_clients[server_id].server_instructions
+                            if mcp_instr:
+                                form_data['messages'] = add_or_update_system_message(
+                                    mcp_instr,
+                                    form_data['messages'],
+                                    append=True,
+                                )
+
                         function_name_filter_list = mcp_server_connection.get('config', {}).get(
                             'function_name_filter_list', ''
                         )

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -50,6 +50,8 @@
 	let headers = '';
 
 	let functionNameFilterList = '';
+	/** MCP: append InitializeResult.instructions to the system prompt (backend). */
+	let forwardMcpInstructions = true;
 	let accessGrants = [];
 
 	let id = '';
@@ -223,6 +225,9 @@
 				if (data.config) {
 					enable = data.config.enable ?? true;
 					accessGrants = data.config.access_grants ?? [];
+					if (data.config.forward_mcp_instructions !== undefined) {
+						forwardMcpInstructions = data.config.forward_mcp_instructions;
+					}
 				}
 
 				toast.success($i18n.t('Import successful'));
@@ -252,7 +257,10 @@
 					id: id,
 					name: name,
 					description: description
-				}
+				},
+				...(type === 'mcp'
+					? { config: { forward_mcp_instructions: forwardMcpInstructions } }
+					: {})
 			}
 		]);
 
@@ -329,7 +337,8 @@
 			config: {
 				enable: enable,
 				function_name_filter_list: functionNameFilterList,
-				access_grants: accessGrants
+				access_grants: accessGrants,
+				...(type === 'mcp' ? { forward_mcp_instructions: forwardMcpInstructions } : {})
 			},
 			info: {
 				id: id,
@@ -368,6 +377,7 @@
 
 		enable = true;
 		functionNameFilterList = '';
+		forwardMcpInstructions = true;
 		accessGrants = [];
 	};
 
@@ -394,6 +404,7 @@
 
 			enable = connection.config?.enable ?? true;
 			functionNameFilterList = connection.config?.function_name_filter_list ?? '';
+			forwardMcpInstructions = connection.config?.forward_mcp_instructions ?? true;
 			accessGrants = connection.config?.access_grants ?? [];
 		}
 	};
@@ -879,6 +890,22 @@
 										</div>
 									</div>
 								</div>
+							{/if}
+
+							{#if type === 'mcp'}
+								<Tooltip
+									className="flex w-full items-center justify-between gap-3 mt-2"
+									content={$i18n.t(
+										'When enabled, instructions returned in the MCP initialize response are appended to the system prompt for chats that use this server.'
+									)}
+								>
+									<span
+										class={`text-xs font-medium ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-700 dark:text-gray-200'}`}
+									>
+										{$i18n.t('Include MCP server instructions')}
+									</span>
+									<Switch bind:state={forwardMcpInstructions} />
+								</Tooltip>
 							{/if}
 						{/if}
 

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -223,10 +223,12 @@
 				}
 
 				if (data.config) {
-					enable = data.config.enable ?? true;
-					accessGrants = data.config.access_grants ?? [];
-					if (data.config.forward_mcp_instructions !== undefined) {
-						forwardMcpInstructions = data.config.forward_mcp_instructions;
+					const c = data.config;
+					if ('enable' in c) enable = c.enable;
+					if ('access_grants' in c) accessGrants = c.access_grants ?? [];
+					if ('forward_mcp_instructions' in c) forwardMcpInstructions = c.forward_mcp_instructions;
+					if ('function_name_filter_list' in c) {
+						functionNameFilterList = c.function_name_filter_list ?? '';
 					}
 				}
 
@@ -259,7 +261,14 @@
 					description: description
 				},
 				...(type === 'mcp'
-					? { config: { forward_mcp_instructions: forwardMcpInstructions } }
+					? {
+							config: {
+								enable,
+								function_name_filter_list: functionNameFilterList,
+								access_grants: accessGrants,
+								forward_mcp_instructions: forwardMcpInstructions
+							}
+						}
 					: {})
 			}
 		]);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

When an admin-configured MCP tool server is used in a chat, Open WebUI now captures optional **`instructions`** from the MCP **`initialize`** response (`InitializeResult.instructions`) and appends them to the **system** message in the chat payload (same pattern as other system-prompt injections). This lets MCP servers document how models should use their tools without duplicating everything in per-tool descriptions.

Per-connection opt-out is available via **`config.forward_mcp_instructions`** (default **true** when omitted). The admin **Add/Edit Connection** modal (MCP) exposes this under **Advanced** as **“Include MCP server instructions”** with a tooltip explaining behavior; import/export JSON includes the flag for MCP connections.

### Added

- Forwarding of MCP server **`initialize`** **`instructions`** into the chat system prompt when the server is connected for a request and forwarding is enabled.
- Connection config key **`forward_mcp_instructions`** (boolean; default **true**).
- Admin UI: MCP-only control under **Advanced** in `AddToolServerModal.svelte` (label + switch + tooltip); wired through save/load/import/export for MCP connections.

### Changed

- `MCPClient` stores `server_instructions` from the post-`initialize` result and clears it on disconnect.

### Security

- Admins should be aware that MCP servers control the **`instructions`** string; disabling forwarding (`forward_mcp_instructions: false`) avoids injecting server-provided text into the model context.

### Breaking Changes

- **BREAKING CHANGE:** None. Existing behavior is preserved when **`forward_mcp_instructions`** is omitted (treated as **true**).

---

### Additional Information

- **Files (high level):** `backend/open_webui/utils/mcp/client.py` (read `InitializeResult.instructions`), `backend/open_webui/utils/middleware.py` (append via `add_or_update_system_message` when enabled), `src/lib/components/AddToolServerModal.svelte` (UI + `config.forward_mcp_instructions`).
- **Dependencies:** None added or upgraded; uses the existing Python **`mcp`** SDK types that already include `InitializeResult.instructions`.
- **Docs:** A short note in the Open WebUI docs (MCP / tool servers) describing **`forward_mcp_instructions`** and the UI toggle would help operators; link the docs PR here when opened.

### Screenshots or Videos

<img width="495" height="633" alt="image" src="https://github.com/user-attachments/assets/d915800c-2082-4c08-90d0-4cbdb6e2b75d" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.