### PR TITLE
perf: use set for O(1) lookup in insert_chat_files dedupe

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1598,11 +1598,11 @@ class ChatTable:
         if not file_ids:
             return None
 
-        chat_message_file_ids = [
+        chat_message_file_ids = {
             item.id for item in await self.get_chat_files_by_chat_id_and_message_id(chat_id, message_id, db=db)
-        ]
+        }
         # Remove duplicates and existing file_ids
-        file_ids = list(set([file_id for file_id in file_ids if file_id and file_id not in chat_message_file_ids]))
+        file_ids = list({file_id for file_id in file_ids if file_id and file_id not in chat_message_file_ids})
         if not file_ids:
             return None
 


### PR DESCRIPTION
Convert chat_message_file_ids from list to set so the membership test in the comprehension is O(1) instead of O(m), turning the dedupe from O(n*m) into O(n+m). Also replace the redundant set([...]) with a set comprehension.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
