### PR TITLE
perf(chats): select only meta column in get_chat_tags_by_id_and_user_id

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1323,8 +1323,10 @@ class ChatTable:
         self, id: str, user_id: str, db: Optional[AsyncSession] = None
     ) -> list[TagModel]:
         async with get_async_db_context(db) as db:
-            chat = await db.get(Chat, id)
-            tag_ids = chat.meta.get('tags', [])
+            stmt = select(Chat.meta).where(Chat.id == id)
+            result = await db.execute(stmt)
+            meta = result.scalar_one_or_none()
+            tag_ids = (meta or {}).get('tags', [])
             return await Tags.get_tags_by_ids_and_user_id(tag_ids, user_id, db=db)
 
     async def get_chat_list_by_user_id_and_tag_name(


### PR DESCRIPTION
Avoid loading the full Chat row (including the potentially large `chat` JSON column) just to read tag IDs from `meta.tags`. Issue a narrow SELECT on `Chat.meta` instead, which is much cheaper for chats with large message histories.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
