### PR TITLE
fix: apply REDIS_KEY_PREFIX to tool_servers and terminal_servers cache keys

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -51,6 +51,7 @@ from open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
     FORWARD_SESSION_INFO_HEADER_CHAT_ID,
     FORWARD_SESSION_INFO_HEADER_MESSAGE_ID,
+    REDIS_KEY_PREFIX,
 )
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.tools.builtin import (
@@ -849,7 +850,9 @@ async def set_tool_servers(request: Request):
     request.app.state.TOOL_SERVERS = await get_tool_servers_data(request.app.state.config.TOOL_SERVER_CONNECTIONS)
 
     if request.app.state.redis is not None:
-        await request.app.state.redis.set('tool_servers', json.dumps(request.app.state.TOOL_SERVERS))
+        await request.app.state.redis.set(
+            f'{REDIS_KEY_PREFIX}:tool_servers', json.dumps(request.app.state.TOOL_SERVERS)
+        )
 
     return request.app.state.TOOL_SERVERS
 
@@ -858,7 +861,7 @@ async def get_tool_servers(request: Request):
     tool_servers = []
     if request.app.state.redis is not None:
         try:
-            tool_servers = json.loads(await request.app.state.redis.get('tool_servers'))
+            tool_servers = json.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
             request.app.state.TOOL_SERVERS = tool_servers
         except Exception as e:
             log.error(f'Error fetching tool_servers from Redis: {e}')
@@ -984,7 +987,9 @@ async def set_terminal_servers(request: Request):
     )
 
     if request.app.state.redis is not None:
-        await request.app.state.redis.set('terminal_servers', json.dumps(request.app.state.TERMINAL_SERVERS))
+        await request.app.state.redis.set(
+            f'{REDIS_KEY_PREFIX}:terminal_servers', json.dumps(request.app.state.TERMINAL_SERVERS)
+        )
 
     return request.app.state.TERMINAL_SERVERS
 
@@ -994,7 +999,9 @@ async def get_terminal_servers(request: Request):
     terminal_servers = []
     if request.app.state.redis is not None:
         try:
-            terminal_servers = json.loads(await request.app.state.redis.get('terminal_servers'))
+            terminal_servers = json.loads(
+                await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            )
             request.app.state.TERMINAL_SERVERS = terminal_servers
         except Exception as e:
             log.error(f'Error fetching terminal_servers from Redis: {e}')


### PR DESCRIPTION
These four Redis calls were the only places in the backend still using bare cache keys. Every other call already namespaces through REDIS_KEY_PREFIX, which is how multiple Open WebUI instances sharing a Redis database stay isolated. Two instances with different TOOL_SERVER_CONNECTIONS or TERMINAL_SERVER_CONNECTIONS would otherwise clobber each other's cached OpenAPI specs.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
