### PR TITLE
fix: prevent first-user admin race in LDAP and OAuth registration

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -479,18 +479,24 @@ async def ldap_auth(
             user = Users.get_user_by_email(email, db=db)
             if not user:
                 try:
-                    role = 'admin' if not Users.has_users(db=db) else request.app.state.config.DEFAULT_USER_ROLE
-
+                    # Insert with default role first to avoid TOCTOU race on
+                    # first-user registration.  Matches signup_handler pattern.
                     user = Auths.insert_new_auth(
                         email=email,
                         password=str(uuid.uuid4()),
                         name=cn,
-                        role=role,
+                        role=request.app.state.config.DEFAULT_USER_ROLE,
                         db=db,
                     )
 
                     if not user:
                         raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+
+                    # Atomically check if this is the only user *after* the
+                    # insert.  Only the single user present should become admin.
+                    if Users.get_num_users(db=db) == 1:
+                        Users.update_user_role_by_id(user.id, 'admin', db=db)
+                        user = Users.get_user_by_id(user.id, db=db)
 
                     apply_default_group_assignment(
                         request.app.state.config.DEFAULT_GROUP_ID,

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1109,9 +1109,12 @@ class OAuthManager:
             log.debug('Assigning the only user the admin role')
             return 'admin'
         if not user and user_count == 0:
-            # If there are no users, assign the role "admin", as the first user will be an admin
-            log.debug('Assigning the first user the admin role')
-            return 'admin'
+            # First-user bootstrap: skip role management gating so the
+            # instance can be initialized.  We intentionally return the
+            # default role here (not 'admin') — admin promotion happens
+            # race-safely *after* insert via get_num_users() == 1.
+            log.debug('First user bootstrap: using default role (admin promotion deferred to post-insert)')
+            return auth_manager_config.DEFAULT_USER_ROLE
 
         if auth_manager_config.ENABLE_OAUTH_ROLE_MANAGEMENT:
             log.debug('Running OAUTH Role management')
@@ -1576,6 +1579,16 @@ class OAuthManager:
                         oauth=oauth_data,
                         db=db,
                     )
+
+                    if not user:
+                        raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+
+                    # Atomically check if this is the only user *after* the
+                    # insert to avoid TOCTOU race on first-user registration.
+                    # Matches signup_handler pattern.
+                    if Users.get_num_users(db=db) == 1:
+                        Users.update_user_role_by_id(user.id, 'admin', db=db)
+                        user = Users.get_user_by_id(user.id, db=db)
 
                     if auth_manager_config.WEBHOOK_URL:
                         await post_webhook(


### PR DESCRIPTION
Both LDAP and OAuth registration checked user count before insert to determine whether to assign admin role.  With multiple workers, concurrent first-user registrations could each see zero users and both create admin accounts.

Applies the insert-first-check-after pattern already used by signup_handler: insert with DEFAULT_USER_ROLE, then atomically check get_num_users()==1 and promote only the sole user to admin.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
