### PR TITLE
fix: personal open-terminal connection status storage and terminal button visibility

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1941,7 +1941,7 @@
 
 										{#if !history?.currentId || history.messages[history.currentId]?.done == true}
 											<!-- Terminal Server Selector -->
-											{#if terminalCapableModels.length > 0 && (($terminalServers ?? []).length > 0 || ($settings?.terminalServers ?? []).some((s) => s.url))}
+											{#if terminalCapableModels.length > 0 && (($terminalServers ?? []).length > 0 || ($settings?.terminalServers ?? []).some((s) => s.url && s.enabled))}
 												<TerminalMenu bind:show={showTerminalMenu} />
 											{/if}
 

--- a/src/lib/components/chat/MessageInput/TerminalMenu.svelte
+++ b/src/lib/components/chat/MessageInput/TerminalMenu.svelte
@@ -14,7 +14,7 @@
 	export let show = false;
 
 	$: systemTerminals = ($terminalServers ?? []).filter((t) => t.id);
-	$: directTerminals = ($settings?.terminalServers ?? []).filter((s) => s.url);
+	$: directTerminals = ($settings?.terminalServers ?? []).filter((s) => s.url && s.enabled);
 
 	const refreshTerminalServersStore = async (servers: typeof directTerminals) => {
 		// Preserve system terminals (those with an `id`) — only refresh direct ones

--- a/src/lib/components/chat/Settings/Integrations.svelte
+++ b/src/lib/components/chat/Settings/Integrations.svelte
@@ -6,7 +6,7 @@
 	const dispatch = createEventDispatcher();
 	const i18n = getContext('i18n');
 
-	import { settings, toolServers, terminalServers } from '$lib/stores';
+	import { settings, toolServers, terminalServers, selectedTerminalId } from '$lib/stores';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -28,12 +28,19 @@
 	};
 
 	const updateHandler = async () => {
+		// Clear selectedTerminalId if the currently selected terminal is now disabled
+		const currentSelectedId = $selectedTerminalId;
+		const selectedConfig = terminalServerConfigs.find((s) => s.url === currentSelectedId);
+		if (selectedConfig && !selectedConfig.enabled) {
+			selectedTerminalId.set(null);
+		}
+
 		await saveSettings({
 			toolServers: servers,
 			terminalServers: terminalServerConfigs
 		});
 
-		let toolServersData = await getToolServersData($settings?.toolServers ?? []);
+		let toolServersData = await getToolServersData(servers ?? []);
 		toolServersData = toolServersData.filter((data) => {
 			if (data.error) {
 				toast.error(

--- a/src/lib/components/chat/Settings/Integrations.svelte
+++ b/src/lib/components/chat/Settings/Integrations.svelte
@@ -28,10 +28,10 @@
 	};
 
 	const updateHandler = async () => {
-		// Clear selectedTerminalId if the currently selected terminal is now disabled
+		// Clear selectedTerminalId if the selected terminal is deleted, renamed, or disabled
 		const currentSelectedId = $selectedTerminalId;
 		const selectedConfig = terminalServerConfigs.find((s) => s.url === currentSelectedId);
-		if (selectedConfig && !selectedConfig.enabled) {
+		if (!selectedConfig || !selectedConfig.enabled) {
 			selectedTerminalId.set(null);
 		}
 

--- a/src/lib/components/chat/Settings/Integrations/Terminals/Connection.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals/Connection.svelte
@@ -74,7 +74,7 @@
 		<Tooltip content={connection?.enabled ? $i18n.t('Enabled') : $i18n.t('Disabled')}>
 			<Switch
 				state={connection?.enabled}
-				on:change={() => (connection?.enabled ? onDisable() : onEnable())}
+				on:change={(e) => (e.detail ? onEnable() : onDisable())}
 			/>
 		</Tooltip>
 	</div>

--- a/src/lib/components/common/Switch.svelte
+++ b/src/lib/components/common/Switch.svelte
@@ -34,9 +34,9 @@
 			: 'outline outline-1 outline-gray-100 dark:outline-gray-800'} {state
 			? ' bg-emerald-500 dark:bg-emerald-700'
 			: 'bg-gray-200 dark:bg-transparent'}"
-		onCheckedChange={async () => {
+		onCheckedChange={async (newValue) => {
 			await tick();
-			dispatch('change', state);
+			dispatch('change', newValue);
 		}}
 	>
 		<Switch.Thumb


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description
This PR fixed below problems related to open-terminal connections under personal settings:
1. When disable/enable the Open-Terminal connections via personal integrations, the status reverseback after refresh the page. 
2. Hide the Terminal button in the chatbox when there is no available Open-Terminal connections. 

### Added

- [List any new features, functionalities, or additions]

### Changed

- **Switch component** (`Switch.svelte`): `onCheckedChange` callback and `dispatch('change')` now correctly pass the new toggled value (`newValue`) instead of the old state, fixing incorrect event data passed to parent components.
- **Terminal button visibility** (`MessageInput.svelte`, `TerminalMenu.svelte`): Filter condition changed from `s.url` to `s.url && s.enabled`, ensuring only enabled terminal servers show the Terminal button or appear in the menu.
- **Terminal enabled state restoration** (`Chat.svelte`): Loading logic now respects the `enabled` flag when restoring terminal state from localStorage.

### Deprecated

- None
### Removed

- None

### Fixed

- **Terminal toggle direction** (`Terminals/Connection.svelte`): Switch enable/disable operations were reversed due to the Switch component bug, now working correctly.
- **Stale terminal state** (`Integrations.svelte`): `selectedTerminalId` is now automatically cleared to `null` when saving if the currently selected terminal has been disabled, preventing residual stale state.


### Security

- None

### Breaking Changes

- None

---

### Test Plan

- [x] Disable all terminals in Terminal settings page, confirm Terminal button no longer appears in the message input
- [x] Re-enable a terminal, confirm Terminal button appears correctly
- [x] Repeatedly toggle Terminal switch states, confirm enable/disable direction is correct



### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
