### PR TITLE
fix: handle ChatGPT exports containing folder/project metadata entries

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -677,7 +677,9 @@ export const calculateSHA256 = async (file) => {
 
 export const getImportOrigin = (_chats) => {
 	// Check what external service chat imports are from
-	if ('mapping' in _chats[0]) {
+	// ChatGPT exports may include folder/project entries without 'mapping',
+	// so check all items rather than only _chats[0].
+	if (_chats.some((chat) => chat != null && typeof chat === 'object' && 'mapping' in chat)) {
 		return 'openai';
 	}
 	return 'webui';
@@ -800,6 +802,11 @@ export const convertOpenAIChats = (_chats) => {
 	const chats = [];
 	let failed = 0;
 	for (const convo of _chats) {
+		// Skip non-conversation entries (e.g. folder/project metadata)
+		if (!convo['mapping']) {
+			continue;
+		}
+
 		const chat = convertOpenAIMessages(convo);
 
 		if (validateChat(chat)) {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Changelog:** Included
- [ ] **Documentation:** No user-facing docs needed (existing import flow, no new behavior)
- [x] **Dependencies:** None
- [x] **Testing:** Manually verified the logic against the reported scenario
- [x] **Agentic AI Code:** Reviewed and manually tested
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** No new settings or architectural changes
- [x] **Git Hygiene:** Single atomic commit on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

ChatGPT recently started including folder and project metadata entries in `conversations.json` exports. These entries lack a `mapping` key. When a folder entry appeared first in the array, `getImportOrigin()` checked only `_chats[0]`, misidentified the file as `webui` format, and `convertOpenAIChats()` was never called — resulting in "Imported 0 Chats".

### Fixed

- `getImportOrigin()`: check if *any* item has a `mapping` key (via `.some()`), not just `_chats[0]`
- `convertOpenAIChats()`: skip entries without `mapping` before attempting conversion, so folder/project metadata doesn't cause failures

### Before

Importing a ChatGPT export that starts with a folder entry:
```
Imported 0 Chats  (green success toast, but nothing imported)
```

### After

Same file imports correctly — folder/project entries are skipped, all conversations are imported.

---

### Additional Information

- Fixes #23505
- The root cause is that ChatGPT exports now contain entries like `{ "id": "...", "title": "My Folder", "type": "folder", ... }` alongside conversation entries. These lack the `mapping` key that conversations have.
- Two prior PRs (#23524, #23525) identified the same root cause but were closed due to targeting `main` instead of `dev` and missing CLA.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.