### PR TITLE
fix: add missing db parameter to filter_allowed_access_grants in update_note_access_by_id

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -397,6 +397,7 @@ async def update_note_access_by_id(
         user.role,
         form_data.access_grants,
         'sharing.public_notes',
+        db=db,
     )
 
     await AccessGrants.set_access_grants('note', id, form_data.access_grants, db=db)


### PR DESCRIPTION
## Description

In `update_note_access_by_id()`, the call to `filter_allowed_access_grants()` at line 394 is missing the `db=db` parameter. The same function is called correctly with `db=db` in `create_new_note()` (line 224) and `update_note_by_id()` (line 336).

Without `db`, the function falls back to `None` and may fail to validate group-based access grants that require database lookups.

### Changelog

- **Fixed**: Missing `db` parameter in `filter_allowed_access_grants()` call within `update_note_access_by_id()`

### Breaking Changes

- None

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.