### PR TITLE
fix: native function calling for REST API consumers

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1739,12 +1739,9 @@ async def chat_completion(
                 'stream_delta_chunk_size': stream_delta_chunk_size,
                 'reasoning_tags': reasoning_tags,
                 'function_calling': (
-                    'native'
-                    if (
-                        form_data.get('params', {}).get('function_calling') == 'native'
-                        or model_info_params.get('function_calling') == 'native'
-                    )
-                    else 'default'
+                    form_data.get('params', {}).get('function_calling')
+                    or model_info_params.get('function_calling')
+                    or 'default'
                 ),
             },
         }
@@ -1794,7 +1791,73 @@ async def chat_completion(
         try:
             form_data, metadata, events = await process_chat_payload(request, form_data, user, metadata, model)
 
-            response = await chat_completion_handler(request, form_data, user)
+            # Native tool-calling loop for REST API (no WebSocket session).
+            # Executes tools server-side and re-invokes the LLM until
+            # finish_reason != 'tool_calls' or max retries reached.
+            is_api_native = (
+                not metadata.get('session_id')
+                and metadata.get('params', {}).get('function_calling') == 'native'
+                and metadata.get('tools')
+            )
+
+            if is_api_native:
+                from open_webui.env import CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES
+
+                original_stream = form_data.get('stream', False)
+                form_data['stream'] = False
+                tools = metadata.get('tools', {})
+
+                pending_tool_results = False
+                for _ in range(CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES):
+                    pending_tool_results = False
+                    response = await chat_completion_handler(request, form_data, user)
+
+                    data = response.body if isinstance(response, JSONResponse) else response
+                    if isinstance(data, bytes):
+                        data = json.loads(data)
+                    if not isinstance(data, dict):
+                        break
+
+                    choice = (data.get('choices') or [{}])[0]
+                    if choice.get('finish_reason') != 'tool_calls':
+                        break
+
+                    tool_calls = (choice.get('message') or {}).get('tool_calls') or []
+                    if not tool_calls:
+                        break
+
+                    # Append assistant message with tool_calls, then each tool result.
+                    form_data['messages'].append(choice['message'])
+                    for tc in tool_calls:
+                        func = tc.get('function', {})
+                        name = func.get('name', '')
+                        try:
+                            args = json.loads(func.get('arguments', '{}'))
+                        except json.JSONDecodeError:
+                            args = {}
+
+                        result = None
+                        callable_tool = tools.get(name, {}).get('callable')
+                        if callable_tool:
+                            try:
+                                result = await callable_tool(**args)
+                            except Exception as e:
+                                result = str(e)
+
+                        form_data['messages'].append({
+                            'role': 'tool',
+                            'tool_call_id': tc.get('id', ''),
+                            'content': str(result) if result is not None else '',
+                        })
+                    pending_tool_results = True
+
+                form_data['stream'] = original_stream
+                # Re-invoke if tool results are pending (LLM hasn't seen them)
+                # or if the caller requested streaming (loop response is JSON).
+                if pending_tool_results or original_stream:
+                    response = await chat_completion_handler(request, form_data, user)
+            else:
+                response = await chat_completion_handler(request, form_data, user)
             if metadata.get('chat_id') and metadata.get('message_id'):
                 try:
                     if not metadata['chat_id'].startswith('local:'):


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

Two fixes for native function calling, especially for REST API consumers that bypass the frontend WebSocket session:

1. **Pass through the `function_calling` value as-is** instead of only checking for `'native'` and falling back to `'default'`. This respects values set via `DEFAULT_MODEL_PARAMS` or per-model params.

2. **Add server-side tool-calling loop for API calls** (no `session_id`). The native tool execution loop is driven by the frontend via WebSocket. REST API calls never enter that loop, so `tool_calls` are returned raw and tools are never executed. This adds a loop that executes tools and re-invokes the LLM until `finish_reason != 'tool_calls'` or `CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES` is reached.

Ref: #9435
Replaces PR: #23515 (closed - updated based on bot review feedback)

# Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** See above and changelog below
- [x] **Changelog:** See below
- [x] **Documentation:** N/A - no new env vars or user-facing config; uses existing `CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES`
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Tested on a deployment environment (AWS ECS Fargate + Bedrock Access Gateway) with Claude models. Verified via REST API (`/api/chat/completions`) with both `stream: true` and `stream: false`. Tool calls are executed server-side and the LLM produces a final response incorporating tool results. Frontend WebSocket flow unaffected.
- [x] **Agentic AI Code:** AI-assisted with human review and manual testing on deployment environment
- [x] **Code review:** Self-reviewed; addressed both findings from automated review on #23515
- [x] **Design & Architecture:** No new settings; uses existing `CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES`
- [x] **Git Hygiene:** Single atomic commit rebased on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- Fix native function calling for REST API consumers (`/api/chat/completions`) that don't use a WebSocket session

### Fixed

- `function_calling` parameter now passes through the configured value instead of only recognizing `'native'` and falling back to `'default'`
- REST API calls with native function calling now execute tools server-side and re-invoke the LLM with tool results, matching the behavior of the frontend WebSocket flow
- Falsy tool results (`0`, `False`, `""`) are preserved correctly via `is not None` check

### Breaking Changes

- None. Behavioral change is scoped to REST API requests with `function_calling: native` and tools - these previously returned raw `tool_calls` without execution.

---

### Additional Information

- Related discussion: #9435 ("The model does nothing with the result of a native tool call") - reported by 30+ users since Feb 2025
- The server-side loop only activates when: no `session_id` (REST API), `function_calling == 'native'`, and tools are present in metadata
- Loop is bounded by existing `CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES` setting
- The loop forces `stream=False` to parse tool_calls from JSON. After the loop, the final LLM call is only made when:
  - Tool results are pending (LLM hasn't seen them), OR
  - The caller requested streaming (loop response is JSON, caller expects SSE)
  - Non-streaming callers reuse the loop's response directly - no extra LLM call

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.