### PR TITLE
perf: redirect default model profile image to static favicon for cache reuse

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -4,6 +4,8 @@ import base64
 import json
 import asyncio
 import logging
+import posixpath
+from urllib.parse import unquote
 
 from open_webui.models.groups import Groups
 from open_webui.models.models import (
@@ -29,18 +31,46 @@ from fastapi import (
     status,
     Response,
 )
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import RedirectResponse, StreamingResponse
 
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
-from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL, STATIC_DIR
+from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
 from open_webui.internal.db import get_async_session
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _safe_static_redirect_path(url: str) -> Optional[str]:
+    """
+    If url is a same-origin static asset path, return a normalized path safe for
+    RedirectResponse Location. Otherwise None (caller should fall back to default).
+    Rejects traversal (..), encoded dots, query/fragment, and non-/static targets.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    path = url.split('?', 1)[0].split('#', 1)[0].strip()
+    for _ in range(2):
+        decoded = unquote(path)
+        if decoded == path:
+            break
+        path = decoded
+    if '\x00' in path or '\\' in path:
+        return None
+    if not path.startswith('/'):
+        return None
+    normalized = posixpath.normpath(path)
+    if normalized in ('.', '/'):
+        return None
+    if not (normalized == '/static' or normalized.startswith('/static/')):
+        return None
+    if normalized == '/static':
+        return '/static/'
+    return normalized
 
 
 def is_valid_model_id(model_id: str) -> bool:
@@ -465,10 +495,25 @@ async def get_model_profile_image(
                     )
                 except Exception as e:
                     pass
+            else:
+                safe_static = _safe_static_redirect_path(model.meta.profile_image_url)
+                if safe_static:
+                    return RedirectResponse(
+                        url=safe_static,
+                        status_code=status.HTTP_302_FOUND,
+                    )
 
-        return FileResponse(f'{STATIC_DIR}/favicon.png')
+        # Canonical URL so browsers cache one asset for all default model avatars
+        # (distinct /profile/image?id=... URLs would otherwise re-download the same bytes).
+        return RedirectResponse(
+            url='/static/favicon.png',
+            status_code=status.HTTP_302_FOUND,
+        )
     else:
-        return FileResponse(f'{STATIC_DIR}/favicon.png')
+        return RedirectResponse(
+            url='/static/favicon.png',
+            status_code=status.HTTP_302_FOUND,
+        )
 
 
 ############################


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing tasks

# Changelog Entry

### Description

Default model avatars are served from `GET /api/v1/models/model/profile/image?id=…`. Each distinct model id produced a **different URL** but the **same fallback file** (`static/favicon.png`, ~22 KB). Browsers therefore downloaded that payload multiple times (visible in Lighthouse transfer size / LCP-related loading).

This change returns **HTTP 302** to the canonical static URL `/static/favicon.png` for the default case, and **302** to `meta.profile_image_url` when it is already a site-relative path under `/static/`. Custom images (`http(s):` redirects and `data:image` inline bodies) are unchanged.

**Impact:** Fewer redundant bytes on pages that show several model avatars; better cache reuse for the default icon. **API behavior:** clients that expected `200` with a PNG body for the default case now receive a redirect (standard for browsers loading `<img src="…">`).

### Added

- Redirect handling for `meta.profile_image_url` values that start with `/static/`.

### Changed

- Default and missing-model branches of `get_model_profile_image` now respond with `RedirectResponse` to `/static/favicon.png` instead of `FileResponse` of the same file from the API route.

### Fixed

- Redundant repeated downloads of the default model profile image when multiple models share the fallback asset.

### Security

- Redirect targets are limited to `/static/…` for stored relative paths, or the fixed default `/static/favicon.png` (no open redirect to arbitrary hosts).

### Breaking Changes

- **BREAKING CHANGE**: Non-browser or custom clients that called `GET …/model/profile/image` and assumed a `200` response with an image body for models without a custom image will now receive `302` to `/static/favicon.png` instead. Browsers and typical `<img>` usage follow redirects by default.

---

### Additional Information

- **Before:** Open DevTools → Network → filter `profile/image` → load chat/home with multiple default model pills; observe multiple ~22 KB responses (one per `id`).
- **After:** First request may still fetch `/static/favicon.png`; subsequent avatars should reuse cache after redirect (depending on cache headers), and per-model responses are small 302s instead of full PNG bodies.
- **Docs:** No Open WebUI docs repo change required; this is an internal HTTP behavior optimization, not a new user-facing setting or env var.
- **Dependencies:** None.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.