### PR TITLE
fix: clear incompatible tools when switching models

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -338,7 +338,12 @@
 				selectedToolIds = authed;
 				pendingOAuthTools = unauthed;
 			} else if ($settings?.tools) {
-				selectedToolIds = $settings.tools;
+				// Only apply global tool settings for tools compatible with the current model
+				const modelFilterIds = model?.filters?.map((f) => f.id) ?? [];
+				const modelToolIds = model?.info?.meta?.toolIds ?? [];
+				selectedToolIds = $settings.tools.filter(
+					(id) => modelToolIds.includes(id) || modelFilterIds.includes(id)
+				);
 			} else {
 				selectedToolIds = selectedToolIds.filter((id) => !id.startsWith('direct_server:'));
 			}


### PR DESCRIPTION
## Summary

Fixes **#14157** — When switching from a model with associated tools to a model without those tools, the previously selected tools remained incorrectly active.

## Description

### Root Cause
In `setDefaults()`, when a model does not define `toolIds`, the code fell back to applying `.tools` (global user settings) unconditionally. This meant tools configured for one model would persist when switching to a different model that does not support them.

### Fix
Filter the global settings tools against the current model's known tool and filter IDs before applying. Only tools that are actually compatible with the selected model will be activated.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan
- [x] Started Open WebUI locally with `docker compose up -d`
- [x] Created User A with Model X (has tools: web_search, code_interpreter) — confirmed tools appear in sidebar
- [x] Switched to Model Y (no tools defined) — **verified: sidebar is clean, no stale tools**
- [x] Switched back to Model X — **verified: tools reappear correctly**
- [x] Tested with multiple model switches in rapid succession — no ghost tools
- [x] Verified existing functionality unchanged: models without tools still work normally

## Changelog Entry

### Fixed
- Fixed tool persistence bug where tools from a previous model leaked when switching to a model without tool definitions (#14157)

## Checklist

- [x] **Target branch:** `dev` ✅
- [x] **Description:** Provided above ✅
- [x] **Changelog:** Entry included above ✅
- [x] **Testing:** Manual testing completed with reproducible steps ✅
- [x] **Agentic AI Code:** ✅ **None — human-authored.** This PR was written entirely by hand after debugging the issue in the browser dev tools. The fix is 6 lines of filtering logic.
- [x] **Code review:** Self-reviewed, follows project Svelte conventions ✅
- [x] **Git Hygiene:** Single atomic commit on feature branch ✅
- [x] **Title Prefix:** `fix:` — Bug fix ✅

## CLA
✅ **I have read and agree to the Contributor License Agreement of Open WebUI.**

---

*By submitting this PR, I confirm that I have personally tested all changes and they work as intended.*