### PR TITLE
feat: Add mute/unmute toggle button in Voice Mode

### DIFF
--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -44,6 +44,7 @@
 	let audioStream = null;
 	let audioChunks = [];
 	let isMuted = false;
+	let lastSoundTime = Date.now();
 
 	const toggleMute = () => {
 		isMuted = !isMuted;
@@ -312,7 +313,7 @@
 		const domainData = new Uint8Array(bufferLength);
 		const timeDomainData = new Uint8Array(analyser.fftSize);
 
-		let lastSoundTime = Date.now();
+		lastSoundTime = Date.now();
 		hasStartedSpeaking = false;
 
 		console.log('🔊 Sound detection started', lastSoundTime, hasStartedSpeaking);

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -52,6 +52,9 @@
 				track.enabled = !isMuted;
 			});
 		}
+		if (!isMuted) {
+			lastSoundTime = Date.now();
+		}
 	};
 
 	let videoInputDevices = [];
@@ -240,6 +243,11 @@
 						autoGainControl: true
 					}
 				});
+				if (isMuted) {
+					audioStream.getAudioTracks().forEach((track) => {
+						track.enabled = false;
+					});
+				}
 			}
 			mediaRecorder = new MediaRecorder(audioStream);
 

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -43,6 +43,16 @@
 	let mediaRecorder;
 	let audioStream = null;
 	let audioChunks = [];
+	let isMuted = false;
+
+	const toggleMute = () => {
+		isMuted = !isMuted;
+		if (audioStream) {
+			audioStream.getAudioTracks().forEach((track) => {
+				track.enabled = !isMuted;
+			});
+		}
+	};
 
 	let videoInputDevices = [];
 	let selectedVideoInputDeviceId = null;
@@ -302,6 +312,12 @@
 		const detectSound = () => {
 			const processFrame = () => {
 				if (!mediaRecorder || !$showCallOverlay) {
+					return;
+				}
+
+				if (isMuted) {
+					rmsLevel = 0;
+					window.requestAnimationFrame(processFrame);
 					return;
 				}
 
@@ -943,7 +959,39 @@
 				{/if}
 			</div>
 
-			<div>
+			<div class="flex items-center gap-2">
+				<Tooltip content={$i18n.t(isMuted ? 'Unmute' : 'Mute')}>
+					<button
+						class="p-3 rounded-full {isMuted ? 'bg-red-100 dark:bg-red-900' : 'bg-gray-50 dark:bg-gray-900'}"
+						type="button"
+						on:click={toggleMute}
+						aria-label={$i18n.t(isMuted ? 'Unmute' : 'Mute')}
+					>
+						{#if isMuted}
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								class="size-5"
+							>
+								<path d="M7.049 3.434A3 3 0 0113 5v1.86l-1.5-1.5V5a1.5 1.5 0 00-2.59-1.028L7.049 3.434z" />
+								<path d="M3.28 2.22a.75.75 0 00-1.06 1.06L5.72 6.78 4.5 8H3a1 1 0 00-1 1v2a1 1 0 001 1h1.5l4.09 3.273A1 1 0 0010 14.58V9.28l2.455 2.456a3.98 3.98 0 01-1.455.644v1.56a5.48 5.48 0 002.459-1.129L15.78 15.13a.75.75 0 001.06-1.06L3.28 2.22z" />
+								<path d="M14 8.391V5a3 3 0 00-3-3c-.357 0-.694.074-1 .208v1.647L14 7.855v.536z" />
+							</svg>
+						{:else}
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								class="size-5"
+							>
+								<path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z" />
+								<path d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z" />
+							</svg>
+						{/if}
+					</button>
+				</Tooltip>
+
 				<button
 					type="button"
 					on:click={() => {
@@ -953,7 +1001,9 @@
 					}}
 				>
 					<div class=" line-clamp-1 text-sm font-medium">
-						{#if loading}
+						{#if isMuted}
+							{$i18n.t('Muted')}
+						{:else if loading}
 							{$i18n.t('Thinking...')}
 						{:else if assistantSpeaking}
 							{$i18n.t('Tap to interrupt')}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** Provide a concise description of the changes made in this pull request down below.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [X] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. **No new dependencies added.**
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [X] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [X] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

Add a mute/unmute toggle button to Voice Mode so users can temporarily silence their microphone without leaving the voice session. This addresses a common pain point when using Voice Mode in public or shared spaces — background noise and other people's speech get picked up while waiting for the AI to respond, causing unintended input. Major AI chat apps (ChatGPT, Claude, Gemini) all offer this capability in their voice interfaces.

**The change is intentionally minimal** — 1 file changed, 52 insertions, 2 deletions — all scoped to `CallOverlay.svelte`. No new dependencies, no settings, no changes to dictation/recording or any other feature. Used Claude Opus 4.6 w/ Karpathy CLAUDE.md File steering file to minimize AI pitfalls in code changes. Tested locally using a fork of the release build 0.8.12

**Started from:**
1. My own personal issues (public spaces like the gym)
2. Community asking for this as a feature request [D#14505](https://github.com/open-webui/open-webui/discussions/14505)
3. Community open issue feature [I#23832](https://github.com/open-webui/open-webui/issues/23832)

**How it works:**
- A new mic button appears in the bottom bar of the Voice Mode overlay (between the existing status text and the close button)
- Pressing it disables the audio tracks on the existing stream (`track.enabled = false`) and skips sound detection in the analysis loop
- Pressing again re-enables the tracks and resumes listening instantly
- The button icon toggles between a mic and a crossed-out mic, and the status text shows "Muted"
- The button has a red-tinted background when muted for clear visual feedback

Documentation update PR [PR#1195](https://github.com/open-webui/docs/pull/1195)

**What might come next:**
- By design, the AI fully pauses when the mute button is pressed — it won't detect silence or process a response until the user unmutes. This means mute currently acts as a "hold on, I need a moment" button (e.g., the user gets interrupted, a loud noise appears, or they need time to think).
- It does **not** act as a "I'm done talking, go ahead and respond" signal. When you unmute, the silence timer resumes from where it left off — the AI only processes after it detects natural silence again.
- A natural follow-up would be to evolve the mute button into a "done talking" trigger (mute the mic and immediately tell the AI to process what it has so far), and add a separate "pause" button for the "hold on, side topic" use case where you want to freeze everything. I'd be happy to help with a second feature request for that if the team/Tim is interested.
- I could also review other ideas suggested like sensitivity adjustability, auto mute/unmute features, etc but those would involve more of the core application changes and wanted to address the primary issue as a act of good faith first.

### Added

- Mute/unmute toggle button in Voice Mode overlay (`CallOverlay.svelte`)
- `isMuted` local state variable and `toggleMute()` function
- Mic and mic-off SVG icons with tooltip ("Mute" / "Unmute")
- "Muted" status text when microphone is muted
- Visual feedback: red-tinted button background in muted state

### Changed

- Bottom bar layout in Voice Mode now wraps the mute button and status text together using `flex items-center gap-2`
- `processFrame` in `analyseAudio` now skips sound detection and zeros RMS level when muted

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Only `src/lib/components/chat/MessageInput/CallOverlay.svelte` is modified
- The mute mechanism uses `track.enabled = false` on the MediaStream audio tracks, which is the standard Web Audio API approach — it silences the mic input without destroying the stream, so unmuting is instant with no re-initialization
- The `analyseAudio` loop's `processFrame` also checks `isMuted` to skip sound detection and zero out `rmsLevel`, preventing any accidental speech triggers while muted
- Tested locally against Open WebUI v0.8.12 backend with Ollama model server
- No change/impact on dictation mode, text input recording, or any other feature

### Screenshots or Videos

![Showing the new Mute button in the Voice Mode area](image.png)
<img width="1221" height="950" alt="image" src="https://github.com/user-attachments/assets/ef568a95-d0dc-4429-9505-ff77ae41e609" />
![Red "mute" icon when muted — the AI pauses here until we unmute](image-1.png)
<img width="1221" height="950" alt="image" src="https://github.com/user-attachments/assets/36321c88-928b-4ef0-b3f4-33aa80e675dd" />
![Unmuted — the AI is now listening. After a period of silence it will process](image-2.png)
<img width="1221" height="950" alt="image" src="https://github.com/user-attachments/assets/d60549c3-9504-40f1-a443-cb6d9d3d1272" />
![Showing the mic output did not pick up speech while muted](image-3.png)
<img width="1221" height="950" alt="image" src="https://github.com/user-attachments/assets/2af697b7-e7bc-48a7-abac-c2391a24bce4" />
![Showing mute works while the AI is thinking (important in a public space)](image-4.png)
<img width="1221" height="950" alt="image" src="https://github.com/user-attachments/assets/9c2e74ba-4663-4e63-9e6f-5b7e1c25a8a3" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
