### PR TITLE
fix: run outlet filters for API callers (streaming + non-streaming)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2867,6 +2867,26 @@ async def get_system_oauth_token(request, user):
     return oauth_token
 
 
+async def _noop_event_emitter(event_data):
+    """No-op emitter used to keep background_tasks_handler's DB-only side
+    effects (auto-title, auto-tags, follow-ups persistence) working for
+    persisted chats whose caller has no WebSocket session."""
+    return None
+
+
+async def _run_background_tasks(ctx):
+    """Run background_tasks_handler with a no-op event_emitter fallback,
+    wrapped so a failure cannot prevent outlet_filter_handler from running."""
+    if ctx.get('event_emitter'):
+        bg_ctx = ctx
+    else:
+        bg_ctx = {**ctx, 'event_emitter': _noop_event_emitter}
+    try:
+        await background_tasks_handler(bg_ctx)
+    except Exception as e:
+        log.debug(f'background_tasks_handler error: {e}')
+
+
 async def background_tasks_handler(ctx):
     request = ctx['request']
     form_data = ctx['form_data']
@@ -3334,14 +3354,11 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                # background_tasks_handler assumes persisted-chat metadata
-                # and a working event_emitter for follow-ups / title / tags
-                # generation; isolate failures so outlet still runs.
-                if is_persisted_chat and event_emitter:
-                    try:
-                        await background_tasks_handler(ctx)
-                    except Exception as e:
-                        log.debug(f'background_tasks_handler error: {e}')
+                # Run follow-ups / auto-title / auto-tags for persisted
+                # chats; uses a no-op emitter fallback when there's no
+                # WebSocket session, so DB side-effects still land.
+                if is_persisted_chat:
+                    await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {
                     'content': content,
@@ -4914,11 +4931,18 @@ async def streaming_chat_response_handler(response, ctx):
             def _parse_line(line):
                 nonlocal accumulated_content, accumulated_usage
                 line = line.strip()
-                # Accept "data: {...}" and "data:{...}" (SSE spec allows both).
-                if not line.startswith('data:'):
+                if not line:
                     return
-                payload = line[5:].lstrip()
-                if not payload or payload == '[DONE]':
+                # Accept SSE framing ("data: {...}" / "data:{...}") AND
+                # raw NDJSON lines (application/x-ndjson is routed through
+                # this same handler by process_chat_response).
+                if line.startswith('data:'):
+                    payload = line[5:].lstrip()
+                    if not payload or payload == '[DONE]':
+                        return
+                elif line.startswith('{') or line.startswith('['):
+                    payload = line
+                else:
                     return
                 try:
                     chunk = json.loads(payload)
@@ -5018,6 +5042,15 @@ async def streaming_chat_response_handler(response, ctx):
                     else []
                 )
 
+                # Normalize usage for schema parity with the main / non-
+                # streaming paths (both call normalize_usage before
+                # persisting / emitting).
+                normalized_usage = (
+                    normalize_usage(accumulated_usage)
+                    if isinstance(accumulated_usage, dict)
+                    else None
+                )
+
                 # Persist the final assistant message for persisted chats.
                 # Backend callers that provide chat_id + message_id but no
                 # session take this fallback path; without this write, outlet
@@ -5032,11 +5065,12 @@ async def streaming_chat_response_handler(response, ctx):
                 # needs to be marked done so the placeholder doesn't linger.
                 fallback_chat_id = metadata.get('chat_id')
                 fallback_message_id = metadata.get('message_id')
-                if (
-                    fallback_chat_id
-                    and fallback_message_id
+                fallback_is_persisted = (
+                    bool(fallback_chat_id)
+                    and bool(fallback_message_id)
                     and not fallback_chat_id.startswith('local:')
-                ):
+                )
+                if fallback_is_persisted:
                     try:
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             fallback_chat_id,
@@ -5046,16 +5080,22 @@ async def streaming_chat_response_handler(response, ctx):
                                 'role': 'assistant',
                                 'content': accumulated_content,
                                 'output': output,
-                                **({'usage': accumulated_usage} if accumulated_usage else {}),
+                                **({'usage': normalized_usage} if normalized_usage else {}),
                             },
                         )
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 
+                    # Mirror the non-streaming path: run follow-ups /
+                    # auto-title / auto-tags for persisted chats even
+                    # without a WebSocket session. Uses a no-op emitter
+                    # so DB side-effects still land.
+                    await _run_background_tasks(ctx)
+
                 ctx['assistant_message'] = {
                     'content': accumulated_content,
                     'output': output,
-                    **({'usage': accumulated_usage} if accumulated_usage else {}),
+                    **({'usage': normalized_usage} if normalized_usage else {}),
                 }
                 await outlet_filter_handler(ctx)
             except Exception as e:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3331,7 +3331,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                if metadata.get('chat_id'):
+                if is_persisted_chat or event_emitter:
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {
@@ -4906,6 +4906,21 @@ async def streaming_chat_response_handler(response, ctx):
             def wrap_item(item):
                 return f'{item}\n' if is_ndjson else f'data: {item}\n\n'
 
+            def _extract_text(value):
+                # Accept plain strings and multimodal content arrays like
+                # [{"type": "text", "text": "..."}, ...].
+                if isinstance(value, str):
+                    return value
+                if isinstance(value, list):
+                    parts = []
+                    for block in value:
+                        if isinstance(block, dict):
+                            text = block.get('text') or block.get('content')
+                            if isinstance(text, str):
+                                parts.append(text)
+                    return ''.join(parts)
+                return ''
+
             def _parse_line(line):
                 nonlocal accumulated_content, accumulated_usage, terminal_content
                 line = line.strip()
@@ -4932,35 +4947,32 @@ async def streaming_chat_response_handler(response, ctx):
                         continue
                     delta = choice.get('delta')
                     if isinstance(delta, dict):
-                        delta_content = delta.get('content')
-                        if isinstance(delta_content, str) and delta_content:
-                            accumulated_content += delta_content
+                        text = _extract_text(delta.get('content'))
+                        if text:
+                            accumulated_content += text
                     else:
                         msg = choice.get('message')
                         if isinstance(msg, dict):
-                            msg_content = msg.get('content')
-                            if isinstance(msg_content, str) and msg_content:
-                                terminal_content = msg_content
+                            text = _extract_text(msg.get('content'))
+                            if text:
+                                terminal_content = text
                 # Responses-API: top-level delta (stream) + response.completed (snapshot).
                 delta = chunk.get('delta')
                 if isinstance(delta, str):
                     accumulated_content += delta
                 elif isinstance(delta, dict):
-                    text = delta.get('text') or delta.get('content')
-                    if isinstance(text, str):
+                    text = _extract_text(delta.get('text') or delta.get('content'))
+                    if text:
                         accumulated_content += text
                 if chunk.get('type') == 'response.completed':
                     resp = chunk.get('response')
                     if isinstance(resp, dict):
                         parts = []
                         for item in resp.get('output') or []:
-                            if not isinstance(item, dict):
-                                continue
-                            for block in item.get('content') or []:
-                                if isinstance(block, dict):
-                                    text = block.get('text')
-                                    if isinstance(text, str):
-                                        parts.append(text)
+                            if isinstance(item, dict):
+                                text = _extract_text(item.get('content'))
+                                if text:
+                                    parts.append(text)
                         if parts:
                             terminal_content = ''.join(parts)
                         if isinstance(resp.get('usage'), dict):
@@ -5072,7 +5084,7 @@ async def streaming_chat_response_handler(response, ctx):
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 
-                if fallback_chat_id:
+                if fallback_is_persisted:
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3157,11 +3157,27 @@ async def outlet_filter_handler(ctx):
             log.debug(f'Pipeline outlet filter error: {e}')
 
         # Function outlet filters
+        # If we synthesised ids for the outlet payload, expose them via
+        # __metadata__ too so filter functions that key correlation off
+        # __metadata__['chat_id' | 'message_id'] see the same values as
+        # form_data. Shallow copy so we don't mutate the caller's dict.
+        if is_temp_chat and (
+            effective_chat_id != metadata.get('chat_id')
+            or effective_message_id != metadata.get('message_id')
+        ):
+            filter_metadata = {
+                **metadata,
+                'chat_id': effective_chat_id,
+                'message_id': effective_message_id,
+            }
+        else:
+            filter_metadata = metadata
+
         extra_params = {
             '__event_emitter__': event_emitter,
             '__event_call__': event_caller,
             '__user__': user.model_dump() if isinstance(user, UserModel) else {},
-            '__metadata__': metadata,
+            '__metadata__': filter_metadata,
             '__request__': request,
             '__model__': model,
         }

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5154,15 +5154,19 @@ async def streaming_chat_response_handler(response, ctx):
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 
-                if fallback_is_persisted:
-                    await _run_background_tasks(ctx)
+                # Skip background tasks and outlet on error to match the
+                # non-streaming path, which never reaches them when content
+                # extraction fails.
+                if accumulated_error is None:
+                    if fallback_is_persisted:
+                        await _run_background_tasks(ctx)
 
-                ctx['assistant_message'] = {
-                    'content': accumulated_content,
-                    'output': output,
-                    **({'usage': normalized_usage} if normalized_usage else {}),
-                }
-                await outlet_filter_handler(ctx)
+                    ctx['assistant_message'] = {
+                        'content': accumulated_content,
+                        'output': output,
+                        **({'usage': normalized_usage} if normalized_usage else {}),
+                    }
+                    await outlet_filter_handler(ctx)
             except Exception as e:
                 log.debug(f'Error running outlet in fallback stream: {e}')
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2769,7 +2769,16 @@ async def get_event_emitter_and_caller(metadata):
 
     # event_emitter broadcasts to a user's websocket room. Require
     # session_id so pure API callers (no WebSocket) fall into the
-    # body-streaming fallback path instead of the event-driven main path.
+    # body-streaming fallback path instead of the event-driven main path
+    # (which delivers content only via WebSocket and returns None as HTTP
+    # body, manifesting as "streaming returns null" for API callers).
+    #
+    # Note: this narrows the emitter to callers with a real WebSocket
+    # session. DB persistence, webhook delivery, and outlet filters are
+    # now gated independently (on chat_id / not-local:) so backend
+    # callers that provide a persisted chat_id + message_id without a
+    # session still get their data persisted — see the non-streaming and
+    # fallback streaming paths below.
     if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
         event_emitter = await get_event_emitter(metadata)
 
@@ -3213,6 +3222,9 @@ async def non_streaming_chat_response_handler(response, ctx):
     if response_data is None:
         return response
 
+    chat_id = metadata.get('chat_id') or ''
+    is_persisted_chat = bool(chat_id) and not chat_id.startswith('local:')
+
     try:
         if 'error' in response_data:
             error = response_data.get('error')
@@ -3224,7 +3236,7 @@ async def non_streaming_chat_response_handler(response, ctx):
 
             log.error('Provider returned error (non-streaming): %s', error)
 
-            if event_emitter:
+            if is_persisted_chat and metadata.get('message_id'):
                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata['chat_id'],
                     metadata['message_id'],
@@ -3232,15 +3244,15 @@ async def non_streaming_chat_response_handler(response, ctx):
                         'error': {'content': error},
                     },
                 )
-                if isinstance(error, str) or isinstance(error, dict):
-                    await event_emitter(
-                        {
-                            'type': 'chat:message:error',
-                            'data': {'error': {'content': error}},
-                        }
-                    )
+            if event_emitter and (isinstance(error, str) or isinstance(error, dict)):
+                await event_emitter(
+                    {
+                        'type': 'chat:message:error',
+                        'data': {'error': {'content': error}},
+                    }
+                )
 
-        if event_emitter and 'selected_model_id' in response_data:
+        if 'selected_model_id' in response_data and is_persisted_chat and metadata.get('message_id'):
             await Chats.upsert_message_to_chat_by_id_and_message_id(
                 metadata['chat_id'],
                 metadata['message_id'],
@@ -3270,6 +3282,10 @@ async def non_streaming_chat_response_handler(response, ctx):
 
                 usage = normalize_usage(response_data.get('usage', {}) or {})
 
+                title = None
+                if is_persisted_chat:
+                    title = await Chats.get_chat_title_by_id(metadata['chat_id'])
+
                 if event_emitter:
                     await event_emitter(
                         {
@@ -3277,9 +3293,6 @@ async def non_streaming_chat_response_handler(response, ctx):
                             'data': response_data,
                         }
                     )
-
-                    title = await Chats.get_chat_title_by_id(metadata['chat_id'])
-
                     await event_emitter(
                         {
                             'type': 'chat:completion',
@@ -3292,7 +3305,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                         }
                     )
 
-                    # Save message in the database
+                if is_persisted_chat and metadata.get('message_id'):
                     await Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata['chat_id'],
                         metadata['message_id'],
@@ -3321,7 +3334,15 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                await background_tasks_handler(ctx)
+                # background_tasks_handler assumes persisted-chat metadata
+                # and a working event_emitter for follow-ups / title / tags
+                # generation; isolate failures so outlet still runs.
+                if is_persisted_chat and event_emitter:
+                    try:
+                        await background_tasks_handler(ctx)
+                    except Exception as e:
+                        log.debug(f'background_tasks_handler error: {e}')
+
                 ctx['assistant_message'] = {
                     'content': content,
                     'output': response_output,
@@ -4894,20 +4915,31 @@ async def streaming_chat_response_handler(response, ctx):
                     return
                 for line in raw.splitlines():
                     line = line.strip()
-                    if not line.startswith('data: '):
+                    # Accept "data: {...}" and "data:{...}" (SSE spec allows both).
+                    if not line.startswith('data:'):
                         continue
-                    payload = line[6:].strip()
+                    payload = line[5:].lstrip()
                     if not payload or payload == '[DONE]':
                         continue
                     try:
                         chunk = json.loads(payload)
                     except Exception:
                         continue
+                    # OpenAI Chat Completions streaming: choices[].delta.content
                     for choice in chunk.get('choices', []) or []:
                         delta = choice.get('delta') or {}
                         delta_content = delta.get('content')
                         if delta_content:
                             accumulated_content += delta_content
+                    # OpenAI Responses-API streaming: top-level delta with text
+                    # (e.g. response.output_text.delta events)
+                    delta = chunk.get('delta')
+                    if isinstance(delta, str):
+                        accumulated_content += delta
+                    elif isinstance(delta, dict):
+                        text = delta.get('text') or delta.get('content')
+                        if isinstance(text, str):
+                            accumulated_content += text
                     if chunk.get('usage'):
                         accumulated_usage = chunk['usage']
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3336,7 +3336,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                if is_persisted_chat:
+                if metadata.get('chat_id'):
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {
@@ -4901,6 +4901,10 @@ async def streaming_chat_response_handler(response, ctx):
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
+            # Terminal snapshot text from non-delta shapes (e.g.
+            # choices[].message.content, response.completed.output).
+            # Used only if no delta-based content was captured.
+            terminal_content = ''
             accumulate_buffer = ''
             # Incremental decoder holds partial multibyte codepoints split
             # across chunk boundaries instead of dropping them.
@@ -4913,7 +4917,7 @@ async def streaming_chat_response_handler(response, ctx):
             def _parse_line(line):
                 # Accepts SSE "data: {...}" framing AND raw NDJSON lines
                 # (process_chat_response routes both through this handler).
-                nonlocal accumulated_content, accumulated_usage
+                nonlocal accumulated_content, accumulated_usage, terminal_content
                 line = line.strip()
                 if not line:
                     return
@@ -4931,19 +4935,27 @@ async def streaming_chat_response_handler(response, ctx):
                     return
                 if not isinstance(chunk, dict):
                     return
-                # OpenAI Chat Completions: choices[].delta.content
+                # OpenAI Chat Completions: choices[].delta.content (streaming)
+                # or choices[].message.content (snapshot/non-delta).
                 choices = chunk.get('choices') or []
                 if isinstance(choices, list):
                     for choice in choices:
                         if not isinstance(choice, dict):
                             continue
                         delta = choice.get('delta')
-                        if not isinstance(delta, dict):
-                            continue
-                        delta_content = delta.get('content')
-                        if isinstance(delta_content, str) and delta_content:
-                            accumulated_content += delta_content
-                # OpenAI Responses-API: top-level delta (str or {text|content}).
+                        if isinstance(delta, dict):
+                            delta_content = delta.get('content')
+                            if isinstance(delta_content, str) and delta_content:
+                                accumulated_content += delta_content
+                        else:
+                            msg = choice.get('message')
+                            if isinstance(msg, dict):
+                                msg_content = msg.get('content')
+                                if isinstance(msg_content, str) and msg_content:
+                                    terminal_content = msg_content
+                # OpenAI Responses-API: top-level delta (str or {text|content})
+                # for streaming, response.completed with response.output[]
+                # .content[].text as the terminal snapshot.
                 delta = chunk.get('delta')
                 if isinstance(delta, str):
                     accumulated_content += delta
@@ -4951,6 +4963,22 @@ async def streaming_chat_response_handler(response, ctx):
                     text = delta.get('text') or delta.get('content')
                     if isinstance(text, str):
                         accumulated_content += text
+                if chunk.get('type') == 'response.completed':
+                    resp = chunk.get('response')
+                    if isinstance(resp, dict):
+                        parts = []
+                        for item in resp.get('output') or []:
+                            if not isinstance(item, dict):
+                                continue
+                            for block in item.get('content') or []:
+                                if isinstance(block, dict):
+                                    text = block.get('text')
+                                    if isinstance(text, str):
+                                        parts.append(text)
+                        if parts:
+                            terminal_content = ''.join(parts)
+                        if isinstance(resp.get('usage'), dict):
+                            accumulated_usage = resp['usage']
                 usage = chunk.get('usage')
                 if isinstance(usage, dict):
                     accumulated_usage = usage
@@ -5017,6 +5045,12 @@ async def streaming_chat_response_handler(response, ctx):
             try:
                 flush_accumulate_buffer()
 
+                # Fall back to terminal-snapshot content only if no
+                # delta-based content was captured, so mixed-shape streams
+                # (deltas + a final snapshot event) don't double-count.
+                if not accumulated_content and terminal_content:
+                    accumulated_content = terminal_content
+
                 output = (
                     [
                         {
@@ -5058,6 +5092,7 @@ async def streaming_chat_response_handler(response, ctx):
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 
+                if fallback_chat_id:
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4901,6 +4901,11 @@ async def streaming_chat_response_handler(response, ctx):
             # produced nothing, so mixed-shape streams don't double-count.
             terminal_content = ''
             accumulate_buffer = ''
+            # Multiple SSE "data:" lines in one event are concatenated with
+            # '\n' per spec; JSON allows embedded whitespace so the result
+            # still parses. Buffered across _process_line calls until a
+            # blank line ends the event.
+            sse_event_data = []
             decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
 
             def wrap_item(item):
@@ -4921,18 +4926,9 @@ async def streaming_chat_response_handler(response, ctx):
                     return ''.join(parts)
                 return ''
 
-            def _parse_line(line):
+            def _parse_payload(payload):
                 nonlocal accumulated_content, accumulated_usage, terminal_content
-                line = line.strip()
-                if not line:
-                    return
-                if line.startswith('data:'):
-                    payload = line[5:].lstrip()
-                    if not payload or payload == '[DONE]':
-                        return
-                elif line.startswith('{') or line.startswith('['):
-                    payload = line
-                else:
+                if not payload or payload == '[DONE]':
                     return
                 try:
                     chunk = json.loads(payload)
@@ -4981,6 +4977,21 @@ async def streaming_chat_response_handler(response, ctx):
                 if isinstance(usage, dict):
                     accumulated_usage = usage
 
+            def _process_line(line):
+                # SSE: blank line ends an event; assemble buffered data lines.
+                # NDJSON: each non-empty line is a standalone JSON object.
+                if not line.strip():
+                    if sse_event_data:
+                        _parse_payload('\n'.join(sse_event_data))
+                        sse_event_data.clear()
+                    return
+                stripped = line.strip()
+                if stripped.startswith('data:'):
+                    sse_event_data.append(stripped[5:].lstrip())
+                elif stripped.startswith('{') or stripped.startswith('['):
+                    _parse_payload(stripped)
+                # Other SSE fields (event:, id:, retry:) are ignored.
+
             def accumulate(raw_bytes):
                 nonlocal accumulate_buffer
                 if isinstance(raw_bytes, bytes):
@@ -4998,7 +5009,7 @@ async def streaming_chat_response_handler(response, ctx):
                 parts = accumulate_buffer.split('\n')
                 accumulate_buffer = parts[-1]
                 for line in parts[:-1]:
-                    _parse_line(line)
+                    _process_line(line)
 
             def flush_accumulate_buffer():
                 nonlocal accumulate_buffer
@@ -5009,8 +5020,12 @@ async def streaming_chat_response_handler(response, ctx):
                 except Exception:
                     pass
                 if accumulate_buffer:
-                    _parse_line(accumulate_buffer)
+                    _process_line(accumulate_buffer)
                     accumulate_buffer = ''
+                # Flush any trailing SSE event that didn't end with a blank line.
+                if sse_event_data:
+                    _parse_payload('\n'.join(sse_event_data))
+                    sse_event_data.clear()
 
             for event in events:
                 event, _ = await process_filter_functions(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3070,8 +3070,7 @@ async def outlet_filter_handler(ctx):
 
     For temp chats (local: prefix) and API callers without a persisted
     chat_id / message_id, messages are built from form_data plus the
-    assistant response message stored in ctx['assistant_message'], since
-    these callers have no DB-persisted history. See #23740.
+    assistant response message stored in ctx['assistant_message'].
     """
     request = ctx['request']
     user = ctx['user']
@@ -3083,29 +3082,15 @@ async def outlet_filter_handler(ctx):
     chat_id = metadata.get('chat_id', '')
     message_id = metadata.get('message_id')
 
-    # In-memory branch covers:
-    #   - temp chats (chat_id starts with 'local:')
-    #   - API callers that omit chat_id and/or id in the request body
-    is_temp_chat = (
-        not chat_id
-        or chat_id.startswith('local:')
-        or not message_id
-    )
+    is_temp_chat = not chat_id or chat_id.startswith('local:') or not message_id
 
     try:
         messages_map = None
 
         if is_temp_chat:
-            # Synthesize local-only ids for the outlet payload when the
-            # caller didn't provide them. Scope these to outlet_data only —
-            # do NOT write them back to metadata, because the surrounding
-            # pipeline (streaming save, event routing, webhook URLs) must
-            # keep seeing the real values.
             effective_chat_id = chat_id or f'local:{uuid4()}'
             effective_message_id = message_id or str(uuid4())
 
-            # Temp / API callers have no DB record — build message list
-            # from the in-memory form_data plus the assistant response.
             form_messages = ctx.get('form_data', {}).get('messages', [])
             assistant_message = ctx.get('assistant_message', {})
 
@@ -3118,7 +3103,6 @@ async def outlet_filter_handler(ctx):
                 if isinstance(m, dict)
             ]
 
-            # Append the full assistant message (content, output, usage, etc.)
             if assistant_message:
                 message_list.append({
                     'id': effective_message_id,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2765,16 +2765,13 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
 
 async def get_event_emitter_and_caller(metadata):
+    # Requires session_id so API callers without a WS session take the
+    # body-streaming fallback; DB/outlet gated independently downstream.
     event_emitter = None
     event_caller = None
-
-    # Both need session_id — API callers without a WS session fall into
-    # the body-streaming fallback; DB/outlet/webhook are gated independently
-    # downstream (on chat_id / not-local:). See #23740.
     if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
         event_emitter = await get_event_emitter(metadata)
         event_caller = await get_event_call(metadata)
-
     return event_emitter, event_caller
 
 
@@ -2860,8 +2857,6 @@ async def _noop_event_emitter(event_data):
 
 
 async def _run_background_tasks(ctx):
-    # No-op emitter fallback keeps DB-only side effects (title/tags/
-    # follow-ups) running for persisted chats without a WS session.
     bg_ctx = ctx if ctx.get('event_emitter') else {**ctx, 'event_emitter': _noop_event_emitter}
     try:
         await background_tasks_handler(bg_ctx)
@@ -4901,22 +4896,17 @@ async def streaming_chat_response_handler(response, ctx):
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
-            # Terminal snapshot text from non-delta shapes (e.g.
-            # choices[].message.content, response.completed.output).
-            # Used only if no delta-based content was captured.
+            # Snapshot content (choices[].message.content,
+            # response.completed.output). Used only if the delta path
+            # produced nothing, so mixed-shape streams don't double-count.
             terminal_content = ''
             accumulate_buffer = ''
-            # Incremental decoder holds partial multibyte codepoints split
-            # across chunk boundaries instead of dropping them.
             decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
 
             def wrap_item(item):
-                # NDJSON = one raw JSON object per line; SSE = "data: ...\n\n".
                 return f'{item}\n' if is_ndjson else f'data: {item}\n\n'
 
             def _parse_line(line):
-                # Accepts SSE "data: {...}" framing AND raw NDJSON lines
-                # (process_chat_response routes both through this handler).
                 nonlocal accumulated_content, accumulated_usage, terminal_content
                 line = line.strip()
                 if not line:
@@ -4935,27 +4925,23 @@ async def streaming_chat_response_handler(response, ctx):
                     return
                 if not isinstance(chunk, dict):
                     return
-                # OpenAI Chat Completions: choices[].delta.content (streaming)
-                # or choices[].message.content (snapshot/non-delta).
-                choices = chunk.get('choices') or []
-                if isinstance(choices, list):
-                    for choice in choices:
-                        if not isinstance(choice, dict):
-                            continue
-                        delta = choice.get('delta')
-                        if isinstance(delta, dict):
-                            delta_content = delta.get('content')
-                            if isinstance(delta_content, str) and delta_content:
-                                accumulated_content += delta_content
-                        else:
-                            msg = choice.get('message')
-                            if isinstance(msg, dict):
-                                msg_content = msg.get('content')
-                                if isinstance(msg_content, str) and msg_content:
-                                    terminal_content = msg_content
-                # OpenAI Responses-API: top-level delta (str or {text|content})
-                # for streaming, response.completed with response.output[]
-                # .content[].text as the terminal snapshot.
+                # Chat Completions: delta.content (stream) or message.content (snapshot).
+                choices = chunk.get('choices')
+                for choice in choices if isinstance(choices, list) else []:
+                    if not isinstance(choice, dict):
+                        continue
+                    delta = choice.get('delta')
+                    if isinstance(delta, dict):
+                        delta_content = delta.get('content')
+                        if isinstance(delta_content, str) and delta_content:
+                            accumulated_content += delta_content
+                    else:
+                        msg = choice.get('message')
+                        if isinstance(msg, dict):
+                            msg_content = msg.get('content')
+                            if isinstance(msg_content, str) and msg_content:
+                                terminal_content = msg_content
+                # Responses-API: top-level delta (stream) + response.completed (snapshot).
                 delta = chunk.get('delta')
                 if isinstance(delta, str):
                     accumulated_content += delta
@@ -4984,8 +4970,6 @@ async def streaming_chat_response_handler(response, ctx):
                     accumulated_usage = usage
 
             def accumulate(raw_bytes):
-                # Rolling buffer — SSE/NDJSON frames may split across chunks,
-                # as can UTF-8 codepoints (hence the incremental decoder).
                 nonlocal accumulate_buffer
                 if isinstance(raw_bytes, bytes):
                     try:
@@ -5044,10 +5028,6 @@ async def streaming_chat_response_handler(response, ctx):
             # Stream complete — persist final message and fire outlet.
             try:
                 flush_accumulate_buffer()
-
-                # Fall back to terminal-snapshot content only if no
-                # delta-based content was captured, so mixed-shape streams
-                # (deltas + a final snapshot event) don't double-count.
                 if not accumulated_content and terminal_content:
                     accumulated_content = terminal_content
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4955,7 +4955,13 @@ async def streaming_chat_response_handler(response, ctx):
                     return
                 try:
                     chunk = json.loads(payload)
-                except Exception:
+                except Exception as e:
+                    log.debug(
+                        'fallback stream parse error (%s, payload=%r): %s',
+                        'NDJSON' if is_ndjson else 'SSE',
+                        payload[:120],
+                        e,
+                    )
                     return
                 if not isinstance(chunk, dict):
                     return

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4912,6 +4912,7 @@ async def streaming_chat_response_handler(response, ctx):
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
+            accumulated_error = None
             # Snapshot content (choices[].message.content,
             # response.completed.output). Used only if the delta path
             # produced nothing, so mixed-shape streams don't double-count.
@@ -4943,7 +4944,7 @@ async def streaming_chat_response_handler(response, ctx):
                 return ''
 
             def _parse_payload(payload):
-                nonlocal accumulated_content, accumulated_usage, terminal_content
+                nonlocal accumulated_content, accumulated_usage, terminal_content, accumulated_error
                 if not payload or payload == '[DONE]':
                     return
                 try:
@@ -4952,6 +4953,24 @@ async def streaming_chat_response_handler(response, ctx):
                     return
                 if not isinstance(chunk, dict):
                     return
+                # Provider errors — capture and stop treating this as success.
+                err = chunk.get('error')
+                if err:
+                    accumulated_error = err
+                    return
+                if chunk.get('type') in ('response.failed', 'response.error'):
+                    accumulated_error = chunk.get('response') or chunk
+                    return
+                chunk_type = chunk.get('type')
+                # Responses-API reasoning/summary/refusal/tool-call events
+                # must NOT leak into the persisted assistant content.
+                is_reasoning_event = isinstance(chunk_type, str) and (
+                    'reasoning' in chunk_type
+                    or 'summary' in chunk_type
+                    or 'refusal' in chunk_type
+                    or 'function_call' in chunk_type
+                    or 'tool_call' in chunk_type
+                )
                 # Chat Completions: delta.content (stream) or message.content (snapshot).
                 choices = chunk.get('choices')
                 for choice in choices if isinstance(choices, list) else []:
@@ -4969,22 +4988,28 @@ async def streaming_chat_response_handler(response, ctx):
                             if text:
                                 terminal_content = text
                 # Responses-API: top-level delta (stream) + response.completed (snapshot).
-                delta = chunk.get('delta')
-                if isinstance(delta, str):
-                    accumulated_content += delta
-                elif isinstance(delta, dict):
-                    text = _extract_text(delta.get('text') or delta.get('content'))
-                    if text:
-                        accumulated_content += text
-                if chunk.get('type') == 'response.completed':
+                if not is_reasoning_event:
+                    delta = chunk.get('delta')
+                    if isinstance(delta, str):
+                        accumulated_content += delta
+                    elif isinstance(delta, dict):
+                        text = _extract_text(delta.get('text') or delta.get('content'))
+                        if text:
+                            accumulated_content += text
+                if chunk_type == 'response.completed':
                     resp = chunk.get('response')
                     if isinstance(resp, dict):
                         parts = []
                         for item in resp.get('output') or []:
-                            if isinstance(item, dict):
-                                text = _extract_text(item.get('content'))
-                                if text:
-                                    parts.append(text)
+                            if not isinstance(item, dict):
+                                continue
+                            # Only assistant message items; skip reasoning,
+                            # summary, function_call, etc.
+                            if item.get('type') != 'message':
+                                continue
+                            text = _extract_text(item.get('content'))
+                            if text:
+                                parts.append(text)
                         if parts:
                             terminal_content = ''.join(parts)
                         if isinstance(resp.get('usage'), dict):
@@ -5049,7 +5074,7 @@ async def streaming_chat_response_handler(response, ctx):
                     filter_functions=filter_functions,
                     filter_type='stream',
                     form_data=event,
-                    extra_params=extra_params,
+                    extra_params={'__body__': form_data, **extra_params},
                 )
 
                 if event:
@@ -5061,7 +5086,7 @@ async def streaming_chat_response_handler(response, ctx):
                     filter_functions=filter_functions,
                     filter_type='stream',
                     form_data=data,
-                    extra_params=extra_params,
+                    extra_params={'__body__': form_data, **extra_params},
                 )
 
                 if data:
@@ -5101,17 +5126,31 @@ async def streaming_chat_response_handler(response, ctx):
                 )
                 if fallback_is_persisted:
                     try:
-                        await Chats.upsert_message_to_chat_by_id_and_message_id(
-                            fallback_chat_id,
-                            fallback_message_id,
-                            {
-                                'done': True,
-                                'role': 'assistant',
-                                'content': accumulated_content,
-                                'output': output,
-                                **({'usage': normalized_usage} if normalized_usage else {}),
-                            },
-                        )
+                        if accumulated_error is not None:
+                            # Persist error state instead of a fake-success
+                            # done:True with empty content.
+                            err = accumulated_error
+                            if isinstance(err, dict):
+                                err_content = err.get('detail') or err.get('message') or err
+                            else:
+                                err_content = str(err)
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                fallback_chat_id,
+                                fallback_message_id,
+                                {'error': {'content': err_content}},
+                            )
+                        else:
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                fallback_chat_id,
+                                fallback_message_id,
+                                {
+                                    'done': True,
+                                    'role': 'assistant',
+                                    'content': accumulated_content,
+                                    'output': output,
+                                    **({'usage': normalized_usage} if normalized_usage else {}),
+                                },
+                            )
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2861,7 +2861,13 @@ async def _run_background_tasks(ctx):
     try:
         await background_tasks_handler(bg_ctx)
     except Exception as e:
-        log.debug(f'background_tasks_handler error: {e}')
+        meta = ctx.get('metadata') or {}
+        log.warning(
+            'background_tasks_handler failed (chat_id=%s message_id=%s): %s',
+            meta.get('chat_id'),
+            meta.get('message_id'),
+            e,
+        )
 
 
 async def background_tasks_handler(ctx):
@@ -3088,7 +3094,7 @@ async def outlet_filter_handler(ctx):
     chat_id = metadata.get('chat_id', '')
     message_id = metadata.get('message_id')
 
-    is_temp_chat = not chat_id or chat_id.startswith('local:') or not message_id
+    is_temp_chat = not chat_id or chat_id.startswith('local:')
 
     try:
         messages_map = None

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2767,24 +2767,11 @@ async def get_event_emitter_and_caller(metadata):
     event_emitter = None
     event_caller = None
 
-    # event_emitter broadcasts to a user's websocket room. Require
-    # session_id so pure API callers (no WebSocket) fall into the
-    # body-streaming fallback path instead of the event-driven main path
-    # (which delivers content only via WebSocket and returns None as HTTP
-    # body, manifesting as "streaming returns null" for API callers).
-    #
-    # Note: this narrows the emitter to callers with a real WebSocket
-    # session. DB persistence, webhook delivery, and outlet filters are
-    # now gated independently (on chat_id / not-local:) so backend
-    # callers that provide a persisted chat_id + message_id without a
-    # session still get their data persisted — see the non-streaming and
-    # fallback streaming paths below.
+    # Both need session_id — API callers without a WS session fall into
+    # the body-streaming fallback; DB/outlet/webhook are gated independently
+    # downstream (on chat_id / not-local:). See #23740.
     if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
         event_emitter = await get_event_emitter(metadata)
-
-    # event_caller needs session_id — it calls back to a specific
-    # websocket session (used by direct tools, pyodide code interpreter).
-    if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
         event_caller = await get_event_call(metadata)
 
     return event_emitter, event_caller
@@ -2868,19 +2855,13 @@ async def get_system_oauth_token(request, user):
 
 
 async def _noop_event_emitter(event_data):
-    """No-op emitter used to keep background_tasks_handler's DB-only side
-    effects (auto-title, auto-tags, follow-ups persistence) working for
-    persisted chats whose caller has no WebSocket session."""
     return None
 
 
 async def _run_background_tasks(ctx):
-    """Run background_tasks_handler with a no-op event_emitter fallback,
-    wrapped so a failure cannot prevent outlet_filter_handler from running."""
-    if ctx.get('event_emitter'):
-        bg_ctx = ctx
-    else:
-        bg_ctx = {**ctx, 'event_emitter': _noop_event_emitter}
+    # No-op emitter fallback keeps DB-only side effects (title/tags/
+    # follow-ups) running for persisted chats without a WS session.
+    bg_ctx = ctx if ctx.get('event_emitter') else {**ctx, 'event_emitter': _noop_event_emitter}
     try:
         await background_tasks_handler(bg_ctx)
     except Exception as e:
@@ -3354,9 +3335,6 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                # Run follow-ups / auto-title / auto-tags for persisted
-                # chats; uses a no-op emitter fallback when there's no
-                # WebSocket session, so DB side-effects still land.
                 if is_persisted_chat:
                     await _run_background_tasks(ctx)
 
@@ -4914,28 +4892,23 @@ async def streaming_chat_response_handler(response, ctx):
         return await response_handler(response, events)
 
     else:
-        # Fallback: stream the upstream body straight to the caller.
-        # Used by pure API callers (no WebSocket session) — we also
-        # accumulate chunks here to fire outlet filters after completion.
+        # Fallback: forward upstream body to the caller and accumulate
+        # chunks to fire outlet after completion (API callers w/o WS).
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
-            # Rolling buffer: SSE frames can be split across network chunks
-            # (e.g. a large JSON payload in one `data:` line). We hold an
-            # incomplete trailing line until the next chunk brings a newline.
             accumulate_buffer = ''
 
             def wrap_item(item):
                 return f'data: {item}\n\n'
 
             def _parse_line(line):
+                # Accepts SSE "data: {...}" framing AND raw NDJSON lines
+                # (process_chat_response routes both through this handler).
                 nonlocal accumulated_content, accumulated_usage
                 line = line.strip()
                 if not line:
                     return
-                # Accept SSE framing ("data: {...}" / "data:{...}") AND
-                # raw NDJSON lines (application/x-ndjson is routed through
-                # this same handler by process_chat_response).
                 if line.startswith('data:'):
                     payload = line[5:].lstrip()
                     if not payload or payload == '[DONE]':
@@ -4948,12 +4921,9 @@ async def streaming_chat_response_handler(response, ctx):
                     chunk = json.loads(payload)
                 except Exception:
                     return
-                # Providers vary in chunk shape; be defensive so a surprise
-                # payload never breaks the generator for API callers on this
-                # path.
                 if not isinstance(chunk, dict):
                     return
-                # OpenAI Chat Completions streaming: choices[].delta.content
+                # OpenAI Chat Completions: choices[].delta.content
                 choices = chunk.get('choices') or []
                 if isinstance(choices, list):
                     for choice in choices:
@@ -4965,8 +4935,7 @@ async def streaming_chat_response_handler(response, ctx):
                         delta_content = delta.get('content')
                         if isinstance(delta_content, str) and delta_content:
                             accumulated_content += delta_content
-                # OpenAI Responses-API streaming: top-level delta with text
-                # (e.g. response.output_text.delta events)
+                # OpenAI Responses-API: top-level delta (str or {text|content}).
                 delta = chunk.get('delta')
                 if isinstance(delta, str):
                     accumulated_content += delta
@@ -4979,14 +4948,13 @@ async def streaming_chat_response_handler(response, ctx):
                     accumulated_usage = usage
 
             def accumulate(raw_bytes):
+                # Rolling buffer — SSE/NDJSON frames may split across chunks.
                 nonlocal accumulate_buffer
                 try:
                     raw = raw_bytes.decode('utf-8') if isinstance(raw_bytes, bytes) else raw_bytes
                 except Exception:
                     return
                 accumulate_buffer += raw
-                # Split on newline; last element is potentially incomplete,
-                # hold it over for the next chunk.
                 parts = accumulate_buffer.split('\n')
                 accumulate_buffer = parts[-1]
                 for line in parts[:-1]:
@@ -5023,9 +4991,8 @@ async def streaming_chat_response_handler(response, ctx):
                     accumulate(data)
                     yield data
 
-            # Stream complete — fire outlet filters with the accumulated content.
+            # Stream complete — persist final message and fire outlet.
             try:
-                # Flush any trailing buffer content from accumulate().
                 flush_accumulate_buffer()
 
                 output = (
@@ -5042,27 +5009,10 @@ async def streaming_chat_response_handler(response, ctx):
                     else []
                 )
 
-                # Normalize usage for schema parity with the main / non-
-                # streaming paths (both call normalize_usage before
-                # persisting / emitting).
                 normalized_usage = (
-                    normalize_usage(accumulated_usage)
-                    if isinstance(accumulated_usage, dict)
-                    else None
+                    normalize_usage(accumulated_usage) if isinstance(accumulated_usage, dict) else None
                 )
 
-                # Persist the final assistant message for persisted chats.
-                # Backend callers that provide chat_id + message_id but no
-                # session take this fallback path; without this write, outlet
-                # would read stale DB content (the empty placeholder inserted
-                # pre-inference). Mirrors the main-path write at middleware.py
-                # lines ~4790-4803.
-                #
-                # We persist even when accumulated_content is empty —
-                # tool-call-only streams, function-call-only streams, and
-                # providers that put final content in non-delta.content
-                # fields produce no accumulated text, but the message still
-                # needs to be marked done so the placeholder doesn't linger.
                 fallback_chat_id = metadata.get('chat_id')
                 fallback_message_id = metadata.get('message_id')
                 fallback_is_persisted = (
@@ -5086,10 +5036,6 @@ async def streaming_chat_response_handler(response, ctx):
                     except Exception as e:
                         log.debug(f'Error persisting streamed message in fallback: {e}')
 
-                    # Mirror the non-streaming path: run follow-ups /
-                    # auto-title / auto-tags for persisted chats even
-                    # without a WebSocket session. Uses a no-op emitter
-                    # so DB side-effects still land.
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2767,10 +2767,10 @@ async def get_event_emitter_and_caller(metadata):
     event_emitter = None
     event_caller = None
 
-    # event_emitter only needs user_id + chat_id + message_id.
-    # It broadcasts to user:{user_id} room AND persists to DB,
-    # so it works for backend-initiated calls (automations, API).
-    if metadata.get('chat_id') and metadata.get('message_id'):
+    # event_emitter broadcasts to a user's websocket room. Require
+    # session_id so pure API callers (no WebSocket) fall into the
+    # body-streaming fallback path instead of the event-driven main path.
+    if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
         event_emitter = await get_event_emitter(metadata)
 
     # event_caller needs session_id — it calls back to a specific
@@ -3213,18 +3213,18 @@ async def non_streaming_chat_response_handler(response, ctx):
     if response_data is None:
         return response
 
-    if event_emitter:
-        try:
-            if 'error' in response_data:
-                error = response_data.get('error')
+    try:
+        if 'error' in response_data:
+            error = response_data.get('error')
 
-                if isinstance(error, dict):
-                    error = error.get('detail', error)
-                else:
-                    error = str(error)
+            if isinstance(error, dict):
+                error = error.get('detail', error)
+            else:
+                error = str(error)
 
-                log.error('Provider returned error (non-streaming): %s', error)
+            log.error('Provider returned error (non-streaming): %s', error)
 
+            if event_emitter:
                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata['chat_id'],
                     metadata['message_id'],
@@ -3240,20 +3240,37 @@ async def non_streaming_chat_response_handler(response, ctx):
                         }
                     )
 
-            if 'selected_model_id' in response_data:
-                await Chats.upsert_message_to_chat_by_id_and_message_id(
-                    metadata['chat_id'],
-                    metadata['message_id'],
-                    {
-                        'selectedModelId': response_data['selected_model_id'],
-                    },
-                )
+        if event_emitter and 'selected_model_id' in response_data:
+            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                metadata['chat_id'],
+                metadata['message_id'],
+                {
+                    'selectedModelId': response_data['selected_model_id'],
+                },
+            )
 
-            choices = response_data.get('choices', [])
-            if choices and choices[0].get('message', {}).get('content'):
-                content = response_data['choices'][0]['message']['content']
+        choices = response_data.get('choices', [])
+        if choices and choices[0].get('message', {}).get('content'):
+            content = response_data['choices'][0]['message']['content']
 
-                if content:
+            if content:
+                # Use output from backend if provided (OR-compliant backends),
+                # otherwise generate from response content
+                response_output = response_data.get('output')
+                if not response_output:
+                    response_output = [
+                        {
+                            'type': 'message',
+                            'id': output_id('msg'),
+                            'status': 'completed',
+                            'role': 'assistant',
+                            'content': [{'type': 'output_text', 'text': content}],
+                        }
+                    ]
+
+                usage = normalize_usage(response_data.get('usage', {}) or {})
+
+                if event_emitter:
                     await event_emitter(
                         {
                             'type': 'chat:completion',
@@ -3262,20 +3279,6 @@ async def non_streaming_chat_response_handler(response, ctx):
                     )
 
                     title = await Chats.get_chat_title_by_id(metadata['chat_id'])
-
-                    # Use output from backend if provided (OR-compliant backends),
-                    # otherwise generate from response content
-                    response_output = response_data.get('output')
-                    if not response_output:
-                        response_output = [
-                            {
-                                'type': 'message',
-                                'id': output_id('msg'),
-                                'status': 'completed',
-                                'role': 'assistant',
-                                'content': [{'type': 'output_text', 'text': content}],
-                            }
-                        ]
 
                     await event_emitter(
                         {
@@ -3290,8 +3293,6 @@ async def non_streaming_chat_response_handler(response, ctx):
                     )
 
                     # Save message in the database
-                    usage = normalize_usage(response_data.get('usage', {}) or {})
-
                     await Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata['chat_id'],
                         metadata['message_id'],
@@ -3320,23 +3321,18 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                    await background_tasks_handler(ctx)
-                    ctx['assistant_message'] = {
-                        'content': content,
-                        'output': response_output,
-                        **({'usage': usage} if usage else {}),
-                    }
-                    await outlet_filter_handler(ctx)
+                await background_tasks_handler(ctx)
+                ctx['assistant_message'] = {
+                    'content': content,
+                    'output': response_output,
+                    **({'usage': usage} if usage else {}),
+                }
+                await outlet_filter_handler(ctx)
 
-            response = build_response_object(response, merge_events_into_response(response_data, events))
-        except Exception as e:
-            log.debug(f'Error occurred while processing request: {e}')
-            pass
-
-        return response
-
-    if isinstance(response, dict):
-        response = merge_events_into_response(response_data, events)
+        response = build_response_object(response, merge_events_into_response(response_data, events))
+    except Exception as e:
+        log.debug(f'Error occurred while processing request: {e}')
+        pass
 
     return response
 
@@ -4880,10 +4876,40 @@ async def streaming_chat_response_handler(response, ctx):
         return await response_handler(response, events)
 
     else:
-        # Fallback to the original response
+        # Fallback: stream the upstream body straight to the caller.
+        # Used by pure API callers (no WebSocket session) — we also
+        # accumulate chunks here to fire outlet filters after completion.
         async def stream_wrapper(original_generator, events):
+            accumulated_content = ''
+            accumulated_usage = None
+
             def wrap_item(item):
                 return f'data: {item}\n\n'
+
+            def accumulate(raw_bytes):
+                nonlocal accumulated_content, accumulated_usage
+                try:
+                    raw = raw_bytes.decode('utf-8') if isinstance(raw_bytes, bytes) else raw_bytes
+                except Exception:
+                    return
+                for line in raw.splitlines():
+                    line = line.strip()
+                    if not line.startswith('data: '):
+                        continue
+                    payload = line[6:].strip()
+                    if not payload or payload == '[DONE]':
+                        continue
+                    try:
+                        chunk = json.loads(payload)
+                    except Exception:
+                        continue
+                    for choice in chunk.get('choices', []) or []:
+                        delta = choice.get('delta') or {}
+                        delta_content = delta.get('content')
+                        if delta_content:
+                            accumulated_content += delta_content
+                    if chunk.get('usage'):
+                        accumulated_usage = chunk['usage']
 
             for event in events:
                 event, _ = await process_filter_functions(
@@ -4907,7 +4933,32 @@ async def streaming_chat_response_handler(response, ctx):
                 )
 
                 if data:
+                    accumulate(data)
                     yield data
+
+            # Stream complete — fire outlet filters with the accumulated content.
+            try:
+                output = (
+                    [
+                        {
+                            'type': 'message',
+                            'id': output_id('msg'),
+                            'status': 'completed',
+                            'role': 'assistant',
+                            'content': [{'type': 'output_text', 'text': accumulated_content}],
+                        }
+                    ]
+                    if accumulated_content
+                    else []
+                )
+                ctx['assistant_message'] = {
+                    'content': accumulated_content,
+                    'output': output,
+                    **({'usage': accumulated_usage} if accumulated_usage else {}),
+                }
+                await outlet_filter_handler(ctx)
+            except Exception as e:
+                log.debug(f'Error running outlet in fallback stream: {e}')
 
         return StreamingResponse(
             stream_wrapper(response.body_iterator, events),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3347,7 +3347,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                if is_persisted_chat or event_emitter:
+                if (is_persisted_chat or event_emitter) and metadata.get('message_id'):
                     await _run_background_tasks(ctx)
 
                 ctx['assistant_message'] = {

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1,3 +1,4 @@
+import codecs
 import copy
 import time
 import logging
@@ -4894,13 +4895,20 @@ async def streaming_chat_response_handler(response, ctx):
     else:
         # Fallback: forward upstream body to the caller and accumulate
         # chunks to fire outlet after completion (API callers w/o WS).
+        content_type = response.headers.get('Content-Type', '')
+        is_ndjson = 'application/x-ndjson' in content_type
+
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
             accumulate_buffer = ''
+            # Incremental decoder holds partial multibyte codepoints split
+            # across chunk boundaries instead of dropping them.
+            decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
 
             def wrap_item(item):
-                return f'data: {item}\n\n'
+                # NDJSON = one raw JSON object per line; SSE = "data: ...\n\n".
+                return f'{item}\n' if is_ndjson else f'data: {item}\n\n'
 
             def _parse_line(line):
                 # Accepts SSE "data: {...}" framing AND raw NDJSON lines
@@ -4948,11 +4956,19 @@ async def streaming_chat_response_handler(response, ctx):
                     accumulated_usage = usage
 
             def accumulate(raw_bytes):
-                # Rolling buffer — SSE/NDJSON frames may split across chunks.
+                # Rolling buffer — SSE/NDJSON frames may split across chunks,
+                # as can UTF-8 codepoints (hence the incremental decoder).
                 nonlocal accumulate_buffer
-                try:
-                    raw = raw_bytes.decode('utf-8') if isinstance(raw_bytes, bytes) else raw_bytes
-                except Exception:
+                if isinstance(raw_bytes, bytes):
+                    try:
+                        raw = decoder.decode(raw_bytes)
+                    except Exception:
+                        return
+                elif isinstance(raw_bytes, str):
+                    raw = raw_bytes
+                else:
+                    return
+                if not raw:
                     return
                 accumulate_buffer += raw
                 parts = accumulate_buffer.split('\n')
@@ -4962,6 +4978,12 @@ async def streaming_chat_response_handler(response, ctx):
 
             def flush_accumulate_buffer():
                 nonlocal accumulate_buffer
+                try:
+                    tail = decoder.decode(b'', final=True)
+                    if tail:
+                        accumulate_buffer += tail
+                except Exception:
+                    pass
                 if accumulate_buffer:
                     _parse_line(accumulate_buffer)
                     accumulate_buffer = ''

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3068,9 +3068,10 @@ async def outlet_filter_handler(ctx):
     Persists outlet-modified content to DB and emits a chat:outlet event
     so the frontend can sync its in-memory state.
 
-    For temp chats (local: prefix), messages are built from form_data
-    plus the assistant response message stored in ctx['assistant_message'],
-    since temp chats have no DB-persisted history.
+    For temp chats (local: prefix) and API callers without a persisted
+    chat_id / message_id, messages are built from form_data plus the
+    assistant response message stored in ctx['assistant_message'], since
+    these callers have no DB-persisted history. See #23740.
     """
     request = ctx['request']
     user = ctx['user']
@@ -3082,17 +3083,29 @@ async def outlet_filter_handler(ctx):
     chat_id = metadata.get('chat_id', '')
     message_id = metadata.get('message_id')
 
-    if not chat_id or not message_id:
-        return
-
-    is_temp_chat = chat_id.startswith('local:')
+    # In-memory branch covers:
+    #   - temp chats (chat_id starts with 'local:')
+    #   - API callers that omit chat_id and/or id in the request body
+    is_temp_chat = (
+        not chat_id
+        or chat_id.startswith('local:')
+        or not message_id
+    )
 
     try:
         messages_map = None
 
         if is_temp_chat:
-            # Temp chats have no DB record — build message list from
-            # the in-memory form_data plus the assistant response.
+            # Synthesize local-only ids for the outlet payload when the
+            # caller didn't provide them. Scope these to outlet_data only —
+            # do NOT write them back to metadata, because the surrounding
+            # pipeline (streaming save, event routing, webhook URLs) must
+            # keep seeing the real values.
+            effective_chat_id = chat_id or f'local:{uuid4()}'
+            effective_message_id = message_id or str(uuid4())
+
+            # Temp / API callers have no DB record — build message list
+            # from the in-memory form_data plus the assistant response.
             form_messages = ctx.get('form_data', {}).get('messages', [])
             assistant_message = ctx.get('assistant_message', {})
 
@@ -3102,16 +3115,19 @@ async def outlet_filter_handler(ctx):
                     'content': m.get('content', ''),
                 }
                 for m in form_messages
+                if isinstance(m, dict)
             ]
 
             # Append the full assistant message (content, output, usage, etc.)
             if assistant_message:
                 message_list.append({
-                    'id': message_id,
+                    'id': effective_message_id,
                     'role': 'assistant',
                     **assistant_message,
                 })
         else:
+            effective_chat_id = chat_id
+            effective_message_id = message_id
             messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
             if not messages_map:
                 return
@@ -3138,9 +3154,9 @@ async def outlet_filter_handler(ctx):
                 for m in message_list
             ],
             'filter_ids': metadata.get('filter_ids', []),
-            'chat_id': chat_id,
+            'chat_id': effective_chat_id,
             'session_id': metadata.get('session_id'),
-            'id': message_id,
+            'id': effective_message_id,
         }
 
         # Pipeline outlet filters

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4924,12 +4924,23 @@ async def streaming_chat_response_handler(response, ctx):
                     chunk = json.loads(payload)
                 except Exception:
                     return
+                # Providers vary in chunk shape; be defensive so a surprise
+                # payload never breaks the generator for API callers on this
+                # path.
+                if not isinstance(chunk, dict):
+                    return
                 # OpenAI Chat Completions streaming: choices[].delta.content
-                for choice in chunk.get('choices', []) or []:
-                    delta = choice.get('delta') or {}
-                    delta_content = delta.get('content')
-                    if delta_content:
-                        accumulated_content += delta_content
+                choices = chunk.get('choices') or []
+                if isinstance(choices, list):
+                    for choice in choices:
+                        if not isinstance(choice, dict):
+                            continue
+                        delta = choice.get('delta')
+                        if not isinstance(delta, dict):
+                            continue
+                        delta_content = delta.get('content')
+                        if isinstance(delta_content, str) and delta_content:
+                            accumulated_content += delta_content
                 # OpenAI Responses-API streaming: top-level delta with text
                 # (e.g. response.output_text.delta events)
                 delta = chunk.get('delta')
@@ -4939,8 +4950,9 @@ async def streaming_chat_response_handler(response, ctx):
                     text = delta.get('text') or delta.get('content')
                     if isinstance(text, str):
                         accumulated_content += text
-                if chunk.get('usage'):
-                    accumulated_usage = chunk['usage']
+                usage = chunk.get('usage')
+                if isinstance(usage, dict):
+                    accumulated_usage = usage
 
             def accumulate(raw_bytes):
                 nonlocal accumulate_buffer
@@ -5012,13 +5024,18 @@ async def streaming_chat_response_handler(response, ctx):
                 # would read stale DB content (the empty placeholder inserted
                 # pre-inference). Mirrors the main-path write at middleware.py
                 # lines ~4790-4803.
+                #
+                # We persist even when accumulated_content is empty —
+                # tool-call-only streams, function-call-only streams, and
+                # providers that put final content in non-delta.content
+                # fields produce no accumulated text, but the message still
+                # needs to be marked done so the placeholder doesn't linger.
                 fallback_chat_id = metadata.get('chat_id')
                 fallback_message_id = metadata.get('message_id')
                 if (
                     fallback_chat_id
                     and fallback_message_id
                     and not fallback_chat_id.startswith('local:')
-                    and accumulated_content
                 ):
                     try:
                         await Chats.upsert_message_to_chat_by_id_and_message_id(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5137,7 +5137,7 @@ async def streaming_chat_response_handler(response, ctx):
                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                 fallback_chat_id,
                                 fallback_message_id,
-                                {'error': {'content': err_content}},
+                                {'done': True, 'error': {'content': err_content}},
                             )
                         else:
                             await Chats.upsert_message_to_chat_by_id_and_message_id(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4903,45 +4903,64 @@ async def streaming_chat_response_handler(response, ctx):
         async def stream_wrapper(original_generator, events):
             accumulated_content = ''
             accumulated_usage = None
+            # Rolling buffer: SSE frames can be split across network chunks
+            # (e.g. a large JSON payload in one `data:` line). We hold an
+            # incomplete trailing line until the next chunk brings a newline.
+            accumulate_buffer = ''
 
             def wrap_item(item):
                 return f'data: {item}\n\n'
 
-            def accumulate(raw_bytes):
+            def _parse_line(line):
                 nonlocal accumulated_content, accumulated_usage
+                line = line.strip()
+                # Accept "data: {...}" and "data:{...}" (SSE spec allows both).
+                if not line.startswith('data:'):
+                    return
+                payload = line[5:].lstrip()
+                if not payload or payload == '[DONE]':
+                    return
+                try:
+                    chunk = json.loads(payload)
+                except Exception:
+                    return
+                # OpenAI Chat Completions streaming: choices[].delta.content
+                for choice in chunk.get('choices', []) or []:
+                    delta = choice.get('delta') or {}
+                    delta_content = delta.get('content')
+                    if delta_content:
+                        accumulated_content += delta_content
+                # OpenAI Responses-API streaming: top-level delta with text
+                # (e.g. response.output_text.delta events)
+                delta = chunk.get('delta')
+                if isinstance(delta, str):
+                    accumulated_content += delta
+                elif isinstance(delta, dict):
+                    text = delta.get('text') or delta.get('content')
+                    if isinstance(text, str):
+                        accumulated_content += text
+                if chunk.get('usage'):
+                    accumulated_usage = chunk['usage']
+
+            def accumulate(raw_bytes):
+                nonlocal accumulate_buffer
                 try:
                     raw = raw_bytes.decode('utf-8') if isinstance(raw_bytes, bytes) else raw_bytes
                 except Exception:
                     return
-                for line in raw.splitlines():
-                    line = line.strip()
-                    # Accept "data: {...}" and "data:{...}" (SSE spec allows both).
-                    if not line.startswith('data:'):
-                        continue
-                    payload = line[5:].lstrip()
-                    if not payload or payload == '[DONE]':
-                        continue
-                    try:
-                        chunk = json.loads(payload)
-                    except Exception:
-                        continue
-                    # OpenAI Chat Completions streaming: choices[].delta.content
-                    for choice in chunk.get('choices', []) or []:
-                        delta = choice.get('delta') or {}
-                        delta_content = delta.get('content')
-                        if delta_content:
-                            accumulated_content += delta_content
-                    # OpenAI Responses-API streaming: top-level delta with text
-                    # (e.g. response.output_text.delta events)
-                    delta = chunk.get('delta')
-                    if isinstance(delta, str):
-                        accumulated_content += delta
-                    elif isinstance(delta, dict):
-                        text = delta.get('text') or delta.get('content')
-                        if isinstance(text, str):
-                            accumulated_content += text
-                    if chunk.get('usage'):
-                        accumulated_usage = chunk['usage']
+                accumulate_buffer += raw
+                # Split on newline; last element is potentially incomplete,
+                # hold it over for the next chunk.
+                parts = accumulate_buffer.split('\n')
+                accumulate_buffer = parts[-1]
+                for line in parts[:-1]:
+                    _parse_line(line)
+
+            def flush_accumulate_buffer():
+                nonlocal accumulate_buffer
+                if accumulate_buffer:
+                    _parse_line(accumulate_buffer)
+                    accumulate_buffer = ''
 
             for event in events:
                 event, _ = await process_filter_functions(
@@ -4970,6 +4989,9 @@ async def streaming_chat_response_handler(response, ctx):
 
             # Stream complete — fire outlet filters with the accumulated content.
             try:
+                # Flush any trailing buffer content from accumulate().
+                flush_accumulate_buffer()
+
                 output = (
                     [
                         {
@@ -4983,6 +5005,36 @@ async def streaming_chat_response_handler(response, ctx):
                     if accumulated_content
                     else []
                 )
+
+                # Persist the final assistant message for persisted chats.
+                # Backend callers that provide chat_id + message_id but no
+                # session take this fallback path; without this write, outlet
+                # would read stale DB content (the empty placeholder inserted
+                # pre-inference). Mirrors the main-path write at middleware.py
+                # lines ~4790-4803.
+                fallback_chat_id = metadata.get('chat_id')
+                fallback_message_id = metadata.get('message_id')
+                if (
+                    fallback_chat_id
+                    and fallback_message_id
+                    and not fallback_chat_id.startswith('local:')
+                    and accumulated_content
+                ):
+                    try:
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            fallback_chat_id,
+                            fallback_message_id,
+                            {
+                                'done': True,
+                                'role': 'assistant',
+                                'content': accumulated_content,
+                                'output': output,
+                                **({'usage': accumulated_usage} if accumulated_usage else {}),
+                            },
+                        )
+                    except Exception as e:
+                        log.debug(f'Error persisting streamed message in fallback: {e}')
+
                 ctx['assistant_message'] = {
                     'content': accumulated_content,
                     'output': output,


### PR DESCRIPTION
Closes #23740, addresses #23770.

Upstream `70a6a24` made `outlet_filter_handler` work for temp chats (`local:` prefix) but left two gaps for API callers of `/api/chat/completions`:

1. **Streaming returns null when event_emitter reifies with a synthetic chat_id.** `streaming_chat_response_handler`'s main path (guarded by `if event_emitter:` at `middleware.py:3376`) has no explicit return in its inner `response_handler` — it returns `None`, leaving the API caller with an empty body. UI callers don't notice because they receive content via WebSocket events.
2. **Outlet filters never fire for API callers.** Both the streaming fallback (`else:` at 4878) and the non-streaming handler gate outlet on `event_emitter`, so callers without a WebSocket session silently skip outlet entirely.


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
