### PR TITLE
fix: remove capitalize class from terminal menu selected label

### DIFF
--- a/src/lib/components/chat/MessageInput/TerminalMenu.svelte
+++ b/src/lib/components/chat/MessageInput/TerminalMenu.svelte
@@ -102,7 +102,7 @@
 				<Cloud className="size-3.5" strokeWidth="2" />
 
 				{#if $selectedTerminalId && selectedLabel}
-					<span class="truncate text-[13px] max-w-[100px] sm:max-w-[150px] capitalize"
+					<span class="truncate text-[13px] max-w-[100px] sm:max-w-[150px]"
 						>{selectedLabel}</span
 					>
 				{/if}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

The Terminal Menu button in the chat input bar (far-right side) incorrectly applied the Tailwind `capitalize` utility class to the label `<span>` that displays the currently selected terminal. This caused domain-based terminal URLs (e.g., `terminal.g30ui.xyz`) to have their first character uppercased by the browser's CSS engine, rendering as `Terminal.G30ui.Xyz`. The fix removes the `capitalize` class so that all terminal label text — whether a custom name or a stripped URL — is rendered exactly as stored, with no CSS-forced capitalization.

### Fixed

- `TerminalMenu.svelte`: Removed the `capitalize` Tailwind class from the selected-terminal label `<span>` in the chat input toolbar. Domain-name labels (e.g., `terminal.example.com`) are no longer incorrectly title-cased to `Terminal.example.com`.

---

### Additional Information

- The affected element is the compact label shown on the Terminal toggle button at the right edge of the chat input field when a terminal server is active.
- The `capitalize` class applies `text-transform: capitalize` via CSS, which uppercases the very first character of the rendered text node. Because the fallback label is derived from the raw URL (protocol stripped via `.replace(/^https?:\/\//, '')`), any domain beginning with a letter — which is virtually all of them — was visually mangled.
- No logic changes were made; this is a pure CSS class removal. The displayed value of `selectedLabel` is unchanged.
- 1 file changed, 1 line changed (`-capitalize` removed).

### Screenshots or Videos

**Before:**

<img width="354" height="154" alt="image" src="https://github.com/user-attachments/assets/25bb0dca-e17a-43ad-950d-9b120a6a367f" />

**After:**

<img width="354" height="154" alt="image" src="https://github.com/user-attachments/assets/b37c2f08-5743-4d4f-b51d-d830d8a081a1" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.