### PR TITLE
fix(db): default DATABASE_ENABLE_SQLITE_WAL to True so async+sync engines stop deadlocking on file lock

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -375,7 +375,15 @@ else:
     except Exception:
         DATABASE_POOL_RECYCLE = 3600
 
-DATABASE_ENABLE_SQLITE_WAL = os.environ.get('DATABASE_ENABLE_SQLITE_WAL', 'False').lower() == 'true'
+# SQLite WAL (Write-Ahead Logging) defaults to *on* because Open WebUI
+# always uses both a sync engine (sqlite3 / sqlcipher3) and an async engine
+# (aiosqlite) against the same database file. Without WAL, the database
+# uses rollback-journal mode where every writer takes an exclusive lock
+# that blocks all readers across both engines, which under concurrent
+# requests cascades into the entire FastAPI loop stalling on lock
+# contention. Operators who explicitly need rollback-journal can opt out
+# by setting `DATABASE_ENABLE_SQLITE_WAL=False`.
+DATABASE_ENABLE_SQLITE_WAL = os.environ.get('DATABASE_ENABLE_SQLITE_WAL', 'True').lower() == 'true'
 
 DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL = os.environ.get('DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL', None)
 if DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL is not None:

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -126,9 +126,15 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
         # Match the journal_mode policy of the unencrypted sqlite path.
         # Without WAL the encrypted sync engine and aiosqlite engine
         # serialize on the same database-file lock, freezing the loop
-        # under concurrent requests.
+        # under concurrent requests. SQLite persists journal_mode in
+        # the database file, so we must explicitly set both branches —
+        # otherwise an operator who flips DATABASE_ENABLE_SQLITE_WAL
+        # back to False after a WAL-enabled run would silently keep
+        # WAL forever.
         if DATABASE_ENABLE_SQLITE_WAL:
             conn.execute('PRAGMA journal_mode=WAL')
+        else:
+            conn.execute('PRAGMA journal_mode=DELETE')
         return conn
 
     # The dummy "sqlite://" URL would cause SQLAlchemy to auto-select

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -108,6 +108,49 @@ def _make_async_url(url: str) -> str:
 #              Alembic, peewee migration, health checks)
 # ============================================================
 
+def _set_sqlite_journal_mode(dbapi_connection, want_wal: bool, *, db_label: str) -> None:
+    """Set SQLite/SQLCipher journal_mode and verify the engine accepted it.
+
+    SQLite's `PRAGMA journal_mode = X` returns the mode the engine
+    actually selected, which is *not* always the one requested:
+    network filesystems frequently reject WAL (because shared-memory
+    mapping is unavailable), and certain SQLCipher builds may also
+    decline. Without verification we'd silently run in rollback-journal
+    while believing WAL was active — and the lock-contention symptoms
+    this branch exists to fix would persist undetected.
+
+    This helper executes the PRAGMA, reads the result, and logs a
+    warning on mismatch so operators can see what happened. It does
+    not fail fast: a downgrade to DELETE is degraded but functional,
+    not broken.
+    """
+    requested = 'WAL' if want_wal else 'DELETE'
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f'PRAGMA journal_mode={requested}')
+        row = cursor.fetchone()
+    finally:
+        cursor.close()
+
+    actual = (row[0] if row else '').upper() if row else ''
+    if not actual:
+        log.warning(
+            'SQLite (%s): PRAGMA journal_mode=%s returned no result; '
+            'unable to confirm active journal mode.',
+            db_label,
+            requested,
+        )
+    elif actual != requested.upper():
+        log.warning(
+            'SQLite (%s): requested journal_mode=%s but engine selected %s. '
+            'On network filesystems WAL is commonly rejected; expect lock '
+            'contention under concurrent load.',
+            db_label,
+            requested,
+            actual,
+        )
+
+
 # Handle SQLCipher URLs
 if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
     database_password = os.environ.get('DATABASE_PASSWORD')
@@ -124,17 +167,17 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
         conn = sqlcipher3.connect(db_path, check_same_thread=False)
         conn.execute(f"PRAGMA key = '{database_password}'")
         # Match the journal_mode policy of the unencrypted sqlite path.
-        # Without WAL the encrypted sync engine and aiosqlite engine
-        # serialize on the same database-file lock, freezing the loop
-        # under concurrent requests. SQLite persists journal_mode in
-        # the database file, so we must explicitly set both branches —
-        # otherwise an operator who flips DATABASE_ENABLE_SQLITE_WAL
-        # back to False after a WAL-enabled run would silently keep
-        # WAL forever.
-        if DATABASE_ENABLE_SQLITE_WAL:
-            conn.execute('PRAGMA journal_mode=WAL')
-        else:
-            conn.execute('PRAGMA journal_mode=DELETE')
+        # SQLCipher URLs are rejected by the async engine path so there
+        # is no aiosqlite engine to coexist with — but the *sync* engine
+        # still serves requests via run_in_threadpool, and the QueuePool
+        # variant above maintains many concurrent sync connections to
+        # the same encrypted DB file. Without WAL those connections
+        # serialize on the database-file lock under load. SQLite
+        # persists journal_mode in the file, so we must explicitly set
+        # both branches — otherwise an operator who flips
+        # DATABASE_ENABLE_SQLITE_WAL back to False after a WAL-enabled
+        # run would silently keep WAL forever.
+        _set_sqlite_journal_mode(conn, DATABASE_ENABLE_SQLITE_WAL, db_label='sqlcipher')
         return conn
 
     # The dummy "sqlite://" URL would cause SQLAlchemy to auto-select
@@ -168,12 +211,9 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
     engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
 
     def on_connect(dbapi_connection, connection_record):
-        cursor = dbapi_connection.cursor()
-        if DATABASE_ENABLE_SQLITE_WAL:
-            cursor.execute('PRAGMA journal_mode=WAL')
-        else:
-            cursor.execute('PRAGMA journal_mode=DELETE')
-        cursor.close()
+        _set_sqlite_journal_mode(
+            dbapi_connection, DATABASE_ENABLE_SQLITE_WAL, db_label='sqlite-sync'
+        )
 
     event.listen(engine, 'connect', on_connect)
 else:
@@ -225,13 +265,11 @@ if 'sqlite' in ASYNC_SQLALCHEMY_DATABASE_URL:
         connect_args={'check_same_thread': False},
     )
 
-    if DATABASE_ENABLE_SQLITE_WAL:
-
-        @event.listens_for(async_engine.sync_engine, 'connect')
-        def _set_sqlite_wal(dbapi_connection, connection_record):
-            cursor = dbapi_connection.cursor()
-            cursor.execute('PRAGMA journal_mode=WAL')
-            cursor.close()
+    @event.listens_for(async_engine.sync_engine, 'connect')
+    def _set_sqlite_wal(dbapi_connection, connection_record):
+        _set_sqlite_journal_mode(
+            dbapi_connection, DATABASE_ENABLE_SQLITE_WAL, db_label='sqlite-async'
+        )
 else:
     if isinstance(DATABASE_POOL_SIZE, int):
         if DATABASE_POOL_SIZE > 0:

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -123,6 +123,12 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
 
         conn = sqlcipher3.connect(db_path, check_same_thread=False)
         conn.execute(f"PRAGMA key = '{database_password}'")
+        # Match the journal_mode policy of the unencrypted sqlite path.
+        # Without WAL the encrypted sync engine and aiosqlite engine
+        # serialize on the same database-file lock, freezing the loop
+        # under concurrent requests.
+        if DATABASE_ENABLE_SQLITE_WAL:
+            conn.execute('PRAGMA journal_mode=WAL')
         return conn
 
     # The dummy "sqlite://" URL would cause SQLAlchemy to auto-select

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -120,19 +120,38 @@ def _set_sqlite_journal_mode(dbapi_connection, want_wal: bool, *, db_label: str)
     this branch exists to fix would persist undetected.
 
     This helper executes the PRAGMA, reads the result, and logs a
-    warning on mismatch so operators can see what happened. It does
-    not fail fast: a downgrade to DELETE is degraded but functional,
-    not broken.
+    warning on mismatch so operators can see what happened. It is
+    deliberately non-failing: it runs from SQLAlchemy `connect`
+    listeners and the SQLCipher creator, where raising would abort
+    connection establishment entirely. Any DB-API failure here (read-
+    only DB, locked DB during mode switch, pragma not permitted by
+    the build) is logged and swallowed — a degraded journal_mode is
+    worse than ideal, but a hard startup outage is worse still.
     """
     requested = 'WAL' if want_wal else 'DELETE'
-    cursor = dbapi_connection.cursor()
+    actual = ''
     try:
-        cursor.execute(f'PRAGMA journal_mode={requested}')
-        row = cursor.fetchone()
-    finally:
-        cursor.close()
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f'PRAGMA journal_mode={requested}')
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        actual = (row[0] or '').upper() if row else ''
+    except Exception as exc:
+        # Don't propagate — the caller is a SQLAlchemy connect event /
+        # connection creator, and raising here aborts the whole
+        # connection instead of just degrading journal_mode policy.
+        log.warning(
+            'SQLite (%s): failed to apply PRAGMA journal_mode=%s: %r. '
+            'Continuing with whatever mode SQLite chose; expect lock '
+            'contention if WAL was requested but not active.',
+            db_label,
+            requested,
+            exc,
+        )
+        return
 
-    actual = (row[0] if row else '').upper() if row else ''
     if not actual:
         log.warning(
             'SQLite (%s): PRAGMA journal_mode=%s returned no result; '
@@ -140,13 +159,31 @@ def _set_sqlite_journal_mode(dbapi_connection, want_wal: bool, *, db_label: str)
             db_label,
             requested,
         )
-    elif actual != requested.upper():
+        return
+
+    if actual == requested.upper():
+        return
+
+    if want_wal:
+        # Requested WAL, got something else — the failure mode this
+        # branch was created to fix.
         log.warning(
-            'SQLite (%s): requested journal_mode=%s but engine selected %s. '
-            'On network filesystems WAL is commonly rejected; expect lock '
-            'contention under concurrent load.',
+            'SQLite (%s): requested journal_mode=WAL but engine selected %s. '
+            'On network filesystems WAL is commonly rejected (no shared-memory '
+            'mapping); expect lock contention under concurrent load.',
             db_label,
-            requested,
+            actual,
+        )
+    else:
+        # Requested DELETE (operator opted out), got something else. The
+        # most common cause is that the DB file was previously opened in
+        # WAL and SQLite refuses to switch back while other connections
+        # hold WAL state — but the message stays neutral so we don't
+        # mislead operators chasing the wrong cause.
+        log.warning(
+            'SQLite (%s): requested journal_mode=DELETE but engine kept %s. '
+            'The opt-out from WAL did not take effect for this connection.',
+            db_label,
             actual,
         )
 


### PR DESCRIPTION
Open WebUI runs both a sync engine (sqlite3 / sqlcipher3 — used at startup, by Alembic, the peewee migration shim, healthchecks, and a couple of legacy paths) and an async engine (aiosqlite) against the same SQLite database file. SQLite's default rollback-journal mode takes an exclusive lock on the entire DB file for every writer, which means the moment one engine writes, every other reader/writer across both engines blocks on the same file lock. Under a normal request mix this surfaces as the entire FastAPI loop stalling whenever a long write (e.g. file-upload metadata + chat persistence + embedding status updates) happens to overlap.

WAL mode lets readers proceed while a writer is committing and is required for the dual-engine layout to behave; rollback-journal is only safe for single-process, single-engine use which Open WebUI is not.

Flip the default of `DATABASE_ENABLE_SQLITE_WAL` from `False` to `True`. Operators who genuinely need rollback-journal can still set `DATABASE_ENABLE_SQLITE_WAL=False` explicitly. Also apply the same journal-mode policy in the SQLCipher connection creator so encrypted deployments get the same fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
