### PR TITLE
fix: pass db session to filter_allowed_access_grants in update_note_access_by_id

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -348,6 +348,7 @@ async def update_note_access_by_id(
         user.role,
         form_data.access_grants,
         'sharing.public_notes',
+        db=db,
     )
 
     AccessGrants.set_access_grants('note', id, form_data.access_grants, db=db)


### PR DESCRIPTION
Closes #23586

## Problem

In `backend/open_webui/routers/notes.py`, the `update_note_access_by_id` endpoint calls `filter_allowed_access_grants` without passing the `db` (SQLAlchemy session) parameter.

The `filter_allowed_access_grants` function internally calls `has_permission()` which calls `Groups.get_groups_by_member_id(user_id, db=db)`. Without a valid `db` session, group-based permission lookups will fail, meaning non-admin users with group-granted `sharing.public_notes` permission will incorrectly have their access grants stripped/filtered when calling `POST /{id}/access/update`.

The **same function call** in `update_note_by_id` (also in `notes.py`) correctly passes `db=db`:

```python
# CORRECT: in update_note_by_id (line ~281)
form_data.access_grants = filter_allowed_access_grants(
    request.app.state.config.USER_PERMISSIONS,
    user.id,
    user.role,
    form_data.access_grants,
    'sharing.public_notes',
    db=db,  # ✅ correctly passed here
)

# BUG: in update_note_access_by_id (line ~345) - missing db=db
form_data.access_grants = filter_allowed_access_grants(
    request.app.state.config.USER_PERMISSIONS,
    user.id,
    user.role,
    form_data.access_grants,
    'sharing.public_notes',
    # ❌ db=db missing!
)
```

## Fix

Added the missing `db=db` keyword argument to the `filter_allowed_access_grants` call in `update_note_access_by_id`:

```python
form_data.access_grants = filter_allowed_access_grants(
    request.app.state.config.USER_PERMISSIONS,
    user.id,
    user.role,
    form_data.access_grants,
    'sharing.public_notes',
    db=db,  # ✅ now correctly passes db session
)
```

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>