### PR TITLE
fix(openai): strip upstream hop-by-hop headers in MOA proxy

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -62,6 +62,8 @@ from open_webui.utils.anthropic import is_anthropic_url, get_anthropic_models
 
 log = logging.getLogger(__name__)
 
+STRIPPED_RESPONSE_HEADERS = frozenset(('transfer-encoding', 'connection', 'content-encoding', 'content-length'))
+
 
 ##########################################
 #
@@ -1186,7 +1188,11 @@ async def generate_chat_completion(
             return StreamingResponse(
                 stream_wrapper(r, session, stream_chunks_handler),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers={
+                    key: value
+                    for key, value in r.headers.items()
+                    if key.lower() not in STRIPPED_RESPONSE_HEADERS
+                },
             )
         else:
             try:


### PR DESCRIPTION
## Description

Fixes ERR_CONTENT_DECODING_FAILED when using 'Merge Responses' with Google/Anthropic models.

**Root cause**: aiohttp auto-decompresses the upstream response body but leaves the `Content-Encoding: gzip` header intact. When the server forwards this header with the already-decoded body, Chrome fails to parse it.

**Fix**: Add `STRIPPED_RESPONSE_HEADERS` constant and filter hop-by-hop headers (`transfer-encoding`, `connection`, `content-encoding`, `content-length`) before forwarding the streaming response. This pattern is already used in `terminals.py`.

**Changes**:
- Add `STRIPPED_RESPONSE_HEADERS = frozenset(...) ` constant near line 63
- Filter headers in `generate_chat_completion` StreamingResponse before forwarding

## Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)