### PR TITLE
fix: preserve reasoning_details for multi-turn continuity

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -219,6 +219,35 @@ def _split_tool_calls(
     return expanded
 
 
+def _merge_reasoning_details(details: list, chunk: object) -> None:
+    """Merge reasoning_details delta items into a list in-place.
+
+    Items sharing an integer index are merged: text and summary deltas
+    concatenate when string-valued, other fields overwrite with the latest
+    delta. Items without a usable index are appended in arrival order.
+    """
+    items = chunk if isinstance(chunk, list) else ([chunk] if isinstance(chunk, dict) else [])
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        idx = item.get('index')
+        existing = None
+        if isinstance(idx, int) and idx >= 0:
+            existing = next((e for e in details if e.get('index') == idx), None)
+        if existing is None:
+            new_entry = dict(item)
+            new_entry.setdefault('type', 'reasoning.text')
+            details.append(new_entry)
+            continue
+        for k, v in item.items():
+            if k in ('text', 'summary'):
+                if isinstance(v, str):
+                    base = existing.get(k)
+                    existing[k] = (base + v) if isinstance(base, str) else v
+            else:
+                existing[k] = v
+
+
 def get_citation_source_from_tool_result(
     tool_name: str, tool_params: dict, tool_result: str, tool_id: str = ''
 ) -> list[dict]:
@@ -523,6 +552,8 @@ def serialize_output(output: list) -> str:
                     pass
 
             reasoning_content = ''.join(reasoning_parts).strip()
+            if not reasoning_content:
+                continue  # no displayable text; item stays in output for round-trip
 
             duration = item.get('duration')
             status = item.get('status', 'in_progress')
@@ -3471,7 +3502,35 @@ async def non_streaming_chat_response_handler(response, ctx):
                     # otherwise generate from response content
                     response_output = response_data.get('output')
                     if not response_output:
-                        response_output = [
+                        message_obj = choices[0].get('message', {})
+                        reasoning_text = (
+                            message_obj.get('reasoning_content')
+                            or message_obj.get('reasoning')
+                        )
+                        reasoning_details = message_obj.get('reasoning_details')
+
+                        response_output = []
+
+                        if reasoning_text or reasoning_details:
+                            r_item = {
+                                'type': 'reasoning',
+                                'id': output_id('r'),
+                                'status': 'completed',
+                                'start_tag': '<think>',
+                                'end_tag': '</think>',
+                                'attributes': {'type': 'reasoning_content'},
+                                'content': [{'type': 'output_text', 'text': reasoning_text}] if reasoning_text else [],
+                                'summary': None,
+                            }
+                            if reasoning_details:
+                                r_item['reasoning_details'] = (
+                                    reasoning_details
+                                    if isinstance(reasoning_details, list)
+                                    else [reasoning_details]
+                                )
+                            response_output.append(r_item)
+
+                        response_output.append(
                             {
                                 'type': 'message',
                                 'id': output_id('msg'),
@@ -3479,7 +3538,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 'role': 'assistant',
                                 'content': [{'type': 'output_text', 'text': content}],
                             }
-                        ]
+                        )
 
                     await event_emitter(
                         {
@@ -3824,6 +3883,8 @@ async def streaming_chat_response_handler(response, ctx):
 
             # Initialize output: use existing from message if continuing, else create new
             existing_output = message.get('output') if message else None
+            _pending_reasoning_details = []
+
             if existing_output:
                 output = existing_output
             else:
@@ -4188,9 +4249,14 @@ async def streaming_chat_response_handler(response, ctx):
                                         or delta.get('reasoning')
                                         or delta.get('thinking')
                                     )
+                                    reasoning_details_chunk = delta.get('reasoning_details')
+
+                                    # Only create a reasoning item for visible reasoning text.
+                                    # Details-only deltas (e.g. Gemini encrypted blobs) are
+                                    # buffered to avoid splitting the assistant message mid-stream.
                                     if reasoning_content:
                                         if not output or output[-1].get('type') != 'reasoning':
-                                            reasoning_item = {
+                                            output.append({
                                                 'type': 'reasoning',
                                                 'id': output_id('r'),
                                                 'status': 'in_progress',
@@ -4200,23 +4266,37 @@ async def streaming_chat_response_handler(response, ctx):
                                                 'content': [],
                                                 'summary': None,
                                                 'started_at': time.time(),
-                                            }
-                                            output.append(reasoning_item)
-                                        else:
-                                            reasoning_item = output[-1]
+                                            })
 
-                                        # Append to reasoning content
+                                    if reasoning_content:
+                                        reasoning_item = output[-1]
                                         parts = reasoning_item.get('content', [])
                                         if parts and parts[-1].get('type') == 'output_text':
                                             parts[-1]['text'] += reasoning_content
                                         else:
-                                            reasoning_item['content'] = [
-                                                {
-                                                    'type': 'output_text',
-                                                    'text': reasoning_content,
-                                                }
-                                            ]
+                                            reasoning_item['content'] = [{'type': 'output_text', 'text': reasoning_content}]
 
+                                        # Flush any buffered details-only chunks into this reasoning item.
+                                        if _pending_reasoning_details:
+                                            _merge_reasoning_details(
+                                                reasoning_item.setdefault('reasoning_details', []),
+                                                _pending_reasoning_details,
+                                            )
+                                            _pending_reasoning_details.clear()
+
+                                    # Accumulate raw structured reasoning_details for provider round-trip.
+                                    if reasoning_details_chunk:
+                                        if output and output[-1].get('type') == 'reasoning':
+                                            _merge_reasoning_details(
+                                                output[-1].setdefault('reasoning_details', []),
+                                                reasoning_details_chunk,
+                                            )
+                                        else:
+                                            # Buffer until a safe boundary (end-of-stream or real reasoning text).
+                                            items = reasoning_details_chunk if isinstance(reasoning_details_chunk, list) else [reasoning_details_chunk]
+                                            _pending_reasoning_details.extend(items)
+
+                                    if reasoning_content or reasoning_details_chunk:
                                         data = {'content': serialize_output(full_output())}
 
                                     if value:
@@ -4429,6 +4509,30 @@ async def streaming_chat_response_handler(response, ctx):
                                     reasoning_item['ended_at'] - reasoning_item['started_at']
                                 )
                                 reasoning_item['status'] = 'completed'
+
+                    # Flush any buffered reasoning_details that never found a reasoning item.
+                    if _pending_reasoning_details:
+                        target = next((item for item in output if item.get('type') == 'reasoning'), None)
+                        if target is None:
+                            target = {
+                                'type': 'reasoning',
+                                'id': output_id('r'),
+                                'status': 'completed',
+                                'start_tag': '<think>',
+                                'end_tag': '</think>',
+                                'attributes': {'type': 'reasoning_content'},
+                                'content': [],
+                                'summary': None,
+                                'started_at': time.time(),
+                                'ended_at': time.time(),
+                                'duration': 0,
+                            }
+                            output.insert(0, target)
+                        _merge_reasoning_details(
+                            target.setdefault('reasoning_details', []),
+                            _pending_reasoning_details,
+                        )
+                        _pending_reasoning_details.clear()
 
                     if response_tool_calls:
                         tool_calls.append(_split_tool_calls(response_tool_calls))

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -159,10 +159,11 @@ def convert_output_to_messages(
     pending_tool_calls = []
     pending_content = []
     pending_reasoning = []  # Only populated when reasoning_format == 'reasoning_content'
+    pending_reasoning_details = None
 
     def flush_pending():
-        nonlocal pending_content, pending_tool_calls, pending_reasoning
-        if not pending_content and not pending_tool_calls and not pending_reasoning:
+        nonlocal pending_content, pending_tool_calls, pending_reasoning, pending_reasoning_details
+        if not pending_content and not pending_tool_calls and not pending_reasoning and not pending_reasoning_details:
             return
 
         message = {
@@ -174,10 +175,14 @@ def convert_output_to_messages(
         if pending_reasoning:
             message['reasoning_content'] = '\n'.join(pending_reasoning)
 
+        if pending_reasoning_details:
+            message['reasoning_details'] = pending_reasoning_details
+
         messages.append(message)
         pending_content = []
         pending_tool_calls = []
         pending_reasoning = []
+        pending_reasoning_details = None
 
     for item in output:
         item_type = item.get('type', '')
@@ -248,7 +253,7 @@ def convert_output_to_messages(
                 )
 
         elif item_type == 'reasoning':
-            if not reasoning_format:
+            if not raw:
                 continue
 
             reasoning_text = ''
@@ -259,15 +264,28 @@ def convert_output_to_messages(
                 elif 'text' in part:
                     reasoning_text += part.get('text', '')
 
+            raw_details = item.get('reasoning_details')
+
             if reasoning_text:
-                if reasoning_format == 'think_tags':
-                    # Ollama: embed in content with the item's original tags
+                if reasoning_format == 'reasoning_content':
+                    # llama.cpp: collect for reasoning_content field
+                    pending_reasoning.append(reasoning_text)
+                elif not raw_details:
+                    # Wrap reasoning in <think> tags for Ollama and any
+                    # provider that lacks structured reasoning_details.
                     start_tag = item.get('start_tag', '<think>')
                     end_tag = item.get('end_tag', '</think>')
                     pending_content.append(f'{start_tag}{reasoning_text}{end_tag}')
-                elif reasoning_format == 'reasoning_content':
-                    # llama.cpp: collect for reasoning_content field
-                    pending_reasoning.append(reasoning_text)
+
+            # Preserve raw structured reasoning_details for provider round-trip
+            if raw_details:
+                if pending_reasoning_details is None:
+                    pending_reasoning_details = list(raw_details) if isinstance(raw_details, list) else [raw_details]
+                elif isinstance(pending_reasoning_details, list):
+                    if isinstance(raw_details, list):
+                        pending_reasoning_details.extend(raw_details)
+                    else:
+                        pending_reasoning_details.append(raw_details)
 
         elif item_type == 'open_webui:code_interpreter':
             # Always include code interpreter content so the LLM knows


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

`reasoning_details` (OpenRouter's structured reasoning payload) was being dropped. It was never stored or sent back on follow-up turns, so models lost their prior reasoning context. This breaks tool-call continuation with reasoning models.

### Added

- [List any new features, functionalities, or additions]

### Changed

- `middleware.py`: Added `_merge_reasoning_details` helper; details-only streaming chunks are buffered and flushed at end-of-stream or when reasoning text appears.

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Streaming `delta.reasoning_details` chunks are merged by index (text concatenated, other fields overwritten). Details-only deltas are buffered to avoid splitting the assistant message mid-stream.
- Non-streaming `message.reasoning_details` is now stored on the assistant output item.
- `convert_output_to_messages(raw=True)` now includes `reasoning_details` on the assistant message so providers get it back on follow-up turns.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- Existing reasoning display is unchanged. Providers that don't emit `reasoning_details` are unaffected.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
