### PR TITLE
fix: null-check file owner, timing-safe SCIM token, GCS nested paths

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -656,7 +656,7 @@ async def get_html_file_content_by_id(id: str, user=Depends(get_verified_user), 
         )
 
     file_user = Users.get_user_by_id(file.user_id, db=db)
-    if not file_user.role == 'admin':
+    if not file_user or file_user.role != 'admin':
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.NOT_FOUND,

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -5,6 +5,7 @@ Provides System for Cross-domain Identity Management endpoints for users and gro
 NOTE: This is an experimental implementation and may not fully comply with SCIM 2.0 standards, and is subject to change.
 """
 
+import hmac
 import logging
 import uuid
 import time
@@ -278,7 +279,7 @@ def get_scim_auth(request: Request, authorization: Optional[str] = Header(None))
         if hasattr(scim_token, 'value'):
             scim_token = scim_token.value
         log.debug(f'SCIM token configured: {bool(scim_token)}')
-        if not scim_token or token != scim_token:
+        if not scim_token or not hmac.compare_digest(token, scim_token):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail='Invalid SCIM token',

--- a/backend/open_webui/storage/provider.py
+++ b/backend/open_webui/storage/provider.py
@@ -233,7 +233,7 @@ class GCSStorageProvider(StorageProvider):
     def get_file(self, file_path: str) -> str:
         """Handles downloading of the file from GCS storage."""
         try:
-            filename = file_path.removeprefix('gs://').split('/')[1]
+            filename = file_path.removeprefix('gs://').split('/')[-1]
             local_file_path = f'{UPLOAD_DIR}/{filename}'
             blob = self.bucket.get_blob(filename)
             blob.download_to_filename(local_file_path)
@@ -245,7 +245,7 @@ class GCSStorageProvider(StorageProvider):
     def delete_file(self, file_path: str) -> None:
         """Handles deletion of the file from GCS storage."""
         try:
-            filename = file_path.removeprefix('gs://').split('/')[1]
+            filename = file_path.removeprefix('gs://').split('/')[-1]
             blob = self.bucket.get_blob(filename)
             blob.delete()
         except NotFound as e:


### PR DESCRIPTION
## Summary

Three independent backend bug fixes:

### 1. Server crash when file owner is deleted (`files.py`)
`Users.get_user_by_id()` returns `None` when the file owner has been deleted, but `.role` is accessed without a null check. Any authenticated user requesting that file gets a 500 Internal Server Error.

**Fix**: Add `not file_user or` guard before accessing `.role`.

### 2. SCIM token vulnerable to timing attack (`scim.py`)
The SCIM bearer token is compared with `!=`, which short-circuits on the first differing character. This allows brute-forcing the token by measuring response time. The codebase already uses `hmac.compare_digest` in `utils/auth.py` for similar purposes.

**Fix**: Replace `token != scim_token` with `not hmac.compare_digest(token, scim_token)`.

### 3. GCS provider breaks on nested paths (`provider.py`)
`get_file` and `delete_file` in the GCS provider use `split('/')[1]` to extract the filename, which returns the wrong segment for paths with subdirectories (e.g. `gs://bucket/subdir/file.txt` returns `subdir` instead of `file.txt`). The S3 provider correctly uses `split('/')[-1]`.

**Fix**: Change `[1]` to `[-1]` in both methods.

## Test Plan

- [ ] Access a file whose owner has been deleted (should return 403/404, not 500)
- [ ] SCIM token authentication still works correctly
- [ ] GCS file operations work with nested bucket paths