### PR TITLE
perf: reuse request db session in get_model_profile_image

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -384,8 +384,12 @@ async def get_model_by_id(id: str, user=Depends(get_verified_user), db: AsyncSes
 
 
 @router.get('/model/profile/image')
-async def get_model_profile_image(id: str, user=Depends(get_verified_user)):
-    model = await Models.get_model_by_id(id)
+async def get_model_profile_image(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(id, db=db)
 
     if model:
         etag = f'"{model.updated_at}"' if model.updated_at else None


### PR DESCRIPTION
Pass the request-scoped AsyncSession into Models.get_model_by_id so the endpoint no longer opens a fresh DB session on every call, avoiding an extra connection acquisition per profile image request.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
