### PR TITLE
fix: guard circular tool server schemas

### DIFF
--- a/backend/open_webui/test/util/test_tools.py
+++ b/backend/open_webui/test/util/test_tools.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import patch
+
+from open_webui.utils.tools import convert_openapi_to_tool_payload, get_tool_servers_data
+
+
+def test_convert_openapi_to_tool_payload_handles_circular_request_refs():
+    spec = {
+        'openapi': '3.1.0',
+        'paths': {
+            '/conditions': {
+                'post': {
+                    'operationId': 'create_condition',
+                    'requestBody': {
+                        'content': {
+                            'application/json': {
+                                'schema': {'$ref': '#/components/schemas/Condition'}
+                            }
+                        }
+                    },
+                }
+            }
+        },
+        'components': {
+            'schemas': {
+                'Condition': {
+                    'type': 'object',
+                    'properties': {
+                        'siblings': {
+                            'type': 'array',
+                            'items': {'$ref': '#/components/schemas/Condition'},
+                        }
+                    },
+                }
+            }
+        },
+    }
+
+    payload = convert_openapi_to_tool_payload(spec)
+
+    assert len(payload) == 1
+    siblings = payload[0]['parameters']['properties']['siblings']
+    assert siblings['type'] == 'array'
+    assert siblings['items'] == {'type': 'object'}
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_data_skips_server_with_spec_conversion_error():
+    servers = [
+        {
+            'type': 'openapi',
+            'url': 'https://bad.example',
+            'spec_type': 'json',
+            'spec': '{"openapi":"3.1.0","paths":{}}',
+            'info': {'id': 'bad'},
+            'config': {'enable': True},
+        },
+        {
+            'type': 'openapi',
+            'url': 'https://good.example',
+            'spec_type': 'json',
+            'spec': '{"openapi":"3.1.0","paths":{}}',
+            'info': {'id': 'good'},
+            'config': {'enable': True},
+        },
+    ]
+
+    with patch(
+        'open_webui.utils.tools.convert_openapi_to_tool_payload',
+        side_effect=[RuntimeError('boom'), []],
+    ):
+        results = await get_tool_servers_data(servers)
+
+    assert [server['id'] for server in results] == ['good']
+    assert results[0]['specs'] == []

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -696,30 +696,36 @@ def get_tool_specs(tool_module: object) -> list[dict]:
     return specs
 
 
-def resolve_schema(schema, components):
+def resolve_schema(schema, components, seen_refs=None):
     """
     Recursively resolves a JSON schema using OpenAPI components.
     """
     if not schema:
         return {}
 
+    if seen_refs is None:
+        seen_refs = frozenset()
+
     if '$ref' in schema:
         ref_path = schema['$ref']
+        if ref_path in seen_refs:
+            # Stop circular expansion and preserve a generic structured value.
+            return {'type': 'object'}
         ref_parts = ref_path.strip('#/').split('/')
         resolved = components
         for part in ref_parts[1:]:  # Skip the initial 'components'
             resolved = resolved.get(part, {})
-        return resolve_schema(resolved, components)
+        return resolve_schema(resolved, components, seen_refs | {ref_path})
 
     resolved_schema = copy.deepcopy(schema)
 
     # Recursively resolve inner schemas
     if 'properties' in resolved_schema:
         for prop, prop_schema in resolved_schema['properties'].items():
-            resolved_schema['properties'][prop] = resolve_schema(prop_schema, components)
+            resolved_schema['properties'][prop] = resolve_schema(prop_schema, components, seen_refs)
 
     if 'items' in resolved_schema:
-        resolved_schema['items'] = resolve_schema(resolved_schema['items'], components)
+        resolved_schema['items'] = resolve_schema(resolved_schema['items'], components, seen_refs)
 
     return resolved_schema
 
@@ -1170,10 +1176,16 @@ async def get_tool_servers_data(servers: List[Dict[str, Any]]) -> List[Dict[str,
             log.warning(f"Invalid OpenAPI spec from {url}: missing 'paths'")
             continue
 
+        try:
+            specs = convert_openapi_to_tool_payload(response)
+        except Exception:
+            log.exception(f'Failed to convert OpenAPI spec for tool server {id}')
+            continue
+
         response = {
             'openapi': response,
             'info': response.get('info', {}),
-            'specs': convert_openapi_to_tool_payload(response),
+            'specs': specs,
         }
 
         openapi_data = response.get('openapi', {})


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** No docs repo update included in this PR; this is a backend utility fix with focused regression coverage only.
- [x] **Dependencies:** No new or upgraded dependencies were added.
- [x] **Testing:** I manually ran the targeted validation steps listed below for this backend fix.
- [ ] **Agentic AI Code:** This PR was agent-assisted; leaving this unchecked for maintainers to evaluate alongside the recorded manual validation notes.
- [x] **Code review:** I performed a focused self-review of the touched utility and regression-test surfaces.
- [x] **Design & Architecture:** This keeps the fix local to the schema-conversion path and avoids new settings or wider behavior changes.
- [x] **Git Hygiene:** This branch was rebased onto `dev` and keeps the change atomic.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Changelog Entry

### Description

- Guard circular OpenAPI request-schema expansion in tool-server conversion and keep one failing server from taking down the entire `/api/v1/tools` response.

### Added

- Focused regression coverage for circular request-body `$ref` handling and per-server conversion isolation.

### Changed

- Tool-server schema resolution now short-circuits repeated `$ref` expansion instead of recursing indefinitely.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixes #23543 by preventing recursive request schemas from causing `RecursionError` during tool-server OpenAPI conversion.
- Prevents a single bad tool-server spec from aborting the whole tool-server list conversion pass.

### Security

- Improves availability and fault isolation for externally supplied tool-server OpenAPI specs by bounding recursive schema expansion.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Touched files:
  - `backend/open_webui/utils/tools.py`
  - `backend/open_webui/test/util/test_tools.py`
- Validation performed:
  - `python -m py_compile backend/open_webui/utils/tools.py backend/open_webui/test/util/test_tools.py`
  - Targeted source-level smoke to confirm circular request schemas are bounded and that one failed tool-server conversion no longer prevents healthy servers from being listed
- No new settings, dependencies, or user-facing UI changes.

### Screenshots or Videos

- Not applicable for this backend utility fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
