### PR TITLE
feat: add a configurable limit for how many model can be prompted in a chat

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1535,6 +1535,12 @@ FOLDER_MAX_FILE_COUNT = PersistentConfig(
     os.environ.get('FOLDER_MAX_FILE_COUNT', ''),
 )
 
+MAX_CHAT_MODELS = PersistentConfig(
+    'MAX_CHAT_MODELS',
+    'chat.max_models',
+    os.environ.get('MAX_CHAT_MODELS', ''),
+)
+
 ENABLE_CHANNELS = PersistentConfig(
     'ENABLE_CHANNELS',
     'channels.enable',

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -383,6 +383,7 @@ from open_webui.config import (
     API_KEYS_ALLOWED_ENDPOINTS,
     ENABLE_FOLDERS,
     FOLDER_MAX_FILE_COUNT,
+    MAX_CHAT_MODELS,
     ENABLE_CHANNELS,
     ENABLE_NOTES,
     ENABLE_USER_STATUS,
@@ -874,6 +875,7 @@ app.state.config.BANNERS = WEBUI_BANNERS
 
 app.state.config.ENABLE_FOLDERS = ENABLE_FOLDERS
 app.state.config.FOLDER_MAX_FILE_COUNT = FOLDER_MAX_FILE_COUNT
+app.state.config.MAX_CHAT_MODELS = MAX_CHAT_MODELS
 app.state.config.ENABLE_CHANNELS = ENABLE_CHANNELS
 app.state.config.ENABLE_NOTES = ENABLE_NOTES
 app.state.config.ENABLE_COMMUNITY_SHARING = ENABLE_COMMUNITY_SHARING
@@ -2093,6 +2095,7 @@ async def get_app_config(request: Request):
                     'enable_direct_connections': app.state.config.ENABLE_DIRECT_CONNECTIONS,
                     'enable_folders': app.state.config.ENABLE_FOLDERS,
                     'folder_max_file_count': app.state.config.FOLDER_MAX_FILE_COUNT,
+                    'max_chat_models': app.state.config.MAX_CHAT_MODELS,
                     'enable_channels': app.state.config.ENABLE_CHANNELS,
                     'enable_notes': app.state.config.ENABLE_NOTES,
                     'enable_web_search': app.state.config.ENABLE_WEB_SEARCH,

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -949,6 +949,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         'ENABLE_MESSAGE_RATING': request.app.state.config.ENABLE_MESSAGE_RATING,
         'ENABLE_FOLDERS': request.app.state.config.ENABLE_FOLDERS,
         'FOLDER_MAX_FILE_COUNT': request.app.state.config.FOLDER_MAX_FILE_COUNT,
+        'MAX_CHAT_MODELS': request.app.state.config.MAX_CHAT_MODELS,
         'ENABLE_CHANNELS': request.app.state.config.ENABLE_CHANNELS,
         'ENABLE_MEMORIES': request.app.state.config.ENABLE_MEMORIES,
         'ENABLE_NOTES': request.app.state.config.ENABLE_NOTES,
@@ -975,6 +976,7 @@ class AdminConfig(BaseModel):
     ENABLE_MESSAGE_RATING: bool
     ENABLE_FOLDERS: bool
     FOLDER_MAX_FILE_COUNT: Optional[int | str] = None
+    MAX_CHAT_MODELS: Optional[int | str] = None
     ENABLE_CHANNELS: bool
     ENABLE_MEMORIES: bool
     ENABLE_NOTES: bool
@@ -999,6 +1001,9 @@ async def update_admin_config(request: Request, form_data: AdminConfig, user=Dep
     request.app.state.config.ENABLE_FOLDERS = form_data.ENABLE_FOLDERS
     request.app.state.config.FOLDER_MAX_FILE_COUNT = (
         int(form_data.FOLDER_MAX_FILE_COUNT) if form_data.FOLDER_MAX_FILE_COUNT else ''
+    )
+    request.app.state.config.MAX_CHAT_MODELS = (
+        int(form_data.MAX_CHAT_MODELS) if form_data.MAX_CHAT_MODELS else ''
     )
     request.app.state.config.ENABLE_CHANNELS = form_data.ENABLE_CHANNELS
     request.app.state.config.ENABLE_MEMORIES = form_data.ENABLE_MEMORIES
@@ -1041,6 +1046,7 @@ async def update_admin_config(request: Request, form_data: AdminConfig, user=Dep
         'ENABLE_MESSAGE_RATING': request.app.state.config.ENABLE_MESSAGE_RATING,
         'ENABLE_FOLDERS': request.app.state.config.ENABLE_FOLDERS,
         'FOLDER_MAX_FILE_COUNT': request.app.state.config.FOLDER_MAX_FILE_COUNT,
+        'MAX_CHAT_MODELS': request.app.state.config.MAX_CHAT_MODELS,
         'ENABLE_CHANNELS': request.app.state.config.ENABLE_CHANNELS,
         'ENABLE_MEMORIES': request.app.state.config.ENABLE_MEMORIES,
         'ENABLE_NOTES': request.app.state.config.ENABLE_NOTES,

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -740,6 +740,28 @@
 						</div>
 					{/if}
 
+					<div class="mb-2.5 w-full justify-between">
+						<div class="flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Max Chat Models')}
+							</div>
+						</div>
+
+						<div class="flex mt-2 space-x-2">
+							<input
+								class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+								type="number"
+								min="1"
+								placeholder={$i18n.t('Leave empty for unlimited')}
+								bind:value={adminConfig.MAX_CHAT_MODELS}
+							/>
+						</div>
+
+						<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+							{$i18n.t('Maximum number of models that can be used in a single chat.')}
+						</div>
+					</div>
+
 					<div class="mb-2.5 flex w-full items-center justify-between pr-2">
 						<div class=" self-center text-xs font-medium">
 							{$i18n.t('Notes')} ({$i18n.t('Beta')})

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1276,6 +1276,11 @@
 					selectedModels = selectedModels.length > 0 ? [selectedModels[0]] : [''];
 				}
 
+				const maxModels = $config?.features?.max_chat_models;
+				if (maxModels && selectedModels.length > maxModels) {
+					selectedModels = selectedModels.slice(0, maxModels);
+				}
+
 				oldSelectedModelIds = structuredClone(selectedModels);
 
 				history =

--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -69,7 +69,7 @@
 			</div>
 
 			{#if $user?.role === 'admin' || ($user?.permissions?.chat?.multiple_models ?? true)}
-				{#if selectedModelIdx === 0}
+			{#if selectedModelIdx === 0 && (!$config?.features?.max_chat_models || selectedModels.length < $config.features.max_chat_models)}
 					<div
 						class="  self-center mx-1 disabled:text-gray-600 disabled:hover:text-gray-600 -translate-y-[0.5px]"
 					>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -288,6 +288,7 @@ type Config = {
 		enable_direct_connections: boolean;
 		enable_version_update_check: boolean;
 		folder_max_file_count?: number;
+		max_chat_models?: number;
 	};
 	oauth: {
 		providers: {


### PR DESCRIPTION
### Description

This PR adds a configurable limit on the number of models that can be used simultaneously in a single chat. By default the limit is unlimited, preserving existing behavior. The number of models can be specified via the `MAX_CHAT_MODELS` environment variable or from the Admin Panel > Settings > General under "Features".

The reason for this is that having the possibility to prompt unlimited models simultaneously, some users will use this feature to the maximum of its capacity generating high cost and big headaches. We have it written in the guidelines to use max 3 models, but nobody reads the guidelines :)

### Added

- New `MAX_CHAT_MODELS` `PersistentConfig` entry, readable from the `MAX_CHAT_MODELS` environment variable (empty = unlimited)
- Initialized `app.state.config.MAX_CHAT_MODELS` on startup
- Exposed `max_chat_models` in the `GET /api/config` features response so the frontend can read it
- Added `MAX_CHAT_MODELS` to the `GET /auths/admin/config` response so the value is loaded in the admin panel
- Added `MAX_CHAT_MODELS` field to the `AdminConfig` Pydantic model
- Saved the value in `POST /auths/admin/config` (casted to int, or `''` for unlimited)
- Included `MAX_CHAT_MODELS` in the `POST` response
- Added `max_chat_models?: number` to the `features` block of the `Config` type.
- New number input field "Max Chat Models" below the "Folder Max File Count" field, following the same pattern: min="1", placeholder "Leave empty for unlimited", linked to `adminConfig.MAX_CHAT_MODELS`
- The "Add Model" button is hidden when the number of selected models reaches the `MAX_CHAT_MODELS`
- When loading a chat, `selectedModels` is trimmed to `max_chat_models` if the saved chat contains more models than the current limit allows. It handles a specific case when a chat was saved when the limit was higher, and later an admin lowers the limit. This way there is no way of going around the limit.

### Note

I made this feature as similar as possible to the `FOLDER_MAX_FILE_COUNT` so that it blends nicely with the existing code.

### Breaking Changes

- None, the default is unlimited as it is now

---

### Test

Build the container with `MAX_CHAT_MODELS=3` and you get this:

<img width="1231" height="593" alt="Screenshot 2026-04-08 at 20 31 27" src="https://github.com/user-attachments/assets/507a3478-b0cd-4cf6-ad10-e2a8f8acc515" />

If I try to set the value to zero it won't let me and will explain why

<img width="705" height="131" alt="Screenshot 2026-04-08 at 20 32 06" src="https://github.com/user-attachments/assets/24e5737d-9c1a-4fa9-aa00-815eda14b0b7" />

Note that after adding the third model the plus sign disappears making it impossible to add more.

<img width="1189" height="745" alt="Screenshot 2026-04-08 at 20 13 44" src="https://github.com/user-attachments/assets/1e8b5e5d-98c1-42e3-80c0-fbdb06d14691" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
