### PR TITLE
fix: native tool-call continuation for Kimi thinking models

### DIFF
--- a/backend/open_webui/test/util/test_misc.py
+++ b/backend/open_webui/test/util/test_misc.py
@@ -1,0 +1,158 @@
+from open_webui.utils.misc import add_reasoning_content_to_tool_messages
+
+
+class TestAddReasoningContentToToolMessages:
+    def test_adds_reasoning_content_for_kimi_tool_messages(self):
+        messages = [
+            {
+                'role': 'assistant',
+                'content': '<think>Need to search.</think>',
+                'tool_calls': [
+                    {
+                        'id': 'call_123',
+                        'type': 'function',
+                        'function': {'name': 'search_web', 'arguments': '{"query":"Rakhi Kaag"}'},
+                    }
+                ],
+            },
+            {'role': 'tool', 'tool_call_id': 'call_123', 'content': 'Search results'},
+        ]
+        output = [
+            {
+                'type': 'reasoning',
+                'summary': [{'type': 'output_text', 'text': 'Need to search.'}],
+            },
+            {
+                'type': 'function_call',
+                'call_id': 'call_123',
+                'name': 'search_web',
+                'arguments': '{"query":"Rakhi Kaag"}',
+            },
+            {'type': 'function_call_output', 'call_id': 'call_123', 'output': []},
+        ]
+
+        adjusted = add_reasoning_content_to_tool_messages(messages, output, 'kimi-k2.6')
+
+        assert adjusted[0]['reasoning_content'] == 'Need to search.'
+        assert adjusted[1] == messages[1]
+
+    def test_scopes_reasoning_to_matching_assistant_message(self):
+        messages = [
+            {
+                'role': 'assistant',
+                'content': '<think>Need to search the web.</think>',
+                'tool_calls': [
+                    {
+                        'id': 'call_1',
+                        'type': 'function',
+                        'function': {'name': 'search_web', 'arguments': '{"query":"Rakhi Kaag"}'},
+                    }
+                ],
+            },
+            {'role': 'tool', 'tool_call_id': 'call_1', 'content': 'First search results'},
+            {
+                'role': 'assistant',
+                'content': '<think>Need to search notes.</think>',
+                'tool_calls': [
+                    {
+                        'id': 'call_2',
+                        'type': 'function',
+                        'function': {'name': 'search_notes', 'arguments': '{"query":"Rakhi Kaag"}'},
+                    }
+                ],
+            },
+        ]
+        output = [
+            {
+                'type': 'reasoning',
+                'summary': [{'type': 'output_text', 'text': 'Need to search the web.'}],
+            },
+            {
+                'type': 'function_call',
+                'call_id': 'call_1',
+                'name': 'search_web',
+                'arguments': '{"query":"Rakhi Kaag"}',
+            },
+            {'type': 'function_call_output', 'call_id': 'call_1', 'output': []},
+            {
+                'type': 'reasoning',
+                'summary': [{'type': 'output_text', 'text': 'Need to search notes.'}],
+            },
+            {
+                'type': 'function_call',
+                'call_id': 'call_2',
+                'name': 'search_notes',
+                'arguments': '{"query":"Rakhi Kaag"}',
+            },
+            {'type': 'function_call_output', 'call_id': 'call_2', 'output': []},
+        ]
+
+        adjusted = add_reasoning_content_to_tool_messages(messages, output, 'kimi-k2.6')
+
+        assert adjusted[0]['reasoning_content'] == 'Need to search the web.'
+        assert adjusted[2]['reasoning_content'] == 'Need to search notes.'
+
+    def test_leaves_non_kimi_models_unchanged(self):
+        messages = [
+            {
+                'role': 'assistant',
+                'content': '<think>Need to search.</think>',
+                'tool_calls': [
+                    {
+                        'id': 'call_123',
+                        'type': 'function',
+                        'function': {'name': 'search_web', 'arguments': '{"query":"Rakhi Kaag"}'},
+                    }
+                ],
+            }
+        ]
+        output = [
+            {
+                'type': 'reasoning',
+                'summary': [{'type': 'output_text', 'text': 'Need to search.'}],
+            },
+            {
+                'type': 'function_call',
+                'call_id': 'call_123',
+                'name': 'search_web',
+                'arguments': '{"query":"Rakhi Kaag"}',
+            },
+            {'type': 'function_call_output', 'call_id': 'call_123', 'output': []},
+        ]
+
+        adjusted = add_reasoning_content_to_tool_messages(messages, output, 'gpt-4.1')
+
+        assert adjusted == messages
+
+    def test_keeps_existing_reasoning_content(self):
+        messages = [
+            {
+                'role': 'assistant',
+                'content': '<think>Need to search.</think>',
+                'reasoning_content': 'Existing reasoning',
+                'tool_calls': [
+                    {
+                        'id': 'call_123',
+                        'type': 'function',
+                        'function': {'name': 'search_web', 'arguments': '{"query":"Rakhi Kaag"}'},
+                    }
+                ],
+            }
+        ]
+        output = [
+            {
+                'type': 'reasoning',
+                'summary': [{'type': 'output_text', 'text': 'Need to search.'}],
+            },
+            {
+                'type': 'function_call',
+                'call_id': 'call_123',
+                'name': 'search_web',
+                'arguments': '{"query":"Rakhi Kaag"}',
+            },
+            {'type': 'function_call_output', 'call_id': 'call_123', 'output': []},
+        ]
+
+        adjusted = add_reasoning_content_to_tool_messages(messages, output, 'moonshot-v1')
+
+        assert adjusted[0]['reasoning_content'] == 'Existing reasoning'

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -98,6 +98,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     get_content_from_message,
     convert_output_to_messages,
+    add_reasoning_content_to_tool_messages,
     strip_empty_content_blocks,
 )
 from open_webui.utils.tools import (
@@ -4660,12 +4661,17 @@ async def streaming_chat_response_handler(response, ctx):
 
                         if ENABLE_RESPONSES_API_STATEFUL and last_response_id:
                             system_message = get_system_message(form_data['messages'])
+                            tool_messages = add_reasoning_content_to_tool_messages(
+                                convert_output_to_messages(output, raw=True), output, model_id
+                            )
                             new_form_data['messages'] = (
                                 [system_message] if system_message else []
-                            ) + convert_output_to_messages(output, raw=True)
+                            ) + tool_messages
                             new_form_data['previous_response_id'] = last_response_id
                         else:
-                            tool_messages = convert_output_to_messages(output, raw=True)
+                            tool_messages = add_reasoning_content_to_tool_messages(
+                                convert_output_to_messages(output, raw=True), output, model_id
+                            )
 
                             # Chat Completions providers don't support multimodal
                             # tool messages.  Extract images into a user message.
@@ -4875,13 +4881,16 @@ async def streaming_chat_response_handler(response, ctx):
                         )
 
                         try:
+                            tool_messages = add_reasoning_content_to_tool_messages(
+                                convert_output_to_messages(output, raw=True), output, model_id
+                            )
                             new_form_data = {
                                 **form_data,
                                 'model': model_id,
                                 'stream': True,
                                 'messages': [
                                     *form_data['messages'],
-                                    *convert_output_to_messages(output, raw=True),
+                                    *tool_messages,
                                 ],
                             }
 

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -129,6 +129,119 @@ def get_content_from_message(message: dict) -> Optional[str]:
     return None
 
 
+def model_requires_reasoning_content_for_tool_calls(model_id: Optional[str]) -> bool:
+    """
+    Some OpenAI-compatible thinking models require assistant tool-call messages
+    to preserve top-level reasoning_content on continuation turns.
+    """
+    if not model_id:
+        return False
+
+    model_name = model_id.lower()
+    return 'kimi' in model_name or 'moonshot' in model_name
+
+
+def _extract_reasoning_content_from_item(item: dict) -> str:
+    reasoning_parts = []
+
+    source_list = item.get('summary', []) or item.get('content', [])
+    for part in source_list:
+        text = part.get('text', '')
+        if text:
+            reasoning_parts.append(text)
+
+    return ''.join(reasoning_parts).strip()
+
+
+def get_assistant_reasoning_content_from_output(output: list[dict]) -> list[str]:
+    """
+    Mirror convert_output_to_messages() assistant-message boundaries so
+    reasoning_content can be reattached to the matching assistant tool-call
+    message instead of being applied globally.
+    """
+    assistant_reasoning = []
+    pending_reasoning = []
+    pending_tool_calls = []
+    pending_content = []
+
+    def flush_pending():
+        nonlocal pending_reasoning, pending_tool_calls, pending_content
+        if pending_content or pending_tool_calls:
+            assistant_reasoning.append(''.join(pending_reasoning).strip())
+            pending_reasoning = []
+            pending_tool_calls = []
+            pending_content = []
+
+    for item in output:
+        item_type = item.get('type', '')
+
+        if item_type == 'message':
+            content_parts = item.get('content', [])
+            text = ''
+            for part in content_parts:
+                if part.get('type') == 'output_text':
+                    text += part.get('text', '')
+            if text:
+                pending_content.append(text)
+
+        elif item_type == 'function_call':
+            pending_tool_calls.append(item)
+
+        elif item_type == 'function_call_output':
+            flush_pending()
+
+        elif item_type == 'reasoning':
+            reasoning_text = _extract_reasoning_content_from_item(item)
+            if reasoning_text:
+                pending_reasoning.append(reasoning_text)
+
+        elif item_type == 'open_webui:code_interpreter':
+            if item.get('code') or item.get('output'):
+                pending_content.append('code_interpreter')
+
+        elif item_type.startswith('open_webui:'):
+            pass
+
+    flush_pending()
+    return assistant_reasoning
+
+
+def add_reasoning_content_to_tool_messages(
+    messages: list[dict], output: list[dict], model_id: Optional[str]
+) -> list[dict]:
+    """
+    Re-add top-level reasoning_content to assistant tool-call messages for
+    providers that require it during the post-tool continuation request.
+    """
+    if not model_requires_reasoning_content_for_tool_calls(model_id):
+        return messages
+
+    assistant_reasoning = get_assistant_reasoning_content_from_output(output)
+    if not any(assistant_reasoning):
+        return messages
+
+    adjusted_messages = []
+    assistant_index = 0
+    for message in messages:
+        reasoning_content = None
+        if message.get('role') == 'assistant':
+            if assistant_index < len(assistant_reasoning):
+                reasoning_content = assistant_reasoning[assistant_index]
+            assistant_index += 1
+
+        if (
+            message.get('role') == 'assistant'
+            and message.get('tool_calls')
+            and reasoning_content
+            and not message.get('reasoning_content')
+        ):
+            message = {**message, 'reasoning_content': reasoning_content}
+
+        adjusted_messages.append(message)
+
+    return adjusted_messages
+
+
 def convert_output_to_messages(output: list, raw: bool = False) -> list[dict]:
     """
     Convert OR-aligned output items to OpenAI Chat Completion-format messages.


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** No new or upgraded dependencies are introduced in this PR.
- [x] **Testing:** Performed manual tests to verify the implemented fix works as intended and does not break the native tool continuation flow. Repro steps and results are documented below.
- [x] **Agentic AI Code:** This change was AI-assisted. It was manually reviewed and tested on a live deployment before submitting this PR.
- [x] **Code review:** Performed a self-review of the code and kept the change scoped to one bug fix.
- [x] **Design & Architecture:** Kept the fix local to provider-specific continuation handling instead of changing generic message reconstruction for every backend.
- [x] **Git Hygiene:** PR is atomic, rebased onto `dev`, and only contains the continuation fix and regression coverage.
- [x] **Title Prefix:** PR title uses the `fix:` prefix.

# Changelog Entry

### Description

- Preserve `reasoning_content` when Open WebUI rebuilds assistant tool-call messages for Kimi/Moonshot continuation turns so native tool calling can continue to a final answer.

### Added

- Regression coverage for reattaching reasoning content to the correct assistant tool-call message boundaries.

### Changed

- Moved provider-specific reasoning-content restoration into middleware continuation handling instead of changing `convert_output_to_messages()` globally.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed native tool-call continuation for Kimi thinking models where the first tool call succeeds, tool output is returned, and the follow-up request fails because the reconstructed assistant tool-call message is missing top-level `reasoning_content`.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Provider-side failure reproduced against the OpenAI-compatible backend as:

```text
thinking is enabled but reasoning_content is missing in assistant tool call message at index 1
```

- Kimi documentation for preserved thinking / multi-step tool calls:
  - <https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#accessing-the-reasoning-content>
- Implementation details:
  - Only reattach `reasoning_content` for model IDs that look like Kimi/Moonshot.
  - Reattach it in both native tool continuation paths in `streaming_chat_response_handler`.
  - Map reasoning back onto the matching assistant message boundaries instead of copying one global reasoning blob onto every earlier tool-call message.

### Screenshots or Videos

- No screenshots attached. Validation was done against a live Open WebUI deployment where the original browser-chat failure reproduced after successful tool execution.

### Testing Performed

- Live browser validation against a private Open WebUI deployment using `kimi-k2.6` in native tool mode:
  - Prompt: `list my notes`
  - Expected/observed: `search_notes` executed and the assistant returned a normal final answer instead of stopping after the tool result.
- Live browser validation of the web-search path on the same deployment:
  - Prompt flow: retried a historical `web search for "Rakhi Kaag"` conversation that previously stopped after `search_web`.
  - Expected/observed: `search_web` executed and the assistant returned a normal final answer after the tool result.
- Provider-level reproduction against the OpenAI-compatible backend:
  - Without top-level `reasoning_content` on the assistant tool-call message, the continuation request failed with the error quoted above.
  - With `reasoning_content` preserved, the provider returned a normal final answer.
- Static validation:
  - `python3 -m py_compile backend/open_webui/utils/misc.py backend/open_webui/utils/middleware.py backend/open_webui/test/util/test_misc.py`
- Targeted helper verification:
  - Directly exercised `add_reasoning_content_to_tool_messages()` with multi-step tool-call output sequences to confirm reasoning is reattached to the matching assistant tool-call turn.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
