### PR TITLE
fix: make UserUpdateForm fields optional to allow partial user updates

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -247,15 +247,17 @@ class UserRoleUpdateForm(BaseModel):
 
 
 class UserUpdateForm(BaseModel):
-    role: str
-    name: str
-    email: str
-    profile_image_url: str
+    role: Optional[str] = None
+    name: Optional[str] = None
+    email: Optional[str] = None
+    profile_image_url: Optional[str] = None
     password: Optional[str] = None
 
     @field_validator('profile_image_url')
     @classmethod
-    def check_profile_image_url(cls, v: str) -> str:
+    def check_profile_image_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
         return validate_profile_image_url(v)
 
 

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -607,9 +607,6 @@ async def update_user_by_id(
             hashed = get_password_hash(form_data.password)
             Auths.update_user_password_by_id(user_id, hashed, db=db)
 
-        if form_data.email is not None:
-            Auths.update_email_by_id(user_id, form_data.email.lower(), db=db)
-
         update_data = {
             k: v
             for k, v in {
@@ -620,6 +617,16 @@ async def update_user_by_id(
             }.items()
             if v is not None
         }
+
+        if not update_data and not form_data.password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='At least one field must be provided to update.',
+            )
+
+        if form_data.email is not None:
+            Auths.update_email_by_id(user_id, form_data.email.lower(), db=db)
+
         updated_user = Users.update_user_by_id(
             user_id,
             update_data,

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -573,7 +573,7 @@ async def update_user_by_id(
                         detail=ERROR_MESSAGES.ACTION_PROHIBITED,
                     )
 
-                if form_data.role != 'admin':
+                if form_data.role is not None and form_data.role != 'admin':
                     # If the primary admin is trying to change their own role, prevent it
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
@@ -590,7 +590,7 @@ async def update_user_by_id(
     user = Users.get_user_by_id(user_id, db=db)
 
     if user:
-        if form_data.email.lower() != user.email:
+        if form_data.email is not None and form_data.email.lower() != user.email:
             email_user = Users.get_user_by_email(form_data.email.lower(), db=db)
             if email_user:
                 raise HTTPException(
@@ -607,15 +607,22 @@ async def update_user_by_id(
             hashed = get_password_hash(form_data.password)
             Auths.update_user_password_by_id(user_id, hashed, db=db)
 
-        Auths.update_email_by_id(user_id, form_data.email.lower(), db=db)
-        updated_user = Users.update_user_by_id(
-            user_id,
-            {
+        if form_data.email is not None:
+            Auths.update_email_by_id(user_id, form_data.email.lower(), db=db)
+
+        update_data = {
+            k: v
+            for k, v in {
                 'role': form_data.role,
                 'name': form_data.name,
-                'email': form_data.email.lower(),
+                'email': form_data.email.lower() if form_data.email is not None else None,
                 'profile_image_url': form_data.profile_image_url,
-            },
+            }.items()
+            if v is not None
+        }
+        updated_user = Users.update_user_by_id(
+            user_id,
+            update_data,
             db=db,
         )
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Testing:** Verified by code inspection and logic review
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Single atomic change, rebased on `dev`

---

# Changelog Entry

### Description

Fixes #23424

The `POST /{user_id}/update` endpoint required all fields (`role`, `name`, `email`, `profile_image_url`) in the request body, even when the caller only wanted to update a single field like `role`. Sending only `{"role": "user"}` resulted in a validation error listing all other fields as required.

### Fixed

- Made `role`, `name`, `email`, and `profile_image_url` optional (`None` by default) in `UserUpdateForm`
- Router now only updates fields that are explicitly provided — unset fields retain their existing values
- Email uniqueness check and `Auths.update_email_by_id` are skipped when `email` is not provided
- Primary admin role guard now only triggers when `role` is explicitly set (not `None`)
- `profile_image_url` validator skips `None` values correctly

**Before:**
```json
// PATCH /api/v1/users/{id}/update
{"role": "user"}
// → 422 Unprocessable Entity: name, email, profile_image_url are required
```

**After:**
```json
{"role": "user"}
// → 200 OK — only role is updated, other fields unchanged
```

---

### Additional Information

- Changes: `backend/open_webui/models/users.py`, `backend/open_webui/routers/users.py`
- No new imports or dependencies
- `password` was already `Optional` — this PR makes the remaining fields consistent

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.