### PR TITLE
i18n: route automation limit error messages through ERROR_MESSAGES

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -91,6 +91,11 @@ class ERROR_MESSAGES(str, Enum):
 
     INVALID_PASSWORD = lambda err='': err if err else 'The password does not meet the required validation criteria.'
 
+    AUTOMATION_LIMIT_REACHED = lambda max_count='': f'Automation limit reached ({max_count})'
+    AUTOMATION_SCHEDULE_TOO_FREQUENT = (
+        lambda min_interval='': f'Schedule too frequent. Minimum interval is {min_interval} seconds.'
+    )
+
 
 class TASKS(str, Enum):
     def __str__(self) -> str:

--- a/backend/open_webui/routers/automations.py
+++ b/backend/open_webui/routers/automations.py
@@ -74,7 +74,7 @@ async def check_automation_limits(request, user, rrule_str: str, db, is_create: 
             if max_count > 0 and await Automations.count_by_user(user.id, db=db) >= max_count:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail=f'Automation limit reached ({max_count})',
+                    detail=ERROR_MESSAGES.AUTOMATION_LIMIT_REACHED(max_count),
                 )
 
     # Min interval (create + update)
@@ -86,7 +86,7 @@ async def check_automation_limits(request, user, rrule_str: str, db, is_create: 
             if interval is not None and interval < min_interval:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f'Schedule too frequent. Minimum interval is {min_interval} seconds.',
+                    detail=ERROR_MESSAGES.AUTOMATION_SCHEDULE_TOO_FREQUENT(min_interval),
                 )
 
 


### PR DESCRIPTION
Move the inline f-string details for the automation max-count and min-interval HTTPExceptions into ERROR_MESSAGES entries so they can be translated/maintained alongside the rest of the backend messages.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
