### PR TITLE
fix: handle string vs dict entries for custom tts endpoint voices

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1344,8 +1344,25 @@ def get_available_voices(request) -> dict:
                 )
                 response.raise_for_status()
                 data = response.json()
-                voices_list = data.get('voices', [])
-                available_voices = {voice['id']: voice['name'] for voice in voices_list}
+                if isinstance(data, dict):
+                    voices_list = data.get('voices', data.get('data', []))
+                elif isinstance(data, list):
+                    voices_list = data
+                else:
+                    voices_list = []
+
+                if not isinstance(voices_list, list):
+                    voices_list = [voices_list]
+
+                available_voices = {}
+                for voice in voices_list:
+                    if isinstance(voice, dict):
+                        voice_id = voice.get('id', voice.get('voice_id', ''))
+                        voice_name = voice.get('name', voice_id)
+                        if voice_id:
+                            available_voices[voice_id] = voice_name
+                    elif isinstance(voice, str):
+                        available_voices[voice] = voice
             except Exception as e:
                 log.error(f'Error fetching voices from custom endpoint: {str(e)}')
                 available_voices = {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** This Pull Request was prepared with the assistance of an AI copilot and has been thoroughly reviewed and manually tested by the author to ensure quality and adherence to project standards.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fixed a bug where configuring a custom TTS endpoint that returned a list of strings would crash `get_available_voices` due to `TypeError: string indices must be integers, not 'str'`. Made the parsing logic far more forgiving, able to handle responses where the endpoint returns the data directly as a list or wrapped in dictionaries, and automatically iterating over voice keys safely regardless of their exact nested type. 

### Fixed

- Handled custom TTS Endpoint formatting gracefully in `audio.py` for `/audio/voices` API compatibility.
- This PR resolves the following error that was being thrown in Open WebUI's backend logs when I visited the `Audio` tab in the user settings:

```cmd
2026-04-13 02:51:32.956 | ERROR    | open_webui.routers.audio:get_available_voices:1350 - Error fetching voices from custom endpoint: string indices must be integers, not 'str'
```

### Screenshots

**Before:**

<img width="1217" height="122" alt="image" src="https://github.com/user-attachments/assets/369c9ef6-f041-4bdf-87c9-2302725befd3" />

**After:**

<img width="1221" height="89" alt="image" src="https://github.com/user-attachments/assets/a4858115-2989-43d4-bb02-16666f615535" />

---

### Additional Information

- Verified that iterating through API voices behaves normally without raising Internal Server Exceptions or logging `TypeError` into the system console when accessing the `Audio` WebUI settings pane.
- **100% Backwards Compatible:** This fix preserves the original functionality completely. It still specifically looks for the `voices` key and extracts the dictionary `id` and `name` attributes seamlessly. The new behavior only kicks in as a fallback to gracefully catch unexpected endpoint formats (like flat string arrays or endpoints returning data nested inside a `data` key) instead of crashing.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.