### PR TITLE
feat: replace Google favicon API with backend proxy

### DIFF
--- a/backend/open_webui/routers/utils.py
+++ b/backend/open_webui/routers/utils.py
@@ -1,13 +1,20 @@
+import asyncio
 import black
+import ipaddress
 import logging
 import markdown
+import socket
+
+import aiohttp
+from bs4 import BeautifulSoup
+from urllib.parse import urlparse, urljoin
 
 from open_webui.models.chats import ChatTitleMessagesForm
 from open_webui.config import DATA_DIR, ENABLE_ADMIN_EXPORT
 from open_webui.constants import ERROR_MESSAGES
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, RedirectResponse
 
 
 from open_webui.utils.misc import get_gravatar_url
@@ -18,6 +25,175 @@ from open_webui.utils.code_interpreter import execute_code_jupyter
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_FAVICON_CACHE: dict[str, bytes] = {}
+_FAVICON_CACHE_MAX = 1024
+_FAVICON_MAX_BYTES = 200 * 1024  # 200 KB — skip oversized responses
+_FAVICON_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+}
+_FAVICON_TIMEOUT = aiohttp.ClientTimeout(total=5)
+
+
+async def _is_safe_host(hostname: str) -> bool:
+    """Return True only if the hostname resolves to a public IP (not private/loopback/link-local)."""
+    try:
+        addrs = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+        for addr in addrs:
+            ip = ipaddress.ip_address(addr[4][0])
+            if (
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+            ):
+                return False
+        return True
+    except Exception:
+        return False
+
+
+def _extract_domain(url: str) -> str | None:
+    try:
+        parsed = urlparse(url if url.startswith('http') else f'https://{url}')
+        return parsed.netloc or parsed.path.split('/')[0] or None
+    except Exception:
+        return None
+
+
+def _resolve_href(href: str, base: str) -> str:
+    """Resolve a potentially relative favicon href to an absolute URL."""
+    if href.startswith('data:'):
+        return ''
+    return urljoin(base, href)
+
+
+def _pick_best_icon(links: list) -> str:
+    """
+    Pick the best favicon from a list of <link> tags.
+    Priority: SVG > PNG/WebP > ICO, then larger declared size wins.
+    """
+    FORMAT_RANK = {'svg': 3, 'png': 2, 'webp': 2, 'gif': 1, 'ico': 0}
+
+    def score(tag):
+        href = tag.get('href', '')
+        mime = (tag.get('type') or '').lower()
+        ext = href.rsplit('.', 1)[-1].lower().split('?')[0] if '.' in href else ''
+        fmt = ext or mime.split('/')[-1]
+        fmt_score = FORMAT_RANK.get(fmt, 1)
+
+        sizes = tag.get('sizes', '')
+        try:
+            w = int(sizes.split('x')[0]) if sizes and sizes != 'any' else 0
+        except (ValueError, IndexError):
+            w = 0
+        return (fmt_score, w)
+
+    links = [t for t in links if t.get('href')]
+    if not links:
+        return ''
+    return max(links, key=score).get('href', '')
+
+
+async def _fetch_favicon_bytes(domain: str) -> bytes | None:
+    if not await _is_safe_host(domain):
+        log.debug('favicon: rejected non-public host %s', domain)
+        return None
+
+    base = f'https://{domain}'
+
+    async with aiohttp.ClientSession(headers=_FAVICON_HEADERS, timeout=_FAVICON_TIMEOUT) as session:
+        # Step 1: try /favicon.ico directly
+        try:
+            async with session.get(f'{base}/favicon.ico', allow_redirects=True) as r:
+                if r.status == 200 and 'image' in r.content_type:
+                    if r.content_length and r.content_length > _FAVICON_MAX_BYTES:
+                        log.debug('favicon step 1: response too large for %s', domain)
+                    else:
+                        data = await r.read()
+                        if len(data) <= _FAVICON_MAX_BYTES:
+                            return data
+        except Exception as e:
+            log.debug('favicon step 1 failed for %s: %s', domain, e)
+
+        # Step 2: parse HTML <head> for <link rel="icon"> tags
+        try:
+            async with session.get(base, allow_redirects=True) as r:
+                if r.status == 200:
+                    html = await r.text(errors='replace')
+                    soup = BeautifulSoup(html, 'html.parser')
+                    head = soup.head or soup
+
+                    rel_values = {'icon', 'shortcut icon', 'apple-touch-icon', 'apple-touch-icon-precomposed'}
+                    links = [
+                        tag for tag in head.find_all('link', rel=True)
+                        if set(tag['rel']) & rel_values
+                    ]
+
+                    href = _pick_best_icon(links)
+                    if href:
+                        icon_url = _resolve_href(href, str(r.url))
+                        if icon_url:
+                            icon_host = urlparse(icon_url).netloc.split(':')[0]
+                            if icon_host and not await _is_safe_host(icon_host):
+                                log.debug('favicon: rejected non-public icon host %s', icon_host)
+                            else:
+                                async with session.get(icon_url, allow_redirects=True) as ir:
+                                    if ir.status == 200 and 'image' in ir.content_type:
+                                        if ir.content_length and ir.content_length > _FAVICON_MAX_BYTES:
+                                            log.debug('favicon step 2: icon response too large for %s', icon_host)
+                                        else:
+                                            data = await ir.read()
+                                            if len(data) <= _FAVICON_MAX_BYTES:
+                                                return data
+        except Exception as e:
+            log.debug('favicon step 2 failed for %s: %s', domain, e)
+
+    return None
+
+
+@router.get('/favicon')
+async def get_favicon(url: str, user=Depends(get_verified_user)):
+    """
+    Proxy a source website's favicon server-side.
+    Results are cached in memory for the lifetime of the process.
+    Falls back to Open WebUI's own favicon if none can be found.
+    """
+    domain = _extract_domain(url)
+    if not domain:
+        return RedirectResponse('/favicon.png')
+
+    data = _FAVICON_CACHE.get(domain)
+    if data is None:
+        data = await _fetch_favicon_bytes(domain)
+        if data and len(_FAVICON_CACHE) < _FAVICON_CACHE_MAX:
+            _FAVICON_CACHE[domain] = data
+
+    if not data:
+        return RedirectResponse('/favicon.png')
+
+    # Detect content type from magic bytes
+    if data[:4] == b'\x89PNG':
+        ct = 'image/png'
+    elif data[:2] == b'\xff\xd8':
+        ct = 'image/jpeg'
+    elif data[:3] == b'GIF':
+        ct = 'image/gif'
+    elif data[:14].startswith(b'<svg') or b'<svg' in data[:256]:
+        ct = 'image/svg+xml'
+    elif data[:4] == b'RIFF' and data[8:12] == b'WEBP':
+        ct = 'image/webp'
+    elif data[:4] == b'\x00\x00\x01\x00':
+        ct = 'image/x-icon'
+    else:
+        ct = 'image/x-icon'
+
+    return Response(
+        content=data,
+        media_type=ct,
+        headers={'Cache-Control': 'public, max-age=86400'},
+    )
 
 
 @router.get('/gravatar')

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -175,7 +175,7 @@
 				<div class="flex -space-x-1 items-center">
 					{#each urlCitations.slice(0, 3) as citation, idx}
 						<img
-							src="https://www.google.com/s2/favicons?sz=32&domain={citation.source.name}"
+							src="/api/v1/utils/favicon?url={encodeURIComponent(citation.source.name)}"
 							alt="favicon"
 							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-white dark:bg-gray-900"
 							on:error={(e) => {

--- a/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
@@ -66,9 +66,12 @@
 					<div class=" flex justify-center items-center gap-3">
 						<div class="w-fit">
 							<img
-								src="https://www.google.com/s2/favicons?sz=32&domain={item.link}"
+								src="/api/v1/utils/favicon?url={encodeURIComponent(item.link)}"
 								alt="{item?.title ?? item.link} favicon"
 								class="size-3.5"
+								on:error={(e) => {
+									e.currentTarget.src = '/favicon.png';
+								}}
 							/>
 						</div>
 
@@ -106,9 +109,12 @@
 					<div class=" flex justify-center items-center gap-3">
 						<div class="w-fit">
 							<img
-								src="https://www.google.com/s2/favicons?sz=32&domain={url}"
+								src="/api/v1/utils/favicon?url={encodeURIComponent(url)}"
 								alt="{url} favicon"
 								class="size-3.5"
+								on:error={(e) => {
+									e.currentTarget.src = '/favicon.png';
+								}}
 							/>
 						</div>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Source icons in RAG citations and web search results were fetched client-side via Google's undocumented favicon service, leaking every cited domain to Google's servers and breaking entirely in offline or air-gapped environments.

This PR adds a backend proxy endpoint (`GET /api/v1/utils/favicon?url=...`) that fetches favicons server-side:

1. Try `https://{domain}/favicon.ico` directly.
2. If that fails, fetch the homepage and parse `<link rel="icon">` tags, picking the best format (SVG > PNG > ICO, larger size preferred).
3. Fall back to Open WebUI's own `/favicon.png`.

Results are cached in memory by domain. `Citations.svelte` and `WebSearchResults.svelte` are updated to use the new endpoint.

### Added

- `GET /api/v1/utils/favicon?url=<encoded-url>` in `backend/open_webui/routers/utils.py`

### Changed

- `Citations.svelte` and `WebSearchResults.svelte`: source icon URLs updated from the Google S2 favicon service to the new endpoint.

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Missing `on:error` fallback in `WebSearchResults.svelte`.

### Security

- Cited source domains are no longer sent to Google.
- The endpoint requires a verified user session.
- `_is_safe_host()` validates the resolved IP of both the domain and any parsed icon URL using `socket.getaddrinfo` + `ipaddress`, blocking loopback, private, link-local, and multicast addresses.

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- Relative `href` values are resolved via `urljoin`, `data:` URIs are skipped, a browser `User-Agent` header is set, and a 5-second timeout is applied per request.
- Content-type is detected from magic bytes in the response.
- Responses are capped at 200 KB; oversized payloads are skipped in both fetch phases.
- In-memory cache is bounded at 1024 entries; failures are not cached, so they retry automatically.
- Both fetch phases log at `DEBUG` level on failure.
- `_is_safe_host()` DNS resolution runs via `asyncio.to_thread` so the event loop is not blocked.
- Icons served with `type="image/svg+xml"` may not have a file extension, so the scorer checks the file extension first and falls back to the MIME subtype.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
