### PR TITLE
feat: add chat encryption at rest (v2)

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -592,6 +592,22 @@ if LICENSE_PUBLIC_KEY:
 
 
 ####################################
+# DATABASE_CHAT_ENCRYPTION_KEY
+####################################
+DATABASE_CHAT_ENCRYPTION_KEY = os.environ.get(
+    'DATABASE_CHAT_ENCRYPTION_KEY',
+    os.environ.get('WEBUI_CHAT_ENCRYPTION_KEY'),
+)
+DATABASE_CHAT_ENCRYPT_OLD_CHATS = (
+    os.environ.get(
+        'DATABASE_CHAT_ENCRYPT_OLD_CHATS',
+        os.environ.get('WEBUI_CHAT_ENCRYPT_OLD_CHATS', 'False'),
+    ).lower()
+    == 'true'
+)
+
+
+####################################
 # MODELS
 ####################################
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -515,6 +515,8 @@ from open_webui.env import (
     LOG_FORMAT,
     # OAuth Back-Channel Logout
     ENABLE_OAUTH_BACKCHANNEL_LOGOUT,
+    DATABASE_CHAT_ENCRYPTION_KEY,
+    DATABASE_CHAT_ENCRYPT_OLD_CHATS,
 )
 
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -515,8 +515,6 @@ from open_webui.env import (
     LOG_FORMAT,
     # OAuth Back-Channel Logout
     ENABLE_OAUTH_BACKCHANNEL_LOGOUT,
-    DATABASE_CHAT_ENCRYPTION_KEY,
-    DATABASE_CHAT_ENCRYPT_OLD_CHATS,
 )
 
 

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -1,11 +1,13 @@
 import json
 import time
 import uuid
+from copy import deepcopy
 from typing import Any, Optional
 
 from sqlalchemy.orm import Session
 from open_webui.internal.db import Base, get_db_context
 from open_webui.utils.response import normalize_usage
+from open_webui.utils.db.chat_encryption import decrypt, encrypt
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
@@ -46,6 +48,41 @@ def get_usage(data: dict) -> Optional[dict]:
     """Extract and normalize usage from message data."""
     usage = data.get('usage') or (data.get('info') or {}).get('usage')
     return normalize_usage(usage) if usage else None
+
+
+def _transform_nested_text_fields(value, transform):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == 'text' and isinstance(item, str):
+                value[key] = transform(item)
+            else:
+                _transform_nested_text_fields(item, transform)
+    elif isinstance(value, list):
+        for item in value:
+            _transform_nested_text_fields(item, transform)
+    return value
+
+
+def _encrypt_message_field(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return encrypt(value)
+    if isinstance(value, (dict, list)):
+        copied = deepcopy(value)
+        return _transform_nested_text_fields(copied, encrypt)
+    return value
+
+
+def _decrypt_message_field(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return decrypt(value, value)
+    if isinstance(value, (dict, list)):
+        copied = deepcopy(value)
+        return _transform_nested_text_fields(copied, lambda s: decrypt(s, s))
+    return value
 
 
 ####################
@@ -129,6 +166,12 @@ class ChatMessageModel(BaseModel):
 
 
 class ChatMessageTable:
+    def _to_decrypted_model(self, message: ChatMessage) -> ChatMessageModel:
+        model = ChatMessageModel.model_validate(message)
+        model.content = _decrypt_message_field(model.content)
+        model.output = _decrypt_message_field(model.output)
+        return model
+
     def upsert_message(
         self,
         message_id: str,
@@ -153,9 +196,9 @@ class ChatMessageTable:
                 if 'parent_id' in data:
                     existing.parent_id = data.get('parent_id') or data.get('parentId')
                 if 'content' in data:
-                    existing.content = data.get('content')
+                    existing.content = _encrypt_message_field(data.get('content'))
                 if 'output' in data:
-                    existing.output = data.get('output')
+                    existing.output = _encrypt_message_field(data.get('output'))
                 if 'model_id' in data or 'model' in data:
                     existing.model_id = data.get('model_id') or data.get('model')
                 if 'files' in data:
@@ -180,7 +223,7 @@ class ChatMessageTable:
                 existing.updated_at = now
                 db.commit()
                 db.refresh(existing)
-                return ChatMessageModel.model_validate(existing)
+                return self._to_decrypted_model(existing)
             else:
                 # Insert new
                 # Extract and normalize usage
@@ -191,8 +234,8 @@ class ChatMessageTable:
                     user_id=user_id,
                     role=data.get('role', 'user'),
                     parent_id=data.get('parent_id') or data.get('parentId'),
-                    content=data.get('content'),
-                    output=data.get('output'),
+                    content=_encrypt_message_field(data.get('content')),
+                    output=_encrypt_message_field(data.get('output')),
                     model_id=data.get('model_id') or data.get('model'),
                     files=data.get('files'),
                     sources=data.get('sources'),
@@ -207,17 +250,17 @@ class ChatMessageTable:
                 db.add(message)
                 db.commit()
                 db.refresh(message)
-                return ChatMessageModel.model_validate(message)
+                return self._to_decrypted_model(message)
 
     def get_message_by_id(self, id: str, db: Optional[Session] = None) -> Optional[ChatMessageModel]:
         with get_db_context(db) as db:
             message = db.get(ChatMessage, id)
-            return ChatMessageModel.model_validate(message) if message else None
+            return self._to_decrypted_model(message) if message else None
 
     def get_messages_by_chat_id(self, chat_id: str, db: Optional[Session] = None) -> list[ChatMessageModel]:
         with get_db_context(db) as db:
             messages = db.query(ChatMessage).filter_by(chat_id=chat_id).order_by(ChatMessage.created_at.asc()).all()
-            return [ChatMessageModel.model_validate(message) for message in messages]
+            return [self._to_decrypted_model(message) for message in messages]
 
     def get_messages_by_user_id(
         self,
@@ -235,7 +278,7 @@ class ChatMessageTable:
                 .limit(limit)
                 .all()
             )
-            return [ChatMessageModel.model_validate(message) for message in messages]
+            return [self._to_decrypted_model(message) for message in messages]
 
     def get_messages_by_model_id(
         self,
@@ -253,7 +296,7 @@ class ChatMessageTable:
             if end_date:
                 query = query.filter(ChatMessage.created_at <= end_date)
             messages = query.order_by(ChatMessage.created_at.desc()).offset(skip).limit(limit).all()
-            return [ChatMessageModel.model_validate(message) for message in messages]
+            return [self._to_decrypted_model(message) for message in messages]
 
     def get_chat_ids_by_model_id(
         self,

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -5,12 +5,14 @@ import uuid
 from typing import Optional
 
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 from open_webui.internal.db import Base, JSONField, get_db, get_db_context
 from open_webui.models.tags import TagModel, Tag, Tags
 from open_webui.models.folders import Folders
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.automations import AutomationRun
 from open_webui.utils.misc import sanitize_data_for_db, sanitize_text_for_db
+from open_webui.utils.db.chat_encryption import encrypt_content, decrypt_content
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
@@ -274,6 +276,17 @@ class ChatTable:
         """Recursively remove null bytes from strings in dict/list structures."""
         return sanitize_data_for_db(obj)
 
+    def _normalize_chat_model(self, chat_model: Optional[ChatModel]) -> Optional[ChatModel]:
+        if chat_model and chat_model.chat:
+            chat_model.chat = decrypt_content(chat_model.chat)
+        return chat_model
+
+    def _normalize_chat_models(self, chat_models: list[ChatModel]) -> list[ChatModel]:
+        for chat_model in chat_models:
+            if chat_model.chat:
+                chat_model.chat = decrypt_content(chat_model.chat)
+        return chat_models
+
     def _sanitize_chat_row(self, chat_item):
         """
         Clean a Chat SQLAlchemy model's title + chat JSON,
@@ -300,14 +313,16 @@ class ChatTable:
     def insert_new_chat(self, user_id: str, form_data: ChatForm, db: Optional[Session] = None) -> Optional[ChatModel]:
         with get_db_context(db) as db:
             id = str(uuid.uuid4())
+            cleaned_chat_dict = self._clean_null_bytes(form_data.chat)
+            processed_chat = encrypt_content(cleaned_chat_dict)
             chat = ChatModel(
                 **{
                     'id': id,
                     'user_id': user_id,
                     'title': self._clean_null_bytes(
-                        form_data.chat['title'] if 'title' in form_data.chat else 'New Chat'
+                        processed_chat.get("title", "New Chat")
                     ),
-                    'chat': self._clean_null_bytes(form_data.chat),
+                    'chat': processed_chat,
                     'folder_id': form_data.folder_id,
                     'created_at': int(time.time()),
                     'updated_at': int(time.time()),
@@ -334,16 +349,18 @@ class ChatTable:
             except Exception as e:
                 log.warning(f'Failed to write initial messages to chat_message table: {e}')
 
-            return ChatModel.model_validate(chat_item) if chat_item else None
+            return self._normalize_chat_model(ChatModel.model_validate(chat_item)) if chat_item else None
 
     def _chat_import_form_to_chat_model(self, user_id: str, form_data: ChatImportForm) -> ChatModel:
         id = str(uuid.uuid4())
+        cleaned_chat = self._clean_null_bytes(form_data.chat)
+        processed_chat = encrypt_content(cleaned_chat)
         chat = ChatModel(
             **{
                 'id': id,
                 'user_id': user_id,
-                'title': self._clean_null_bytes(form_data.chat['title'] if 'title' in form_data.chat else 'New Chat'),
-                'chat': self._clean_null_bytes(form_data.chat),
+                'title': self._clean_null_bytes(processed_chat.get("title", "New Chat")),
+                'chat': processed_chat,
                 'meta': form_data.meta,
                 'pinned': form_data.pinned,
                 'folder_id': form_data.folder_id,
@@ -385,21 +402,23 @@ class ChatTable:
             except Exception as e:
                 log.warning(f'Failed to write imported messages to chat_message table: {e}')
 
-            return [ChatModel.model_validate(chat) for chat in chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in chats])
 
     def update_chat_by_id(self, id: str, chat: dict, db: Optional[Session] = None) -> Optional[ChatModel]:
         try:
             with get_db_context(db) as db:
+                cleaned_chat = self._clean_null_bytes(chat)
+                processed_chat = encrypt_content(cleaned_chat)
                 chat_item = db.get(Chat, id)
-                chat_item.chat = self._clean_null_bytes(chat)
-                chat_item.title = self._clean_null_bytes(chat['title']) if 'title' in chat else 'New Chat'
+                chat_item.chat = processed_chat
+                chat_item.title = self._clean_null_bytes(processed_chat.get("title", "New Chat"))
 
                 chat_item.updated_at = int(time.time())
 
                 db.commit()
                 db.refresh(chat_item)
 
-                return ChatModel.model_validate(chat_item)
+                return self._normalize_chat_model(ChatModel.model_validate(chat_item))
         except Exception:
             return None
 
@@ -427,7 +446,8 @@ class ChatTable:
                 chat_item.updated_at = int(time.time())
                 db.commit()
                 db.refresh(chat_item)
-                return ChatModel.model_validate(chat_item)
+                return self._normalize_chat_model(ChatModel.model_validate(chat_item))
+
         except Exception:
             return None
 
@@ -454,7 +474,7 @@ class ChatTable:
             if removed:
                 self.delete_orphan_tags_for_user(list(removed), user.id, db=db)
 
-            return ChatModel.model_validate(chat)
+            return self._normalize_chat_model(ChatModel.model_validate(chat))
 
     def get_chat_title_by_id(self, id: str) -> Optional[str]:
         with get_db_context() as db:
@@ -607,7 +627,7 @@ class ChatTable:
                 db.commit()
                 db.refresh(shared_chat)
 
-                return ChatModel.model_validate(shared_chat)
+                return self._normalize_chat_model(ChatModel.model_validate(shared_chat))
         except Exception:
             return None
 
@@ -644,7 +664,7 @@ class ChatTable:
                 chat.share_id = share_id
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -656,7 +676,7 @@ class ChatTable:
                 chat.updated_at = int(time.time())
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -669,7 +689,7 @@ class ChatTable:
                 chat.updated_at = int(time.time())
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -910,7 +930,7 @@ class ChatTable:
                 .order_by(Chat.updated_at.desc())
                 .all()
             )
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def get_chat_by_id(self, id: str, db: Optional[Session] = None) -> Optional[ChatModel]:
         try:
@@ -923,7 +943,10 @@ class ChatTable:
                     db.commit()
                     db.refresh(chat_item)
 
-                return ChatModel.model_validate(chat_item)
+                chat_model = ChatModel.model_validate(chat_item)
+                chat_model.chat = decrypt_content(chat_model.chat)
+                
+                return chat_model
         except Exception:
             return None
 
@@ -945,7 +968,7 @@ class ChatTable:
         try:
             with get_db_context(db) as db:
                 chat = db.query(Chat).filter_by(id=id, user_id=user_id).first()
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -979,7 +1002,7 @@ class ChatTable:
                 # .limit(limit).offset(skip)
                 .order_by(Chat.updated_at.desc())
             )
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def get_chats_by_user_id(
         self,
@@ -1022,7 +1045,7 @@ class ChatTable:
 
             return ChatListResponse(
                 **{
-                    'items': [ChatModel.model_validate(chat) for chat in all_chats],
+                    "items": self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats]),
                     'total': total,
                 }
             )
@@ -1051,7 +1074,7 @@ class ChatTable:
     def get_archived_chats_by_user_id(self, user_id: str, db: Optional[Session] = None) -> list[ChatModel]:
         with get_db_context(db) as db:
             all_chats = db.query(Chat).filter_by(user_id=user_id, archived=True).order_by(Chat.updated_at.desc())
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def get_chats_by_user_id_and_search_text(
         self,
@@ -1244,7 +1267,7 @@ class ChatTable:
             log.info(f'The number of chats: {len(all_chats)}')
 
             # Validate and return chats
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def get_chats_by_folder_id_and_user_id(
         self,
@@ -1293,7 +1316,7 @@ class ChatTable:
             query = query.order_by(Chat.updated_at.desc())
 
             all_chats = query.all()
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def update_chat_folder_id_by_id_and_user_id(
         self, id: str, user_id: str, folder_id: str, db: Optional[Session] = None
@@ -1306,7 +1329,7 @@ class ChatTable:
                 chat.pinned = False
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -1380,7 +1403,7 @@ class ChatTable:
                     }
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 
@@ -1642,7 +1665,7 @@ class ChatTable:
                 .all()
             )
 
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            return self._normalize_chat_models([ChatModel.model_validate(chat) for chat in all_chats])
 
     def update_chat_tasks_by_id(self, id: str, tasks: list[dict]) -> Optional[ChatModel]:
         """Update the tasks list on a chat."""
@@ -1654,7 +1677,7 @@ class ChatTable:
                 chat.tasks = tasks
                 db.commit()
                 db.refresh(chat)
-                return ChatModel.model_validate(chat)
+                return self._normalize_chat_model(ChatModel.model_validate(chat))
         except Exception:
             return None
 

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -4,6 +4,7 @@ import uuid
 import time
 import datetime
 import logging
+import threading
 from aiohttp import ClientSession
 import urllib
 
@@ -43,7 +44,6 @@ from open_webui.env import (
     ENABLE_OAUTH_TOKEN_EXCHANGE,
     AIOHTTP_CLIENT_SESSION_SSL,
     DATABASE_CHAT_ENCRYPT_OLD_CHATS,
-    DATABASE_CHAT_ENCRYPTION_KEY,
 )
 from fastapi import APIRouter, Depends, HTTPException, Request, status, BackgroundTasks
 from fastapi.responses import RedirectResponse, Response, JSONResponse
@@ -80,6 +80,7 @@ from open_webui.utils.groups import apply_default_group_assignment
 
 from open_webui.utils.redis import get_redis_client
 from open_webui.utils.rate_limit import RateLimiter
+from open_webui.utils.db.chat_encryption import CHAT_ENCRYPTION_ENABLED
 from open_webui.utils.db.encrypt_old_chats import encrypt_old_chats_for_user
 
 
@@ -97,6 +98,28 @@ log = logging.getLogger(__name__)
 # Forgive us our failed attempts, as we forgive those
 # who exceed their allotted rate against this gate.
 signin_rate_limiter = RateLimiter(redis_client=get_redis_client(), limit=5 * 3, window=60 * 3)
+
+# Idempotency guard for old chat encryption backfill: only schedule one backfill task per user
+old_chat_backfill_running_users: set[str] = set()
+old_chat_backfill_lock = threading.Lock()
+
+async def queue_old_chat_encryption_backfill(request: Request, background_tasks: BackgroundTasks, user_id: str):
+    if not (DATABASE_CHAT_ENCRYPT_OLD_CHATS and CHAT_ENCRYPTION_ENABLED):
+        return
+
+    with old_chat_backfill_lock:
+        if user_id in old_chat_backfill_running_users:
+            return
+        old_chat_backfill_running_users.add(user_id)
+
+    async def _run(uid: str):
+        try:
+            await encrypt_old_chats_for_user(uid)
+        finally:
+            with old_chat_backfill_lock:
+                old_chat_backfill_running_users.discard(uid)
+
+    background_tasks.add_task(_run, user_id)
 
 
 def create_session_response(request: Request, user, db, response: Response = None, set_cookie: bool = False) -> dict:
@@ -639,8 +662,7 @@ async def signin(
         )
 
     if user:
-        if DATABASE_CHAT_ENCRYPTION_KEY and DATABASE_CHAT_ENCRYPT_OLD_CHATS:
-            background_tasks.add_task(encrypt_old_chats_for_user, user.id)
+        await queue_old_chat_encryption_backfill(request, background_tasks, user.id)
         return create_session_response(request, user, db, response, set_cookie=True)
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -42,8 +42,10 @@ from open_webui.env import (
     ENABLE_INITIAL_ADMIN_SIGNUP,
     ENABLE_OAUTH_TOKEN_EXCHANGE,
     AIOHTTP_CLIENT_SESSION_SSL,
+    DATABASE_CHAT_ENCRYPT_OLD_CHATS,
+    DATABASE_CHAT_ENCRYPTION_KEY,
 )
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status, BackgroundTasks
 from fastapi.responses import RedirectResponse, Response, JSONResponse
 from open_webui.config import (
     OPENID_PROVIDER_URL,
@@ -78,6 +80,7 @@ from open_webui.utils.groups import apply_default_group_assignment
 
 from open_webui.utils.redis import get_redis_client
 from open_webui.utils.rate_limit import RateLimiter
+from open_webui.utils.db.encrypt_old_chats import encrypt_old_chats_for_user
 
 
 from typing import Optional, List
@@ -536,6 +539,8 @@ async def signin(
     request: Request,
     response: Response,
     form_data: SigninForm,
+    background_tasks: BackgroundTasks,
+
     db: Session = Depends(get_session),
 ):
     if not ENABLE_PASSWORD_AUTH:
@@ -634,6 +639,8 @@ async def signin(
         )
 
     if user:
+        if DATABASE_CHAT_ENCRYPTION_KEY and DATABASE_CHAT_ENCRYPT_OLD_CHATS:
+            background_tasks.add_task(encrypt_old_chats_for_user, user.id)
         return create_session_response(request, user, db, response, set_cookie=True)
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -13,7 +13,8 @@ from open_webui.models.chats import (
     ChatImportForm,
     ChatUsageStatsListResponse,
     ChatsImportForm,
-    ChatResponse,
+    ChatResponse,    
+    ChatModel,
     Chats,
     ChatTitleIdResponse,
     SharedChatResponse,
@@ -35,10 +36,22 @@ from pydantic import BaseModel
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission
+from open_webui.utils.db.chat_encryption import decrypt_content
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _normalize_chat_for_response(chat: ChatModel) -> ChatResponse:
+    chat_dict = chat.model_dump()
+    chat_dict['chat'] = decrypt_content(chat_dict.get('chat'))
+    return ChatResponse(**chat_dict)
+
+
+def _normalize_chat_list_for_response(chats: list[ChatModel]) -> list[ChatResponse]:
+    return [_normalize_chat_for_response(chat) for chat in chats]
+
 
 ############################
 # GetChatList
@@ -554,7 +567,7 @@ async def create_new_chat(
 ):
     try:
         chat = Chats.insert_new_chat(user.id, form_data, db=db)
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
     except Exception as e:
         log.exception(e)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.DEFAULT())
@@ -573,7 +586,7 @@ async def import_chats(
 ):
     try:
         chats = Chats.import_chats(user.id, form_data.chats, db=db)
-        return chats
+        return _normalize_chat_list_for_response(chats)
     except Exception as e:
         log.exception(e)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.DEFAULT())
@@ -626,10 +639,7 @@ async def get_chats_by_folder_id(folder_id: str, user=Depends(get_verified_user)
     if children_folders:
         folder_ids.extend([folder.id for folder in children_folders])
 
-    return [
-        ChatResponse(**chat.model_dump())
-        for chat in Chats.get_chats_by_folder_ids_and_user_id(folder_ids, user.id, db=db)
-    ]
+    return _normalize_chat_list_for_response(Chats.get_chats_by_folder_ids_and_user_id(folder_ids, user.id, db=db))
 
 
 @router.get('/folder/{folder_id}/list')
@@ -672,7 +682,7 @@ async def get_user_pinned_chats(user=Depends(get_verified_user), db: Session = D
 @router.get('/all', response_model=list[ChatResponse])
 async def get_user_chats(user=Depends(get_verified_user), db: Session = Depends(get_session)):
     result = Chats.get_chats_by_user_id(user.id, db=db)
-    return [ChatResponse(**chat.model_dump()) for chat in result.items]
+    return _normalize_chat_list_for_response(result.items)
 
 
 ############################
@@ -682,8 +692,8 @@ async def get_user_chats(user=Depends(get_verified_user), db: Session = Depends(
 
 @router.get('/all/archived', response_model=list[ChatResponse])
 async def get_user_archived_chats(user=Depends(get_verified_user), db: Session = Depends(get_session)):
-    return [ChatResponse(**chat.model_dump()) for chat in Chats.get_archived_chats_by_user_id(user.id, db=db)]
-
+    chats = Chats.get_archived_chats_by_user_id(user.id, db=db)
+    return _normalize_chat_list_for_response(chats)
 
 ############################
 # GetAllTags
@@ -712,7 +722,7 @@ async def get_all_user_chats_in_db(user=Depends(get_admin_user), db: Session = D
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
-    return [ChatResponse(**chat.model_dump()) for chat in Chats.get_chats(db=db)]
+    return _normalize_chat_list_for_response(Chats.get_chats(db=db))
 
 
 ############################
@@ -825,7 +835,7 @@ async def get_shared_chat_by_id(share_id: str, user=Depends(get_verified_user), 
         chat = Chats.get_chat_by_id(share_id, db=db)
 
     if chat:
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
 
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
@@ -868,7 +878,7 @@ async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: Session =
     chat = Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
 
     if chat:
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
 
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
@@ -890,7 +900,7 @@ async def update_chat_by_id(
     if chat:
         updated_chat = {**chat.chat, **form_data.chat}
         chat = Chats.update_chat_by_id(id, updated_chat, db=db)
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
     else:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -956,7 +966,7 @@ async def update_chat_message_by_id(
             }
         )
 
-    return ChatResponse(**chat.model_dump())
+    return _normalize_chat_for_response(chat)
 
 
 ############################
@@ -1074,7 +1084,7 @@ async def pin_chat_by_id(id: str, user=Depends(get_verified_user), db: Session =
     chat = Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
         chat = Chats.toggle_chat_pinned_by_id(id, db=db)
-        return chat
+        return _normalize_chat_for_response(chat)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())
 
@@ -1121,7 +1131,7 @@ async def clone_chat_by_id(
 
         if chats:
             chat = chats[0]
-            return ChatResponse(**chat.model_dump())
+            return _normalize_chat_for_response(chat)
         else:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1168,7 +1178,7 @@ async def clone_shared_chat_by_id(id: str, user=Depends(get_verified_user), db: 
 
         if chats:
             chat = chats[0]
-            return ChatResponse(**chat.model_dump())
+            return _normalize_chat_for_response(chat)
         else:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1197,7 +1207,7 @@ async def archive_chat_by_id(id: str, user=Depends(get_verified_user), db: Sessi
             # Unarchived — ensure tag rows exist
             Tags.ensure_tags_exist(tag_ids, user.id, db=db)
 
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())
 
@@ -1227,7 +1237,7 @@ async def share_chat_by_id(
     if chat:
         if chat.share_id:
             shared_chat = Chats.update_shared_chat_by_chat_id(chat.id, db=db)
-            return ChatResponse(**shared_chat.model_dump())
+            return _normalize_chat_for_response(shared_chat)
 
         shared_chat = Chats.insert_shared_chat_by_chat_id(chat.id, db=db)
         if not shared_chat:
@@ -1235,7 +1245,7 @@ async def share_chat_by_id(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=ERROR_MESSAGES.DEFAULT(),
             )
-        return ChatResponse(**shared_chat.model_dump())
+        return _normalize_chat_for_response(shared_chat)
 
     else:
         raise HTTPException(
@@ -1286,7 +1296,7 @@ async def update_chat_folder_id_by_id(
     chat = Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
         chat = Chats.update_chat_folder_id_by_id_and_user_id(id, user.id, form_data.folder_id, db=db)
-        return ChatResponse(**chat.model_dump())
+        return _normalize_chat_for_response(chat)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1084,6 +1084,8 @@ async def pin_chat_by_id(id: str, user=Depends(get_verified_user), db: Session =
     chat = Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
         chat = Chats.toggle_chat_pinned_by_id(id, db=db)
+        if chat is None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.DEFAULT())
         return _normalize_chat_for_response(chat)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.DEFAULT())

--- a/backend/open_webui/utils/db/chat_encryption.py
+++ b/backend/open_webui/utils/db/chat_encryption.py
@@ -13,15 +13,18 @@ log = logging.getLogger(__name__)
 
 WEBUI_CHAT_ENCRYPTION_CIPHER = None
 STRUCTURED_PAYLOAD_PREFIX = '__owui_json__:'
+CHAT_ENCRYPTION_ENABLED = False
 
 
 # Initialization checks
 if DATABASE_CHAT_ENCRYPTION_KEY:
     try:
         WEBUI_CHAT_ENCRYPTION_CIPHER = Fernet(DATABASE_CHAT_ENCRYPTION_KEY.encode())
+        CHAT_ENCRYPTION_ENABLED = True
         log.info("Encryption Cipher initialized successfully")
     except Exception as e:
         log.error("Cipher initialization failed (Invalid Key): %s", e)
+        raise RuntimeError("Invalid DATABASE_CHAT_ENCRYPTION_KEY; refusing to start with encryption misconfigured") from e
 else:
     log.warning("DATABASE_CHAT_ENCRYPTION_KEY environment variable is missing: Chat encryption disabled")
 

--- a/backend/open_webui/utils/db/chat_encryption.py
+++ b/backend/open_webui/utils/db/chat_encryption.py
@@ -12,6 +12,7 @@ from open_webui.env import DATABASE_CHAT_ENCRYPTION_KEY
 log = logging.getLogger(__name__)
 
 WEBUI_CHAT_ENCRYPTION_CIPHER = None
+STRUCTURED_PAYLOAD_PREFIX = '__owui_json__:'
 
 
 # Initialization checks
@@ -32,7 +33,10 @@ def encrypt(data):
     if data is None:
         return None
     try:
-        val = json.dumps(data) if isinstance(data, dict) else str(data)
+        if isinstance(data, (dict, list)):
+            val = f"{STRUCTURED_PAYLOAD_PREFIX}{json.dumps(data)}"
+        else:
+            val = str(data)
         encrypted_data = WEBUI_CHAT_ENCRYPTION_CIPHER.encrypt(val.encode()).decode()
         return encrypted_data
     except Exception as e:
@@ -46,10 +50,9 @@ def decrypt(enc_val, plain_val):
         return plain_val
     try:
         decrypted = WEBUI_CHAT_ENCRYPTION_CIPHER.decrypt(enc_val.encode()).decode()
-        try:
-            return json.loads(decrypted)
-        except json.JSONDecodeError:
-            return decrypted
+        if decrypted.startswith(STRUCTURED_PAYLOAD_PREFIX):
+            return json.loads(decrypted[len(STRUCTURED_PAYLOAD_PREFIX):])
+        return decrypted
     except Exception:
         return enc_val
 

--- a/backend/open_webui/utils/db/chat_encryption.py
+++ b/backend/open_webui/utils/db/chat_encryption.py
@@ -1,0 +1,130 @@
+"""
+Chat Encryption Implementation for Open WebUI
+
+Encrypts chat content at rest using Fernet encryption to ensure chat content are not stored in the database as plaintext. 
+Requires DATABASE_CHAT_ENCRYPTION_KEY environment variable to be set.
+"""
+
+import json
+import logging
+from cryptography.fernet import Fernet
+from open_webui.env import DATABASE_CHAT_ENCRYPTION_KEY
+log = logging.getLogger(__name__)
+
+WEBUI_CHAT_ENCRYPTION_CIPHER = None
+
+
+# Initialization checks
+if DATABASE_CHAT_ENCRYPTION_KEY:
+    try:
+        WEBUI_CHAT_ENCRYPTION_CIPHER = Fernet(DATABASE_CHAT_ENCRYPTION_KEY.encode())
+        log.info("Encryption Cipher initialized successfully")
+    except Exception as e:
+        log.error("Cipher initialization failed (Invalid Key): %s", e)
+else:
+    log.warning("DATABASE_CHAT_ENCRYPTION_KEY environment variable is missing: Chat encryption disabled")
+
+
+# Encrypt function
+def encrypt(data):
+    if not WEBUI_CHAT_ENCRYPTION_CIPHER:
+        return data
+    if data is None:
+        return None
+    try:
+        val = json.dumps(data) if isinstance(data, dict) else str(data)
+        encrypted_data = WEBUI_CHAT_ENCRYPTION_CIPHER.encrypt(val.encode()).decode()
+        return encrypted_data
+    except Exception as e:
+        log.error("Encryption processing failed: %s", e)
+        return data
+
+
+# Decrypt function
+def decrypt(enc_val, plain_val):
+    if not WEBUI_CHAT_ENCRYPTION_CIPHER or not enc_val or not isinstance(enc_val, str):
+        return plain_val
+    try:
+        decrypted = WEBUI_CHAT_ENCRYPTION_CIPHER.decrypt(enc_val.encode()).decode()
+        try:
+            return json.loads(decrypted)
+        except json.JSONDecodeError:
+            return decrypted
+    except Exception:
+        return enc_val
+
+
+def _transform_nested_text_fields(value, transform):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "text" and isinstance(item, str):
+                value[key] = transform(item)
+            else:
+                _transform_nested_text_fields(item, transform)
+    elif isinstance(value, list):
+        for item in value:
+            _transform_nested_text_fields(item, transform)
+    return value
+
+
+def _transform_content_fields(value, transform_string_content, transform_nested_text):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "content":
+                if isinstance(item, str):
+                    value[key] = transform_string_content(item)
+                elif isinstance(item, (dict, list)):
+                    value[key] = _transform_nested_text_fields(item, transform_nested_text)
+            else:
+                _transform_content_fields(item, transform_string_content, transform_nested_text)
+    elif isinstance(value, list):
+        for item in value:
+            _transform_content_fields(item, transform_string_content, transform_nested_text)
+    return value
+
+
+# Encrypt chat content
+def encrypt_content(chat_data: dict) -> dict:
+    if not chat_data or not WEBUI_CHAT_ENCRYPTION_CIPHER:
+        return chat_data
+    
+    # History
+    messages_dict = chat_data.get("history", {}).get("messages", {})
+    for msg_id in messages_dict:
+        _transform_content_fields(messages_dict[msg_id], encrypt, encrypt)
+            
+        
+    # Messages
+    messages_list = chat_data.get("messages", [])
+    for msg in messages_list:
+        _transform_content_fields(msg, encrypt, encrypt)
+            
+    return chat_data
+
+
+# Decrypt chat content
+def decrypt_content(chat_data: dict) -> dict:
+    if not chat_data or not WEBUI_CHAT_ENCRYPTION_CIPHER:
+        return chat_data
+
+    # History 
+    messages_dict = chat_data.get("history", {}).get("messages", {})
+    for msg_id in messages_dict:
+        _transform_content_fields(
+            messages_dict[msg_id],
+            lambda s: decrypt(s, s),
+            lambda s: decrypt(s, s),
+        )
+            
+    # Messages
+    messages_list = chat_data.get("messages", [])
+    for msg in messages_list:
+        _transform_content_fields(
+            msg,
+            lambda s: decrypt(s, s),
+            lambda s: decrypt(s, s),
+        )
+            
+    return chat_data
+
+

--- a/backend/open_webui/utils/db/encrypt_old_chats.py
+++ b/backend/open_webui/utils/db/encrypt_old_chats.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from open_webui.internal.db import get_db_context
 from open_webui.models.chats import Chat
 from open_webui.models.chat_messages import ChatMessage
-from open_webui.utils.db.chat_encryption import encrypt, encrypt_content
+from open_webui.utils.db.chat_encryption import CHAT_ENCRYPTION_ENABLED, encrypt, encrypt_content
 
 log = logging.getLogger(__name__)
 
@@ -107,14 +107,18 @@ def chat_is_encrypted(chat_json: dict) -> bool:
 # Old chat encryption function (encrypt all plaintext chats for a user in batches)
 async def encrypt_old_chats_for_user(user_id: Any, db: Optional[Any] = None, chunk_size: int = 100) -> int:
     """Encrypt old plaintext chats and chat_message payloads for a user asynchronously."""
-    log.info("Starting old-chat encryption for user %s", user_id)
+    if not CHAT_ENCRYPTION_ENABLED:
+        #log.warning("Chat encryption is not enabled; skipping old-chat backfill for user %s", user_id)
+        return 0
+
+    log.debug("Starting old-chat encryption for user %s", user_id)
     encrypted_count = 0
     try:
         def _encrypt_chats():
             count = 0
             with get_db_context(db) as session:
                 # Backfill chat table
-                chat_query = session.query(Chat).filter(Chat.user_id == user_id)
+                chat_query = session.query(Chat).filter(Chat.user_id == user_id).order_by(Chat.id.asc())
                 offset = 0
                 while True:
                     batch = chat_query.offset(offset).limit(chunk_size).all()
@@ -138,7 +142,11 @@ async def encrypt_old_chats_for_user(user_id: Any, db: Optional[Any] = None, chu
                     offset += chunk_size
 
                 # Backfill chat_message table
-                message_query = session.query(ChatMessage).filter(ChatMessage.user_id == user_id)
+                message_query = (
+                    session.query(ChatMessage)
+                    .filter(ChatMessage.user_id == user_id)
+                    .order_by(ChatMessage.id.asc())
+                )
                 offset = 0
                 while True:
                     batch = message_query.offset(offset).limit(chunk_size).all()
@@ -173,7 +181,7 @@ async def encrypt_old_chats_for_user(user_id: Any, db: Optional[Any] = None, chu
             return count
         
         encrypted_count = await asyncio.to_thread(_encrypt_chats)
-        log.info("Successfully encrypted %d chats for user %s", encrypted_count, user_id)
+        log.debug("Successfully encrypted %d chats for user %s", encrypted_count, user_id)
     except Exception as e:
         log.exception("Error encrypting old chats for user %s: %s", user_id, e)
     return encrypted_count

--- a/backend/open_webui/utils/db/encrypt_old_chats.py
+++ b/backend/open_webui/utils/db/encrypt_old_chats.py
@@ -1,0 +1,179 @@
+"""
+Encryption of Old Chats Implementation for Open WebUI
+
+Batch-encrypts historical chat contents when a user logs in using Fernet encryption to ensure old chat content is not stored in the database as plaintext. 
+"""
+
+import asyncio
+import logging
+from copy import deepcopy
+from typing import Any, Optional
+from sqlalchemy.orm.attributes import flag_modified
+from open_webui.internal.db import get_db_context
+from open_webui.models.chats import Chat
+from open_webui.models.chat_messages import ChatMessage
+from open_webui.utils.db.chat_encryption import encrypt, encrypt_content
+
+log = logging.getLogger(__name__)
+
+
+# Encryption checks
+def is_encrypted_string(s: str) -> bool:
+    """Return True if string is Fernet-encrypted."""
+    return isinstance(s, str) and s.startswith("gAAAAAB")
+
+
+def _nested_content_text_is_encrypted(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "text" and isinstance(item, str) and not is_encrypted_string(item):
+                return False
+            if not _nested_content_text_is_encrypted(item):
+                return False
+    elif isinstance(value, list):
+        for item in value:
+            if not _nested_content_text_is_encrypted(item):
+                return False
+    return True
+
+
+def _field_is_encrypted(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return is_encrypted_string(value)
+    if isinstance(value, (dict, list)):
+        return _nested_content_text_is_encrypted(value)
+    return True
+
+
+def _transform_nested_text_fields(value: Any, transform):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == 'text' and isinstance(item, str):
+                value[key] = transform(item)
+            else:
+                _transform_nested_text_fields(item, transform)
+    elif isinstance(value, list):
+        for item in value:
+            _transform_nested_text_fields(item, transform)
+    return value
+
+
+def _encrypt_message_field(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return encrypt(value)
+    if isinstance(value, (dict, list)):
+        copied = deepcopy(value)
+        return _transform_nested_text_fields(copied, encrypt)
+    return value
+
+
+def _message_content_is_encrypted(message: dict) -> bool:
+    if not isinstance(message, dict):
+        return True
+
+    for key, value in message.items():
+        if key == "content":
+            if isinstance(value, str) and not is_encrypted_string(value):
+                return False
+            if isinstance(value, (dict, list)) and not _nested_content_text_is_encrypted(value):
+                return False
+        elif isinstance(value, dict):
+            if not _message_content_is_encrypted(value):
+                return False
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict) and not _message_content_is_encrypted(item):
+                    return False
+    return True
+
+
+def chat_is_encrypted(chat_json: dict) -> bool:
+    """Return True if all chat message contents are encrypted."""
+    history = chat_json.get("history", {})
+    messages = history.get("messages", {})
+    for m in messages.values():
+        if not _message_content_is_encrypted(m):
+            return False
+    for msg in chat_json.get("messages", []):
+        if not _message_content_is_encrypted(msg):
+            return False
+    return True
+
+
+# Old chat encryption function (encrypt all plaintext chats for a user in batches)
+async def encrypt_old_chats_for_user(user_id: Any, db: Optional[Any] = None, chunk_size: int = 100) -> int:
+    """Encrypt old plaintext chats and chat_message payloads for a user asynchronously."""
+    log.info("Starting old-chat encryption for user %s", user_id)
+    encrypted_count = 0
+    try:
+        def _encrypt_chats():
+            count = 0
+            with get_db_context(db) as session:
+                # Backfill chat table
+                chat_query = session.query(Chat).filter(Chat.user_id == user_id)
+                offset = 0
+                while True:
+                    batch = chat_query.offset(offset).limit(chunk_size).all()
+                    if not batch:
+                        break
+                    modified = False
+                    for chat_item in batch:
+                        chat_json = chat_item.chat
+                        if chat_json and not chat_is_encrypted(chat_json):
+                            chat_item.chat = encrypt_content(chat_json)
+                            flag_modified(chat_item, 'chat')
+                            modified = True
+                            count += 1
+                    if modified:
+                        try:
+                            session.commit()
+                        except Exception as e:
+                            log.exception('Failed to commit encrypted chat rows: %s', e)
+                            session.rollback()
+                            raise
+                    offset += chunk_size
+
+                # Backfill chat_message table
+                message_query = session.query(ChatMessage).filter(ChatMessage.user_id == user_id)
+                offset = 0
+                while True:
+                    batch = message_query.offset(offset).limit(chunk_size).all()
+                    if not batch:
+                        break
+                    modified = False
+                    for message_item in batch:
+                        changed = False
+
+                        if not _field_is_encrypted(message_item.content):
+                            message_item.content = _encrypt_message_field(message_item.content)
+                            flag_modified(message_item, 'content')
+                            changed = True
+
+                        if not _field_is_encrypted(message_item.output):
+                            message_item.output = _encrypt_message_field(message_item.output)
+                            flag_modified(message_item, 'output')
+                            changed = True
+
+                        if changed:
+                            modified = True
+                            count += 1
+
+                    if modified:
+                        try:
+                            session.commit()
+                        except Exception as e:
+                            log.exception('Failed to commit encrypted chat_message rows: %s', e)
+                            session.rollback()
+                            raise
+                    offset += chunk_size
+            return count
+        
+        encrypted_count = await asyncio.to_thread(_encrypt_chats)
+        log.info("Successfully encrypted %d chats for user %s", encrypted_count, user_id)
+    except Exception as e:
+        log.exception("Error encrypting old chats for user %s: %s", user_id, e)
+    return encrypted_count


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Adds application-level encryption of chat content at rest, controlled by two environment variables:

- `DATABASE_CHAT_ENCRYPTION_KEY`:  When set, chat content is encrypted before being written to the database (chat/chat_message tables) and and transparently decrypted on read. The UI experience is unchanged.
- `DATABASE_CHAT_ENCRYPT_OLD_CHATS` : When `true`, schedules per-user background encryption of existing plaintext chats at sign-in, avoiding bulk-operation container timeouts. Once all historical chats are encrypted the flag can be disabled.

This is a database-agnostic solution that specifically addresses deployments using PostgreSQL (e.g. on Azure or AWS) where the existing SQLCipher approach is not applicable, as confirmed in [Discussion #21469](https://github.com/open-webui/open-webui/discussions/21469).

**Outcome:** Admin users can no longer view user chat content in plaintext via database exports or direct database access. Both features are optional and entirely controlled with the environment variables.

**Changes from v1 (prior closed [PR](https://github.com/open-webui/open-webui/pull/23548))** 
- Rebased 
- Environment variables naming aligned with database naming scheme
- tested thoroughly (unit + manual UI flows)
- Applies encryption for the chat_message table
- Tested against reported issues (automated code review) + tests for the chat_message handling
- Unit tests not included

### Added
- `DATABASE_CHAT_ENCRYPTION_KEY` env var: enables encryption of chat content at rest. Encryption is idempotent: plaintext content is detected and encrypted; already-encrypted content is left untouched.
- `DATABASE_CHAT_ENCRYPT_OLD_CHATS` env var: when `true`, triggers per-user background encryption of historical plaintext chats on sign-in.
- `backend/open_webui/utils/db/chat_encryption.py`: centralised encrypt/decrypt helper functions.
- `backend/open_webui/utils/db/encrypt_old_chats.py`: batch encryption utility function for historical chats.

### Changed
- `backend/open_webui/env.py`: Expose `DATABASE_CHAT_ENCRYPTION_KEY` and `DATABASE_CHAT_ENCRYPT_OLD_CHATS` configuration.
- `backend/open_webui/main.py`: Initialise encryption configuration at startup.
- `backend/open_webui/models/chats.py`: Encrypt chat content on write; decrypt (normalise) on read so the UI always receives plaintext.
- `backend/open_webui/routers/chats.py`: Normalise chat payloads before returning to callers.
- `backend/open_webui/routers/chat_messages.py`: Normalise chat_messages payloads before returning to callers.
- `backend/open_webui/routers/auths.py`: Trigger old-chat encryption task on user sign-in when `DATABASE_CHAT_ENCRYPT_OLD_CHATS=true`.

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- Chat content stored in the database is now encrypted at rest when environment variables are configured. This prevents direct database access or database exports from exposing user chat content in plaintext, including admin-level accounts.

### Breaking Changes

- None

---

### Additional Information

- Supersedes prior closed [PR](https://github.com/open-webui/open-webui/pull/23548)

### Screenshots or Videos

<img width="2535" height="958" alt="ow_pg" src="https://github.com/user-attachments/assets/e82b074d-5fce-4f89-8dbc-517a0c9d80aa" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.