### PR TITLE
fix: handle ChatGPT exports with folder/project entries

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -677,7 +677,9 @@ export const calculateSHA256 = async (file) => {
 
 export const getImportOrigin = (_chats) => {
 	// Check what external service chat imports are from
-	if ('mapping' in _chats[0]) {
+	// Some ChatGPT exports include folder/project entries that lack 'mapping',
+	// so we check if ANY item has it rather than relying on _chats[0].
+	if (_chats.some((chat) => typeof chat === 'object' && chat !== null && 'mapping' in chat)) {
 		return 'openai';
 	}
 	return 'webui';
@@ -799,7 +801,14 @@ export const convertOpenAIChats = (_chats) => {
 	// Create a list of dictionaries with each conversation from import
 	const chats = [];
 	let failed = 0;
+	let skipped = 0;
 	for (const convo of _chats) {
+		// Skip entries that are not actual conversations (e.g. folder/project metadata)
+		if (!convo['mapping']) {
+			skipped++;
+			continue;
+		}
+
 		const chat = convertOpenAIMessages(convo);
 
 		if (validateChat(chat)) {
@@ -814,6 +823,7 @@ export const convertOpenAIChats = (_chats) => {
 			failed++;
 		}
 	}
+	if (skipped > 0) console.log(skipped, 'Non-conversation entries skipped (folders/projects)');
 	console.log(failed, 'Conversations could not be imported');
 	return chats;
 };


### PR DESCRIPTION
## Summary
Fixes #23505 — Import of ChatGPT export file results in "Imported 0 Chats".

## Root Cause
ChatGPT export files (conversations.json) can include folder and project metadata entries that lack a mapping key. This caused two problems:
1. `getImportOrigin()` only checked `_chats[0]` for the mapping key. If a folder entry appeared first in the array, the export was misidentified as webui format and `convertOpenAIChats()` was never called — resulting in 0 imports.
2. `convertOpenAIChats()` did not skip non-conversation entries, so even when origin detection worked, folder/project entries would fail validation silently.

## Changes
- `src/lib/utils/index.ts` — `getImportOrigin()`: Check if any item in the array has a mapping key, instead of only checking `_chats[0]`.
- `src/lib/utils/index.ts` — `convertOpenAIChats()`: Skip entries without a mapping key (folders/projects) before attempting conversion, with a console log for visibility.

## Testing
Tested with a ChatGPT export containing both folder entries and conversations — all conversations are now correctly imported.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.