### PR TITLE
fix: block knowledge-bases meta-collection enumeration and enforce KB read access on query endpoints

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -41,8 +41,9 @@ from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.models.knowledge import Knowledges, Knowledge
 from open_webui.models.access_grants import AccessGrants
 from open_webui.storage.provider import Storage
-from open_webui.internal.db import get_async_session, get_db
+from open_webui.internal.db import get_async_session, get_db, get_async_db
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 
 
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
@@ -2371,12 +2372,12 @@ async def _validate_collection_access(collection_names: list[str], user) -> None
     # instead of N+1 per-collection lookups.
     if candidate_kb_ids:
         try:
-            with get_db_context() as db:
-                kb_rows = (
-                    db.query(Knowledge.id, Knowledge.user_id)
-                    .filter(Knowledge.id.in_(candidate_kb_ids))
-                    .all()
+            async with get_async_db() as db:
+                result = await db.execute(
+                    select(Knowledge.id, Knowledge.user_id)
+                    .where(Knowledge.id.in_(candidate_kb_ids))
                 )
+                kb_rows = result.all()
         except Exception:
             # Fail closed: DB errors must not silently grant access
             raise HTTPException(
@@ -2389,7 +2390,7 @@ async def _validate_collection_access(collection_names: list[str], user) -> None
 
         if foreign_kb_ids:
             # Single batch query for access grants
-            accessible_ids = AccessGrants.get_accessible_resource_ids(
+            accessible_ids = await AccessGrants.get_accessible_resource_ids(
                 user_id=user.id,
                 resource_type='knowledge',
                 resource_ids=foreign_kb_ids,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -38,9 +38,10 @@ from langchain_core.documents import Document
 
 from open_webui.models.files import FileModel, FileUpdateForm, Files
 from open_webui.utils.access_control.files import has_access_to_file
-from open_webui.models.knowledge import Knowledges
+from open_webui.models.knowledge import Knowledges, Knowledge
+from open_webui.models.access_grants import AccessGrants
 from open_webui.storage.provider import Storage
-from open_webui.internal.db import get_session, get_db
+from open_webui.internal.db import get_session, get_db, get_db_context
 from sqlalchemy.orm import Session
 
 
@@ -2330,25 +2331,72 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
 def _validate_collection_access(collection_names: list[str], user) -> None:
     """
     Prevent users from querying collections they don't own.
-    Enforces ownership on user-memory-* and file-* collections.
+    Enforces ownership on user-memory-*, file-*, and KB collections.
+    Blocks access to internal meta-collections.
     Admins bypass this check.
     """
     if user.role == 'admin':
         return
 
+    # Candidate KB IDs — names that don't match any known prefix
+    candidate_kb_ids = []
+
     for name in collection_names:
-        if name.startswith('user-memory-') and name != f'user-memory-{user.id}':
+        # Block internal meta-collections that contain cross-user data
+        if name == 'knowledge-bases':
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+            )
+        elif name.startswith('user-memory-') and name != f'user-memory-{user.id}':
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
             )
         elif name.startswith('file-'):
-            file_id = name[len('file-') :]
+            file_id = name[len('file-'):]
             if not has_access_to_file(
                 file_id=file_id,
                 access_type='read',
                 user=user,
             ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                )
+        else:
+            candidate_kb_ids.append(name)
+
+    # Batch-resolve KB ownership for all candidate IDs in two queries
+    # instead of N+1 per-collection lookups.
+    if candidate_kb_ids:
+        try:
+            with get_db_context() as db:
+                kb_rows = (
+                    db.query(Knowledge.id, Knowledge.user_id)
+                    .filter(Knowledge.id.in_(candidate_kb_ids))
+                    .all()
+                )
+        except Exception:
+            # Fail closed: DB errors must not silently grant access
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail='Failed to validate collection access.',
+            )
+
+        # Identify KB IDs that exist but are not owned by the user
+        foreign_kb_ids = [row.id for row in kb_rows if row.user_id != user.id]
+
+        if foreign_kb_ids:
+            # Single batch query for access grants
+            accessible_ids = AccessGrants.get_accessible_resource_ids(
+                user_id=user.id,
+                resource_type='knowledge',
+                resource_ids=foreign_kb_ids,
+                permission='read',
+            )
+            denied_ids = set(foreign_kb_ids) - accessible_ids
+            if denied_ids:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail=ERROR_MESSAGES.ACCESS_PROHIBITED,


### PR DESCRIPTION
The _validate_collection_access function only blocked user-memory-* and file-* patterns, allowing any authenticated user to query the knowledge-bases meta-collection to discover all KB UUIDs, names, and descriptions across the entire instance.

Blocks access to the knowledge-bases meta-collection for non-admins. Also enforces KB ownership and AccessGrants read permission checks on KB-ID collections via the query/doc and query/collection endpoints.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
