### PR TITLE
fix: only set finish_reason 'stop' on final SSE chunk when usage is present

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -504,7 +504,7 @@ def openai_chat_chunk_message_template(
     if tool_calls:
         template['choices'][0]['delta']['tool_calls'] = tool_calls
 
-    if not content and not reasoning_content and not tool_calls:
+    if usage and not content and not reasoning_content and not tool_calls:
         template['choices'][0]['finish_reason'] = 'stop'
 
     if usage:


### PR DESCRIPTION
## Summary

Fixes #23921 (Ref: #23917 Bug 2)

- One-line fix in `misc.py`: add `usage and` to the `finish_reason` condition
- Empty `content`/`thinking` strings from Ollama's first chunk are falsy in Python
- This caused `finish_reason: "stop"` on the very first SSE chunk
- API clients close the stream immediately, missing all reasoning and content