### PR TITLE
fix: drop extra='allow' on FolderForm and FolderUpdateForm

### DIFF
--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -74,14 +74,12 @@ class FolderForm(BaseModel):
     data: Optional[dict] = None
     meta: Optional[dict] = None
     parent_id: Optional[str] = None
-    model_config = ConfigDict(extra='allow')
 
 
 class FolderUpdateForm(BaseModel):
     name: Optional[str] = None
     data: Optional[dict] = None
     meta: Optional[dict] = None
-    model_config = ConfigDict(extra='allow')
 
 
 class FolderTable:

--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -74,12 +74,14 @@ class FolderForm(BaseModel):
     data: Optional[dict] = None
     meta: Optional[dict] = None
     parent_id: Optional[str] = None
+    model_config = ConfigDict(extra='forbid')
 
 
 class FolderUpdateForm(BaseModel):
     name: Optional[str] = None
     data: Optional[dict] = None
     meta: Optional[dict] = None
+    model_config = ConfigDict(extra='forbid')
 
 
 class FolderTable:


### PR DESCRIPTION
These request models were configured to accept arbitrary extra fields, which were then merged into the folder row via form_data.model_dump(). In insert_new_folder the server-assigned user_id is placed before the form spread, so a client-supplied user_id in the request body would override it and the folder would be persisted against another account.

Strictly typed inputs are the correct shape for these endpoints — the client has no legitimate reason to send fields beyond the declared ones, and dropping extra='allow' closes the mass-assignment sink at the validation layer instead of relying on every callsite to merge fields in the right order.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
