### PR TITLE
fix: remove undefined cookie_expires from OAuth session cookie

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1683,7 +1683,7 @@ class OAuthManager:
                     httponly=True,
                     samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
                     secure=WEBUI_AUTH_COOKIE_SECURE,
-                    **({'max_age': cookie_max_age, 'expires': cookie_expires} if cookie_max_age is not None else {}),
+                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
                 )
 
                 log.info(f'Stored OAuth session server-side for user {user.id}, provider {provider}')


### PR DESCRIPTION
## Bug

handle_callback in oauth.py (line 1686) references cookie_expires when setting the oauth_session_id cookie, but this variable is never defined. This causes a NameError that silently prevents OAuth sessions from being stored server-side.

Error: Failed to store OAuth session server-side: name 'cookie_expires' is not defined

This breaks:
- system_oauth auth type for OpenAI connections (no session to read the token from)
- Any feature that depends on the OAuth session being stored

## Fix

Remove cookie_expires from the dict spread. cookie_max_age (which IS defined at line 1627) is sufficient and is the standard way to set cookie expiry. All other set_cookie calls in the same function correctly use only cookie_max_age.