### PR TITLE
fix: honor REDIS_SOCKET_CONNECT_TIMEOUT on non-sentinel clients

### DIFF
--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -191,6 +191,12 @@ def get_redis_connection(
 
     connection = None
 
+    connect_timeout_kwargs = (
+        {'socket_connect_timeout': REDIS_SOCKET_CONNECT_TIMEOUT}
+        if REDIS_SOCKET_CONNECT_TIMEOUT
+        else {}
+    )
+
     if async_mode:
         import redis.asyncio as redis
 
@@ -214,9 +220,17 @@ def get_redis_connection(
         elif redis_cluster:
             if not redis_url:
                 raise ValueError('Redis URL must be provided for cluster mode.')
-            return redis.cluster.RedisCluster.from_url(redis_url, decode_responses=decode_responses)
+            return redis.cluster.RedisCluster.from_url(
+                redis_url,
+                decode_responses=decode_responses,
+                **connect_timeout_kwargs,
+            )
         elif redis_url:
-            connection = redis.from_url(redis_url, decode_responses=decode_responses)
+            connection = redis.from_url(
+                redis_url,
+                decode_responses=decode_responses,
+                **connect_timeout_kwargs,
+            )
     else:
         import redis
 
@@ -239,9 +253,17 @@ def get_redis_connection(
         elif redis_cluster:
             if not redis_url:
                 raise ValueError('Redis URL must be provided for cluster mode.')
-            return redis.cluster.RedisCluster.from_url(redis_url, decode_responses=decode_responses)
+            return redis.cluster.RedisCluster.from_url(
+                redis_url,
+                decode_responses=decode_responses,
+                **connect_timeout_kwargs,
+            )
         elif redis_url:
-            connection = redis.Redis.from_url(redis_url, decode_responses=decode_responses)
+            connection = redis.Redis.from_url(
+                redis_url,
+                decode_responses=decode_responses,
+                **connect_timeout_kwargs,
+            )
 
     _CONNECTION_CACHE[cache_key] = connection
     return connection

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -193,7 +193,7 @@ def get_redis_connection(
 
     connect_timeout_kwargs = (
         {'socket_connect_timeout': REDIS_SOCKET_CONNECT_TIMEOUT}
-        if REDIS_SOCKET_CONNECT_TIMEOUT
+        if REDIS_SOCKET_CONNECT_TIMEOUT is not None
         else {}
     )
 


### PR DESCRIPTION
Previously only the sentinel path passed REDIS_SOCKET_CONNECT_TIMEOUT through to the Redis client. Plain redis:// and cluster URLs fell back to redis-py's default (no explicit connect timeout), so a hung Redis or a black-holed network path could stall the whole worker until the kernel gave up. Forwarding the same env var to from_url()/RedisCluster keeps the behavior consistent across all deployment topologies.



### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
