### PR TITLE
perf: avoid redundant knowledge re-fetch in update_knowledge_access_by_id

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -539,10 +539,12 @@ async def update_knowledge_access_by_id(
         'sharing.public_knowledge',
     )
 
-    await AccessGrants.set_access_grants('knowledge', id, form_data.access_grants, db=db)
+    knowledge.access_grants = await AccessGrants.set_access_grants(
+        'knowledge', id, form_data.access_grants, db=db
+    )
 
     return KnowledgeFilesResponse(
-        **(await Knowledges.get_knowledge_by_id(id=id, db=db)).model_dump(),
+        **knowledge.model_dump(),
         files=await Knowledges.get_file_metadatas_by_id(id, db=db),
     )
 


### PR DESCRIPTION
After set_access_grants, the handler was reloading the same knowledge record via get_knowledge_by_id, which triggers an extra SELECT plus a nested fetch of access grants. set_access_grants already returns the newly-written grants and the local knowledge object is otherwise unchanged, so update it in place and reuse it for the response.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
