### PR TITLE
fix: use admin-configured WEB_SEARCH_RESULT_COUNT as default IF MODEL DID NOT PROVIDE PARAMTER

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -149,7 +149,7 @@ async def calculate_timestamp(
 
 async def search_web(
     query: str,
-    count: int = 5,
+    count: Optional[int] = None,
     __request__: Request = None,
     __user__: dict = None,
 ) -> str:
@@ -158,7 +158,7 @@ async def search_web(
     or topics not covered in internal documents.
 
     :param query: The search query to look up
-    :param count: Number of results to return (default: 5)
+    :param count: Number of results to return (default: admin-configured value)
     :return: JSON with search results containing title, link, and snippet for each result
     """
     if __request__ is None:
@@ -168,12 +168,9 @@ async def search_web(
         engine = __request__.app.state.config.WEB_SEARCH_ENGINE
         user = UserModel(**__user__) if __user__ else None
 
-        # Enforce maximum result count from config to prevent abuse
-        count = (
-            count
-            if count < __request__.app.state.config.WEB_SEARCH_RESULT_COUNT
-            else __request__.app.state.config.WEB_SEARCH_RESULT_COUNT
-        )
+        configured = __request__.app.state.config.WEB_SEARCH_RESULT_COUNT
+        max_count = 5 if configured is None else configured
+        count = max(1, min(count, max_count)) if count is not None else max_count
 
         results = await asyncio.to_thread(_search_web, __request__, engine, query, user)
 


### PR DESCRIPTION
The built-in search_web tool hardcoded count=5 as the default, ignoring the admin-configured WEB_SEARCH_RESULT_COUNT setting. **When the LLM did not specify a count, the tool always returned 5 results regardless of admin configuration.**

Now the tool defaults to the admin-configured value when the LLM omits the count parameter, while still capping LLM-requested values at the admin maximum to prevent abuse.

Closes #23485

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
