### PR TITLE
feat: inlet: Add configurable propagation of user auth context for pipelines

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -4148,3 +4148,24 @@ LDAP_ATTRIBUTE_FOR_GROUPS = PersistentConfig(
     'ldap.server.attribute_for_groups',
     os.environ.get('LDAP_ATTRIBUTE_FOR_GROUPS', 'memberOf'),
 )
+
+####################################
+# Pipelines 
+####################################
+ENABLE_PIPELINE_USER_GROUPS = PersistentConfig(
+    "ENABLE_PIPELINE_USER_GROUPS",
+    "pipeline.user_groups",
+    os.environ.get("ENABLE_PIPELINE_USER_GROUPS", "False").lower() =="true"
+)
+
+ENABLE_PIPELINE_USER_OAUTH = PersistentConfig(
+    "ENABLE_PIPELINE_USER_OAUTH",
+    "pipeline.user_oauth",
+    os.environ.get("ENABLE_PIPELINE_USER_OAUTH", "False").lower() =="true"
+)
+
+ENABLE_PIPELINE_USER_API_KEY = PersistentConfig(
+    "ENABLE_PIPELINE_USER_API_KEY",
+    "pipeline.user_api_key",
+    os.environ.get("ENABLE_PIPELINE_USER_API_KEY", "False").lower() =="true"
+)

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -18,7 +18,14 @@ from starlette.responses import FileResponse
 from typing import Optional
 
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
-from open_webui.config import CACHE_DIR
+from open_webui.config import (
+    CACHE_DIR, 
+    ENABLE_PIPELINE_USER_GROUPS, 
+    ENABLE_PIPELINE_USER_OAUTH,
+    ENABLE_PIPELINE_USER_API_KEY
+)
+from open_webui.models.groups import Groups
+from open_webui.models.users import Users
 from open_webui.constants import ERROR_MESSAGES
 
 
@@ -55,7 +62,17 @@ def get_sorted_filters(model_id, models):
 
 
 async def process_pipeline_inlet_filter(request, payload, user, models):
-    user = {'id': user.id, 'email': user.email, 'name': user.name, 'role': user.role}
+    user_info = {"id": user.id, "email": user.email, "name": user.name, "role": user.role}
+
+    # Option to pass additional user info and auth to the Pipelines container
+    if ENABLE_PIPELINE_USER_GROUPS:
+        user_info["groups"] = [g.name for g in await Groups.get_groups_by_member_id(user.id)]
+    if ENABLE_PIPELINE_USER_OAUTH:
+        user_info["oauth"] = user.oauth or {}
+    if ENABLE_PIPELINE_USER_API_KEY:
+        user_info['api_key'] = await Users.get_user_api_key_by_id(user.id)
+    user = user_info
+
     model_id = payload['model']
     sorted_filters = get_sorted_filters(model_id, models)
     model = models[model_id]


### PR DESCRIPTION
# Changelog Entry

### Description

- Adds configurable options to extend user dict in inlet function to include user Oauth and groups for downstream system authentication as well as user api key for reverse proxy. Resolves #23607.

### Added

- Added configurable environment variables for ENABLE_PIPELINE_USER_GROUPS, ENABLE_PIPELINE_USER_OAUTH, and 
ENABLE_PIPELINE_USER_API_KEY. Each optionally enhances the user dict context propagated to the inlet function in the pipeline container. Each variable defaults to false.

### Testing

- Testing included building the container with the included env variables and testing the payload to a pipeline inlet function.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.