### PR TITLE
fix(db): patch SQLAlchemy ↔ aiosqlite ≥0.20 terminate_force_close incompatibility

### DIFF
--- a/backend/open_webui/internal/_aiosqlite_compat.py
+++ b/backend/open_webui/internal/_aiosqlite_compat.py
@@ -1,0 +1,110 @@
+"""
+Compatibility shim for SQLAlchemy ↔ aiosqlite ≥ 0.20.
+
+Background
+----------
+SQLAlchemy ≥ 2.0.36 added a `terminate_force_close()` path on its
+async DB-API adapters, used by the connection pool when a connection
+must be invalidated immediately — typically because the operation it
+was running was cancelled (for example, a request was aborted by the
+client mid-query).
+
+For the aiosqlite dialect this implementation lives at
+`sqlalchemy.dialects.sqlite.aiosqlite.AsyncAdapt_aiosqlite_connection
+._terminate_force_close` and unconditionally accesses
+`self._connection.stop`. That attribute existed on
+`aiosqlite.Connection` in 0.18 and earlier (where Connection
+sub-classed `threading.Thread` and exposed a `stop()` method). It was
+removed in aiosqlite 0.20 when the worker model was refactored.
+
+The result, on the version combo Open WebUI pins
+(SQLAlchemy 2.0.48 + aiosqlite 0.21.0), is that *every* cancellation
+mid-DB-call produces a multi-page
+
+    NotImplementedError: terminate_force_close() not implemented by this DBAPI shim
+
+at ERROR level — drowning real errors in noise even though the
+underlying connection is being torn down correctly by aiosqlite's own
+worker on the next iteration.
+
+Fix
+---
+Replace `_terminate_force_close` with one that understands both the
+old `Connection.stop()` API and the modern internal `_running` flag.
+Setting `_running = False` causes the aiosqlite worker thread to
+break out of its loop on the next tick, which is the same end-state
+the original code was after.
+
+Apply this patch once, at import time, before any async engine is
+created. Idempotent and safe to import on systems where the affected
+SQLAlchemy/aiosqlite versions are not in use — it bails out silently
+if the symbol is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def install() -> None:
+    try:
+        from sqlalchemy.dialects.sqlite import aiosqlite as _sa_aiosqlite
+    except ImportError:
+        # SQLAlchemy installed without sqlite+aiosqlite — nothing to patch.
+        return
+
+    target_cls = getattr(_sa_aiosqlite, 'AsyncAdapt_aiosqlite_connection', None)
+    if target_cls is None or not hasattr(target_cls, '_terminate_force_close'):
+        # Either an older SQLAlchemy without the terminate path, or an
+        # upstream rewrite that no longer needs this shim.
+        return
+
+    if getattr(target_cls._terminate_force_close, '__open_webui_patched__', False):
+        return  # Idempotent — already applied.
+
+    def _terminate_force_close(self) -> None:
+        conn = getattr(self, '_connection', None)
+        if conn is None:
+            return
+
+        # aiosqlite ≤ 0.18 — original API.
+        stop = getattr(conn, 'stop', None)
+        if callable(stop):
+            try:
+                stop()
+            except Exception:
+                log.debug(
+                    'aiosqlite Connection.stop() raised during force-close; '
+                    'connection will be cleaned up by garbage collection.',
+                    exc_info=True,
+                )
+            return
+
+        # aiosqlite ≥ 0.20 — the worker thread observes its own
+        # `_running` flag and exits on the next loop tick, releasing
+        # the underlying sqlite3 connection.
+        if hasattr(conn, '_running'):
+            try:
+                conn._running = False
+            except Exception:
+                log.debug(
+                    'Could not flip aiosqlite Connection._running during '
+                    'force-close; connection will be cleaned up by garbage '
+                    'collection.',
+                    exc_info=True,
+                )
+            return
+
+        # Unknown aiosqlite internals — fall back to leaving the
+        # connection to garbage collection. Do *not* re-raise: the pool
+        # has already removed the connection record and there is
+        # nothing useful for the caller to do.
+        log.debug(
+            'aiosqlite Connection has neither stop() nor _running; relying '
+            'on garbage collection to release the underlying sqlite3 handle.'
+        )
+
+    _terminate_force_close.__open_webui_patched__ = True  # type: ignore[attr-defined]
+    target_cls._terminate_force_close = _terminate_force_close

--- a/backend/open_webui/internal/_aiosqlite_compat.py
+++ b/backend/open_webui/internal/_aiosqlite_compat.py
@@ -30,19 +30,34 @@ worker on the next iteration.
 Fix
 ---
 Replace `_terminate_force_close` with one that understands both the
-old `Connection.stop()` API and the modern internal `_running` flag.
-Setting `_running = False` causes the aiosqlite worker thread to
-break out of its loop on the next tick, which is the same end-state
-the original code was after.
+old `Connection.stop()` API and the modern post-0.20 internals (a
+private worker thread fed by an `_tx` queue, gated by a `_running`
+flag). The replacement is best-effort: the connection record has
+already been removed from the pool by the time this is called, and
+aiosqlite's own GC will release the underlying sqlite3 handle. We
+nudge the worker (sentinel + `_running = False`) so it doesn't linger
+on the queue indefinitely, but we do not raise on failure.
 
 Apply this patch once, at import time, before any async engine is
-created. Idempotent and safe to import on systems where the affected
-SQLAlchemy/aiosqlite versions are not in use — it bails out silently
-if the symbol is missing.
+created. To keep the blast radius small the install is:
+
+  * a no-op if the SQLAlchemy build doesn't ship the affected
+    `_terminate_force_close` symbol (older or upstream-fixed
+    versions);
+  * a no-op if the upstream implementation has already moved off the
+    `self._connection.stop` reference — detected by inspecting the
+    original source — so a future SQLAlchemy fix isn't shadowed by
+    this shim;
+  * idempotent so repeated imports don't stack patches.
+
+The caller in `internal.db` only invokes `install()` when the runtime
+async URL is sqlite-based, so PostgreSQL / MySQL / etc. deployments
+get no global mutation at all.
 """
 
 from __future__ import annotations
 
+import inspect
 import logging
 
 log = logging.getLogger(__name__)
@@ -61,15 +76,35 @@ def install() -> None:
         # upstream rewrite that no longer needs this shim.
         return
 
-    if getattr(target_cls._terminate_force_close, '__open_webui_patched__', False):
+    original = target_cls._terminate_force_close
+    if getattr(original, '__open_webui_patched__', False):
         return  # Idempotent — already applied.
 
+    # Only patch the specific buggy implementation. If upstream has
+    # changed how `_terminate_force_close` is implemented (no longer
+    # touching `self._connection.stop`) defer to whatever they ship.
+    try:
+        original_source = inspect.getsource(original)
+    except (OSError, TypeError):
+        original_source = ''
+    if 'self._connection.stop' not in original_source:
+        return
+
     def _terminate_force_close(self) -> None:
+        """Best-effort force close of an aiosqlite connection.
+
+        The pool has already removed the connection record by the time
+        this is called; aiosqlite's own GC will release the underlying
+        sqlite3 handle either way. We try to nudge the worker so it
+        exits promptly on both the pre-0.18 and post-0.20 internals,
+        but we never raise: there is nothing useful for the caller to
+        do with a failure here.
+        """
         conn = getattr(self, '_connection', None)
         if conn is None:
             return
 
-        # aiosqlite ≤ 0.18 — original API.
+        # aiosqlite ≤ 0.18 — original public API.
         stop = getattr(conn, 'stop', None)
         if callable(stop):
             try:
@@ -82,29 +117,40 @@ def install() -> None:
                 )
             return
 
-        # aiosqlite ≥ 0.20 — the worker thread observes its own
-        # `_running` flag and exits on the next loop tick, releasing
-        # the underlying sqlite3 connection.
+        # aiosqlite ≥ 0.20 — the worker thread blocks on `_tx.get()`
+        # waiting for callables. Setting `_running = False` alone does
+        # not wake it; the queue needs a sentinel push so the loop
+        # observes the flag on the next iteration.
+        nudged = False
+        tx = getattr(conn, '_tx', None)
+        if tx is not None:
+            try:
+                tx.put_nowait((None, None))
+                nudged = True
+            except Exception:
+                log.debug(
+                    'aiosqlite worker queue rejected the termination '
+                    'sentinel; relying on garbage collection.',
+                    exc_info=True,
+                )
+
         if hasattr(conn, '_running'):
             try:
                 conn._running = False
+                nudged = True
             except Exception:
                 log.debug(
                     'Could not flip aiosqlite Connection._running during '
-                    'force-close; connection will be cleaned up by garbage '
-                    'collection.',
+                    'force-close.',
                     exc_info=True,
                 )
-            return
 
-        # Unknown aiosqlite internals — fall back to leaving the
-        # connection to garbage collection. Do *not* re-raise: the pool
-        # has already removed the connection record and there is
-        # nothing useful for the caller to do.
-        log.debug(
-            'aiosqlite Connection has neither stop() nor _running; relying '
-            'on garbage collection to release the underlying sqlite3 handle.'
-        )
+        if not nudged:
+            log.debug(
+                'aiosqlite Connection has neither stop(), _tx nor _running; '
+                'relying on garbage collection to release the underlying '
+                'sqlite3 handle.'
+            )
 
     _terminate_force_close.__open_webui_patched__ = True  # type: ignore[attr-defined]
     target_cls._terminate_force_close = _terminate_force_close

--- a/backend/open_webui/internal/_aiosqlite_compat.py
+++ b/backend/open_webui/internal/_aiosqlite_compat.py
@@ -45,9 +45,11 @@ created. To keep the blast radius small the install is:
     `_terminate_force_close` symbol (older or upstream-fixed
     versions);
   * a no-op if the upstream implementation has already moved off the
-    `self._connection.stop` reference — detected by inspecting the
-    original source — so a future SQLAlchemy fix isn't shadowed by
-    this shim;
+    `self._connection.stop` reference — detected via source
+    inspection with a bytecode fallback (so the heuristic still
+    works on zipped, pyc-only or otherwise stripped builds where
+    `inspect.getsource()` raises) — so a future SQLAlchemy fix
+    isn't shadowed by this shim;
   * idempotent so repeated imports don't stack patches.
 
 The caller in `internal.db` only invokes `install()` when the runtime
@@ -61,6 +63,53 @@ import inspect
 import logging
 
 log = logging.getLogger(__name__)
+
+
+def _looks_buggy(original) -> bool:
+    """Return True if `original` looks like the buggy upstream impl
+    that references `self._connection.stop`.
+
+    Two signals, in order of preference:
+
+    1. Source text inspection — exact and obvious, but fails on
+       deployments where source isn't on disk (zipped distributions,
+       pyc-only installs, frozen runtimes).
+    2. Bytecode `co_names` inspection — works on every CPython build
+       that exposes `__code__`. Both `_connection` and `stop` appear
+       in `co_names` whenever the function does an attribute access of
+       the form `self._connection.stop`, regardless of whitespace or
+       formatting changes.
+
+    If neither inspection succeeds we err on the side of patching:
+    the upstream `_terminate_force_close` already raised
+    `NotImplementedError` for us once (which is why we're here), and
+    a possibly-redundant shim is preferable to silently restoring the
+    multi-page ERROR traceback the user explicitly reported.
+    """
+    try:
+        original_source = inspect.getsource(original)
+    except (OSError, TypeError):
+        original_source = None
+
+    if original_source is not None:
+        return 'self._connection.stop' in original_source
+
+    code = getattr(original, '__code__', None)
+    if code is not None:
+        names = set(getattr(code, 'co_names', ()))
+        if {'_connection', 'stop'}.issubset(names):
+            return True
+        # Bytecode says it's not the buggy shape — believe it.
+        return False
+
+    # Neither source nor bytecode available. Patch defensively; the
+    # caller already established that the buggy `NotImplementedError`
+    # path is the existing behaviour.
+    log.debug(
+        'aiosqlite shim: could not inspect upstream _terminate_force_close '
+        'via source or bytecode; applying compatibility patch defensively.'
+    )
+    return True
 
 
 def install() -> None:
@@ -80,14 +129,7 @@ def install() -> None:
     if getattr(original, '__open_webui_patched__', False):
         return  # Idempotent — already applied.
 
-    # Only patch the specific buggy implementation. If upstream has
-    # changed how `_terminate_force_close` is implemented (no longer
-    # touching `self._connection.stop`) defer to whatever they ship.
-    try:
-        original_source = inspect.getsource(original)
-    except (OSError, TypeError):
-        original_source = ''
-    if 'self._connection.stop' not in original_source:
+    if not _looks_buggy(original):
         return
 
     def _terminate_force_close(self) -> None:

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -205,6 +205,15 @@ get_db = contextmanager(get_session)
 # ASYNC ENGINE (used for ALL runtime database operations)
 # ============================================================
 
+# Patch SQLAlchemy's aiosqlite connector before any async engine is
+# created. Without this, every cancelled aiosqlite query produces a
+# multi-page `terminate_force_close() not implemented` ERROR traceback
+# because SQLAlchemy 2.0.x's shim references `Connection.stop`, which
+# aiosqlite removed in 0.20+. See `_aiosqlite_compat` for details.
+from open_webui.internal._aiosqlite_compat import install as _install_aiosqlite_compat
+
+_install_aiosqlite_compat()
+
 ASYNC_SQLALCHEMY_DATABASE_URL = _make_async_url(SQLALCHEMY_DATABASE_URL)
 
 if 'sqlite' in ASYNC_SQLALCHEMY_DATABASE_URL:

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -205,18 +205,22 @@ get_db = contextmanager(get_session)
 # ASYNC ENGINE (used for ALL runtime database operations)
 # ============================================================
 
-# Patch SQLAlchemy's aiosqlite connector before any async engine is
-# created. Without this, every cancelled aiosqlite query produces a
-# multi-page `terminate_force_close() not implemented` ERROR traceback
-# because SQLAlchemy 2.0.x's shim references `Connection.stop`, which
-# aiosqlite removed in 0.20+. See `_aiosqlite_compat` for details.
-from open_webui.internal._aiosqlite_compat import install as _install_aiosqlite_compat
-
-_install_aiosqlite_compat()
-
 ASYNC_SQLALCHEMY_DATABASE_URL = _make_async_url(SQLALCHEMY_DATABASE_URL)
 
 if 'sqlite' in ASYNC_SQLALCHEMY_DATABASE_URL:
+    # Patch SQLAlchemy's aiosqlite connector before the engine — and
+    # therefore any pooled connection — is created. Without this, every
+    # cancelled aiosqlite query produces a multi-page
+    # `terminate_force_close() not implemented` ERROR traceback because
+    # SQLAlchemy 2.0.x's shim references `Connection.stop`, which
+    # aiosqlite removed in 0.20+. The install is a no-op when the
+    # affected upstream code is absent or already fixed; it is gated
+    # behind the sqlite URL check so non-sqlite deployments get no
+    # global SQLAlchemy mutation. See `_aiosqlite_compat` for details.
+    from open_webui.internal._aiosqlite_compat import install as _install_aiosqlite_compat
+
+    _install_aiosqlite_compat()
+
     async_engine = create_async_engine(
         ASYNC_SQLALCHEMY_DATABASE_URL,
         connect_args={'check_same_thread': False},


### PR DESCRIPTION
SQLAlchemy 2.0.36+ added a `terminate_force_close()` path on its async DB-API adapters, used by the connection pool when a connection must be invalidated immediately (typically when an in-flight query was cancelled — request aborted by client, timeout, etc.).

For the aiosqlite dialect, `_terminate_force_close` unconditionally accesses `self._connection.stop`. That attribute existed on `aiosqlite.Connection` up to 0.18 (where Connection sub-classed `threading.Thread`) and was removed in 0.20+ when the worker model was refactored.

On the version pin Open WebUI ships (sqlalchemy 2.0.48 + aiosqlite 0.21.0) every cancelled aiosqlite call therefore produces a multi-page

  NotImplementedError: terminate_force_close() not implemented by this DBAPI shim

ERROR traceback, drowning real errors in noise even though the underlying connection is correctly torn down by aiosqlite's own worker on the next loop tick.

Add `internal/_aiosqlite_compat.install()` which monkey-patches the shim to understand both APIs:

  * aiosqlite ≤ 0.18 — call `Connection.stop()` as before.
  * aiosqlite ≥ 0.20 — flip the worker thread's `_running` flag so it exits on the next iteration (the same end-state the original code achieved on the old API).
  * Anything else — log at debug and fall back to GC.

The patch is idempotent, runs once at db.py import time before the async engine is created, and is a no-op on installations whose SQLAlchemy doesn't ship the affected symbol — so it won't break future upstream rewrites.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
