### PR TITLE
fix: Correct the OAuth2.1 static flow

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -101,6 +101,7 @@ class OAuthClientRegistrationForm(BaseModel):
     url: str
     client_id: str
     client_name: Optional[str] = None
+    oauth_client_id: Optional[str] = None
     client_secret: Optional[str] = None
 
 
@@ -117,12 +118,17 @@ async def register_oauth_client(
             oauth_client_id = f'{type}:{form_data.client_id}'
 
         if form_data.client_secret:
+            if not form_data.client_id or not form_data.client_secret:
+                raise HTTPException(
+                    status_code=400,
+                    detail="oauth_client_id and oauth_client_secret are required for static registration",
+                )
             # Static credentials: skip dynamic registration, build from provided credentials
             oauth_client_info = await get_oauth_client_info_with_static_credentials(
                 request,
                 oauth_client_id,
                 form_data.url,
-                oauth_client_id=form_data.client_id,
+                oauth_client_id=form_data.oauth_client_id,
                 oauth_client_secret=form_data.client_secret,
             )
         else:

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -121,7 +121,7 @@ async def register_oauth_client(
             if not form_data.client_id or not form_data.client_secret:
                 raise HTTPException(
                     status_code=400,
-                    detail="oauth_client_id and oauth_client_secret are required for static registration",
+                    detail='oauth_client_id and oauth_client_secret are required for static registration',
                 )
             # Static credentials: skip dynamic registration, build from provided credentials
             oauth_client_info = await get_oauth_client_info_with_static_credentials(

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -498,10 +498,10 @@ async def get_oauth_client_info_with_static_credentials(
 
         redirect_base_url = (str(request.app.state.config.WEBUI_URL or request.base_url)).rstrip('/')
         oauth_client_metadata = OAuthClientMetadata(
-            client_name="Open WebUI",
-            redirect_uris=[f"{redirect_base_url}/oauth/clients/{client_id}/callback"],
-            grant_types=["authorization_code", "refresh_token"],
-            response_types=["code"],
+            client_name='Open WebUI',
+            redirect_uris=[f'{redirect_base_url}/oauth/clients/{client_id}/callback'],
+            grant_types=['authorization_code', 'refresh_token'],
+            response_types=['code'],
         )
 
         # Discover server metadata (authorization endpoint, token endpoint, scopes, etc.)
@@ -518,46 +518,38 @@ async def get_oauth_client_info_with_static_credentials(
                                 oauth_client_metadata.scope is None
                                 and oauth_server_metadata.scopes_supported is not None
                             ):
-                                oauth_client_metadata.scope = " ".join(oauth_server_metadata.scopes_supported)
+                                oauth_client_metadata.scope = ' '.join(oauth_server_metadata.scopes_supported)
 
-                            supported_auth_methods = (
-                                oauth_server_metadata.token_endpoint_auth_methods_supported
-                                or []
-                            )
+                            supported_auth_methods = oauth_server_metadata.token_endpoint_auth_methods_supported or []
                             if (
                                 supported_auth_methods
-                                and oauth_client_metadata.token_endpoint_auth_method
-                                not in supported_auth_methods
+                                and oauth_client_metadata.token_endpoint_auth_method not in supported_auth_methods
                             ):
-                                if "client_secret_post" in supported_auth_methods:
-                                    oauth_client_metadata.token_endpoint_auth_method = (
-                                        "client_secret_post"
-                                    )
-                                elif "client_secret_basic" in supported_auth_methods:
-                                    oauth_client_metadata.token_endpoint_auth_method = (
-                                        "client_secret_basic"
-                                    )
+                                if 'client_secret_post' in supported_auth_methods:
+                                    oauth_client_metadata.token_endpoint_auth_method = 'client_secret_post'
+                                elif 'client_secret_basic' in supported_auth_methods:
+                                    oauth_client_metadata.token_endpoint_auth_method = 'client_secret_basic'
                                 else:
-                                    oauth_client_metadata.token_endpoint_auth_method = (
-                                        supported_auth_methods[0]
-                                    )
+                                    oauth_client_metadata.token_endpoint_auth_method = supported_auth_methods[0]
                             break
                         except Exception as e:
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        oauth_client_info = OAuthClientInformationFull.model_validate({
-            "client_id": oauth_client_id,
-            "client_secret": oauth_client_secret,
-            "issuer": oauth_server_metadata_url,
-            "server_metadata": oauth_server_metadata,
-            "redirect_uris": oauth_client_metadata.redirect_uris,
-            "grant_types": oauth_client_metadata.grant_types,
-            "response_types": oauth_client_metadata.response_types,
-            "client_name": oauth_client_metadata.client_name,
-            "scope": oauth_client_metadata.scope,
-            "token_endpoint_auth_method": oauth_client_metadata.token_endpoint_auth_method,
-        })
+        oauth_client_info = OAuthClientInformationFull.model_validate(
+            {
+                'client_id': oauth_client_id,
+                'client_secret': oauth_client_secret,
+                'issuer': oauth_server_metadata_url,
+                'server_metadata': oauth_server_metadata,
+                'redirect_uris': oauth_client_metadata.redirect_uris,
+                'grant_types': oauth_client_metadata.grant_types,
+                'response_types': oauth_client_metadata.response_types,
+                'client_name': oauth_client_metadata.client_name,
+                'scope': oauth_client_metadata.scope,
+                'token_endpoint_auth_method': oauth_client_metadata.token_endpoint_auth_method,
+            }
+        )
 
         log.info(
             f'Static OAuth client info built for {oauth_client_id} using metadata from {oauth_server_metadata_url}'

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -497,7 +497,12 @@ async def get_oauth_client_info_with_static_credentials(
         oauth_server_metadata_url = None
 
         redirect_base_url = (str(request.app.state.config.WEBUI_URL or request.base_url)).rstrip('/')
-        redirect_uri = f'{redirect_base_url}/oauth/clients/{client_id}/callback'
+        oauth_client_metadata = OAuthClientMetadata(
+            client_name="Open WebUI",
+            redirect_uris=[f"{redirect_base_url}/oauth/clients/{client_id}/callback"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+        )
 
         # Discover server metadata (authorization endpoint, token endpoint, scopes, etc.)
         discovery_urls = await get_discovery_urls(oauth_server_url)
@@ -508,36 +513,51 @@ async def get_oauth_client_info_with_static_credentials(
                         try:
                             oauth_server_metadata = OAuthMetadata.model_validate(await resp.json())
                             oauth_server_metadata_url = url
+
+                            if (
+                                oauth_client_metadata.scope is None
+                                and oauth_server_metadata.scopes_supported is not None
+                            ):
+                                oauth_client_metadata.scope = " ".join(oauth_server_metadata.scopes_supported)
+
+                            supported_auth_methods = (
+                                oauth_server_metadata.token_endpoint_auth_methods_supported
+                                or []
+                            )
+                            if (
+                                supported_auth_methods
+                                and oauth_client_metadata.token_endpoint_auth_method
+                                not in supported_auth_methods
+                            ):
+                                if "client_secret_post" in supported_auth_methods:
+                                    oauth_client_metadata.token_endpoint_auth_method = (
+                                        "client_secret_post"
+                                    )
+                                elif "client_secret_basic" in supported_auth_methods:
+                                    oauth_client_metadata.token_endpoint_auth_method = (
+                                        "client_secret_basic"
+                                    )
+                                else:
+                                    oauth_client_metadata.token_endpoint_auth_method = (
+                                        supported_auth_methods[0]
+                                    )
                             break
                         except Exception as e:
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        # Determine scope from server metadata if available
-        scope = None
-        if oauth_server_metadata and oauth_server_metadata.scopes_supported:
-            scope = ' '.join(oauth_server_metadata.scopes_supported)
-
-        # Determine token_endpoint_auth_method
-        token_endpoint_auth_method = 'client_secret_post'
-        if (
-            oauth_server_metadata
-            and oauth_server_metadata.token_endpoint_auth_methods_supported
-            and token_endpoint_auth_method not in oauth_server_metadata.token_endpoint_auth_methods_supported
-        ):
-            token_endpoint_auth_method = oauth_server_metadata.token_endpoint_auth_methods_supported[0]
-
-        oauth_client_info = OAuthClientInformationFull(
-            client_id=oauth_client_id,
-            client_secret=oauth_client_secret,
-            redirect_uris=[redirect_uri],
-            grant_types=['authorization_code', 'refresh_token'],
-            response_types=['code'],
-            scope=scope,
-            token_endpoint_auth_method=token_endpoint_auth_method,
-            issuer=oauth_server_metadata_url,
-            server_metadata=oauth_server_metadata,
-        )
+        oauth_client_info = OAuthClientInformationFull.model_validate({
+            "client_id": oauth_client_id,
+            "client_secret": oauth_client_secret,
+            "issuer": oauth_server_metadata_url,
+            "server_metadata": oauth_server_metadata,
+            "redirect_uris": oauth_client_metadata.redirect_uris,
+            "grant_types": oauth_client_metadata.grant_types,
+            "response_types": oauth_client_metadata.response_types,
+            "client_name": oauth_client_metadata.client_name,
+            "scope": oauth_client_metadata.scope,
+            "token_endpoint_auth_method": oauth_client_metadata.token_endpoint_auth_method,
+        })
 
         log.info(
             f'Static OAuth client info built for {oauth_client_id} using metadata from {oauth_server_metadata_url}'

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -377,6 +377,7 @@ type RegisterOAuthClientForm = {
 	url: string;
 	client_id: string;
 	client_name?: string;
+	oauth_client_id?: string;
 	client_secret?: string;
 };
 

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -89,7 +89,7 @@
 		const formData: { url: string; client_id: string; client_secret?: string } = {
 			url: url,
 			client_id: id,
-			...(auth_type === 'oauth_2.1_static' ? { client_secret: oauthClientSecret } : {})
+			...(auth_type === 'oauth_2.1_static' ? { client_secret: oauthClientSecret, oauth_client_id: oauthClientId } : {})
 		};
 
 		const res = await registerOAuthClient(localStorage.token, formData, 'mcp').catch((err) => {

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -89,7 +89,9 @@
 		const formData: { url: string; client_id: string; client_secret?: string } = {
 			url: url,
 			client_id: id,
-			...(auth_type === 'oauth_2.1_static' ? { client_secret: oauthClientSecret, oauth_client_id: oauthClientId } : {})
+			...(auth_type === 'oauth_2.1_static'
+				? { client_secret: oauthClientSecret, oauth_client_id: oauthClientId }
+				: {})
 		};
 
 		const res = await registerOAuthClient(localStorage.token, formData, 'mcp').catch((err) => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Changelog Entry

### Description
The OAuth2.1 Static workflow was not working as intended. Somewhere in the conversion of the Static OAuth2.1 authentication for MCP servers Pull Request there was some lost in translation issues i believe (because the original [Pull Request](https://github.com/open-webui/open-webui/pull/22266/changes) has some different functionality than what has been [merged](https://github.com/open-webui/open-webui/commit/601bb783587a3e965cf88c148e4856b988655b13). This Pull Request is intended to correct the issues.

### Fixed
- Fix the authentication flow for OAuth2.1 Static authentication for MCP servers

---

### Additional Information
The intended flow for Static OAuth2.1 credentials is as following:
1. The user gets the static `client_id` and `client_secret` from the provider of the MCP server
2. The user will enter these in the current modal box to manage the MCP server (see below)
<img width="479" height="562" alt="Screenshot 2026-04-14 at 13 31 04" src="https://github.com/user-attachments/assets/ce91857a-c6fd-4dec-8d8b-e0629de63064" />

3. The user can (optionally) verify the connection, but Must (not optional) register the client. This client will ALWAYS make use of the entered client_id and client_secret
4. Whenever the user selects/enables the tool server in his/her chat, the user will be redirected to the authentication page of the MCP provider
<img width="392" height="254" alt="Screenshot 2026-04-14 at 13 25 54" src="https://github.com/user-attachments/assets/c9a8bfab-051d-4515-9faf-5430edc4df49" />

5. The MCP provider will do a callback to the oauth client callback URL. For the example in the screenshots above, that would be `http://localhost:3000/oauth/clients/mcp:udemy/callback`. It is possible that this callback URL needs to be configured on the side of the MCP provider as well.

6. The MCP server will then be enabled for the user and can be queried accordingly 
<img width="1050" height="371" alt="Screenshot 2026-04-14 at 13 35 33" src="https://github.com/user-attachments/assets/d936e94e-fe10-4bae-a20b-a6c90d386bcb" />

Please let me know if there are any unclarities about this feature, i am more than willing to help!

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
