### PR TITLE
fix: add missing db parameter to filter_allowed_access_grants in update_note_access_by_id

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -348,6 +348,7 @@ async def update_note_access_by_id(
         user.role,
         form_data.access_grants,
         'sharing.public_notes',
+        db=db,
     )
 
     AccessGrants.set_access_grants('note', id, form_data.access_grants, db=db)


### PR DESCRIPTION
## Description

In `update_note_access_by_id()`, the call to `filter_allowed_access_grants()` at line 345 is missing the `db=db` parameter. The same function is called correctly with `db=db` in `update_note_by_id()` at line 281.

`filter_allowed_access_grants()` accepts `db: Session | None = None` and uses it for database operations when filtering access grants. Without it, the function may fail to properly validate group-based access grants that require database lookups.

## Changes

Add the missing `db=db` parameter to the `filter_allowed_access_grants()` call in `update_note_access_by_id()`, matching the pattern already used in `update_note_by_id()`.