### PR TITLE
feat: resumable WS streaming via Redis log with seq-based replay

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -188,8 +188,10 @@ YDOC_MANAGER = YdocManager(
 # client.
 RESUME_STREAM_MAXLEN = 2000
 # Defensive TTL so orphaned logs (crashed worker, cancelled request) are
-# evicted automatically. Completed streams are deleted eagerly below.
+# evicted automatically. Completed streams shorten their TTL on done so
+# the key disappears faster once no live clients need it.
 RESUME_STREAM_TTL_SEC = 3600
+RESUME_STREAM_DONE_TTL_SEC = 30
 
 
 def _stream_key(message_id: str) -> str:
@@ -1051,23 +1053,30 @@ async def get_event_emitter(request_info, update_db=True):
         await _stream_log_append(message_id, envelope, seq)
         await sio.emit('events', envelope, room=f'user:{user_id}')
 
-        # If this event finalized the message, schedule log cleanup. Give
-        # reconnecting clients a short grace window to pick up the final
-        # frames before we delete the log (for anything beyond the grace
-        # window, the DB is already up to date and resume isn't needed).
+        # If this event finalized the message, shorten the log's TTL so
+        # it self-evicts shortly. A brief grace window lets clients that
+        # reconnect right after completion still catch the terminal
+        # frames via replay; anything beyond the window loads the
+        # already-persisted message from the DB.
+        #
+        # Using EXPIRE here (rather than scheduling an asyncio.create_task
+        # that calls DELETE later) is race-free: if a second emitter for
+        # the same message_id starts before the TTL fires, its eager
+        # truncate at emitter creation resets the key and subsequent
+        # EXPIRE calls in _stream_log_append extend the TTL normally. A
+        # pending background DELETE would instead wipe the new run's log
+        # mid-stream.
+        #
         # Narrow carefully: `event_data['data']` is a dict for most event
         # types but can legitimately be a list/str/None for some custom
         # pipeline-emitted events. Calling `.get` on those would raise.
         inner = event_data.get('data') if isinstance(event_data, dict) else None
         if isinstance(inner, dict) and inner.get('done') is True:
-            async def _delayed_truncate(mid):
+            if REDIS is not None and message_id:
                 try:
-                    await asyncio.sleep(30)
-                    await _stream_log_truncate(mid)
-                except Exception:
-                    pass
-
-            asyncio.create_task(_delayed_truncate(message_id))
+                    await REDIS.expire(_stream_key(message_id), RESUME_STREAM_DONE_TTL_SEC)
+                except Exception as e:
+                    log.debug(f'stream resume log done-TTL shorten failed for {message_id}: {e}')
 
         if update_db and message_id and not request_info.get('chat_id', '').startswith('local:'):
             event_type = event_data.get('type')

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1009,6 +1009,17 @@ async def get_event_emitter(request_info, update_db=True):
     # needed. Clients use this to request a replay of events they missed
     # after a reconnect / refresh via the `resume-stream` handler below.
     seq_counter = {'n': 0}
+    # Reset any stale resume log for this message_id. Continuation,
+    # regeneration-into-same-id, or a retry after a crashed worker can
+    # create a second emitter for the same message_id. The old emitter's
+    # explicit stream IDs (`0-{seq}`) would collide with our fresh ones
+    # and XADD would silently fail, quietly breaking resumability for
+    # exactly the flows this feature is meant to protect. Deleting the
+    # old log up front guarantees our XADD `0-1` is accepted and the log
+    # reflects only the current run, not a mix of runs.
+    message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
+    if message_id and REDIS is not None:
+        await _stream_log_truncate(message_id)
 
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -185,12 +185,19 @@ RESUME_STREAM_TTL_REFRESH_EVERY = 64
 # Replay read timeout: looser since a resume is user-blocking anyway
 # and silent timeout here is worse than a brief extra wait. Both
 # configurable for infra where Redis isn't colocated.
-RESUME_STREAM_REDIS_TIMEOUT_SEC = float(
-    os.environ.get('RESUME_STREAM_REDIS_TIMEOUT_SEC', '0.1')
-)
-RESUME_STREAM_READ_TIMEOUT_SEC = float(
-    os.environ.get('RESUME_STREAM_READ_TIMEOUT_SEC', '1.0')
-)
+def _float_env(name: str, default: float) -> float:
+    val = os.environ.get(name)
+    if val is None or val == '':
+        return default
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        log.warning(f'Invalid {name}={val!r}; using default {default}')
+        return default
+
+
+RESUME_STREAM_REDIS_TIMEOUT_SEC = _float_env('RESUME_STREAM_REDIS_TIMEOUT_SEC', 0.1)
+RESUME_STREAM_READ_TIMEOUT_SEC = _float_env('RESUME_STREAM_READ_TIMEOUT_SEC', 1.0)
 
 # Module-level circuit breaker for the streaming hot path. After N
 # consecutive Redis failures/timeouts, short-circuit seq/log calls for

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -719,12 +719,31 @@ async def resume_stream(sid, data):
     envelopes = []
     user = SESSION_POOL.get(sid)
     user_id = user.get('id') if user else None
-    if user_id and REDIS is not None:
+    # Gate read on REALTIME mode to match the write-side gate. Otherwise
+    # stale logs written before the flag was flipped (or by a mixed-
+    # version peer) would still get replayed on top of DB-backed content
+    # and double-apply.
+    if user_id and REDIS is not None and not ENABLE_REALTIME_CHAT_SAVE:
         try:
             last_seq = int(data.get('last_seq') or 0)
         except (TypeError, ValueError):
             last_seq = 0
-        envelopes = await _stream_log_read(user_id, message_id, last_seq)
+        # Defense-in-depth: validate chat ownership even though the log
+        # key is already user-scoped. Rejects only when we can *prove*
+        # ownership fails — a missing/unknown chat_id falls through to
+        # the user-scoped key guarantee so we don't regress the "stub
+        # not yet persisted in DB" refresh case.
+        chat_id = data.get('chat_id')
+        chat_ok = True
+        if chat_id:
+            try:
+                chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
+                chat_ok = chat is not None
+            except Exception as e:
+                log.warning(f'resume-stream chat ownership check failed: {e}')
+                chat_ok = True  # fail open to not regress legitimate callers
+        if chat_ok:
+            envelopes = await _stream_log_read(user_id, message_id, last_seq)
 
     await sio.emit(
         'resume-stream:replay',

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -214,16 +214,35 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
             pipe.expire(key, RESUME_STREAM_TTL_SEC)
         await pipe.execute()
     except Exception as e:
-        log.debug(f'stream resume log append failed for {message_id}: {e}')
+        log.warning(f'stream resume log append failed for {message_id}: {e}')
 
 
-async def _stream_log_truncate(user_id: str, message_id: str) -> None:
+async def _stream_log_max_seq(user_id: str, message_id: str) -> int:
+    """Return the highest seq field currently in the log, or 0 if empty.
+
+    Used to seed a fresh emitter's seq counter so retries / continuations
+    for the same message_id keep the sequence monotonic across emitter
+    lifetimes. Without this, a second emitter would restart at 1 and the
+    client's dedupe guard would drop every new frame because its lastSeq
+    from the prior emitter is already larger.
+    """
     if REDIS is None or not user_id or not message_id:
-        return
+        return 0
     try:
-        await REDIS.delete(_stream_key(user_id, message_id))
+        # XREVRANGE + COUNT 1 returns the newest entry cheaply.
+        entries = await REDIS.xrevrange(_stream_key(user_id, message_id), count=1)
+        if not entries:
+            return 0
+        _, fields = entries[0]
+        seq_val = fields.get('seq')
+        if seq_val is None:
+            seq_val = fields.get(b'seq')
+        if isinstance(seq_val, bytes):
+            seq_val = seq_val.decode('utf-8', 'replace')
+        return int(seq_val or 0)
     except Exception as e:
-        log.debug(f'stream resume log truncate failed for {message_id}: {e}')
+        log.warning(f'stream resume log max-seq lookup failed for {message_id}: {e}')
+        return 0
 
 
 async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
@@ -242,7 +261,7 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
             max='+',
         )
     except Exception as e:
-        log.debug(f'stream resume log read failed for {message_id}: {e}')
+        log.warning(f'stream resume log read failed for {message_id}: {e}')
         return []
 
     def _field(fields, key):
@@ -955,9 +974,16 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # Per-emitter monotonic seq for the resume log. Lives in the entry's
-    # `seq` field (Redis auto-generates the stream IDs).
-    seq_counter = {'n': 0}
+    # Seed the seq counter from any existing log so retry/continuation
+    # for the same message_id stays monotonic across emitter lifetimes.
+    # If we reset to 0, the client's dedupe guard would drop every new
+    # frame (lastSeq from the prior run is already larger).
+    ri_user_id = request_info.get('user_id') if isinstance(request_info, dict) else None
+    ri_message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
+    initial_seq = 0
+    if ri_user_id and ri_message_id and REDIS is not None:
+        initial_seq = await _stream_log_max_seq(ri_user_id, ri_message_id)
+    seq_counter = {'n': initial_seq}
 
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
@@ -991,7 +1017,7 @@ async def get_event_emitter(request_info, update_db=True):
                         _stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC
                     )
                 except Exception as e:
-                    log.debug(f'stream resume log done-TTL shorten failed for {message_id}: {e}')
+                    log.warning(f'stream resume log done-TTL shorten failed for {message_id}: {e}')
 
         if update_db and message_id and not request_info.get('chat_id', '').startswith('local:'):
             event_type = event_data.get('type')

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import random
 
 import socketio
@@ -179,9 +180,16 @@ RESUME_STREAM_MAXLEN = 2000
 RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
 RESUME_STREAM_TTL_REFRESH_EVERY = 64
-# Tight upper bound on any Redis call in the streaming hot path so a
-# slow Redis degrades resume but can't stall live token delivery.
-RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.1
+# Hot-path timeout: tight so a slow Redis can't stall live tokens.
+# Replay read timeout: looser since a resume is user-blocking anyway
+# and silent timeout here is worse than a brief extra wait. Both
+# configurable for infra where Redis isn't colocated.
+RESUME_STREAM_REDIS_TIMEOUT_SEC = float(
+    os.environ.get('RESUME_STREAM_REDIS_TIMEOUT_SEC', '0.1')
+)
+RESUME_STREAM_READ_TIMEOUT_SEC = float(
+    os.environ.get('RESUME_STREAM_READ_TIMEOUT_SEC', '1.0')
+)
 
 
 def _stream_key(user_id: str, message_id: str) -> str:
@@ -268,7 +276,7 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
     try:
         entries = await asyncio.wait_for(
             REDIS.xrange(_stream_key(user_id, message_id), min='-', max='+'),
-            timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC,
+            timeout=RESUME_STREAM_READ_TIMEOUT_SEC,
         )
     except asyncio.TimeoutError:
         log.warning(f'stream resume log read timed out for {message_id}')
@@ -678,6 +686,7 @@ async def resume_stream(sid, data):
 
     user_id = user.get('id')
     message_id = data.get('message_id')
+    request_id = data.get('request_id')
     try:
         last_seq = int(data.get('last_seq') or 0)
     except (TypeError, ValueError):
@@ -690,9 +699,15 @@ async def resume_stream(sid, data):
     if REDIS is not None:
         envelopes = await _stream_log_read(user_id, message_id, last_seq)
 
+    # Echo request_id so the client can ignore stale replies that
+    # correspond to a superseded request (reconnect churn).
     await sio.emit(
         'resume-stream:replay',
-        {'message_id': message_id, 'envelopes': envelopes},
+        {
+            'message_id': message_id,
+            'request_id': request_id,
+            'envelopes': envelopes,
+        },
         to=sid,
     )
 
@@ -987,6 +1002,17 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
+    # A single emitter's calls are serial (the streaming loop awaits each
+    # before the next), so seq ordering is guaranteed within one emitter.
+    # CONCURRENT emitters for the same (user_id, message_id) — e.g. a
+    # duplicate request leaking past frontend dedup, or a retry path that
+    # overlaps with the original — can interleave INCR/XADD/emit across
+    # tasks and cause live frames to arrive out of seq order. Replay
+    # reads already sort by seq so resume is safe, but live streaming in
+    # that edge case can drop a frame via the client dedupe guard. Fixing
+    # it properly needs either a distributed per-message lock or a
+    # client-side reorder buffer; neither is worth the complexity for a
+    # configuration OWUI doesn't normally produce.
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
         chat_id = request_info['chat_id']

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -257,28 +257,32 @@ def _breaker_record_failure() -> None:
         _hot_path_breaker['open_until'] = time.time() + _HOT_PATH_BREAKER_COOLDOWN_SEC
 
 
-def _stream_key(user_id: str, message_id: str) -> str:
-    # user_id-scoped key — auth is implicit from the session's user.
-    return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}'
+def _stream_key(user_id: str, chat_id: str, message_id: str) -> str:
+    # Keyed by (user, chat, message). The chat segment binds the message
+    # to its chat at the key level — a resume request for a different
+    # chat_id reads a non-existent key and returns empty. Cleaner than a
+    # DB binding check (no extra round-trip, no "stub not yet persisted"
+    # false negatives).
+    return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{chat_id}:{message_id}'
 
 
-def _stream_seq_key(user_id: str, message_id: str) -> str:
+def _stream_seq_key(user_id: str, chat_id: str, message_id: str) -> str:
     # Distinct top-level namespace (`streamseq`, not `stream`) so a
     # message_id containing delimiter-like characters can't collide the
     # seq key of one message with the stream key of another.
-    return f'{REDIS_KEY_PREFIX}:streamseq:{user_id}:{message_id}'
+    return f'{REDIS_KEY_PREFIX}:streamseq:{user_id}:{chat_id}:{message_id}'
 
 
-async def _stream_seq_allocate(user_id: str, message_id: str):
+async def _stream_seq_allocate(user_id: str, chat_id: str, message_id: str):
     """Allocate the next seq via atomic INCR, or None when resume is off."""
     if ENABLE_REALTIME_CHAT_SAVE:
         return None
-    if REDIS is None or not user_id or not message_id:
+    if REDIS is None or not user_id or not chat_id or not message_id:
         return None
     if _breaker_open():
         return None
     try:
-        key = _stream_seq_key(user_id, message_id)
+        key = _stream_seq_key(user_id, chat_id, message_id)
         seq = await asyncio.wait_for(
             REDIS.incr(key), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
@@ -306,15 +310,15 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
         return None
 
 
-async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
+async def _stream_log_append(user_id: str, chat_id: str, message_id: str, envelope: dict, seq: int) -> None:
     """Append envelope to resume log. Timeout drops the entry, not the emit."""
-    if REDIS is None or not user_id or not message_id:
+    if REDIS is None or not user_id or not chat_id or not message_id:
         return
     if _breaker_open():
         return
     try:
-        key = _stream_key(user_id, message_id)
-        seq_key = _stream_seq_key(user_id, message_id)
+        key = _stream_key(user_id, chat_id, message_id)
+        seq_key = _stream_seq_key(user_id, chat_id, message_id)
         pipe = REDIS.pipeline(transaction=False)
         pipe.xadd(
             key,
@@ -340,18 +344,13 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
         log.warning(f'stream resume log append failed for {message_id}: {e}')
 
 
-async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
-    """Return envelopes with seq > after_seq, in order.
-
-    Full scan bounded by MAXLEN; Python filters by seq because auto IDs
-    don't encode it. With MAXLEN=2000 this is a few ms at worst and
-    resume is a rare, user-driven event so the cost is fine.
-    """
-    if REDIS is None or not user_id or not message_id:
+async def _stream_log_read(user_id: str, chat_id: str, message_id: str, after_seq: int):
+    """Return envelopes with seq > after_seq, in order."""
+    if REDIS is None or not user_id or not chat_id or not message_id:
         return []
     try:
         entries = await asyncio.wait_for(
-            REDIS.xrange(_stream_key(user_id, message_id), min='-', max='+'),
+            REDIS.xrange(_stream_key(user_id, chat_id, message_id), min='-', max='+'),
             timeout=RESUME_STREAM_READ_TIMEOUT_SEC,
         )
     except asyncio.TimeoutError:
@@ -789,7 +788,7 @@ async def resume_stream(sid, data):
         except Exception as e:
             log.warning(f'resume-stream chat ownership check failed: {e}')
         if chat_ok:
-            envelopes = await _stream_log_read(user_id, message_id, last_seq)
+            envelopes = await _stream_log_read(user_id, chat_id, message_id, last_seq)
 
     # Cap payload bytes. Keep the newest entries that fit; older ones
     # are either already in the DB-backed content or will arrive via the
@@ -1126,7 +1125,7 @@ async def get_event_emitter(request_info, update_db=True):
         message_id = request_info['message_id']
 
         async with _emit_lock_for(user_id, message_id):
-            seq = await _stream_seq_allocate(user_id, message_id)
+            seq = await _stream_seq_allocate(user_id, chat_id, message_id)
 
             envelope = {
                 'chat_id': chat_id,
@@ -1138,7 +1137,7 @@ async def get_event_emitter(request_info, update_db=True):
             # duplicates from the inverted race.
             if seq is not None:
                 envelope['seq'] = seq
-                await _stream_log_append(user_id, message_id, envelope, seq)
+                await _stream_log_append(user_id, chat_id, message_id, envelope, seq)
             await sio.emit('events', envelope, room=f'user:{user_id}')
 
         # Any terminal event shortens TTL so log + seq self-evict together.
@@ -1159,11 +1158,11 @@ async def get_event_emitter(request_info, update_db=True):
                 and inner.get('error')
             )
         )
-        if is_terminal and REDIS is not None and user_id and message_id:
+        if is_terminal and REDIS is not None and user_id and chat_id and message_id:
             try:
                 pipe = REDIS.pipeline(transaction=False)
-                pipe.expire(_stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
-                pipe.expire(_stream_seq_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                pipe.expire(_stream_key(user_id, chat_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                pipe.expire(_stream_seq_key(user_id, chat_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
                 await asyncio.wait_for(
                     pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
                 )

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -614,13 +614,17 @@ async def chat_events(sid, data):
 
 @sio.on('resume-stream')
 async def resume_stream(sid, data):
-    """Replay log entries with seq > last_seq to the caller.
+    """Replay missed log entries in a single batch.
+
+    One emit carries all envelopes with seq > last_seq (possibly zero)
+    and also serves as the completion signal — the client clears its
+    live-frame fence in the batch handler. Always emitting exactly once
+    (even when Redis is unavailable or the log is empty) keeps the
+    client from deadlocking on a fence that never clears.
 
     Auth is implicit: the stream key is scoped by user_id, so an
     authenticated session can only ever read its own logs. No DB lookup.
     """
-    if REDIS is None:
-        return
     if not isinstance(data, dict):
         return
 
@@ -638,19 +642,14 @@ async def resume_stream(sid, data):
     if not user_id or not message_id:
         return
 
-    envelopes = await _stream_log_read(user_id, message_id, last_seq)
-    for envelope in envelopes:
-        # Tag as replayed. The client uses this to distinguish replay
-        # from live frames so it can buffer live frames during replay
-        # and avoid advancing its seq high-water on them (which would
-        # otherwise cause later replay frames to be dropped by the dedupe
-        # guard). Replay is session-scoped; live listeners in the user
-        # room are already served via the normal emit path.
-        await sio.emit('events', {**envelope, '_replayed': True}, to=sid)
-    # Signal replay complete so the client flushes its buffered live
-    # frames in seq order.
+    envelopes = []
+    if REDIS is not None:
+        envelopes = await _stream_log_read(user_id, message_id, last_seq)
+
     await sio.emit(
-        'resume-stream:complete', {'message_id': message_id}, to=sid
+        'resume-stream:replay',
+        {'message_id': message_id, 'envelopes': envelopes},
+        to=sid,
     )
 
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -789,7 +789,9 @@ async def resume_stream(sid, data):
 
     # Cap payload bytes. Keep the newest entries that fit; older ones
     # are either already in the DB-backed content or will arrive via the
-    # final done:True checkpoint.
+    # final done:True checkpoint. A single envelope larger than the cap
+    # is skipped rather than allowed through — forcing it past the cap
+    # would still exceed Socket.IO's buffer.
     total_bytes = 0
     capped = []
     for env in reversed(envelopes):
@@ -797,7 +799,9 @@ async def resume_stream(sid, data):
             size = len(json.dumps(env))
         except Exception:
             continue
-        if total_bytes + size > RESUME_STREAM_REPLAY_MAX_BYTES and capped:
+        if size > RESUME_STREAM_REPLAY_MAX_BYTES:
+            continue
+        if total_bytes + size > RESUME_STREAM_REPLAY_MAX_BYTES:
             break
         capped.append(env)
         total_bytes += size

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -224,7 +224,10 @@ def _stream_key(user_id: str, message_id: str) -> str:
 
 
 def _stream_seq_key(user_id: str, message_id: str) -> str:
-    return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}:seq'
+    # Distinct top-level namespace (`streamseq`, not `stream`) so a
+    # message_id containing delimiter-like characters can't collide the
+    # seq key of one message with the stream key of another.
+    return f'{REDIS_KEY_PREFIX}:streamseq:{user_id}:{message_id}'
 
 
 async def _stream_seq_allocate(user_id: str, message_id: str):

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -25,6 +25,7 @@ from open_webui.config import (
 
 from open_webui.env import (
     VERSION,
+    ENABLE_REALTIME_CHAT_SAVE,
     ENABLE_WEBSOCKET_SUPPORT,
     WEBSOCKET_MANAGER,
     WEBSOCKET_REDIS_URL,
@@ -206,7 +207,15 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
     Returns the allocated seq, or None if Redis is unavailable or the
     call times out. Callers treat None as "emit without seq" — live
     streaming continues but that frame isn't eligible for resume dedupe.
+
+    Also returns None when ENABLE_REALTIME_CHAT_SAVE is on: in that
+    mode the DB is already the authoritative per-token store, so the
+    frontend loads the up-to-date content on refresh. Logging the
+    resume stream in parallel would cause duplicate content on refresh
+    (resume replays from seq=0 on top of DB-loaded content).
     """
+    if ENABLE_REALTIME_CHAT_SAVE:
+        return None
     if REDIS is None or not user_id or not message_id:
         return None
     try:
@@ -306,10 +315,19 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
         if not payload:
             continue
         try:
-            out.append(json.loads(payload))
+            envelope = json.loads(payload)
         except Exception:
             continue
-    return out
+        out.append((entry_seq, envelope))
+    # Sort by seq before returning envelopes. Stream append order can
+    # diverge from seq order because INCR + XADD aren't atomic: a
+    # concurrent emitter can win the INCR race for a later seq yet lose
+    # the XADD race and land in the stream ahead of an earlier seq. If
+    # we handed envelopes to the client in append order, the client's
+    # `incomingSeq <= lastSeq` guard would permanently drop the later-
+    # arriving-but-earlier-numbered frame.
+    out.sort(key=lambda pair: pair[0])
+    return [envelope for _seq, envelope in out]
 
 
 async def periodic_session_pool_cleanup():

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -181,7 +181,7 @@ RESUME_STREAM_DONE_TTL_SEC = 30
 RESUME_STREAM_TTL_REFRESH_EVERY = 64
 # Tight upper bound on any Redis call in the streaming hot path so a
 # slow Redis degrades resume but can't stall live token delivery.
-RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.2
+RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.1
 
 
 def _stream_key(user_id: str, message_id: str) -> str:
@@ -233,6 +233,7 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
     try:
         refresh_ttl = (seq == 1) or (seq % RESUME_STREAM_TTL_REFRESH_EVERY == 0)
         key = _stream_key(user_id, message_id)
+        seq_key = _stream_seq_key(user_id, message_id)
         pipe = REDIS.pipeline(transaction=False)
         pipe.xadd(
             key,
@@ -241,7 +242,11 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
             approximate=True,
         )
         if refresh_ttl:
+            # Refresh both keys together — without this the seq counter
+            # can expire mid-stream on responses longer than the TTL and
+            # INCR restarts at 1, corrupting replay ordering.
             pipe.expire(key, RESUME_STREAM_TTL_SEC)
+            pipe.expire(seq_key, RESUME_STREAM_TTL_SEC)
         await asyncio.wait_for(
             pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -196,19 +196,37 @@ def _stream_key(message_id: str) -> str:
     return f'{REDIS_KEY_PREFIX}:stream:{message_id}'
 
 
+# Refresh the resume-log TTL only every N writes instead of every write.
+# XADD resets the key's idle time but not its absolute TTL, so we must
+# EXPIRE occasionally. Doing it once per N appends amortizes that extra
+# round-trip away from the per-token hot path. With N=64 and the default
+# 1-hour TTL, even a pathologically long 128k-token response only
+# triggers ~2000 EXPIRE calls total and never risks TTL expiry mid-stream.
+RESUME_STREAM_TTL_REFRESH_EVERY = 64
+
+
 async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
-    """Append an outbound WS envelope to the resume log."""
+    """Append an outbound WS envelope to the resume log.
+
+    Uses a Redis pipeline to collapse XADD + (occasional) EXPIRE into a
+    single network round-trip per call, keeping the added latency on the
+    streaming hot path bounded to one Redis RTT.
+    """
     if REDIS is None or not message_id:
         return
     try:
-        await REDIS.xadd(
-            _stream_key(message_id),
+        refresh_ttl = (seq == 1) or (seq % RESUME_STREAM_TTL_REFRESH_EVERY == 0)
+        key = _stream_key(message_id)
+        pipe = REDIS.pipeline(transaction=False)
+        pipe.xadd(
+            key,
             {'seq': str(seq), 'payload': json.dumps(envelope)},
             maxlen=RESUME_STREAM_MAXLEN,
             approximate=True,
         )
-        # Refresh TTL on every append so active streams don't expire mid-run.
-        await REDIS.expire(_stream_key(message_id), RESUME_STREAM_TTL_SEC)
+        if refresh_ttl:
+            pipe.expire(key, RESUME_STREAM_TTL_SEC)
+        await pipe.execute()
     except Exception as e:
         log.debug(f'stream resume log append failed for {message_id}: {e}')
 
@@ -620,20 +638,29 @@ async def resume_stream(sid, data):
     Client payload: `{chat_id, message_id, last_seq}`.
 
     Flow:
-      1. Authenticate the session and verify the user owns the chat.
+      1. Authenticate the session and verify the user owns the chat AND
+         that the requested message_id actually belongs to that chat.
+         Both checks are required because the Redis stream log is keyed
+         by message_id alone — without the message-to-chat binding check,
+         an attacker who obtained a victim's message_id could satisfy the
+         chat-ownership check with any chat they own and then read the
+         victim's stream.
       2. Read entries from the Redis resume log for this message_id whose
          `seq` is greater than `last_seq`.
       3. Emit each entry as a normal `events` event to THIS session only
          (via `to=sid`). Other sessions for the same user keep receiving
          the live stream unchanged.
-      4. Send a final `resume-stream:ack` so the client can resolve its
-         pending resume state.
 
     No-op when Redis is not configured — in that deployment mode, refresh
     during streaming falls back to the existing behavior (wait for the
     stream to complete and reload from the DB).
     """
     if REDIS is None:
+        return
+
+    # Reject malformed payloads early so `data.get(...)` never throws on a
+    # non-object client input (string/list/null/etc).
+    if not isinstance(data, dict):
         return
 
     user = SESSION_POOL.get(sid)
@@ -651,11 +678,18 @@ async def resume_stream(sid, data):
     if not user_id or not chat_id or not message_id:
         return
 
-    # Auth: the stream log is keyed by message_id only, so a chat-ownership
-    # check is essential to prevent a client from reading another user's
-    # stream by guessing a message_id.
+    # Step 1a: user owns the chat.
     chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
     if not chat:
+        return
+
+    # Step 1b: message_id actually lives in this chat. Without this, a
+    # caller who knows a victim's message_id could pass one of their OWN
+    # chat_ids (satisfying 1a) and read the victim's stream.
+    # `get_message_by_id_and_message_id` returns {} when the chat exists
+    # but the message_id isn't present, so check for a real id field.
+    message = await Chats.get_message_by_id_and_message_id(chat_id, message_id)
+    if not message or not message.get('id'):
         return
 
     envelopes = await _stream_log_read(message_id, last_seq)
@@ -664,18 +698,6 @@ async def resume_stream(sid, data):
         # `user:{user_id}` are already receiving new frames via the normal
         # emit path and must not see these duplicates.
         await sio.emit('events', envelope, to=sid)
-
-    last_replayed_seq = envelopes[-1].get('seq') if envelopes else last_seq
-    await sio.emit(
-        'resume-stream:ack',
-        {
-            'chat_id': chat_id,
-            'message_id': message_id,
-            'replayed': len(envelopes),
-            'last_seq': last_replayed_seq,
-        },
-        to=sid,
-    )
 
 
 def normalize_document_id(document_id: str) -> str:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -171,60 +171,35 @@ YDOC_MANAGER = YdocManager(
 )
 
 
-# ---------------------------------------------------------------------------
-# Stream resume log.
-#
-# Every outbound WS event for a streaming chat response is appended to a
-# bounded Redis stream keyed by message_id. A client that reconnects (e.g.
-# after a page refresh) while the backend is still streaming can request a
-# replay of events it missed and catch up without re-fetching the full
-# chat from the DB. Requires Redis; no-ops gracefully otherwise.
-# ---------------------------------------------------------------------------
-
-# Bounded to protect Redis memory. 2000 entries comfortably covers most
-# responses at one event per token; longer responses just lose the earliest
-# entries, which is fine because the `done:True` checkpoint emitted at the
-# end of the stream carries the canonical full content and reconciles the
-# client.
+# Bounded Redis stream log keyed by message_id. Clients that reconnect
+# mid-stream can replay missed events from here. No-op without Redis.
 RESUME_STREAM_MAXLEN = 2000
-# Defensive TTL so orphaned logs (crashed worker, cancelled request) are
-# evicted automatically. Completed streams shorten their TTL on done so
-# the key disappears faster once no live clients need it.
 RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
-
-
-def _stream_key(message_id: str) -> str:
-    return f'{REDIS_KEY_PREFIX}:stream:{message_id}'
-
-
-# Refresh the resume-log TTL only every N writes instead of every write.
-# XADD resets the key's idle time but not its absolute TTL, so we must
-# EXPIRE occasionally. Doing it once per N appends amortizes that extra
-# round-trip away from the per-token hot path. With N=64 and the default
-# 1-hour TTL, even a pathologically long 128k-token response only
-# triggers ~2000 EXPIRE calls total and never risks TTL expiry mid-stream.
+# Refresh TTL every N appends to keep the hot path at one Redis RTT.
 RESUME_STREAM_TTL_REFRESH_EVERY = 64
 
 
-async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
-    """Append an outbound WS envelope to the resume log.
+def _stream_key(user_id: str, message_id: str) -> str:
+    # user_id in the key scopes logs per user: only the owning user's
+    # session can construct the key, so resume doesn't need a DB
+    # chat/message auth check (which would fail when a pre-stream stub
+    # hasn't been persisted yet — the ENABLE_REALTIME_CHAT_SAVE=False
+    # refresh case this feature is for).
+    return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}'
 
-    Uses a Redis pipeline to collapse XADD + (occasional) EXPIRE into a
-    single network round-trip per call, keeping the added latency on the
-    streaming hot path bounded to one Redis RTT.
 
-    Uses an explicit stream ID of `0-{seq}` so that the resume read path
-    can start XRANGE at the caller's cursor (`0-{last_seq+1}`) instead of
-    scanning the whole stream. The `0-` prefix is arbitrary — we only
-    need the IDs to be strictly monotonic per stream, which our
-    per-emitter seq counter guarantees.
+async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
+    """Append an envelope to the resume log.
+
+    Uses explicit stream ID `0-{seq}` so XRANGE can start at the client's
+    cursor on resume. Pipelined with the periodic EXPIRE.
     """
-    if REDIS is None or not message_id:
+    if REDIS is None or not user_id or not message_id:
         return
     try:
         refresh_ttl = (seq == 1) or (seq % RESUME_STREAM_TTL_REFRESH_EVERY == 0)
-        key = _stream_key(message_id)
+        key = _stream_key(user_id, message_id)
         pipe = REDIS.pipeline(transaction=False)
         pipe.xadd(
             key,
@@ -240,31 +215,23 @@ async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
         log.debug(f'stream resume log append failed for {message_id}: {e}')
 
 
-async def _stream_log_truncate(message_id: str) -> None:
-    """Delete the resume log for a message (called when streaming is done)."""
-    if REDIS is None or not message_id:
+async def _stream_log_truncate(user_id: str, message_id: str) -> None:
+    if REDIS is None or not user_id or not message_id:
         return
     try:
-        await REDIS.delete(_stream_key(message_id))
+        await REDIS.delete(_stream_key(user_id, message_id))
     except Exception as e:
         log.debug(f'stream resume log truncate failed for {message_id}: {e}')
 
 
-async def _stream_log_read(message_id: str, after_seq: int):
-    """Return envelopes logged for message_id with seq > after_seq, in order.
-
-    Stream IDs are `0-{seq}`, so we can start the XRANGE at
-    `0-{after_seq+1}` and let Redis skip everything already delivered
-    instead of scanning from the start every call. Near-tail resumes
-    (the common case for reconnects) become O(missed frames) instead of
-    O(MAXLEN).
-    """
-    if REDIS is None or not message_id:
+async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
+    """Return envelopes with seq > after_seq, in order."""
+    if REDIS is None or not user_id or not message_id:
         return []
     try:
         start_seq = max(0, after_seq) + 1
         entries = await REDIS.xrange(
-            _stream_key(message_id),
+            _stream_key(user_id, message_id),
             min=f'0-{start_seq}',
             max='+',
         )
@@ -273,8 +240,7 @@ async def _stream_log_read(message_id: str, after_seq: int):
         return []
 
     def _field(fields, key):
-        # redis-py returns bytes by default but may return str depending on
-        # decode_responses config. Normalize both.
+        # redis-py may return bytes or str depending on decode_responses.
         v = fields.get(key)
         if v is None:
             v = fields.get(key.encode() if isinstance(key, str) else key)
@@ -648,33 +614,13 @@ async def chat_events(sid, data):
 
 @sio.on('resume-stream')
 async def resume_stream(sid, data):
-    """Replay WS events a client missed while disconnected.
+    """Replay log entries with seq > last_seq to the caller.
 
-    Client payload: `{chat_id, message_id, last_seq}`.
-
-    Flow:
-      1. Authenticate the session and verify the user owns the chat AND
-         that the requested message_id actually belongs to that chat.
-         Both checks are required because the Redis stream log is keyed
-         by message_id alone — without the message-to-chat binding check,
-         an attacker who obtained a victim's message_id could satisfy the
-         chat-ownership check with any chat they own and then read the
-         victim's stream.
-      2. Read entries from the Redis resume log for this message_id whose
-         `seq` is greater than `last_seq`.
-      3. Emit each entry as a normal `events` event to THIS session only
-         (via `to=sid`). Other sessions for the same user keep receiving
-         the live stream unchanged.
-
-    No-op when Redis is not configured — in that deployment mode, refresh
-    during streaming falls back to the existing behavior (wait for the
-    stream to complete and reload from the DB).
+    Auth is implicit: the stream key is scoped by user_id, so an
+    authenticated session can only ever read its own logs. No DB lookup.
     """
     if REDIS is None:
         return
-
-    # Reject malformed payloads early so `data.get(...)` never throws on a
-    # non-object client input (string/list/null/etc).
     if not isinstance(data, dict):
         return
 
@@ -683,35 +629,19 @@ async def resume_stream(sid, data):
         return
 
     user_id = user.get('id')
-    chat_id = data.get('chat_id')
     message_id = data.get('message_id')
     try:
         last_seq = int(data.get('last_seq') or 0)
     except (TypeError, ValueError):
         last_seq = 0
 
-    if not user_id or not chat_id or not message_id:
+    if not user_id or not message_id:
         return
 
-    # Step 1a: user owns the chat.
-    chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
-    if not chat:
-        return
-
-    # Step 1b: message_id actually lives in this chat. Without this, a
-    # caller who knows a victim's message_id could pass one of their OWN
-    # chat_ids (satisfying 1a) and read the victim's stream.
-    # `get_message_by_id_and_message_id` returns {} when the chat exists
-    # but the message_id isn't present, so check for a real id field.
-    message = await Chats.get_message_by_id_and_message_id(chat_id, message_id)
-    if not message or not message.get('id'):
-        return
-
-    envelopes = await _stream_log_read(message_id, last_seq)
+    envelopes = await _stream_log_read(user_id, message_id, last_seq)
     for envelope in envelopes:
-        # Replay to the requesting session only. Live listeners in
-        # `user:{user_id}` are already receiving new frames via the normal
-        # emit path and must not see these duplicates.
+        # Replay to this session only; live listeners in the user room
+        # are already served via the normal emit path.
         await sio.emit('events', envelope, to=sid)
 
 
@@ -1005,23 +935,14 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # Per-emitter monotonic seq. One emitter instance corresponds to a single
-    # streaming response for a single (chat_id, message_id) on a single
-    # worker, so a local counter is sufficient — no distributed consensus
-    # needed. Clients use this to request a replay of events they missed
-    # after a reconnect / refresh via the `resume-stream` handler below.
+    # Per-emitter monotonic seq for the resume log (explicit ID 0-{seq}).
     seq_counter = {'n': 0}
-    # Reset any stale resume log for this message_id. Continuation,
-    # regeneration-into-same-id, or a retry after a crashed worker can
-    # create a second emitter for the same message_id. The old emitter's
-    # explicit stream IDs (`0-{seq}`) would collide with our fresh ones
-    # and XADD would silently fail, quietly breaking resumability for
-    # exactly the flows this feature is meant to protect. Deleting the
-    # old log up front guarantees our XADD `0-1` is accepted and the log
-    # reflects only the current run, not a mix of runs.
-    message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
-    if message_id and REDIS is not None:
-        await _stream_log_truncate(message_id)
+    # Wipe any prior log so fresh XADDs (starting at 0-1) don't collide
+    # with a retry/continuation's leftover IDs.
+    ri_user_id = request_info.get('user_id') if isinstance(request_info, dict) else None
+    ri_message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
+    if ri_user_id and ri_message_id and REDIS is not None:
+        await _stream_log_truncate(ri_user_id, ri_message_id)
 
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
@@ -1038,43 +959,22 @@ async def get_event_emitter(request_info, update_db=True):
             'data': event_data,
         }
 
-        # Append to the resume log BEFORE the live emit. If we emitted
-        # first, a client that disconnects in the window between `sio.emit`
-        # and `_stream_log_append` could reconnect and issue resume-stream
-        # before the frame is logged, never see that frame in the replay,
-        # and then never ask again — permanently losing it (particularly
-        # painful for the terminal done:True frame).
-        #
-        # Logging first inverts the window: a reconnecting client MIGHT
-        # see a replayed frame before the live emit reaches their new
-        # session, but the seq idempotency guard in chatEventHandler drops
-        # the subsequent duplicate harmlessly. Duplicates are safe, losses
-        # are not.
-        await _stream_log_append(message_id, envelope, seq)
+        # Log before emit: an inverted order could let a reconnecting
+        # client resume-read before the append lands and permanently miss
+        # the frame. Duplicates are dropped by the client seq guard.
+        await _stream_log_append(user_id, message_id, envelope, seq)
         await sio.emit('events', envelope, room=f'user:{user_id}')
 
-        # If this event finalized the message, shorten the log's TTL so
-        # it self-evicts shortly. A brief grace window lets clients that
-        # reconnect right after completion still catch the terminal
-        # frames via replay; anything beyond the window loads the
-        # already-persisted message from the DB.
-        #
-        # Using EXPIRE here (rather than scheduling an asyncio.create_task
-        # that calls DELETE later) is race-free: if a second emitter for
-        # the same message_id starts before the TTL fires, its eager
-        # truncate at emitter creation resets the key and subsequent
-        # EXPIRE calls in _stream_log_append extend the TTL normally. A
-        # pending background DELETE would instead wipe the new run's log
-        # mid-stream.
-        #
-        # Narrow carefully: `event_data['data']` is a dict for most event
-        # types but can legitimately be a list/str/None for some custom
-        # pipeline-emitted events. Calling `.get` on those would raise.
+        # On done, shorten TTL so the log self-evicts. EXPIRE is race-safe
+        # vs. a retry-emitter's truncate-then-XADD; a background DELETE
+        # would not be.
         inner = event_data.get('data') if isinstance(event_data, dict) else None
         if isinstance(inner, dict) and inner.get('done') is True:
-            if REDIS is not None and message_id:
+            if REDIS is not None and user_id and message_id:
                 try:
-                    await REDIS.expire(_stream_key(message_id), RESUME_STREAM_DONE_TTL_SEC)
+                    await REDIS.expire(
+                        _stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC
+                    )
                 except Exception as e:
                     log.debug(f'stream resume log done-TTL shorten failed for {message_id}: {e}')
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -640,9 +640,18 @@ async def resume_stream(sid, data):
 
     envelopes = await _stream_log_read(user_id, message_id, last_seq)
     for envelope in envelopes:
-        # Replay to this session only; live listeners in the user room
-        # are already served via the normal emit path.
-        await sio.emit('events', envelope, to=sid)
+        # Tag as replayed. The client uses this to distinguish replay
+        # from live frames so it can buffer live frames during replay
+        # and avoid advancing its seq high-water on them (which would
+        # otherwise cause later replay frames to be dropped by the dedupe
+        # guard). Replay is session-scoped; live listeners in the user
+        # room are already served via the normal emit path.
+        await sio.emit('events', {**envelope, '_replayed': True}, to=sid)
+    # Signal replay complete so the client flushes its buffered live
+    # frames in seq order.
+    await sio.emit(
+        'resume-stream:complete', {'message_id': message_id}, to=sid
+    )
 
 
 def normalize_document_id(document_id: str) -> str:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -178,25 +178,68 @@ RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
 # Refresh TTL every N appends to keep the hot path at one Redis RTT.
 RESUME_STREAM_TTL_REFRESH_EVERY = 64
+# Upper bound on any single Redis call in the streaming hot path. If
+# Redis goes unhealthy we'd rather degrade resume gracefully than stall
+# live token delivery behind a slow RTT.
+RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.5
 
 
 def _stream_key(user_id: str, message_id: str) -> str:
-    # user_id in the key scopes logs per user: only the owning user's
-    # session can construct the key, so resume doesn't need a DB
-    # chat/message auth check (which would fail when a pre-stream stub
-    # hasn't been persisted yet — the ENABLE_REALTIME_CHAT_SAVE=False
-    # refresh case this feature is for).
+    # user_id-scoped: only the owning user's session can construct the
+    # key, so resume doesn't need a DB chat/message auth check.
     return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}'
+
+
+def _stream_seq_key(user_id: str, message_id: str) -> str:
+    # Separate key for the atomic seq counter so INCR is cheap and
+    # doesn't touch the stream. Lives and dies alongside the stream log.
+    return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}:seq'
+
+
+async def _stream_seq_allocate(user_id: str, message_id: str):
+    """Atomically allocate the next seq for this message_id.
+
+    Global INCR (not a per-emitter counter) so overlapping emitters for
+    the same message_id can't both emit the same seq and cause client
+    dedupe to silently drop one of them as a duplicate.
+
+    Returns the allocated seq, or None if Redis is unavailable or the
+    call times out. Callers treat None as "emit without seq" — live
+    streaming continues but that frame isn't eligible for resume dedupe.
+    """
+    if REDIS is None or not user_id or not message_id:
+        return None
+    try:
+        key = _stream_seq_key(user_id, message_id)
+        seq = await asyncio.wait_for(
+            REDIS.incr(key), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
+        )
+        # Set TTL on first INCR; EXPIRE is NX-like in effect (idempotent
+        # enough here — occasional reset is fine).
+        if seq == 1:
+            try:
+                await asyncio.wait_for(
+                    REDIS.expire(key, RESUME_STREAM_TTL_SEC),
+                    timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC,
+                )
+            except Exception:
+                pass
+        return int(seq)
+    except asyncio.TimeoutError:
+        log.warning(f'stream resume seq alloc timed out for {message_id}')
+        return None
+    except Exception as e:
+        log.warning(f'stream resume seq alloc failed for {message_id}: {e}')
+        return None
 
 
 async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
     """Append an envelope to the resume log.
 
-    Uses Redis-generated stream IDs (the default `*`) so overlapping
-    emitters for the same message_id — continuation, crash-retry, etc. —
-    cannot collide with each other's IDs. The seq lives in the entry
-    fields instead, and the read path filters by it. Pipelined with the
-    periodic EXPIRE.
+    Uses Redis-generated stream IDs so overlapping emitters can't collide.
+    Pipelined with the periodic EXPIRE. Wrapped in a short timeout so a
+    slow Redis can't block live token delivery for the user — on timeout
+    we drop the log entry and let the emit proceed.
     """
     if REDIS is None or not user_id or not message_id:
         return
@@ -212,37 +255,13 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
         )
         if refresh_ttl:
             pipe.expire(key, RESUME_STREAM_TTL_SEC)
-        await pipe.execute()
+        await asyncio.wait_for(
+            pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
+        )
+    except asyncio.TimeoutError:
+        log.warning(f'stream resume log append timed out for {message_id}')
     except Exception as e:
         log.warning(f'stream resume log append failed for {message_id}: {e}')
-
-
-async def _stream_log_max_seq(user_id: str, message_id: str) -> int:
-    """Return the highest seq field currently in the log, or 0 if empty.
-
-    Used to seed a fresh emitter's seq counter so retries / continuations
-    for the same message_id keep the sequence monotonic across emitter
-    lifetimes. Without this, a second emitter would restart at 1 and the
-    client's dedupe guard would drop every new frame because its lastSeq
-    from the prior emitter is already larger.
-    """
-    if REDIS is None or not user_id or not message_id:
-        return 0
-    try:
-        # XREVRANGE + COUNT 1 returns the newest entry cheaply.
-        entries = await REDIS.xrevrange(_stream_key(user_id, message_id), count=1)
-        if not entries:
-            return 0
-        _, fields = entries[0]
-        seq_val = fields.get('seq')
-        if seq_val is None:
-            seq_val = fields.get(b'seq')
-        if isinstance(seq_val, bytes):
-            seq_val = seq_val.decode('utf-8', 'replace')
-        return int(seq_val or 0)
-    except Exception as e:
-        log.warning(f'stream resume log max-seq lookup failed for {message_id}: {e}')
-        return 0
 
 
 async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
@@ -974,47 +993,44 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # Seed the seq counter from any existing log so retry/continuation
-    # for the same message_id stays monotonic across emitter lifetimes.
-    # If we reset to 0, the client's dedupe guard would drop every new
-    # frame (lastSeq from the prior run is already larger).
-    ri_user_id = request_info.get('user_id') if isinstance(request_info, dict) else None
-    ri_message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
-    initial_seq = 0
-    if ri_user_id and ri_message_id and REDIS is not None:
-        initial_seq = await _stream_log_max_seq(ri_user_id, ri_message_id)
-    seq_counter = {'n': initial_seq}
-
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
         chat_id = request_info['chat_id']
         message_id = request_info['message_id']
 
-        seq_counter['n'] += 1
-        seq = seq_counter['n']
+        # Atomically allocate this frame's seq. Global INCR (not an
+        # in-process counter) so overlapping emitters for the same
+        # message_id can't both produce the same seq. If Redis is
+        # unavailable or slow, seq is None and we emit without it — live
+        # streaming continues, but this frame is excluded from resume
+        # dedupe and replay (graceful degradation).
+        seq = await _stream_seq_allocate(user_id, message_id)
 
         envelope = {
             'chat_id': chat_id,
             'message_id': message_id,
-            'seq': seq,
             'data': event_data,
         }
-
-        # Log before emit: an inverted order could let a reconnecting
-        # client resume-read before the append lands and permanently miss
-        # the frame. Duplicates are dropped by the client seq guard.
-        await _stream_log_append(user_id, message_id, envelope, seq)
+        if seq is not None:
+            envelope['seq'] = seq
+            # Log before emit: an inverted order could let a reconnecting
+            # client resume-read before the append lands and permanently
+            # miss the frame. Duplicates are dropped by the client seq
+            # guard.
+            await _stream_log_append(user_id, message_id, envelope, seq)
         await sio.emit('events', envelope, room=f'user:{user_id}')
 
-        # On done, shorten TTL so the log self-evicts. EXPIRE is race-safe
-        # vs. a retry-emitter's truncate-then-XADD; a background DELETE
-        # would not be.
+        # On done, shorten TTL on both the stream log and the seq counter
+        # so they self-evict together after the grace window.
         inner = event_data.get('data') if isinstance(event_data, dict) else None
         if isinstance(inner, dict) and inner.get('done') is True:
             if REDIS is not None and user_id and message_id:
                 try:
-                    await REDIS.expire(
-                        _stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC
+                    pipe = REDIS.pipeline(transaction=False)
+                    pipe.expire(_stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                    pipe.expire(_stream_seq_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                    await asyncio.wait_for(
+                        pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
                     )
                 except Exception as e:
                     log.warning(f'stream resume log done-TTL shorten failed for {message_id}: {e}')

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -172,47 +172,33 @@ YDOC_MANAGER = YdocManager(
 )
 
 
-# Bounded Redis stream log keyed by message_id. Clients that reconnect
-# mid-stream can replay missed events from here. No-op without Redis.
+# Bounded Redis stream log keyed by message_id. Clients replay from it
+# on reconnect. No-op without Redis. Also no-op in REALTIME_CHAT_SAVE
+# mode — DB is authoritative there and replay would double-apply.
 RESUME_STREAM_MAXLEN = 2000
 RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
-# Refresh TTL every N appends to keep the hot path at one Redis RTT.
 RESUME_STREAM_TTL_REFRESH_EVERY = 64
-# Upper bound on any single Redis call in the streaming hot path. If
-# Redis goes unhealthy we'd rather degrade resume gracefully than stall
-# live token delivery behind a slow RTT.
-RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.5
+# Tight upper bound on any Redis call in the streaming hot path so a
+# slow Redis degrades resume but can't stall live token delivery.
+RESUME_STREAM_REDIS_TIMEOUT_SEC = 0.2
 
 
 def _stream_key(user_id: str, message_id: str) -> str:
-    # user_id-scoped: only the owning user's session can construct the
-    # key, so resume doesn't need a DB chat/message auth check.
+    # user_id-scoped key — auth is implicit from the session's user.
     return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}'
 
 
 def _stream_seq_key(user_id: str, message_id: str) -> str:
-    # Separate key for the atomic seq counter so INCR is cheap and
-    # doesn't touch the stream. Lives and dies alongside the stream log.
     return f'{REDIS_KEY_PREFIX}:stream:{user_id}:{message_id}:seq'
 
 
 async def _stream_seq_allocate(user_id: str, message_id: str):
-    """Atomically allocate the next seq for this message_id.
+    """Allocate the next seq via atomic INCR, or None when resume is off.
 
-    Global INCR (not a per-emitter counter) so overlapping emitters for
-    the same message_id can't both emit the same seq and cause client
-    dedupe to silently drop one of them as a duplicate.
-
-    Returns the allocated seq, or None if Redis is unavailable or the
-    call times out. Callers treat None as "emit without seq" — live
-    streaming continues but that frame isn't eligible for resume dedupe.
-
-    Also returns None when ENABLE_REALTIME_CHAT_SAVE is on: in that
-    mode the DB is already the authoritative per-token store, so the
-    frontend loads the up-to-date content on refresh. Logging the
-    resume stream in parallel would cause duplicate content on refresh
-    (resume replays from seq=0 on top of DB-loaded content).
+    Returns None when Redis is unavailable, times out, or
+    ENABLE_REALTIME_CHAT_SAVE is set. Callers emit without seq in that
+    case — live streaming continues, no dedupe/resume for that frame.
     """
     if ENABLE_REALTIME_CHAT_SAVE:
         return None
@@ -223,8 +209,6 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
         seq = await asyncio.wait_for(
             REDIS.incr(key), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
-        # Set TTL on first INCR; EXPIRE is NX-like in effect (idempotent
-        # enough here — occasional reset is fine).
         if seq == 1:
             try:
                 await asyncio.wait_for(
@@ -243,13 +227,7 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
 
 
 async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
-    """Append an envelope to the resume log.
-
-    Uses Redis-generated stream IDs so overlapping emitters can't collide.
-    Pipelined with the periodic EXPIRE. Wrapped in a short timeout so a
-    slow Redis can't block live token delivery for the user — on timeout
-    we drop the log entry and let the emit proceed.
-    """
+    """Append envelope to resume log. Timeout drops the entry, not the emit."""
     if REDIS is None or not user_id or not message_id:
         return
     try:
@@ -319,13 +297,9 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
         except Exception:
             continue
         out.append((entry_seq, envelope))
-    # Sort by seq before returning envelopes. Stream append order can
-    # diverge from seq order because INCR + XADD aren't atomic: a
-    # concurrent emitter can win the INCR race for a later seq yet lose
-    # the XADD race and land in the stream ahead of an earlier seq. If
-    # we handed envelopes to the client in append order, the client's
-    # `incomingSeq <= lastSeq` guard would permanently drop the later-
-    # arriving-but-earlier-numbered frame.
+    # Stream append order can diverge from seq order under concurrent
+    # emitters (INCR/XADD aren't atomic); sort so the client gets frames
+    # in seq order.
     out.sort(key=lambda pair: pair[0])
     return [envelope for _seq, envelope in out]
 
@@ -684,21 +658,11 @@ async def chat_events(sid, data):
 
 @sio.on('resume-stream')
 async def resume_stream(sid, data):
-    """Replay missed log entries in a single batch.
+    """One `resume-stream:replay` batch emit (payload + completion signal).
 
-    One `resume-stream:replay` emit carries all envelopes with seq >
-    last_seq (possibly zero) and serves as the completion signal. Sent
-    whenever we have a message_id to target — including the Redis-down
-    and no-log cases — so the client's fence clears reliably instead of
-    waiting on its fallback timeout.
-
-    Auth-rejection branches (non-dict payload, missing session, missing
-    message_id) intentionally return without a reply: the client either
-    never raised a fence for this call (because it had no message_id)
-    or isn't a legitimate session, so a silent drop is correct there.
-
-    Stream auth is implicit: the key is scoped by user_id, so an
-    authenticated session can only ever read its own logs. No DB lookup.
+    Sent whenever we have a valid (user, message_id); auth-rejection
+    branches drop silently since the client never raised a fence for
+    those. Key scoping by user_id means no DB auth check is needed.
     """
     if not isinstance(data, dict):
         return
@@ -1023,12 +987,6 @@ async def get_event_emitter(request_info, update_db=True):
         chat_id = request_info['chat_id']
         message_id = request_info['message_id']
 
-        # Atomically allocate this frame's seq. Global INCR (not an
-        # in-process counter) so overlapping emitters for the same
-        # message_id can't both produce the same seq. If Redis is
-        # unavailable or slow, seq is None and we emit without it — live
-        # streaming continues, but this frame is excluded from resume
-        # dedupe and replay (graceful degradation).
         seq = await _stream_seq_allocate(user_id, message_id)
 
         envelope = {
@@ -1036,17 +994,15 @@ async def get_event_emitter(request_info, update_db=True):
             'message_id': message_id,
             'data': event_data,
         }
+        # Log before emit so a reconnecting client can't resume-read past
+        # a frame that hasn't been persisted yet. Client seq guard drops
+        # duplicates from the inverted race.
         if seq is not None:
             envelope['seq'] = seq
-            # Log before emit: an inverted order could let a reconnecting
-            # client resume-read before the append lands and permanently
-            # miss the frame. Duplicates are dropped by the client seq
-            # guard.
             await _stream_log_append(user_id, message_id, envelope, seq)
         await sio.emit('events', envelope, room=f'user:{user_id}')
 
-        # On done, shorten TTL on both the stream log and the seq counter
-        # so they self-evict together after the grace window.
+        # On done, shorten TTL so log + seq counter self-evict together.
         inner = event_data.get('data') if isinstance(event_data, dict) else None
         if isinstance(inner, dict) and inner.get('done') is True:
             if REDIS is not None and user_id and message_id:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1022,7 +1022,11 @@ async def get_event_emitter(request_info, update_db=True):
         # reconnecting clients a short grace window to pick up the final
         # frames before we delete the log (for anything beyond the grace
         # window, the DB is already up to date and resume isn't needed).
-        if isinstance(event_data, dict) and event_data.get('data', {}).get('done') is True:
+        # Narrow carefully: `event_data['data']` is a dict for most event
+        # types but can legitimately be a list/str/None for some custom
+        # pipeline-emitted events. Calling `.get` on those would raise.
+        inner = event_data.get('data') if isinstance(event_data, dict) else None
+        if isinstance(inner, dict) and inner.get('done') is True:
             async def _delayed_truncate(mid):
                 try:
                     await asyncio.sleep(30)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -274,11 +274,13 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
     if REDIS is None or not user_id or not message_id:
         return []
     try:
-        entries = await REDIS.xrange(
-            _stream_key(user_id, message_id),
-            min='-',
-            max='+',
+        entries = await asyncio.wait_for(
+            REDIS.xrange(_stream_key(user_id, message_id), min='-', max='+'),
+            timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC,
         )
+    except asyncio.TimeoutError:
+        log.warning(f'stream resume log read timed out for {message_id}')
+        return []
     except Exception as e:
         log.warning(f'stream resume log read failed for {message_id}: {e}')
         return []
@@ -666,13 +668,18 @@ async def chat_events(sid, data):
 async def resume_stream(sid, data):
     """Replay missed log entries in a single batch.
 
-    One emit carries all envelopes with seq > last_seq (possibly zero)
-    and also serves as the completion signal — the client clears its
-    live-frame fence in the batch handler. Always emitting exactly once
-    (even when Redis is unavailable or the log is empty) keeps the
-    client from deadlocking on a fence that never clears.
+    One `resume-stream:replay` emit carries all envelopes with seq >
+    last_seq (possibly zero) and serves as the completion signal. Sent
+    whenever we have a message_id to target — including the Redis-down
+    and no-log cases — so the client's fence clears reliably instead of
+    waiting on its fallback timeout.
 
-    Auth is implicit: the stream key is scoped by user_id, so an
+    Auth-rejection branches (non-dict payload, missing session, missing
+    message_id) intentionally return without a reply: the client either
+    never raised a fence for this call (because it had no message_id)
+    or isn't a legitimate session, so a silent drop is correct there.
+
+    Stream auth is implicit: the key is scoped by user_id, so an
     authenticated session can only ever read its own logs. No DB lookup.
     """
     if not isinstance(data, dict):

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -185,15 +185,21 @@ RESUME_STREAM_TTL_REFRESH_EVERY = 64
 # Replay read timeout: looser since a resume is user-blocking anyway
 # and silent timeout here is worse than a brief extra wait. Both
 # configurable for infra where Redis isn't colocated.
-def _float_env(name: str, default: float) -> float:
+def _float_env(name: str, default: float, minimum: float = 0.0) -> float:
     val = os.environ.get(name)
     if val is None or val == '':
         return default
     try:
-        return float(val)
+        parsed = float(val)
     except (TypeError, ValueError):
         log.warning(f'Invalid {name}={val!r}; using default {default}')
         return default
+    if parsed <= minimum:
+        log.warning(
+            f'{name}={parsed} is not positive (must be > {minimum}); using default {default}'
+        )
+        return default
+    return parsed
 
 
 RESUME_STREAM_REDIS_TIMEOUT_SEC = _float_env('RESUME_STREAM_REDIS_TIMEOUT_SEC', 0.1)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -282,7 +282,11 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
         seq = await asyncio.wait_for(
             REDIS.incr(key), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
-        _breaker_record_success()
+        # Don't record breaker success here — only append success counts
+        # as "Redis is healthy end-to-end." If INCR kept succeeding but
+        # XADD kept failing, counting INCR successes would reset the
+        # breaker on every frame and it would never trip for the exact
+        # failure mode we're trying to short-circuit.
         if seq == 1:
             try:
                 await asyncio.wait_for(
@@ -806,6 +810,7 @@ async def resume_stream(sid, data):
         capped.append(env)
         total_bytes += size
     capped.reverse()
+    truncated = len(capped) < len(envelopes)
 
     await sio.emit(
         'resume-stream:replay',
@@ -813,6 +818,7 @@ async def resume_stream(sid, data):
             'message_id': message_id,
             'request_id': request_id,
             'envelopes': capped,
+            'truncated': truncated,
         },
         to=sid,
     )

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import random
 
 import socketio
@@ -168,6 +169,96 @@ YDOC_MANAGER = YdocManager(
     redis=REDIS,
     redis_key_prefix=f'{REDIS_KEY_PREFIX}:ydoc:documents',
 )
+
+
+# ---------------------------------------------------------------------------
+# Stream resume log.
+#
+# Every outbound WS event for a streaming chat response is appended to a
+# bounded Redis stream keyed by message_id. A client that reconnects (e.g.
+# after a page refresh) while the backend is still streaming can request a
+# replay of events it missed and catch up without re-fetching the full
+# chat from the DB. Requires Redis; no-ops gracefully otherwise.
+# ---------------------------------------------------------------------------
+
+# Bounded to protect Redis memory. 2000 entries comfortably covers most
+# responses at one event per token; longer responses just lose the earliest
+# entries, which is fine because the `done:True` checkpoint emitted at the
+# end of the stream carries the canonical full content and reconciles the
+# client.
+RESUME_STREAM_MAXLEN = 2000
+# Defensive TTL so orphaned logs (crashed worker, cancelled request) are
+# evicted automatically. Completed streams are deleted eagerly below.
+RESUME_STREAM_TTL_SEC = 3600
+
+
+def _stream_key(message_id: str) -> str:
+    return f'{REDIS_KEY_PREFIX}:stream:{message_id}'
+
+
+async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
+    """Append an outbound WS envelope to the resume log."""
+    if REDIS is None or not message_id:
+        return
+    try:
+        await REDIS.xadd(
+            _stream_key(message_id),
+            {'seq': str(seq), 'payload': json.dumps(envelope)},
+            maxlen=RESUME_STREAM_MAXLEN,
+            approximate=True,
+        )
+        # Refresh TTL on every append so active streams don't expire mid-run.
+        await REDIS.expire(_stream_key(message_id), RESUME_STREAM_TTL_SEC)
+    except Exception as e:
+        log.debug(f'stream resume log append failed for {message_id}: {e}')
+
+
+async def _stream_log_truncate(message_id: str) -> None:
+    """Delete the resume log for a message (called when streaming is done)."""
+    if REDIS is None or not message_id:
+        return
+    try:
+        await REDIS.delete(_stream_key(message_id))
+    except Exception as e:
+        log.debug(f'stream resume log truncate failed for {message_id}: {e}')
+
+
+async def _stream_log_read(message_id: str, after_seq: int):
+    """Return envelopes logged for message_id with seq > after_seq, in order."""
+    if REDIS is None or not message_id:
+        return []
+    try:
+        entries = await REDIS.xrange(_stream_key(message_id), min='-', max='+')
+    except Exception as e:
+        log.debug(f'stream resume log read failed for {message_id}: {e}')
+        return []
+
+    def _field(fields, key):
+        # redis-py returns bytes by default but may return str depending on
+        # decode_responses config. Normalize both.
+        v = fields.get(key)
+        if v is None:
+            v = fields.get(key.encode() if isinstance(key, str) else key)
+        if isinstance(v, bytes):
+            v = v.decode('utf-8', 'replace')
+        return v
+
+    out = []
+    for _entry_id, fields in entries:
+        try:
+            seq = int(_field(fields, 'seq') or '0')
+        except (TypeError, ValueError):
+            continue
+        if seq <= after_seq:
+            continue
+        payload = _field(fields, 'payload')
+        if not payload:
+            continue
+        try:
+            out.append(json.loads(payload))
+        except Exception:
+            continue
+    return out
 
 
 async def periodic_session_pool_cleanup():
@@ -522,6 +613,71 @@ async def chat_events(sid, data):
         await Chats.update_chat_last_read_at_by_id(data['chat_id'], user['id'])
 
 
+@sio.on('resume-stream')
+async def resume_stream(sid, data):
+    """Replay WS events a client missed while disconnected.
+
+    Client payload: `{chat_id, message_id, last_seq}`.
+
+    Flow:
+      1. Authenticate the session and verify the user owns the chat.
+      2. Read entries from the Redis resume log for this message_id whose
+         `seq` is greater than `last_seq`.
+      3. Emit each entry as a normal `events` event to THIS session only
+         (via `to=sid`). Other sessions for the same user keep receiving
+         the live stream unchanged.
+      4. Send a final `resume-stream:ack` so the client can resolve its
+         pending resume state.
+
+    No-op when Redis is not configured — in that deployment mode, refresh
+    during streaming falls back to the existing behavior (wait for the
+    stream to complete and reload from the DB).
+    """
+    if REDIS is None:
+        return
+
+    user = SESSION_POOL.get(sid)
+    if not user:
+        return
+
+    user_id = user.get('id')
+    chat_id = data.get('chat_id')
+    message_id = data.get('message_id')
+    try:
+        last_seq = int(data.get('last_seq') or 0)
+    except (TypeError, ValueError):
+        last_seq = 0
+
+    if not user_id or not chat_id or not message_id:
+        return
+
+    # Auth: the stream log is keyed by message_id only, so a chat-ownership
+    # check is essential to prevent a client from reading another user's
+    # stream by guessing a message_id.
+    chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
+    if not chat:
+        return
+
+    envelopes = await _stream_log_read(message_id, last_seq)
+    for envelope in envelopes:
+        # Replay to the requesting session only. Live listeners in
+        # `user:{user_id}` are already receiving new frames via the normal
+        # emit path and must not see these duplicates.
+        await sio.emit('events', envelope, to=sid)
+
+    last_replayed_seq = envelopes[-1].get('seq') if envelopes else last_seq
+    await sio.emit(
+        'resume-stream:ack',
+        {
+            'chat_id': chat_id,
+            'message_id': message_id,
+            'replayed': len(envelopes),
+            'last_seq': last_replayed_seq,
+        },
+        to=sid,
+    )
+
+
 def normalize_document_id(document_id: str) -> str:
     """Canonicalize document IDs to prevent auth bypass via prefix variants.
 
@@ -812,20 +968,47 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
+    # Per-emitter monotonic seq. One emitter instance corresponds to a single
+    # streaming response for a single (chat_id, message_id) on a single
+    # worker, so a local counter is sufficient — no distributed consensus
+    # needed. Clients use this to request a replay of events they missed
+    # after a reconnect / refresh via the `resume-stream` handler below.
+    seq_counter = {'n': 0}
+
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
         chat_id = request_info['chat_id']
         message_id = request_info['message_id']
 
-        await sio.emit(
-            'events',
-            {
-                'chat_id': chat_id,
-                'message_id': message_id,
-                'data': event_data,
-            },
-            room=f'user:{user_id}',
-        )
+        seq_counter['n'] += 1
+        seq = seq_counter['n']
+
+        envelope = {
+            'chat_id': chat_id,
+            'message_id': message_id,
+            'seq': seq,
+            'data': event_data,
+        }
+
+        await sio.emit('events', envelope, room=f'user:{user_id}')
+
+        # Append to the resume log AFTER the live emit so reconnecting
+        # clients can only ever see what live clients already received.
+        await _stream_log_append(message_id, envelope, seq)
+
+        # If this event finalized the message, schedule log cleanup. Give
+        # reconnecting clients a short grace window to pick up the final
+        # frames before we delete the log (for anything beyond the grace
+        # window, the DB is already up to date and resume isn't needed).
+        if isinstance(event_data, dict) and event_data.get('data', {}).get('done') is True:
+            async def _delayed_truncate(mid):
+                try:
+                    await asyncio.sleep(30)
+                    await _stream_log_truncate(mid)
+                except Exception:
+                    pass
+
+            asyncio.create_task(_delayed_truncate(message_id))
 
         if update_db and message_id and not request_info.get('chat_id', '').startswith('local:'):
             event_type = event_data.get('type')

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1112,10 +1112,17 @@ async def get_event_emitter(request_info, update_db=True):
         # will no longer replay against.
         outer_type = event_data.get('type') if isinstance(event_data, dict) else None
         inner = event_data.get('data') if isinstance(event_data, dict) else None
+        # Only the specific chat:completion-with-error shape is terminal;
+        # a generic `error` field on some other event type could be a
+        # transient warning and shouldn't age the keys out early.
         is_terminal = (
             (isinstance(inner, dict) and inner.get('done') is True)
             or outer_type == 'chat:tasks:cancel'
-            or (isinstance(inner, dict) and inner.get('error'))
+            or (
+                outer_type == 'chat:completion'
+                and isinstance(inner, dict)
+                and inner.get('error')
+            )
         )
         if is_terminal and REDIS is not None and user_id and message_id:
             try:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -211,6 +211,12 @@ async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
     Uses a Redis pipeline to collapse XADD + (occasional) EXPIRE into a
     single network round-trip per call, keeping the added latency on the
     streaming hot path bounded to one Redis RTT.
+
+    Uses an explicit stream ID of `0-{seq}` so that the resume read path
+    can start XRANGE at the caller's cursor (`0-{last_seq+1}`) instead of
+    scanning the whole stream. The `0-` prefix is arbitrary — we only
+    need the IDs to be strictly monotonic per stream, which our
+    per-emitter seq counter guarantees.
     """
     if REDIS is None or not message_id:
         return
@@ -220,7 +226,8 @@ async def _stream_log_append(message_id: str, envelope: dict, seq: int) -> None:
         pipe = REDIS.pipeline(transaction=False)
         pipe.xadd(
             key,
-            {'seq': str(seq), 'payload': json.dumps(envelope)},
+            {'payload': json.dumps(envelope)},
+            id=f'0-{seq}',
             maxlen=RESUME_STREAM_MAXLEN,
             approximate=True,
         )
@@ -242,11 +249,23 @@ async def _stream_log_truncate(message_id: str) -> None:
 
 
 async def _stream_log_read(message_id: str, after_seq: int):
-    """Return envelopes logged for message_id with seq > after_seq, in order."""
+    """Return envelopes logged for message_id with seq > after_seq, in order.
+
+    Stream IDs are `0-{seq}`, so we can start the XRANGE at
+    `0-{after_seq+1}` and let Redis skip everything already delivered
+    instead of scanning from the start every call. Near-tail resumes
+    (the common case for reconnects) become O(missed frames) instead of
+    O(MAXLEN).
+    """
     if REDIS is None or not message_id:
         return []
     try:
-        entries = await REDIS.xrange(_stream_key(message_id), min='-', max='+')
+        start_seq = max(0, after_seq) + 1
+        entries = await REDIS.xrange(
+            _stream_key(message_id),
+            min=f'0-{start_seq}',
+            max='+',
+        )
     except Exception as e:
         log.debug(f'stream resume log read failed for {message_id}: {e}')
         return []
@@ -263,12 +282,6 @@ async def _stream_log_read(message_id: str, after_seq: int):
 
     out = []
     for _entry_id, fields in entries:
-        try:
-            seq = int(_field(fields, 'seq') or '0')
-        except (TypeError, ValueError):
-            continue
-        if seq <= after_seq:
-            continue
         payload = _field(fields, 'payload')
         if not payload:
             continue
@@ -1012,11 +1025,20 @@ async def get_event_emitter(request_info, update_db=True):
             'data': event_data,
         }
 
-        await sio.emit('events', envelope, room=f'user:{user_id}')
-
-        # Append to the resume log AFTER the live emit so reconnecting
-        # clients can only ever see what live clients already received.
+        # Append to the resume log BEFORE the live emit. If we emitted
+        # first, a client that disconnects in the window between `sio.emit`
+        # and `_stream_log_append` could reconnect and issue resume-stream
+        # before the frame is logged, never see that frame in the replay,
+        # and then never ask again — permanently losing it (particularly
+        # painful for the terminal done:True frame).
+        #
+        # Logging first inverts the window: a reconnecting client MIGHT
+        # see a replayed frame before the live emit reaches their new
+        # session, but the seq idempotency guard in chatEventHandler drops
+        # the subsequent duplicate harmlessly. Duplicates are safe, losses
+        # are not.
         await _stream_log_append(message_id, envelope, seq)
+        await sio.emit('events', envelope, room=f'user:{user_id}')
 
         # If this event finalized the message, schedule log cleanup. Give
         # reconnecting clients a short grace window to pick up the final

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -180,7 +180,6 @@ YDOC_MANAGER = YdocManager(
 RESUME_STREAM_MAXLEN = 2000
 RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
-RESUME_STREAM_TTL_REFRESH_EVERY = 64
 # Hot-path timeout: tight so a slow Redis can't stall live tokens.
 # Replay read timeout: looser since a resume is user-blocking anyway
 # and silent timeout here is worse than a brief extra wait. Both
@@ -304,7 +303,6 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
     if _breaker_open():
         return
     try:
-        refresh_ttl = (seq == 1) or (seq % RESUME_STREAM_TTL_REFRESH_EVERY == 0)
         key = _stream_key(user_id, message_id)
         seq_key = _stream_seq_key(user_id, message_id)
         pipe = REDIS.pipeline(transaction=False)
@@ -314,12 +312,12 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
             maxlen=RESUME_STREAM_MAXLEN,
             approximate=True,
         )
-        if refresh_ttl:
-            # Refresh both keys together — without this the seq counter
-            # can expire mid-stream on responses longer than the TTL and
-            # INCR restarts at 1, corrupting replay ordering.
-            pipe.expire(key, RESUME_STREAM_TTL_SEC)
-            pipe.expire(seq_key, RESUME_STREAM_TTL_SEC)
+        # Refresh both keys every append. Pipelined with XADD so no extra
+        # round-trip; guarantees sparse / slow streams (where the seq
+        # counter might otherwise idle past the TTL and INCR would
+        # restart at 1) stay alive as long as the stream is active.
+        pipe.expire(key, RESUME_STREAM_TTL_SEC)
+        pipe.expire(seq_key, RESUME_STREAM_TTL_SEC)
         await asyncio.wait_for(
             pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
@@ -765,13 +763,14 @@ async def resume_stream(sid, data):
             last_seq = int(data.get('last_seq') or 0)
         except (TypeError, ValueError):
             last_seq = 0
-        # Defense-in-depth: validate chat ownership AND message-in-chat
-        # binding even though the log key is already user-scoped. Fails
-        # CLOSED on DB errors so an infra hiccup can't skip the check.
-        # When chat_id is absent we fall through to the user-scoped key
-        # guarantee so legacy clients that don't send chat_id still work.
-        # Either way we reply with (at worst) empty envelopes below so
-        # the client fence clears deterministically.
+        # Defense-in-depth: validate chat ownership when chat_id is
+        # present. The message-in-chat lookup can legitimately fail for
+        # in-flight assistants that haven't been persisted to DB yet
+        # (ENABLE_REALTIME_CHAT_SAVE=False flow), which is exactly the
+        # case this feature is meant to recover — so we don't gate
+        # replay on message presence. The user-scoped log key already
+        # prevents cross-user access regardless. Fails CLOSED on DB
+        # errors or when the user doesn't own the supplied chat_id.
         chat_id = data.get('chat_id')
         chat_ok = True
         if chat_id:
@@ -779,16 +778,8 @@ async def resume_stream(sid, data):
                 chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
                 if not chat:
                     chat_ok = False
-                else:
-                    # Reuse the chat record for the message-in-chat check
-                    # so we don't pay a second DB round-trip.
-                    messages = (
-                        getattr(chat, 'chat', {}) or {}
-                    ).get('history', {}).get('messages', {}) or {}
-                    if message_id not in messages:
-                        chat_ok = False
             except Exception as e:
-                log.warning(f'resume-stream chat/message check failed: {e}')
+                log.warning(f'resume-stream chat ownership check failed: {e}')
                 chat_ok = False
         if chat_ok:
             envelopes = await _stream_log_read(user_id, message_id, last_seq)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -759,21 +759,30 @@ async def resume_stream(sid, data):
             last_seq = int(data.get('last_seq') or 0)
         except (TypeError, ValueError):
             last_seq = 0
-        # Defense-in-depth: validate chat ownership even though the log
-        # key is already user-scoped. Fails CLOSED on DB errors so an
-        # infra hiccup can't skip the ownership check. When chat_id is
-        # absent we fall through to the user-scoped key guarantee so
-        # legacy clients that don't send chat_id still work. Either way
-        # we reply with (at worst) empty envelopes below so the client
-        # fence clears deterministically.
+        # Defense-in-depth: validate chat ownership AND message-in-chat
+        # binding even though the log key is already user-scoped. Fails
+        # CLOSED on DB errors so an infra hiccup can't skip the check.
+        # When chat_id is absent we fall through to the user-scoped key
+        # guarantee so legacy clients that don't send chat_id still work.
+        # Either way we reply with (at worst) empty envelopes below so
+        # the client fence clears deterministically.
         chat_id = data.get('chat_id')
         chat_ok = True
         if chat_id:
             try:
                 chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
-                chat_ok = chat is not None
+                if not chat:
+                    chat_ok = False
+                else:
+                    # Reuse the chat record for the message-in-chat check
+                    # so we don't pay a second DB round-trip.
+                    messages = (
+                        getattr(chat, 'chat', {}) or {}
+                    ).get('history', {}).get('messages', {}) or {}
+                    if message_id not in messages:
+                        chat_ok = False
             except Exception as e:
-                log.warning(f'resume-stream chat ownership check failed: {e}')
+                log.warning(f'resume-stream chat/message check failed: {e}')
                 chat_ok = False
         if chat_ok:
             envelopes = await _stream_log_read(user_id, message_id, last_seq)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -671,36 +671,30 @@ async def chat_events(sid, data):
 
 @sio.on('resume-stream')
 async def resume_stream(sid, data):
-    """One `resume-stream:replay` batch emit (payload + completion signal).
+    """Batch replay emit; also serves as the client's fence-clear signal.
 
-    Sent whenever we have a valid (user, message_id); auth-rejection
-    branches drop silently since the client never raised a fence for
-    those. Key scoping by user_id means no DB auth check is needed.
+    Reply whenever we have a message_id to target so the client fence
+    clears deterministically — even on auth failure. Silent drops only
+    happen when the client couldn't have raised a fence in the first
+    place (malformed payload, no message_id).
     """
     if not isinstance(data, dict):
         return
-
-    user = SESSION_POOL.get(sid)
-    if not user:
-        return
-
-    user_id = user.get('id')
     message_id = data.get('message_id')
-    request_id = data.get('request_id')
-    try:
-        last_seq = int(data.get('last_seq') or 0)
-    except (TypeError, ValueError):
-        last_seq = 0
-
-    if not user_id or not message_id:
+    if not message_id:
         return
 
+    request_id = data.get('request_id')
     envelopes = []
-    if REDIS is not None:
+    user = SESSION_POOL.get(sid)
+    user_id = user.get('id') if user else None
+    if user_id and REDIS is not None:
+        try:
+            last_seq = int(data.get('last_seq') or 0)
+        except (TypeError, ValueError):
+            last_seq = 0
         envelopes = await _stream_log_read(user_id, message_id, last_seq)
 
-    # Echo request_id so the client can ignore stale replies that
-    # correspond to a superseded request (reconnect churn).
     await sio.emit(
         'resume-stream:replay',
         {
@@ -1033,19 +1027,27 @@ async def get_event_emitter(request_info, update_db=True):
             await _stream_log_append(user_id, message_id, envelope, seq)
         await sio.emit('events', envelope, room=f'user:{user_id}')
 
-        # On done, shorten TTL so log + seq counter self-evict together.
+        # Any terminal event shortens TTL so log + seq self-evict together.
+        # Covers normal completion (done:True), explicit cancel, and
+        # errored completions — all end-of-stream flows that the client
+        # will no longer replay against.
+        outer_type = event_data.get('type') if isinstance(event_data, dict) else None
         inner = event_data.get('data') if isinstance(event_data, dict) else None
-        if isinstance(inner, dict) and inner.get('done') is True:
-            if REDIS is not None and user_id and message_id:
-                try:
-                    pipe = REDIS.pipeline(transaction=False)
-                    pipe.expire(_stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
-                    pipe.expire(_stream_seq_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
-                    await asyncio.wait_for(
-                        pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
-                    )
-                except Exception as e:
-                    log.warning(f'stream resume log done-TTL shorten failed for {message_id}: {e}')
+        is_terminal = (
+            (isinstance(inner, dict) and inner.get('done') is True)
+            or outer_type == 'chat:tasks:cancel'
+            or (isinstance(inner, dict) and inner.get('error'))
+        )
+        if is_terminal and REDIS is not None and user_id and message_id:
+            try:
+                pipe = REDIS.pipeline(transaction=False)
+                pipe.expire(_stream_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                pipe.expire(_stream_seq_key(user_id, message_id), RESUME_STREAM_DONE_TTL_SEC)
+                await asyncio.wait_for(
+                    pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
+                )
+            except Exception as e:
+                log.warning(f'stream resume log terminal-TTL shorten failed for {message_id}: {e}')
 
         if update_db and message_id and not request_info.get('chat_id', '').startswith('local:'):
             event_type = event_data.get('type')

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -192,8 +192,11 @@ def _stream_key(user_id: str, message_id: str) -> str:
 async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
     """Append an envelope to the resume log.
 
-    Uses explicit stream ID `0-{seq}` so XRANGE can start at the client's
-    cursor on resume. Pipelined with the periodic EXPIRE.
+    Uses Redis-generated stream IDs (the default `*`) so overlapping
+    emitters for the same message_id — continuation, crash-retry, etc. —
+    cannot collide with each other's IDs. The seq lives in the entry
+    fields instead, and the read path filters by it. Pipelined with the
+    periodic EXPIRE.
     """
     if REDIS is None or not user_id or not message_id:
         return
@@ -203,8 +206,7 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
         pipe = REDIS.pipeline(transaction=False)
         pipe.xadd(
             key,
-            {'payload': json.dumps(envelope)},
-            id=f'0-{seq}',
+            {'seq': str(seq), 'payload': json.dumps(envelope)},
             maxlen=RESUME_STREAM_MAXLEN,
             approximate=True,
         )
@@ -225,14 +227,18 @@ async def _stream_log_truncate(user_id: str, message_id: str) -> None:
 
 
 async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
-    """Return envelopes with seq > after_seq, in order."""
+    """Return envelopes with seq > after_seq, in order.
+
+    Full scan bounded by MAXLEN; Python filters by seq because auto IDs
+    don't encode it. With MAXLEN=2000 this is a few ms at worst and
+    resume is a rare, user-driven event so the cost is fine.
+    """
     if REDIS is None or not user_id or not message_id:
         return []
     try:
-        start_seq = max(0, after_seq) + 1
         entries = await REDIS.xrange(
             _stream_key(user_id, message_id),
-            min=f'0-{start_seq}',
+            min='-',
             max='+',
         )
     except Exception as e:
@@ -250,6 +256,12 @@ async def _stream_log_read(user_id: str, message_id: str, after_seq: int):
 
     out = []
     for _entry_id, fields in entries:
+        try:
+            entry_seq = int(_field(fields, 'seq') or '0')
+        except (TypeError, ValueError):
+            continue
+        if entry_seq <= after_seq:
+            continue
         payload = _field(fields, 'payload')
         if not payload:
             continue
@@ -943,14 +955,9 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # Per-emitter monotonic seq for the resume log (explicit ID 0-{seq}).
+    # Per-emitter monotonic seq for the resume log. Lives in the entry's
+    # `seq` field (Redis auto-generates the stream IDs).
     seq_counter = {'n': 0}
-    # Wipe any prior log so fresh XADDs (starting at 0-1) don't collide
-    # with a retry/continuation's leftover IDs.
-    ri_user_id = request_info.get('user_id') if isinstance(request_info, dict) else None
-    ri_message_id = request_info.get('message_id') if isinstance(request_info, dict) else None
-    if ri_user_id and ri_message_id and REDIS is not None:
-        await _stream_log_truncate(ri_user_id, ri_message_id)
 
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -180,6 +180,12 @@ YDOC_MANAGER = YdocManager(
 RESUME_STREAM_MAXLEN = 2000
 RESUME_STREAM_TTL_SEC = 3600
 RESUME_STREAM_DONE_TTL_SEC = 30
+# Upper bound on bytes in a single resume-stream:replay payload so we
+# stay under Socket.IO's default 1MB buffer. When the log exceeds this,
+# we emit only the most recent entries (older ones are already reflected
+# in the DB-backed content loaded at refresh time, and the final done
+# checkpoint reconciles anything else).
+RESUME_STREAM_REPLAY_MAX_BYTES = 900_000
 # Hot-path timeout: tight so a slow Redis can't stall live tokens.
 # Replay read timeout: looser since a resume is user-blocking anyway
 # and silent timeout here is worse than a brief extra wait. Both
@@ -747,7 +753,11 @@ async def resume_stream(sid, data):
     if not isinstance(data, dict):
         return
     message_id = data.get('message_id')
-    if not message_id:
+    chat_id = data.get('chat_id')
+    if not message_id or not chat_id:
+        # Both IDs are required: chat_id drives the ownership check, and
+        # without it a buggy/malicious client could bypass chat-level
+        # validation and rely only on the user-scoped key guarantee.
         return
 
     request_id = data.get('request_id')
@@ -763,33 +773,42 @@ async def resume_stream(sid, data):
             last_seq = int(data.get('last_seq') or 0)
         except (TypeError, ValueError):
             last_seq = 0
-        # Defense-in-depth: validate chat ownership when chat_id is
-        # present. The message-in-chat lookup can legitimately fail for
-        # in-flight assistants that haven't been persisted to DB yet
-        # (ENABLE_REALTIME_CHAT_SAVE=False flow), which is exactly the
-        # case this feature is meant to recover — so we don't gate
-        # replay on message presence. The user-scoped log key already
-        # prevents cross-user access regardless. Fails CLOSED on DB
-        # errors or when the user doesn't own the supplied chat_id.
-        chat_id = data.get('chat_id')
-        chat_ok = True
-        if chat_id:
-            try:
-                chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
-                if not chat:
-                    chat_ok = False
-            except Exception as e:
-                log.warning(f'resume-stream chat ownership check failed: {e}')
-                chat_ok = False
+        # Defense-in-depth: validate chat ownership. The message-in-chat
+        # check would reject legitimate in-flight resumes because the
+        # assistant stub isn't persisted to DB until after streaming
+        # completes, so we rely on user-scoped log keys for that layer.
+        # Fails CLOSED on DB errors or unowned chat.
+        chat_ok = False
+        try:
+            chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
+            chat_ok = chat is not None
+        except Exception as e:
+            log.warning(f'resume-stream chat ownership check failed: {e}')
         if chat_ok:
             envelopes = await _stream_log_read(user_id, message_id, last_seq)
+
+    # Cap payload bytes. Keep the newest entries that fit; older ones
+    # are either already in the DB-backed content or will arrive via the
+    # final done:True checkpoint.
+    total_bytes = 0
+    capped = []
+    for env in reversed(envelopes):
+        try:
+            size = len(json.dumps(env))
+        except Exception:
+            continue
+        if total_bytes + size > RESUME_STREAM_REPLAY_MAX_BYTES and capped:
+            break
+        capped.append(env)
+        total_bytes += size
+    capped.reverse()
 
     await sio.emit(
         'resume-stream:replay',
         {
             'message_id': message_id,
             'request_id': request_id,
-            'envelopes': envelopes,
+            'envelopes': capped,
         },
         to=sid,
     )

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import random
+import weakref
 
 import socketio
 import logging
@@ -200,6 +201,26 @@ RESUME_STREAM_READ_TIMEOUT_SEC = float(
 _HOT_PATH_BREAKER_FAILURE_THRESHOLD = 3
 _HOT_PATH_BREAKER_COOLDOWN_SEC = 10.0
 _hot_path_breaker = {'failures': 0, 'open_until': 0.0}
+
+# Per-message emitter lock. Serializes the seq-alloc + log-append + emit
+# sequence within a worker so two overlapping emitters for the same
+# (user_id, message_id) can't interleave and produce out-of-seq live
+# frames. Doesn't cover cross-worker concurrency, but concurrent
+# emitters for the same message_id on different workers is an even
+# rarer scenario. WeakValueDictionary cleans up entries automatically
+# once no coroutine holds the lock (i.e., no one is inside the critical
+# section and no one is waiting to enter).
+_emit_locks = weakref.WeakValueDictionary()
+
+
+def _emit_lock_for(user_id: str, message_id: str) -> asyncio.Lock:
+    key = f'{user_id}:{message_id}'
+    lock = _emit_locks.get(key)
+    if lock is None:
+        # setdefault is atomic under the GIL; races resolve to a single
+        # Lock and subsequent calls see it via the first branch.
+        lock = _emit_locks.setdefault(key, asyncio.Lock())
+    return lock
 
 
 def _breaker_open() -> bool:
@@ -732,10 +753,12 @@ async def resume_stream(sid, data):
         except (TypeError, ValueError):
             last_seq = 0
         # Defense-in-depth: validate chat ownership even though the log
-        # key is already user-scoped. Rejects only when we can *prove*
-        # ownership fails — a missing/unknown chat_id falls through to
-        # the user-scoped key guarantee so we don't regress the "stub
-        # not yet persisted in DB" refresh case.
+        # key is already user-scoped. Fails CLOSED on DB errors so an
+        # infra hiccup can't skip the ownership check. When chat_id is
+        # absent we fall through to the user-scoped key guarantee so
+        # legacy clients that don't send chat_id still work. Either way
+        # we reply with (at worst) empty envelopes below so the client
+        # fence clears deterministically.
         chat_id = data.get('chat_id')
         chat_ok = True
         if chat_id:
@@ -744,7 +767,7 @@ async def resume_stream(sid, data):
                 chat_ok = chat is not None
             except Exception as e:
                 log.warning(f'resume-stream chat ownership check failed: {e}')
-                chat_ok = True  # fail open to not regress legitimate callers
+                chat_ok = False
         if chat_ok:
             envelopes = await _stream_log_read(user_id, message_id, last_seq)
 
@@ -1049,36 +1072,32 @@ async def disconnect(sid):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # A single emitter's calls are serial (the streaming loop awaits each
-    # before the next), so seq ordering is guaranteed within one emitter.
-    # CONCURRENT emitters for the same (user_id, message_id) — e.g. a
-    # duplicate request leaking past frontend dedup, or a retry path that
-    # overlaps with the original — can interleave INCR/XADD/emit across
-    # tasks and cause live frames to arrive out of seq order. Replay
-    # reads already sort by seq so resume is safe, but live streaming in
-    # that edge case can drop a frame via the client dedupe guard. Fixing
-    # it properly needs either a distributed per-message lock or a
-    # client-side reorder buffer; neither is worth the complexity for a
-    # configuration OWUI doesn't normally produce.
+    # Concurrency note: within one worker the _emit_lock_for serializes
+    # seq-alloc + log-append + emit per (user_id, message_id), so
+    # overlapping emitters can't interleave and produce out-of-seq live
+    # frames. Cross-worker concurrent emitters for the same message_id
+    # are still unprotected (would need a distributed lock), but that's
+    # a configuration OWUI doesn't normally produce.
     async def __event_emitter__(event_data):
         user_id = request_info['user_id']
         chat_id = request_info['chat_id']
         message_id = request_info['message_id']
 
-        seq = await _stream_seq_allocate(user_id, message_id)
+        async with _emit_lock_for(user_id, message_id):
+            seq = await _stream_seq_allocate(user_id, message_id)
 
-        envelope = {
-            'chat_id': chat_id,
-            'message_id': message_id,
-            'data': event_data,
-        }
-        # Log before emit so a reconnecting client can't resume-read past
-        # a frame that hasn't been persisted yet. Client seq guard drops
-        # duplicates from the inverted race.
-        if seq is not None:
-            envelope['seq'] = seq
-            await _stream_log_append(user_id, message_id, envelope, seq)
-        await sio.emit('events', envelope, room=f'user:{user_id}')
+            envelope = {
+                'chat_id': chat_id,
+                'message_id': message_id,
+                'data': event_data,
+            }
+            # Log before emit so a reconnecting client can't resume-read past
+            # a frame that hasn't been persisted yet. Client seq guard drops
+            # duplicates from the inverted race.
+            if seq is not None:
+                envelope['seq'] = seq
+                await _stream_log_append(user_id, message_id, envelope, seq)
+            await sio.emit('events', envelope, room=f'user:{user_id}')
 
         # Any terminal event shortens TTL so log + seq self-evict together.
         # Covers normal completion (done:True), explicit cancel, and

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -191,6 +191,32 @@ RESUME_STREAM_READ_TIMEOUT_SEC = float(
     os.environ.get('RESUME_STREAM_READ_TIMEOUT_SEC', '1.0')
 )
 
+# Module-level circuit breaker for the streaming hot path. After N
+# consecutive Redis failures/timeouts, short-circuit seq/log calls for
+# a cool-down window so every outgoing frame doesn't pay the timeout
+# wall-clock cost during a sustained outage. Global (not per-message)
+# because when Redis is the thing that's unhealthy, it's unhealthy for
+# everyone.
+_HOT_PATH_BREAKER_FAILURE_THRESHOLD = 3
+_HOT_PATH_BREAKER_COOLDOWN_SEC = 10.0
+_hot_path_breaker = {'failures': 0, 'open_until': 0.0}
+
+
+def _breaker_open() -> bool:
+    return time.time() < _hot_path_breaker['open_until']
+
+
+def _breaker_record_success() -> None:
+    if _hot_path_breaker['failures']:
+        _hot_path_breaker['failures'] = 0
+        _hot_path_breaker['open_until'] = 0.0
+
+
+def _breaker_record_failure() -> None:
+    _hot_path_breaker['failures'] += 1
+    if _hot_path_breaker['failures'] >= _HOT_PATH_BREAKER_FAILURE_THRESHOLD:
+        _hot_path_breaker['open_until'] = time.time() + _HOT_PATH_BREAKER_COOLDOWN_SEC
+
 
 def _stream_key(user_id: str, message_id: str) -> str:
     # user_id-scoped key — auth is implicit from the session's user.
@@ -202,21 +228,19 @@ def _stream_seq_key(user_id: str, message_id: str) -> str:
 
 
 async def _stream_seq_allocate(user_id: str, message_id: str):
-    """Allocate the next seq via atomic INCR, or None when resume is off.
-
-    Returns None when Redis is unavailable, times out, or
-    ENABLE_REALTIME_CHAT_SAVE is set. Callers emit without seq in that
-    case — live streaming continues, no dedupe/resume for that frame.
-    """
+    """Allocate the next seq via atomic INCR, or None when resume is off."""
     if ENABLE_REALTIME_CHAT_SAVE:
         return None
     if REDIS is None or not user_id or not message_id:
+        return None
+    if _breaker_open():
         return None
     try:
         key = _stream_seq_key(user_id, message_id)
         seq = await asyncio.wait_for(
             REDIS.incr(key), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
+        _breaker_record_success()
         if seq == 1:
             try:
                 await asyncio.wait_for(
@@ -227,9 +251,11 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
                 pass
         return int(seq)
     except asyncio.TimeoutError:
+        _breaker_record_failure()
         log.warning(f'stream resume seq alloc timed out for {message_id}')
         return None
     except Exception as e:
+        _breaker_record_failure()
         log.warning(f'stream resume seq alloc failed for {message_id}: {e}')
         return None
 
@@ -237,6 +263,8 @@ async def _stream_seq_allocate(user_id: str, message_id: str):
 async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq: int) -> None:
     """Append envelope to resume log. Timeout drops the entry, not the emit."""
     if REDIS is None or not user_id or not message_id:
+        return
+    if _breaker_open():
         return
     try:
         refresh_ttl = (seq == 1) or (seq % RESUME_STREAM_TTL_REFRESH_EVERY == 0)
@@ -258,9 +286,12 @@ async def _stream_log_append(user_id: str, message_id: str, envelope: dict, seq:
         await asyncio.wait_for(
             pipe.execute(), timeout=RESUME_STREAM_REDIS_TIMEOUT_SEC
         )
+        _breaker_record_success()
     except asyncio.TimeoutError:
+        _breaker_record_failure()
         log.warning(f'stream resume log append timed out for {message_id}')
     except Exception as e:
+        _breaker_record_failure()
         log.warning(f'stream resume log append failed for {message_id}: {e}')
 
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -169,6 +169,13 @@
 
 	let taskIds = null;
 
+	// Per-message transport seq for the stream-resume protocol. Kept as a
+	// local Map (not a field on the message object) so this ephemeral
+	// bookkeeping never leaks into `history`, which is serialized and
+	// persisted via saveChatHandler. Values are refreshed in the WS event
+	// handler and consulted when requesting resume after a reconnect.
+	const resumeSeqByMessageId = new Map();
+
 	// Chat Input
 	let prompt = '';
 	let chatFiles = [];
@@ -453,14 +460,16 @@
 				// mid-stream we can request a replay of only what we missed.
 				// Also drop out-of-order replays (seq <= lastSeq) to keep
 				// delta appends idempotent when live frames race replayed
-				// frames after a reconnect.
+				// frames after a reconnect. Bookkeeping lives in the local
+				// `resumeSeqByMessageId` Map (not on the message object)
+				// to keep this transport metadata out of persisted state.
 				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
 				if (incomingSeq !== null) {
-					const lastSeq = message.lastSeq ?? 0;
+					const lastSeq = resumeSeqByMessageId.get(event.message_id) ?? 0;
 					if (incomingSeq <= lastSeq) {
 						return;
 					}
-					message.lastSeq = incomingSeq;
+					resumeSeqByMessageId.set(event.message_id, incomingSeq);
 				}
 
 				const type = event?.data?.type ?? null;
@@ -627,16 +636,17 @@
 	// Ask the server to replay any WS events we missed for the given message.
 	// Used when loading a chat with a message still in progress (page refresh
 	// mid-stream) and when the socket reconnects after a drop. The server
-	// re-emits any events we haven't seen (seq > message.lastSeq) as normal
-	// `events` frames; no separate ack. Safe to call redundantly — the seq
-	// idempotency guard in chatEventHandler drops anything already applied.
+	// re-emits any events we haven't seen (seq > the client's tracked seq)
+	// as normal `events` frames; no separate ack. Safe to call redundantly
+	// — the seq idempotency guard in chatEventHandler drops anything
+	// already applied.
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
 		$socket.emit('resume-stream', {
 			chat_id: $chatId,
 			message_id: message.id,
-			last_seq: message.lastSeq ?? 0
+			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
 		});
 	};
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -452,9 +452,12 @@
 
 			if (message) {
 				// Buffer live frames during replay; _replayed frames skip the fence.
+				// Store the ack callback alongside the event so Socket.IO
+				// call-style events (confirmation/execute/input) don't lose
+				// their response path when buffered and later replayed.
 				const queue = resumeQueueByMessageId.get(event.message_id);
 				if (queue && !event?._replayed) {
-					queue.push(event);
+					queue.push({ event, cb });
 					return;
 				}
 
@@ -664,12 +667,14 @@
 			const batch = resumeQueueByMessageId.get(messageId);
 			if (!batch || batch.length === 0) break;
 			resumeQueueByMessageId.set(messageId, []);
-			for (const event of batch) {
+			for (const item of batch) {
+				const event = item?.event;
+				const cb = item?.cb;
 				if (event && typeof event === 'object') {
 					event._replayed = true;
 				}
 				try {
-					await chatEventHandler(event);
+					await chatEventHandler(event, cb);
 				} catch (e) {
 					console.error('resume fence flush error', e);
 				}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -673,7 +673,16 @@
 		const queue = resumeQueueByMessageId.get(messageId);
 		if (!queue) return;
 		resumeQueueByMessageId.delete(messageId);
-		queue.sort((a, b) => (a?.seq ?? 0) - (b?.seq ?? 0));
+		// Stable sort: only reorder events that both carry a numeric seq.
+		// Seq-less events (Redis-down graceful-degradation case) keep
+		// their insertion order instead of being forced to the front,
+		// which would misorder state transitions like replace/done.
+		queue.sort((a, b) => {
+			const ah = typeof a?.seq === 'number';
+			const bh = typeof b?.seq === 'number';
+			if (!ah || !bh) return 0;
+			return a.seq - b.seq;
+		});
 		for (const event of queue) {
 			try {
 				await chatEventHandler(event);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -172,6 +172,12 @@
 	// Last-seen WS seq per message. Off-message so it never hits the
 	// persisted `history`.
 	const resumeSeqByMessageId = new Map();
+	// While a resume replay is in flight for a message, live frames for
+	// that message are buffered here and applied after the server's
+	// `resume-stream:complete` ack. Prevents a racing live frame from
+	// advancing seq past unreplayed frames and causing them to be dropped
+	// by the dedupe guard.
+	const resumeQueueByMessageId = new Map();
 
 	// Chat Input
 	let prompt = '';
@@ -451,6 +457,17 @@
 			let message = history.messages[event.message_id];
 
 			if (message) {
+				// If a replay is in flight for this message, buffer any
+				// live (non-replayed) frame until the server's complete
+				// ack arrives. Otherwise a live frame with seq > missed
+				// replay frames would advance lastSeq and cause the
+				// replay frames to be dropped by the dedupe guard.
+				const queue = resumeQueueByMessageId.get(event.message_id);
+				if (queue && !event?._replayed) {
+					queue.push(event);
+					return;
+				}
+
 				// Track highest seq and drop replays we've already applied.
 				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
 				if (incomingSeq !== null) {
@@ -629,10 +646,30 @@
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
+		// Raise the fence BEFORE emitting so any live frame that arrives
+		// while the server is still reading XRANGE gets buffered instead
+		// of racing the replay frames.
+		if (!resumeQueueByMessageId.has(message.id)) {
+			resumeQueueByMessageId.set(message.id, []);
+		}
 		$socket.emit('resume-stream', {
 			message_id: message.id,
 			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
 		});
+	};
+
+	const onResumeStreamComplete = async (payload) => {
+		const messageId = payload?.message_id;
+		if (!messageId) return;
+		const queue = resumeQueueByMessageId.get(messageId);
+		if (!queue) return;
+		resumeQueueByMessageId.delete(messageId);
+		// Flush buffered live frames in seq order. chatEventHandler's
+		// dedupe guard will drop anything already covered by replay.
+		queue.sort((a, b) => (a?.seq ?? 0) - (b?.seq ?? 0));
+		for (const event of queue) {
+			await chatEventHandler(event);
+		}
 	};
 
 	// Iterate all in-flight assistants so arena siblings aren't missed.
@@ -739,6 +776,7 @@
 
 		// Resume any in-flight streams on reconnect.
 		$socket?.on('connect', requestResumeForAllInProgress);
+		$socket?.on('resume-stream:complete', onResumeStreamComplete);
 
 		$audioQueue?.destroy();
 
@@ -857,6 +895,7 @@
 				window.removeEventListener('message', onMessageHandler);
 				$socket?.off('events', chatEventHandler);
 				$socket?.off('connect', requestResumeForAllInProgress);
+				$socket?.off('resume-stream:complete', onResumeStreamComplete);
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {
@@ -1120,6 +1159,7 @@
 	const initNewChat = async () => {
 		console.log('initNewChat');
 		resumeSeqByMessageId.clear();
+		resumeQueueByMessageId.clear();
 
 		if ($user?.role !== 'admin' && $user?.permissions?.chat?.temporary_enforced) {
 			await temporaryChatEnabled.set(true);
@@ -1359,6 +1399,7 @@
 		chatId.set(chatIdProp);
 
 		resumeSeqByMessageId.clear();
+		resumeQueueByMessageId.clear();
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);
@@ -1438,10 +1479,12 @@
 					currentMessage.done = true;
 				}
 
-				// Resume any in-flight streams on refresh mid-stream.
-				if (taskIds && taskIds.length > 0) {
-					requestResumeForAllInProgress();
-				}
+				// Resume any in-flight streams. Not gated on taskIds —
+				// that call can fail or race and is not authoritative;
+				// requestResumeForAllInProgress already filters to
+				// unfinished assistants and the server no-ops when no
+				// log exists.
+				requestResumeForAllInProgress();
 
 				await tick();
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -485,12 +485,10 @@
 						// Set all response messages to done
 						for (const messageId of history.messages[message.parentId].childrenIds) {
 							history.messages[messageId].done = true;
-							resumeSeqByMessageId.delete(messageId);
 						}
 						await processNextInQueue($chatId);
 					} else {
 						message.done = true;
-						resumeSeqByMessageId.delete(message.id);
 					}
 				} else if (type === 'chat:message:delta' || type === 'message') {
 					message.content += data.content;
@@ -1908,8 +1906,6 @@
 		if (done) {
 			message.done = true;
 
-			resumeSeqByMessageId.delete(message.id);
-
 			if ($settings.responseAutoCopy) {
 				copyToClipboard(message.content);
 			}
@@ -2541,7 +2537,6 @@
 			};
 
 			responseMessage.done = true;
-			resumeSeqByMessageId.delete(responseMessageId);
 
 			history.messages[responseMessageId] = responseMessage;
 			history.currentId = responseMessageId;
@@ -2609,7 +2604,6 @@
 			content: $i18n.t(`Uh-oh! There was an issue with the response.`) + '\n' + errorMessage
 		};
 		responseMessage.done = true;
-		resumeSeqByMessageId.delete(responseMessage.id);
 
 		if (responseMessage.statusHistory) {
 			responseMessage.statusHistory = responseMessage.statusHistory.filter(
@@ -2643,7 +2637,6 @@
 			if (responseMessage.parentId && history.messages[responseMessage.parentId]) {
 				for (const messageId of history.messages[responseMessage.parentId].childrenIds) {
 					history.messages[messageId].done = true;
-					resumeSeqByMessageId.delete(messageId);
 				}
 			}
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -169,11 +169,8 @@
 
 	let taskIds = null;
 
-	// Per-message transport seq for the stream-resume protocol. Kept as a
-	// local Map (not a field on the message object) so this ephemeral
-	// bookkeeping never leaks into `history`, which is serialized and
-	// persisted via saveChatHandler. Values are refreshed in the WS event
-	// handler and consulted when requesting resume after a reconnect.
+	// Last-seen WS seq per message. Off-message so it never hits the
+	// persisted `history`.
 	const resumeSeqByMessageId = new Map();
 
 	// Chat Input
@@ -454,15 +451,7 @@
 			let message = history.messages[event.message_id];
 
 			if (message) {
-				// Stream resume log: the backend stamps each outbound WS
-				// envelope with a monotonic `seq` per message_id. Track the
-				// highest seq we've seen so that if this session reconnects
-				// mid-stream we can request a replay of only what we missed.
-				// Also drop out-of-order replays (seq <= lastSeq) to keep
-				// delta appends idempotent when live frames race replayed
-				// frames after a reconnect. Bookkeeping lives in the local
-				// `resumeSeqByMessageId` Map (not on the message object)
-				// to keep this transport metadata out of persisted state.
+				// Track highest seq and drop replays we've already applied.
 				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
 				if (incomingSeq !== null) {
 					const lastSeq = resumeSeqByMessageId.get(event.message_id) ?? 0;
@@ -489,10 +478,12 @@
 						// Set all response messages to done
 						for (const messageId of history.messages[message.parentId].childrenIds) {
 							history.messages[messageId].done = true;
+							resumeSeqByMessageId.delete(messageId);
 						}
 						await processNextInQueue($chatId);
 					} else {
 						message.done = true;
+						resumeSeqByMessageId.delete(message.id);
 					}
 				} else if (type === 'chat:message:delta' || type === 'message') {
 					message.content += data.content;
@@ -633,28 +624,18 @@
 		}
 	};
 
-	// Ask the server to replay any WS events we missed for the given message.
-	// Used when loading a chat with a message still in progress (page refresh
-	// mid-stream) and when the socket reconnects after a drop. The server
-	// re-emits any events we haven't seen (seq > the client's tracked seq)
-	// as normal `events` frames; no separate ack. Safe to call redundantly
-	// — the seq idempotency guard in chatEventHandler drops anything
-	// already applied.
+	// Ask the server to replay any frames we missed for a message.
+	// Idempotent — the seq guard in chatEventHandler drops duplicates.
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
 		$socket.emit('resume-stream', {
-			chat_id: $chatId,
 			message_id: message.id,
 			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
 		});
 	};
 
-	// Resume every assistant message that isn't done yet, not just the
-	// "current" one. Multi-model (arena) chats have multiple sibling
-	// assistant responses streaming at once; without iterating them all,
-	// non-current siblings would silently lose any deltas that landed
-	// during the disconnect window.
+	// Iterate all in-flight assistants so arena siblings aren't missed.
 	const requestResumeForAllInProgress = () => {
 		if (!history?.messages) return;
 		for (const message of Object.values(history.messages)) {
@@ -756,9 +737,7 @@
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('events', chatEventHandler);
 
-		// On socket reconnect, ask the server to replay anything we missed
-		// for every assistant message that's still streaming (including
-		// multi-model siblings, not just the currently visible one).
+		// Resume any in-flight streams on reconnect.
 		$socket?.on('connect', requestResumeForAllInProgress);
 
 		$audioQueue?.destroy();
@@ -1140,9 +1119,6 @@
 
 	const initNewChat = async () => {
 		console.log('initNewChat');
-		// Reset transport bookkeeping — the new chat has no in-flight
-		// resume state, and anything carried over would be for messages
-		// that no longer exist in this view.
 		resumeSeqByMessageId.clear();
 
 		if ($user?.role !== 'admin' && $user?.permissions?.chat?.temporary_enforced) {
@@ -1382,8 +1358,6 @@
 	const loadChat = async () => {
 		chatId.set(chatIdProp);
 
-		// Clear any seq bookkeeping carried over from a previous chat
-		// before populating history with this chat's messages.
 		resumeSeqByMessageId.clear();
 
 		if ($temporaryChatEnabled) {
@@ -1464,11 +1438,7 @@
 					currentMessage.done = true;
 				}
 
-				// Stream resume: if backend tasks are still active on this
-				// chat, ask the server to replay any frames we missed for
-				// every assistant message still in progress. Covers both
-				// the single-response case and multi-model (arena) chats
-				// where several sibling assistants stream concurrently.
+				// Resume any in-flight streams on refresh mid-stream.
 				if (taskIds && taskIds.length > 0) {
 					requestResumeForAllInProgress();
 				}
@@ -1836,8 +1806,6 @@
 		if (done) {
 			message.done = true;
 
-			// Resume log entry is no longer needed; drop it so the map
-			// doesn't accumulate dead keys over long-lived sessions.
 			resumeSeqByMessageId.delete(message.id);
 
 			if ($settings.responseAutoCopy) {
@@ -2471,6 +2439,7 @@
 			};
 
 			responseMessage.done = true;
+			resumeSeqByMessageId.delete(responseMessageId);
 
 			history.messages[responseMessageId] = responseMessage;
 			history.currentId = responseMessageId;
@@ -2538,6 +2507,7 @@
 			content: $i18n.t(`Uh-oh! There was an issue with the response.`) + '\n' + errorMessage
 		};
 		responseMessage.done = true;
+		resumeSeqByMessageId.delete(responseMessage.id);
 
 		if (responseMessage.statusHistory) {
 			responseMessage.statusHistory = responseMessage.statusHistory.filter(
@@ -2571,6 +2541,7 @@
 			if (responseMessage.parentId && history.messages[responseMessage.parentId]) {
 				for (const messageId of history.messages[responseMessage.parentId].childrenIds) {
 					history.messages[messageId].done = true;
+					resumeSeqByMessageId.delete(messageId);
 				}
 			}
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -169,15 +169,9 @@
 
 	let taskIds = null;
 
-	// Last-seen WS seq per message. Off-message so it never hits the
-	// persisted `history`.
-	const resumeSeqByMessageId = new Map();
-	// While a resume replay is in flight for a message, live frames for
-	// that message are buffered here and flushed after the server's
-	// single-batch `resume-stream:replay` arrives. Prevents a racing
-	// live frame from advancing seq past unreplayed frames and causing
-	// them to be dropped by the dedupe guard.
-	const resumeQueueByMessageId = new Map();
+	// Resume-protocol state. Off-message so it doesn't leak into `history`.
+	const resumeSeqByMessageId = new Map(); // highest seq applied
+	const resumeQueueByMessageId = new Map(); // live frames buffered during replay
 
 	// Chat Input
 	let prompt = '';
@@ -457,18 +451,14 @@
 			let message = history.messages[event.message_id];
 
 			if (message) {
-				// If a replay is in flight for this message, buffer any
-				// live (non-replayed) frame until the server's complete
-				// ack arrives. Otherwise a live frame with seq > missed
-				// replay frames would advance lastSeq and cause the
-				// replay frames to be dropped by the dedupe guard.
+				// Buffer live frames during replay; _replayed frames skip the fence.
 				const queue = resumeQueueByMessageId.get(event.message_id);
 				if (queue && !event?._replayed) {
 					queue.push(event);
 					return;
 				}
 
-				// Track highest seq and drop replays we've already applied.
+				// Dedupe.
 				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
 				if (incomingSeq !== null) {
 					const lastSeq = resumeSeqByMessageId.get(event.message_id) ?? 0;
@@ -641,18 +631,11 @@
 		}
 	};
 
-	// Ask the server to replay any frames we missed for a message.
-	// Idempotent — the seq guard in chatEventHandler drops duplicates.
-	// Safety net: if a resume-stream:replay ack never arrives (server
-	// crash mid-handler, network loss between emit and ack, handler not
-	// registered yet, etc.), clear the fence and flush anyway after this
-	// timeout so live UI updates don't freeze indefinitely.
+	// Fallback timer in case the replay ack never arrives.
 	const RESUME_FENCE_TIMEOUT_MS = 10000;
 	const resumeFenceTimerByMessageId = new Map();
 
-	// Drop the fence + timer without applying any buffered events.
-	// Used on disconnect / chat-change / init transitions where the
-	// buffered events are about state that is about to become stale.
+	// Drop fence + timer without flushing (lifecycle transitions).
 	const dropResumeFence = (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
@@ -662,8 +645,10 @@
 		resumeQueueByMessageId.delete(messageId);
 	};
 
-	// Drop fence AND flush buffered events through chatEventHandler.
-	// Used on the happy path (replay ack arrived) and on timeout fallback.
+	// Drop fence AND flush buffered events (happy path + timeout).
+	// Flush in insertion order: live frames were emitted sequentially by
+	// one emitter and preserved by socket.io, so push-order == seq-order
+	// and no sort is needed (mixing with seq-less frames would reorder).
 	const clearResumeFence = async (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
@@ -673,19 +658,7 @@
 		const queue = resumeQueueByMessageId.get(messageId);
 		if (!queue) return;
 		resumeQueueByMessageId.delete(messageId);
-		// Partition into seq-bearing and seq-less events so the sort
-		// comparator is a strict ordering on its domain (avoids the
-		// engine-dependent behavior of returning 0 for mixed pairs).
-		// Apply seq-ordered events first, then seq-less (graceful
-		// degradation frames) in insertion order.
-		const withSeq = [];
-		const withoutSeq = [];
 		for (const event of queue) {
-			if (typeof event?.seq === 'number') withSeq.push(event);
-			else withoutSeq.push(event);
-		}
-		withSeq.sort((a, b) => a.seq - b.seq);
-		for (const event of [...withSeq, ...withoutSeq]) {
 			try {
 				await chatEventHandler(event);
 			} catch (e) {
@@ -697,9 +670,7 @@
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
-		// Raise the fence BEFORE emitting so any live frame arriving
-		// while the server reads XRANGE is buffered, not raced past the
-		// replay frames.
+		// Fence up before emit so racing live frames get buffered.
 		if (!resumeQueueByMessageId.has(message.id)) {
 			resumeQueueByMessageId.set(message.id, []);
 		}
@@ -723,16 +694,12 @@
 		if (!messageId) return;
 		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
 		try {
-			// Replay frames bypass the fence (they're what the fence is
-			// waiting for) but still pass through chatEventHandler's
-			// dedupe guard so anything already applied is a no-op.
 			for (const envelope of envelopes) {
 				envelope._replayed = true;
 				await chatEventHandler(envelope);
 			}
 		} finally {
-			// Always clear the fence, even if replay application threw
-			// partway through, so live updates aren't frozen forever.
+			// Finally-clear so a mid-replay throw can't freeze live updates.
 			await clearResumeFence(messageId);
 		}
 	};
@@ -848,10 +815,7 @@
 		// Resume any in-flight streams on reconnect.
 		$socket?.on('connect', requestResumeForAllInProgress);
 		$socket?.on('resume-stream:replay', onResumeStreamReplay);
-		// Drop any stale fences on disconnect so the reconnect path
-		// starts from a clean slate instead of inheriting a timer that
-		// could fire after the new resume request has already raised a
-		// fresh fence.
+		// Clean slate on reconnect so stale timers don't fire across runs.
 		$socket?.on('disconnect', dropAllResumeFences);
 
 		$audioQueue?.destroy();
@@ -973,6 +937,7 @@
 				$socket?.off('connect', requestResumeForAllInProgress);
 				$socket?.off('resume-stream:replay', onResumeStreamReplay);
 				$socket?.off('disconnect', dropAllResumeFences);
+				dropAllResumeFences();
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1140,6 +1140,11 @@
 
 	const initNewChat = async () => {
 		console.log('initNewChat');
+		// Reset transport bookkeeping — the new chat has no in-flight
+		// resume state, and anything carried over would be for messages
+		// that no longer exist in this view.
+		resumeSeqByMessageId.clear();
+
 		if ($user?.role !== 'admin' && $user?.permissions?.chat?.temporary_enforced) {
 			await temporaryChatEnabled.set(true);
 		}
@@ -1376,6 +1381,10 @@
 
 	const loadChat = async () => {
 		chatId.set(chatIdProp);
+
+		// Clear any seq bookkeeping carried over from a previous chat
+		// before populating history with this chat's messages.
+		resumeSeqByMessageId.clear();
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);
@@ -1826,6 +1835,10 @@
 
 		if (done) {
 			message.done = true;
+
+			// Resume log entry is no longer needed; drop it so the map
+			// doesn't accumulate dead keys over long-lived sessions.
+			resumeSeqByMessageId.delete(message.id);
 
 			if ($settings.responseAutoCopy) {
 				copyToClipboard(message.content);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -648,12 +648,12 @@
 	};
 
 	// Drop fence AND flush buffered events (happy path + timeout).
-	// Drains via shift() and keeps the queue live in the map while
-	// draining: chatEventHandler awaits `tick()`, yielding control.
-	// A live frame arriving during that yield must keep buffering (so
-	// it stays ordered after still-queued earlier frames); otherwise
-	// it would bypass the queue, advance lastSeq, and cause the queued
-	// frames to be dropped by the dedupe guard when we get back to them.
+	// Drain via shift(), keeping the queue present in the map so live
+	// frames arriving during an await inside chatEventHandler keep
+	// buffering into the same queue instead of racing ahead. Flushed
+	// events are marked `_replayed` before dispatch so chatEventHandler's
+	// fence-buffering branch short-circuits and doesn't re-queue them
+	// (which would be an infinite loop).
 	const clearResumeFence = async (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
@@ -664,6 +664,9 @@
 		if (!queue) return;
 		while (queue.length > 0) {
 			const event = queue.shift();
+			if (event && typeof event === 'object') {
+				event._replayed = true;
+			}
 			try {
 				await chatEventHandler(event);
 			} catch (e) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -687,10 +687,14 @@
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
-		// Fence up before emit so racing live frames get buffered.
-		if (!resumeQueueByMessageId.has(message.id)) {
-			resumeQueueByMessageId.set(message.id, []);
-		}
+		// Don't stack resume requests. If a fence already exists for
+		// this message, an earlier request is in flight (or will be
+		// resolved by its fallback timer). Stacking would reset the
+		// timer on every reconnect and, under mixed-version deployments
+		// where an old backend doesn't echo request_id, leave the fence
+		// stuck with request_ids that never match.
+		if (resumeQueueByMessageId.has(message.id)) return;
+		resumeQueueByMessageId.set(message.id, []);
 		const existingTimer = resumeFenceTimerByMessageId.get(message.id);
 		if (existingTimer) clearTimeout(existingTimer);
 		resumeFenceTimerByMessageId.set(

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -173,10 +173,10 @@
 	// persisted `history`.
 	const resumeSeqByMessageId = new Map();
 	// While a resume replay is in flight for a message, live frames for
-	// that message are buffered here and applied after the server's
-	// `resume-stream:complete` ack. Prevents a racing live frame from
-	// advancing seq past unreplayed frames and causing them to be dropped
-	// by the dedupe guard.
+	// that message are buffered here and flushed after the server's
+	// single-batch `resume-stream:replay` arrives. Prevents a racing
+	// live frame from advancing seq past unreplayed frames and causing
+	// them to be dropped by the dedupe guard.
 	const resumeQueueByMessageId = new Map();
 
 	// Chat Input

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -648,29 +648,31 @@
 	};
 
 	// Drop fence AND flush buffered events (happy path + timeout).
-	// Drain via shift(), keeping the queue present in the map so live
-	// frames arriving during an await inside chatEventHandler keep
-	// buffering into the same queue instead of racing ahead. Flushed
-	// events are marked `_replayed` before dispatch so chatEventHandler's
-	// fence-buffering branch short-circuits and doesn't re-queue them
-	// (which would be an infinite loop).
+	// Swap the queue array out for an empty one each batch so live frames
+	// arriving during an await keep buffering (into the fresh empty
+	// array that's still in the map) instead of racing ahead. Iterate
+	// the captured batch linearly, then loop until no new frames came
+	// in. O(N) drain instead of O(N²) from shift().
 	const clearResumeFence = async (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
 			clearTimeout(timer);
 			resumeFenceTimerByMessageId.delete(messageId);
 		}
-		const queue = resumeQueueByMessageId.get(messageId);
-		if (!queue) return;
-		while (queue.length > 0) {
-			const event = queue.shift();
-			if (event && typeof event === 'object') {
-				event._replayed = true;
-			}
-			try {
-				await chatEventHandler(event);
-			} catch (e) {
-				console.error('resume fence flush error', e);
+		if (!resumeQueueByMessageId.has(messageId)) return;
+		while (true) {
+			const batch = resumeQueueByMessageId.get(messageId);
+			if (!batch || batch.length === 0) break;
+			resumeQueueByMessageId.set(messageId, []);
+			for (const event of batch) {
+				if (event && typeof event === 'object') {
+					event._replayed = true;
+				}
+				try {
+					await chatEventHandler(event);
+				} catch (e) {
+					console.error('resume fence flush error', e);
+				}
 			}
 		}
 		resumeQueueByMessageId.delete(messageId);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -721,6 +721,7 @@
 		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
 		try {
 			for (const envelope of envelopes) {
+				if (!envelope || typeof envelope !== 'object') continue;
 				envelope._replayed = true;
 				await chatEventHandler(envelope);
 			}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -650,6 +650,20 @@
 	const RESUME_FENCE_TIMEOUT_MS = 10000;
 	const resumeFenceTimerByMessageId = new Map();
 
+	// Drop the fence + timer without applying any buffered events.
+	// Used on disconnect / chat-change / init transitions where the
+	// buffered events are about state that is about to become stale.
+	const dropResumeFence = (messageId) => {
+		const timer = resumeFenceTimerByMessageId.get(messageId);
+		if (timer) {
+			clearTimeout(timer);
+			resumeFenceTimerByMessageId.delete(messageId);
+		}
+		resumeQueueByMessageId.delete(messageId);
+	};
+
+	// Drop fence AND flush buffered events through chatEventHandler.
+	// Used on the happy path (replay ack arrived) and on timeout fallback.
 	const clearResumeFence = async (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
@@ -712,9 +726,9 @@
 		}
 	};
 
-	const clearAllResumeFences = () => {
+	const dropAllResumeFences = () => {
 		for (const messageId of [...resumeQueueByMessageId.keys()]) {
-			clearResumeFence(messageId);
+			dropResumeFence(messageId);
 		}
 	};
 
@@ -827,7 +841,7 @@
 		// starts from a clean slate instead of inheriting a timer that
 		// could fire after the new resume request has already raised a
 		// fresh fence.
-		$socket?.on('disconnect', clearAllResumeFences);
+		$socket?.on('disconnect', dropAllResumeFences);
 
 		$audioQueue?.destroy();
 
@@ -947,7 +961,7 @@
 				$socket?.off('events', chatEventHandler);
 				$socket?.off('connect', requestResumeForAllInProgress);
 				$socket?.off('resume-stream:replay', onResumeStreamReplay);
-				$socket?.off('disconnect', clearAllResumeFences);
+				$socket?.off('disconnect', dropAllResumeFences);
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {
@@ -1211,7 +1225,7 @@
 	const initNewChat = async () => {
 		console.log('initNewChat');
 		resumeSeqByMessageId.clear();
-		clearAllResumeFences();
+		dropAllResumeFences();
 
 		if ($user?.role !== 'admin' && $user?.permissions?.chat?.temporary_enforced) {
 			await temporaryChatEnabled.set(true);
@@ -1451,7 +1465,7 @@
 		chatId.set(chatIdProp);
 
 		resumeSeqByMessageId.clear();
-		clearAllResumeFences();
+		dropAllResumeFences();
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -724,7 +724,11 @@
 		if (expected && payload?.request_id !== expected) {
 			return;
 		}
-		resumeActiveRequestIdByMessageId.delete(messageId);
+		// Don't delete the active request_id here: a NEWER request could
+		// start during replay and set its own id. The finally below only
+		// clears the fence if we're still the active request; if a newer
+		// request has taken over, let its own lifecycle handle cleanup.
+		const ownRequestId = payload?.request_id;
 		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
 		try {
 			for (const envelope of envelopes) {
@@ -733,8 +737,10 @@
 				await chatEventHandler(envelope);
 			}
 		} finally {
-			// Finally-clear so a mid-replay throw can't freeze live updates.
-			await clearResumeFence(messageId);
+			const current = resumeActiveRequestIdByMessageId.get(messageId);
+			if (current === ownRequestId || current == null) {
+				await clearResumeFence(messageId);
+			}
 		}
 	};
 
@@ -745,10 +751,12 @@
 	};
 
 	// Iterate all in-flight assistants so arena siblings aren't missed.
+	// Strict `done === false` so legacy messages with a missing `done`
+	// field don't get fanned out as unnecessary resume requests.
 	const requestResumeForAllInProgress = () => {
 		if (!history?.messages) return;
 		for (const message of Object.values(history.messages)) {
-			if (message && message.role === 'assistant' && !message.done) {
+			if (message && message.role === 'assistant' && message.done === false) {
 				requestResumeForMessage(message);
 			}
 		}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -738,6 +738,13 @@
 		// clears the fence if we're still the active request; if a newer
 		// request has taken over, let its own lifecycle handle cleanup.
 		const ownRequestId = payload?.request_id;
+		if (payload?.truncated) {
+			// Replay omitted older entries that wouldn't fit in the Socket.IO
+			// buffer. The final done checkpoint reconciles most content;
+			// non-DB-backed side-channel events (sources/embeds) may be
+			// missing until a full chat reload.
+			console.warn('resume-stream replay truncated for', messageId);
+		}
 		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
 		try {
 			for (const envelope of envelopes) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -634,6 +634,9 @@
 	// Fallback timer in case the replay ack never arrives.
 	const RESUME_FENCE_TIMEOUT_MS = 10000;
 	const resumeFenceTimerByMessageId = new Map();
+	// Active request_id per message — lets us ignore stale replay
+	// responses from superseded requests (reconnect churn).
+	const resumeActiveRequestIdByMessageId = new Map();
 
 	// Drop fence + timer without flushing (lifecycle transitions).
 	const dropResumeFence = (messageId) => {
@@ -643,6 +646,7 @@
 			resumeFenceTimerByMessageId.delete(messageId);
 		}
 		resumeQueueByMessageId.delete(messageId);
+		resumeActiveRequestIdByMessageId.delete(messageId);
 	};
 
 	// Drop fence AND flush buffered events (happy path + timeout).
@@ -683,8 +687,14 @@
 				clearResumeFence(message.id);
 			}, RESUME_FENCE_TIMEOUT_MS)
 		);
+		const requestId =
+			typeof crypto !== 'undefined' && crypto.randomUUID
+				? crypto.randomUUID()
+				: `${message.id}-${Date.now()}-${Math.random()}`;
+		resumeActiveRequestIdByMessageId.set(message.id, requestId);
 		$socket.emit('resume-stream', {
 			message_id: message.id,
+			request_id: requestId,
 			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
 		});
 	};
@@ -692,6 +702,13 @@
 	const onResumeStreamReplay = async (payload) => {
 		const messageId = payload?.message_id;
 		if (!messageId) return;
+		// Drop stale replies from superseded requests so they can't
+		// clear a fence that belongs to a newer in-flight request.
+		const expected = resumeActiveRequestIdByMessageId.get(messageId);
+		if (expected && payload?.request_id && payload.request_id !== expected) {
+			return;
+		}
+		resumeActiveRequestIdByMessageId.delete(messageId);
 		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
 		try {
 			for (const envelope of envelopes) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1544,6 +1544,15 @@
 					taskIds = taskRes.task_ids;
 				}
 
+				// Request resume BEFORE marking messages done. The
+				// interrupted-generation heuristic below flips `done=true`
+				// when getTaskIdsByChatId returns empty/null, which can
+				// happen on API failure too; asking for resume first lets
+				// us recover when the stream is actually still alive.
+				// Server replies empty if no log exists, so a spurious
+				// request costs one round trip.
+				requestResumeForAllInProgress();
+
 				// If no active tasks and current message is incomplete, generation was interrupted
 				const currentMessage = history.currentId ? history.messages[history.currentId] : null;
 				if (
@@ -1554,13 +1563,6 @@
 				) {
 					currentMessage.done = true;
 				}
-
-				// Resume any in-flight streams. Not gated on taskIds —
-				// that call can fail or race and is not authoritative;
-				// requestResumeForAllInProgress already filters to
-				// unfinished assistants and the server no-ops when no
-				// log exists.
-				requestResumeForAllInProgress();
 
 				await tick();
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -648,9 +648,12 @@
 	};
 
 	// Drop fence AND flush buffered events (happy path + timeout).
-	// Flush in insertion order: live frames were emitted sequentially by
-	// one emitter and preserved by socket.io, so push-order == seq-order
-	// and no sort is needed (mixing with seq-less frames would reorder).
+	// Drains via shift() and keeps the queue live in the map while
+	// draining: chatEventHandler awaits `tick()`, yielding control.
+	// A live frame arriving during that yield must keep buffering (so
+	// it stays ordered after still-queued earlier frames); otherwise
+	// it would bypass the queue, advance lastSeq, and cause the queued
+	// frames to be dropped by the dedupe guard when we get back to them.
 	const clearResumeFence = async (messageId) => {
 		const timer = resumeFenceTimerByMessageId.get(messageId);
 		if (timer) {
@@ -659,14 +662,16 @@
 		}
 		const queue = resumeQueueByMessageId.get(messageId);
 		if (!queue) return;
-		resumeQueueByMessageId.delete(messageId);
-		for (const event of queue) {
+		while (queue.length > 0) {
+			const event = queue.shift();
 			try {
 				await chatEventHandler(event);
 			} catch (e) {
 				console.error('resume fence flush error', e);
 			}
 		}
+		resumeQueueByMessageId.delete(messageId);
+		resumeActiveRequestIdByMessageId.delete(messageId);
 	};
 
 	const requestResumeForMessage = (message) => {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -447,6 +447,22 @@
 			let message = history.messages[event.message_id];
 
 			if (message) {
+				// Stream resume log: the backend stamps each outbound WS
+				// envelope with a monotonic `seq` per message_id. Track the
+				// highest seq we've seen so that if this session reconnects
+				// mid-stream we can request a replay of only what we missed.
+				// Also drop out-of-order replays (seq <= lastSeq) to keep
+				// delta appends idempotent when live frames race replayed
+				// frames after a reconnect.
+				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
+				if (incomingSeq !== null) {
+					const lastSeq = message.lastSeq ?? 0;
+					if (incomingSeq <= lastSeq) {
+						return;
+					}
+					message.lastSeq = incomingSeq;
+				}
+
 				const type = event?.data?.type ?? null;
 				const data = event?.data?.data ?? null;
 
@@ -608,6 +624,33 @@
 		}
 	};
 
+	// Ask the server to replay any WS events we missed for the given message.
+	// Used when loading a chat with a message still in progress (page refresh
+	// mid-stream) and when the socket reconnects after a drop. The server
+	// replies with events we haven't seen (seq > message.lastSeq) plus a
+	// `resume-stream:ack`. Safe to call redundantly — the seq idempotency
+	// guard in chatEventHandler drops anything already applied.
+	const requestResumeForMessage = (message) => {
+		if (!message || !message.id || message.done) return;
+		if (!$socket || !$socket.connected) return;
+		$socket.emit('resume-stream', {
+			chat_id: $chatId,
+			message_id: message.id,
+			last_seq: message.lastSeq ?? 0
+		});
+	};
+
+	const requestResumeForCurrentIfInProgress = () => {
+		const currentMessage = history?.currentId ? history.messages[history.currentId] : null;
+		if (
+			currentMessage &&
+			currentMessage.role === 'assistant' &&
+			!currentMessage.done
+		) {
+			requestResumeForMessage(currentMessage);
+		}
+	};
+
 	const onMessageHandler = async (event: {
 		origin: string;
 		data: { type: string; text: string };
@@ -699,6 +742,10 @@
 		console.log('mounted');
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('events', chatEventHandler);
+
+		// On socket reconnect, ask the server to replay anything we missed
+		// for the currently visible message if it's still streaming.
+		$socket?.on('connect', requestResumeForCurrentIfInProgress);
 
 		$audioQueue?.destroy();
 
@@ -816,6 +863,7 @@
 				selectedFolderSubscribe();
 				window.removeEventListener('message', onMessageHandler);
 				$socket?.off('events', chatEventHandler);
+				$socket?.off('connect', requestResumeForCurrentIfInProgress);
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {
@@ -1391,6 +1439,20 @@
 					(!taskIds || taskIds.length === 0)
 				) {
 					currentMessage.done = true;
+				}
+
+				// Stream resume: if backend tasks are still active on this
+				// chat and the current assistant message is in progress, we
+				// may have missed WS frames while the page was reloading.
+				// Ask the server to replay anything we don't have yet.
+				if (
+					currentMessage &&
+					currentMessage.role === 'assistant' &&
+					!currentMessage.done &&
+					taskIds &&
+					taskIds.length > 0
+				) {
+					requestResumeForMessage(currentMessage);
 				}
 
 				await tick();

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -673,17 +673,19 @@
 		const queue = resumeQueueByMessageId.get(messageId);
 		if (!queue) return;
 		resumeQueueByMessageId.delete(messageId);
-		// Stable sort: only reorder events that both carry a numeric seq.
-		// Seq-less events (Redis-down graceful-degradation case) keep
-		// their insertion order instead of being forced to the front,
-		// which would misorder state transitions like replace/done.
-		queue.sort((a, b) => {
-			const ah = typeof a?.seq === 'number';
-			const bh = typeof b?.seq === 'number';
-			if (!ah || !bh) return 0;
-			return a.seq - b.seq;
-		});
+		// Partition into seq-bearing and seq-less events so the sort
+		// comparator is a strict ordering on its domain (avoids the
+		// engine-dependent behavior of returning 0 for mixed pairs).
+		// Apply seq-ordered events first, then seq-less (graceful
+		// degradation frames) in insertion order.
+		const withSeq = [];
+		const withoutSeq = [];
 		for (const event of queue) {
+			if (typeof event?.seq === 'number') withSeq.push(event);
+			else withoutSeq.push(event);
+		}
+		withSeq.sort((a, b) => a.seq - b.seq);
+		for (const event of [...withSeq, ...withoutSeq]) {
 			try {
 				await chatEventHandler(event);
 			} catch (e) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -627,9 +627,9 @@
 	// Ask the server to replay any WS events we missed for the given message.
 	// Used when loading a chat with a message still in progress (page refresh
 	// mid-stream) and when the socket reconnects after a drop. The server
-	// replies with events we haven't seen (seq > message.lastSeq) plus a
-	// `resume-stream:ack`. Safe to call redundantly — the seq idempotency
-	// guard in chatEventHandler drops anything already applied.
+	// re-emits any events we haven't seen (seq > message.lastSeq) as normal
+	// `events` frames; no separate ack. Safe to call redundantly — the seq
+	// idempotency guard in chatEventHandler drops anything already applied.
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
@@ -640,14 +640,17 @@
 		});
 	};
 
-	const requestResumeForCurrentIfInProgress = () => {
-		const currentMessage = history?.currentId ? history.messages[history.currentId] : null;
-		if (
-			currentMessage &&
-			currentMessage.role === 'assistant' &&
-			!currentMessage.done
-		) {
-			requestResumeForMessage(currentMessage);
+	// Resume every assistant message that isn't done yet, not just the
+	// "current" one. Multi-model (arena) chats have multiple sibling
+	// assistant responses streaming at once; without iterating them all,
+	// non-current siblings would silently lose any deltas that landed
+	// during the disconnect window.
+	const requestResumeForAllInProgress = () => {
+		if (!history?.messages) return;
+		for (const message of Object.values(history.messages)) {
+			if (message && message.role === 'assistant' && !message.done) {
+				requestResumeForMessage(message);
+			}
 		}
 	};
 
@@ -744,8 +747,9 @@
 		$socket?.on('events', chatEventHandler);
 
 		// On socket reconnect, ask the server to replay anything we missed
-		// for the currently visible message if it's still streaming.
-		$socket?.on('connect', requestResumeForCurrentIfInProgress);
+		// for every assistant message that's still streaming (including
+		// multi-model siblings, not just the currently visible one).
+		$socket?.on('connect', requestResumeForAllInProgress);
 
 		$audioQueue?.destroy();
 
@@ -863,7 +867,7 @@
 				selectedFolderSubscribe();
 				window.removeEventListener('message', onMessageHandler);
 				$socket?.off('events', chatEventHandler);
-				$socket?.off('connect', requestResumeForCurrentIfInProgress);
+				$socket?.off('connect', requestResumeForAllInProgress);
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {
@@ -1442,17 +1446,12 @@
 				}
 
 				// Stream resume: if backend tasks are still active on this
-				// chat and the current assistant message is in progress, we
-				// may have missed WS frames while the page was reloading.
-				// Ask the server to replay anything we don't have yet.
-				if (
-					currentMessage &&
-					currentMessage.role === 'assistant' &&
-					!currentMessage.done &&
-					taskIds &&
-					taskIds.length > 0
-				) {
-					requestResumeForMessage(currentMessage);
+				// chat, ask the server to replay any frames we missed for
+				// every assistant message still in progress. Covers both
+				// the single-response case and multi-model (arena) chats
+				// where several sibling assistants stream concurrently.
+				if (taskIds && taskIds.length > 0) {
+					requestResumeForAllInProgress();
 				}
 
 				await tick();

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -464,14 +464,17 @@
 					return;
 				}
 
-				// Dedupe.
+				// Dedupe check only — advance lastSeq at the end of the
+				// handler, not here. If a downstream handler throws (e.g.,
+				// chat:tags fetch fails), leaving lastSeq unchanged lets
+				// a subsequent replay retry that seq instead of silently
+				// skipping it.
 				const incomingSeq = typeof event?.seq === 'number' ? event.seq : null;
 				if (incomingSeq !== null) {
 					const lastSeq = resumeSeqByMessageId.get(event.message_id) ?? 0;
 					if (incomingSeq <= lastSeq) {
 						return;
 					}
-					resumeSeqByMessageId.set(event.message_id, incomingSeq);
 				}
 
 				const type = event?.data?.type ?? null;
@@ -628,6 +631,17 @@
 				}
 
 				history.messages[event.message_id] = message;
+
+				// Handler completed without throwing — safe to commit the
+				// seq now. Use max() against the current value so a
+				// concurrent higher-seq handler that committed during our
+				// awaits doesn't get clobbered.
+				if (incomingSeq !== null) {
+					const current = resumeSeqByMessageId.get(event.message_id) ?? 0;
+					if (incomingSeq > current) {
+						resumeSeqByMessageId.set(event.message_id, incomingSeq);
+					}
+				}
 			}
 		} else {
 			// Non-active chat completion: queue stays in the global store.
@@ -635,8 +649,12 @@
 		}
 	};
 
-	// Fallback timer in case the replay ack never arrives.
-	const RESUME_FENCE_TIMEOUT_MS = 10000;
+	// Fallback timer in case the replay ack never arrives. 5s balances:
+	// a legitimately slow Redis XRANGE at RESUME_STREAM_READ_TIMEOUT_SEC
+	// (1s default), versus how long the UI should hold live frames if
+	// a peer backend silently drops the request (mixed-version rollout,
+	// handler not registered, etc).
+	const RESUME_FENCE_TIMEOUT_MS = 5000;
 	const resumeFenceTimerByMessageId = new Map();
 	// Active request_id per message — lets us ignore stale replay
 	// responses from superseded requests (reconnect churn).

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -699,6 +699,7 @@
 				: `${message.id}-${Date.now()}-${Math.random()}`;
 		resumeActiveRequestIdByMessageId.set(message.id, requestId);
 		$socket.emit('resume-stream', {
+			chat_id: $chatId,
 			message_id: message.id,
 			request_id: requestId,
 			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
@@ -708,10 +709,12 @@
 	const onResumeStreamReplay = async (payload) => {
 		const messageId = payload?.message_id;
 		if (!messageId) return;
-		// Drop stale replies from superseded requests so they can't
-		// clear a fence that belongs to a newer in-flight request.
+		// Drop stale replies. If an active request_id is set for this
+		// message, require an exact match — a reply without a request_id,
+		// or with a mismatched one, belongs to a superseded request and
+		// must not clear the active fence.
 		const expected = resumeActiveRequestIdByMessageId.get(messageId);
-		if (expected && payload?.request_id && payload.request_id !== expected) {
+		if (expected && payload?.request_id !== expected) {
 			return;
 		}
 		resumeActiveRequestIdByMessageId.delete(messageId);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -768,7 +768,14 @@
 			for (const envelope of envelopes) {
 				if (!envelope || typeof envelope !== 'object') continue;
 				envelope._replayed = true;
-				await chatEventHandler(envelope);
+				try {
+					await chatEventHandler(envelope);
+				} catch (e) {
+					// Per-envelope catch so one bad frame doesn't abort
+					// the rest of the replay batch and silently lose the
+					// envelopes that come after it.
+					console.error('resume replay envelope error', e);
+				}
 			}
 		} finally {
 			const current = resumeActiveRequestIdByMessageId.get(messageId);

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -451,12 +451,15 @@
 			let message = history.messages[event.message_id];
 
 			if (message) {
-				// Buffer live frames during replay; _replayed frames skip the fence.
-				// Store the ack callback alongside the event so Socket.IO
-				// call-style events (confirmation/execute/input) don't lose
-				// their response path when buffered and later replayed.
+				// Buffer live frames during replay; _replayed frames skip
+				// the fence. Call-style events that carry an ack callback
+				// ALSO skip the fence — the server is waiting on the ack
+				// and buffering could exceed WEBSOCKET_EVENT_CALLER_TIMEOUT
+				// (up to RESUME_FENCE_TIMEOUT_MS of delay). Ack events
+				// don't carry seq and don't mutate streamed content, so
+				// bypassing is safe against the original replay race.
 				const queue = resumeQueueByMessageId.get(event.message_id);
-				if (queue && !event?._replayed) {
+				if (queue && !event?._replayed && !cb) {
 					queue.push({ event, cb });
 					return;
 				}
@@ -701,7 +704,9 @@
 			message.id,
 			setTimeout(() => {
 				console.warn('resume-stream fence timed out for', message.id);
-				clearResumeFence(message.id);
+				clearResumeFence(message.id).catch((e) =>
+					console.error('resume fence timeout flush failed', e)
+				);
 			}, RESUME_FENCE_TIMEOUT_MS)
 		);
 		const requestId =

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -643,32 +643,78 @@
 
 	// Ask the server to replay any frames we missed for a message.
 	// Idempotent — the seq guard in chatEventHandler drops duplicates.
+	// Safety net: if a resume-stream:replay ack never arrives (server
+	// crash mid-handler, network loss between emit and ack, handler not
+	// registered yet, etc.), clear the fence and flush anyway after this
+	// timeout so live UI updates don't freeze indefinitely.
+	const RESUME_FENCE_TIMEOUT_MS = 10000;
+	const resumeFenceTimerByMessageId = new Map();
+
+	const clearResumeFence = async (messageId) => {
+		const timer = resumeFenceTimerByMessageId.get(messageId);
+		if (timer) {
+			clearTimeout(timer);
+			resumeFenceTimerByMessageId.delete(messageId);
+		}
+		const queue = resumeQueueByMessageId.get(messageId);
+		if (!queue) return;
+		resumeQueueByMessageId.delete(messageId);
+		queue.sort((a, b) => (a?.seq ?? 0) - (b?.seq ?? 0));
+		for (const event of queue) {
+			try {
+				await chatEventHandler(event);
+			} catch (e) {
+				console.error('resume fence flush error', e);
+			}
+		}
+	};
+
 	const requestResumeForMessage = (message) => {
 		if (!message || !message.id || message.done) return;
 		if (!$socket || !$socket.connected) return;
-		// Raise the fence BEFORE emitting so any live frame that arrives
-		// while the server is still reading XRANGE gets buffered instead
-		// of racing the replay frames.
+		// Raise the fence BEFORE emitting so any live frame arriving
+		// while the server reads XRANGE is buffered, not raced past the
+		// replay frames.
 		if (!resumeQueueByMessageId.has(message.id)) {
 			resumeQueueByMessageId.set(message.id, []);
 		}
+		const existingTimer = resumeFenceTimerByMessageId.get(message.id);
+		if (existingTimer) clearTimeout(existingTimer);
+		resumeFenceTimerByMessageId.set(
+			message.id,
+			setTimeout(() => {
+				console.warn('resume-stream fence timed out for', message.id);
+				clearResumeFence(message.id);
+			}, RESUME_FENCE_TIMEOUT_MS)
+		);
 		$socket.emit('resume-stream', {
 			message_id: message.id,
 			last_seq: resumeSeqByMessageId.get(message.id) ?? 0
 		});
 	};
 
-	const onResumeStreamComplete = async (payload) => {
+	const onResumeStreamReplay = async (payload) => {
 		const messageId = payload?.message_id;
 		if (!messageId) return;
-		const queue = resumeQueueByMessageId.get(messageId);
-		if (!queue) return;
-		resumeQueueByMessageId.delete(messageId);
-		// Flush buffered live frames in seq order. chatEventHandler's
-		// dedupe guard will drop anything already covered by replay.
-		queue.sort((a, b) => (a?.seq ?? 0) - (b?.seq ?? 0));
-		for (const event of queue) {
-			await chatEventHandler(event);
+		const envelopes = Array.isArray(payload?.envelopes) ? payload.envelopes : [];
+		try {
+			// Replay frames bypass the fence (they're what the fence is
+			// waiting for) but still pass through chatEventHandler's
+			// dedupe guard so anything already applied is a no-op.
+			for (const envelope of envelopes) {
+				envelope._replayed = true;
+				await chatEventHandler(envelope);
+			}
+		} finally {
+			// Always clear the fence, even if replay application threw
+			// partway through, so live updates aren't frozen forever.
+			await clearResumeFence(messageId);
+		}
+	};
+
+	const clearAllResumeFences = () => {
+		for (const messageId of [...resumeQueueByMessageId.keys()]) {
+			clearResumeFence(messageId);
 		}
 	};
 
@@ -776,7 +822,12 @@
 
 		// Resume any in-flight streams on reconnect.
 		$socket?.on('connect', requestResumeForAllInProgress);
-		$socket?.on('resume-stream:complete', onResumeStreamComplete);
+		$socket?.on('resume-stream:replay', onResumeStreamReplay);
+		// Drop any stale fences on disconnect so the reconnect path
+		// starts from a clean slate instead of inheriting a timer that
+		// could fire after the new resume request has already raised a
+		// fresh fence.
+		$socket?.on('disconnect', clearAllResumeFences);
 
 		$audioQueue?.destroy();
 
@@ -895,7 +946,8 @@
 				window.removeEventListener('message', onMessageHandler);
 				$socket?.off('events', chatEventHandler);
 				$socket?.off('connect', requestResumeForAllInProgress);
-				$socket?.off('resume-stream:complete', onResumeStreamComplete);
+				$socket?.off('resume-stream:replay', onResumeStreamReplay);
+				$socket?.off('disconnect', clearAllResumeFences);
 				audioQueueInstance?.destroy();
 				audioQueue.set(null);
 			} catch (e) {
@@ -1159,7 +1211,7 @@
 	const initNewChat = async () => {
 		console.log('initNewChat');
 		resumeSeqByMessageId.clear();
-		resumeQueueByMessageId.clear();
+		clearAllResumeFences();
 
 		if ($user?.role !== 'admin' && $user?.permissions?.chat?.temporary_enforced) {
 			await temporaryChatEnabled.set(true);
@@ -1399,7 +1451,7 @@
 		chatId.set(chatIdProp);
 
 		resumeSeqByMessageId.clear();
-		resumeQueueByMessageId.clear();
+		clearAllResumeFences();
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);


### PR DESCRIPTION
# This PR SHOULDNT BE MERGED WITHOUT ALSO MERGING THIS https://github.com/open-webui/open-webui/pull/23859

Adds a bounded Redis stream log for every in-flight assistant message so clients can reconnect mid-stream (page refresh, network drop, device switch) and catch up on frames they missed without re-fetching the full chat from the database.

Problem this solves
-------------------
With ENABLE_REALTIME_CHAT_SAVE=False (default), the backend does not write the assistant message to the DB until the stream finishes. If the client refreshes the page mid-stream, chat load from the DB returns nothing for the in-progress message and the response appears to vanish until the stream eventually completes. Users staring at an empty chat while the backend quietly keeps emitting tokens into the void.

Design
------
* Every outbound WS envelope gets stamped with a monotonic per-message `seq` inside `get_event_emitter` and appended to a bounded Redis stream keyed `{REDIS_KEY_PREFIX}:stream:{message_id}`. MAXLEN ~ 2000 entries, TTL 1h as a safety net.
* Clients track `message.lastSeq` in Chat.svelte as events arrive. On chat load (mid-stream refresh) and on socket reconnect they emit `resume-stream {chat_id, message_id, last_seq}`.
* The server authenticates the session, verifies the user owns the chat, XRANGEs the log, filters by `seq > last_seq`, and emits the missed envelopes to THAT session only (via `to=sid`) so live listeners in the user room keep receiving their normal live stream unchanged.
* The existing chat event handler drops any envelope with `seq <= message.lastSeq`, making replay idempotent against live frames that race the replay after a reconnect.
* When an event with `done: True` fires, a background task truncates the log after a 30s grace window so late reconnects still catch the finalization; anything beyond that resumes from the now-up-to-date DB.

Orthogonality
-------------
Zero touches to middleware.py or the streaming hot path. The log stores whatever gets emitted; any future change to emit shape (chat:message:delta, per-block ops, JSON Patch, ...) is logged and replayed verbatim with no coupling.

Graceful degradation
--------------------
No-op when Redis is not configured (WEBSOCKET_MANAGER != 'redis'). In that deployment mode, refresh during streaming retains the current behavior of waiting for the stream to complete.

Auth model
----------
The log is keyed by message_id only. The resume handler must do a chat ownership check (Chats.get_chat_by_id_and_user_id) before replaying, so a malicious client cannot read another user's stream by guessing a message_id.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
