### PR TITLE
perf: build mention regex once in factory closure

### DIFF
--- a/src/lib/utils/marked/mention-extension.ts
+++ b/src/lib/utils/marked/mention-extension.ts
@@ -18,24 +18,6 @@ function mentionStart(src: string) {
 	return src.indexOf('<');
 }
 
-function mentionTokenizer(this: any, src: string, options: MentionOptions = {}) {
-	const trigger = options.triggerChar ?? '@';
-	// Build dynamic regex for `<@id>`, `<@id|label>`, `<@id|>`
-	// Added forward slash (/) to the character class for IDs
-	const re = new RegExp(`^<\\${trigger}([\\w.\\-:/]+)(?:\\|([^>]*))?>`);
-	const m = re.exec(src);
-	if (!m) return;
-
-	const [, id, label] = m;
-	return {
-		type: 'mention',
-		raw: m[0],
-		triggerChar: trigger,
-		id,
-		label: label && label.length > 0 ? label : id
-	};
-}
-
 function mentionRenderer(token: any, options: MentionOptions = {}) {
 	const trigger = options.triggerChar ?? '@';
 	const cls = options.className ?? 'mention';
@@ -55,15 +37,30 @@ function mentionRenderer(token: any, options: MentionOptions = {}) {
 }
 
 export function mentionExtension(opts: MentionOptions = {}) {
+	// Compile the regex once when the extension is created, not on every tokenizer call.
+	// mentionStart fires on every '<' in the document, making the tokenizer a hot path.
+	const trigger = opts.triggerChar ?? '@';
+	const re = new RegExp(`^<\\${trigger}([\\w.\\-:/]+)(?:\\|([^>]*))?>`);
+	const snapshot: MentionOptions = { triggerChar: trigger, className: opts.className, extraAttrs: opts.extraAttrs };
+
 	return {
 		name: 'mention',
 		level: 'inline' as const,
 		start: mentionStart,
 		tokenizer(src: string) {
-			return mentionTokenizer.call(this, src, opts);
+			const m = re.exec(src);
+			if (!m) return;
+			const [, id, label] = m;
+			return {
+				type: 'mention',
+				raw: m[0],
+				triggerChar: trigger,
+				id,
+				label: label && label.length > 0 ? label : id
+			};
 		},
 		renderer(token: any) {
-			return mentionRenderer(token, opts);
+			return mentionRenderer(token, snapshot);
 		}
 	};
 }


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

`mentionTokenizer` called `new RegExp(...)` on every invocation. Since `mentionStart` returns `src.indexOf('<')`, the tokenizer fires on every `<` in the document, and with 3 extension instances (`@`, `#`, `$`) this accumulates fast on messages with HTML, file paths, or tool output.

The regex is now compiled once in `mentionExtension()` and closed over by the tokenizer. `mentionTokenizer` is removed.

### Added

- [List any new features, functionalities, or additions]

### Changed

- `src/lib/utils/marked/mention-extension.ts`: compile the per-trigger regex in the `mentionExtension()` closure; remove `mentionTokenizer`

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- [List any fixes, corrections, or bug fixes]

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
