### PR TITLE
fix: always use calling model for create_automation

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2494,7 +2494,6 @@ async def create_automation(
     name: str,
     prompt: str,
     rrule: str,
-    model_id: Optional[str] = None,
     __request__: Request = None,
     __user__: dict = None,
     __metadata__: dict = None,
@@ -2516,7 +2515,6 @@ async def create_automation(
     :param name: A short descriptive name for the automation
     :param prompt: The prompt/instructions to execute on each run
     :param rrule: An iCalendar RRULE string defining the schedule
-    :param model_id: Optional model ID to use. Defaults to the current chat model if omitted.
     :return: JSON with the created automation details including id, next scheduled runs
     """
     if __request__ is None:
@@ -2535,11 +2533,10 @@ async def create_automation(
         if not user:
             return json.dumps({'error': 'User not found'})
 
-        # Default to current chat's model if not specified
+        # Always use the model that called this tool
+        model_id = (__metadata__ or {}).get('model_id') or (__metadata__ or {}).get('model')
         if not model_id:
-            model_id = (__metadata__ or {}).get('model_id') or (__metadata__ or {}).get('model')
-        if not model_id:
-            return json.dumps({'error': 'model_id is required (could not detect current model)'})
+            return json.dumps({'error': 'Could not determine the current model'})
 
         # Validate the RRULE
         try:


### PR DESCRIPTION
Remove model_id parameter from create_automation. The automation now always inherits the model from the current conversation via __metadata__, preventing the LLM from passing incorrect or hallucinated model IDs.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
