### PR TITLE
fix: add health_check_interval to detect stale pooled connections

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -435,6 +435,20 @@ REDIS_SOCKET_KEEPALIVE = (
     os.environ.get('REDIS_SOCKET_KEEPALIVE', 'False').lower() == 'true'
 )
 
+# How often (in seconds) redis-py should PING an idle pooled connection
+# before reusing it. Opt-in: defaults to unset (empty string) so behavior
+# is unchanged for existing deployments. When set, should be shorter than
+# the Redis server `timeout` setting and any firewall/LB idle timeout on
+# the path to Redis, so stale connections are detected before a real
+# command lands on them. Set to 0 or empty to disable.
+REDIS_HEALTH_CHECK_INTERVAL = os.environ.get('REDIS_HEALTH_CHECK_INTERVAL', '')
+try:
+    REDIS_HEALTH_CHECK_INTERVAL = int(REDIS_HEALTH_CHECK_INTERVAL)
+    if REDIS_HEALTH_CHECK_INTERVAL <= 0:
+        REDIS_HEALTH_CHECK_INTERVAL = None
+except ValueError:
+    REDIS_HEALTH_CHECK_INTERVAL = None
+
 REDIS_RECONNECT_DELAY = os.environ.get('REDIS_RECONNECT_DELAY', '')
 
 if REDIS_RECONNECT_DELAY == '':

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -9,6 +9,7 @@ import redis
 
 from open_webui.env import (
     REDIS_CLUSTER,
+    REDIS_HEALTH_CHECK_INTERVAL,
     REDIS_SOCKET_CONNECT_TIMEOUT,
     REDIS_SOCKET_KEEPALIVE,
     REDIS_SENTINEL_HOSTS,
@@ -202,6 +203,12 @@ def get_redis_connection(
         {'socket_keepalive': True} if REDIS_SOCKET_KEEPALIVE else {}
     )
 
+    health_check_kwargs = (
+        {'health_check_interval': REDIS_HEALTH_CHECK_INTERVAL}
+        if REDIS_HEALTH_CHECK_INTERVAL
+        else {}
+    )
+
     if async_mode:
         import redis.asyncio as redis
 
@@ -217,6 +224,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
             connection = SentinelRedisProxy(
                 sentinel,
@@ -231,6 +239,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
         elif redis_url:
             connection = redis.from_url(
@@ -238,6 +247,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
     else:
         import redis
@@ -253,6 +263,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 socket_connect_timeout=REDIS_SOCKET_CONNECT_TIMEOUT,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
             connection = SentinelRedisProxy(
                 sentinel,
@@ -267,6 +278,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
         elif redis_url:
             connection = redis.Redis.from_url(
@@ -274,6 +286,7 @@ def get_redis_connection(
                 decode_responses=decode_responses,
                 **connect_timeout_kwargs,
                 **keepalive_kwargs,
+                **health_check_kwargs,
             )
 
     _CONNECTION_CACHE[cache_key] = connection


### PR DESCRIPTION
Introduces REDIS_HEALTH_CHECK_INTERVAL and wires it through to every Redis client created by get_redis_connection (plain, cluster and sentinel paths, sync and async). When set to a positive integer, redis-py will PING any pooled connection idle longer than the interval on checkout, so dead sockets are surfaced as reconnectable errors before a real command lands on them.
Backward compatible / opt-in. Defaults to unset (empty string), which is parsed to None and skipped at the call site — so existing deployments see zero behavioural change after merging this PR. Operators who want the protection set REDIS_HEALTH_CHECK_INTERVAL in their environment (e.g. 60), and must pick a value shorter than both the Redis server timeout setting and any firewall/LB idle timeout on the path to Redis.
Why we need this
Our Redis server reaps stale connections via timeout 1800. Open WebUI doesn't currently check/ping pooled Redis connections before reusing them, so the first request that grabs a reaped socket out of the pool blows up with redis.exceptions.ConnectionError: Connection reset by peer, which bubbles up through AppConfig.__getattr__ / the request middleware and surfaces as user-visible 500s and unexpected runtime errors.
Server-side reaping is non-negotiable for us — without it we run out of pool slots because Open WebUI doesn't appear to close Redis connections deterministically, which is why we originally raised maxclients from 1000 to 50000 and set timeout 1800 in the first place.
With this PR merged and REDIS_HEALTH_CHECK_INTERVAL=60 set, redis-py PINGs any idle connection before handing it back to a caller, which both (a) validates the socket and (b) resets Redis's idle-timeout counter for that connection. Connections still in active rotation stay warm indefinitely; orphaned/leaked ones still get reaped by the server timeout as a safety net. Two different failure modes, covered by two different mechanisms, no conflict between them.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
