### PR TITLE
fix: include token in terminal orchestrator websocket URL

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -106,6 +106,10 @@ async def proxy_terminal(
         target_url += f'?{request.query_params}'
 
     headers = {'X-User-Id': user.id}
+    # Forward per-session cwd tracking header
+    session_id = request.headers.get('x-session-id')
+    if session_id:
+        headers['X-Session-Id'] = session_id
     cookies = {}
     auth_type = connection.get('auth_type', 'bearer')
 

--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -18,6 +18,7 @@ from open_webui.utils.auth import get_verified_user
 from open_webui.utils.access_control import has_connection_access
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
+from open_webui.utils.terminals import build_terminal_ws_url
 
 log = logging.getLogger(__name__)
 
@@ -105,10 +106,6 @@ async def proxy_terminal(
         target_url += f'?{request.query_params}'
 
     headers = {'X-User-Id': user.id}
-    # Forward per-session cwd tracking header
-    session_id = request.headers.get('x-session-id')
-    if session_id:
-        headers['X-Session-Id'] = session_id
     cookies = {}
     auth_type = connection.get('auth_type', 'bearer')
 
@@ -259,23 +256,16 @@ async def ws_terminal(
         await ws.close(code=4003, reason='Terminal server URL not configured')
         return
 
-    # Build upstream WebSocket URL (no token in URL)
-    ws_base = base_url.replace('https://', 'wss://').replace('http://', 'ws://')
-
-    # Route through orchestrator policy endpoint if policy_id is set
-    policy_id = connection.get('policy_id')
-    upstream_params = {}
-    # For orchestrator-backed servers, pass user_id
-    upstream_params['user_id'] = user.id
-
-    import urllib.parse
-
-    if policy_id:
-        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{session_id}'
-    else:
-        upstream_url = f'{ws_base}/api/terminals/{session_id}'
-    if upstream_params:
-        upstream_url += f'?{urllib.parse.urlencode(upstream_params)}'
+    auth_type = connection.get('auth_type', 'bearer')
+    key = connection.get('key', '')
+    upstream_url = build_terminal_ws_url(
+        base_url=base_url,
+        session_id=session_id,
+        user_id=user.id,
+        policy_id=connection.get('policy_id'),
+        auth_type=auth_type,
+        key=key,
+    )
 
     session = aiohttp.ClientSession()
     try:
@@ -283,10 +273,8 @@ async def ws_terminal(
             import asyncio
             import json as _json
 
-            # First-message auth to upstream terminal server
-            auth_type = connection.get('auth_type', 'bearer')
+            # Keep the auth frame for backends that still expect it after connect.
             if auth_type == 'bearer':
-                key = connection.get('key', '')
                 await upstream.send_str(_json.dumps({'type': 'auth', 'token': key}))
 
             async def _client_to_upstream():

--- a/backend/open_webui/test/util/test_terminals.py
+++ b/backend/open_webui/test/util/test_terminals.py
@@ -1,0 +1,44 @@
+from open_webui.utils.terminals import build_terminal_ws_url
+
+
+def test_build_terminal_ws_url_adds_bearer_token_query_param():
+    url = build_terminal_ws_url(
+        base_url='http://orchestrator.openwebui.svc.cluster.local:8080/',
+        session_id='abc123',
+        user_id='user-1',
+        auth_type='bearer',
+        key='secret-token',
+    )
+
+    assert (
+        url
+        == 'ws://orchestrator.openwebui.svc.cluster.local:8080/api/terminals/abc123?user_id=user-1&token=secret-token'
+    )
+
+
+def test_build_terminal_ws_url_uses_policy_route_when_configured():
+    url = build_terminal_ws_url(
+        base_url='https://orchestrator.example.com',
+        session_id='abc123',
+        user_id='user-1',
+        policy_id='policy-9',
+        auth_type='bearer',
+        key='secret-token',
+    )
+
+    assert (
+        url
+        == 'wss://orchestrator.example.com/p/policy-9/api/terminals/abc123?user_id=user-1&token=secret-token'
+    )
+
+
+def test_build_terminal_ws_url_omits_token_for_non_bearer_auth():
+    url = build_terminal_ws_url(
+        base_url='https://orchestrator.example.com',
+        session_id='abc123',
+        user_id='user-1',
+        auth_type='session',
+        key='secret-token',
+    )
+
+    assert url == 'wss://orchestrator.example.com/api/terminals/abc123?user_id=user-1'

--- a/backend/open_webui/utils/terminals.py
+++ b/backend/open_webui/utils/terminals.py
@@ -1,0 +1,24 @@
+from urllib.parse import urlencode
+
+
+def build_terminal_ws_url(
+    base_url: str,
+    session_id: str,
+    user_id: str,
+    *,
+    policy_id: str | None = None,
+    auth_type: str = 'bearer',
+    key: str = '',
+) -> str:
+    ws_base = base_url.rstrip('/').replace('https://', 'wss://').replace('http://', 'ws://')
+
+    if policy_id:
+        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{session_id}'
+    else:
+        upstream_url = f'{ws_base}/api/terminals/{session_id}'
+
+    upstream_params = {'user_id': user_id}
+    if auth_type == 'bearer' and key:
+        upstream_params['token'] = key
+
+    return f'{upstream_url}?{urlencode(upstream_params)}'


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors
I did not open a discussion before submitting this fix because this is a narrow bugfix with a focused regression test and manual validation, not a large feature or architectural change.

**Before submitting, make sure you've checked the following:**
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** A concise description of the changes is included below.
- [x] **Changelog:** A changelog entry following the requested format is included below.
- [ ] **Documentation:** I do not believe this requires docs in the docs repository because it fixes internal terminal WebSocket auth behavior rather than changing user-facing configuration or deployment steps.
- [x] **Dependencies:** No new or upgraded dependencies were added.
- [x] **Testing:** I performed unit tests and manual validation in Kubernetes, with reproducible before/after behavior documented below.
- [x] **Agentic AI Code:** This change has gone through additional human review and manual testing before submission.
- [x] **Code review:** I performed a self-review of the code and kept the change narrow.
- [x] **Design & Architecture:** This uses the existing terminal connection model and avoids introducing new settings.
- [x] **Git Hygiene:** This PR is atomic and scoped to one logical fix.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

## Description

This PR fixes terminal WebSocket proxy connections to the terminals orchestrator by including the bearer token in the upstream WebSocket query string.

Today `Open WebUI` opens the upstream terminal WebSocket with `user_id` only, then sends an auth message after the connection is established. The terminals orchestrator validates bearer auth during the WebSocket handshake, so the connection is rejected with `403` before that auth frame can be sent.

This patch:
- adds `token` to the upstream WebSocket query params for bearer-auth terminal connections
- keeps the existing post-connect auth frame for compatibility with backends that still expect it
- adds regression tests for bearer, non-bearer, and policy-scoped terminal routes

## Repro / Root Cause

When `Open WebUI` is configured to use the terminals orchestrator, terminal session creation succeeds but interactive attach fails with a WebSocket handshake error:

```text
WSServerHandshakeError: 403
```

In my case, the failure was reproducible because:
- `POST /api/terminals` succeeded
- proxied HTTP calls to the terminal backend succeeded
- WebSocket connect to the orchestrator without `token` failed with `403`
- WebSocket connect to the same orchestrator with `?token=...&user_id=...` succeeded

So the issue is isolated to the upstream WebSocket auth shape.

The root cause is that the terminals orchestrator validates WebSocket auth during the handshake and expects the bearer token to be present on the upstream WebSocket request.

`Open WebUI` was building the upstream WebSocket URL with only:
- `user_id`

and then sending:
- `{"type":"auth","token":"..."}`

after the socket connected.

That does not work when the upstream rejects the handshake before accepting the connection.

## Testing

### Unit tests

```bash
PYTHONPATH=backend python3 -m pytest backend/open_webui/test/util/test_terminals.py -q
```

Result:

```text
3 passed
```

### Manual validation

I am also running this successfully in a Kubernetes cluster using the terminals orchestrator flow.

Tested setup:
- terminals orchestrator: `ghcr.io/open-webui/terminals:0.0.2`
- terminals operator: `ghcr.io/open-webui/terminals-operator:0.0.2`
- terminal image: `ghcr.io/open-webui/open-terminal:0.11.34`
- `Open WebUI` configured to connect to the orchestrator service over the in-cluster service URL
- per-user terminal pods created dynamically via the operator

Before this patch:
- terminal session creation succeeded
- terminal backend HTTP proxying succeeded
- interactive terminal attach failed with `WSServerHandshakeError: 403`

After this patch:
- terminal session creation still succeeds
- interactive terminal attach succeeds
- I can open and use the terminal normally through the `Open WebUI` interface

I also reproduced the orchestrator behavior directly by connecting to the orchestrator WebSocket endpoint:
- without `token` in the query string: `403`
- with `token` in the query string: connection succeeds

### Edge cases covered by tests

- bearer auth adds `token`
- non-bearer auth does not add `token`
- policy-scoped routes generate the correct path

# Changelog Entry

### Description
- Fix terminal WebSocket proxying to the terminals orchestrator by including the bearer token in the upstream WebSocket query string during handshake.

### Added
- A small helper to build terminal WebSocket URLs.
- Regression tests covering bearer, non-bearer, and policy-scoped terminal routes.

### Changed
- Upstream terminal WebSocket URL construction now includes `token` when `auth_type == "bearer"` and a key is present.
- The existing post-connect auth frame is preserved for compatibility.

### Deprecated
- None.

### Removed
- None.

### Fixed
- Fixed terminal attach failures where the terminals orchestrator rejects the upstream WebSocket handshake with `403` because the bearer token is missing from the query string.

### Security
- No new security features or dependency changes.
- This change aligns `Open WebUI`'s upstream WebSocket auth behavior with the orchestrator's existing handshake validation requirements.

### Breaking Changes
- **BREAKING CHANGE**: None.

---

### Additional Information
- This is intentionally narrow and does not add new settings or change non-bearer terminal behavior.
- No dependencies were added or upgraded.
- The existing auth frame sent after connection establishment is still preserved for compatibility with backends that expect it.

### Screenshots or Videos
- No screenshots attached.
- This change affects the terminal WebSocket handshake path rather than visible UI layout.
- If needed, I can add a short screen recording showing terminal attach failure before the fix and successful attach after the fix.

### Contributor License Agreement
- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.