### PR TITLE
fix(terminals): mirror HTTP auth modes in websocket terminal proxy

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -172,7 +172,7 @@ async def _resolve_authenticated_connection(ws: WebSocket, server_id: str):
     The client must send ``{"type": "auth", "token": "<jwt>"}`` as its first
     message after connecting.
 
-    Returns ``(user, connection)`` on success, or ``None`` after closing *ws*
+    Returns ``(user, connection, token)`` on success, or ``None`` after closing *ws*
     with an appropriate error code.
     """
     import asyncio
@@ -215,7 +215,7 @@ async def _resolve_authenticated_connection(ws: WebSocket, server_id: str):
         await ws.close(code=4003, reason='Access denied')
         return None
 
-    return user, connection
+    return user, connection, token
 
 
 @router.websocket('/{server_id}/api/terminals/{session_id}')
@@ -235,7 +235,7 @@ async def ws_terminal(
     result = await _resolve_authenticated_connection(ws, server_id)
     if result is None:
         return
-    user, connection = result
+    user, connection, token = result
 
     base_url = (connection.get('url') or '').rstrip('/')
     if not base_url:
@@ -248,7 +248,12 @@ async def ws_terminal(
         user_id=user.id,
         policy_id=connection.get('policy_id'),
     )
-    headers, cookies, auth_type = build_terminal_proxy_auth(ws, connection, user.id)
+    headers, cookies, auth_type = build_terminal_proxy_auth(
+        ws,
+        connection,
+        user.id,
+        session_token=token,
+    )
 
     session = aiohttp.ClientSession()
     try:

--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -16,6 +16,7 @@ from starlette.background import BackgroundTask
 
 from open_webui.utils.auth import get_verified_user
 from open_webui.utils.access_control import has_connection_access
+from open_webui.utils.terminals import build_terminal_proxy_auth, build_terminal_ws_url
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
 
@@ -104,25 +105,7 @@ async def proxy_terminal(
     if request.query_params:
         target_url += f'?{request.query_params}'
 
-    headers = {'X-User-Id': user.id}
-    # Forward per-session cwd tracking header
-    session_id = request.headers.get('x-session-id')
-    if session_id:
-        headers['X-Session-Id'] = session_id
-    cookies = {}
-    auth_type = connection.get('auth_type', 'bearer')
-
-    if auth_type == 'bearer':
-        headers['Authorization'] = f'Bearer {connection.get("key", "")}'
-    elif auth_type == 'session':
-        cookies = request.cookies
-        headers['Authorization'] = f'Bearer {request.state.token.credentials}'
-    elif auth_type == 'system_oauth':
-        cookies = request.cookies
-        oauth_token = request.headers.get('x-oauth-access-token', '')
-        if oauth_token:
-            headers['Authorization'] = f'Bearer {oauth_token}'
-    # auth_type == "none": no Authorization header
+    headers, cookies, _ = build_terminal_proxy_auth(request, connection, user.id)
 
     content_type = request.headers.get('content-type')
     if content_type:
@@ -259,32 +242,25 @@ async def ws_terminal(
         await ws.close(code=4003, reason='Terminal server URL not configured')
         return
 
-    # Build upstream WebSocket URL (no token in URL)
-    ws_base = base_url.replace('https://', 'wss://').replace('http://', 'ws://')
-
-    # Route through orchestrator policy endpoint if policy_id is set
-    policy_id = connection.get('policy_id')
-    upstream_params = {}
-    # For orchestrator-backed servers, pass user_id
-    upstream_params['user_id'] = user.id
-
-    import urllib.parse
-
-    if policy_id:
-        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{session_id}'
-    else:
-        upstream_url = f'{ws_base}/api/terminals/{session_id}'
-    if upstream_params:
-        upstream_url += f'?{urllib.parse.urlencode(upstream_params)}'
+    upstream_url = build_terminal_ws_url(
+        base_url=base_url,
+        session_id=session_id,
+        user_id=user.id,
+        policy_id=connection.get('policy_id'),
+    )
+    headers, cookies, auth_type = build_terminal_proxy_auth(ws, connection, user.id)
 
     session = aiohttp.ClientSession()
     try:
-        async with session.ws_connect(upstream_url) as upstream:
+        async with session.ws_connect(
+            upstream_url,
+            headers=headers,
+            cookies=cookies,
+        ) as upstream:
             import asyncio
             import json as _json
 
             # First-message auth to upstream terminal server
-            auth_type = connection.get('auth_type', 'bearer')
             if auth_type == 'bearer':
                 key = connection.get('key', '')
                 await upstream.send_str(_json.dumps({'type': 'auth', 'token': key}))

--- a/backend/open_webui/test/util/test_terminals.py
+++ b/backend/open_webui/test/util/test_terminals.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from open_webui.utils.terminals import build_terminal_proxy_auth, build_terminal_ws_url
+
+
+def _request(headers=None, cookies=None, token=None):
+    return SimpleNamespace(
+        headers=headers or {},
+        cookies=cookies or {},
+        state=SimpleNamespace(token=token),
+    )
+
+
+def test_build_terminal_proxy_auth_bearer():
+    headers, cookies, auth_type = build_terminal_proxy_auth(
+        _request(),
+        {'auth_type': 'bearer', 'key': 'secret-token'},
+        'user-1',
+    )
+
+    assert auth_type == 'bearer'
+    assert headers == {
+        'X-User-Id': 'user-1',
+        'Authorization': 'Bearer secret-token',
+    }
+    assert cookies == {}
+
+
+def test_build_terminal_proxy_auth_session():
+    request = _request(
+        headers={'x-session-id': 'session-1'},
+        cookies={'token': 'cookie-token'},
+        token=SimpleNamespace(credentials='session-token'),
+    )
+
+    headers, cookies, auth_type = build_terminal_proxy_auth(
+        request,
+        {'auth_type': 'session'},
+        'user-1',
+    )
+
+    assert auth_type == 'session'
+    assert headers == {
+        'X-User-Id': 'user-1',
+        'X-Session-Id': 'session-1',
+        'Authorization': 'Bearer session-token',
+    }
+    assert cookies == {'token': 'cookie-token'}
+
+
+def test_build_terminal_proxy_auth_system_oauth():
+    request = _request(
+        headers={'x-oauth-access-token': 'oauth-token'},
+        cookies={'oauth': 'cookie'},
+    )
+
+    headers, cookies, auth_type = build_terminal_proxy_auth(
+        request,
+        {'auth_type': 'system_oauth'},
+        'user-1',
+    )
+
+    assert auth_type == 'system_oauth'
+    assert headers == {
+        'X-User-Id': 'user-1',
+        'Authorization': 'Bearer oauth-token',
+    }
+    assert cookies == {'oauth': 'cookie'}
+
+
+def test_build_terminal_ws_url_uses_policy_route_when_configured():
+    url = build_terminal_ws_url(
+        base_url='https://orchestrator.example.com',
+        session_id='abc123',
+        user_id='user-1',
+        policy_id='policy-9',
+    )
+
+    assert url == 'wss://orchestrator.example.com/p/policy-9/api/terminals/abc123?user_id=user-1'

--- a/backend/open_webui/test/util/test_terminals.py
+++ b/backend/open_webui/test/util/test_terminals.py
@@ -68,6 +68,29 @@ def test_build_terminal_proxy_auth_system_oauth():
     assert cookies == {'oauth': 'cookie'}
 
 
+def test_build_terminal_proxy_auth_session_uses_explicit_session_token():
+    request = _request(
+        headers={'x-session-id': 'session-1'},
+        cookies={'token': 'cookie-token'},
+        token=None,
+    )
+
+    headers, cookies, auth_type = build_terminal_proxy_auth(
+        request,
+        {'auth_type': 'session'},
+        'user-1',
+        session_token='validated-jwt',
+    )
+
+    assert auth_type == 'session'
+    assert headers == {
+        'X-User-Id': 'user-1',
+        'X-Session-Id': 'session-1',
+        'Authorization': 'Bearer validated-jwt',
+    }
+    assert cookies == {'token': 'cookie-token'}
+
+
 def test_build_terminal_ws_url_uses_policy_route_when_configured():
     url = build_terminal_ws_url(
         base_url='https://orchestrator.example.com',

--- a/backend/open_webui/utils/terminals.py
+++ b/backend/open_webui/utils/terminals.py
@@ -1,7 +1,13 @@
 from urllib.parse import urlencode
 
 
-def build_terminal_proxy_auth(request, connection: dict, user_id: str) -> tuple[dict, dict, str]:
+def build_terminal_proxy_auth(
+    request,
+    connection: dict,
+    user_id: str,
+    *,
+    session_token: str | None = None,
+) -> tuple[dict, dict, str]:
     headers = {'X-User-Id': user_id}
 
     session_id = request.headers.get('x-session-id')
@@ -15,7 +21,7 @@ def build_terminal_proxy_auth(request, connection: dict, user_id: str) -> tuple[
         headers['Authorization'] = f'Bearer {connection.get("key", "")}'
     elif auth_type == 'session':
         cookies = request.cookies
-        token = getattr(getattr(request.state, 'token', None), 'credentials', None)
+        token = session_token or getattr(getattr(request.state, 'token', None), 'credentials', None)
         if token:
             headers['Authorization'] = f'Bearer {token}'
     elif auth_type == 'system_oauth':

--- a/backend/open_webui/utils/terminals.py
+++ b/backend/open_webui/utils/terminals.py
@@ -1,0 +1,44 @@
+from urllib.parse import urlencode
+
+
+def build_terminal_proxy_auth(request, connection: dict, user_id: str) -> tuple[dict, dict, str]:
+    headers = {'X-User-Id': user_id}
+
+    session_id = request.headers.get('x-session-id')
+    if session_id:
+        headers['X-Session-Id'] = session_id
+
+    cookies = {}
+    auth_type = connection.get('auth_type', 'bearer')
+
+    if auth_type == 'bearer':
+        headers['Authorization'] = f'Bearer {connection.get("key", "")}'
+    elif auth_type == 'session':
+        cookies = request.cookies
+        token = getattr(getattr(request.state, 'token', None), 'credentials', None)
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+    elif auth_type == 'system_oauth':
+        cookies = request.cookies
+        oauth_token = request.headers.get('x-oauth-access-token', '')
+        if oauth_token:
+            headers['Authorization'] = f'Bearer {oauth_token}'
+
+    return headers, cookies, auth_type
+
+
+def build_terminal_ws_url(
+    base_url: str,
+    session_id: str,
+    user_id: str,
+    *,
+    policy_id: str | None = None,
+) -> str:
+    ws_base = base_url.rstrip('/').replace('https://', 'wss://').replace('http://', 'ws://')
+
+    if policy_id:
+        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{session_id}'
+    else:
+        upstream_url = f'{ws_base}/api/terminals/{session_id}'
+
+    return f'{upstream_url}?{urlencode({"user_id": user_id})}'


### PR DESCRIPTION
Terminal connections already advertise multiple auth modes, and `proxy_terminal` forwards bearer, session, and system_oauth credentials. `ws_terminal` only sent an upstream auth frame for bearer, so session-backed and OAuth-backed terminal connections had no equivalent upstream auth material on the websocket path.

This extracts the terminal auth assembly into a shared helper and reuses it for both the HTTP proxy and the websocket handshake. The websocket keeps the existing bearer auth frame and now sends the same handshake headers/cookies used by the HTTP proxy for the other auth modes.

Related: #23788

### Testing

- `python3 -m py_compile backend/open_webui/routers/terminals.py backend/open_webui/utils/terminals.py`
- `PYTHONPATH=backend PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q backend/open_webui/test/util/test_terminals.py`
- local source-faithful harness showing that the old websocket logic sent an auth frame for `bearer` but nothing for `session` or `system_oauth`

# Changelog Entry

### Description

- keep terminal websocket auth behavior aligned with the terminal HTTP proxy

### Added

- focused terminal auth helper tests for bearer, session, and system_oauth modes

### Fixed

- terminal websocket handshakes now reuse the same auth assembly as the HTTP proxy instead of silently dropping non-bearer modes

### Additional Information

- This is distinct from `#22581` (`ws://` vs `wss://` under HTTPS).
- There was a nearby closed PR (`#23603`) on terminal websocket auth; this keeps the scope narrow and fixes the current `main` mismatch between `proxy_terminal` and `ws_terminal`.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
