### PR TITLE
perf: add index on memory.user_id

### DIFF
--- a/backend/open_webui/migrations/versions/a749ab2aa953_add_memory_user_id_index.py
+++ b/backend/open_webui/migrations/versions/a749ab2aa953_add_memory_user_id_index.py
@@ -7,7 +7,6 @@ Create Date: 2026-04-17 00:00:00.000000
 """
 
 from alembic import op
-import sqlalchemy as sa
 
 revision = 'a749ab2aa953'
 down_revision = 'c1d2e3f4a5b6'

--- a/backend/open_webui/migrations/versions/a749ab2aa953_add_memory_user_id_index.py
+++ b/backend/open_webui/migrations/versions/a749ab2aa953_add_memory_user_id_index.py
@@ -1,0 +1,26 @@
+"""Add index on memory.user_id
+
+Revision ID: a749ab2aa953
+Revises: c1d2e3f4a5b6
+Create Date: 2026-04-17 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'a749ab2aa953'
+down_revision = 'c1d2e3f4a5b6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Memory.user_id is filtered on every per-user query
+    # (get_memories_by_user_id, delete_memories_by_user_id),
+    # so a btree index prevents full-table scans as the table grows.
+    op.create_index('memory_user_id_idx', 'memory', ['user_id'])
+
+
+def downgrade():
+    op.drop_index('memory_user_id_idx', table_name='memory')

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from open_webui.internal.db import Base, get_async_db_context
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import BigInteger, Column, String, Text
+from sqlalchemy import BigInteger, Column, Index, String, Text
 
 ####################
 # Memory DB Schema
@@ -19,10 +19,14 @@ class Memory(Base):
     __tablename__ = 'memory'
 
     id = Column(String, primary_key=True, unique=True)
-    user_id = Column(String, index=True)
+    user_id = Column(String)
     content = Column(Text)
     updated_at = Column(BigInteger)
     created_at = Column(BigInteger)
+
+    __table_args__ = (
+        Index('memory_user_id_idx', 'user_id'),
+    )
 
 
 class MemoryModel(BaseModel):

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -19,7 +19,7 @@ class Memory(Base):
     __tablename__ = 'memory'
 
     id = Column(String, primary_key=True, unique=True)
-    user_id = Column(String)
+    user_id = Column(String, index=True)
     content = Column(Text)
     updated_at = Column(BigInteger)
     created_at = Column(BigInteger)


### PR DESCRIPTION
Memory queries filter by user_id (get_memories_by_user_id,
delete_memories_by_user_id) but the column had no index, forcing
a full table scan per request. Adds a btree index via Alembic
migration plus index=True on the model so fresh installs include it.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
