### PR TITLE
fix(storage): expose async Storage methods so async handlers stop blocking on file I/O

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -124,7 +124,7 @@ async def process_uploaded_file(
                 stt_supported_content_types = getattr(request.app.state.config, 'STT_SUPPORTED_CONTENT_TYPES', [])
 
                 if strict_match_mime_type(stt_supported_content_types, content_type):
-                    file_path_processed = Storage.get_file(file_path)
+                    file_path_processed = await Storage.aget_file(file_path)
                     result = transcribe(request, file_path_processed, file_metadata, user)
 
                     await process_file(
@@ -242,7 +242,7 @@ async def upload_file_handler(
         id = str(uuid.uuid4())
         name = filename
         filename = f'{id}_{filename}'
-        contents, file_path = Storage.upload_file(
+        contents, file_path = await Storage.aupload_file(
             file.file,
             filename,
             {
@@ -406,7 +406,7 @@ async def delete_all_files(user=Depends(get_admin_user), db: AsyncSession = Depe
     result = await Files.delete_all_files(db=db)
     if result:
         try:
-            Storage.delete_all_files()
+            await Storage.adelete_all_files()
             VECTOR_DB_CLIENT.reset()
         except Exception as e:
             log.exception(e)
@@ -618,7 +618,7 @@ async def get_file_content_by_id(
 
     if file.user_id == user.id or user.role == 'admin' or await has_access_to_file(id, 'read', user, db=db):
         try:
-            file_path = Storage.get_file(file.path)
+            file_path = await Storage.aget_file(file.path)
             file_path = Path(file_path)
 
             # Check if the file already exists in the cache
@@ -685,7 +685,7 @@ async def get_html_file_content_by_id(
 
     if file.user_id == user.id or user.role == 'admin' or await has_access_to_file(id, 'read', user, db=db):
         try:
-            file_path = Storage.get_file(file.path)
+            file_path = await Storage.aget_file(file.path)
             file_path = Path(file_path)
 
             # Check if the file already exists in the cache
@@ -734,7 +734,7 @@ async def get_file_content_by_id(
         headers = {'Content-Disposition': f"attachment; filename*=UTF-8''{encoded_filename}"}
 
         if file_path:
-            file_path = Storage.get_file(file_path)
+            file_path = await Storage.aget_file(file_path)
             file_path = Path(file_path)
 
             # Check if the file already exists in the cache
@@ -798,7 +798,7 @@ async def delete_file_by_id(id: str, user=Depends(get_verified_user), db: AsyncS
         result = await Files.delete_file_by_id(id, db=db)
         if result:
             try:
-                Storage.delete_file(file.path)
+                await Storage.adelete_file(file.path)
                 VECTOR_DB_CLIENT.delete(collection_name=f'file-{id}')
             except Exception as e:
                 log.exception(e)

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1609,7 +1609,7 @@ async def process_file(
                 # Usage: /files/
                 file_path = file.path
                 if file_path:
-                    file_path = Storage.get_file(file_path)
+                    file_path = await Storage.aget_file(file_path)
                     loader = Loader(
                         engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
                         user=user,

--- a/backend/open_webui/storage/provider.py
+++ b/backend/open_webui/storage/provider.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 import json
@@ -53,6 +54,37 @@ class StorageProvider(ABC):
     @abstractmethod
     def delete_file(self, file_path: str) -> None:
         pass
+
+    # ------------------------------------------------------------------
+    # Async wrappers
+    #
+    # Every concrete provider performs blocking I/O — local filesystem
+    # reads/writes for `LocalStorageProvider`, network round-trips for
+    # the S3/GCS/Azure backends. Calling them directly from an async
+    # handler blocks the event loop for the entire duration of the
+    # operation, which on slow networks or large files freezes every
+    # other in-flight request.
+    #
+    # These default async implementations off-load the corresponding
+    # sync method to a worker thread via `asyncio.to_thread`, giving
+    # async callers a uniform `await Storage.aXxx(...)` API. Concrete
+    # providers that gain a native async client in the future can
+    # override these methods without breaking callers.
+    # ------------------------------------------------------------------
+
+    async def aget_file(self, file_path: str) -> str:
+        return await asyncio.to_thread(self.get_file, file_path)
+
+    async def aupload_file(
+        self, file: BinaryIO, filename: str, tags: Dict[str, str]
+    ) -> Tuple[bytes, str]:
+        return await asyncio.to_thread(self.upload_file, file, filename, tags)
+
+    async def adelete_all_files(self) -> None:
+        return await asyncio.to_thread(self.delete_all_files)
+
+    async def adelete_file(self, file_path: str) -> None:
+        return await asyncio.to_thread(self.delete_file, file_path)
 
 
 class LocalStorageProvider(StorageProvider):

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -51,7 +51,7 @@ async def get_image_base64_from_url(url: str) -> Optional[str]:
             if not file:
                 return None
 
-            file_path = Storage.get_file(file.path)
+            file_path = await Storage.aget_file(file.path)
             file_path = Path(file_path)
 
             if file_path.is_file():
@@ -172,7 +172,7 @@ async def get_image_base64_from_file_id(id: str) -> Optional[str]:
         return None
 
     try:
-        file_path = Storage.get_file(file.path)
+        file_path = await Storage.aget_file(file.path)
         file_path = Path(file_path)
 
         # Check if the file already exists in the cache


### PR DESCRIPTION
Every concrete `StorageProvider` performs blocking I/O — local FS reads and writes for `LocalStorageProvider`, full network round-trips for the S3/GCS/Azure backends. The sync methods were being awaited (implicitly, by being called inside `async def`) from upload, download and processing routes — including the upload handler that reads the incoming file off the temp spool and writes it to disk. On large files or slow network backends this freezes the event loop and every other in-flight request stalls until the I/O completes.

Add async sibling methods (`aget_file`, `aupload_file`, `adelete_file`, `adelete_all_files`) directly on the `StorageProvider` base. The defaults wrap the existing sync methods with `asyncio.to_thread`, so every concrete provider gains a uniform async API for free without any backend-specific changes — and providers that ever gain a native async client can override these methods later without touching call sites.

Update every async caller (`utils/files`, `routers/files`, `routers/retrieval.process_file`) to use the `aXxx` variants. Sync helpers like `_is_text_file` keep using the sync API.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
