### PR TITLE
feat(otel): add W3C TraceContext propagator for distributed tracing

### DIFF
--- a/backend/open_webui/utils/telemetry/setup.py
+++ b/backend/open_webui/utils/telemetry/setup.py
@@ -1,5 +1,9 @@
 from fastapi import FastAPI
 from opentelemetry import trace
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
 
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -30,6 +34,11 @@ def setup(app: FastAPI, db_engine: Engine):
     resource = Resource.create(attributes={SERVICE_NAME: OTEL_SERVICE_NAME})
     if ENABLE_OTEL_TRACES:
         trace.set_tracer_provider(TracerProvider(resource=resource))
+        set_global_textmap(
+            CompositePropagator(
+                [TraceContextTextMapPropagator(), W3CBaggagePropagator()]
+            )
+        )
 
         # Add basic auth header only if both username and password are not empty
         headers = []


### PR DESCRIPTION
# Description

Open WebUI configures a `TracerProvider` and instruments HTTP clients, but never configures a propagator — so `traceparent` headers are never injected into outgoing requests. Downstream services (LLM backends, etc.) start isolated traces instead of joining the parent trace.

This PR configures the standard W3C TraceContext + Baggage propagators so that the existing `requests`/`httpx`/`aiohttp` instrumentation propagates trace context automatically.

### Added

- W3C TraceContext and Baggage propagators (standard OTEL defaults)

### Fixed

- Trace context is no longer dropped at outgoing HTTP boundaries

### Dependencies

No changes — all classes come from `opentelemetry-api`, already in requirements.

---

## Testing

Deployed in a Kubernetes environment with Open WebUI → LiteLLM → vLLM. Before: three disconnected traces. After: single end-to-end trace across all three services. Running in production for ~5 days without issues.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
