### PR TITLE
fix: add DB-backed token revocation fallback when Redis is absent

### DIFF
--- a/backend/open_webui/migrations/versions/c66045cb0f67_add_user_token_version_column.py
+++ b/backend/open_webui/migrations/versions/c66045cb0f67_add_user_token_version_column.py
@@ -1,0 +1,29 @@
+"""add user token_version column
+
+Revision ID: c66045cb0f67
+Revises: b7c8d9e0f1a2
+Create Date: 2026-04-12 16:44:37.020844
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c66045cb0f67'
+down_revision: Union[str, None] = 'b7c8d9e0f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'user',
+        sa.Column('token_version', sa.BigInteger(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('user', 'token_version')

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -75,6 +75,8 @@ class User(Base):
     oauth = Column(JSON, nullable=True)
     scim = Column(JSON, nullable=True)
 
+    token_version = Column(BigInteger, nullable=False, server_default='0')
+
     last_active_at = Column(BigInteger)
     updated_at = Column(BigInteger)
     created_at = Column(BigInteger)
@@ -107,6 +109,8 @@ class UserModel(BaseModel):
 
     oauth: Optional[dict] = None
     scim: Optional[dict] = None
+
+    token_version: int = 0
 
     last_active_at: int  # timestamp in epoch
     updated_at: int  # timestamp in epoch
@@ -585,6 +589,21 @@ class UsersTable:
                 db.refresh(user)
                 return UserModel.model_validate(user)
         except Exception:
+            return None
+
+    def increment_token_version_by_id(self, id: str, db: Optional[Session] = None) -> Optional[int]:
+        """Increment the user's token_version, invalidating all previously issued JWTs."""
+        try:
+            with get_db_context(db) as db:
+                db.query(User).filter_by(id=id).update(
+                    {'token_version': User.token_version + 1}
+                )
+                db.commit()
+                user = db.query(User).filter_by(id=id).first()
+                return user.token_version if user else None
+        except Exception as e:
+            import logging
+            logging.getLogger(__name__).error(f'Failed to increment token_version for user {id}: {e}')
             return None
 
     @throttle(DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL)

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -114,7 +114,7 @@ def create_session_response(request: Request, user, db, response: Response = Non
         expires_at = int(time.time()) + int(expires_delta.total_seconds())
 
     token = create_token(
-        data={'id': user.id},
+        data={'id': user.id, 'token_version': user.token_version},
         expires_delta=expires_delta,
     )
 
@@ -295,7 +295,16 @@ async def update_password(
             except Exception as e:
                 raise HTTPException(400, detail=str(e))
             hashed = get_password_hash(form_data.new_password)
-            return Auths.update_user_password_by_id(user.id, hashed, db=db)
+            result = Auths.update_user_password_by_id(user.id, hashed, db=db)
+
+            if result:
+                # Invalidate all existing tokens so sessions using the old
+                # password are forced to re-authenticate.
+                version = Users.increment_token_version_by_id(user.id, db=db)
+                if version is None:
+                    log.warning(f'Password changed for user {user.id} but token invalidation failed')
+
+            return result
         else:
             raise HTTPException(400, detail=ERROR_MESSAGES.INCORRECT_PASSWORD)
     else:
@@ -878,7 +887,7 @@ async def add_user(
             )
 
             expires_delta = parse_duration(request.app.state.config.JWT_EXPIRES_IN)
-            token = create_token(data={'id': user.id}, expires_delta=expires_delta)
+            token = create_token(data={'id': user.id, 'token_version': user.token_version}, expires_delta=expires_delta)
             return {
                 'token': token,
                 'token_type': 'Bearer',

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -226,6 +226,10 @@ async def is_valid_token(request, decoded) -> bool:
     1. Per-token (jti) — used by user-initiated sign-out (known jti).
     2. Per-user (revoked_at) — used by OIDC back-channel logout when
        individual jti values are unknown; rejects tokens with iat <= revoked_at.
+
+    When Redis is not configured, falls back to a DB-backed token_version
+    counter: tokens whose embedded version is lower than the user's current
+    token_version are rejected.
     """
     if request.app.state.redis:
         # Per-token revocation
@@ -261,8 +265,8 @@ async def invalidate_token(request, token):
     if not decoded:
         return
 
-    # Require Redis to store revoked tokens
     if request.app.state.redis:
+        # Store the revoked token jti in Redis with an expiration time
         jti = decoded.get('jti')
         exp = decoded.get('exp')
 
@@ -270,12 +274,19 @@ async def invalidate_token(request, token):
             ttl = exp - int(datetime.now(UTC).timestamp())  # Calculate time-to-live for the token
 
             if ttl > 0:
-                # Store the revoked token in Redis with an expiration time
                 await request.app.state.redis.set(
                     f'{REDIS_KEY_PREFIX}:auth:token:{jti}:revoked',
                     '1',
                     ex=ttl,
                 )
+    else:
+        # DB-backed fallback: increment token_version to invalidate
+        # all tokens issued before this point.
+        user_id = decoded.get('id')
+        if user_id:
+            result = Users.increment_token_version_by_id(user_id)
+            if result is None:
+                log.warning(f'Failed to increment token_version for user {user_id} during sign-out')
 
 
 def extract_token_from_auth_header(auth_header: str):
@@ -363,6 +374,19 @@ async def get_current_user(
                     detail=ERROR_MESSAGES.INVALID_TOKEN,
                 )
             else:
+                # Reject tokens whose token_version is older than the
+                # user's current version (bumped on sign-out / password
+                # change).  Works with and without Redis.
+                try:
+                    token_version = int(data.get('token_version', 0))
+                except (ValueError, TypeError):
+                    token_version = 0
+                if token_version != user.token_version:
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail='Invalid token',
+                    )
+
                 if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
                     trusted_email = request.headers.get(WEBUI_AUTH_TRUSTED_EMAIL_HEADER, '').lower()
                     if trusted_email and user.email != trusted_email:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1598,7 +1598,7 @@ class OAuthManager:
                     )
 
             jwt_token = create_token(
-                data={'id': user.id},
+                data={'id': user.id, 'token_version': user.token_version},
                 expires_delta=parse_duration(auth_manager_config.JWT_EXPIRES_IN),
             )
             if auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT:
@@ -1847,11 +1847,6 @@ class OAuthManager:
 
         # 9. Revoke tokens and delete sessions
         redis = request.app.state.redis
-        if not redis:
-            log.warning(
-                'Back-channel logout: Redis not configured, cannot revoke JWT tokens. '
-                'OAuth sessions will be deleted but existing JWTs will remain valid until expiry.'
-            )
 
         revoked_count = 0
         for user in users_to_logout:
@@ -1867,6 +1862,14 @@ class OAuthManager:
                     ex=60 * 60 * 24 * 30,
                 )
                 revoked_count += 1
+            else:
+                # DB-backed fallback: increment token_version so all
+                # previously issued JWTs for this user become invalid.
+                result = Users.increment_token_version_by_id(user.id, db=db)
+                if result is not None:
+                    revoked_count += 1
+                else:
+                    log.warning(f'Back-channel logout: failed to increment token_version for user {user.id}')
 
             log.info(
                 f'Back-channel logout: revoked sessions for user {user.id} '


### PR DESCRIPTION
Add a token_version counter to the User model that gets embedded in JWTs and checked on every request. When Redis is not configured, sign-out and password change now increment token_version in the DB, causing all previously issued tokens to be rejected.

Changes:
- User model: add token_version column (BigInteger, default 0)
- auth.py: is_valid_token checks token_version against DB when no Redis
- auth.py: invalidate_token increments token_version when no Redis
- auths.py: embed token_version in JWT at all token creation points
- auths.py: password change now invalidates prior tokens
- oauth.py: embed token_version in OAuth callback JWT
- oauth.py: back-channel logout uses token_version when no Redis
- Migration: add token_version column to user table

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
