### PR TITLE
perf: improve splash LCP image discovery in app.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -71,6 +71,16 @@
 					metaThemeColorTag.setAttribute('content', '#171717');
 				}
 
+				const preloadHref = document.documentElement.classList.contains('dark')
+					? '/static/splash-dark.png'
+					: '/static/splash.png';
+				const preload = document.createElement('link');
+				preload.rel = 'preload';
+				preload.as = 'image';
+				preload.href = preloadHref;
+				preload.setAttribute('fetchpriority', 'high');
+				document.head.appendChild(preload);
+
 				window.matchMedia('(prefers-color-scheme: dark)').addListener((e) => {
 					if (localStorage.theme === 'system') {
 						if (e.matches) {
@@ -90,6 +100,8 @@
 				logo.id = 'logo';
 				logo.style =
 					'position: absolute; width: auto; height: 6rem; top: 44%; left: 50%; transform: translateX(-50%); display:block;';
+				logo.loading = 'eager';
+				logo.fetchPriority = 'high';
 				logo.src = isDarkMode ? '/static/splash-dark.png' : '/static/splash.png';
 
 				document.addEventListener('DOMContentLoaded', function () {
@@ -139,6 +151,8 @@
 					id="logo-her"
 					style="width: auto; height: 13rem"
 					src="/static/splash.png"
+					loading="eager"
+					fetchpriority="high"
 					class="animate-pulse-fast"
 				/>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Not needed (no new env vars, public APIs, or deployment changes).
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manual tests performed (see below); verified splash behavior and Lighthouse/LCP guidance around splash image discovery.
- [x] **Agentic AI Code:** This change has been human-reviewed and manually tested.
- [x] **Code review:** Self-reviewed for scope and consistency with existing `app.html` splash behavior.
- [x] **Design & Architecture:** No new settings; only adjusts how the existing splash logo is loaded.
- [x] **Git Hygiene:** Atomic PR (splash/LCP loading only), rebased on `dev`.
- [x] **Title Prefix:** `perf`

# Changelog Entry

### Description

Improve first-load **LCP** for the splash screen by making the splash logo URL **discoverable earlier** from the initial HTML and by avoiding deferred image loading behavior.

- Adds a **theme-resolved** `<link rel="preload" as="image">` for the active splash asset (`/static/splash-dark.png` vs `/static/splash.png`) with **`fetchpriority="high"`**, inserted from the existing inline theme bootstrap script in `src/app.html`.
- Ensures splash images explicitly use **eager loading** and **high fetch priority** where applicable (including the dynamically inserted `#logo` image and the `#logo-her` markup path).

Motivation: Lighthouse/LCP audits flag late discovery when the LCP image request is not visible in the initial document and/or is not prioritized like other above-the-fold content.

### Added

- Theme-resolved splash image preload in `src/app.html` (`as="image"`, `fetchpriority="high"`).

### Changed

- `src/app.html`
  - Splash logo loading hints updated to prioritize the LCP candidate and avoid lazy-loading patterns.
  - Preload targets only the splash variant selected by the resolved theme class logic (reduces unused preload warnings vs preloading both assets).

### Fixed

- Browser console warnings related to **preload request mode mismatch** (e.g., `crossorigin` on preload not matching the eventual image request) by aligning preload attributes with the actual image fetch mode.

---

### Additional Information

**Manual testing**

- Cold load with **dark** theme: splash shows correct asset; verify splash image is requested early; no preload mismatch warnings.
- Cold load with **light** theme: same checks for `/static/splash.png`.
- **`her` theme path**: confirm existing splash behavior remains correct (this change should not alter `her` splash logic beyond loading hints on shared markup where applied).
- Lighthouse/PageSpeed: confirm “LCP request discovery” guidance is addressed for the splash image (or materially improved), understanding remaining LCP time may still include render/main-thread components unrelated to image fetch.

### Screenshots or Videos

<img width="329" height="249" alt="image" src="https://github.com/user-attachments/assets/fb2a5ccf-4932-49b8-902b-4758acab0489" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.