### PR TITLE
perf(chats): avoid redundant fetch in get_chat_by_share_id

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -928,12 +928,16 @@ class ChatTable:
         try:
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(Chat).filter_by(share_id=id))
-                chat = result.scalars().first()
+                chat_item = result.scalars().first()
 
-                if chat:
-                    return await self.get_chat_by_id(id, db=db)
-                else:
+                if chat_item is None:
                     return None
+
+                if self._sanitize_chat_row(chat_item):
+                    await db.commit()
+                    await db.refresh(chat_item)
+
+                return ChatModel.model_validate(chat_item)
         except Exception:
             return None
 


### PR DESCRIPTION
get_chat_by_share_id already loads the Chat row via share_id lookup, then discarded it and re-fetched through get_chat_by_id. Drop the second query and return the row we already have, preserving the null-byte sanitization behavior inline.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
