### PR TITLE
fix(ui): prevent showControls cross-tab state leak via localStorage

### DIFF
--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -217,7 +217,9 @@
 							<button
 								class=" flex cursor-pointer px-2 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"
 								on:click={async () => {
-									await showControls.set(!$showControls);
+									const next = !$showControls;
+									await showControls.set(next);
+									localStorage.showControls = next ? 'true' : 'false';
 								}}
 								aria-label="Controls"
 							>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -344,12 +344,10 @@
 				checkForVersionUpdates();
 			}
 		}
-		// Persist showControls: track open/close state separately from saved size
-		// chatControlsSize always retains the last width for openPane()
+		// Restore showControls from the user's last explicit toggle.
+		// We intentionally do NOT subscribe here — programmatic changes from
+		// Artifacts or Citations must not bleed into other tabs via localStorage.
 		await showControls.set(!$mobile ? localStorage.showControls === 'true' : false);
-		showControls.subscribe((value) => {
-			localStorage.showControls = value ? 'true' : 'false';
-		});
 
 		// Persist selectedTerminalId across page loads
 		selectedTerminalId.set(localStorage.selectedTerminalId ?? null);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Concise description provided below.
- [x] **Changelog:** Changelog entry included below.
- [ ] **Documentation:** No user-facing docs change needed — this is an internal UI state bug.
- [x] **Dependencies:** No new or changed dependencies.
- [x] **Testing:** Manually verified — steps to reproduce the issue and confirm the fix are included below.
- [x] **Agentic AI Code:** This PR was written and reviewed by me. I traced the bug, understood the root cause, and made the minimal surgical change.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** No new settings introduced. Ephemeral UI state (Artifacts, Citations) no longer bleeds into localStorage.
- [x] **Git Hygiene:** Single logical change, rebased on `dev`.
- [x] **Title Prefix:** `fix` prefix applied.

---

## Description

Fixes #23232.

Opening an Artifacts preview in one tab silently set `localStorage.showControls = 'true'`. Any new tab navigating to Home would then read that value on mount and auto-expand the Controls panel without any user interaction.

### Root cause

`(app)/+layout.svelte` subscribed to the `showControls` Svelte store unconditionally:

```ts
showControls.subscribe((value) => {
    localStorage.showControls = value ? 'true' : 'false';
});
```

This persisted **every** mutation — including programmatic `showControls.set(false)` calls from `Artifacts.svelte` and `showControls.set(true)` from `Citations.svelte` / `ContentRenderer.svelte`. Those writes propagated to every other tab via shared localStorage.

### Fix

Remove the unconditional subscriber from the layout. The layout still reads `localStorage.showControls` once on mount to restore the user's preference. Persistence is now written only in `Navbar.svelte`, inside the Controls button's `on:click` handler — so localStorage only reflects deliberate user toggles.

### Files changed

- `src/routes/(app)/+layout.svelte` — removed `showControls.subscribe()` that was writing to localStorage
- `src/lib/components/chat/Navbar.svelte` — added explicit `localStorage.showControls` write on user click

### Steps to reproduce (before fix)

1. Open Open WebUI in Tab A
2. Start a chat and trigger an Artifacts preview (any code/HTML artifact)
3. Open Tab B → navigate to Home
4. **Observe:** Controls/Advanced Settings panel auto-expands in Tab B with no user action

### After fix

Tab B opens with Controls panel collapsed, regardless of what Tab A did programmatically.

---

# Changelog Entry

### Fixed

- Fixed cross-tab UI state leak where opening an Artifacts preview in one tab would cause the Controls/Advanced Settings panel to auto-expand in other tabs. `showControls` is now only persisted to `localStorage` on explicit user interaction, not on programmatic store mutations from Artifacts or Citations components.

---

### Additional Information

- Related to the general principle noted in the PR template: ephemeral UI logic should use local state, not shared storage.

### Screenshots or Videos

N/A — the fix is a state management correction with no visual change to the Controls panel itself.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.