### PR TITLE
fix: skip <think> wrap for native reasoning_content round-trip

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -235,7 +235,7 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
 
         elif item_type == 'reasoning':
             if raw:
-                # Include reasoning with original tags for LLM re-processing
+                # Include reasoning for LLM re-processing.
                 reasoning_text = ''
                 source_list = item.get('summary', []) or item.get('content', [])
                 for part in source_list:
@@ -245,13 +245,18 @@ def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
                         reasoning_text += part.get('text', '')
 
                 if reasoning_text:
-                    start_tag = item.get('start_tag', '<think>')
-                    end_tag = item.get('end_tag', '</think>')
-                    pending_content.append(f'{start_tag}{reasoning_text}{end_tag}')
                     # Preserve raw reasoning text as reasoning_content for
                     # providers that require it on assistant tool-call messages
                     # (e.g. Moonshot/Kimi K2.5).
                     pending_reasoning += reasoning_text
+
+                    # Skip the <think> wrap when reasoning came from a native
+                    # field. Some chat templates don't strip <think>, so the
+                    # tags would leak into the prompt (e.g. Gemma 4).
+                    if item.get('attributes', {}).get('type') != 'reasoning_content':
+                        start_tag = item.get('start_tag', '<think>')
+                        end_tag = item.get('end_tag', '</think>')
+                        pending_content.append(f'{start_tag}{reasoning_text}{end_tag}')
             # else: skip reasoning blocks for normal LLM messages
 
         elif item_type == 'open_webui:code_interpreter':


### PR DESCRIPTION
Chat templates that don't strip <think> (e.g. Gemma 4) leak the tags into the prompt, causing reasoning markup to bleed into the visible reply after a tool call. Only add the wrap for inline-tag-detected reasoning; native-field reasoning ships as reasoning_content alone.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- `convert_output_to_messages` emits reasoning received via native provider fields (`delta.reasoning_content`/`.reasoning`/`.thinking`) only as the structured `reasoning_content` field on the assistant message, without the additional `<think>…</think>` wrap inside `content`. Reasoning detected from inline tags is unchanged. Fixes a regression introduced by PR #23742 where chat templates that don't strip `<think>` (Gemma 4's `strip_thinking` only removes `<|channel>…<channel|>`, same pattern for gpt-oss harmony and Qwen3-thinking) passed the foreign tags into the prompt after a tool round-trip, leaking literal `thought` / `<channel|>` markup into the visible reply.

### Added

- N/A

### Changed

- Reasoning items with `attributes.type == 'reasoning_content'` are no longer duplicated as a `<think>…</think>` wrap in `content` when reconstructing assistant history for the backend; only the structured `reasoning_content` field is sent. Inline-tag-detected reasoning keeps the existing behavior.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Visible `thought` / `<channel|>` leak in replies after native tool calls on reasoning-capable models whose chat templates consume `reasoning_content` natively but do not strip `<think>` from `content` (Gemma 4, gpt-oss harmony, Qwen3-thinking). Regression of PR #23742.

### Security

- N/A

### Breaking Changes

- None.

---

### Additional Information

**Problem.** The partial fix in 3dd825581 introduced `pending_reasoning` so assistant tool-call messages include a `reasoning_content` field (needed by Kimi K2.5). It still also emits a `<think>…</think>` wrap in `content`. Gemma 4's `strip_thinking` macro only strips `<|channel>…<channel|>`, so the `<think>` tags pass into the prompt. The model's own channel markers then either get rendered as empty special tokens or bleed into `delta.content`, producing visible `thought\n<channel|>…` leakage.

**Fix.** Branch on the existing provenance marker `attributes.type == 'reasoning_content'` (set at `middleware.py:3774` only for reasoning from native provider fields, and already used at `middleware.py:3852` by the `inside_tag_block` guard). For those items, emit only the structured field; skip the `<think>` wrap. Inline-tag-detected items keep the wrap since those models emit and expect inline tags.

**Scope.** One function, one branch. No changes to DB schema, frontend rendering, export, or other call sites. No new config.

**Manual verification.** Direct API curl: before, `delta.content` starts with literal `thought` / `\n` / `<channel|>`; after, reasoning streams in `delta.reasoning_content` and content stays clean. End-to-end via OpenWebUI + Gemma 4 + a Python tool: reply renders a clean "Thought for N seconds" collapsible.


### Screenshots or Videos

Before:
<img width="1076" height="957" alt="Zen 2026-04-17 15 03 27" src="https://github.com/user-attachments/assets/0e84eab1-2db2-4eb7-bd9e-8288a0257105" />
After:
<img width="1094" height="408" alt="Zen 2026-04-17 15 03 40" src="https://github.com/user-attachments/assets/63b1dd9b-f137-4c55-9294-2872db23eb88" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.