### PR TITLE
fix: fix RichTextInput configuration 

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -737,6 +737,17 @@
 				StarterKit.configure({
 					link: link,
 					code: false, // Disabled in favor of FixedCode (see workaround above)
+					// When rich text is on, ListKit + CodeBlockLowlight provide these.
+					// Disable StarterKit's equivalents to avoid duplicate extension names.
+					...(richText
+						? {
+								codeBlock: false,
+								bulletList: false,
+								orderedList: false,
+								listItem: false,
+								listKeymap: false
+							}
+						: {}),
 					// When rich text is off, disable Strike from StarterKit so we can
 					// re-add it below without its Mod-Shift-s shortcut (which conflicts
 					// with the Toggle Sidebar shortcut). When rich text is on, the user


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Not needed (no new env vars, APIs, or deployment changes).
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manual validation completed (details below).
- [x] **Agentic AI Code:** This PR has gone through additional human review and manual testing.
- [x] **Code review:** Self-reviewed for scope and coding standards.
- [x] **Design & Architecture:** No new settings introduced; follows existing editor extension structure.
- [x] **Git Hygiene:** Atomic PR with one logical fix, based on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Fix duplicate TipTap extension registration in `RichTextInput.svelte` when `richText` mode is enabled.

`StarterKit` and `ListKit`/`CodeBlockLowlight` were both registering overlapping list/code block extensions, producing duplicate extension warnings and risking inconsistent editor behavior.

### Changed

- In `src/lib/components/common/RichTextInput.svelte`, `StarterKit.configure(...)` now conditionally disables overlapping extensions when `richText` is enabled:
  - `codeBlock`
  - `bulletList`
  - `orderedList`
  - `listItem`
  - `listKeymap`

This ensures `ListKit` and `CodeBlockLowlight` are the single source of truth for those nodes/commands in rich text mode.

### Fixed

- TipTap warning about duplicate extension names:
  - `codeBlock`
  - `bulletList`
  - `listItem`
  - `listKeymap`
  - `orderedList`
- Potential rich text editor conflicts from duplicate extension ownership.

---

### Additional Information

- **Manual testing**
  - Confirm duplicate extension warning is gone.
  - Validate list features: bullet list, ordered list, nesting/indent/outdent.
  - Validate code block insert/edit behavior.
  - Verify no regressions in normal rich text editing interactions.

### Screenshots or Videos

<img width="997" height="29" alt="image" src="https://github.com/user-attachments/assets/fe4cfaa3-3c4f-44cc-825e-878dcaac804e" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.