### PR TITLE
fix: Yandex web search parsing with missing XML fields

### DIFF
--- a/backend/open_webui/retrieval/web/yandex.py
+++ b/backend/open_webui/retrieval/web/yandex.py
@@ -19,7 +19,10 @@ from xml.etree.ElementTree import Element
 log = logging.getLogger(__name__)
 
 
-def xml_element_contents_to_string(element: Element) -> str:
+def xml_element_contents_to_string(element: Optional[Element]) -> str:
+    if element is None:
+        return ''
+
     buffer = [element.text if element.text else '']
 
     for child in element:
@@ -91,11 +94,20 @@ def search_yandex(
         results = []
 
         for group in doc_root.findall('response/results/grouping/group'):
+            url = xml_element_contents_to_string(group.find('doc/url')).strip('\n')
+            title = xml_element_contents_to_string(group.find('doc/title')).strip('\n')
+            snippet = xml_element_contents_to_string(group.find('doc/passages/passage'))
+
+            # Some Yandex results do not include all expected doc fields.
+            # Skip invalid entries instead of failing the full search request.
+            if not url or not title:
+                continue
+
             results.append(
                 {
-                    'url': xml_element_contents_to_string(group.find('doc/url')).strip('\n'),
-                    'title': xml_element_contents_to_string(group.find('doc/title')).strip('\n'),
-                    'snippet': xml_element_contents_to_string(group.find('doc/passages/passage')),
+                    'url': url,
+                    'title': title,
+                    'snippet': snippet,
                 }
             )
 

--- a/backend/open_webui/test/retrieval/web/test_yandex.py
+++ b/backend/open_webui/test/retrieval/web/test_yandex.py
@@ -1,0 +1,106 @@
+import base64
+import importlib
+import os
+
+from fastapi import FastAPI, Request
+from starlette.datastructures import Headers
+
+
+def _import_yandex_module():
+    # Avoid env initialization failures when importing open_webui modules in tests.
+    os.environ.setdefault('WEBUI_SECRET_KEY', 'test-webui-secret-key')
+    return importlib.import_module('open_webui.retrieval.web.yandex')
+
+
+class MockResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _build_request() -> Request:
+    return Request(
+        {
+            'type': 'http',
+            'asgi.version': '3.0',
+            'asgi.spec_version': '2.0',
+            'method': 'GET',
+            'path': '/internal',
+            'query_string': b'',
+            'headers': Headers({}).raw,
+            'client': ('127.0.0.1', 12345),
+            'server': ('127.0.0.1', 80),
+            'scheme': 'http',
+            'app': FastAPI(),
+        },
+        None,
+    )
+
+
+def test_xml_element_contents_to_string_returns_empty_for_none():
+    yandex = _import_yandex_module()
+    assert yandex.xml_element_contents_to_string(None) == ''
+
+
+def test_search_yandex_skips_invalid_groups_without_crashing(monkeypatch):
+    yandex = _import_yandex_module()
+
+    raw_xml = '''
+<yandexsearch>
+  <response>
+    <results>
+      <grouping>
+        <group>
+          <doc>
+            <url>https://example.com/1</url>
+            <title>Valid title</title>
+            <passages><passage>Valid snippet</passage></passages>
+          </doc>
+        </group>
+        <group>
+          <doc>
+            <url>https://example.com/2</url>
+            <title>No passage title</title>
+          </doc>
+        </group>
+        <group>
+          <doc>
+            <url>https://example.com/3</url>
+            <passages><passage>No title snippet</passage></passages>
+          </doc>
+        </group>
+      </grouping>
+    </results>
+  </response>
+</yandexsearch>
+'''.strip()
+
+    payload = {'rawData': base64.b64encode(raw_xml.encode('utf-8')).decode('utf-8')}
+
+    def mock_post(*args, **kwargs):
+        return MockResponse(payload)
+
+    monkeypatch.setattr(yandex.requests, 'post', mock_post)
+
+    results = yandex.search_yandex(
+        request=_build_request(),
+        yandex_search_url='',
+        yandex_search_api_key='test-key',
+        yandex_search_config='',
+        query='test query',
+        count=3,
+    )
+
+    assert len(results) == 2
+    assert results[0].link == 'https://example.com/1'
+    assert results[0].title == 'Valid title'
+    assert results[0].snippet == 'Valid snippet'
+
+    assert results[1].link == 'https://example.com/2'
+    assert results[1].title == 'No passage title'
+    assert results[1].snippet == ''


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Fix Yandex web search parsing when Yandex Search API returns groups with missing XML nodes (e.g. missing `doc/passages/passage` or `doc/title`), which previously caused an exception and resulted in `No results found from web search`.

### Added

- Added backend unit test: `backend/open_webui/test/retrieval/web/test_yandex.py`.
- Added test coverage for:
  - `xml_element_contents_to_string(None)` returning empty string.
  - `search_yandex` behavior with partial Yandex XML groups.

### Changed

- Updated `xml_element_contents_to_string` to safely handle `None` elements.
- Updated Yandex result parsing loop to skip invalid groups that are missing required fields (`url`/`title`) instead of failing the whole request.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed Yandex web search failure caused by `AttributeError: 'NoneType' object has no attribute 'text'` on partial XML responses.
- Web search now returns available valid results instead of failing the entire search operation.

### Security

- No security-related changes.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- No new dependencies were added.
- No user-facing settings/API/env changes were introduced; documentation update in `open-webui/docs` is not required for this backend parsing fix.
- Reproducible behavior before fix:
  1. Configure Open WebUI web search engine as `yandex`.
  2. Run web search queries where Yandex can return partial groups.
  3. Observe backend error and empty search result.
- After fix:
  - Partial groups are tolerated.
  - Valid groups are still returned.
- Branch is rebased on `dev` and PR is intentionally atomic (single logical fix + tests).
- AI-assisted draft was additionally manually reviewed and manually tested by the author before submission.

### Screenshots or Videos

- N/A (backend-only bugfix, no UI changes).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
