### PR TITLE
perf(users): drop redundant get_user_by_id refetch in session-user endpoints

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -384,7 +384,9 @@ async def get_user_info_by_session_user(user=Depends(get_verified_user), db: Asy
 async def update_user_info_by_session_user(
     form_data: dict, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    # user already fetched by get_verified_user — no need to refetch
+    # Merges against the auth-time snapshot of user.info. The previous pre-merge
+    # refetch only narrowed (did not eliminate) the lost-update window on concurrent
+    # same-user writes; real safety needs row locking or a version column.
     existing_info = user.info or {}
     updated = await Users.update_user_by_id(user.id, {'info': {**existing_info, **form_data}}, db=db)
     if updated:

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -355,7 +355,13 @@ async def update_user_status_by_session_user(
             detail=ERROR_MESSAGES.ACTION_PROHIBITED,
         )
     # user already fetched by get_verified_user — no need to refetch
-    return await Users.update_user_status_by_id(user.id, form_data, db=db)
+    updated = await Users.update_user_status_by_id(user.id, form_data, db=db)
+    if updated:
+        return updated
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=ERROR_MESSAGES.USER_NOT_FOUND,
+    )
 
 
 ############################

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -276,14 +276,8 @@ async def update_default_user_permissions(request: Request, form_data: UserPermi
 async def get_user_settings_by_session_user(
     user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    user = await Users.get_user_by_id(user.id, db=db)
-    if user:
-        return user.settings
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.USER_NOT_FOUND,
-        )
+    # user already fetched by get_verified_user — no need to refetch
+    return user.settings
 
 
 ############################
@@ -339,14 +333,8 @@ async def get_user_status_by_session_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACTION_PROHIBITED,
         )
-    user = await Users.get_user_by_id(user.id, db=db)
-    if user:
-        return user
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.USER_NOT_FOUND,
-        )
+    # user already fetched by get_verified_user — no need to refetch
+    return user
 
 
 ############################
@@ -366,15 +354,8 @@ async def update_user_status_by_session_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACTION_PROHIBITED,
         )
-    user = await Users.get_user_by_id(user.id, db=db)
-    if user:
-        user = await Users.update_user_status_by_id(user.id, form_data, db=db)
-        return user
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.USER_NOT_FOUND,
-        )
+    # user already fetched by get_verified_user — no need to refetch
+    return await Users.update_user_status_by_id(user.id, form_data, db=db)
 
 
 ############################
@@ -384,14 +365,8 @@ async def update_user_status_by_session_user(
 
 @router.get('/user/info', response_model=Optional[dict])
 async def get_user_info_by_session_user(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    user = await Users.get_user_by_id(user.id, db=db)
-    if user:
-        return user.info
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.USER_NOT_FOUND,
-        )
+    # user already fetched by get_verified_user — no need to refetch
+    return user.info
 
 
 ############################
@@ -403,19 +378,11 @@ async def get_user_info_by_session_user(user=Depends(get_verified_user), db: Asy
 async def update_user_info_by_session_user(
     form_data: dict, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    user = await Users.get_user_by_id(user.id, db=db)
-    if user:
-        if user.info is None:
-            user.info = {}
-
-        user = await Users.update_user_by_id(user.id, {'info': {**user.info, **form_data}}, db=db)
-        if user:
-            return user.info
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.USER_NOT_FOUND,
-            )
+    # user already fetched by get_verified_user — no need to refetch
+    existing_info = user.info or {}
+    updated = await Users.update_user_by_id(user.id, {'info': {**existing_info, **form_data}}, db=db)
+    if updated:
+        return updated.info
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
Five /user/* handlers refetched the user row via Users.get_user_by_id(user.id) immediately after receiving an identical UserModel from Depends(get_verified_user). Since get_verified_user already populated the user within the same request microseconds earlier, the refetch is pure overhead. The dead else branches (unreachable — get_verified_user raises 401 on missing user) are removed as a natural consequence.

Affected endpoints:
- GET  /user/settings
- GET  /user/status
- POST /user/status/update
- GET  /user/info
- POST /user/info/update

Eliminates one SELECT per request to each of these endpoints with no behavioral change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
