### PR TITLE
fix: consistent chat message bubble widths in widescreen mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -103,7 +103,7 @@ textarea::placeholder {
 }
 
 .markdown-prose {
-	@apply prose dark:prose-invert prose-blockquote:border-s-gray-100 prose-blockquote:dark:border-gray-800 prose-blockquote:border-s-2 prose-blockquote:not-italic prose-blockquote:font-normal  prose-headings:font-semibold prose-hr:my-4 prose-hr:border-gray-50 prose-hr:dark:border-gray-850 prose-p:my-0 prose-img:my-1 prose-headings:my-1 prose-pre:my-0 prose-table:my-0 prose-blockquote:my-0 prose-ul:-my-0 prose-ol:-my-0 prose-li:-my-0 whitespace-pre-line;
+	@apply prose max-w-none dark:prose-invert prose-blockquote:border-s-gray-100 prose-blockquote:dark:border-gray-800 prose-blockquote:border-s-2 prose-blockquote:not-italic prose-blockquote:font-normal  prose-headings:font-semibold prose-hr:my-4 prose-hr:border-gray-50 prose-hr:dark:border-gray-850 prose-p:my-0 prose-img:my-1 prose-headings:my-1 prose-pre:my-0 prose-table:my-0 prose-blockquote:my-0 prose-ul:-my-0 prose-ol:-my-0 prose-li:-my-0 whitespace-pre-line;
 }
 
 .markdown-prose-sm {


### PR DESCRIPTION
## Summary

Fixes the inconsistent conversation bubble sizing reported in #5975.

The root cause is that the `.markdown-prose` class applies Tailwind's `prose` plugin, which sets a default `max-width: 65ch`. This conflicts with the explicit `w-full min-w-full` on message containers. When content like YAML code blocks exceeds the 65ch character limit, the prose max-width constraint causes the bubble to resize inconsistently as the browser recalculates layout during scrolling.

The fix adds `max-w-none` to `.markdown-prose`, removing the prose plugin's default max-width. The parent `Message` component already controls the overall container width via `max-w-5xl` (normal mode) or `max-w-full` (widescreen mode), so no additional width constraint is needed on the prose wrapper. Code blocks continue to handle horizontal overflow correctly via their existing `overflow-x-auto`.

## Changes

- `src/app.css`: Added `max-w-none` to `.markdown-prose` class

Fixes #5975