### PR TITLE
fix: filter on is_active in channel membership checks

### DIFF
--- a/backend/open_webui/models/channels.py
+++ b/backend/open_webui/models/channels.py
@@ -508,6 +508,7 @@ class ChannelTable:
                 .filter(
                     ChannelMember.channel_id == channel_id,
                     ChannelMember.user_id == user_id,
+                    ChannelMember.is_active.is_(True),
                     ChannelMember.role == 'manager',
                 )
                 .first()
@@ -667,6 +668,7 @@ class ChannelTable:
                 .filter(
                     ChannelMember.channel_id == channel_id,
                     ChannelMember.user_id == user_id,
+                    ChannelMember.is_active.is_(True),
                 )
                 .first()
             )


### PR DESCRIPTION
is_user_channel_member and is_user_channel_manager did not filter on is_active, allowing deactivated members to retain read/write access to group channels via direct API calls.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
