### PR TITLE
fix: fallback to /models for custom TTS endpoints breaking on /audio/models

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1293,13 +1293,38 @@ def get_available_models(request: Request) -> list[dict]:
         # Use custom endpoint if not using the official OpenAI API URL
         if not request.app.state.config.TTS_OPENAI_API_BASE_URL.startswith('https://api.openai.com'):
             try:
-                response = requests.get(
-                    f'{request.app.state.config.TTS_OPENAI_API_BASE_URL}/audio/models',
-                    timeout=AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
-                )
-                response.raise_for_status()
+                try:
+                    response = requests.get(
+                        f'{request.app.state.config.TTS_OPENAI_API_BASE_URL}/audio/models',
+                        timeout=AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+                    )
+                    response.raise_for_status()
+                except Exception:
+                    response = requests.get(
+                        f'{request.app.state.config.TTS_OPENAI_API_BASE_URL}/models',
+                        timeout=AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
+                    )
+                    response.raise_for_status()
+
                 data = response.json()
-                available_models = data.get('models', [])
+                if isinstance(data, dict):
+                    models_list = data.get('models', data.get('data', []))
+                elif isinstance(data, list):
+                    models_list = data
+                else:
+                    models_list = []
+
+                if isinstance(models_list, dict):
+                    models_list = [{'id': k, 'name': str(v)} for k, v in models_list.items()]
+                elif not isinstance(models_list, list):
+                    models_list = [models_list]
+
+                available_models = []
+                for model in models_list:
+                    if isinstance(model, dict):
+                        available_models.append(model)
+                    elif isinstance(model, str) and model.strip():
+                        available_models.append({'id': model})
             except Exception as e:
                 log.error(f'Error fetching models from custom endpoint: {str(e)}')
                 available_models = [{'id': 'tts-1'}, {'id': 'tts-1-hd'}]
@@ -1344,8 +1369,29 @@ def get_available_voices(request) -> dict:
                 )
                 response.raise_for_status()
                 data = response.json()
-                voices_list = data.get('voices', [])
-                available_voices = {voice['id']: voice['name'] for voice in voices_list}
+
+                if isinstance(data, dict):
+                    voices_list = data.get('voices', data.get('data', []))
+                elif isinstance(data, list):
+                    voices_list = data
+                else:
+                    voices_list = []
+
+                if isinstance(voices_list, dict):
+                    available_voices = voices_list
+                else:
+                    if not isinstance(voices_list, list):
+                        voices_list = [voices_list]
+
+                    available_voices = {}
+                    for voice in voices_list:
+                        if isinstance(voice, dict):
+                            voice_id = voice.get('id') or voice.get('voice_id') or ''
+                            voice_name = voice.get('name') or voice_id
+                            if voice_id:
+                                available_voices[voice_id] = voice_name
+                        elif isinstance(voice, str):
+                            available_voices[voice] = voice
             except Exception as e:
                 log.error(f'Error fetching voices from custom endpoint: {str(e)}')
                 available_voices = {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** This Pull Request was prepared with the assistance of an AI copilot and has been thoroughly reviewed and manually tested by the author to ensure quality and adherence to project standards.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work


# Changelog Entry

### Description

- Fixed an issue causing custom audio TTS providers (like KokoroTTS API) to trigger 404s when attempting to fetch models by explicitly providing a fallback route mapping `/audio/models` directly down to `/models` upon failure. Furthermore, fortified model formatting dynamically across models arrays regardless of whether dicts or raw strings were yielded dynamically.

### Fixed

- Fallback HTTP Request handling to `/models` for endpoint `/audio/models` compatibility in custom TTS setups like KokoroTTS.
- Prevented string-based endpoint response parsing logic explosions by validating dictionaries natively with `id` keys.
- Prevented the adjacent `string indices must be integers` crash from bleeding into the Admin Panel when simultaneously fetching `/audio/voices` in tandem.
- Safely stripped explicit `None` or falsy elements structurally from lists to prevent synthesizing bogus `{'id': 'None'}` items out onto the UI.
- Stabilized network-request exception fallback mappings inherently ensuring broken TLS TCP sockets or connection faults don't fatally drop threads natively.
- Also prevented the same `string indices must be integers` crash from bleeding into the Admin Panel when simultaneously fetching `/audio/voices` in tandem.

---

### Additional Information

- Verified navigating to the Admin settings tab gracefully defaults off of `/audio/models` throwing 404 directly up to recovering with `/models` under-the-hood.
- Verified 100% backward compliance via dynamic payload inference structures for fully standard API structures natively.

### Screenshots or Videos

## Part 1 of fix
**Before:**

<img width="1217" height="122" alt="image" src="https://github.com/user-attachments/assets/369c9ef6-f041-4bdf-87c9-2302725befd3" />

**After:**

<img width="1221" height="89" alt="image" src="https://github.com/user-attachments/assets/a4858115-2989-43d4-bb02-16666f615535" />


### Part 2 of fix
**Before:**

<img width="594" height="410" alt="image" src="https://github.com/user-attachments/assets/081bfbba-de8b-4769-949d-06c8f5ff5d43" />

**After:**

<img width="594" height="410" alt="image" src="https://github.com/user-attachments/assets/cdbcc708-0dc7-4f2e-96d4-50e995a6db21" />

### Part 3 of fix

**Before:**

<img width="893" height="1272" alt="image" src="https://github.com/user-attachments/assets/1bfeee08-e690-4aff-874a-46f3fb1e4da5" />

**After:**

<img width="893" height="1272" alt="image" src="https://github.com/user-attachments/assets/df9e5d5b-f4f1-4447-9451-4f5d9eef7e63" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.