### PR TITLE
fix: strip client-provided tools for models without native tool calling

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2465,6 +2465,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # tool resolution (tool_ids, MCP servers, builtin tools).
     payload_tools = form_data.get('tools', None)
 
+    # Strip client-provided tools for models that don't support native tool calling.
+    # API clients (e.g. @ai-sdk/openai-compatible) may always send tools/tool_choice
+    # even for models that reject them (DeepSeek R1, etc.), causing Ollama errors.
+    if payload_tools:
+        function_calling_mode = metadata.get('params', {}).get('function_calling') or \
+            model.get('info', {}).get('params', {}).get('function_calling')
+        if function_calling_mode != 'native':
+            form_data.pop('tools', None)
+            form_data.pop('tool_choice', None)
+            payload_tools = None
+
     # Skills
     user_skill_ids = set(form_data.pop('skill_ids', None) or [])
     model_skill_ids = set(model.get('info', {}).get('meta', {}).get('skillIds', []))


### PR DESCRIPTION
## Summary

Fixes #23924 (Ref: #23917 Bug 5)

- Strip `tools` and `tool_choice` from `form_data` when the model doesn't have `function_calling: "native"`
- API clients automatically send tools for features like title generation, causing Ollama to reject non-tool-capable models
- The error handler returns `null`, crashing the SDK and killing concurrent streams