### PR TITLE
fix: run outlet filters for API callers without chat_id / message_id

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3070,8 +3070,7 @@ async def outlet_filter_handler(ctx):
 
     For temp chats (local: prefix) and API callers without a persisted
     chat_id / message_id, messages are built from form_data plus the
-    assistant response message stored in ctx['assistant_message'], since
-    these callers have no DB-persisted history. See #23740.
+    assistant response message stored in ctx['assistant_message'].
     """
     request = ctx['request']
     user = ctx['user']
@@ -3083,29 +3082,15 @@ async def outlet_filter_handler(ctx):
     chat_id = metadata.get('chat_id', '')
     message_id = metadata.get('message_id')
 
-    # In-memory branch covers:
-    #   - temp chats (chat_id starts with 'local:')
-    #   - API callers that omit chat_id and/or id in the request body
-    is_temp_chat = (
-        not chat_id
-        or chat_id.startswith('local:')
-        or not message_id
-    )
+    is_temp_chat = not chat_id or chat_id.startswith('local:') or not message_id
 
     try:
         messages_map = None
 
         if is_temp_chat:
-            # Synthesize local-only ids for the outlet payload when the
-            # caller didn't provide them. Scope these to outlet_data only —
-            # do NOT write them back to metadata, because the surrounding
-            # pipeline (streaming save, event routing, webhook URLs) must
-            # keep seeing the real values.
             effective_chat_id = chat_id or f'local:{uuid4()}'
             effective_message_id = message_id or str(uuid4())
 
-            # Temp / API callers have no DB record — build message list
-            # from the in-memory form_data plus the assistant response.
             form_messages = ctx.get('form_data', {}).get('messages', [])
             assistant_message = ctx.get('assistant_message', {})
 
@@ -3118,7 +3103,6 @@ async def outlet_filter_handler(ctx):
                 if isinstance(m, dict)
             ]
 
-            # Append the full assistant message (content, output, usage, etc.)
             if assistant_message:
                 message_list.append({
                     'id': effective_message_id,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3068,9 +3068,10 @@ async def outlet_filter_handler(ctx):
     Persists outlet-modified content to DB and emits a chat:outlet event
     so the frontend can sync its in-memory state.
 
-    For temp chats (local: prefix), messages are built from form_data
-    plus the assistant response message stored in ctx['assistant_message'],
-    since temp chats have no DB-persisted history.
+    For temp chats (local: prefix) and API callers without a persisted
+    chat_id / message_id, messages are built from form_data plus the
+    assistant response message stored in ctx['assistant_message'], since
+    these callers have no DB-persisted history. See #23740.
     """
     request = ctx['request']
     user = ctx['user']
@@ -3082,17 +3083,29 @@ async def outlet_filter_handler(ctx):
     chat_id = metadata.get('chat_id', '')
     message_id = metadata.get('message_id')
 
-    if not chat_id or not message_id:
-        return
-
-    is_temp_chat = chat_id.startswith('local:')
+    # In-memory branch covers:
+    #   - temp chats (chat_id starts with 'local:')
+    #   - API callers that omit chat_id and/or id in the request body
+    is_temp_chat = (
+        not chat_id
+        or chat_id.startswith('local:')
+        or not message_id
+    )
 
     try:
         messages_map = None
 
         if is_temp_chat:
-            # Temp chats have no DB record — build message list from
-            # the in-memory form_data plus the assistant response.
+            # Synthesize local-only ids for the outlet payload when the
+            # caller didn't provide them. Scope these to outlet_data only —
+            # do NOT write them back to metadata, because the surrounding
+            # pipeline (streaming save, event routing, webhook URLs) must
+            # keep seeing the real values.
+            effective_chat_id = chat_id or f'local:{uuid4()}'
+            effective_message_id = message_id or str(uuid4())
+
+            # Temp / API callers have no DB record — build message list
+            # from the in-memory form_data plus the assistant response.
             form_messages = ctx.get('form_data', {}).get('messages', [])
             assistant_message = ctx.get('assistant_message', {})
 
@@ -3102,16 +3115,19 @@ async def outlet_filter_handler(ctx):
                     'content': m.get('content', ''),
                 }
                 for m in form_messages
+                if isinstance(m, dict)
             ]
 
             # Append the full assistant message (content, output, usage, etc.)
             if assistant_message:
                 message_list.append({
-                    'id': message_id,
+                    'id': effective_message_id,
                     'role': 'assistant',
                     **assistant_message,
                 })
         else:
+            effective_chat_id = chat_id
+            effective_message_id = message_id
             messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
             if not messages_map:
                 return
@@ -3138,9 +3154,9 @@ async def outlet_filter_handler(ctx):
                 for m in message_list
             ],
             'filter_ids': metadata.get('filter_ids', []),
-            'chat_id': chat_id,
+            'chat_id': effective_chat_id,
             'session_id': metadata.get('session_id'),
-            'id': message_id,
+            'id': effective_message_id,
         }
 
         # Pipeline outlet filters


### PR DESCRIPTION
Upstream 70a6a24 extended outlet_filter_handler to handle temp chats (chat_id prefixed with 'local:') by building the message list in-memory from form_data + ctx['assistant_message']. API callers of /api/chat/completions that omit chat_id and/or id in the request body still hit the early-return guard and never had their outlet filters run.

Route those callers into the same in-memory branch and synthesize local-only chat_id / message_id values scoped to the outlet payload (never written back to metadata, so streaming save, event routing and webhook URLs keep seeing the real None values). Closes #23740.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
