### PR TITLE
fix: enable TCP socket keepalive on all client connections for better Redis reliability

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -426,6 +426,15 @@ try:
 except ValueError:
     REDIS_SOCKET_CONNECT_TIMEOUT = None
 
+# Whether to enable TCP SO_KEEPALIVE on Redis client sockets. Opt-in:
+# defaults to off so behavior is unchanged for existing deployments. When
+# enabled, the kernel sends TCP keepalive probes on idle connections so
+# half-closed sockets (e.g. after a silent firewall/LB reset or a NIC
+# flap) are detected before the next command lands on them.
+REDIS_SOCKET_KEEPALIVE = (
+    os.environ.get('REDIS_SOCKET_KEEPALIVE', 'False').lower() == 'true'
+)
+
 REDIS_RECONNECT_DELAY = os.environ.get('REDIS_RECONNECT_DELAY', '')
 
 if REDIS_RECONNECT_DELAY == '':

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -10,6 +10,7 @@ import redis
 from open_webui.env import (
     REDIS_CLUSTER,
     REDIS_SOCKET_CONNECT_TIMEOUT,
+    REDIS_SOCKET_KEEPALIVE,
     REDIS_SENTINEL_HOSTS,
     REDIS_SENTINEL_MAX_RETRY_COUNT,
     REDIS_SENTINEL_PORT,
@@ -197,6 +198,10 @@ def get_redis_connection(
         else {}
     )
 
+    keepalive_kwargs = (
+        {'socket_keepalive': True} if REDIS_SOCKET_KEEPALIVE else {}
+    )
+
     if async_mode:
         import redis.asyncio as redis
 
@@ -211,6 +216,7 @@ def get_redis_connection(
                 password=redis_config['password'],
                 decode_responses=decode_responses,
                 socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
+                **keepalive_kwargs,
             )
             connection = SentinelRedisProxy(
                 sentinel,
@@ -224,12 +230,14 @@ def get_redis_connection(
                 redis_url,
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
+                **keepalive_kwargs,
             )
         elif redis_url:
             connection = redis.from_url(
                 redis_url,
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
+                **keepalive_kwargs,
             )
     else:
         import redis
@@ -244,6 +252,7 @@ def get_redis_connection(
                 password=redis_config['password'],
                 decode_responses=decode_responses,
                 socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
+                **keepalive_kwargs,
             )
             connection = SentinelRedisProxy(
                 sentinel,
@@ -257,12 +266,14 @@ def get_redis_connection(
                 redis_url,
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
+                **keepalive_kwargs,
             )
         elif redis_url:
             connection = redis.Redis.from_url(
                 redis_url,
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
+                **keepalive_kwargs,
             )
 
     _CONNECTION_CACHE[cache_key] = connection


### PR DESCRIPTION
Turns on socket_keepalive=True for every Redis client created by get_redis_connection (plain, cluster and sentinel paths, sync and async). Lets the kernel detect dead peers on idle connections and avoids "Connection reset by peer" errors from the next request picking a half-closed socket out of the pool.

This improves redis reliability.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
