### PR TITLE
fix(packaging): add explicit greenlet dependency

### DIFF
--- a/backend/requirements-min.txt
+++ b/backend/requirements-min.txt
@@ -26,6 +26,7 @@ httpx[socks,http2,zstd,cli,brotli]==0.28.1
 starsessions[redis]==2.2.1
 
 sqlalchemy==2.0.48
+greenlet==3.1.1
 aiosqlite==0.21.0
 asyncpg==0.30.0
 alembic==1.18.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ starsessions[redis]==2.2.1
 python-mimeparse==2.0.0
 
 sqlalchemy==2.0.48
+greenlet==3.1.1
 aiosqlite==0.21.0
 asyncpg==0.30.0
 alembic==1.18.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "python-mimeparse==2.0.0",
 
     "sqlalchemy==2.0.48",
+    "greenlet==3.1.1",
     "aiosqlite==0.21.0",
     "asyncpg==0.30.0",
     "alembic==1.18.4",


### PR DESCRIPTION
Summary
- add greenlet==3.1.1 to the published project dependencies in pyproject.toml
- mirror the same dependency in backend/requirements.txt
- mirror the same dependency in backend/requirements-min.txt

Closes #23942.

Testing
- git diff --check
