### PR TITLE
Filter hop-by-hop headers in ALL SSE proxy paths (openai.py) - fix #23856

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -62,6 +62,18 @@ from open_webui.utils.anthropic import is_anthropic_url, get_anthropic_models
 
 log = logging.getLogger(__name__)
 
+# Hop-by-hop headers that must not be forwarded by a proxy.
+# These are stripped to prevent ERR_CONTENT_DECODING_FAILED and similar errors
+# when the upstream response is re-streamed through a different HTTP stack.
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    ("transfer-encoding", "connection", "content-encoding", "content-length")
+)
+
+
+def _filter_upstream_headers(headers: dict) -> dict:
+    """Remove hop-by-hop headers that should not be forwarded."""
+    return {k: v for k, v in headers.items() if k.lower() not in STRIPPED_RESPONSE_HEADERS}
+
 
 ##########################################
 #
@@ -1186,7 +1198,7 @@ async def generate_chat_completion(
             return StreamingResponse(
                 stream_wrapper(r, session, stream_chunks_handler),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers=_filter_upstream_headers(dict(r.headers)),
             )
         else:
             try:
@@ -1273,7 +1285,7 @@ async def embeddings(request: Request, form_data: dict, user):
             return StreamingResponse(
                 stream_wrapper(r, session),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers=_filter_upstream_headers(dict(r.headers)),
             )
         else:
             try:
@@ -1389,7 +1401,7 @@ async def responses(
             return StreamingResponse(
                 stream_wrapper(r, session),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers=_filter_upstream_headers(dict(r.headers)),
             )
         else:
             try:
@@ -1495,7 +1507,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
             return StreamingResponse(
                 stream_wrapper(r, session),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers=_filter_upstream_headers(dict(r.headers)),
             )
         else:
             try:


### PR DESCRIPTION
## Summary

Extends the fix from PR #23856 to all streaming response paths in  that forward upstream headers to the client. The original PR only addressed , but , , and  can also trigger  when hop-by-hop headers like , , , and  are forwarded through a different HTTP stack.

## Changes

- Added  constant (matching the pattern already used in )
- Added  helper function
- Applied the helper to all four SSE streaming paths in :
  1.  (line ~1201)
  2.  (line ~1288)
  3.  (line ~1404)
  4.  (line ~1510)

## Testing

The fix follows the same pattern as the existing fix in  which correctly strips these headers. All four code paths now use the same filtering approach before passing headers to .

## Fixes

Fixes open-webui#23856