### PR TITLE
fix(openai): strip hop-by-hop headers from proxied SSE responses

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -62,6 +62,10 @@ from open_webui.utils.anthropic import is_anthropic_url, get_anthropic_models
 
 log = logging.getLogger(__name__)
 
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    ("transfer-encoding", "connection", "content-encoding", "content-length")
+)
+
 
 ##########################################
 #
@@ -1186,7 +1190,11 @@ async def generate_chat_completion(
             return StreamingResponse(
                 stream_wrapper(r, session, stream_chunks_handler),
                 status_code=r.status,
-                headers=dict(r.headers),
+                headers={
+                    key: value
+                    for key, value in r.headers.items()
+                    if key.lower() not in STRIPPED_RESPONSE_HEADERS
+                },
             )
         else:
             try:


### PR DESCRIPTION
## Problem

Merge Responses (MOA) using Google/Anthropic API models fails with browser error `ERR_CONTENT_DECODING_FAILED` on the `/api/v1/tasks/moa/completions` endpoint. The request returns 200 OK but the browser cannot decode the body.

## Root Cause

When proxying streaming responses from Anthropic/Google APIs through aiohttp, the session auto-decompresses the response body (default `auto_decompress=True`), but the upstream `content-encoding: gzip` header is forwarded unchanged. The browser receives a decoded plaintext body with a header claiming it is gzip-encoded, causing the decoding failure.

## Fix

Strip hop-by-hop and transport headers (`transfer-encoding`, `connection`, `content-encoding`, `content-length`) from the forwarded `StreamingResponse` headers in `generate_chat_completion`. This mirrors the existing pattern already used in `terminals.py`.

Fixes #23855