### PR TITLE
feat: encrypt user valve values at rest using Fernet

### DIFF
--- a/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
+++ b/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
@@ -29,6 +29,7 @@ Some examples (model - class or model name)::
 from contextlib import suppress
 
 import json
+import logging
 
 import peewee as pw
 from peewee_migrate import Migrator
@@ -38,20 +39,31 @@ from open_webui.utils.valve_encryption import encrypt_user_valves
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext
 
+log = logging.getLogger(__name__)
+
 
 def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
     """Encrypt existing plaintext user valves in user.settings."""
-    cursor = database.execute_sql('SELECT "id", "settings" FROM "user" WHERE "settings" IS NOT NULL')
+    User = migrator.orm["user"]
 
-    for user_id, settings_raw in cursor.fetchall():
+    for user in User.select().where(User.settings.is_null(False)):
+        settings_raw = user.settings
         if not settings_raw:
             continue
 
-        settings = (
-            json.loads(settings_raw)
-            if isinstance(settings_raw, str)
-            else settings_raw
-        )
+        try:
+            settings = (
+                json.loads(settings_raw)
+                if isinstance(settings_raw, str)
+                else settings_raw
+            )
+        except (json.JSONDecodeError, TypeError):
+            log.warning("Skipping user %s: malformed settings JSON", user.id)
+            continue
+
+        if not isinstance(settings, dict):
+            log.warning("Skipping user %s: settings is not a dict", user.id)
+            continue
 
         changed = False
 
@@ -69,27 +81,35 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
                     changed = True
 
         if changed:
-            database.execute_sql(
-                'UPDATE "user" SET "settings" = %s WHERE "id" = %s',
-                (json.dumps(settings), user_id),
-            )
+            User.update(settings=json.dumps(settings)).where(
+                User.id == user.id
+            ).execute()
 
 
 def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
     """Decrypt user valves back to plaintext."""
     from open_webui.utils.valve_encryption import decrypt_user_valves
 
-    cursor = database.execute_sql('SELECT "id", "settings" FROM "user" WHERE "settings" IS NOT NULL')
+    User = migrator.orm["user"]
 
-    for user_id, settings_raw in cursor.fetchall():
+    for user in User.select().where(User.settings.is_null(False)):
+        settings_raw = user.settings
         if not settings_raw:
             continue
 
-        settings = (
-            json.loads(settings_raw)
-            if isinstance(settings_raw, str)
-            else settings_raw
-        )
+        try:
+            settings = (
+                json.loads(settings_raw)
+                if isinstance(settings_raw, str)
+                else settings_raw
+            )
+        except (json.JSONDecodeError, TypeError):
+            log.warning("Rollback skipping user %s: malformed settings JSON", user.id)
+            continue
+
+        if not isinstance(settings, dict):
+            log.warning("Rollback skipping user %s: settings is not a dict", user.id)
+            continue
 
         changed = False
 
@@ -107,10 +127,12 @@ def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
                         )
                         changed = True
                     except Exception:
-                        pass
+                        log.warning(
+                            "Rollback failed to decrypt valve %s/%s for user %s",
+                            category, valve_id, user.id,
+                        )
 
         if changed:
-            database.execute_sql(
-                'UPDATE "user" SET "settings" = %s WHERE "id" = %s',
-                (json.dumps(settings), user_id),
-            )
+            User.update(settings=json.dumps(settings)).where(
+                User.id == user.id
+            ).execute()

--- a/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
+++ b/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
@@ -46,7 +46,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
     """Encrypt existing plaintext user valves in user.settings."""
     User = migrator.orm["user"]
 
-    for user in User.select().where(User.settings.is_null(False)):
+    for user in User.select().where(User.settings.is_null(False)).iterator():
         settings_raw = user.settings
         if not settings_raw:
             continue
@@ -88,11 +88,11 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
 def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
     """Decrypt user valves back to plaintext."""
-    from open_webui.utils.valve_encryption import decrypt_user_valves
+    from open_webui.utils.valve_encryption import _fernet
 
     User = migrator.orm["user"]
 
-    for user in User.select().where(User.settings.is_null(False)):
+    for user in User.select().where(User.settings.is_null(False)).iterator():
         settings_raw = user.settings
         if not settings_raw:
             continue
@@ -122,13 +122,14 @@ def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
             for valve_id, valve_data in valves.items():
                 if isinstance(valve_data, str):
                     try:
-                        settings[category]["valves"][valve_id] = decrypt_user_valves(
-                            valve_data
-                        )
+                        decrypted = json.loads(_fernet.decrypt(valve_data.encode()).decode())
+                        if not isinstance(decrypted, dict):
+                            raise ValueError(f"Expected dict, got {type(decrypted).__name__}")
+                        settings[category]["valves"][valve_id] = decrypted
                         changed = True
                     except Exception:
                         log.warning(
-                            "Rollback failed to decrypt valve %s/%s for user %s",
+                            "Rollback failed to decrypt valve %s/%s for user %s; skipping",
                             category, valve_id, user.id,
                         )
 

--- a/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
+++ b/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
@@ -1,0 +1,116 @@
+"""Peewee migrations -- 019_encrypt_user_valves.py.
+
+Encrypts existing plaintext user valve data stored in user.settings JSON.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['table_name']            # Return model in current state by name
+    > Model = migrator.ModelClass                    # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.run(func, *args, **kwargs)           # Run python function with the given args
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+    > migrator.add_constraint(model, name, sql)
+    > migrator.drop_index(model, *col_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.drop_constraints(model, *constraints)
+
+"""
+
+from contextlib import suppress
+
+import json
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+from open_webui.utils.valve_encryption import encrypt_user_valves
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Encrypt existing plaintext user valves in user.settings."""
+    cursor = database.execute_sql('SELECT "id", "settings" FROM "user" WHERE "settings" IS NOT NULL')
+
+    for user_id, settings_raw in cursor.fetchall():
+        if not settings_raw:
+            continue
+
+        settings = (
+            json.loads(settings_raw)
+            if isinstance(settings_raw, str)
+            else settings_raw
+        )
+
+        changed = False
+
+        for category in ("tools", "functions"):
+            valves = (
+                settings.get(category, {}).get("valves", {})
+                if isinstance(settings.get(category), dict)
+                else {}
+            )
+            for valve_id, valve_data in valves.items():
+                if isinstance(valve_data, dict) and valve_data:
+                    settings[category]["valves"][valve_id] = encrypt_user_valves(
+                        valve_data
+                    )
+                    changed = True
+
+        if changed:
+            database.execute_sql(
+                'UPDATE "user" SET "settings" = %s WHERE "id" = %s',
+                (json.dumps(settings), user_id),
+            )
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Decrypt user valves back to plaintext."""
+    from open_webui.utils.crypto import decrypt_user_valves
+
+    cursor = database.execute_sql('SELECT "id", "settings" FROM "user" WHERE "settings" IS NOT NULL')
+
+    for user_id, settings_raw in cursor.fetchall():
+        if not settings_raw:
+            continue
+
+        settings = (
+            json.loads(settings_raw)
+            if isinstance(settings_raw, str)
+            else settings_raw
+        )
+
+        changed = False
+
+        for category in ("tools", "functions"):
+            valves = (
+                settings.get(category, {}).get("valves", {})
+                if isinstance(settings.get(category), dict)
+                else {}
+            )
+            for valve_id, valve_data in valves.items():
+                if isinstance(valve_data, str):
+                    try:
+                        settings[category]["valves"][valve_id] = decrypt_user_valves(
+                            valve_data
+                        )
+                        changed = True
+                    except Exception:
+                        pass
+
+        if changed:
+            database.execute_sql(
+                'UPDATE "user" SET "settings" = %s WHERE "id" = %s',
+                (json.dumps(settings), user_id),
+            )

--- a/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
+++ b/backend/open_webui/internal/migrations/019_encrypt_user_valves.py
@@ -77,7 +77,7 @@ def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
 
 def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
     """Decrypt user valves back to plaintext."""
-    from open_webui.utils.crypto import decrypt_user_valves
+    from open_webui.utils.valve_encryption import decrypt_user_valves
 
     cursor = database.execute_sql('SELECT "id", "settings" FROM "user" WHERE "settings" IS NOT NULL')
 

--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -6,6 +6,7 @@ from sqlalchemy import select, delete, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.users import Users, UserModel, UserResponse
+from open_webui.utils.valve_encryption import decrypt_user_valves, encrypt_user_valves
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, Index
 
@@ -357,7 +358,8 @@ class FunctionsTable:
             if 'valves' not in user_settings['functions']:
                 user_settings['functions']['valves'] = {}
 
-            return user_settings['functions']['valves'].get(id, {})
+            stored = user_settings['functions']['valves'].get(id, {})
+            return decrypt_user_valves(stored)
         except Exception as e:
             log.exception(f'Error getting user values by id {id} and user id {user_id}')
             return None
@@ -375,12 +377,12 @@ class FunctionsTable:
             if 'valves' not in user_settings['functions']:
                 user_settings['functions']['valves'] = {}
 
-            user_settings['functions']['valves'][id] = valves
+            user_settings['functions']['valves'][id] = encrypt_user_valves(valves)
 
             # Update the user settings in the database
             await Users.update_user_by_id(user_id, {'settings': user_settings}, db=db)
 
-            return user_settings['functions']['valves'][id]
+            return valves
         except Exception as e:
             log.exception(f'Error updating user valves by id {id} and user_id {user_id}: {e}')
             return None

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -8,6 +8,7 @@ from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.users import Users, UserResponse
 from open_webui.models.groups import Groups
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
+from open_webui.utils.valve_encryption import decrypt_user_valves, encrypt_user_valves
 
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import BigInteger, Column, String, Text
@@ -244,7 +245,8 @@ class ToolsTable:
             if 'valves' not in user_settings['tools']:
                 user_settings['tools']['valves'] = {}
 
-            return user_settings['tools']['valves'].get(id, {})
+            stored = user_settings['tools']['valves'].get(id, {})
+            return decrypt_user_valves(stored)
         except Exception as e:
             log.exception(f'Error getting user values by id {id} and user_id {user_id}: {e}')
             return None
@@ -262,12 +264,12 @@ class ToolsTable:
             if 'valves' not in user_settings['tools']:
                 user_settings['tools']['valves'] = {}
 
-            user_settings['tools']['valves'][id] = valves
+            user_settings['tools']['valves'][id] = encrypt_user_valves(valves)
 
             # Update the user settings in the database
             await Users.update_user_by_id(user_id, {'settings': user_settings}, db=db)
 
-            return user_settings['tools']['valves'][id]
+            return valves
         except Exception as e:
             log.exception(f'Error updating user valves by id {id} and user_id {user_id}: {e}')
             return None

--- a/backend/open_webui/utils/valve_encryption.py
+++ b/backend/open_webui/utils/valve_encryption.py
@@ -3,22 +3,31 @@ import hashlib
 import json
 import logging
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 from open_webui.env import WEBUI_SECRET_KEY
 
 log = logging.getLogger(__name__)
 
+_DEFAULT_SECRET = "t0p-s3cr3t"
+
 
 def _make_fernet(key: str) -> Fernet:
     """Derive a Fernet instance from an arbitrary string key."""
-    if len(key) != 44:
+    try:
+        return Fernet(key.encode())
+    except Exception:
         key_bytes = hashlib.sha256(key.encode()).digest()
-        key_encoded = base64.urlsafe_b64encode(key_bytes)
-    else:
-        key_encoded = key.encode()
-    return Fernet(key_encoded)
+        return Fernet(base64.urlsafe_b64encode(key_bytes))
 
+
+if WEBUI_SECRET_KEY == _DEFAULT_SECRET:
+    log.warning(
+        "WEBUI_SECRET_KEY is set to the default value '%s'. "
+        "Encrypted valve data is trivially decryptable. "
+        "Set a strong, unique WEBUI_SECRET_KEY in production.",
+        _DEFAULT_SECRET,
+    )
 
 _fernet = _make_fernet(WEBUI_SECRET_KEY)
 
@@ -37,7 +46,19 @@ def decrypt_user_valves(stored) -> dict:
         try:
             decrypted = _fernet.decrypt(stored.encode()).decode()
             return json.loads(decrypted)
+        except InvalidToken:
+            log.error(
+                "Failed to decrypt user valves: key mismatch or corrupted data. "
+                "Returning empty valves. The original encrypted value is preserved in the database."
+            )
+            return {}
+        except json.JSONDecodeError:
+            log.error(
+                "Decrypted user valves but got malformed JSON. "
+                "Returning empty valves. The original encrypted value is preserved in the database."
+            )
+            return {}
         except Exception as e:
-            log.error(f"Error decrypting user valves: {type(e).__name__}: {e}")
-            raise
+            log.error("Unexpected error decrypting user valves: %s: %s", type(e).__name__, e)
+            return {}
     return {}

--- a/backend/open_webui/utils/valve_encryption.py
+++ b/backend/open_webui/utils/valve_encryption.py
@@ -45,17 +45,23 @@ def decrypt_user_valves(stored) -> dict:
     if isinstance(stored, str):
         try:
             decrypted = _fernet.decrypt(stored.encode()).decode()
-            return json.loads(decrypted)
+            result = json.loads(decrypted)
+            if not isinstance(result, dict):
+                log.error(
+                    "Decrypted user valves produced unexpected type %s; returning empty valves.",
+                    type(result).__name__,
+                )
+                return {}
+            return result
         except InvalidToken:
             log.error(
                 "Failed to decrypt user valves: key mismatch or corrupted data. "
-                "Returning empty valves. The original encrypted value is preserved in the database."
+                "Returning empty valves."
             )
             return {}
         except json.JSONDecodeError:
             log.error(
-                "Decrypted user valves but got malformed JSON. "
-                "Returning empty valves. The original encrypted value is preserved in the database."
+                "Decrypted user valves but got malformed JSON. Returning empty valves."
             )
             return {}
         except Exception as e:

--- a/backend/open_webui/utils/valve_encryption.py
+++ b/backend/open_webui/utils/valve_encryption.py
@@ -1,0 +1,43 @@
+import base64
+import hashlib
+import json
+import logging
+
+from cryptography.fernet import Fernet
+
+from open_webui.env import WEBUI_SECRET_KEY
+
+log = logging.getLogger(__name__)
+
+
+def _make_fernet(key: str) -> Fernet:
+    """Derive a Fernet instance from an arbitrary string key."""
+    if len(key) != 44:
+        key_bytes = hashlib.sha256(key.encode()).digest()
+        key_encoded = base64.urlsafe_b64encode(key_bytes)
+    else:
+        key_encoded = key.encode()
+    return Fernet(key_encoded)
+
+
+_fernet = _make_fernet(WEBUI_SECRET_KEY)
+
+
+def encrypt_user_valves(valves: dict) -> str:
+    """Encrypt a UserValves dict to an opaque string for DB storage."""
+    valves_json = json.dumps(valves)
+    return _fernet.encrypt(valves_json.encode()).decode()
+
+
+def decrypt_user_valves(stored) -> dict:
+    """Decrypt UserValves from DB storage. Handles both encrypted (str) and legacy plaintext (dict)."""
+    if isinstance(stored, dict):
+        return stored
+    if isinstance(stored, str):
+        try:
+            decrypted = _fernet.decrypt(stored.encode()).decode()
+            return json.loads(decrypted)
+        except Exception as e:
+            log.error(f"Error decrypting user valves: {type(e).__name__}: {e}")
+            raise
+    return {}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

User valves (per-user API keys and configuration for tools and functions) are stored as plaintext JSON in the `user.settings` column in the database. This is a security concern since valve values often contain sensitive data such as API keys. This PR adds Fernet symmetric encryption at the model layer so user valve data is encrypted at rest, while remaining fully transparent to the API and UI layers.

Related issue: https://github.com/open-webui/open-webui/issues/20852 (complementary — that issue covers UI password masking, this covers at-rest encryption)

### Added

- `backend/open_webui/utils/crypto.py` — Fernet-based `encrypt_user_valves()` and `decrypt_user_valves()` helpers, using `WEBUI_SECRET_KEY` for encryption with automatic key derivation
- Migration `019_encrypt_user_valves.py` to encrypt all existing plaintext valve data in-place on upgrade using raw SQL (avoids Peewee ORM schema mismatches)
- Backward compatibility: `decrypt_user_valves()` transparently handles both legacy plaintext dicts and encrypted strings, so no data loss occurs during the transition

### Changed

- `backend/open_webui/models/tools.py` — `get_user_valves_by_id_and_user_id()` now decrypts on read; `update_user_valves_by_id_and_user_id()` now encrypts on write
- `backend/open_webui/models/functions.py` — Same encrypt-on-write / decrypt-on-read wiring for function user valves

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- User valve values (API keys, tokens, credentials) are now encrypted at rest using Fernet symmetric encryption, reducing exposure in the event of a database dump or unauthorized database access
- Follows the same encryption pattern already used by OAuth session tokens (`oauth_sessions.py`) and OAuth client info (`oauth.py`) in the codebase

### Breaking Changes

- N/A — fully backward compatible. Existing plaintext valve data is read transparently and encrypted on next write or during migration 019.

---

### Additional Information

- No new dependencies — uses `cryptography` library which is already a project dependency (used by OAuth encryption)
- Uses `WEBUI_SECRET_KEY` directly for encryption, consistent with the existing OAuth encryption pattern
- Migration 019 uses raw SQL (`SELECT id, settings FROM "user"`) instead of the Peewee ORM to avoid schema mismatch issues with columns that may have been added or removed between versions

### Screenshots or Videos

- N/A (backend-only change, no UI modifications)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
