### PR TITLE
fix: ComfyUI concurrent image generation hangs due to reused client_id

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -681,7 +681,7 @@ async def image_generations(
             res = await comfyui_create_image(
                 model,
                 form_data,
-                user.id,
+                str(uuid.uuid4()),
                 request.app.state.config.COMFYUI_BASE_URL,
                 request.app.state.config.COMFYUI_API_KEY,
             )
@@ -1011,7 +1011,7 @@ async def image_edits(
             res = await comfyui_edit_image(
                 model,
                 form_data,
-                user.id,
+                str(uuid.uuid4()),
                 request.app.state.config.IMAGES_EDIT_COMFYUI_BASE_URL,
                 request.app.state.config.IMAGES_EDIT_COMFYUI_API_KEY,
             )


### PR DESCRIPTION
When using ComfyUI as the image generation backend, concurrent image generation/editing requests from the same user (e.g., multi-model chat, or rapid overlapping requests) cause some requests to hang indefinitely. ComfyUI's server stores WebSocket connections in a dict keyed by `clientId`, replacing earlier connections when a new one arrives with the same ID. Since Open WebUI passes `user.id` as `client_id`, displaced connections never receive completion messages.

This PR replaces `user.id` with `str(uuid.uuid4())` to generate a unique `client_id` per request, matching ComfyUI's own [websockets_api_example.py](https://github.com/Comfy-Org/ComfyUI/blob/a2840e75520b7dc40958866b3c4da1345d5cfa9c/script_examples/websockets_api_example.py).

Discussion: #23591

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Replace `user.id` with `str(uuid.uuid4())` as the `client_id` for ComfyUI WebSocket connections, fixing hangs during concurrent image generation/editing.

### Fixed

- ComfyUI image generation/editing hangs when the same user triggers multiple concurrent requests (e.g., multi-model chat). ComfyUI's server replaces WebSocket connections sharing the same `clientId`, causing displaced connections to never receive completion messages.

---

### Additional Information

- Discussion: #23591
- No new dependencies. `uuid` is already imported in the file.
- ComfyUI's own [websockets_api_example.py](https://github.com/Comfy-Org/ComfyUI/blob/a2840e75520b7dc40958866b3c4da1345d5cfa9c/script_examples/websockets_api_example.py) uses `str(uuid.uuid4())` as the `client_id`.

### Manual Test

1. Enable ComfyUI as the image generation backend.
2. Open a multi-model chat with 3 instances of the same model.
3. Ask each model to generate an image.
4. Before this fix, some requests remain stuck at "Creating image" / "Executing".
5. After this fix, all requests complete.

### Screenshots or Videos

**Before (non-Native FC, 3 models — middle one hangs at "Creating image"):**

<img width="1114" height="1211" alt="20260411_152331_firefox" src="https://github.com/user-attachments/assets/2c02f202-1a2b-4c17-bd13-870f0b7bbecf" />

**After (non-Native FC, 3 models — all complete):**

<img width="1114" height="1212" alt="20260411_153910_firefox" src="https://github.com/user-attachments/assets/4ba9bd8d-1831-45ea-907d-a2f16b7713e1" />

See #23591 for additional before/after screenshots (Native FC, image editing).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
