### PR TITLE
feat: move Artifacts from hamburger menu to sidebar tab

### DIFF
--- a/src/lib/components/chat/Artifacts.svelte
+++ b/src/lib/components/chat/Artifacts.svelte
@@ -128,7 +128,7 @@
 			<div
 				class="pointer-events-auto z-20 flex justify-between items-center p-2.5 font-primar text-gray-900 dark:text-white"
 			>
-				<div class="flex-1 flex items-center justify-between pr-1">
+				<div class="flex-1 flex items-center justify-between">
 					<div class="flex items-center space-x-2">
 						<div class="flex items-center gap-0.5 self-center min-w-fit" dir="ltr">
 							<button
@@ -217,16 +217,6 @@
 					</div>
 				</div>
 
-				<button
-					class="self-center pointer-events-auto p-1 rounded-full bg-white dark:bg-gray-850"
-					on:click={() => {
-						dispatch('close');
-						showControls.set(false);
-						showArtifacts.set(false);
-					}}
-				>
-					<XMark className="size-3.5 text-gray-900 dark:text-white" />
-				</button>
 			</div>
 		{/if}
 

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -20,7 +20,8 @@
 		settings,
 		showFileNavPath,
 		selectedTerminalId,
-		user
+		user,
+		artifactContents
 	} from '$lib/stores';
 
 	import { uploadFile } from '$lib/apis/files';
@@ -75,8 +76,10 @@
 		!!$selectedTerminalId ||
 		(codeInterpreterEnabled && $config?.code?.interpreter_engine !== 'jupyter');
 	$: showOverviewTab = hasMessages;
+	$: showArtifactsTab = ($artifactContents ?? []).length > 0;
 
 	// Tab fallback: if active tab becomes hidden, switch to next available
+	$: if (!showArtifactsTab && activeTab === 'artifacts') activeTab = 'controls';
 	$: if (!showOverviewTab && activeTab === 'overview') activeTab = 'controls';
 	$: if (!showFilesTab && activeTab === 'files') activeTab = 'controls';
 	$: if (!showControlsTab && activeTab === 'controls') {
@@ -93,6 +96,12 @@
 	$: if ($showFileNavPath) {
 		activeTab = 'files';
 		showControls.set(true);
+	}
+
+	$: if ($showArtifacts) {
+		activeTab = 'artifacts';
+		showControls.set(true);
+		showArtifacts.set(false);
 	}
 
 	// Auto-open Files tab when a terminal is selected (suppress panel open when full-screen)
@@ -258,7 +267,7 @@
 	$: if (paneReady && !chatId) closeHandler();
 
 	// Helper: is a "special" full-screen panel active?
-	$: specialPanel = $showCallOverlay || $showArtifacts || $showEmbeds;
+	$: specialPanel = $showCallOverlay || $showEmbeds;
 </script>
 
 {#if !largeScreen}
@@ -285,17 +294,15 @@
 					</div>
 				{:else if $showEmbeds}
 					<Embeds />
-				{:else if $showArtifacts}
-					<Artifacts {history} />
 				{:else}
 					<!-- Controls + Files tabs -->
 					<div class="flex flex-col h-full min-h-0">
 						<!-- Tab bar -->
 						<div class="flex items-center justify-between px-2 pt-2 pb-2 shrink-0">
-							<div class="flex gap-1 min-w-0 overflow-x-auto scrollbar-hidden">
+							<div class="flex-1 flex gap-1 min-w-0 overflow-x-auto scrollbar-hidden">
 								{#if showControlsTab}
 									<button
-										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+										class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 										'controls'
 											? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 											: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -306,7 +313,7 @@
 								{/if}
 								{#if showFilesTab}
 									<button
-										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+										class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 										'files'
 											? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 											: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -317,7 +324,7 @@
 								{/if}
 								{#if showOverviewTab}
 									<button
-										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+										class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 										'overview'
 											? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 											: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -326,9 +333,20 @@
 										{$i18n.t('Overview')}
 									</button>
 								{/if}
+								{#if showArtifactsTab}
+									<button
+										class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
+										'artifacts'
+											? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
+											: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+										on:click={() => (activeTab = 'artifacts')}
+									>
+										{$i18n.t('Artifacts')}
+									</button>
+								{/if}
 							</div>
 							<button
-								class="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+								class="p-1 shrink-0 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
 								on:click={() => showControls.set(false)}
 								aria-label={$i18n.t('Close')}
 							>
@@ -352,7 +370,7 @@
 									? 'overflow-y-auto px-3 pt-1'
 									: ''}"
 						>
-							{#if activeTab === 'overview'}
+								{#if activeTab === 'overview'}
 								<Overview
 									{history}
 									onNodeClick={(e) => {
@@ -361,6 +379,8 @@
 									}}
 									onClose={() => showControls.set(false)}
 								/>
+							{:else if activeTab === 'artifacts'}
+								<Artifacts {history} />
 							{:else if activeTab === 'files' && $selectedTerminalId}
 								<FileNav onAttach={handleTerminalAttach} {chatId} />
 							{:else if activeTab === 'files' && codeInterpreterEnabled}
@@ -431,17 +451,15 @@
 						</div>
 					{:else if $showEmbeds}
 						<Embeds overlay={dragged} />
-					{:else if $showArtifacts}
-						<Artifacts {history} overlay={dragged} />
 					{:else}
 						<!-- Controls + Files tabs -->
 						<div class="flex flex-col h-full min-h-0">
 							<!-- Tab bar -->
 							<div class="flex items-center justify-between px-2 pt-2 pb-2 shrink-0">
-								<div class="flex gap-1 min-w-0 overflow-x-auto scrollbar-hidden">
+								<div class="flex-1 flex gap-1 min-w-0 overflow-x-auto scrollbar-hidden">
 									{#if showControlsTab}
 										<button
-											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+											class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 											'controls'
 												? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 												: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -452,7 +470,7 @@
 									{/if}
 									{#if showFilesTab}
 										<button
-											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+											class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 											'files'
 												? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 												: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -463,7 +481,7 @@
 									{/if}
 									{#if showOverviewTab}
 										<button
-											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
+											class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
 											'overview'
 												? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
 												: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
@@ -472,9 +490,20 @@
 											{$i18n.t('Overview')}
 										</button>
 									{/if}
+									{#if showArtifactsTab}
+										<button
+											class="flex-1 px-2 py-1 text-[13px] rounded-lg transition whitespace-nowrap {activeTab ===
+											'artifacts'
+												? 'bg-gray-100 dark:bg-gray-800 font-medium text-gray-900 dark:text-white'
+												: 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
+											on:click={() => (activeTab = 'artifacts')}
+										>
+											{$i18n.t('Artifacts')}
+										</button>
+									{/if}
 								</div>
 								<button
-									class="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+									class="p-1 shrink-0 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
 									on:click={() => showControls.set(false)}
 									aria-label={$i18n.t('Close')}
 								>
@@ -512,6 +541,8 @@
 										}}
 										onClose={() => showControls.set(false)}
 									/>
+								{:else if activeTab === 'artifacts'}
+									<Artifacts {history} overlay={dragged} />
 								{:else if activeTab === 'files' && $selectedTerminalId}
 									<FileNav onAttach={handleTerminalAttach} overlay={dragged} {chatId} />
 								{:else if activeTab === 'files' && codeInterpreterEnabled}

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -309,23 +309,7 @@
 				<div class="flex items-center">{$i18n.t('Settings')}</div>
 			</DropdownMenu.Item> -->
 
-			{#if ($artifactContents ?? []).length > 0}
-				<button
-					draggable="false"
-					class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full"
-					id="chat-artifacts-button"
-					on:click={async () => {
-						await showControls.set(true);
-						await showArtifacts.set(true);
-						await showEmbeds.set(false);
-					}}
-				>
-					<Cube className=" size-4" strokeWidth="1.5" />
-					<div class="flex items-center">{$i18n.t('Artifacts')}</div>
-				</button>
 
-				<hr class="border-gray-50/30 dark:border-gray-800/30 my-1" />
-			{/if}
 
 			{#if !$temporaryChatEnabled && ($user?.role === 'admin' || ($user.permissions?.chat?.share ?? true))}
 				<button


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

- Moved the `Artifacts` view from the top right chat menu into a dedicated right-hand sidebar tab next to the `Overview` tab. This improves visibility and accessibility of artifacts generated during chat sessions. Also removed the redundant "X" close button inside the artifact header, allowing action buttons (Copy, Download, Fullscreen) to cleanly align to the right edge.

### Added

- Added an `Artifacts` tab to `ChatControls.svelte` which dynamically appears when artifacts are present in the current chat.

### Changed

- Re-styled the sidebar tabs (`Controls`, `Files`, `Overview`, `Artifacts`) with `flex-1` and slightly reduced padding to ensure they perfectly distribute their widths and prevent horizontal scrolling at minimal sidebar sizes.
- Shifted the Artifact header action buttons (Copy, Download, Fullscreen) to the right by removing the redundant inner "X" close button inside `Artifacts.svelte`.

### Removed

- Removed the `Artifacts` button from the top right hamburger menu (`Navbar/Menu.svelte`).
- Removed the inner "X" (close) button from the artifact rendering view header.

### Fixed

- Fixed disproportionate spacing of sidebar tabs that previously caused the UI to look unbalanced or "right-centered" when the sidebar was expanded.

---

### Additional Information

- The sidebar will still automatically open and switch to the Artifacts tab when a new artifact is rendered in the chat stream when `Detect Artifacts Automatically` is toggled **ON** in the user settings menu, maintaining the fluid UX previously expected when generating visual components.

### Screenshots or Videos

[Screencast from 2026-04-20 23-17-15.webm](https://github.com/user-attachments/assets/98771c92-36a0-444f-8803-69edb72d2e9a)

[Screencast from 2026-04-20 23-22-11.webm](https://github.com/user-attachments/assets/e13a4085-ff08-499c-8c0e-02f4e6c5158e)

[Screencast from 2026-04-20 23-39-59.webm](https://github.com/user-attachments/assets/21e7e507-21e3-453d-a584-1c7bcc7f04be)

[Screencast from 2026-04-20 23-43-31.webm](https://github.com/user-attachments/assets/19a8be66-43db-4f54-a1ac-f07a2f6e40cd)

<img width="473" height="1283" alt="image" src="https://github.com/user-attachments/assets/62e96783-cb42-44dd-8498-737d2ee41498" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.