### PR TITLE
feat: show valve config button on active filter badges

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1745,16 +1745,8 @@
 											{@const filter = toggleFilters.find((f) => f.id === filterId)}
 											{#if filter}
 												<Tooltip content={filter?.name} placement="top">
-													<button
-														on:click|preventDefault={() => {
-															selectedFilterIds = selectedFilterIds.filter((id) => id !== filterId);
-														}}
-														type="button"
-														class="group p-[7px] flex gap-1.5 items-center text-sm rounded-full transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {selectedFilterIds.includes(
-															filterId
-														)
-															? 'text-sky-500 dark:text-sky-300 bg-sky-50 hover:bg-sky-100 dark:bg-sky-400/10 dark:hover:bg-sky-600/10 border border-sky-200/40 dark:border-sky-500/20'
-															: 'bg-transparent text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 '} capitalize"
+													<div
+														class="p-[7px] flex gap-1.5 items-center text-sm rounded-full transition-colors duration-300 max-w-full overflow-hidden text-sky-500 dark:text-sky-300 bg-sky-50 dark:bg-sky-400/10 border border-sky-200/40 dark:border-sky-500/20"
 													>
 														{#if filter?.icon}
 															<div class="size-4 items-center flex justify-center">
@@ -1770,10 +1762,31 @@
 														{:else}
 															<Sparkles className="size-4" strokeWidth="1.75" />
 														{/if}
-														<div class="hidden group-hover:block">
-															<XMark className="size-4" strokeWidth="1.75" />
-														</div>
-													</button>
+
+														{#if filter?.has_user_valves && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.valves ?? true))}
+															<button
+																type="button"
+																class="hover:text-sky-700 dark:hover:text-sky-100 transition"
+																on:click|preventDefault|stopPropagation={() => {
+																	selectedValvesType = 'function';
+																	selectedValvesItemId = filterId;
+																	showValvesModal = true;
+																}}
+															>
+																<Knobs className="size-3.5" />
+															</button>
+														{/if}
+
+														<button
+															type="button"
+															class="hover:text-sky-700 dark:hover:text-sky-100 transition"
+															on:click|preventDefault|stopPropagation={() => {
+																selectedFilterIds = selectedFilterIds.filter((id) => id !== filterId);
+															}}
+														>
+															<XMark className="size-3.5" strokeWidth="1.75" />
+														</button>
+													</div>
 												</Tooltip>
 											{/if}
 										{/each}


### PR DESCRIPTION
When a filter is enabled and shown as a badge in the chat input, the badge now shows a Knobs icon (if the filter has user valves) that opens the ValvesModal directly. Previously, users had to navigate into the Integrations menu to find valve settings, which was unintuitive since the sparkle icon looked like it should offer configuration. The X button to remove the filter is now always visible instead of only on hover.

Addresses: https://github.com/open-webui/open-webui/issues/23811

<img width="362" height="186" alt="image" src="https://github.com/user-attachments/assets/ff192f9e-5762-4dff-b87f-3682f7a8fa4c" />

Not hovering over it = not shown

<img width="305" height="143" alt="image" src="https://github.com/user-attachments/assets/ce474c45-0a9b-4490-84d6-2e0b7393d1a8" />

Hovering over it = shown

<img width="438" height="106" alt="image" src="https://github.com/user-attachments/assets/967f3b0d-df99-4075-a829-a8b2077317ab" />

<img width="646" height="285" alt="image" src="https://github.com/user-attachments/assets/4ac74067-3ff3-4e14-8399-a909aa823b83" />



### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
