### PR TITLE
feat: open settings modal to 'Connections' tab for  'Add Terminal' button

### DIFF
--- a/src/lib/components/chat/MessageInput/TerminalMenu.svelte
+++ b/src/lib/components/chat/MessageInput/TerminalMenu.svelte
@@ -2,7 +2,7 @@
 	import { getContext } from 'svelte';
 	import { goto } from '$app/navigation';
 
-	import { settings, showSettings, terminalServers, selectedTerminalId, user } from '$lib/stores';
+	import { settings, showSettings, settingsTab, terminalServers, selectedTerminalId, user } from '$lib/stores';
 	import { getToolServersData } from '$lib/apis';
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
@@ -125,6 +125,7 @@
 								class="p-0.5 rounded-md text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition"
 								on:click|stopPropagation={() => {
 									show = false;
+									settingsTab.set('tools');
 									showSettings.set(true);
 								}}
 							>

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext, onMount, tick } from 'svelte';
 	import { toast } from 'svelte-sonner';
-	import { config, models, settings, user } from '$lib/stores';
+	import { config, models, settings, settingsTab, user } from '$lib/stores';
 	import { updateUserSettings } from '$lib/apis/users';
 	import { getModels as _getModels } from '$lib/apis';
 	import { goto } from '$app/navigation';
@@ -547,6 +547,14 @@
 	};
 
 	let selectedTab = 'general';
+
+	$: if (show) {
+		selectedTab = $settingsTab || 'general';
+	}
+
+	$: if (selectedTab) {
+		settingsTab.set(selectedTab);
+	}
 
 	// Function to handle sideways scrolling
 	const scrollHandler = (event) => {

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -93,6 +93,7 @@ export const sidebarWidth = writable(260);
 export const showSidebar = writable(false);
 export const showSearch = writable(false);
 export const showSettings = writable(false);
+export const settingsTab = writable(null);
 export const showShortcuts = writable(false);
 export const showArchivedChats = writable(false);
 export const showChangelog = writable(false);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **feat**: Introduces a new feature or enhancement to the codebase

# Changelog Entry

### Description

- Implemented a mechanism to open the Settings modal at a specific tab by introducing a global `settingsTab` store.
- Updated the "Add Terminal" (+) button in the "Direct" connection pop-up to redirect users specifically to the "Integrations" tab, streamlining the workflow for adding new terminal servers.

### Added

- New `settingsTab` store in `src/lib/stores/index.ts` to manage the active settings tab state globally.

### Changed

- `SettingsModal.svelte`: Synchronized internal tab state with the `settingsTab` store, allowing for external control and persistence of the last active tab.
- `TerminalMenu.svelte`: Updated the "Add Terminal" (+) button to set the `settingsTab` to `'tools'` (Integrations) before opening the modal.

### Fixed

- Improved UX by ensuring that specific "Add" buttons within the UI take the user to the relevant settings section rather than always defaulting to the "General" tab.

---

### Additional Information

- The `settingsTab` store is initialized to `null` to follow project-wide conventions, with `SettingsModal.svelte` providing a default fallback to the `'general'` tab.

### Screenshots or Videos

<img width="351" height="173" alt="image" src="https://github.com/user-attachments/assets/65bf316d-3948-4557-8ef6-5d4534ebfee1" />

**Before: (Would open up to the `General` user settings tab)**

<img width="1378" height="777" alt="image" src="https://github.com/user-attachments/assets/0eb54ea4-a710-42d4-80b9-dbf03775fe2f" />

**After: (Now opens up to the `Tools` (Integrations) user settings tab)**

<img width="1378" height="777" alt="image" src="https://github.com/user-attachments/assets/4d648c93-7126-413a-be5a-4925dae3e1e5" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.