### PR TITLE
fix: exclude empty assistant placeholder from Notes chat payload

### DIFF
--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -175,7 +175,7 @@ Based on the user's instruction, update and enhance the existing notes or select
 					role: 'system',
 					content: `${system}`
 				},
-				...messages
+				...messages.filter((m) => m !== responseMessage)
 			])
 		);
 


### PR DESCRIPTION
The Notes AI Chat pushes an empty assistant message to the local messages array so it can stream delta content into it. That placeholder was also being sent in the chat/completions request, which llama.cpp interprets as an assistant response prefill. For models with thinking enabled in their chat template (Qwen3, gpt-oss, etc.), llama.cpp rejects the combination with: "Assistant response prefill is incompatible with enable_thinking." (400).

Filter the streaming placeholder out of the outgoing payload so the conversation ends with the user turn, matching the OpenAI spec and avoiding the prefill interpretation. The placeholder is still used locally for streaming UI updates.

Fixes open-webui/open-webui#23703

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
