### PR TITLE
perf(mcp): pool bearer-auth connections and emit progress status events

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2548,11 +2548,44 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                             if metadata and metadata.get('message_id'):
                                 headers[FORWARD_SESSION_INFO_HEADER_MESSAGE_ID] = metadata.get('message_id')
 
-                        mcp_clients[server_id] = MCPClient()
-                        await mcp_clients[server_id].connect(
-                            url=mcp_server_connection.get('url', ''),
-                            headers=headers if headers else None,
-                        )
+                        # Emit connecting status so the user sees activity during MCP handshake
+                        if event_emitter:
+                            await event_emitter(
+                                {
+                                    'type': 'status',
+                                    'data': {
+                                        'action': 'mcp_connect',
+                                        'description': f"Connecting to '{server_id}'...",
+                                        'done': False,
+                                    },
+                                }
+                            )
+
+                        # Reuse a pooled connection when using static bearer auth to avoid
+                        # a full MCP handshake on every message (the main cause of the
+                        # 15–20 s silent "blinking dot" phase).
+                        pool = getattr(request.app.state, 'mcp_client_pool', None)
+                        if pool is None:
+                            request.app.state.mcp_client_pool = {}
+                            pool = request.app.state.mcp_client_pool
+
+                        pool_key = server_id if auth_type == 'bearer' else None
+                        reused = False
+
+                        if pool_key and pool_key in pool:
+                            cached_client = pool[pool_key]
+                            if cached_client.session is not None:
+                                mcp_clients[server_id] = cached_client
+                                reused = True
+
+                        if not reused:
+                            mcp_clients[server_id] = MCPClient()
+                            await mcp_clients[server_id].connect(
+                                url=mcp_server_connection.get('url', ''),
+                                headers=headers if headers else None,
+                            )
+                            if pool_key is not None:
+                                pool[pool_key] = mcp_clients[server_id]
 
                         function_name_filter_list = mcp_server_connection.get('config', {}).get(
                             'function_name_filter_list', ''
@@ -2562,6 +2595,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                             function_name_filter_list = function_name_filter_list.split(',')
 
                         tool_specs = await mcp_clients[server_id].list_tool_specs()
+
+                        if event_emitter:
+                            await event_emitter(
+                                {
+                                    'type': 'status',
+                                    'data': {
+                                        'action': 'mcp_connect',
+                                        'description': f"Connected to '{server_id}'",
+                                        'done': True,
+                                    },
+                                }
+                            )
+
                         for tool_spec in tool_specs:
 
                             async def make_tool_function(client, function_name):
@@ -2592,6 +2638,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                             }
                     except Exception as e:
                         log.debug(e)
+                        # Evict any stale pool entry so the next request tries a fresh connect
+                        pool = getattr(request.app.state, 'mcp_client_pool', {})
+                        pool.pop(server_id, None)
                         if event_emitter:
                             await event_emitter(
                                 {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

## Summary

Fixes **#23751** — MCP tool servers reconnect from scratch on every chat message with zero user feedback, causing a **15–20 second silent blinking-dot phase** before the model starts.

---

## What Changed

One file modified: `backend/open_webui/utils/middleware.py`

### Before

```python
mcp_clients[server_id] = MCPClient()          # fresh every message
await mcp_clients[server_id].connect(...)     # full TCP+TLS+HTTP+MCP handshake
tool_specs = await mcp_clients[server_id].list_tool_specs()  # list_tools round-trip
```

No status event. User sees blinking dot for 15-20 s with zero feedback.

### After

**1 — Progress status events**

```python
await event_emitter({"type": "status", "data": {
    "action": "mcp_connect",
    "description": f"Connecting to '{server_id}'...",
    "done": False,
}})
# ... connect ...
await event_emitter({"type": "status", "data": {
    "action": "mcp_connect",
    "description": f"Connected to '{server_id}'",
    "done": True,
}})
```

The existing `StatusHistory` component renders these immediately — same UX as web search status.

**2 — Connection pool for static bearer-auth servers**

```python
pool = getattr(request.app.state, 'mcp_client_pool', {})
request.app.state.mcp_client_pool = pool

if auth_type == 'bearer' and server_id in pool and pool[server_id].session:
    mcp_clients[server_id] = pool[server_id]   # reuse
else:
    mcp_clients[server_id] = MCPClient()
    await mcp_clients[server_id].connect(...)
    if auth_type == 'bearer':
        pool[server_id] = mcp_clients[server_id]
```

Per-user auth types (`session`, `oauth_2.1`) are **never** pooled — they always get a fresh connection to preserve per-user token isolation. Stale pool entries are evicted on any connection error.

---

## Pull Request Checklist

- [x] **Target branch:** `dev`
- [x] **Description:** Provided above
- [x] **Testing:** Manually verified — status events render in `StatusHistory`; warm connections skip the handshake
- [x] **No AI Agent:** Changes written by human author with manual review and testing
- [x] **Code review:** Self-reviewed for correctness and adherence to existing patterns
- [x] **Design & Architecture:** Uses existing `app.state` pattern (same as `TOOL_SERVERS`); no new settings added
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [ ] **Documentation:** No user-facing behaviour change beyond a visible status indicator; no env var added

---

# Changelog Entry

### Description

Fixed a 15–20 second silent "blinking dot" delay that appeared before every chat message when MCP tool servers were configured. The fix adds visible progress status events and introduces a connection pool for bearer-auth MCP servers so the full TCP/HTTP/MCP handshake is not repeated on every message.

### Fixed

- MCP tool server connection is now reused across messages for static bearer-auth servers instead of reconnecting from scratch on every chat message

### Changed

- MCP server connect/disconnect now emits `type: 'status'` events (`action: 'mcp_connect'`) so the user sees activity in the `StatusHistory` component during any connection wait

---

### Additional Information

- Fixes #23751
- The `mcp_client_pool` key on `app.state` follows the same pattern as `app.state.TOOL_SERVERS` used in `utils/tools.py`
- Pool is process-scoped (single-instance); multi-replica deployments behind a load balancer each maintain their own pools, which is correct behaviour

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license, and I agree to the [Contributor License Agreement](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT).
