### PR TITLE
fix(ratingdata): add validator for model rating, forcing the value to be between 1 and 10

### DIFF
--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
 from open_webui.models.users import User
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import BigInteger, Column, Text, JSON, Boolean
 
 log = logging.getLogger(__name__)
@@ -81,7 +81,17 @@ class RatingData(BaseModel):
     sibling_model_ids: Optional[list[str]] = None
     reason: Optional[str] = None
     comment: Optional[str] = None
+    details: Optional[dict] = None
     model_config = ConfigDict(extra='allow', protected_namespaces=())
+
+    @field_validator('details')
+    @classmethod
+    def clamp_details_rating(cls, v: Optional[dict]) -> Optional[dict]:
+        if isinstance(v, dict) and 'rating' in v:
+            r = v['rating']
+            if isinstance(r, (int, float)):
+                v['rating'] = max(1, min(10, int(r)))
+        return v
 
 
 class MetaData(BaseModel):

--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -89,8 +89,10 @@ class RatingData(BaseModel):
     def clamp_details_rating(cls, v: Optional[dict]) -> Optional[dict]:
         if isinstance(v, dict) and 'rating' in v:
             r = v['rating']
-            if isinstance(r, (int, float)):
+            if isinstance(r, (int, float)) and not isinstance(r, bool):
                 v['rating'] = max(1, min(10, int(r)))
+            else:
+                del v['rating']
         return v
 
 


### PR DESCRIPTION
### Description

**Problem**: when giving a numeric feedback to a model, a user can skew the statistic by sending a manual request with an arbitrarily positive or negative number.
The backend should always validate inputs at the system boundary regardless of how unlikely abuse is. This was flagged by internal QA during a pentest as a medium severity finding.

**Solution**: I added some validation to force the numeric feedback between 1 and 10. 

**Note**: 
- If the feedback is a negative number, it's registered as 1. 
- If it's a number greater than 10, it's registered as 10.
- If it's anything else, the `details` field is empty


### Added

- Added a `details` field to `RatingData`: it reflects what the json object actually is when a rating is applied
- Added a validator that cap the rating between 1 and 10

### Breaking Changes

- None: this change has no effect other that adding a `"details": null` to the record if no rating is provided.

---

### Test

#### Before

1. Start a new chat
2. Say "hello"
3. Click thumbs up or down and select rating
4. Click send
5. Intercept the request
6. Copy json, change the details
7. Use `curl` to send the changed payload

```
curl -XPOST  --header "Content-Type: application/json" --header "Authorization: Bearer xxx" 'http://localhost:8080/api/v1/evaluations/feedback/947a071b-269f-4e91-a245-902ab840fd68' -d @rating.json
```

where the `rating.json` has for example

```json
"data": {
    "rating": 1,
    "tags": ["General"],
    "reason": "",
    "comment": "",
    "details": { "rating": -1000 },
    "model_id": "gemma4:31b-cloud"
  },
```

and you can read in the response

```json
"data": {
    "rating": 1,
    "model_id": "gemma4:31b-cloud",
    "sibling_model_ids": null,
    "reason": "",
    "comment": "",
    "tags": ["General"],
    "details": { "rating": -1000 }
  }
```

and you get

<img width="994" height="832" alt="image" src="https://github.com/user-attachments/assets/27cf5c49-d65d-4d78-92d4-7e89f62fbbd0" />

### After

Do the same thing, but this time

```json
"data": {
    "rating": 1,
    "tags": ["General"],
    "reason": "",
    "comment": "",
    "details": { "rating": 12345 },
    "model_id": "gemma4:31b-cloud"
  }
```

results in

```json
"details":{"rating":10}
```

and 

```json
"data": {
    "rating": 1,
    "tags": ["General"],
    "reason": "",
    "comment": "",
    "details": { "rating": -12345 },
    "model_id": "gemma4:31b-cloud"
  }
```

```json
"details":{"rating":1}
```
<img width="491" height="402" alt="Screenshot 2026-04-08 at 12 13 42" src="https://github.com/user-attachments/assets/580b7dcd-2b63-4913-9b00-490ad62106d1" />

<img width="470" height="391" alt="Screenshot 2026-04-08 at 12 12 19" src="https://github.com/user-attachments/assets/29e4cc60-657a-4f4e-b9d2-fa7953b89ba6" />

If I pass a string

```json
"data": {
    "rating": 1,
    "tags": ["General"],
    "reason": "",
    "comment": "",
    "details": { "rating": "geiwffwegfu" },
    "model_id": "gemma4:31b-cloud"
  }
```

I get 

```json
"data": {
    "rating": 1,
    "tags": ["General"],
    "reason": "",
    "comment": "",
    "details": {},
    "model_id": "gemma4:31b-cloud"
  }
```

and in the UI I have

<img width="932" height="780" alt="image" src="https://github.com/user-attachments/assets/43d4d5df-27ea-460e-ab63-adf0e8aaea0c" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
