### PR TITLE
feat: add support for custom SSO/OAuth providers

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -559,6 +559,28 @@ FEISHU_REDIRECT_URI = PersistentConfig(
     os.environ.get('FEISHU_REDIRECT_URI', ''),
 )
 
+####################################
+# Custom OAuth Providers
+####################################
+
+_custom_oauth_providers_env = []
+try:
+    _custom_oauth_providers_env = json.loads(
+        os.environ.get('CUSTOM_OAUTH_PROVIDERS_CONFIG', '[]')
+    )
+    if not isinstance(_custom_oauth_providers_env, list):
+        log.warning('CUSTOM_OAUTH_PROVIDERS_CONFIG must be a JSON array, ignoring')
+        _custom_oauth_providers_env = []
+except (json.JSONDecodeError, TypeError):
+    log.warning('CUSTOM_OAUTH_PROVIDERS_CONFIG is not valid JSON, ignoring')
+    _custom_oauth_providers_env = []
+
+CUSTOM_OAUTH_PROVIDERS_CONFIG = PersistentConfig(
+    'CUSTOM_OAUTH_PROVIDERS_CONFIG',
+    'oauth.custom_providers',
+    _custom_oauth_providers_env,
+)
+
 ENABLE_OAUTH_ROLE_MANAGEMENT = PersistentConfig(
     'ENABLE_OAUTH_ROLE_MANAGEMENT',
     'oauth.enable_role_mapping',
@@ -667,6 +689,65 @@ if _oauth_authorize_params:
         log.warning('OAUTH_AUTHORIZE_PARAMS is not valid JSON, ignoring')
 
 
+BUILTIN_OAUTH_PROVIDER_SLUGS = frozenset(
+    {'google', 'microsoft', 'github', 'oidc', 'feishu'}
+)
+
+import re
+
+_CUSTOM_PROVIDER_SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$')
+
+
+def _is_valid_custom_slug(slug: str) -> bool:
+    return (
+        isinstance(slug, str)
+        and 2 <= len(slug) <= 50
+        and bool(_CUSTOM_PROVIDER_SLUG_RE.match(slug))
+        and slug not in BUILTIN_OAUTH_PROVIDER_SLUGS
+    )
+
+
+def _build_custom_provider_register(cfg: dict):
+    """Build an Authlib OAuth register function from a custom provider config dict."""
+    slug = cfg['slug']
+
+    def _register(oauth: OAuth):
+        client_kwargs = {
+            'scope': cfg.get('scope', 'openid email profile'),
+        }
+        if cfg.get('token_endpoint_auth_method'):
+            client_kwargs['token_endpoint_auth_method'] = cfg['token_endpoint_auth_method']
+        if cfg.get('timeout'):
+            client_kwargs['timeout'] = int(cfg['timeout'])
+        if cfg.get('code_challenge_method') == 'S256':
+            client_kwargs['code_challenge_method'] = 'S256'
+
+        kwargs = {
+            'name': slug,
+            'client_id': cfg['client_id'],
+            'client_secret': cfg.get('client_secret', ''),
+            'client_kwargs': client_kwargs,
+        }
+        if cfg.get('server_metadata_url'):
+            kwargs['server_metadata_url'] = cfg['server_metadata_url']
+        if cfg.get('authorize_url'):
+            kwargs['authorize_url'] = cfg['authorize_url']
+        if cfg.get('access_token_url'):
+            kwargs['access_token_url'] = cfg['access_token_url']
+        if cfg.get('userinfo_endpoint'):
+            kwargs['userinfo_endpoint'] = cfg['userinfo_endpoint']
+        if cfg.get('api_base_url'):
+            kwargs['api_base_url'] = cfg['api_base_url']
+        if cfg.get('redirect_uri'):
+            kwargs['redirect_uri'] = cfg['redirect_uri']
+        if cfg.get('authorize_params') and isinstance(cfg['authorize_params'], dict):
+            kwargs['authorize_params'] = cfg['authorize_params']
+
+        return oauth.register(**kwargs)
+
+    return _register
+
+
 def load_oauth_providers():
     OAUTH_PROVIDERS.clear()
     if GOOGLE_CLIENT_ID.value and GOOGLE_CLIENT_SECRET.value:
@@ -687,7 +768,9 @@ def load_oauth_providers():
             return client
 
         OAUTH_PROVIDERS['google'] = {
+            'name': 'Google',
             'register': google_oauth_register,
+            'provider_type': 'google',
         }
 
     if MICROSOFT_CLIENT_ID.value and MICROSOFT_CLIENT_SECRET.value and MICROSOFT_CLIENT_TENANT_ID.value:
@@ -707,8 +790,10 @@ def load_oauth_providers():
             return client
 
         OAUTH_PROVIDERS['microsoft'] = {
+            'name': 'Microsoft',
             'picture_url': MICROSOFT_CLIENT_PICTURE_URL.value,
             'register': microsoft_oauth_register,
+            'provider_type': 'microsoft',
         }
 
     if GITHUB_CLIENT_ID.value and GITHUB_CLIENT_SECRET.value:
@@ -731,8 +816,10 @@ def load_oauth_providers():
             return client
 
         OAUTH_PROVIDERS['github'] = {
+            'name': 'GitHub',
             'register': github_oauth_register,
             'sub_claim': 'id',
+            'provider_type': 'github',
         }
 
     if (
@@ -773,6 +860,7 @@ def load_oauth_providers():
         OAUTH_PROVIDERS['oidc'] = {
             'name': OAUTH_PROVIDER_NAME.value,
             'register': oidc_oauth_register,
+            'provider_type': 'oidc',
         }
 
     if FEISHU_CLIENT_ID.value and FEISHU_CLIENT_SECRET.value:
@@ -795,9 +883,54 @@ def load_oauth_providers():
             return client
 
         OAUTH_PROVIDERS['feishu'] = {
+            'name': 'Feishu',
             'register': feishu_oauth_register,
-            'sub_claim': 'user_id',
+            'sub_claim': 'open_id',
+            'provider_type': 'feishu',
         }
+
+    # Load custom OAuth providers
+    custom_providers = CUSTOM_OAUTH_PROVIDERS_CONFIG.value
+    if isinstance(custom_providers, list):
+        for provider_cfg in custom_providers:
+            if not isinstance(provider_cfg, dict):
+                continue
+            if not provider_cfg.get('enabled', True):
+                continue
+            slug = provider_cfg.get('slug', '')
+            if not _is_valid_custom_slug(slug):
+                log.warning(
+                    f"Skipping custom OAuth provider with invalid slug: '{slug}'"
+                )
+                continue
+            if slug in OAUTH_PROVIDERS:
+                log.warning(
+                    f"Skipping custom OAuth provider '{slug}': duplicate slug"
+                )
+                continue
+            if not provider_cfg.get('client_id'):
+                log.warning(
+                    f"Skipping custom OAuth provider '{slug}': missing client_id"
+                )
+                continue
+            try:
+                register_fn = _build_custom_provider_register(provider_cfg)
+                OAUTH_PROVIDERS[slug] = {
+                    'name': provider_cfg.get('display_name', slug),
+                    'register': register_fn,
+                    'redirect_uri': provider_cfg.get('redirect_uri', ''),
+                    'sub_claim': provider_cfg.get('sub_claim'),
+                    'icon_url': provider_cfg.get('icon_url', ''),
+                    'provider_type': provider_cfg.get('provider_type', 'custom'),
+                    'is_custom': True,
+                    'email_claim': provider_cfg.get('email_claim'),
+                    'username_claim': provider_cfg.get('username_claim'),
+                    'picture_claim': provider_cfg.get('picture_claim'),
+                    'email_fallback': provider_cfg.get('email_fallback', False),
+                }
+                log.info(f"Loaded custom OAuth provider: {slug}")
+            except Exception as e:
+                log.error(f"Failed to load custom OAuth provider '{slug}': {e}")
 
     configured_providers = []
     if GOOGLE_CLIENT_ID.value:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -440,6 +440,7 @@ from open_webui.config import (
     CORS_ALLOW_ORIGIN,
     DEFAULT_LOCALE,
     OAUTH_PROVIDERS,
+    CUSTOM_OAUTH_PROVIDERS_CONFIG,
     WEBUI_URL,
     RESPONSE_WATERMARK,
     # Admin
@@ -908,6 +909,8 @@ app.state.config.ENABLE_OAUTH_ROLE_MANAGEMENT = ENABLE_OAUTH_ROLE_MANAGEMENT
 app.state.config.OAUTH_ROLES_CLAIM = OAUTH_ROLES_CLAIM
 app.state.config.OAUTH_ALLOWED_ROLES = OAUTH_ALLOWED_ROLES
 app.state.config.OAUTH_ADMIN_ROLES = OAUTH_ADMIN_ROLES
+
+app.state.config.CUSTOM_OAUTH_PROVIDERS_CONFIG = CUSTOM_OAUTH_PROVIDERS_CONFIG
 
 app.state.config.ENABLE_LDAP = ENABLE_LDAP
 app.state.config.LDAP_SERVER_LABEL = LDAP_SERVER_LABEL
@@ -2075,7 +2078,17 @@ async def get_app_config(request: Request):
         'name': app.state.WEBUI_NAME,
         'version': VERSION,
         'default_locale': str(DEFAULT_LOCALE),
-        'oauth': {'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()}},
+        'oauth': {
+            'providers': {
+                name: {
+                    'name': config.get('name', name),
+                    'icon_url': config.get('icon_url', ''),
+                    'is_custom': config.get('is_custom', False),
+                    'provider_type': config.get('provider_type', name),
+                }
+                for name, config in OAUTH_PROVIDERS.items()
+            }
+        },
         'features': {
             'auth': WEBUI_AUTH,
             'auth_trusted_header': bool(app.state.AUTH_TRUSTED_EMAIL_HEADER),

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -53,6 +53,9 @@ from open_webui.config import (
     ENABLE_PASSWORD_AUTH,
     OAUTH_PROVIDERS,
     OAUTH_MERGE_ACCOUNTS_BY_EMAIL,
+    CUSTOM_OAUTH_PROVIDERS_CONFIG,
+    _is_valid_custom_slug,
+    load_oauth_providers,
 )
 from pydantic import BaseModel
 
@@ -1145,6 +1148,136 @@ class LdapConfigForm(BaseModel):
 async def update_ldap_config(request: Request, form_data: LdapConfigForm, user=Depends(get_admin_user)):
     request.app.state.config.ENABLE_LDAP = form_data.enable_ldap
     return {'ENABLE_LDAP': request.app.state.config.ENABLE_LDAP}
+
+
+############################
+# Custom OAuth Providers
+############################
+
+class CustomOAuthProviderForm(BaseModel):
+    slug: str
+    display_name: str
+    icon_url: Optional[str] = None
+    provider_type: str = 'custom'
+    client_id: str
+    client_secret: str = ''
+    server_metadata_url: Optional[str] = None
+    authorize_url: Optional[str] = None
+    access_token_url: Optional[str] = None
+    userinfo_endpoint: Optional[str] = None
+    api_base_url: Optional[str] = None
+    scope: str = 'openid email profile'
+    redirect_uri: Optional[str] = None
+    timeout: Optional[int] = None
+    sub_claim: Optional[str] = None
+    email_claim: Optional[str] = None
+    username_claim: Optional[str] = None
+    picture_claim: Optional[str] = None
+    token_endpoint_auth_method: Optional[str] = None
+    code_challenge_method: Optional[str] = None
+    authorize_params: Optional[dict] = None
+    email_fallback: bool = False
+    sort_order: int = 0
+    enabled: bool = True
+
+
+def _validate_slug(slug: str):
+    if not _is_valid_custom_slug(slug):
+        raise HTTPException(
+            400,
+            detail='Slug must be 2-50 characters, lowercase alphanumeric and hyphens, '
+            'start/end with alphanumeric, and not conflict with built-in providers',
+        )
+
+
+def _get_providers_list() -> list:
+    """Get custom providers list, filtering out any non-dict entries."""
+    raw = CUSTOM_OAUTH_PROVIDERS_CONFIG.value or []
+    return [p for p in raw if isinstance(p, dict)]
+
+
+def _reload_oauth(request: Request):
+    """Reload OAuth providers and re-initialize the OAuth manager."""
+    load_oauth_providers()
+    if hasattr(request.app.state, 'oauth_manager') and request.app.state.oauth_manager:
+        request.app.state.oauth_manager.reload_providers()
+
+
+@router.get('/admin/config/oauth/custom')
+async def get_custom_oauth_providers(request: Request, user=Depends(get_admin_user)):
+    providers = _get_providers_list()
+    # Redact client_secret
+    return [
+        {**p, 'client_secret': '***' if p.get('client_secret') else ''}
+        for p in providers
+    ]
+
+
+@router.post('/admin/config/oauth/custom')
+async def create_custom_oauth_provider(
+    request: Request,
+    form_data: CustomOAuthProviderForm,
+    user=Depends(get_admin_user),
+):
+    _validate_slug(form_data.slug)
+    providers = _get_providers_list()
+
+    # Check for duplicate slug
+    if any(p.get('slug') == form_data.slug for p in providers):
+        raise HTTPException(400, detail=f"Provider with slug '{form_data.slug}' already exists")
+
+    providers.append(form_data.model_dump())
+    request.app.state.config.CUSTOM_OAUTH_PROVIDERS_CONFIG = providers
+    _reload_oauth(request)
+
+    return {'status': True, 'slug': form_data.slug}
+
+
+@router.post('/admin/config/oauth/custom/{slug}')
+async def update_custom_oauth_provider(
+    slug: str,
+    request: Request,
+    form_data: CustomOAuthProviderForm,
+    user=Depends(get_admin_user),
+):
+    providers = _get_providers_list()
+    idx = next((i for i, p in enumerate(providers) if p.get('slug') == slug), None)
+    if idx is None:
+        raise HTTPException(404, detail=f"Provider '{slug}' not found")
+
+    # If slug changed, validate new slug
+    if form_data.slug != slug:
+        _validate_slug(form_data.slug)
+        if any(p.get('slug') == form_data.slug for p in providers):
+            raise HTTPException(400, detail=f"Provider with slug '{form_data.slug}' already exists")
+
+    new_data = form_data.model_dump()
+    # Preserve existing client_secret if masked value submitted
+    if new_data.get('client_secret') == '***':
+        new_data['client_secret'] = providers[idx].get('client_secret', '')
+
+    providers[idx] = new_data
+    request.app.state.config.CUSTOM_OAUTH_PROVIDERS_CONFIG = providers
+    _reload_oauth(request)
+
+    return {'status': True, 'slug': form_data.slug}
+
+
+@router.delete('/admin/config/oauth/custom/{slug}')
+async def delete_custom_oauth_provider(
+    slug: str,
+    request: Request,
+    user=Depends(get_admin_user),
+):
+    providers = _get_providers_list()
+    new_providers = [p for p in providers if p.get('slug') != slug]
+    if len(new_providers) == len(providers):
+        raise HTTPException(404, detail=f"Provider '{slug}' not found")
+
+    request.app.state.config.CUSTOM_OAUTH_PROVIDERS_CONFIG = new_providers
+    _reload_oauth(request)
+
+    return {'status': True}
 
 
 ############################

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -938,6 +938,19 @@ class OAuthManager:
             client = provider_config['register'](self.oauth)
             self._clients[name] = client
 
+    def reload_providers(self):
+        """Re-initialize OAuth clients from the current OAUTH_PROVIDERS dict."""
+        self._clients.clear()
+        self.oauth = OAuth()
+        for name, provider_config in OAUTH_PROVIDERS.items():
+            if 'register' not in provider_config:
+                continue
+            try:
+                client = provider_config['register'](self.oauth)
+                self._clients[name] = client
+            except Exception as e:
+                log.error(f'Failed to reload OAuth provider {name}: {e}')
+
     def get_client(self, provider_name):
         if provider_name not in self._clients:
             self._clients[provider_name] = self.oauth.create_client(provider_name)
@@ -1404,10 +1417,14 @@ class OAuthManager:
             # Preserve extra claims from the ID token (e.g. roles, groups for
             # Microsoft Entra ID) before the userinfo endpoint possibly overwrites them.
             id_token_claims = dict(user_data) if user_data else {}
+            provider_config = OAUTH_PROVIDERS.get(provider, {})
+            provider_type = provider_config.get('provider_type', provider)
+            _effective_email_claim = provider_config.get('email_claim') or auth_manager_config.OAUTH_EMAIL_CLAIM
+            _effective_username_claim = provider_config.get('username_claim') or auth_manager_config.OAUTH_USERNAME_CLAIM
             if (
                 (not user_data)
-                or (auth_manager_config.OAUTH_EMAIL_CLAIM not in user_data)
-                or (auth_manager_config.OAUTH_USERNAME_CLAIM not in user_data)
+                or (_effective_email_claim not in user_data)
+                or (_effective_username_claim not in user_data)
             ):
                 user_data: UserInfo = await client.userinfo(token=token)
                 # Merge back ID token claims that the userinfo endpoint doesn't
@@ -1416,18 +1433,22 @@ class OAuthManager:
                     for key, value in id_token_claims.items():
                         if key not in user_data:
                             user_data[key] = value
-            if provider == 'feishu' and isinstance(user_data, dict) and 'data' in user_data:
+            if provider_type == 'feishu' and isinstance(user_data, dict) and 'data' in user_data:
                 user_data = user_data['data']
             if not user_data:
                 log.warning(f'OAuth callback failed, user data is missing: {token}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
 
-            # Extract the "sub" claim, using custom claim if configured
-            if auth_manager_config.OAUTH_SUB_CLAIM:
-                sub = user_data.get(auth_manager_config.OAUTH_SUB_CLAIM)
+            # Extract the "sub" claim.
+            # For custom providers: per-provider sub_claim takes priority.
+            # For built-in providers: global OAUTH_SUB_CLAIM takes priority (backward compatible).
+            if provider_config.get('is_custom') and provider_config.get('sub_claim'):
+                sub_claim = provider_config['sub_claim']
+            elif auth_manager_config.OAUTH_SUB_CLAIM:
+                sub_claim = auth_manager_config.OAUTH_SUB_CLAIM
             else:
-                # Fallback to the default sub claim if not configured
-                sub = user_data.get(OAUTH_PROVIDERS[provider].get('sub_claim', 'sub'))
+                sub_claim = provider_config.get('sub_claim') or 'sub'
+            sub = user_data.get(sub_claim)
             if not sub:
                 log.warning(f'OAuth callback failed, sub is missing: {user_data}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
@@ -1437,12 +1458,14 @@ class OAuthManager:
                 'sub': sub,
             }
 
-            # Email extraction
-            email_claim = auth_manager_config.OAUTH_EMAIL_CLAIM
+            # Email extraction: per-provider override > global config
+            email_claim = provider_config.get('email_claim') or auth_manager_config.OAUTH_EMAIL_CLAIM
             email = user_data.get(email_claim, '')
             # We currently mandate that email addresses are provided
             if not email:
-                # If the provider is GitHub,and public email is not provided, we can use the access token to fetch the user's email
+                # If the provider is the built-in GitHub provider, and public email is not provided,
+                # we can use the access token to fetch the user's email from GitHub API.
+                # Only allow this for the built-in 'github' provider to avoid leaking tokens to GitHub.
                 if provider == 'github':
                     try:
                         access_token = token.get('access_token')
@@ -1471,7 +1494,7 @@ class OAuthManager:
                     except Exception as e:
                         log.warning(f'Error fetching GitHub email: {e}')
                         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
-                elif ENABLE_OAUTH_EMAIL_FALLBACK:
+                elif ENABLE_OAUTH_EMAIL_FALLBACK or provider_config.get('email_fallback'):
                     email = f'{provider}@{sub}.local'
                 else:
                     log.warning(f'OAuth callback failed, email is missing: {user_data}')
@@ -1506,7 +1529,7 @@ class OAuthManager:
                     user.role = determined_role
 
                 if auth_manager_config.OAUTH_UPDATE_NAME_ON_LOGIN:
-                    username_claim = auth_manager_config.OAUTH_USERNAME_CLAIM
+                    username_claim = provider_config.get('username_claim') or auth_manager_config.OAUTH_USERNAME_CLAIM
                     if username_claim:
                         new_name = user_data.get(username_claim)
                         if new_name and new_name != user.name:
@@ -1515,7 +1538,7 @@ class OAuthManager:
                             log.debug(f'Updated name for user {user.email}')
 
                 if auth_manager_config.OAUTH_UPDATE_EMAIL_ON_LOGIN:
-                    email_claim = auth_manager_config.OAUTH_EMAIL_CLAIM
+                    email_claim = provider_config.get('email_claim') or auth_manager_config.OAUTH_EMAIL_CLAIM
                     if email_claim:
                         new_email = user_data.get(email_claim)
                         if new_email and new_email.lower() != user.email.lower():
@@ -1531,7 +1554,7 @@ class OAuthManager:
 
                 # Update profile picture if enabled and different from current
                 if auth_manager_config.OAUTH_UPDATE_PICTURE_ON_LOGIN:
-                    picture_claim = auth_manager_config.OAUTH_PICTURE_CLAIM
+                    picture_claim = provider_config.get('picture_claim') or auth_manager_config.OAUTH_PICTURE_CLAIM
                     if picture_claim:
                         new_picture_url = user_data.get(
                             picture_claim,
@@ -1551,16 +1574,16 @@ class OAuthManager:
                     if existing_user:
                         raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
-                    picture_claim = auth_manager_config.OAUTH_PICTURE_CLAIM
+                    picture_claim = provider_config.get('picture_claim') or auth_manager_config.OAUTH_PICTURE_CLAIM
                     if picture_claim:
                         picture_url = user_data.get(
                             picture_claim,
-                            OAUTH_PROVIDERS[provider].get('picture_url', ''),
+                            provider_config.get('picture_url', ''),
                         )
                         picture_url = await self._process_picture_url(picture_url, token.get('access_token'))
                     else:
                         picture_url = '/user.png'
-                    username_claim = auth_manager_config.OAUTH_USERNAME_CLAIM
+                    username_claim = provider_config.get('username_claim') or auth_manager_config.OAUTH_USERNAME_CLAIM
 
                     name = user_data.get(username_claim)
                     if not name:

--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -712,3 +712,103 @@ export const deleteAPIKey = async (token: string) => {
 	}
 	return res;
 };
+
+// Custom OAuth Providers
+
+export const getCustomOAuthProviders = async (token: string) => {
+	let error = null;
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/admin/config/oauth/custom`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const createCustomOAuthProvider = async (token: string, data: object) => {
+	let error = null;
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/admin/config/oauth/custom`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(data)
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const updateCustomOAuthProvider = async (token: string, slug: string, data: object) => {
+	let error = null;
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/admin/config/oauth/custom/${slug}`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(data)
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const deleteCustomOAuthProvider = async (token: string, slug: string) => {
+	let error = null;
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/admin/config/oauth/custom/${slug}`, {
+		method: 'DELETE',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+	if (error) {
+		throw error;
+	}
+	return res;
+};

--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -91,7 +91,10 @@
 				'reverse proxy',
 				'webhook',
 				'community',
-				'channels'
+				'channels',
+				'sso',
+				'oauth',
+				'custom provider'
 			]
 		},
 		{

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -9,7 +9,11 @@
 		getLdapServer,
 		updateAdminConfig,
 		updateLdapConfig,
-		updateLdapServer
+		updateLdapServer,
+		getCustomOAuthProviders,
+		createCustomOAuthProvider,
+		updateCustomOAuthProvider,
+		deleteCustomOAuthProvider
 	} from '$lib/apis/auths';
 	import { getBanners, setBanners } from '$lib/apis/configs';
 	import { getGroups } from '$lib/apis/groups';
@@ -40,6 +44,100 @@
 	let groups = [];
 
 	let banners: Banner[] = [];
+
+	// Custom OAuth Providers
+	let customOAuthProviders: any[] = [];
+	let showCustomOAuthForm = false;
+	let editingProvider: any = null;
+	let customOAuthForm = {
+		slug: '',
+		display_name: '',
+		icon_url: '',
+		provider_type: 'custom',
+		client_id: '',
+		client_secret: '',
+		server_metadata_url: '',
+		authorize_url: '',
+		access_token_url: '',
+		userinfo_endpoint: '',
+		scope: 'openid email profile',
+		redirect_uri: '',
+		sub_claim: '',
+		email_claim: '',
+		username_claim: '',
+		picture_claim: '',
+		token_endpoint_auth_method: '',
+		code_challenge_method: '',
+		email_fallback: false,
+		sort_order: 0,
+		enabled: true
+	};
+
+	const resetCustomOAuthForm = () => {
+		customOAuthForm = {
+			slug: '',
+			display_name: '',
+			icon_url: '',
+			provider_type: 'custom',
+			client_id: '',
+			client_secret: '',
+			server_metadata_url: '',
+			authorize_url: '',
+			access_token_url: '',
+			userinfo_endpoint: '',
+			scope: 'openid email profile',
+			redirect_uri: '',
+			sub_claim: '',
+			email_claim: '',
+			username_claim: '',
+			picture_claim: '',
+			token_endpoint_auth_method: '',
+			code_challenge_method: '',
+			email_fallback: false,
+			sort_order: 0,
+			enabled: true
+		};
+		editingProvider = null;
+		showCustomOAuthForm = false;
+	};
+
+	const loadCustomOAuthProviders = async () => {
+		customOAuthProviders = (await getCustomOAuthProviders(localStorage.token)) ?? [];
+	};
+
+	const saveCustomOAuthProvider = async () => {
+		try {
+			if (editingProvider) {
+				await updateCustomOAuthProvider(localStorage.token, editingProvider, customOAuthForm);
+				toast.success($i18n.t('Provider updated'));
+			} else {
+				await createCustomOAuthProvider(localStorage.token, customOAuthForm);
+				toast.success($i18n.t('Provider created'));
+			}
+			await loadCustomOAuthProviders();
+			await config.set(await getBackendConfig());
+			resetCustomOAuthForm();
+		} catch (error) {
+			toast.error(`${error}`);
+		}
+	};
+
+	const removeCustomOAuthProvider = async (slug: string) => {
+		try {
+			await deleteCustomOAuthProvider(localStorage.token, slug);
+			toast.success($i18n.t('Provider deleted'));
+			await loadCustomOAuthProviders();
+			await config.set(await getBackendConfig());
+		} catch (error) {
+			toast.error(`${error}`);
+		}
+	};
+
+	const editProvider = (provider: any) => {
+		editingProvider = provider.slug;
+		customOAuthForm = { ...provider };
+		showCustomOAuthForm = true;
+	};
 
 	// LDAP
 	let ENABLE_LDAP = false;
@@ -123,7 +221,8 @@
 			})(),
 			(async () => {
 				groups = await getGroups(localStorage.token);
-			})()
+			})(),
+			loadCustomOAuthProviders()
 		]);
 
 		const ldapConfig = await getLdapConfig(localStorage.token);
@@ -686,6 +785,269 @@
 								</div>
 							{/if}
 						</div>
+					</div>
+				</div>
+
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Custom SSO Providers')}</div>
+
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					<div class="space-y-3">
+						{#if customOAuthProviders.length > 0}
+							<div class="flex flex-col gap-2">
+								{#each customOAuthProviders as provider}
+									<div
+										class="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg"
+									>
+										<div class="flex items-center gap-3">
+											<div
+												class="w-2 h-2 rounded-full {provider.enabled
+													? 'bg-green-500'
+													: 'bg-gray-400'}"
+											></div>
+											<div>
+												<div class="text-sm font-medium">
+													{provider.display_name || provider.slug}
+												</div>
+												<div class="text-xs text-gray-500">
+													{provider.slug} &middot; {provider.provider_type}
+												</div>
+											</div>
+										</div>
+										<div class="flex gap-2">
+											<button
+												class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+												type="button"
+												on:click={() => editProvider(provider)}
+											>
+												{$i18n.t('Edit')}
+											</button>
+											<button
+												class="text-xs text-red-500 hover:text-red-700"
+												type="button"
+												on:click={() => removeCustomOAuthProvider(provider.slug)}
+											>
+												{$i18n.t('Delete')}
+											</button>
+										</div>
+									</div>
+								{/each}
+							</div>
+						{/if}
+
+						{#if showCustomOAuthForm}
+							<div class="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-3">
+								<div class="text-sm font-medium">
+									{editingProvider
+										? $i18n.t('Edit Provider')
+										: $i18n.t('Add Provider')}
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Slug')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="e.g. feishu-company-b"
+											bind:value={customOAuthForm.slug}
+											disabled={!!editingProvider}
+											required
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Display Name')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="e.g. Feishu Enterprise B"
+											bind:value={customOAuthForm.display_name}
+											required
+										/>
+									</div>
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Provider Type')}</div>
+										<select
+											class="w-full bg-transparent outline-hidden py-0.5"
+											bind:value={customOAuthForm.provider_type}
+										>
+											<option value="custom">Custom</option>
+											<option value="oidc">OIDC</option>
+											<option value="feishu">Feishu</option>
+											<option value="github">GitHub</option>
+										</select>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Scope')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="openid email profile"
+											bind:value={customOAuthForm.scope}
+										/>
+									</div>
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Client ID</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="Client ID"
+											bind:value={customOAuthForm.client_id}
+											required
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Client Secret</div>
+										<SensitiveInput
+											placeholder="Client Secret"
+											bind:value={customOAuthForm.client_secret}
+										/>
+									</div>
+								</div>
+
+								<div class="w-full">
+									<div class="text-xs font-medium mb-1">
+										{$i18n.t('OIDC Discovery URL')}
+										<span class="text-gray-400 font-normal">({$i18n.t('or set endpoints manually below')})</span>
+									</div>
+									<input
+										class="w-full bg-transparent outline-hidden py-0.5"
+										placeholder="https://example.com/.well-known/openid-configuration"
+										bind:value={customOAuthForm.server_metadata_url}
+									/>
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Authorize URL')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="https://..."
+											bind:value={customOAuthForm.authorize_url}
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Token URL')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="https://..."
+											bind:value={customOAuthForm.access_token_url}
+										/>
+									</div>
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Userinfo URL')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="https://..."
+											bind:value={customOAuthForm.userinfo_endpoint}
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">{$i18n.t('Redirect URI')}</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="{$i18n.t('Leave empty for auto')}"
+											bind:value={customOAuthForm.redirect_uri}
+										/>
+									</div>
+								</div>
+
+								<div class="text-xs font-medium mt-2 text-gray-500">{$i18n.t('Claim Mappings')}</div>
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Sub Claim</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="sub"
+											bind:value={customOAuthForm.sub_claim}
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Email Claim</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="email"
+											bind:value={customOAuthForm.email_claim}
+										/>
+									</div>
+								</div>
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Username Claim</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="name"
+											bind:value={customOAuthForm.username_claim}
+										/>
+									</div>
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Picture Claim</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="picture"
+											bind:value={customOAuthForm.picture_claim}
+										/>
+									</div>
+								</div>
+
+								<div class="flex w-full gap-2">
+									<div class="w-full">
+										<div class="text-xs font-medium mb-1">Icon URL</div>
+										<input
+											class="w-full bg-transparent outline-hidden py-0.5"
+											placeholder="{$i18n.t('Optional custom icon URL')}"
+											bind:value={customOAuthForm.icon_url}
+										/>
+									</div>
+								</div>
+
+								<div class="flex items-center justify-between">
+									<div class="flex items-center gap-4">
+										<label class="flex items-center gap-2 text-xs">
+											<input type="checkbox" bind:checked={customOAuthForm.enabled} />
+											{$i18n.t('Enabled')}
+										</label>
+										<label class="flex items-center gap-2 text-xs">
+											<input type="checkbox" bind:checked={customOAuthForm.email_fallback} />
+											{$i18n.t('Email Fallback')}
+										</label>
+									</div>
+									<div class="flex gap-2">
+										<button
+											class="text-xs px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+											type="button"
+											on:click={resetCustomOAuthForm}
+										>
+											{$i18n.t('Cancel')}
+										</button>
+										<button
+											class="text-xs px-3 py-1.5 rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+											type="button"
+											on:click={saveCustomOAuthProvider}
+										>
+											{editingProvider ? $i18n.t('Update') : $i18n.t('Save')}
+										</button>
+									</div>
+								</div>
+							</div>
+						{:else}
+							<button
+								class="text-xs px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+								type="button"
+								on:click={() => {
+									resetCustomOAuthForm();
+									showCustomOAuthForm = true;
+								}}
+							>
+								+ {$i18n.t('Add Provider')}
+							</button>
+						{/if}
 					</div>
 				</div>
 

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -429,128 +429,94 @@
 									<hr class="w-32 h-px my-4 border-0 dark:bg-gray-100/10 bg-gray-700/10" />
 								</div>
 								<div class="flex flex-col space-y-2">
-									{#if $config?.oauth?.providers?.google}
+									{#each Object.entries($config?.oauth?.providers ?? {}) as [providerKey, providerInfo]}
 										<button
 											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/google/login`;
+												window.location.href = `${WEBUI_BASE_URL}/oauth/${providerKey}/login`;
 											}}
 										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 48 48"
-												class="size-6 mr-3"
-												aria-hidden="true"
-											>
-												<path
-													fill="#EA4335"
-													d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
-												/><path
-													fill="#4285F4"
-													d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
-												/><path
-													fill="#FBBC05"
-													d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
-												/><path
-													fill="#34A853"
-													d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
-												/><path fill="none" d="M0 0h48v48H0z" />
-											</svg>
-											<span>{$i18n.t('Continue with {{provider}}', { provider: 'Google' })}</span>
-										</button>
-									{/if}
-									{#if $config?.oauth?.providers?.microsoft}
-										<button
-											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
-											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/microsoft/login`;
-											}}
-										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 21 21"
-												class="size-6 mr-3"
-												aria-hidden="true"
-											>
-												<rect x="1" y="1" width="9" height="9" fill="#f25022" /><rect
-													x="1"
-													y="11"
-													width="9"
-													height="9"
-													fill="#00a4ef"
-												/><rect x="11" y="1" width="9" height="9" fill="#7fba00" /><rect
-													x="11"
-													y="11"
-													width="9"
-													height="9"
-													fill="#ffb900"
-												/>
-											</svg>
-											<span>{$i18n.t('Continue with {{provider}}', { provider: 'Microsoft' })}</span
-											>
-										</button>
-									{/if}
-									{#if $config?.oauth?.providers?.github}
-										<button
-											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
-											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/github/login`;
-											}}
-										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 24 24"
-												class="size-6 mr-3"
-												aria-hidden="true"
-											>
-												<path
-													fill="currentColor"
-													d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.92 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57C20.565 21.795 24 17.31 24 12c0-6.63-5.37-12-12-12z"
-												/>
-											</svg>
-											<span>{$i18n.t('Continue with {{provider}}', { provider: 'GitHub' })}</span>
-										</button>
-									{/if}
-									{#if $config?.oauth?.providers?.oidc}
-										<button
-											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
-											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/oidc/login`;
-											}}
-										>
-											<svg
-												xmlns="http://www.w3.org/2000/svg"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke-width="1.5"
-												stroke="currentColor"
-												class="size-6 mr-3"
-												aria-hidden="true"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
-												/>
-											</svg>
+											{#if providerKey === 'google'}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 48 48"
+													class="size-6 mr-3"
+													aria-hidden="true"
+												>
+													<path
+														fill="#EA4335"
+														d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+													/><path
+														fill="#4285F4"
+														d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+													/><path
+														fill="#FBBC05"
+														d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+													/><path
+														fill="#34A853"
+														d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+													/><path fill="none" d="M0 0h48v48H0z" />
+												</svg>
+											{:else if providerKey === 'microsoft'}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 21 21"
+													class="size-6 mr-3"
+													aria-hidden="true"
+												>
+													<rect x="1" y="1" width="9" height="9" fill="#f25022" /><rect
+														x="1"
+														y="11"
+														width="9"
+														height="9"
+														fill="#00a4ef"
+													/><rect x="11" y="1" width="9" height="9" fill="#7fba00" /><rect
+														x="11"
+														y="11"
+														width="9"
+														height="9"
+														fill="#ffb900"
+													/>
+												</svg>
+											{:else if providerKey === 'github'}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													class="size-6 mr-3"
+													aria-hidden="true"
+												>
+													<path
+														fill="currentColor"
+														d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.92 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57C20.565 21.795 24 17.31 24 12c0-6.63-5.37-12-12-12z"
+													/>
+												</svg>
+											{:else if providerInfo.icon_url}
+												<img src={providerInfo.icon_url} class="size-6 mr-3" alt="" />
+											{:else}
+												<svg
+													xmlns="http://www.w3.org/2000/svg"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke-width="1.5"
+													stroke="currentColor"
+													class="size-6 mr-3"
+													aria-hidden="true"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
+													/>
+												</svg>
+											{/if}
 
 											<span
 												>{$i18n.t('Continue with {{provider}}', {
-													provider: $config?.oauth?.providers?.oidc ?? 'SSO'
+													provider: providerInfo?.name ?? providerKey
 												})}</span
 											>
 										</button>
-									{/if}
-									{#if $config?.oauth?.providers?.feishu}
-										<button
-											class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
-											on:click={() => {
-												window.location.href = `${WEBUI_BASE_URL}/oauth/feishu/login`;
-											}}
-										>
-											<span>{$i18n.t('Continue with {{provider}}', { provider: 'Feishu' })}</span>
-										</button>
-									{/if}
+									{/each}
 								</div>
 							{/if}
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Discussion:** https://github.com/open-webui/open-webui/discussions/23536

- [x] **Target branch:** `dev`
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** Will add docs if PR is accepted.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested with real Feishu OAuth — built-in provider login, custom provider login, dual-provider display, per-provider claim overrides, Admin UI CRUD, slug validation, malformed env var graceful fallback.
- [x] **Agentic AI Code:** Human reviewed and manually tested with real Feishu OAuth flow.
- [x] **Code review:** Self-reviewed, also addressed automated code review findings.
- [x] **Design & Architecture:** Extends existing OAuth system — adds a section in existing General settings.
- [x] **Git Hygiene:** Single atomic commit on feature branch, rebased on `dev`.
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Description

Allow administrators to configure **multiple custom OAuth/SSO providers** at runtime via Admin UI or `CUSTOM_OAUTH_PROVIDERS_CONFIG` environment variable. This enables use cases like multiple Feishu enterprises, multiple OIDC providers, or any OAuth2-compatible provider — without code changes.

Related PRs #12945 and #18948 focus on Admin UI for existing single-instance OAuth config. This PR specifically addresses the **multiple providers of the same type** use case.

### Added

- `CUSTOM_OAUTH_PROVIDERS_CONFIG` PersistentConfig for dynamic custom OAuth provider storage (supports both env var JSON array and Admin UI)
- Admin CRUD API endpoints at `/api/v1/auths/admin/config/oauth/custom`
- "Custom SSO Providers" management section in Admin Settings > General
- Per-provider claim overrides: `sub_claim`, `email_claim`, `username_claim`, `picture_claim`, `email_fallback`
- `provider_type` field on all providers to generalize type-specific logic
- `reload_providers()` on OAuthManager for hot-reloading after config changes
- Dynamic OAuth login button rendering via `{#each}` loop

### Changed

- `/api/config` `oauth.providers` values from plain strings to objects `{name, icon_url, is_custom, provider_type}`
- Feishu data-unwrap logic generalized via `provider_type` instead of hardcoded provider name
- Built-in providers now include `name` and `provider_type` fields

### Fixed

- Feishu `sub_claim` from `user_id` to `open_id` to match actual Feishu v1 userinfo API response

### Security

- Client secrets redacted in admin API GET responses
- Slug validation prevents conflicts with built-in provider names
- GitHub email fetch restricted to built-in `github` provider only
- Malformed env var handled gracefully with fallback

### Breaking Changes

- **BREAKING CHANGE**: `/api/config` `oauth.providers` response format changed from `{key: name_string}` to `{key: {name, icon_url, is_custom, provider_type}}`. Only affects the bundled frontend (updated in this PR).

---

### Configuration Example

```bash
CUSTOM_OAUTH_PROVIDERS_CONFIG='[{
  "slug": "feishu-enterprise-b",
  "display_name": "Feishu Enterprise B",
  "provider_type": "feishu",
  "client_id": "cli_xxx",
  "client_secret": "xxx",
  "authorize_url": "https://accounts.feishu.cn/open-apis/authen/v1/authorize",
  "access_token_url": "https://open.feishu.cn/open-apis/authen/v2/oauth/token",
  "userinfo_endpoint": "https://open.feishu.cn/open-apis/authen/v1/user_info",
  "scope": "contact:user.base:readonly",
  "sub_claim": "open_id",
  "email_fallback": true,
  "enabled": true
}]'
```

No database migration needed.

### Testing Performed

1. Started Open WebUI locally with `FEISHU_CLIENT_ID` + `CUSTOM_OAUTH_PROVIDERS_CONFIG` (two Feishu providers)
2. Verified `/api/config` returns both providers in new object format
3. Login page displayed both "Feishu" and "飞书企业B" buttons
4. Built-in Feishu OAuth login: redirect → authorize → callback → user created successfully
5. Custom feishu-b OAuth: redirect → authorize → callback → correctly detected email conflict (same test account)
6. Unit tests: slug validation (11 cases pass), malformed JSON graceful fallback, provider reload add/remove

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.