### PR TITLE
fix: balanced display math parsing in markdown renderer

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
@@ -109,7 +109,7 @@
 		<del><svelte:self id={`${id}-del`} tokens={token.tokens} {onSourceClick} /></del>
 	{:else if token.type === 'inlineKatex'}
 		{#if token.text}
-			<KatexRenderer content={token.text} displayMode={false} />
+			<KatexRenderer content={token.text} displayMode={token?.displayMode ?? false} />
 		{/if}
 	{:else if token.type === 'iframe'}
 		<iframe

--- a/src/lib/utils/marked/katex-extension.test.ts
+++ b/src/lib/utils/marked/katex-extension.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { Marked } from 'marked';
+
+import katexExtension from './katex-extension';
+
+const createMarked = () => {
+	const parser = new Marked();
+	parser.use(katexExtension({ throwOnError: false, breaks: true }));
+	return parser;
+};
+
+const collectKatexTokens = (tokens: any[]): any[] => {
+	const result: any[] = [];
+
+	for (const token of tokens) {
+		if (token.type === 'inlineKatex' || token.type === 'blockKatex') {
+			result.push(token);
+		}
+
+		if (token.tokens) {
+			result.push(...collectKatexTokens(token.tokens));
+		}
+	}
+
+	return result;
+};
+
+describe('katex-extension', () => {
+	it('renders balanced single-line $$...$$ as display math', () => {
+		const tokens = createMarked().lexer('$$x^2$$');
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({
+			type: 'blockKatex',
+			text: 'x^2',
+			displayMode: true
+		});
+	});
+
+	it('renders multiline $$...$$ as display math', () => {
+		const input = '$$\n\\int_0^1 x^2 \\, dx\n= \\frac{1}{3}\n$$';
+		const tokens = createMarked().lexer(input);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({
+			type: 'blockKatex',
+			text: '\n\\int_0^1 x^2 \\, dx\n= \\frac{1}{3}\n',
+			displayMode: true
+		});
+	});
+
+	it('treats trailing spaces before newline as a block boundary', () => {
+		const tokens = createMarked().lexer('$$x^2$$   \nnext line');
+
+		expect(tokens[0]).toMatchObject({
+			type: 'blockKatex',
+			text: 'x^2',
+			displayMode: true
+		});
+	});
+
+	it('treats CRLF after closing $$ as a block boundary', () => {
+		const tokens = createMarked().lexer('$$x^2$$\r\nnext line');
+
+		expect(tokens[0]).toMatchObject({
+			type: 'blockKatex',
+			text: 'x^2',
+			displayMode: true
+		});
+	});
+
+	it('leaves stray $$ as plain text', () => {
+		const tokens = createMarked().lexer('stray $$ delimiter');
+
+		expect(collectKatexTokens(tokens)).toHaveLength(0);
+		expect(tokens[0]?.type).toBe('paragraph');
+		expect(tokens[0]?.text).toContain('stray');
+		expect(tokens[0]?.text).toContain('$$ delimiter');
+	});
+
+	it('leaves normal prose with dollar signs untouched', () => {
+		const tokens = createMarked().lexer('The total is $5.00 in normal prose.');
+
+		expect(collectKatexTokens(tokens)).toHaveLength(0);
+		expect(tokens[0]).toMatchObject({
+			type: 'paragraph',
+			text: 'The total is $5.00 in normal prose.'
+		});
+	});
+
+	it('keeps punctuation after closing $$ attached to the surrounding paragraph', () => {
+		const tokens = createMarked().lexer('Result: $$x^2$$.');
+		const mathTokens = collectKatexTokens(tokens);
+
+		expect(tokens[0]?.type).toBe('paragraph');
+		expect(mathTokens).toHaveLength(1);
+		expect(mathTokens[0]).toMatchObject({
+			type: 'inlineKatex',
+			text: 'x^2',
+			displayMode: true
+		});
+		expect(tokens[0]?.text).toContain('.');
+	});
+
+	it('does not interfere with fenced math code blocks', () => {
+		const tokens = createMarked().lexer('```math\nx^2\n```');
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]).toMatchObject({
+			type: 'code',
+			lang: 'math',
+			text: 'x^2'
+		});
+	});
+});

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -66,6 +66,62 @@ function generateRegexRules(delimiters) {
 
 const { inlineRule, blockRule } = generateRegexRules(DELIMITER_LIST);
 
+function hasAllowedTrailingChar(src: string, index: number) {
+	return index >= src.length || ALLOWED_SURROUNDING_CHARS_REGEX.test(src.charAt(index));
+}
+
+function hasBlockTrailingChar(src: string, index: number) {
+	return /^(?:[ \t]*\r?\n|$)/.test(src.slice(index));
+}
+
+function findDisplayMathEnd(src: string, startIndex: number) {
+	for (let i = startIndex; i < src.length - 1; i++) {
+		if (src.charAt(i) === '\\') {
+			i += 1;
+			continue;
+		}
+
+		if (src.charAt(i) === '$' && src.charAt(i + 1) === '$') {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+export function tokenizeDisplayMath(
+	src: string,
+	type: 'inlineKatex' | 'blockKatex',
+	requireBlockBoundary = false
+) {
+	if (!src.startsWith('$$')) {
+		return;
+	}
+
+	const endIndex = findDisplayMathEnd(src, 2);
+	if (endIndex === -1) {
+		return;
+	}
+
+	const raw = src.slice(0, endIndex + 2);
+	const text = raw.slice(2, -2);
+
+	if (!text.trim() || !hasAllowedTrailingChar(src, endIndex + 2)) {
+		return;
+	}
+
+	if (requireBlockBoundary && !hasBlockTrailingChar(src, endIndex + 2)) {
+		return;
+	}
+
+	return {
+		type,
+		raw,
+		text,
+		displayMode: true
+	};
+}
+
 export default function (options = {}) {
 	return {
 		extensions: [inlineKatex(options), blockKatex(options)]
@@ -102,6 +158,17 @@ function katexStart(src, displayMode: boolean) {
 }
 
 function katexTokenizer(src, tokens, displayMode: boolean) {
+	if (src.startsWith('$$')) {
+		const displayToken = tokenizeDisplayMath(
+			src,
+			displayMode ? 'blockKatex' : 'inlineKatex',
+			displayMode
+		);
+		if (displayToken) {
+			return displayToken;
+		}
+	}
+
 	const ruleReg = displayMode ? blockRule : inlineRule;
 	const type = displayMode ? 'blockKatex' : 'inlineKatex';
 


### PR DESCRIPTION
 Fixes #23526

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

  ## Description

  This PR fixes a frontend markdown/math parsing bug where balanced `$$...$$` display math could render unreliably and stray `$$` could interfere with message rendering.

  The change is intentionally narrow:
  - adds balanced `$$...$$` tokenization for display math
  - leaves unmatched `$$` as plain text
  - preserves existing fenced ```math blocks
  - respects `displayMode` for inline-rendered math tokens when appropriate

  This is a small renderer bugfix linked to the issue above.

  ## Changelog Entry

  ### Description
  Fixes unreliable balanced `$$...$$` display math parsing in the frontend markdown renderer and prevents stray `$$` from disrupting message rendering.

  ### Added
  - Focused frontend tests for balanced display math, multiline display math, stray delimiters, normal dollar-sign prose, punctuation-adjacent delimiters, and fenced `math` blocks

  ### Changed
  - Narrowed the custom markdown math tokenizer to scan for balanced `$$...$$` delimiters before falling back to existing regex handling
  - Updated inline math rendering to honor `displayMode` when the tokenizer marks a token as display math

  ### Deprecated
  - None

  ### Removed
  - None

  ### Fixed
  - Balanced `$$...$$` display math now renders reliably
  - Multiline `$$ ... $$` display math is handled correctly
  - Stray `$$` no longer breaks or destabilizes message rendering
  - Normal prose containing dollar signs is not aggressively transformed
  - Existing fenced ```math blocks continue to work

  ### Security
  ### Breaking Changes
  - None

  ## Testing

  Manual:
  1. Open a chat in Open WebUI.
  2. Submit prompts containing:
     - `$$x^2$$`
     - multiline `$$ ... $$`
     - stray `$$`
     - normal prose with dollar signs
     - punctuation after closing delimiters
     - fenced ```math blocks
  3. Verify balanced display math renders, stray delimiters remain plain text, and fenced math blocks still work.

  Automated:
  - `./node_modules/.bin/vitest run src/lib/utils/marked/katex-extension.test.ts`

  Result:
  - `8 tests passed`

  ## Dependencies

  - No new dependencies
  - No dependency upgrades included in this PR

  ## Documentation

  - No docs update included because this is a narrow bugfix with no new user-facing settings, env vars, or public interfaces

  ## Additional Information

  Files changed:
  - `src/lib/utils/marked/katex-extension.ts`
  - `src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte`
  - `src/lib/utils/marked/katex-extension.test.ts`
 
### Screenshots or Videos

Before fix:
<img width="1230" height="1226" alt="Screenshot 2026-04-09 003501" src="https://github.com/user-attachments/assets/6cbcb10a-866d-404f-8e22-54c2d3d110ee" />
<img width="933" height="599" alt="Screenshot 2026-04-09 003520" src="https://github.com/user-attachments/assets/6e01dd04-f7c9-4b5e-9e62-21fd7bcef353" />
<img width="853" height="1140" alt="Screenshot 2026-04-09 010129" src="https://github.com/user-attachments/assets/5dabf15e-209b-42f5-a8b5-dbaa2e9f1663" />

After fix:
<img width="1235" height="1160" alt="Screenshot 2026-04-09 003401" src="https://github.com/user-attachments/assets/07a31894-ccf3-4ff1-8154-26324c6bc92e" />
<img width="873" height="507" alt="Screenshot 2026-04-09 003420" src="https://github.com/user-attachments/assets/86a12e72-d5e7-4864-a887-40cd3c50263b" />
<img width="1030" height="787" alt="Screenshot 2026-04-09 010211" src="https://github.com/user-attachments/assets/86cc930e-e9d8-42c6-a904-cfc5ab0518ed" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
