### PR TITLE
fix: always include stream_options for usage tracking in streaming requests

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1171,6 +1171,12 @@ async def generate_chat_completion(
                     part.get('text', '') for part in message['content'] if part.get('type') in ('input_text', 'text')
                 )
 
+    # Always request usage data in streaming responses for analytics token tracking.
+    # Without this, providers like AWS Bedrock don't include token counts unless
+    # the client explicitly opts in via stream_options.
+    if payload.get('stream', False) and 'stream_options' not in payload and not is_responses:
+        payload['stream_options'] = {'include_usage': True}
+
     payload = json.dumps(payload)
 
     r = None


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Testing:** Manually tested on ECS deployment with OpenRouter, Bedrock Gateway, and Bedrock Mantle
- [x] **Code review:** Self-reviewed
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Fixed

- Always include `stream_options: { include_usage: true }` in streaming chat completion requests so providers that require explicit opt-in (e.g., AWS Bedrock) return token usage data for analytics

---

### Description

Providers like AWS Bedrock only return token usage data in streaming responses when the client sends `stream_options: { include_usage: true }`. Without this, the analytics dashboard shows zero tokens for these models.

Currently, the frontend only sends `stream_options` when a model's metadata includes `capabilities.usage = true`, which requires manual admin configuration via `DEFAULT_MODEL_METADATA`. This change injects it server-side so analytics work out of the box for all providers.

OpenRouter and OpenAI already return usage by default and safely ignore the extra field. The Responses API is excluded since it doesn't support `stream_options`.

Related: #21347, #23322

### Changes

One-line addition in `backend/open_webui/routers/openai.py` — before serializing the payload, inject `stream_options: { include_usage: true }` for streaming requests that don't already have it set.

### Testing

Tested on an ECS Fargate deployment with three providers:
- **OpenRouter** — already returned usage, continues to work (field is ignored if already present)
- **AWS Bedrock (via bedrock-access-gateway sidecar)** — previously showed 0 tokens in analytics, now correctly reports input/output tokens
- **AWS Bedrock Mantle** — same fix, now returns usage data

Verified via CloudWatch logs that raw provider responses include `prompt_tokens` and `completion_tokens` after the change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.