### PR TITLE
test: add integration tests for notes API

### DIFF
--- a/backend/open_webui/test/apps/webui/routers/test_notes.py
+++ b/backend/open_webui/test/apps/webui/routers/test_notes.py
@@ -1,0 +1,343 @@
+from test.util.abstract_integration_test import AbstractPostgresTest
+from test.util.mock_user import mock_webui_user
+
+
+class TestNotes(AbstractPostgresTest):
+    BASE_PATH = '/api/v1/notes'
+
+    def setup_class(cls):
+        super().setup_class()
+        from open_webui.models.notes import Notes
+        from open_webui.models.users import Users
+
+        cls.notes = Notes
+        cls.users = Users
+
+    def setup_method(self):
+        super().setup_method()
+        self.users.insert_new_user(
+            id='user-1',
+            name='Alice',
+            email='alice@openwebui.com',
+            profile_image_url='/alice.png',
+            role='user',
+        )
+        self.users.insert_new_user(
+            id='user-2',
+            name='Bob',
+            email='bob@openwebui.com',
+            profile_image_url='/bob.png',
+            role='user',
+        )
+
+    # ──────────────────────────────────────────────
+    # Create
+    # ──────────────────────────────────────────────
+
+    def test_create_note(self):
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'My First Note', 'data': {'content': {'md': 'Hello world'}}},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data['title'] == 'My First Note'
+        assert data['user_id'] == 'user-1'
+        assert data['id'] is not None
+
+    def test_create_note_without_notes_permission_returns_401(self):
+        # Disable the notes feature for regular users via app config
+        from open_webui.main import app
+
+        original = app.state.config.USER_PERMISSIONS.get('features', {}).get('notes', True)
+        app.state.config.USER_PERMISSIONS.setdefault('features', {})['notes'] = False
+        try:
+            with mock_webui_user(id='user-1'):
+                response = self.fast_api_client.post(
+                    self.create_url('/create'),
+                    json={'title': 'Forbidden Note'},
+                )
+            assert response.status_code == 401
+        finally:
+            app.state.config.USER_PERMISSIONS['features']['notes'] = original
+
+    # ──────────────────────────────────────────────
+    # Get by ID
+    # ──────────────────────────────────────────────
+
+    def test_get_note_by_id(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Fetch Me', 'data': {'content': {'md': 'content'}}},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url(f'/{note_id}'))
+        assert response.status_code == 200
+        data = response.json()
+        assert data['id'] == note_id
+        assert data['title'] == 'Fetch Me'
+        assert data['write_access'] is True
+
+    def test_get_note_by_id_not_found(self):
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/nonexistent-id'))
+        assert response.status_code == 404
+
+    def test_get_note_by_id_other_user_forbidden(self):
+        """A note owner's note is not visible to an unrelated user."""
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Private Note'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-2'):
+            response = self.fast_api_client.get(self.create_url(f'/{note_id}'))
+        assert response.status_code == 403
+
+    # ──────────────────────────────────────────────
+    # List / GET /
+    # ──────────────────────────────────────────────
+
+    def test_get_notes_empty(self):
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/'))
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_notes_returns_own_notes(self):
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Note A'},
+            )
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Note B'},
+            )
+
+        with mock_webui_user(id='user-2'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': "Bob's note"},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/'))
+        assert response.status_code == 200
+        titles = [n['title'] for n in response.json()]
+        assert 'Note A' in titles
+        assert 'Note B' in titles
+        assert "Bob's note" not in titles
+
+    # ──────────────────────────────────────────────
+    # Search
+    # ──────────────────────────────────────────────
+
+    def test_search_notes_single_word(self):
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Shopping list', 'data': {'content': {'md': 'Buy apples'}}},
+            )
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Work tasks', 'data': {'content': {'md': 'Finish report'}}},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/search'), params={'query': 'shopping'})
+        assert response.status_code == 200
+        data = response.json()
+        assert data['total'] == 1
+        assert data['items'][0]['title'] == 'Shopping list'
+
+    def test_search_notes_multi_word_query(self):
+        """Multi-word queries are normalised (spaces stripped) before matching.
+
+        'to do' should match a note titled 'to-do list' because the search
+        normalises both sides by removing hyphens and spaces.
+        """
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'to-do list', 'data': {'content': {'md': 'task one'}}},
+            )
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'meeting notes', 'data': {'content': {'md': 'agenda'}}},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/search'), params={'query': 'to do'})
+        assert response.status_code == 200
+        data = response.json()
+        assert data['total'] == 1
+        assert data['items'][0]['title'] == 'to-do list'
+
+    def test_search_notes_by_content(self):
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Recipes', 'data': {'content': {'md': 'pasta carbonara ingredients'}}},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/search'), params={'query': 'carbonara'})
+        assert response.status_code == 200
+        data = response.json()
+        assert data['total'] == 1
+        assert data['items'][0]['title'] == 'Recipes'
+
+    def test_search_notes_no_results(self):
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Random note'},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/search'), params={'query': 'zzznomatch'})
+        assert response.status_code == 200
+        data = response.json()
+        assert data['total'] == 0
+        assert data['items'] == []
+
+    def test_search_notes_scoped_to_user(self):
+        """Search must not return another user's private notes."""
+        with mock_webui_user(id='user-1'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Alice secret'},
+            )
+        with mock_webui_user(id='user-2'):
+            self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Bob secret'},
+            )
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url('/search'), params={'query': 'secret'})
+        assert response.status_code == 200
+        data = response.json()
+        titles = [item['title'] for item in data['items']]
+        assert 'Alice secret' in titles
+        assert 'Bob secret' not in titles
+
+    # ──────────────────────────────────────────────
+    # Update
+    # ──────────────────────────────────────────────
+
+    def test_update_note(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Original Title', 'data': {'content': {'md': 'old content'}}},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.post(
+                self.create_url(f'/{note_id}/update'),
+                json={'title': 'Updated Title', 'data': {'content': {'md': 'new content'}}},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data['title'] == 'Updated Title'
+
+    def test_update_note_by_other_user_forbidden(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Alice note'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-2'):
+            response = self.fast_api_client.post(
+                self.create_url(f'/{note_id}/update'),
+                json={'title': 'Hijacked'},
+            )
+        assert response.status_code == 403
+
+    def test_update_note_not_found(self):
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.post(
+                self.create_url('/nonexistent-id/update'),
+                json={'title': 'Whatever'},
+            )
+        assert response.status_code == 404
+
+    # ──────────────────────────────────────────────
+    # Delete
+    # ──────────────────────────────────────────────
+
+    def test_delete_note(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'To Be Deleted'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.delete(self.create_url(f'/{note_id}/delete'))
+        assert response.status_code == 200
+        assert response.json() is True
+
+        # Confirm it's gone
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.get(self.create_url(f'/{note_id}'))
+        assert response.status_code == 404
+
+    def test_delete_note_by_other_user_forbidden(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'Protected'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='user-2'):
+            response = self.fast_api_client.delete(self.create_url(f'/{note_id}/delete'))
+        assert response.status_code == 403
+
+    def test_delete_note_not_found(self):
+        with mock_webui_user(id='user-1'):
+            response = self.fast_api_client.delete(self.create_url('/nonexistent-id/delete'))
+        assert response.status_code == 404
+
+    # ──────────────────────────────────────────────
+    # Admin access
+    # ──────────────────────────────────────────────
+
+    def test_admin_can_get_any_note(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'User note'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='admin-1', role='admin'):
+            response = self.fast_api_client.get(self.create_url(f'/{note_id}'))
+        assert response.status_code == 200
+        assert response.json()['id'] == note_id
+
+    def test_admin_can_delete_any_note(self):
+        with mock_webui_user(id='user-1'):
+            create_resp = self.fast_api_client.post(
+                self.create_url('/create'),
+                json={'title': 'User note'},
+            )
+        note_id = create_resp.json()['id']
+
+        with mock_webui_user(id='admin-1', role='admin'):
+            response = self.fast_api_client.delete(self.create_url(f'/{note_id}/delete'))
+        assert response.status_code == 200
+        assert response.json() is True

--- a/backend/open_webui/test/util/abstract_integration_test.py
+++ b/backend/open_webui/test/util/abstract_integration_test.py
@@ -1,0 +1,163 @@
+import logging
+import os
+import time
+
+import docker
+import pytest
+from docker import DockerClient
+from pytest_docker.plugin import get_docker_ip
+from fastapi.testclient import TestClient
+from sqlalchemy import text, create_engine
+
+
+log = logging.getLogger(__name__)
+
+
+def get_fast_api_client():
+    from open_webui.main import app
+
+    with TestClient(app) as c:
+        return c
+
+
+class AbstractIntegrationTest:
+    BASE_PATH = None
+
+    def create_url(self, path='', query_params=None):
+        if self.BASE_PATH is None:
+            raise Exception('BASE_PATH is not set')
+        parts = self.BASE_PATH.split('/')
+        parts = [part.strip() for part in parts if part.strip() != '']
+        path_parts = path.split('/')
+        path_parts = [part.strip() for part in path_parts if part.strip() != '']
+        query_parts = ''
+        if query_params:
+            query_parts = '&'.join([f'{key}={value}' for key, value in query_params.items()])
+            query_parts = f'?{query_parts}'
+        return '/'.join(parts + path_parts) + query_parts
+
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    def setup_method(self):
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    def teardown_method(self):
+        pass
+
+
+class AbstractPostgresTest(AbstractIntegrationTest):
+    DOCKER_CONTAINER_NAME = 'postgres-test-container-will-get-deleted'
+    docker_client: DockerClient
+
+    @classmethod
+    def _create_db_url(cls, env_vars_postgres: dict) -> str:
+        host = get_docker_ip()
+        user = env_vars_postgres['POSTGRES_USER']
+        pw = env_vars_postgres['POSTGRES_PASSWORD']
+        port = 8081
+        db = env_vars_postgres['POSTGRES_DB']
+        return f'postgresql://{user}:{pw}@{host}:{port}/{db}'
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        try:
+            env_vars_postgres = {
+                'POSTGRES_USER': 'user',
+                'POSTGRES_PASSWORD': 'example',
+                'POSTGRES_DB': 'openwebui',
+            }
+            cls.docker_client = docker.from_env()
+            cls.docker_client.containers.run(
+                'postgres:16.2',
+                detach=True,
+                environment=env_vars_postgres,
+                name=cls.DOCKER_CONTAINER_NAME,
+                ports={5432: ('0.0.0.0', 8081)},
+                command='postgres -c log_statement=all',
+            )
+            time.sleep(0.5)
+
+            database_url = cls._create_db_url(env_vars_postgres)
+            os.environ['DATABASE_URL'] = database_url
+            retries = 10
+            db = None
+            while retries > 0:
+                try:
+                    from open_webui.config import OPEN_WEBUI_DIR
+
+                    db = create_engine(database_url, pool_pre_ping=True)
+                    db = db.connect()
+                    log.info('postgres is ready!')
+                    break
+                except Exception as e:
+                    log.warning(e)
+                    time.sleep(3)
+                    retries -= 1
+
+            if db:
+                cls.fast_api_client = get_fast_api_client()
+                db.close()
+            else:
+                raise Exception('Could not connect to Postgres')
+        except Exception as ex:
+            log.error(ex)
+            cls.teardown_class()
+            pytest.fail(f'Could not setup test environment: {ex}')
+
+    def _check_db_connection(self):
+        from open_webui.internal.db import SessionLocal
+
+        retries = 10
+        while retries > 0:
+            try:
+                session = SessionLocal()
+                session.execute(text('SELECT 1'))
+                session.commit()
+                session.close()
+                break
+            except Exception as e:
+                session.rollback()
+                session.close()
+                log.warning(e)
+                time.sleep(3)
+                retries -= 1
+
+    def setup_method(self):
+        super().setup_method()
+        self._check_db_connection()
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        super().teardown_class()
+        cls.docker_client.containers.get(cls.DOCKER_CONTAINER_NAME).remove(force=True)
+
+    def teardown_method(self):
+        from open_webui.internal.db import SessionLocal
+
+        session = SessionLocal()
+        try:
+            tables = [
+                'access_grant',
+                'note',
+                'model',
+                'prompt',
+                'memory',
+                'tag',
+                'auth',
+                '"user"',
+            ]
+            for table in tables:
+                session.execute(text(f'TRUNCATE TABLE {table} CASCADE'))
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()

--- a/backend/open_webui/test/util/mock_user.py
+++ b/backend/open_webui/test/util/mock_user.py
@@ -1,0 +1,45 @@
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+
+
+@contextmanager
+def mock_webui_user(**kwargs):
+    from open_webui.main import app
+
+    with mock_user(app, **kwargs):
+        yield
+
+
+@contextmanager
+def mock_user(app: FastAPI, **kwargs):
+    from open_webui.utils.auth import (
+        get_current_user,
+        get_verified_user,
+        get_admin_user,
+        get_current_user_by_api_key,
+    )
+    from open_webui.models.users import User
+
+    def create_user():
+        user_parameters = {
+            'id': '1',
+            'name': 'John Doe',
+            'email': 'john.doe@openwebui.com',
+            'role': 'user',
+            'profile_image_url': '/user.png',
+            'last_active_at': 1627351200,
+            'updated_at': 1627351200,
+            'created_at': 162735120,
+            **kwargs,
+        }
+        return User(**user_parameters)
+
+    app.dependency_overrides = {
+        get_current_user: create_user,
+        get_verified_user: create_user,
+        get_admin_user: create_user,
+        get_current_user_by_api_key: create_user,
+    }
+    yield
+    app.dependency_overrides = {}


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.  
- [x] **Description:** Provided below.  
- [x] **Changelog:** Added below.  
- [x] **Documentation:** No user-facing behaviour changed — no docs needed.  
- [x] **Dependencies:** No new or upgraded dependencies.  
- [x] **Testing:** All 20 tests pass locally against a real Postgres instance via Docker.  
- [x] **Agentic AI Code:** Confirm this Pull Request is not written by any AI Agent or has at least gone through additional human review AND manual testing.  
- [x] **Code review:** Self-reviewed.  
- [x] **Design & Architecture:** Test files only - no settings, no UI, no architecture changes.  
- [x] **Git Hygiene:** Single atomic commit targeting one logical change.  
- [x] **Title Prefix:** `test:`  

---

# Changelog Entry

## Description

The notes API (`routers/notes.py`) had no test coverage. This PR adds a full integration test suite for it, following the same pattern as `test_users.py`.

It also introduces the shared test utilities (`AbstractPostgresTest`, `mock_webui_user`) that the existing test files depend on but were previously absent from the repository.

## Added

- `backend/open_webui/test/apps/webui/routers/test_notes.py` — 20 integration tests covering:
  - Create: happy path, 401 when the notes feature is disabled via `USER_PERMISSIONS`
  - Get by ID: owner access (`write_access: true`), 404 for unknown ID, 403 for a non-owner with no access grant
  - List: empty result, results scoped to the requesting user only
  - Search:
    - Single-word title match  
    - Multi-word normalization (`"to do"` matches `"to-do list"`)  
    - Content body match  
    - No-results case  
    - Cross-user isolation  
  - Update: happy path, 403 for non-owner, 404 for unknown ID
  - Delete: happy path, confirmed gone on re-fetch, 403 for non-owner, 404 for unknown ID
  - Admin: can get and delete any user's note regardless of ownership

- `backend/open_webui/test/util/abstract_integration_test.py` — Postgres Docker fixture base class (`AbstractPostgresTest`)  
- `backend/open_webui/test/util/mock_user.py` — auth dependency override helper (`mock_webui_user`)  

## Fixed

- Adds a regression test (`test_search_notes_multi_word_query`) that validates the multi-word search normalization fix, ensuring queries like `"to do"` correctly match notes titled `"to-do list"` via hyphen/space stripping.

---

## Additional Information

- Closes #23613  
- Related to #21783 (backend has no test coverage in CI)  
- Tests use a real Postgres instance (no mocks), consistent with the existing test infrastructure in this repository.

## Screenshots or Videos

N/A — backend tests only.

---

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.