### PR TITLE
perf(channels): batch user lookup in model_response_handler thread history

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -925,8 +925,8 @@ async def model_response_handler(request, channel, message, user, db=None):
                 images = []
 
                 # Batch fetch all users in a single query (fixes N+1 problem)
-                user_ids = list({m.user_id for m in thread_messages})
-                message_users = {u.id: u for u in await Users.get_users_by_user_ids(user_ids, db=db)}
+                user_ids = list({message.user_id for message in thread_messages})
+                message_users = {user.id: user for user in await Users.get_users_by_user_ids(user_ids, db=db)}
 
                 for thread_message in thread_messages:
                     message_user = message_users.get(thread_message.user_id)

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -923,15 +923,13 @@ async def model_response_handler(request, channel, message, user, db=None):
 
                 thread_history = []
                 images = []
-                message_users = {}
+
+                # Batch fetch all users in a single query (fixes N+1 problem)
+                user_ids = list({m.user_id for m in thread_messages})
+                message_users = {u.id: u for u in await Users.get_users_by_user_ids(user_ids, db=db)}
 
                 for thread_message in thread_messages:
-                    message_user = None
-                    if thread_message.user_id not in message_users:
-                        message_user = await Users.get_user_by_id(thread_message.user_id, db=db)
-                        message_users[thread_message.user_id] = message_user
-                    else:
-                        message_user = message_users[thread_message.user_id]
+                    message_user = message_users.get(thread_message.user_id)
 
                     if thread_message.meta and thread_message.meta.get('model_id', None):
                         # If the message was sent by a model, use the model name


### PR DESCRIPTION
The thread-history builder in model_response_handler called Users.get_user_by_id once per thread message (deduped via an intra-loop dict), producing N individual SELECTs for a thread of N unique authors.

Replace with a single Users.get_users_by_user_ids call that returns all authors in one WHERE id IN (...) query, matching the batch pattern already used elsewhere in this file (lines 739, 804, 1320).

Behavior is preserved: deleted users still resolve to None and fall through to the existing 'Unknown' fallback via .get().

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
