### PR TITLE
fix(oauth): prefer admin-provided scope over discovered scopes_supported in static-credential flow

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2338,6 +2338,7 @@ async def register_client(request, client_id: str) -> bool:
                 server_url,
                 oauth_client_id=existing_data.get('client_id', ''),
                 oauth_client_secret=existing_data.get('client_secret', ''),
+                scope=existing_data.get('scope') or None,
             )
         else:
             oauth_client_info = await get_oauth_client_info_with_dynamic_client_registration(

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -101,6 +101,7 @@ class OAuthClientRegistrationForm(BaseModel):
     client_id: str
     client_name: Optional[str] = None
     client_secret: Optional[str] = None
+    scope: Optional[str] = None
 
 
 @router.post('/oauth/clients/register')
@@ -123,6 +124,7 @@ async def register_oauth_client(
                 form_data.url,
                 oauth_client_id=form_data.client_id,
                 oauth_client_secret=form_data.client_secret,
+                scope=form_data.scope or None,
             )
         else:
             oauth_client_info = await get_oauth_client_info_with_dynamic_client_registration(

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -448,6 +448,7 @@ async def get_oauth_client_info_with_static_credentials(
     oauth_server_url: str,
     oauth_client_id: str,
     oauth_client_secret: str,
+    scope: str | None = None,
 ) -> OAuthClientInformationFull:
     """
     Build an OAuthClientInformationFull from user-provided static credentials.
@@ -475,10 +476,12 @@ async def get_oauth_client_info_with_static_credentials(
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        # Determine scope from server metadata if available
-        scope = None
-        if oauth_server_metadata and oauth_server_metadata.scopes_supported:
+        # Determine scope: prefer admin-provided scope; fall back to discovered scopes_supported.
+        # Unconditionally overwriting with scopes_supported would silently discard any
+        # custom scope string the admin supplied (e.g. Azure resource-specific scopes).
+        if scope is None and oauth_server_metadata and oauth_server_metadata.scopes_supported:
             scope = ' '.join(oauth_server_metadata.scopes_supported)
+            log.debug(f'No explicit scope provided; using discovered scopes: {scope}')
 
         # Determine token_endpoint_auth_method
         token_endpoint_auth_method = 'client_secret_post'


### PR DESCRIPTION
Fixes #23668

## Problem

`get_oauth_client_info_with_static_credentials` unconditionally overwrites the OAuth scope with the authorization server's `scopes_supported` metadata:

```python
scope = None
if oauth_server_metadata and oauth_server_metadata.scopes_supported:
    scope = ' '.join(oauth_server_metadata.scopes_supported)   # silently drops admin scope
```

This breaks setups that rely on **scope bundling** — e.g. registering multiple MCP servers backed by the same Entra AD/Azure app where a single consent should cover Calendar + Mail + User resource scopes. The metadata endpoint returns only generic OpenID scopes (`openid profile offline_access`), so the actual resource scopes are lost, causing repeated consent prompts or missing token audiences.

## Fix

Three-part change:

1. **`utils/oauth.py`** — add an optional `scope` parameter to `get_oauth_client_info_with_static_credentials`. The discovered `scopes_supported` is used **only** when no explicit scope was provided (and a debug log makes this visible).

2. **`routers/configs.py`** — add `scope: Optional[str] = None` to `OAuthClientRegistrationForm` and forward it to the function, so admins can supply a custom scope string when registering a tool server with static credentials.

3. **`main.py`** — when re-authenticating an existing static-credential client (refreshing endpoints), read the scope that was persisted in the encrypted client-info blob and pass it back, so the scope is preserved across re-auth cycles.

## Behaviour

| Situation | Before | After |
|-----------|--------|-------|
| Admin provides explicit scope | Silently replaced by `scopes_supported` | Honoured as-is |
| No scope provided, server advertises `scopes_supported` | Used (unchanged) | Used, with a debug log |
| No scope, no `scopes_supported` | `None` | `None` (unchanged) |
| Re-auth of existing static client | Scope re-discovered, may differ | Stored scope preserved |