### PR TITLE
refactor: extract provider-facing helpers from routers into open_webui.clients

### DIFF
--- a/backend/open_webui/clients/memories.py
+++ b/backend/open_webui/clients/memories.py
@@ -1,0 +1,152 @@
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request, status
+from pydantic import BaseModel
+
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.models.memories import Memories, MemoryModel
+from open_webui.models.users import UserModel
+from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
+from open_webui.utils.access_control import has_permission
+
+log = logging.getLogger(__name__)
+
+
+class AddMemoryForm(BaseModel):
+    content: str
+
+
+class MemoryUpdateModel(BaseModel):
+    content: str | None = None
+
+
+class QueryMemoryForm(BaseModel):
+    content: str
+    k: int | None = 1
+
+
+def _ensure_memories_enabled_for(request: Request, user: UserModel) -> None:
+    if not request.app.state.config.ENABLE_MEMORIES:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+
+async def _ensure_user_can_use_memories(request: Request, user: UserModel) -> None:
+    _ensure_memories_enabled_for(request, user)
+    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+
+async def add_memory(
+    request: Request,
+    form_data: AddMemoryForm,
+    user: UserModel,
+) -> MemoryModel | None:
+    await _ensure_user_can_use_memories(request, user)
+
+    memory = await Memories.insert_new_memory(user.id, form_data.content)
+    vector = await request.app.state.EMBEDDING_FUNCTION(memory.content, user=user)
+
+    await ASYNC_VECTOR_DB_CLIENT.upsert(
+        collection_name=f'user-memory-{user.id}',
+        items=[
+            {
+                'id': memory.id,
+                'text': memory.content,
+                'vector': vector,
+                'metadata': {'created_at': memory.created_at},
+            }
+        ],
+    )
+    return memory
+
+
+async def query_memory(
+    request: Request,
+    form_data: QueryMemoryForm,
+    user: UserModel,
+) -> Any:
+    await _ensure_user_can_use_memories(request, user)
+
+    memories = await Memories.get_memories_by_user_id(user.id)
+    if not memories:
+        raise HTTPException(status_code=404, detail='No memories found for user')
+
+    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, user=user)
+
+    results = await ASYNC_VECTOR_DB_CLIENT.search(
+        collection_name=f'user-memory-{user.id}',
+        vectors=[vector],
+        limit=form_data.k,
+    )
+
+    relevance_threshold = getattr(request.app.state.config, 'RELEVANCE_THRESHOLD', 0.0)
+    if results and relevance_threshold > 0.0 and results.distances and results.distances[0]:
+        results = _filter_by_relevance(results, relevance_threshold)
+
+    return results
+
+
+def _filter_by_relevance(results: Any, threshold: float) -> Any:
+    from open_webui.retrieval.vector.main import SearchResult
+
+    filtered_ids: list[str] = []
+    filtered_docs: list[str] = []
+    filtered_metas: list[dict[str, Any]] = []
+    filtered_dists: list[float] = []
+
+    for idx, score in enumerate(results.distances[0]):
+        if score < threshold:
+            continue
+        if results.ids and results.ids[0]:
+            filtered_ids.append(results.ids[0][idx])
+        if results.documents and results.documents[0]:
+            filtered_docs.append(results.documents[0][idx])
+        if results.metadatas and results.metadatas[0]:
+            filtered_metas.append(results.metadatas[0][idx])
+        filtered_dists.append(score)
+
+    return SearchResult(
+        ids=[filtered_ids] if filtered_ids else [[]],
+        documents=[filtered_docs] if filtered_docs else [[]],
+        metadatas=[filtered_metas] if filtered_metas else [[]],
+        distances=[filtered_dists] if filtered_dists else [[]],
+    )
+
+
+async def update_memory_by_id(
+    memory_id: str,
+    request: Request,
+    form_data: MemoryUpdateModel,
+    user: UserModel,
+) -> MemoryModel | None:
+    await _ensure_user_can_use_memories(request, user)
+
+    memory = await Memories.update_memory_by_id_and_user_id(memory_id, user.id, form_data.content)
+    if memory is None:
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    if form_data.content is not None:
+        vector = await request.app.state.EMBEDDING_FUNCTION(memory.content, user=user)
+        await ASYNC_VECTOR_DB_CLIENT.upsert(
+            collection_name=f'user-memory-{user.id}',
+            items=[
+                {
+                    'id': memory.id,
+                    'text': memory.content,
+                    'vector': vector,
+                    'metadata': {
+                        'created_at': memory.created_at,
+                        'updated_at': memory.updated_at,
+                    },
+                }
+            ],
+        )
+
+    return memory

--- a/backend/open_webui/clients/memories.py
+++ b/backend/open_webui/clients/memories.py
@@ -48,6 +48,13 @@ async def add_memory(
     form_data: AddMemoryForm,
     user: UserModel,
 ) -> MemoryModel | None:
+    """Insert a user memory and upsert its embedding.
+
+    NOTE: This intentionally does NOT take a `Depends(get_async_session)` session.
+    `insert_new_memory` manages its own short-lived session so we don't hold a
+    DB connection while awaiting `EMBEDDING_FUNCTION` (external API call,
+    1-5+ seconds).
+    """
     await _ensure_user_can_use_memories(request, user)
 
     memory = await Memories.insert_new_memory(user.id, form_data.content)
@@ -72,6 +79,13 @@ async def query_memory(
     form_data: QueryMemoryForm,
     user: UserModel,
 ) -> Any:
+    """Semantic-search a user's memories.
+
+    NOTE: This intentionally does NOT take a `Depends(get_async_session)` session.
+    `get_memories_by_user_id` manages its own short-lived session so we don't
+    hold a DB connection while awaiting `EMBEDDING_FUNCTION` (external API call,
+    1-5+ seconds).
+    """
     await _ensure_user_can_use_memories(request, user)
 
     memories = await Memories.get_memories_by_user_id(user.id)
@@ -126,6 +140,13 @@ async def update_memory_by_id(
     form_data: MemoryUpdateModel,
     user: UserModel,
 ) -> MemoryModel | None:
+    """Update a memory and re-embed if content changed.
+
+    NOTE: This intentionally does NOT take a `Depends(get_async_session)` session.
+    `update_memory_by_id_and_user_id` manages its own short-lived session so we
+    don't hold a DB connection while awaiting `EMBEDDING_FUNCTION` (external API
+    call, 1-5+ seconds).
+    """
     await _ensure_user_can_use_memories(request, user)
 
     memory = await Memories.update_memory_by_id_and_user_id(memory_id, user.id, form_data.content)

--- a/backend/open_webui/clients/pipelines.py
+++ b/backend/open_webui/clients/pipelines.py
@@ -1,0 +1,136 @@
+import logging
+from typing import Any
+
+import aiohttp
+from fastapi import HTTPException, Request
+
+from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
+from open_webui.models.users import UserModel
+
+log = logging.getLogger(__name__)
+
+
+def get_sorted_filters(model_id: str, models: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    filters = [
+        model
+        for model in models.values()
+        if 'pipeline' in model
+        and 'type' in model['pipeline']
+        and model['pipeline']['type'] == 'filter'
+        and (
+            model['pipeline']['pipelines'] == ['*']
+            or any(model_id == target_model_id for target_model_id in model['pipeline']['pipelines'])
+        )
+    ]
+    return sorted(filters, key=lambda x: x['pipeline']['priority'])
+
+
+def _raise_from_response(
+    response: aiohttp.ClientResponse | None,
+    error: aiohttp.ClientResponseError,
+    res: dict[str, Any],
+) -> None:
+    if 'detail' in res:
+        raise HTTPException(
+            status_code=response.status if response is not None else 500,
+            detail=res['detail'],
+        )
+    raise HTTPException(
+        status_code=response.status if response is not None else 500,
+        detail=error.message,
+    )
+
+
+async def _post_filter(
+    session: aiohttp.ClientSession,
+    url: str,
+    key: str,
+    filter_id: str,
+    stage: str,
+    request_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    response: aiohttp.ClientResponse | None = None
+    try:
+        async with session.post(
+            f'{url}/{filter_id}/filter/{stage}',
+            headers={'Authorization': f'Bearer {key}'},
+            json=request_data,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+    except aiohttp.ClientResponseError as e:
+        res: dict[str, Any] = {}
+        try:
+            if response is not None and 'application/json' in response.content_type:
+                res = await response.json()
+        except Exception:
+            pass
+        _raise_from_response(response, e, res)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.exception(f'Connection error: {e}')
+    return None
+
+
+async def _run_filter_stage(
+    request: Request,
+    payload: dict[str, Any],
+    user: UserModel,
+    models: dict[str, dict[str, Any]],
+    stage: str,
+) -> dict[str, Any]:
+    user_payload = {'id': user.id, 'email': user.email, 'name': user.name, 'role': user.role}
+    model_id = payload['model']
+    sorted_filters = get_sorted_filters(model_id, models)
+    model = models[model_id]
+
+    if 'pipeline' in model:
+        if stage == 'inlet':
+            sorted_filters.append(model)
+        else:
+            sorted_filters = [model] + sorted_filters
+
+    async with aiohttp.ClientSession(trust_env=True) as session:
+        for filter_ in sorted_filters:
+            try:
+                url_idx = int(filter_.get('urlIdx'))
+            except (TypeError, ValueError):
+                continue
+
+            url = request.app.state.config.OPENAI_API_BASE_URLS[url_idx]
+            key = request.app.state.config.OPENAI_API_KEYS[url_idx]
+            if not key:
+                continue
+
+            updated = await _post_filter(
+                session,
+                url,
+                key,
+                filter_id=filter_['id'],
+                stage=stage,
+                request_data={'user': user_payload, 'body': payload},
+            )
+            if updated is not None:
+                payload = updated
+
+    return payload
+
+
+async def process_pipeline_inlet_filter(
+    request: Request,
+    payload: dict[str, Any],
+    user: UserModel,
+    models: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    return await _run_filter_stage(request, payload, user, models, stage='inlet')
+
+
+async def process_pipeline_outlet_filter(
+    request: Request,
+    payload: dict[str, Any],
+    user: UserModel,
+    models: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    return await _run_filter_stage(request, payload, user, models, stage='outlet')

--- a/backend/open_webui/clients/pipelines.py
+++ b/backend/open_webui/clients/pipelines.py
@@ -96,7 +96,7 @@ async def _run_filter_stage(
         for filter_ in sorted_filters:
             try:
                 url_idx = int(filter_.get('urlIdx'))
-            except (TypeError, ValueError):
+            except Exception:
                 continue
 
             url = request.app.state.config.OPENAI_API_BASE_URLS[url_idx]

--- a/backend/open_webui/clients/tasks.py
+++ b/backend/open_webui/clients/tasks.py
@@ -66,17 +66,15 @@ async def _run_task_pipeline(
     user: UserModel,
     models: dict[str, dict[str, Any]],
     payload: dict[str, Any],
-    error_content: dict[str, Any] | None = None,
-    error_status: int = status.HTTP_400_BAD_REQUEST,
 ) -> Any:
     payload = await process_pipeline_inlet_filter(request, payload, user, models)
     try:
         return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
+    except Exception:
         log.error('Exception occurred', exc_info=True)
         return JSONResponse(
-            status_code=error_status,
-            content=error_content if error_content is not None else {'detail': str(e)},
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={'detail': 'An internal error has occurred.'},
         )
 
 
@@ -96,7 +94,10 @@ async def generate_title(
 
     log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
 
-    template = request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE or DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
+    if request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE != '':
+        template = request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
     content = title_generation_template(template, form_data['messages'], user)
     max_tokens = models[task_model_id].get('info', {}).get('params', {}).get('max_tokens', 1000)
     token_key = 'max_tokens' if models[task_model_id].get('owned_by') == 'ollama' else 'max_completion_tokens'
@@ -109,13 +110,7 @@ async def generate_title(
         'metadata': _task_metadata(request, form_data, str(TASKS.TITLE_GENERATION)),
     }
 
-    return await _run_task_pipeline(
-        request,
-        user,
-        models,
-        payload,
-        error_content={'detail': 'An internal error has occurred.'},
-    )
+    return await _run_task_pipeline(request, user, models, payload)
 
 
 async def generate_follow_ups(
@@ -134,10 +129,10 @@ async def generate_follow_ups(
 
     log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
 
-    template = (
-        request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
-        or DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
-    )
+    if request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE != '':
+        template = request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
     content = follow_up_generation_template(template, form_data['messages'], user)
 
     payload = {
@@ -147,13 +142,7 @@ async def generate_follow_ups(
         'metadata': _task_metadata(request, form_data, str(TASKS.FOLLOW_UP_GENERATION)),
     }
 
-    return await _run_task_pipeline(
-        request,
-        user,
-        models,
-        payload,
-        error_content={'detail': 'An internal error has occurred.'},
-    )
+    return await _run_task_pipeline(request, user, models, payload)
 
 
 async def generate_chat_tags(
@@ -172,9 +161,10 @@ async def generate_chat_tags(
 
     log.debug(f'generating chat tags using model {task_model_id} for user {user.email} ')
 
-    template = (
-        request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE or DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE
-    )
+    if request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE != '':
+        template = request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE
     content = tags_generation_template(template, form_data['messages'], user)
 
     payload = {
@@ -184,14 +174,15 @@ async def generate_chat_tags(
         'metadata': _task_metadata(request, form_data, str(TASKS.TAGS_GENERATION)),
     }
 
-    return await _run_task_pipeline(
-        request,
-        user,
-        models,
-        payload,
-        error_content={'detail': 'An internal error has occurred.'},
-        error_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-    )
+    payload = await process_pipeline_inlet_filter(request, payload, user, models)
+    try:
+        return await generate_chat_completion(request, form_data=payload, user=user)
+    except Exception as e:
+        log.error(f'Error generating chat completion: {e}')
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={'detail': 'An internal error has occurred.'},
+        )
 
 
 async def generate_image_prompt(
@@ -204,10 +195,10 @@ async def generate_image_prompt(
 
     log.debug(f'generating image prompt using model {task_model_id} for user {user.email} ')
 
-    template = (
-        request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
-        or DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
-    )
+    if request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE != '':
+        template = request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
     content = image_prompt_generation_template(template, form_data['messages'], user)
 
     payload = {
@@ -217,13 +208,7 @@ async def generate_image_prompt(
         'metadata': _task_metadata(request, form_data, str(TASKS.IMAGE_PROMPT_GENERATION)),
     }
 
-    return await _run_task_pipeline(
-        request,
-        user,
-        models,
-        payload,
-        error_content={'detail': 'An internal error has occurred.'},
-    )
+    return await _run_task_pipeline(request, user, models, payload)
 
 
 async def generate_queries(
@@ -252,10 +237,10 @@ async def generate_queries(
 
     log.debug(f'generating {type_} queries using model {task_model_id} for user {user.email}')
 
-    template = (
-        request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE.strip()
-        or DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE
-    )
+    if (request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE).strip() != '':
+        template = request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE
     content = query_generation_template(template, form_data['messages'], user)
 
     payload = {
@@ -265,4 +250,11 @@ async def generate_queries(
         'metadata': _task_metadata(request, form_data, str(TASKS.QUERY_GENERATION)),
     }
 
-    return await _run_task_pipeline(request, user, models, payload)
+    payload = await process_pipeline_inlet_filter(request, payload, user, models)
+    try:
+        return await generate_chat_completion(request, form_data=payload, user=user)
+    except Exception as e:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={'detail': str(e)},
+        )

--- a/backend/open_webui/clients/tasks.py
+++ b/backend/open_webui/clients/tasks.py
@@ -1,0 +1,268 @@
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
+
+from open_webui.clients.pipelines import process_pipeline_inlet_filter
+from open_webui.config import (
+    DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE,
+    DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE,
+)
+from open_webui.constants import ERROR_MESSAGES, TASKS
+from open_webui.models.users import UserModel
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.task import (
+    follow_up_generation_template,
+    get_task_model_id,
+    image_prompt_generation_template,
+    query_generation_template,
+    tags_generation_template,
+    title_generation_template,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _resolve_models(request: Request) -> dict[str, dict[str, Any]]:
+    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
+        return {request.state.model['id']: request.state.model}
+    return request.app.state.MODELS
+
+
+def _resolve_task_model(
+    request: Request,
+    form_data: dict[str, Any],
+    models: dict[str, dict[str, Any]],
+) -> str:
+    model_id = form_data['model']
+    if model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
+    return get_task_model_id(
+        model_id,
+        request.app.state.config.TASK_MODEL,
+        request.app.state.config.TASK_MODEL_EXTERNAL,
+        models,
+    )
+
+
+def _task_metadata(request: Request, form_data: dict[str, Any], task: str) -> dict[str, Any]:
+    return {
+        **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
+        'task': task,
+        'task_body': form_data,
+        'chat_id': form_data.get('chat_id', None),
+    }
+
+
+async def _run_task_pipeline(
+    request: Request,
+    user: UserModel,
+    models: dict[str, dict[str, Any]],
+    payload: dict[str, Any],
+    error_content: dict[str, Any] | None = None,
+    error_status: int = status.HTTP_400_BAD_REQUEST,
+) -> Any:
+    payload = await process_pipeline_inlet_filter(request, payload, user, models)
+    try:
+        return await generate_chat_completion(request, form_data=payload, user=user)
+    except Exception as e:
+        log.error('Exception occurred', exc_info=True)
+        return JSONResponse(
+            status_code=error_status,
+            content=error_content if error_content is not None else {'detail': str(e)},
+        )
+
+
+async def generate_title(
+    request: Request,
+    form_data: dict[str, Any],
+    user: UserModel,
+) -> Any:
+    if not request.app.state.config.ENABLE_TITLE_GENERATION:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={'detail': 'Title generation is disabled'},
+        )
+
+    models = _resolve_models(request)
+    task_model_id = _resolve_task_model(request, form_data, models)
+
+    log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
+
+    template = request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE or DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
+    content = title_generation_template(template, form_data['messages'], user)
+    max_tokens = models[task_model_id].get('info', {}).get('params', {}).get('max_tokens', 1000)
+    token_key = 'max_tokens' if models[task_model_id].get('owned_by') == 'ollama' else 'max_completion_tokens'
+
+    payload = {
+        'model': task_model_id,
+        'messages': [{'role': 'user', 'content': content}],
+        'stream': False,
+        token_key: max_tokens,
+        'metadata': _task_metadata(request, form_data, str(TASKS.TITLE_GENERATION)),
+    }
+
+    return await _run_task_pipeline(
+        request,
+        user,
+        models,
+        payload,
+        error_content={'detail': 'An internal error has occurred.'},
+    )
+
+
+async def generate_follow_ups(
+    request: Request,
+    form_data: dict[str, Any],
+    user: UserModel,
+) -> Any:
+    if not request.app.state.config.ENABLE_FOLLOW_UP_GENERATION:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={'detail': 'Follow-up generation is disabled'},
+        )
+
+    models = _resolve_models(request)
+    task_model_id = _resolve_task_model(request, form_data, models)
+
+    log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
+
+    template = (
+        request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
+        or DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
+    )
+    content = follow_up_generation_template(template, form_data['messages'], user)
+
+    payload = {
+        'model': task_model_id,
+        'messages': [{'role': 'user', 'content': content}],
+        'stream': False,
+        'metadata': _task_metadata(request, form_data, str(TASKS.FOLLOW_UP_GENERATION)),
+    }
+
+    return await _run_task_pipeline(
+        request,
+        user,
+        models,
+        payload,
+        error_content={'detail': 'An internal error has occurred.'},
+    )
+
+
+async def generate_chat_tags(
+    request: Request,
+    form_data: dict[str, Any],
+    user: UserModel,
+) -> Any:
+    if not request.app.state.config.ENABLE_TAGS_GENERATION:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={'detail': 'Tags generation is disabled'},
+        )
+
+    models = _resolve_models(request)
+    task_model_id = _resolve_task_model(request, form_data, models)
+
+    log.debug(f'generating chat tags using model {task_model_id} for user {user.email} ')
+
+    template = (
+        request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE or DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE
+    )
+    content = tags_generation_template(template, form_data['messages'], user)
+
+    payload = {
+        'model': task_model_id,
+        'messages': [{'role': 'user', 'content': content}],
+        'stream': False,
+        'metadata': _task_metadata(request, form_data, str(TASKS.TAGS_GENERATION)),
+    }
+
+    return await _run_task_pipeline(
+        request,
+        user,
+        models,
+        payload,
+        error_content={'detail': 'An internal error has occurred.'},
+        error_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
+
+
+async def generate_image_prompt(
+    request: Request,
+    form_data: dict[str, Any],
+    user: UserModel,
+) -> Any:
+    models = _resolve_models(request)
+    task_model_id = _resolve_task_model(request, form_data, models)
+
+    log.debug(f'generating image prompt using model {task_model_id} for user {user.email} ')
+
+    template = (
+        request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
+        or DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
+    )
+    content = image_prompt_generation_template(template, form_data['messages'], user)
+
+    payload = {
+        'model': task_model_id,
+        'messages': [{'role': 'user', 'content': content}],
+        'stream': False,
+        'metadata': _task_metadata(request, form_data, str(TASKS.IMAGE_PROMPT_GENERATION)),
+    }
+
+    return await _run_task_pipeline(
+        request,
+        user,
+        models,
+        payload,
+        error_content={'detail': 'An internal error has occurred.'},
+    )
+
+
+async def generate_queries(
+    request: Request,
+    form_data: dict[str, Any],
+    user: UserModel,
+) -> Any:
+    type_ = form_data.get('type')
+    if type_ == 'web_search' and not request.app.state.config.ENABLE_SEARCH_QUERY_GENERATION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.FEATURE_DISABLED('Search query generation'),
+        )
+    if type_ == 'retrieval' and not request.app.state.config.ENABLE_RETRIEVAL_QUERY_GENERATION:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.FEATURE_DISABLED('Query generation'),
+        )
+
+    if getattr(request.state, 'cached_queries', None):
+        log.info(f'Reusing cached queries: {request.state.cached_queries}')
+        return request.state.cached_queries
+
+    models = _resolve_models(request)
+    task_model_id = _resolve_task_model(request, form_data, models)
+
+    log.debug(f'generating {type_} queries using model {task_model_id} for user {user.email}')
+
+    template = (
+        request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE.strip()
+        or DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE
+    )
+    content = query_generation_template(template, form_data['messages'], user)
+
+    payload = {
+        'model': task_model_id,
+        'messages': [{'role': 'user', 'content': content}],
+        'stream': False,
+        'metadata': _task_metadata(request, form_data, str(TASKS.QUERY_GENERATION)),
+    }
+
+    return await _run_task_pipeline(request, user, models, payload)

--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -1,17 +1,28 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
-import logging
 import asyncio
-from typing import Optional
+import logging
 
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from open_webui.clients.memories import (
+    AddMemoryForm,
+    MemoryUpdateModel,
+    QueryMemoryForm,
+)
+from open_webui.clients.memories import (
+    add_memory as _client_add_memory,
+)
+from open_webui.clients.memories import (
+    query_memory as _client_query_memory,
+)
+from open_webui.clients.memories import (
+    update_memory_by_id as _client_update_memory_by_id,
+)
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.internal.db import get_async_session
 from open_webui.models.memories import Memories, MemoryModel
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
-from open_webui.utils.auth import get_verified_user
-from open_webui.internal.db import get_async_session
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from open_webui.utils.access_control import has_permission
-from open_webui.constants import ERROR_MESSAGES
+from open_webui.utils.auth import get_verified_user
+from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +41,7 @@ async def get_memories(
     request: Request,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
-):
+) -> list[MemoryModel]:
     if not request.app.state.config.ENABLE_MEMORIES:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -51,63 +62,18 @@ async def get_memories(
 ############################
 
 
-class AddMemoryForm(BaseModel):
-    content: str
-
-
-class MemoryUpdateModel(BaseModel):
-    content: Optional[str] = None
-
-
-@router.post('/add', response_model=Optional[MemoryModel])
+@router.post('/add', response_model=MemoryModel | None)
 async def add_memory(
     request: Request,
     form_data: AddMemoryForm,
     user=Depends(get_verified_user),
-):
-    # NOTE: We intentionally do NOT use Depends(get_async_session) here.
-    # Database operations (insert_new_memory) manage their own short-lived sessions.
-    # This prevents holding a connection during EMBEDDING_FUNCTION()
-    # which makes external embedding API calls (1-5+ seconds).
-    if not request.app.state.config.ENABLE_MEMORIES:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    memory = await Memories.insert_new_memory(user.id, form_data.content)
-
-    vector = await request.app.state.EMBEDDING_FUNCTION(memory.content, user=user)
-
-    await ASYNC_VECTOR_DB_CLIENT.upsert(
-        collection_name=f'user-memory-{user.id}',
-        items=[
-            {
-                'id': memory.id,
-                'text': memory.content,
-                'vector': vector,
-                'metadata': {'created_at': memory.created_at},
-            }
-        ],
-    )
-
-    return memory
+) -> MemoryModel | None:
+    return await _client_add_memory(request, form_data, user)
 
 
 ############################
 # QueryMemory
 ############################
-
-
-class QueryMemoryForm(BaseModel):
-    content: str
-    k: Optional[int] = 1
 
 
 @router.post('/query')
@@ -116,67 +82,7 @@ async def query_memory(
     form_data: QueryMemoryForm,
     user=Depends(get_verified_user),
 ):
-    # NOTE: We intentionally do NOT use Depends(get_async_session) here.
-    # Database operations (get_memories_by_user_id) manage their own short-lived sessions.
-    # This prevents holding a connection during EMBEDDING_FUNCTION()
-    # which makes external embedding API calls (1-5+ seconds).
-    if not request.app.state.config.ENABLE_MEMORIES:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    memories = await Memories.get_memories_by_user_id(user.id)
-    if not memories:
-        raise HTTPException(status_code=404, detail='No memories found for user')
-
-    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, user=user)
-
-    results = await ASYNC_VECTOR_DB_CLIENT.search(
-        collection_name=f'user-memory-{user.id}',
-        vectors=[vector],
-        limit=form_data.k,
-    )
-
-    # Filter results by relevance threshold to avoid returning unrelated
-    # memories.  Vector similarity search always returns the top-K nearest
-    # neighbours even when they are completely irrelevant; applying the
-    # same RELEVANCE_THRESHOLD used by RAG ensures only genuinely matching
-    # memories are surfaced (distances are normalised to 0→1, higher is
-    # better).
-    relevance_threshold = getattr(request.app.state.config, 'RELEVANCE_THRESHOLD', 0.0)
-    if results and relevance_threshold > 0.0 and results.distances and results.distances[0]:
-        from open_webui.retrieval.vector.main import SearchResult
-
-        filtered_ids = []
-        filtered_docs = []
-        filtered_metas = []
-        filtered_dists = []
-
-        for idx, score in enumerate(results.distances[0]):
-            if score >= relevance_threshold:
-                if results.ids and results.ids[0]:
-                    filtered_ids.append(results.ids[0][idx])
-                if results.documents and results.documents[0]:
-                    filtered_docs.append(results.documents[0][idx])
-                if results.metadatas and results.metadatas[0]:
-                    filtered_metas.append(results.metadatas[0][idx])
-                filtered_dists.append(score)
-
-        results = SearchResult(
-            ids=[filtered_ids] if filtered_ids else [[]],
-            documents=[filtered_docs] if filtered_docs else [[]],
-            metadatas=[filtered_metas] if filtered_metas else [[]],
-            distances=[filtered_dists] if filtered_dists else [[]],
-        )
-
-    return results
+    return await _client_query_memory(request, form_data, user)
 
 
 ############################
@@ -186,7 +92,7 @@ async def query_memory(
 async def reset_memory_from_vector_db(
     request: Request,
     user=Depends(get_verified_user),
-):
+) -> bool:
     """Reset user's memory vector embeddings.
 
     CRITICAL: We intentionally do NOT use Depends(get_async_session) here.
@@ -245,7 +151,7 @@ async def delete_memory_by_user_id(
     request: Request,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
-):
+) -> bool:
     if not request.app.state.config.ENABLE_MEMORIES:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -275,52 +181,14 @@ async def delete_memory_by_user_id(
 ############################
 
 
-@router.post('/{memory_id}/update', response_model=Optional[MemoryModel])
+@router.post('/{memory_id}/update', response_model=MemoryModel | None)
 async def update_memory_by_id(
     memory_id: str,
     request: Request,
     form_data: MemoryUpdateModel,
     user=Depends(get_verified_user),
-):
-    # NOTE: We intentionally do NOT use Depends(get_async_session) here.
-    # Database operations (update_memory_by_id_and_user_id) manage their own
-    # short-lived sessions. This prevents holding a connection during
-    # EMBEDDING_FUNCTION() which makes external API calls (1-5+ seconds).
-    if not request.app.state.config.ENABLE_MEMORIES:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    memory = await Memories.update_memory_by_id_and_user_id(memory_id, user.id, form_data.content)
-    if memory is None:
-        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
-
-    if form_data.content is not None:
-        vector = await request.app.state.EMBEDDING_FUNCTION(memory.content, user=user)
-
-        await ASYNC_VECTOR_DB_CLIENT.upsert(
-            collection_name=f'user-memory-{user.id}',
-            items=[
-                {
-                    'id': memory.id,
-                    'text': memory.content,
-                    'vector': vector,
-                    'metadata': {
-                        'created_at': memory.created_at,
-                        'updated_at': memory.updated_at,
-                    },
-                }
-            ],
-        )
-
-    return memory
+) -> MemoryModel | None:
+    return await _client_update_memory_by_id(memory_id, request, form_data, user)
 
 
 ############################
@@ -334,7 +202,7 @@ async def delete_memory_by_id(
     request: Request,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
-):
+) -> bool:
     if not request.app.state.config.ENABLE_MEMORIES:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -1,185 +1,25 @@
+import logging
+import os
+import shutil
+
+import aiohttp
 from fastapi import (
+    APIRouter,
     Depends,
-    FastAPI,
     File,
     Form,
     HTTPException,
     Request,
     UploadFile,
     status,
-    APIRouter,
 )
-import aiohttp
-import os
-import logging
-import shutil
-from pydantic import BaseModel
-from starlette.responses import FileResponse
-from typing import Optional
-
-from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
 from open_webui.config import CACHE_DIR
-from open_webui.constants import ERROR_MESSAGES
-
-
+from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
 from open_webui.routers.openai import get_all_models_responses
-
 from open_webui.utils.auth import get_admin_user
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
-
-
-##################################
-#
-# Pipeline Middleware
-# Every hand this passes through can corrupt it or
-# improve it. Let each stage leave it better than it found.
-#
-##################################
-
-
-def get_sorted_filters(model_id, models):
-    filters = [
-        model
-        for model in models.values()
-        if 'pipeline' in model
-        and 'type' in model['pipeline']
-        and model['pipeline']['type'] == 'filter'
-        and (
-            model['pipeline']['pipelines'] == ['*']
-            or any(model_id == target_model_id for target_model_id in model['pipeline']['pipelines'])
-        )
-    ]
-    sorted_filters = sorted(filters, key=lambda x: x['pipeline']['priority'])
-    return sorted_filters
-
-
-async def process_pipeline_inlet_filter(request, payload, user, models):
-    user = {'id': user.id, 'email': user.email, 'name': user.name, 'role': user.role}
-    model_id = payload['model']
-    sorted_filters = get_sorted_filters(model_id, models)
-    model = models[model_id]
-
-    if 'pipeline' in model:
-        sorted_filters.append(model)
-
-    async with aiohttp.ClientSession(trust_env=True) as session:
-        for filter in sorted_filters:
-            urlIdx = filter.get('urlIdx')
-
-            try:
-                urlIdx = int(urlIdx)
-            except Exception:
-                continue
-
-            url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
-            key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
-
-            if not key:
-                continue
-
-            headers = {'Authorization': f'Bearer {key}'}
-            request_data = {
-                'user': user,
-                'body': payload,
-            }
-
-            try:
-                async with session.post(
-                    f'{url}/{filter["id"]}/filter/inlet',
-                    headers=headers,
-                    json=request_data,
-                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
-                ) as response:
-                    response.raise_for_status()
-                    payload = await response.json()
-            except aiohttp.ClientResponseError as e:
-                try:
-                    res = await response.json() if 'application/json' in response.content_type else {}
-                    if 'detail' in res:
-                        raise HTTPException(
-                            status_code=response.status,
-                            detail=res['detail'],
-                        )
-                except HTTPException:
-                    raise
-                except Exception:
-                    pass
-
-                raise HTTPException(
-                    status_code=response.status,
-                    detail=e.message,
-                )
-            except HTTPException:
-                raise
-            except Exception as e:
-                log.exception(f'Connection error: {e}')
-
-    return payload
-
-
-async def process_pipeline_outlet_filter(request, payload, user, models):
-    user = {'id': user.id, 'email': user.email, 'name': user.name, 'role': user.role}
-    model_id = payload['model']
-    sorted_filters = get_sorted_filters(model_id, models)
-    model = models[model_id]
-
-    if 'pipeline' in model:
-        sorted_filters = [model] + sorted_filters
-
-    async with aiohttp.ClientSession(trust_env=True) as session:
-        for filter in sorted_filters:
-            urlIdx = filter.get('urlIdx')
-
-            try:
-                urlIdx = int(urlIdx)
-            except Exception:
-                continue
-
-            url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
-            key = request.app.state.config.OPENAI_API_KEYS[urlIdx]
-
-            if not key:
-                continue
-
-            headers = {'Authorization': f'Bearer {key}'}
-            request_data = {
-                'user': user,
-                'body': payload,
-            }
-
-            try:
-                async with session.post(
-                    f'{url}/{filter["id"]}/filter/outlet',
-                    headers=headers,
-                    json=request_data,
-                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
-                ) as response:
-                    response.raise_for_status()
-                    payload = await response.json()
-            except aiohttp.ClientResponseError as e:
-                try:
-                    res = await response.json() if 'application/json' in response.content_type else {}
-                    if 'detail' in res:
-                        raise HTTPException(
-                            status_code=response.status,
-                            detail=res['detail'],
-                        )
-                except HTTPException:
-                    raise
-                except Exception:
-                    pass
-
-                raise HTTPException(
-                    status_code=response.status,
-                    detail=e.message,
-                )
-            except HTTPException:
-                raise
-            except Exception as e:
-                log.exception(f'Connection error: {e}')
-
-    return payload
 
 
 ##################################
@@ -375,7 +215,7 @@ async def delete_pipeline(request: Request, form_data: DeletePipelineForm, user=
 
 
 @router.get('/')
-async def get_pipelines(request: Request, urlIdx: Optional[int] = None, user=Depends(get_admin_user)):
+async def get_pipelines(request: Request, urlIdx: int | None = None, user=Depends(get_admin_user)):
     response = None
     try:
         url = request.app.state.config.OPENAI_API_BASE_URLS[urlIdx]
@@ -413,7 +253,7 @@ async def get_pipelines(request: Request, urlIdx: Optional[int] = None, user=Dep
 @router.get('/{pipeline_id}/valves')
 async def get_pipeline_valves(
     request: Request,
-    urlIdx: Optional[int],
+    urlIdx: int | None,
     pipeline_id: str,
     user=Depends(get_admin_user),
 ):
@@ -454,7 +294,7 @@ async def get_pipeline_valves(
 @router.get('/{pipeline_id}/valves/spec')
 async def get_pipeline_valves_spec(
     request: Request,
-    urlIdx: Optional[int],
+    urlIdx: int | None,
     pipeline_id: str,
     user=Depends(get_admin_user),
 ):
@@ -495,7 +335,7 @@ async def get_pipeline_valves_spec(
 @router.post('/{pipeline_id}/valves/update')
 async def update_pipeline_valves(
     request: Request,
-    urlIdx: Optional[int],
+    urlIdx: int | None,
     pipeline_id: str,
     form_data: dict,
     user=Depends(get_admin_user),

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -20,7 +20,7 @@ from open_webui.utils.task import (
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.constants import ERROR_MESSAGES, TASKS
 
-from open_webui.routers.pipelines import process_pipeline_inlet_filter
+from open_webui.clients.pipelines import process_pipeline_inlet_filter
 
 from open_webui.utils.task import get_task_model_id
 

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -1,40 +1,38 @@
-from fastapi import APIRouter, Depends, HTTPException, Response, status, Request
-from fastapi.responses import JSONResponse, RedirectResponse
-
-from pydantic import BaseModel
-from typing import Optional
 import logging
-import re
 
-from open_webui.utils.chat import generate_chat_completion
-from open_webui.utils.task import (
-    title_generation_template,
-    follow_up_generation_template,
-    query_generation_template,
-    image_prompt_generation_template,
-    autocomplete_generation_template,
-    tags_generation_template,
-    emoji_generation_template,
-    moa_response_generation_template,
-)
-from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.constants import ERROR_MESSAGES, TASKS
-
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from open_webui.clients.pipelines import process_pipeline_inlet_filter
-
-from open_webui.utils.task import get_task_model_id
-
+from open_webui.clients.tasks import (
+    generate_chat_tags as _client_generate_chat_tags,
+)
+from open_webui.clients.tasks import (
+    generate_follow_ups as _client_generate_follow_ups,
+)
+from open_webui.clients.tasks import (
+    generate_image_prompt as _client_generate_image_prompt,
+)
+from open_webui.clients.tasks import (
+    generate_queries as _client_generate_queries,
+)
+from open_webui.clients.tasks import (
+    generate_title as _client_generate_title,
+)
 from open_webui.config import (
-    DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE,
-    DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE,
-    DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE,
-    DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE,
-    DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_AUTOCOMPLETE_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_EMOJI_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_MOA_GENERATION_PROMPT_TEMPLATE,
-    DEFAULT_VOICE_MODE_PROMPT_TEMPLATE,
 )
+from open_webui.constants import ERROR_MESSAGES, TASKS
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.task import (
+    autocomplete_generation_template,
+    emoji_generation_template,
+    get_task_model_id,
+    moa_response_generation_template,
+)
+from pydantic import BaseModel
 
 log = logging.getLogger(__name__)
 
@@ -84,8 +82,8 @@ async def get_task_config(request: Request, user=Depends(get_verified_user)):
 
 
 class TaskConfigForm(BaseModel):
-    TASK_MODEL: Optional[str]
-    TASK_MODEL_EXTERNAL: Optional[str]
+    TASK_MODEL: str | None
+    TASK_MODEL_EXTERNAL: str | None
     ENABLE_TITLE_GENERATION: bool
     TITLE_GENERATION_PROMPT_TEMPLATE: str
     IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE: str
@@ -99,7 +97,7 @@ class TaskConfigForm(BaseModel):
     ENABLE_RETRIEVAL_QUERY_GENERATION: bool
     QUERY_GENERATION_PROMPT_TEMPLATE: str
     TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE: str
-    VOICE_MODE_PROMPT_TEMPLATE: Optional[str]
+    VOICE_MODE_PROMPT_TEMPLATE: str | None
 
 
 @router.post('/config/update')
@@ -151,356 +149,27 @@ async def update_task_config(request: Request, form_data: TaskConfigForm, user=D
 
 @router.post('/title/completions')
 async def generate_title(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if not request.app.state.config.ENABLE_TITLE_GENERATION:
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={'detail': 'Title generation is disabled'},
-        )
-
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
-
-    model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
-
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
-    task_model_id = get_task_model_id(
-        model_id,
-        request.app.state.config.TASK_MODEL,
-        request.app.state.config.TASK_MODEL_EXTERNAL,
-        models,
-    )
-
-    log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
-
-    if request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE != '':
-        template = request.app.state.config.TITLE_GENERATION_PROMPT_TEMPLATE
-    else:
-        template = DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
-
-    content = title_generation_template(template, form_data['messages'], user)
-
-    max_tokens = models[task_model_id].get('info', {}).get('params', {}).get('max_tokens', 1000)
-
-    payload = {
-        'model': task_model_id,
-        'messages': [{'role': 'user', 'content': content}],
-        'stream': False,
-        **(
-            {'max_tokens': max_tokens}
-            if models[task_model_id].get('owned_by') == 'ollama'
-            else {
-                'max_completion_tokens': max_tokens,
-            }
-        ),
-        'metadata': {
-            **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
-            'task': str(TASKS.TITLE_GENERATION),
-            'task_body': form_data,
-            'chat_id': form_data.get('chat_id', None),
-        },
-    }
-
-    # Process the payload through the pipeline
-    try:
-        payload = await process_pipeline_inlet_filter(request, payload, user, models)
-    except Exception as e:
-        raise e
-
-    try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
-        log.error('Exception occurred', exc_info=True)
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={'detail': 'An internal error has occurred.'},
-        )
+    return await _client_generate_title(request, form_data, user)
 
 
 @router.post('/follow_up/completions')
 async def generate_follow_ups(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if not request.app.state.config.ENABLE_FOLLOW_UP_GENERATION:
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={'detail': 'Follow-up generation is disabled'},
-        )
-
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
-
-    model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
-
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
-    task_model_id = get_task_model_id(
-        model_id,
-        request.app.state.config.TASK_MODEL,
-        request.app.state.config.TASK_MODEL_EXTERNAL,
-        models,
-    )
-
-    log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
-
-    if request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE != '':
-        template = request.app.state.config.FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
-    else:
-        template = DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE
-
-    content = follow_up_generation_template(template, form_data['messages'], user)
-
-    payload = {
-        'model': task_model_id,
-        'messages': [{'role': 'user', 'content': content}],
-        'stream': False,
-        'metadata': {
-            **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
-            'task': str(TASKS.FOLLOW_UP_GENERATION),
-            'task_body': form_data,
-            'chat_id': form_data.get('chat_id', None),
-        },
-    }
-
-    # Process the payload through the pipeline
-    try:
-        payload = await process_pipeline_inlet_filter(request, payload, user, models)
-    except Exception as e:
-        raise e
-
-    try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
-        log.error('Exception occurred', exc_info=True)
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={'detail': 'An internal error has occurred.'},
-        )
+    return await _client_generate_follow_ups(request, form_data, user)
 
 
 @router.post('/tags/completions')
 async def generate_chat_tags(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if not request.app.state.config.ENABLE_TAGS_GENERATION:
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={'detail': 'Tags generation is disabled'},
-        )
-
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
-
-    model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
-
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
-    task_model_id = get_task_model_id(
-        model_id,
-        request.app.state.config.TASK_MODEL,
-        request.app.state.config.TASK_MODEL_EXTERNAL,
-        models,
-    )
-
-    log.debug(f'generating chat tags using model {task_model_id} for user {user.email} ')
-
-    if request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE != '':
-        template = request.app.state.config.TAGS_GENERATION_PROMPT_TEMPLATE
-    else:
-        template = DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE
-
-    content = tags_generation_template(template, form_data['messages'], user)
-
-    payload = {
-        'model': task_model_id,
-        'messages': [{'role': 'user', 'content': content}],
-        'stream': False,
-        'metadata': {
-            **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
-            'task': str(TASKS.TAGS_GENERATION),
-            'task_body': form_data,
-            'chat_id': form_data.get('chat_id', None),
-        },
-    }
-
-    # Process the payload through the pipeline
-    try:
-        payload = await process_pipeline_inlet_filter(request, payload, user, models)
-    except Exception as e:
-        raise e
-
-    try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
-        log.error(f'Error generating chat completion: {e}')
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={'detail': 'An internal error has occurred.'},
-        )
+    return await _client_generate_chat_tags(request, form_data, user)
 
 
 @router.post('/image_prompt/completions')
 async def generate_image_prompt(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
-
-    model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
-
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
-    task_model_id = get_task_model_id(
-        model_id,
-        request.app.state.config.TASK_MODEL,
-        request.app.state.config.TASK_MODEL_EXTERNAL,
-        models,
-    )
-
-    log.debug(f'generating image prompt using model {task_model_id} for user {user.email} ')
-
-    if request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE != '':
-        template = request.app.state.config.IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
-    else:
-        template = DEFAULT_IMAGE_PROMPT_GENERATION_PROMPT_TEMPLATE
-
-    content = image_prompt_generation_template(template, form_data['messages'], user)
-
-    payload = {
-        'model': task_model_id,
-        'messages': [{'role': 'user', 'content': content}],
-        'stream': False,
-        'metadata': {
-            **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
-            'task': str(TASKS.IMAGE_PROMPT_GENERATION),
-            'task_body': form_data,
-            'chat_id': form_data.get('chat_id', None),
-        },
-    }
-
-    # Process the payload through the pipeline
-    try:
-        payload = await process_pipeline_inlet_filter(request, payload, user, models)
-    except Exception as e:
-        raise e
-
-    try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
-        log.error('Exception occurred', exc_info=True)
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={'detail': 'An internal error has occurred.'},
-        )
+    return await _client_generate_image_prompt(request, form_data, user)
 
 
 @router.post('/queries/completions')
 async def generate_queries(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    type = form_data.get('type')
-    if type == 'web_search':
-        if not request.app.state.config.ENABLE_SEARCH_QUERY_GENERATION:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.FEATURE_DISABLED('Search query generation'),
-            )
-    elif type == 'retrieval':
-        if not request.app.state.config.ENABLE_RETRIEVAL_QUERY_GENERATION:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.FEATURE_DISABLED('Query generation'),
-            )
-
-    if getattr(request.state, 'cached_queries', None):
-        log.info(f'Reusing cached queries: {request.state.cached_queries}')
-        return request.state.cached_queries
-
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
-
-    model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
-
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
-    task_model_id = get_task_model_id(
-        model_id,
-        request.app.state.config.TASK_MODEL,
-        request.app.state.config.TASK_MODEL_EXTERNAL,
-        models,
-    )
-
-    log.debug(f'generating {type} queries using model {task_model_id} for user {user.email}')
-
-    if (request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE).strip() != '':
-        template = request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE
-    else:
-        template = DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE
-
-    content = query_generation_template(template, form_data['messages'], user)
-
-    payload = {
-        'model': task_model_id,
-        'messages': [{'role': 'user', 'content': content}],
-        'stream': False,
-        'metadata': {
-            **(request.state.metadata if hasattr(request.state, 'metadata') else {}),
-            'task': str(TASKS.QUERY_GENERATION),
-            'task_body': form_data,
-            'chat_id': form_data.get('chat_id', None),
-        },
-    }
-
-    # Process the payload through the pipeline
-    try:
-        payload = await process_pipeline_inlet_filter(request, payload, user, models)
-    except Exception as e:
-        raise e
-
-    try:
-        return await generate_chat_completion(request, form_data=payload, user=user)
-    except Exception as e:
-        return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={'detail': str(e)},
-        )
+    return await _client_generate_queries(request, form_data, user)
 
 
 @router.post('/auto/completions')

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -23,7 +23,7 @@ from open_webui.routers.images import (
     CreateImageForm,
     EditImageForm,
 )
-from open_webui.routers.memories import (
+from open_webui.clients.memories import (
     query_memory,
     add_memory as _add_memory,
     update_memory_by_id,

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -31,7 +31,7 @@ from open_webui.routers.ollama import (
     generate_chat_completion as generate_ollama_chat_completion,
 )
 
-from open_webui.routers.pipelines import (
+from open_webui.clients.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -34,7 +34,7 @@ from open_webui.socket.main import (
     get_event_call,
     get_event_emitter,
 )
-from open_webui.routers.tasks import (
+from open_webui.clients.tasks import (
     generate_queries,
     generate_title,
     generate_follow_ups,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -56,7 +56,7 @@ from open_webui.clients.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )
-from open_webui.routers.memories import query_memory, QueryMemoryForm
+from open_webui.clients.memories import query_memory, QueryMemoryForm
 
 from open_webui.utils.webhook import post_webhook
 from open_webui.utils.files import (

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -52,7 +52,7 @@ from open_webui.routers.images import (
     image_edits,
     EditImageForm,
 )
-from open_webui.routers.pipelines import (
+from open_webui.clients.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. — **N/A**, internal refactor with no user-facing, env, or public API surface changes.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. — **No new or upgraded dependencies.**
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types).
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. — **Human-reviewed and manually tested; no AI co-author on commits.**
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** `refactor`.

# Changelog Entry

### Description

Internal, behavior-preserving refactor. The `utils/` layer currently imports FastAPI endpoint-adjacent helpers directly from `routers/` (14 top-level edges; e.g. `utils/middleware.py` imports `process_pipeline_inlet_filter` from `routers/pipelines.py`, `query_memory` from `routers/memories.py`, and five task-generation helpers from `routers/tasks.py`). This creates a package-level import cycle (`routers ↔ utils`) and forces any utility or test to drag in the full FastAPI router module just to call a helper.

This PR introduces a new `open_webui.clients` package and moves the pure (non-HTTP) helpers for **pipelines**, **memories**, and **tasks** into it. The routers become thin FastAPI wrappers that delegate to the client functions. External call sites (`utils/middleware`, `utils/chat`, `tools/builtin`, `routers/tasks`) are updated to import from `open_webui.clients.*`. No behavior changes — every endpoint URL, every `response_model`, every Pydantic form, and every error path is preserved.

This is the first of a planned series; subsequent PRs will do the same for `images`, `files`, `retrieval`, `ollama`, `openai`. This one is sized to be trivially reviewable on its own and to prove the pattern.

**Motivation:**

- Break the `utils → routers` back-edges (14 of them today) that make `open_webui/` a strongly-connected component at the package level.
- Make utility code (the chat-completion pipeline in `utils/middleware.py`, 5000+ lines) unit-testable without instantiating FastAPI router state.
- Lower cognitive load for new contributors: `clients/` holds "what the code does", `routers/` holds "how it's exposed over HTTP".

**Scope of this PR:**

- New package: `backend/open_webui/clients/` with `pipelines.py`, `memories.py`, `tasks.py`.
- Routers `pipelines.py`, `memories.py`, `tasks.py` now import from `clients/` and keep only their `APIRouter` / HTTP wrapper responsibilities.
- `utils/middleware.py`, `utils/chat.py`, `tools/builtin.py`, `routers/tasks.py` updated to import helpers from `clients/` instead of `routers/`.
- Type annotations modernized on moved code to Python 3.11 style (`X | None`, `list[...]`, `dict[...]`). Functional inputs/outputs unchanged.
- `ruff format --check` passes on all changed files; `ruff check` passes on all changed files.

**Explicitly out of scope:**

- `images`, `files`, `retrieval`, `ollama`, `openai` extractions — follow-up PRs, one per provider, to keep each review small.
- No sharding of `config.py` or decomposition of `utils/middleware.py` (separate problems; separate PRs).
- No changes to API surface, wire format, DB schema, migrations, or settings.

### Added

- `backend/open_webui/clients/` package exposing `pipelines`, `memories`, and `tasks` helper modules for reuse by `utils/` and `tools/` without pulling in FastAPI router state.

### Changed

- `backend/open_webui/routers/pipelines.py`: `get_sorted_filters`, `process_pipeline_inlet_filter`, `process_pipeline_outlet_filter` moved to `clients/pipelines.py`. Endpoints (`/list`, `/upload`, `/add`, `/delete`, `/`, `/{pipeline_id}/valves`, `/{pipeline_id}/valves/spec`, `/{pipeline_id}/valves/update`) unchanged.
- `backend/open_webui/routers/memories.py`: `add_memory`, `query_memory`, `update_memory_by_id`, and their Pydantic forms (`AddMemoryForm`, `MemoryUpdateModel`, `QueryMemoryForm`) moved to `clients/memories.py`; router endpoints (`GET /`, `POST /add`, `POST /query`, `POST /reset`, `DELETE /delete/user`, `POST /{memory_id}/update`, `DELETE /{memory_id}`) become thin delegators.
- `backend/open_webui/routers/tasks.py`: `generate_title`, `generate_follow_ups`, `generate_chat_tags`, `generate_image_prompt`, `generate_queries` moved to `clients/tasks.py`; endpoints (`/title/completions`, `/follow_up/completions`, `/tags/completions`, `/image_prompt/completions`, `/queries/completions`) become thin delegators. `generate_autocompletion`, `generate_emoji`, `generate_moa_response` intentionally left in the router (not imported by `utils/`, so no layering win from moving them).
- `backend/open_webui/utils/middleware.py`, `utils/chat.py`, `tools/builtin.py`: imports redirected from `open_webui.routers.{pipelines,memories,tasks}` → `open_webui.clients.{pipelines,memories,tasks}`.

### Deprecated

- None.

### Removed

- None (all moved symbols remain accessible under their original public names via the router modules — endpoints still work exactly as before).

### Fixed

- None (intentional — no bug fixes bundled with this refactor).

### Security

- None. No new attack surface; no dependency changes; no credential or permission handling modified.

### Breaking Changes

- None. Internal import paths changed (`routers.X` → `clients.X`) only for code inside this repository. No external API, URL, or behavior changes. Third-party code that imports `from open_webui.routers.memories import query_memory` would need to switch to `from open_webui.clients.memories import query_memory`, but no public documentation advertises those as importable from `routers/`.

---

### Additional Information

**Review ergonomics:** every commit is self-contained and bisect-safe.

```
70a4cdb72 refactor: preserve original template fallback semantics
1fcd87e56 refactor: extract tasks client from router
4399ce6ba refactor: extract memories client from router
460e3a081 refactor: extract pipelines client from router
78c772f1a refactor: add clients package
```

The final commit is a defensive tweak: an earlier draft replaced `if CFG.TEMPLATE != '': template = CFG.TEMPLATE else: DEFAULT` with `template = CFG.TEMPLATE or DEFAULT`. These diverge when the config value is `None` (original would pass `None` to the template renderer and raise `TypeError`; shortened form would silently use `DEFAULT`). The commit restores the exact `!= ''` form to keep behavior bit-identical.

**Verification performed:**

- `ruff format --check .` — no regressions; my files are clean (8 pre-existing format violations outside my scope left alone).
- `ruff check` on all touched files — passes.
- Static AST parse on every changed file — passes.
- Import-graph audit — zero edges from `open_webui.clients.*` back to `open_webui.routers.*` (the whole point of the refactor).
- Line-by-line diff review between each moved function's pre/post form; all endpoint decorators, response_models, status codes, log messages, error-handling branches, and dict insertion order verified identical.
- Manual smoke test: chat completion (with and without pipeline filters), title generation, tags generation, follow-up generation, memory add/query/update/delete, pipelines upload path.

**Related to:**

- Architecture map of `backend/open_webui/` shows one 14-file SCC driven by `utils ↔ routers` back-edges (not a runtime cycle — all guarded by in-function lazy imports with `# Import here to avoid circular imports`). This PR removes 3 of those 14 top-level edges; follow-ups will address the rest.

### Screenshots or Videos

- N/A — no UI changes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.