### PR TITLE
fix: send admin-entered client_id (not tool server id) during oauth_2.1_static registration

### DIFF
--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -89,7 +89,7 @@
 				toast.error($i18n.t('Please enter Client ID and Client Secret'));
 				return;
 			}
-			formData.client_id = id;
+			formData.client_id = oauthClientId;
 			formData.client_secret = oauthClientSecret;
 		}
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** No user-facing docs changes needed — purely a bug fix in the admin-only MCP registration form.
- [x] **Dependencies:** No new or upgraded dependencies.
- [ ] **Testing:** See testing notes in the description; the submitter will confirm manual verification before marking ready for review.
- [ ] **Agentic AI Code:** Submitter will confirm human review + manual testing before marking ready for review.
- [x] **Code review:** Self-reviewed; single-line fix.
- [x] **Design & Architecture:** No new settings, no architectural changes.
- [x] **Git Hygiene:** Single atomic commit targeting `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

When registering an MCP tool server with `auth_type: oauth_2.1_static`, the frontend incorrectly POSTs the tool server's **internal id** as `client_id` instead of the admin-entered OAuth Client ID (`oauthClientId`). The `client_secret` is sent correctly; only the `client_id` is wrong. As a result, registration against the IdP is attempted with an invalid client and fails (or succeeds with an unusable record), even though the admin entered valid credentials.

The correct value is already held in component state — it is used elsewhere in the same file when building the `info` object for the save payload (see `info.oauth_client_id: oauthClientId`). The registration POST is the only call site still binding to the wrong variable.

Net diff: 1 line in 1 file.

### Fixed

- Fixed `AddToolServerModal.svelte` sending the tool server's internal id as `client_id` during the `oauth_2.1_static` registration POST. It now sends the admin-entered OAuth Client ID, matching what the backend (`configs.py` `OAuthClientRegistrationForm`) expects and what the rest of the frontend already stores in `info.oauth_client_id`. Closes #23670.

### Related (already fixed in `dev`, pointing out for future reference)

Two other `oauth_2.1_static` wiring gaps were filed as issues — both turned out to already be fixed on `dev`, so they are **not** addressed by this PR:
- #23665 — middleware `Authorization` header for static MCP — already fixed on `dev` (`backend/open_webui/utils/middleware.py:2520`).
- #23666 — `authenticated` flag in tool listing — already fixed on `dev` (`backend/open_webui/routers/tools.py:123,151`).

The issues can be closed once this PR lands.

---

### Additional Information

**Repro (before fix):**
1. As admin, open Admin → Settings → Tools → Add Tool Server.
2. Choose type `MCP`, set an ID (e.g. `calendar`), URL, auth type `OAuth 2.1 (Static)`.
3. Enter a valid OAuth Client ID (e.g. your Entra app client id) and Client Secret.
4. Click Register. Network inspector shows `POST /configs/oauth/clients/register` with `client_id = "calendar"` instead of the Entra app client id. Registration against the IdP fails.

**Expected (after fix):** the POST carries the admin-entered OAuth Client ID, registration succeeds.

### Screenshots or Videos

- To be attached by the submitter after manual verification against a real Entra AD / M365 MCP setup.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.