### PR TITLE
fix: null-check file owner, timing-safe SCIM token, GCS nested paths

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -656,7 +656,7 @@ async def get_html_file_content_by_id(id: str, user=Depends(get_verified_user), 
         )
 
     file_user = Users.get_user_by_id(file.user_id, db=db)
-    if not file_user.role == 'admin':
+    if not file_user or file_user.role != 'admin':
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.NOT_FOUND,

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -5,6 +5,7 @@ Provides System for Cross-domain Identity Management endpoints for users and gro
 NOTE: This is an experimental implementation and may not fully comply with SCIM 2.0 standards, and is subject to change.
 """
 
+import hmac
 import logging
 import uuid
 import time
@@ -278,7 +279,7 @@ def get_scim_auth(request: Request, authorization: Optional[str] = Header(None))
         if hasattr(scim_token, 'value'):
             scim_token = scim_token.value
         log.debug(f'SCIM token configured: {bool(scim_token)}')
-        if not scim_token or token != scim_token:
+        if not scim_token or not hmac.compare_digest(token, scim_token):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail='Invalid SCIM token',

--- a/backend/open_webui/storage/provider.py
+++ b/backend/open_webui/storage/provider.py
@@ -233,7 +233,7 @@ class GCSStorageProvider(StorageProvider):
     def get_file(self, file_path: str) -> str:
         """Handles downloading of the file from GCS storage."""
         try:
-            filename = file_path.removeprefix('gs://').split('/')[1]
+            filename = file_path.removeprefix('gs://').split('/')[-1]
             local_file_path = f'{UPLOAD_DIR}/{filename}'
             blob = self.bucket.get_blob(filename)
             blob.download_to_filename(local_file_path)
@@ -245,7 +245,7 @@ class GCSStorageProvider(StorageProvider):
     def delete_file(self, file_path: str) -> None:
         """Handles deletion of the file from GCS storage."""
         try:
-            filename = file_path.removeprefix('gs://').split('/')[1]
+            filename = file_path.removeprefix('gs://').split('/')[-1]
             blob = self.bucket.get_blob(filename)
             blob.delete()
         except NotFound as e:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Provided below.
- [x] **Testing:** Manually verified the logic of each fix.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed.
- [x] **Git Hygiene:** Atomic commits, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Three independent backend bug fixes found during code audit.

### Fixed

- **files.py**: `get_html_file_content_by_id` crashes with 500 when accessing a file whose owner has been deleted. `Users.get_user_by_id()` returns `None` but `.role` is accessed without null check. Added `not file_user or` guard.
- **scim.py**: SCIM bearer token compared with `!=` which is vulnerable to timing side-channel attacks. Replaced with `hmac.compare_digest()`, consistent with the existing pattern in `utils/auth.py`.
- **provider.py**: GCS `get_file` and `delete_file` use `split('/')[1]` to extract filename, which returns the wrong segment for nested paths (e.g. `gs://bucket/subdir/file.txt` returns `subdir`). Changed to `split('/')[-1]`, consistent with the S3 provider.

### Security

- SCIM token comparison now uses constant-time `hmac.compare_digest` to prevent timing attacks

---

### Additional Information

- The file owner null-check bug is triggered when an admin deletes a user but their uploaded files remain
- The GCS bug only affects deployments using GCS with key prefixes or subdirectories
- No new dependencies added

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.