### PR TITLE
Fix: Enable outlet filters for direct API clients by integrating /chat/completed processing into /chat/completion

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1976,19 +1976,14 @@ async def generate_messages(
 
 @app.post('/api/chat/completed')
 async def chat_completed(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    try:
-        model_item = form_data.pop('model_item', {})
-
-        if model_item.get('direct', False):
-            request.state.direct = True
-            request.state.model = model_item
-
-        return await chat_completed_handler(request, form_data, user)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        )
+    """
+    Outlet filters already run in /chat/completion.
+    This endpoint returns the original form_data for backward compatibility.
+    Outlet filters are NOT run again (they already ran in /chat/completion).
+    """
+    # Return the original form_data as-is (no outlet processing)
+    # This matches the original response structure
+    return form_data
 
 
 @app.post('/api/chat/actions/{action_id}')

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -70,8 +70,12 @@ from open_webui.utils.files import (
 from open_webui.models.users import UserModel
 from open_webui.models.functions import Functions
 from open_webui.models.models import Models
+from open_webui.models.chats import Chats
 
 from open_webui.retrieval.utils import get_sources_from_items
+
+from open_webui.socket.main import get_event_emitter, get_event_call
+from open_webui.utils.filter import get_sorted_filter_ids, process_filter_functions
 
 
 from open_webui.utils.sanitize import sanitize_code
@@ -2192,6 +2196,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     form_data = await convert_url_images_to_base64(form_data)
 
+    # Generate message_id if not provided (for correlation between inlet and outlet)
+    if not metadata.get('message_id'):
+        metadata['message_id'] = str(uuid4())
+
+    # Generate local chat_id if not provided (for outlet filter correlation)
+    # Using 'local:' prefix ensures it's treated as temporary and not persisted
+    if not metadata.get('chat_id'):
+        metadata['chat_id'] = f'local:{str(uuid4())}'
+
     event_emitter = get_event_emitter(metadata)
     event_caller = get_event_call(metadata)
 
@@ -2773,6 +2786,120 @@ def get_event_emitter_and_caller(metadata):
     return event_emitter, event_caller
 
 
+async def run_outlet_filters(request, form_data, metadata, user, model, output_data):
+    """
+    Run outlet filters with the given output data.
+
+    This function replicates the behavior of /chat/completed.
+    Must be called as the last step before sending response to client.
+
+    Args:
+        request: Request object
+        form_data: Original form data (includes messages)
+        metadata: Request metadata
+        user: User object
+        model: Model dict
+        output_data: Final output from stream/response (dict with 'output', 'content', 'usage')
+
+    Returns:
+        Modified output_data (modifications are NOT persisted in Option A)
+    """
+    # Build outlet form_data in OWUI format
+    # Construct messages array with proper metadata (id, timestamp, usage, etc.)
+    messages = []
+
+    # Add user messages from form_data (exclude system messages)
+    for msg in form_data.get('messages', []):
+        if msg.get('role') != 'system':
+            messages.append({
+                'id': msg.get('id', str(uuid4())),
+                'role': msg['role'],
+                'content': msg.get('content', ''),
+                'timestamp': int(msg.get('timestamp', time.time())),
+            })
+
+    # Add assistant message from output_data (use metadata ID generated at inlet)
+    assistant_message = {
+        'id': metadata['message_id'],
+        'role': 'assistant',
+        'content': output_data.get('content', ''),
+        'timestamp': int(time.time()),
+        'usage': output_data.get('usage'),
+    }
+    messages.append(assistant_message)
+
+    outlet_form_data = {
+        'model': metadata['model']['id'] if isinstance(metadata['model'], dict) else metadata['model'],
+        'chat_id': metadata['chat_id'],
+        'id': metadata['message_id'],
+        'session_id': metadata['session_id'],
+        'filter_ids': metadata.get('filter_ids', []),
+        'messages': messages,
+        **output_data  # Includes 'output', 'content', 'usage', etc.
+    }
+
+    # Get models
+    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
+        models = {request.state.model['id']: request.state.model}
+    else:
+        models = request.app.state.MODELS
+
+    model_id = outlet_form_data['model']
+    if model_id not in models:
+        log.warning(f'Model {model_id} not found for outlet processing')
+        return output_data  # Skip if model not found
+
+    outlet_model = models[model_id]
+
+    # Build metadata for filter functions
+    filter_metadata = {
+        'chat_id': outlet_form_data['chat_id'],
+        'message_id': outlet_form_data['id'],
+        'filter_ids': outlet_form_data.get('filter_ids', []),
+        'session_id': outlet_form_data['session_id'],
+        'user_id': user.id,
+    }
+
+    # Build extra params with event emitter
+    extra_params = {
+        '__event_emitter__': get_event_emitter(filter_metadata),
+        '__event_call__': get_event_call(filter_metadata),
+        '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+        '__metadata__': filter_metadata,
+        '__request__': request,
+        '__model__': outlet_model,
+    }
+
+    # Step 1: Run pipeline outlet filters (HTTP-based external filters)
+    try:
+        from open_webui.routers.pipelines import process_pipeline_outlet_filter
+        outlet_form_data = await process_pipeline_outlet_filter(
+            request, outlet_form_data, user, models
+        )
+    except Exception as e:
+        log.error(f'Pipeline outlet filter error: {e}')
+        # Continue to filter functions even if pipeline filters fail
+
+    # Step 2: Get filter functions
+    filter_ids = get_sorted_filter_ids(request, outlet_model, filter_metadata.get('filter_ids', []))
+    filter_functions = Functions.get_functions_by_ids(filter_ids)
+
+    # Step 3: Run filter outlet functions (Python-based custom filters)
+    try:
+        result, _ = await process_filter_functions(
+            request=request,
+            filter_functions=filter_functions,
+            filter_type='outlet',
+            form_data=outlet_form_data,
+            extra_params=extra_params,
+        )
+        # Return modified result (caller decides whether to persist)
+        return result
+    except Exception as e:
+        log.error(f'Filter outlet function error: {e}')
+        return output_data  # Return original on error
+
+
 def build_chat_response_context(request, form_data, user, model, metadata, tasks, events):
     event_emitter, event_caller = get_event_emitter_and_caller(metadata)
     return {
@@ -3172,6 +3299,22 @@ async def non_streaming_chat_response_handler(response, ctx):
                             )
 
                     await background_tasks_handler(ctx)
+
+                    # === NEW: Run outlet filters (AFTER background tasks, BEFORE return) ===
+                    output_data = {
+                        'output': response_output,
+                        'content': content,
+                        'usage': usage,
+                    }
+
+                    # Run outlet filters
+                    outlet_result = await run_outlet_filters(
+                        request, form_data, metadata, user, model, output_data
+                    )
+
+                    # Option A: Discard modifications (preserve current behavior)
+                    # Outlet filters ran and emitted events, but we use original output
+                    # === END NEW ===
 
             response = build_response_object(response, merge_events_into_response(response_data, events))
         except Exception as e:
@@ -4681,6 +4824,22 @@ async def streaming_chat_response_handler(response, ctx):
                 )
 
                 await background_tasks_handler(ctx)
+
+                # === NEW: Run outlet filters (AFTER background tasks, BEFORE stream closes) ===
+                output_data = {
+                    'output': output,
+                    'content': serialize_output(output),
+                    'usage': usage,
+                }
+
+                # Run outlet filters
+                outlet_result = await run_outlet_filters(
+                    request, form_data, metadata, user, model, output_data
+                )
+
+                # Option A: Discard modifications (preserve current behavior)
+                # Outlet filters ran and emitted events, but we use original output
+                # === END NEW ===
             except asyncio.CancelledError:
                 log.warning('Task was cancelled!')
                 await event_emitter({'type': 'chat:tasks:cancel'})
@@ -4714,6 +4873,9 @@ async def streaming_chat_response_handler(response, ctx):
             def wrap_item(item):
                 return f'data: {item}\n\n'
 
+            # Accumulate stream chunks for outlet processing
+            accumulated_chunks = []
+
             for event in events:
                 event, _ = await process_filter_functions(
                     request=request,
@@ -4736,7 +4898,59 @@ async def streaming_chat_response_handler(response, ctx):
                 )
 
                 if data:
+                    accumulated_chunks.append(data)
                     yield data
+
+            # Run outlet filters after stream completes
+            # Reconstruct output from accumulated chunks (simplified for fallback path)
+            try:
+                # Combine all chunks to get final content
+                final_content = ''
+                usage_data = {}
+                for chunk_bytes in accumulated_chunks:
+                    try:
+                        # Parse JSON from bytes
+                        chunk_str = chunk_bytes.decode('utf-8') if isinstance(chunk_bytes, bytes) else chunk_bytes
+
+                        # Skip SSE prefix
+                        if chunk_str.startswith('data: '):
+                            chunk_str = chunk_str[6:]
+
+                        # Skip empty lines and [DONE]
+                        chunk_str = chunk_str.strip()
+                        if not chunk_str or chunk_str == '[DONE]':
+                            continue
+
+                        # Parse JSON
+                        chunk = json.loads(chunk_str)
+
+                        if isinstance(chunk, dict) and 'choices' in chunk:
+                            for choice in chunk['choices']:
+                                if 'delta' in choice and choice['delta'].get('content'):
+                                    final_content += choice['delta']['content']
+
+                        # Extract usage data if present (usually in final chunk)
+                        if 'usage' in chunk and chunk['usage']:
+                            usage_data = chunk['usage']
+                    except json.JSONDecodeError as e:
+                        # Skip invalid JSON chunks
+                        log.warning(f'Skipping invalid JSON chunk: {e}')
+                        continue
+
+                if final_content:
+                    output_data = {
+                        'output': [],
+                        'content': final_content,
+                        'usage': usage_data,
+                    }
+
+                    # Run outlet filters
+                    await run_outlet_filters(
+                        request, form_data, metadata, user, model, output_data
+                    )
+            except Exception as e:
+                log.error(f'Outlet filter error in fallback path: {e}')
+                # Continue without failing the response
 
         return StreamingResponse(
             stream_wrapper(response.body_iterator, events),


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [N] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [N] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [X] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes a long-standing issue where direct API clients (e.g., opencode, cline, openclaw, Langfuse integrations) could not trigger outlet filters because they don't call the /api/chat/completed endpoint. Now, outlet filters run universally for all completion requests, regardless of the client type.

### Added

- Added run_outlet_filters() function (middleware.py)

### Changed

- Integrated outlet filters into completion handlers (middleware.py)

### Deprecated

- Made /api/chat/completed a no-op (main.py)

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- #3237

### Security

- N/A

### Breaking Changes

- **BREAKING CHANGE**: Unknown

---

### Additional Information

#### Problem

Previously, outlet filters (used for logging, analytics, content moderation, etc.) only executed when the `/api/chat/completed` endpoint was called. The Web UI calls this endpoint after receiving a completion response, but direct API clients typically don't know about this endpoint and never call it. This meant:

-  Outlet filters never ran for direct API clients
-  Logging/analytics tools like Langfuse couldn't capture complete conversation data
-  Inconsistent behavior between Web UI and API clients
-  Custom filter outlet functions were silently skipped

#### Solution

Outlet filter processing has been moved from `/api/chat/completed` into the `/api/chat/completion` endpoint itself. Outlet filters now run as the final step of the completion flow, after background tasks (title generation, tag generation, etc.) but before the response is returned to the client.

**Key Decision:** Outlet filters run **after** background tasks (not before). This ensures that title and tag generation complete first, so outlet filters see the final state. An alternative design could run outlet filters before background tasks, but that would mean filters wouldn't see generated titles/tags. This matches the behavior as if calling /chat/completed

#### Testing

Basic testing has been performed with the following scenarios:
-  Normal chat with Web UI (outlet filters run)
-  Temporary chat (now triggers outlet filters where it didn't before). Temporary chats remain temporary and are not saved.
-  Direct API clients (opencode, cline, openclaw)
-  Streaming and non-streaming responses
-  Outlet filters with both pipeline and custom filter functions

All of these scenarios have been verified to show up in langfuse (pipeline filter) and work correctly with my own filters that I have installed.

#### Backward Compatibility

-  **Web UI behavior preserved:**  Web UI continues to work as before (can decide to remove completed later if desired)
-  **`/api/chat/completed` remains functional:** Returns input payload unchanged (no-op)
-  **No breaking changes:** All existing functionality is preserved (as far as I've tested locally)
-  **Filter compatibility:** Existing outlet filters work without modification (the ones I've tested)

#### Performance Considerations

- The stream fallback path accumulates all chunks in memory before running outlet filters. This could cause memory pressure for very long streams.
- Response latency may increase slightly due to inline outlet filter execution (filters now run during the request instead of after response is sent).
- No formal performance benchmarks have been conducted.

#### Notes

- - **Community Distribution:** This fix is being made primarily being made available for the community to apply to their own installations, as the core Open WebUI project does not seem eager to adopt this change.

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
