### PR TITLE
perf: defer RichTextInput formatting toolbar invalidation to rAF

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -302,6 +302,25 @@
 	let bubbleMenuElement: Element | null = null;
 	let element: Element | null = null;
 
+	/** Defer FormattingButtons refresh to after layout so we don't interleave Svelte DOM work with ProseMirror's updateStateInner (reduces forced reflow). */
+	let toolbarInvalidateRaf = 0;
+
+	const scheduleToolbarInvalidation = () => {
+		if (!richText || !showFormattingToolbar) {
+			if (toolbarInvalidateRaf) {
+				cancelAnimationFrame(toolbarInvalidateRaf);
+				toolbarInvalidateRaf = 0;
+			}
+			return;
+		}
+		if (toolbarInvalidateRaf) cancelAnimationFrame(toolbarInvalidateRaf);
+		toolbarInvalidateRaf = requestAnimationFrame(() => {
+			toolbarInvalidateRaf = 0;
+			if (!editor || editor.isDestroyed) return;
+			editor = editor;
+		});
+	};
+
 	const options = {
 		throwOnError: false
 	};
@@ -855,8 +874,7 @@
 			content: collaboration ? undefined : content,
 			autofocus: messageInput ? true : false,
 			onTransaction: () => {
-				// force re-render so `editor.isActive` works as expected
-				editor = editor;
+				scheduleToolbarInvalidation();
 				if (!editor) return;
 
 				htmlValue = editor.getHTML();
@@ -1223,6 +1241,11 @@
 	});
 
 	onDestroy(() => {
+		if (toolbarInvalidateRaf) {
+			cancelAnimationFrame(toolbarInvalidateRaf);
+			toolbarInvalidateRaf = 0;
+		}
+
 		if (provider) {
 			provider.destroy();
 		}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. *(Not applicable: no user-facing behavior or API changes.)*
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. *(None.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes. *(No new settings; local rAF scheduling only.)*
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **perf**: Performance improvement *(used in PR title)*

# Changelog Entry

### Description

- `RichTextInput` previously assigned `editor = editor` on every TipTap transaction so `FormattingButtons` (bubble + floating toolbars) refreshed `editor.isActive(...)`. That reconciles Svelte UI in the same turn as ProseMirror’s editor update. This PR defers that assignment with `requestAnimationFrame` when `richText && showFormattingToolbar`, and cancels the pending frame in `onDestroy`. `onChange`, `getHTML`, and markdown export remain synchronous so bound prompt state does not lag before send.

### Changed

- RichTextInput: defer formatting toolbar Svelte invalidation to `requestAnimationFrame` to reduce interleaved layout work with the TipTap/ProseMirror update cycle.

---

### Additional Information

- **Before (issue):** Typing with the formatting toolbar enabled could contribute to extra main-thread / layout work (e.g. forced reflow warnings in Chrome Performance) because Svelte toolbar updates ran immediately after each editor transaction.
- **After:** Toolbar invalidation runs on the next animation frame; text and `onChange` behavior are unchanged.
- **Tradeoff:** Toolbar button “active” styling may update up to one frame later; expected to be imperceptible in normal use.
- **Scope:** `src/lib/components/common/RichTextInput.svelte` only.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.