### PR TITLE
feat: per-group token usage limits with enforcement

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -94,6 +94,7 @@ from open_webui.routers import (
     skills,
     tools,
     users,
+    usage_limits,
     utils,
     scim,
     terminals,
@@ -1527,6 +1528,7 @@ app.include_router(skills.router, prefix='/api/v1/skills', tags=['skills'])
 app.include_router(memories.router, prefix='/api/v1/memories', tags=['memories'])
 app.include_router(folders.router, prefix='/api/v1/folders', tags=['folders'])
 app.include_router(groups.router, prefix='/api/v1/groups', tags=['groups'])
+app.include_router(usage_limits.router, prefix='/api/v1/usage-limits', tags=['usage-limits'])
 app.include_router(files.router, prefix='/api/v1/files', tags=['files'])
 app.include_router(functions.router, prefix='/api/v1/functions', tags=['functions'])
 app.include_router(evaluations.router, prefix='/api/v1/evaluations', tags=['evaluations'])

--- a/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_usage_ledger_table.py
+++ b/backend/open_webui/migrations/versions/c3d4e5f6a7b8_add_usage_ledger_table.py
@@ -1,0 +1,102 @@
+"""Add usage_ledger table and change chat_message.chat_id FK to SET NULL
+
+Revision ID: c3d4e5f6a7b8
+Revises: b7c8d9e0f1a2
+Create Date: 2026-04-08 10:00:00.000000
+
+- Adds usage_ledger table for tracking temp chat and direct API call usage
+- Changes chat_message.chat_id from CASCADE to SET NULL and makes it nullable,
+  so usage metadata survives when chats are deleted
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from open_webui.migrations.util import get_existing_tables
+
+revision: str = 'c3d4e5f6a7b8'
+down_revision: Union[str, None] = 'b7c8d9e0f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    existing_tables = set(get_existing_tables())
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    # Create usage_ledger table
+    if 'usage_ledger' not in existing_tables:
+        op.create_table(
+            'usage_ledger',
+            sa.Column('id', sa.Text(), nullable=False, primary_key=True),
+            sa.Column('user_id', sa.Text(), nullable=False),
+            sa.Column('model_id', sa.Text(), nullable=True),
+            sa.Column('input_tokens', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('output_tokens', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+        )
+        op.create_index('ix_usage_ledger_user_id', 'usage_ledger', ['user_id'])
+        op.create_index('ix_usage_ledger_created_at', 'usage_ledger', ['created_at'])
+        op.create_index('usage_ledger_user_created_idx', 'usage_ledger', ['user_id', 'created_at'])
+
+    # Change chat_message.chat_id: CASCADE -> SET NULL, make nullable
+    if 'chat_message' in existing_tables:
+        if dialect == 'postgresql':
+            conn.execute(sa.text(
+                'ALTER TABLE chat_message ALTER COLUMN chat_id DROP NOT NULL'
+            ))
+            conn.execute(sa.text(
+                'ALTER TABLE chat_message DROP CONSTRAINT IF EXISTS chat_message_chat_id_fkey'
+            ))
+            conn.execute(sa.text(
+                'ALTER TABLE chat_message ADD CONSTRAINT chat_message_chat_id_fkey '
+                'FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE SET NULL'
+            ))
+        else:
+            # SQLite: use batch mode (recreates table)
+            with op.batch_alter_table('chat_message') as batch:
+                batch.alter_column('chat_id', existing_type=sa.Text(), nullable=True)
+                batch.drop_constraint('chat_message_chat_id_fkey', type_='foreignkey')
+                batch.create_foreign_key(
+                    'chat_message_chat_id_fkey',
+                    'chat',
+                    ['chat_id'],
+                    ['id'],
+                    ondelete='SET NULL',
+                )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == 'postgresql':
+        conn.execute(sa.text(
+            'ALTER TABLE chat_message DROP CONSTRAINT IF EXISTS chat_message_chat_id_fkey'
+        ))
+        conn.execute(sa.text(
+            'ALTER TABLE chat_message ADD CONSTRAINT chat_message_chat_id_fkey '
+            'FOREIGN KEY (chat_id) REFERENCES chat(id) ON DELETE CASCADE'
+        ))
+        conn.execute(sa.text(
+            'ALTER TABLE chat_message ALTER COLUMN chat_id SET NOT NULL'
+        ))
+    else:
+        with op.batch_alter_table('chat_message') as batch:
+            batch.drop_constraint('chat_message_chat_id_fkey', type_='foreignkey')
+            batch.create_foreign_key(
+                'chat_message_chat_id_fkey',
+                'chat',
+                ['chat_id'],
+                ['id'],
+                ondelete='CASCADE',
+            )
+            batch.alter_column('chat_id', existing_type=sa.Text(), nullable=False)
+
+    op.drop_index('usage_ledger_user_created_idx', table_name='usage_ledger')
+    op.drop_index('ix_usage_ledger_created_at', table_name='usage_ledger')
+    op.drop_index('ix_usage_ledger_user_id', table_name='usage_ledger')
+    op.drop_table('usage_ledger')

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -58,7 +58,7 @@ class ChatMessage(Base):
 
     # Identity
     id = Column(Text, primary_key=True)
-    chat_id = Column(Text, ForeignKey('chat.id', ondelete='CASCADE'), nullable=False, index=True)
+    chat_id = Column(Text, ForeignKey('chat.id', ondelete='SET NULL'), nullable=True, index=True)
     user_id = Column(Text, index=True)
 
     # Structure

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1470,13 +1470,31 @@ class ChatTable:
         except Exception:
             return False
 
+    def _strip_chat_message_content(self, db, filter_kwargs=None, filter_expr=None):
+        """Strip content from chat_message rows but preserve usage data for token tracking.
+        Also nulls chat_id to detach from the chat before it's deleted (prevents CASCADE)."""
+        update_values = {
+            ChatMessage.chat_id: None,
+            ChatMessage.content: None,
+            ChatMessage.output: None,
+            ChatMessage.files: None,
+            ChatMessage.sources: None,
+            ChatMessage.embeds: None,
+            ChatMessage.status_history: None,
+            ChatMessage.error: None,
+        }
+        if filter_kwargs:
+            db.query(ChatMessage).filter_by(**filter_kwargs).update(update_values, synchronize_session=False)
+        elif filter_expr is not None:
+            db.query(ChatMessage).filter(filter_expr).update(update_values, synchronize_session=False)
+
     def delete_chat_by_id(self, id: str, db: Optional[Session] = None) -> bool:
         try:
             with get_db_context(db) as db:
                 db.query(AutomationRun).filter_by(chat_id=id).update(
                     {AutomationRun.chat_id: None}, synchronize_session=False
                 )
-                db.query(ChatMessage).filter_by(chat_id=id).delete()
+                self._strip_chat_message_content(db, filter_kwargs={'chat_id': id})
                 db.query(Chat).filter_by(id=id).delete()
                 db.commit()
 
@@ -1490,7 +1508,7 @@ class ChatTable:
                 db.query(AutomationRun).filter_by(chat_id=id).update(
                     {AutomationRun.chat_id: None}, synchronize_session=False
                 )
-                db.query(ChatMessage).filter_by(chat_id=id).delete()
+                self._strip_chat_message_content(db, filter_kwargs={'chat_id': id})
                 db.query(Chat).filter_by(id=id, user_id=user_id).delete()
                 db.commit()
 
@@ -1507,9 +1525,7 @@ class ChatTable:
                 db.query(AutomationRun).filter(AutomationRun.chat_id.in_(chat_id_subquery)).update(
                     {AutomationRun.chat_id: None}, synchronize_session=False
                 )
-                db.query(ChatMessage).filter(ChatMessage.chat_id.in_(chat_id_subquery)).delete(
-                    synchronize_session=False
-                )
+                self._strip_chat_message_content(db, filter_expr=ChatMessage.chat_id.in_(chat_id_subquery))
                 db.query(Chat).filter_by(user_id=user_id).delete()
                 db.commit()
 
@@ -1524,9 +1540,7 @@ class ChatTable:
                 db.query(AutomationRun).filter(AutomationRun.chat_id.in_(chat_id_subquery)).update(
                     {AutomationRun.chat_id: None}, synchronize_session=False
                 )
-                db.query(ChatMessage).filter(ChatMessage.chat_id.in_(chat_id_subquery)).delete(
-                    synchronize_session=False
-                )
+                self._strip_chat_message_content(db, filter_expr=ChatMessage.chat_id.in_(chat_id_subquery))
                 db.query(Chat).filter_by(user_id=user_id, folder_id=folder_id).delete()
                 db.commit()
 

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -410,6 +410,26 @@ class GroupTable:
             log.exception(e)
             return None
 
+    def update_group_permissions_by_id(
+        self,
+        id: str,
+        permissions: dict,
+        db: Optional[Session] = None,
+    ) -> bool:
+        try:
+            with get_db_context(db) as db:
+                db.query(Group).filter_by(id=id).update(
+                    {
+                        'permissions': permissions,
+                        'updated_at': int(time.time()),
+                    }
+                )
+                db.commit()
+                return True
+        except Exception as e:
+            log.exception(e)
+            return False
+
     def delete_group_by_id(self, id: str, db: Optional[Session] = None) -> bool:
         try:
             with get_db_context(db) as db:

--- a/backend/open_webui/models/usage_ledger.py
+++ b/backend/open_webui/models/usage_ledger.py
@@ -1,0 +1,144 @@
+import logging
+import time
+import uuid
+from typing import Optional
+
+from sqlalchemy.orm import Session
+from open_webui.internal.db import Base, get_db_context
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    Text,
+    Index,
+    func,
+)
+
+log = logging.getLogger(__name__)
+
+####################
+# UsageLedger DB Schema
+####################
+
+
+class UsageLedgerEntry(Base):
+    __tablename__ = 'usage_ledger'
+
+    id = Column(Text, primary_key=True)
+    user_id = Column(Text, nullable=False, index=True)
+    model_id = Column(Text, nullable=True)
+    input_tokens = Column(BigInteger, default=0)
+    output_tokens = Column(BigInteger, default=0)
+    created_at = Column(BigInteger, nullable=False, index=True)
+
+    __table_args__ = (
+        Index('usage_ledger_user_created_idx', 'user_id', 'created_at'),
+    )
+
+
+####################
+# Pydantic Models
+####################
+
+
+class UsageLedgerModel(BaseModel):
+    id: str
+    user_id: str
+    model_id: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+####################
+# UsageLedger Table Operations
+####################
+
+
+class UsageLedgerTable:
+    def log_usage(
+        self,
+        user_id: str,
+        model_id: Optional[str] = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        db: Optional[Session] = None,
+    ) -> Optional[UsageLedgerModel]:
+        """Append an immutable usage record. This is never deleted by user actions."""
+        try:
+            with get_db_context(db) as db:
+                entry = UsageLedgerEntry(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    model_id=model_id,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    created_at=int(time.time()),
+                )
+                db.add(entry)
+                db.commit()
+                db.refresh(entry)
+                return UsageLedgerModel.model_validate(entry)
+        except Exception as e:
+            log.warning(f'Failed to log usage: {e}')
+            return None
+
+    def get_user_usage_since(
+        self,
+        user_id: str,
+        since: int,
+        db: Optional[Session] = None,
+    ) -> dict:
+        """Get total token usage for a user since a given timestamp."""
+        with get_db_context(db) as db:
+            result = db.query(
+                func.coalesce(func.sum(UsageLedgerEntry.input_tokens), 0).label('input_tokens'),
+                func.coalesce(func.sum(UsageLedgerEntry.output_tokens), 0).label('output_tokens'),
+            ).filter(
+                UsageLedgerEntry.user_id == user_id,
+                UsageLedgerEntry.created_at >= since,
+            ).first()
+
+            input_tokens = int(result.input_tokens) if result else 0
+            output_tokens = int(result.output_tokens) if result else 0
+
+            return {
+                'input_tokens': input_tokens,
+                'output_tokens': output_tokens,
+                'total_tokens': input_tokens + output_tokens,
+            }
+
+    def get_user_usage_by_model_since(
+        self,
+        user_id: str,
+        since: int,
+        db: Optional[Session] = None,
+    ) -> list[dict]:
+        """Get token usage for a user broken down by model since a given timestamp."""
+        with get_db_context(db) as db:
+            results = db.query(
+                UsageLedgerEntry.model_id,
+                func.coalesce(func.sum(UsageLedgerEntry.input_tokens), 0).label('input_tokens'),
+                func.coalesce(func.sum(UsageLedgerEntry.output_tokens), 0).label('output_tokens'),
+            ).filter(
+                UsageLedgerEntry.user_id == user_id,
+                UsageLedgerEntry.created_at >= since,
+            ).group_by(
+                UsageLedgerEntry.model_id
+            ).all()
+
+            return [
+                {
+                    'model_id': r.model_id,
+                    'input_tokens': int(r.input_tokens),
+                    'output_tokens': int(r.output_tokens),
+                    'total_tokens': int(r.input_tokens) + int(r.output_tokens),
+                }
+                for r in results
+            ]
+
+
+UsageLedger = UsageLedgerTable()

--- a/backend/open_webui/routers/usage_limits.py
+++ b/backend/open_webui/routers/usage_limits.py
@@ -1,0 +1,151 @@
+import logging
+from typing import Optional
+
+from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from open_webui.internal.db import get_session
+from open_webui.models.groups import Groups
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.usage_limits import (
+    check_usage_limit,
+    get_period_start,
+    get_user_usage_limit,
+)
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+############################
+# Pydantic Forms
+############################
+
+
+class UsageLimitForm(BaseModel):
+    token_limit: int  # max total tokens per period
+    limit_period: str = 'daily'  # "daily" or "monthly"
+    soft_limit: Optional[int] = None  # warn at this threshold
+    priority: int = 100  # lower = higher priority
+
+
+############################
+# Get current user's usage status
+############################
+
+
+@router.get('/status')
+async def get_usage_status(user=Depends(get_verified_user)):
+    """Get the current user's usage status against their limits."""
+    return check_usage_limit(user.id)
+
+
+############################
+# Get a specific user's usage status (admin only)
+############################
+
+
+@router.get('/users/{user_id}/status')
+async def get_user_usage_status(user_id: str, user=Depends(get_admin_user)):
+    """Get a specific user's usage status (admin only)."""
+    return check_usage_limit(user_id)
+
+
+############################
+# Get usage limits for a group (admin only)
+############################
+
+
+@router.get('/groups/{group_id}')
+async def get_group_usage_limits(
+    group_id: str,
+    user=Depends(get_admin_user),
+    db: Session = Depends(get_session),
+):
+    """Get the usage limits configured for a group."""
+    group = Groups.get_group_by_id(group_id, db=db)
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Group not found',
+        )
+
+    permissions = group.permissions or {}
+    return permissions.get('usage_limits') or {}
+
+
+############################
+# Set usage limits for a group (admin only)
+############################
+
+
+@router.post('/groups/{group_id}')
+async def set_group_usage_limits(
+    group_id: str,
+    form_data: UsageLimitForm,
+    user=Depends(get_admin_user),
+    db: Session = Depends(get_session),
+):
+    """Set usage limits for a group."""
+    group = Groups.get_group_by_id(group_id, db=db)
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Group not found',
+        )
+
+    if form_data.limit_period not in ('daily', 'monthly'):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='limit_period must be "daily" or "monthly"',
+        )
+
+    if form_data.soft_limit and form_data.soft_limit >= form_data.token_limit:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='soft_limit must be less than token_limit',
+        )
+
+    permissions = group.permissions or {}
+    permissions['usage_limits'] = form_data.model_dump()
+
+    if not Groups.update_group_permissions_by_id(group_id, permissions, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail='Failed to update group permissions',
+        )
+
+    return permissions['usage_limits']
+
+
+############################
+# Delete usage limits for a group (admin only)
+############################
+
+
+@router.delete('/groups/{group_id}')
+async def delete_group_usage_limits(
+    group_id: str,
+    user=Depends(get_admin_user),
+    db: Session = Depends(get_session),
+):
+    """Remove usage limits from a group."""
+    group = Groups.get_group_by_id(group_id, db=db)
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Group not found',
+        )
+
+    permissions = group.permissions or {}
+    permissions.pop('usage_limits', None)
+
+    if not Groups.update_group_permissions_by_id(group_id, permissions, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail='Failed to update group permissions',
+        )
+
+    return {'status': True}

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -10,7 +10,7 @@ import json
 import uuid
 import asyncio
 
-from fastapi import Request, status
+from fastapi import Request, HTTPException, status
 from starlette.responses import Response, StreamingResponse, JSONResponse
 
 
@@ -49,6 +49,7 @@ from open_webui.utils.filter import (
     get_sorted_filter_ids,
     process_filter_functions,
 )
+from open_webui.utils.usage_limits import check_usage_limit
 
 from open_webui.env import GLOBAL_LOG_LEVEL, BYPASS_MODEL_ACCESS_CONTROL
 
@@ -202,6 +203,21 @@ async def generate_chat_completion(
                 check_model_access(user, model)
             except Exception as e:
                 raise e
+
+        # Check usage limits (skip for admins and background tasks like title/tag/follow-up gen)
+        task_type = form_data.get('metadata', {}).get('task')
+        is_background_task = bypass_filter or bool(task_type)
+        if not is_background_task and user.role != 'admin':
+            limit_check = check_usage_limit(user.id)
+            if not limit_check['allowed']:
+                raise HTTPException(
+                    status_code=429,
+                    detail=limit_check['message'],
+                )
+            if limit_check.get('warning') and limit_check.get('message'):
+                # Store warning for middleware to emit as a status event
+                if not hasattr(request.state, 'usage_warning'):
+                    request.state.usage_warning = limit_check['message']
 
         # Arena model — sub-model was already resolved by process_chat_payload.
         # Inject selected_model_id into the response for the frontend.

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3155,6 +3155,30 @@ async def non_streaming_chat_response_handler(response, ctx):
                         },
                     )
 
+                    # For temp chats and direct API calls, write usage to usage_ledger
+                    # (chat_message FK requires a chat row which these don't have)
+                    chat_id = metadata.get('chat_id') or ''
+                    if usage and (not chat_id or chat_id.startswith('local:')):
+                        from open_webui.models.usage_ledger import UsageLedger
+                        UsageLedger.log_usage(
+                            user_id=user.id,
+                            model_id=metadata.get('model_id') or ctx.get('form_data', {}).get('model'),
+                            input_tokens=usage.get('input_tokens', 0),
+                            output_tokens=usage.get('output_tokens', 0),
+                        )
+
+                    # Emit soft limit warning if approaching usage limit
+                    usage_warning = getattr(request.state, 'usage_warning', None)
+                    if usage_warning and event_emitter:
+                        await event_emitter(
+                            {
+                                'type': 'chat:completion',
+                                'data': {
+                                    'usage_warning': usage_warning,
+                                },
+                            }
+                        )
+
                     # Send a webhook notification if the user is not active
                     if request.app.state.config.ENABLE_USER_WEBHOOKS and not Users.is_user_active(user.id):
                         webhook_url = Users.get_user_webhook_url_by_id(user.id)
@@ -3182,6 +3206,18 @@ async def non_streaming_chat_response_handler(response, ctx):
 
     if isinstance(response, dict):
         response = merge_events_into_response(response_data, events)
+
+    # Track usage for direct API calls (no event_emitter, no chat_message row)
+    if response_data and not event_emitter:
+        usage = normalize_usage(response_data.get('usage', {}) or {})
+        if usage and user:
+            from open_webui.models.usage_ledger import UsageLedger
+            UsageLedger.log_usage(
+                user_id=user.id,
+                model_id=response_data.get('model') or ctx.get('form_data', {}).get('model'),
+                input_tokens=usage.get('input_tokens', 0),
+                output_tokens=usage.get('output_tokens', 0),
+            )
 
     return response
 
@@ -4655,6 +4691,30 @@ async def streaming_chat_response_handler(response, ctx):
                         metadata['chat_id'],
                         metadata['message_id'],
                         {'done': True},
+                    )
+
+                # For temp chats and direct API calls, write usage to usage_ledger
+                # (chat_message FK requires a chat row which these don't have)
+                _chat_id = metadata.get('chat_id') or ''
+                if usage and (not _chat_id or _chat_id.startswith('local:')):
+                    from open_webui.models.usage_ledger import UsageLedger
+                    UsageLedger.log_usage(
+                        user_id=user.id,
+                        model_id=model_id,
+                        input_tokens=usage.get('input_tokens', 0),
+                        output_tokens=usage.get('output_tokens', 0),
+                    )
+
+                # Emit soft limit warning if approaching usage limit
+                usage_warning = getattr(request.state, 'usage_warning', None)
+                if usage_warning and event_emitter:
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': {
+                                'usage_warning': usage_warning,
+                            },
+                        }
                     )
 
                 # Send a webhook notification if the user is not active

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -1,0 +1,153 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+from open_webui.models.chat_messages import ChatMessages
+from open_webui.models.usage_ledger import UsageLedger
+from open_webui.models.groups import Groups
+
+log = logging.getLogger(__name__)
+
+
+def get_period_start(period: str) -> int:
+    """Get the epoch timestamp for the start of the current period."""
+    now = datetime.now()  # Uses server timezone (TZ env var)
+
+    if period == 'daily':
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    elif period == 'monthly':
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    else:
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    return int(start.timestamp())
+
+
+def get_user_usage_limit(user_id: str) -> Optional[dict]:
+    """
+    Get the effective usage limit for a user based on their group memberships.
+
+    Returns the limit from the highest-priority group (lowest priority number).
+    Groups without usage_limits configured are skipped.
+
+    Returns None if no limits are configured for any of the user's groups.
+
+    Expected permissions.usage_limits format:
+    {
+        "token_limit": 1000000,       # max total tokens per period
+        "limit_period": "daily",       # "daily" or "monthly"
+        "soft_limit": 800000,          # optional: warn at this threshold
+        "priority": 10                 # lower = higher priority
+    }
+    """
+    user_groups = Groups.get_groups_by_member_id(user_id)
+    if not user_groups:
+        return None
+
+    best_limit = None
+    best_priority = float('inf')
+
+    for group in user_groups:
+        permissions = group.permissions or {}
+        usage_limits = permissions.get('usage_limits')
+        if not usage_limits:
+            continue
+
+        token_limit = usage_limits.get('token_limit')
+        if token_limit is None:
+            continue
+
+        priority = usage_limits.get('priority', 100)
+        if priority < best_priority:
+            best_priority = priority
+            best_limit = {
+                'token_limit': token_limit,
+                'limit_period': usage_limits.get('limit_period', 'daily'),
+                'soft_limit': usage_limits.get('soft_limit'),
+                'group_name': group.name,
+            }
+
+    return best_limit
+
+
+def check_usage_limit(user_id: str) -> dict:
+    """
+    Check whether a user has exceeded their usage limit.
+    Reads from chat_message table (same source as analytics).
+    """
+    limit = get_user_usage_limit(user_id)
+
+    # No limits configured — always allow
+    if limit is None:
+        return {
+            'allowed': True,
+            'warning': False,
+            'usage': None,
+            'limit': None,
+            'message': None,
+        }
+
+    period_start = get_period_start(limit['limit_period'])
+
+    # Sum usage from chat_message (normal chats) + usage_ledger (temp chats)
+    cm_usage = ChatMessages.get_token_usage_by_user(start_date=period_start)
+    cm_user = cm_usage.get(user_id, {'input_tokens': 0, 'output_tokens': 0, 'total_tokens': 0})
+    ledger_usage = UsageLedger.get_user_usage_since(user_id, period_start)
+
+    user_usage = {
+        'input_tokens': cm_user['input_tokens'] + ledger_usage['input_tokens'],
+        'output_tokens': cm_user['output_tokens'] + ledger_usage['output_tokens'],
+        'total_tokens': cm_user['total_tokens'] + ledger_usage['total_tokens'],
+    }
+    total_tokens = user_usage['total_tokens']
+
+    token_limit = limit['token_limit']
+    soft_limit = limit.get('soft_limit')
+    period_label = limit['limit_period']
+
+    log.info(
+        f'[USAGE_LIMIT] user={user_id} period={period_label} '
+        f'usage={total_tokens}/{token_limit} '
+        f'(input={user_usage["input_tokens"]}, output={user_usage["output_tokens"]}) '
+        f'group={limit.get("group_name", "?")} soft_limit={soft_limit}'
+    )
+
+    # Hard limit exceeded
+    if total_tokens >= token_limit:
+        log.warning(f'[USAGE_LIMIT] BLOCKED user={user_id} ({total_tokens}/{token_limit})')
+        return {
+            'allowed': False,
+            'warning': False,
+            'usage': user_usage,
+            'limit': limit,
+            'message': (
+                f'You have reached your {period_label} token limit '
+                f'({total_tokens:,} / {token_limit:,} tokens). '
+                f'Your limit resets at the start of the next {period_label} period.'
+            ),
+        }
+
+    # Soft limit warning
+    if soft_limit and total_tokens >= soft_limit:
+        remaining = token_limit - total_tokens
+        log.info(f'[USAGE_LIMIT] WARNING user={user_id} ({total_tokens}/{token_limit})')
+        return {
+            'allowed': True,
+            'warning': True,
+            'usage': user_usage,
+            'limit': limit,
+            'message': (
+                f'You are approaching your {period_label} token limit '
+                f'({total_tokens:,} / {token_limit:,} tokens). '
+                f'{remaining:,} tokens remaining.'
+            ),
+        }
+
+    # Under limits
+    return {
+        'allowed': True,
+        'warning': False,
+        'usage': user_usage,
+        'limit': limit,
+        'message': None,
+    }

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -67,7 +67,8 @@
 				access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...loadedPermissions.access_grants },
 				chat: { ...DEFAULT_PERMISSIONS.chat, ...loadedPermissions.chat },
 				features: { ...DEFAULT_PERMISSIONS.features, ...loadedPermissions.features },
-				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings }
+				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings },
+				...(loadedPermissions.usage_limits ? { usage_limits: loadedPermissions.usage_limits } : {})
 			};
 			data = group?.data ?? {};
 

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -10,6 +10,8 @@
 	export let permissions = {};
 	export let defaultPermissions = {};
 
+	let usageLimitsEnabled = false;
+
 	// Reactive statement to ensure all fields are present in `permissions`
 	$: {
 		permissions = fillMissingProperties(permissions, DEFAULT_PERMISSIONS);
@@ -30,6 +32,7 @@
 
 	onMount(() => {
 		permissions = fillMissingProperties(permissions, DEFAULT_PERMISSIONS);
+		usageLimitsEnabled = !!permissions.usage_limits?.token_limit;
 	});
 </script>
 
@@ -938,5 +941,83 @@
 				</div>
 			{/if}
 		</div>
+	</div>
+
+	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
+
+	<div>
+		<div class=" mb-2 text-sm font-medium">{$i18n.t('Usage Limits')}</div>
+
+		<div class="flex flex-col w-full">
+			<div class="flex w-full justify-between my-1">
+				<div class=" self-center text-xs font-medium">
+					{$i18n.t('Enable Token Limits')}
+				</div>
+				<Switch
+					state={usageLimitsEnabled}
+					on:change={() => {
+						usageLimitsEnabled = !usageLimitsEnabled;
+						if (!usageLimitsEnabled) {
+							delete permissions.usage_limits;
+						} else {
+							permissions.usage_limits = {
+								token_limit: 1000000,
+								limit_period: 'daily',
+								soft_limit: 0,
+								priority: 100
+							};
+						}
+					}}
+				/>
+			</div>
+		</div>
+
+		{#if usageLimitsEnabled && permissions.usage_limits}
+			<div class="ml-2 flex flex-col gap-3 pt-1 pb-1">
+				<div class="flex flex-col gap-1">
+					<div class="text-xs text-gray-500">{$i18n.t('Token Limit (per period)')}</div>
+					<input
+						type="number"
+						class="w-full rounded-lg py-1.5 px-3 text-sm bg-transparent border border-gray-200 dark:border-gray-700 outline-none"
+						bind:value={permissions.usage_limits.token_limit}
+						min="0"
+						placeholder="1000000"
+					/>
+				</div>
+
+				<div class="flex flex-col gap-1">
+					<div class="text-xs text-gray-500">{$i18n.t('Period')}</div>
+					<select
+						class="w-full rounded-lg py-1.5 px-3 text-sm bg-transparent border border-gray-200 dark:border-gray-700 outline-none"
+						bind:value={permissions.usage_limits.limit_period}
+					>
+						<option value="daily">{$i18n.t('Daily')}</option>
+						<option value="monthly">{$i18n.t('Monthly')}</option>
+					</select>
+				</div>
+
+				<div class="flex flex-col gap-1">
+					<div class="text-xs text-gray-500">{$i18n.t('Soft Limit (warning threshold, optional)')}</div>
+					<input
+						type="number"
+						class="w-full rounded-lg py-1.5 px-3 text-sm bg-transparent border border-gray-200 dark:border-gray-700 outline-none"
+						bind:value={permissions.usage_limits.soft_limit}
+						min="0"
+						placeholder={$i18n.t('Leave empty for no warning')}
+					/>
+				</div>
+
+				<div class="flex flex-col gap-1">
+					<div class="text-xs text-gray-500">{$i18n.t('Priority (lower = higher priority)')}</div>
+					<input
+						type="number"
+						class="w-full rounded-lg py-1.5 px-3 text-sm bg-transparent border border-gray-200 dark:border-gray-700 outline-none"
+						bind:value={permissions.usage_limits.priority}
+						min="1"
+						placeholder="100"
+					/>
+				</div>
+			</div>
+		{/if}
 	</div>
 </div>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1648,7 +1648,7 @@
 	};
 
 	const chatCompletionEventHandler = async (data, message, chatId) => {
-		const { id, done, choices, content, output, sources, selected_model_id, error, usage } = data;
+		const { id, done, choices, content, output, sources, selected_model_id, error, usage, usage_warning } = data;
 
 		// Store raw OR-aligned output items from backend
 		if (output) {
@@ -1657,6 +1657,10 @@
 
 		if (error) {
 			await handleOpenAIError(error, message);
+		}
+
+		if (usage_warning) {
+			toast.warning(usage_warning, { duration: 8000 });
 		}
 
 		if (sources && !message?.sources) {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Testing:** Extensively tested on ECS Fargate deployment with OpenRouter and AWS Bedrock
- [x] **Code review:** Self-reviewed
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Added

- Per-group token usage limits with configurable daily/monthly enforcement
- Admin UI for setting token limits, soft limits, and priority per group
- Soft limit warning toast and hard limit 429 block
- Usage tracking for direct API calls and temporary chats
- Usage data preserved when chats are deleted (content stripped, usage metadata retained)

---

### Description

Adds per-group token usage limits that enforce daily or monthly caps on non-admin users. Full design discussion in #23558.

**How it works:**

- **Enforcement**: Pre-request check in `generate_chat_completion` queries `chat_message` for the user's token usage in the current period. If over the group's limit, returns 429. Background tasks (title/tag/follow-up generation) are skipped via `metadata.task` check.
- **Usage data preservation**: Chat deletion strips message content but preserves usage metadata (user_id, model_id, tokens, timestamps). Prevents users from resetting usage by deleting chats.
- **Temp chats & API calls**: Since `chat_message` has a FK to `chat` (which doesn't exist for these), usage is written to a small `usage_ledger` table. Enforcement sums both tables.
- **Configuration**: Stored in the existing group `permissions` JSON field. Admin UI added to the Permissions tab in group settings.
- **Soft/hard limits**: Configurable soft limit shows a warning toast; hard limit blocks with 429.
- **Priority**: When a user belongs to multiple groups, the limit from the highest-priority group (lowest priority number) applies.

### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Testing

Tested on an ECS Fargate deployment (CUNY AI Lab, PostgreSQL 16.3) with:
- OpenRouter (Gemma 4 31B) and AWS Bedrock (Nova Pro, Nova Premier)
- Token counts verified to match analytics dashboard
- Background tasks (title/tag/follow-up gen) excluded from counting and enforcement — verified via CloudWatch logs
- Chat deletion confirmed to preserve usage counts (FK changed to SET NULL, verified via `pg_constraint` query)
- Soft limit warning toasts and hard limit 429 blocks working
- Admin users bypass all limits
- Direct API calls (`POST /api/chat/completions` with JWT, no `chat_id`, `stream: false`) — both enforced and tracked
- Alembic migration tested on PostgreSQL (uses raw SQL for FK alteration, batch mode for SQLite)
- Automated code review via pr-validator-bot — both findings addressed and retested
### Breaking Changes

- Chat message content is now stripped (set to NULL) on deletion instead of row deletion. Usage metadata (user_id, model_id, input_tokens, output_tokens, timestamps) is preserved. This changes the behavior of `delete_chat_by_id`, `delete_chat_by_id_and_user_id`, `delete_chats_by_user_id`, and `delete_chats_by_user_id_and_folder_id`.

### Additional Information

- Discussion: #23558
- Related: #21675 (analytics enhancements), #23323 (original feature request)
- New Alembic migration adds `usage_ledger` table (revision `c3d4e5f6a7b8`, depends on `b7c8d9e0f1a2`)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.