### PR TITLE
fix: automatically close channel input more menu dropdown dynamically on file interactions

### DIFF
--- a/src/lib/components/channel/MessageInput/InputMenu.svelte
+++ b/src/lib/components/channel/MessageInput/InputMenu.svelte
@@ -51,6 +51,7 @@
 				type="button"
 				on:click={() => {
 					uploadFilesHandler();
+					show = false;
 				}}
 			>
 				<Clip />
@@ -62,6 +63,7 @@
 				type="button"
 				on:click={() => {
 					screenCaptureHandler();
+					show = false;
 				}}
 			>
 				<Camera />


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** This Pull Request was prepared with the assistance of an AI copilot and has been thoroughly reviewed and manually tested by the author to ensure quality and adherence to project standards.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

- Fixed an interface bug localized specifically to global Workspace Channels where actively invoking utilities (i.e. click handlers for Upload Files or Capture) inside the native `+` Input Dropdown failed to collapse the open Dropdown modal organically, creating a visual discrepancy compared to standard active chat input behaviors.

### Fixed

- Injected native state closure commands (`show = false;`) bound directly onto the `on:click` bindings inside Channels (`src/lib/components/channel/MessageInput/InputMenu.svelte`), seamlessly mirroring standard Svelte reactive dismissal protocols utilized gracefully in traditional Chat input layouts.

---

### Additional Information

- Validated Dropdown closure behaviors upon clicking the "Upload Files" or "Capture" utilities uniformly across standard Channels interface.

### Screenshots or Videos

<img width="282" height="155" alt="image" src="https://github.com/user-attachments/assets/a030bc04-dd62-47a6-8a10-936dad9994bf" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.