### PR TITLE
perf(chats): drop redundant db.refresh after commit in update_chat_by_id

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -393,7 +393,6 @@ class ChatTable:
                 chat_item.updated_at = int(time.time())
 
                 await db.commit()
-                await db.refresh(chat_item)
 
                 return ChatModel.model_validate(chat_item)
         except Exception:


### PR DESCRIPTION
# Pull Request Checklist

- [x] Target branch: `dev`
- [x] Description + reasoning below
- [x] Changelog entry at bottom
- [x] No docs changes (backend-only, no user-facing behaviour)
- [x] No new or upgraded dependencies
- [x] Testing: patch is running in our production fork (pre-0.9 branch) since 2026-04-20; same single-line removal reapplied to the async version on `dev`. I have not yet run 0.9.1 in production.
- [x] Agentic AI Code: change drafted with AI assistance, then human-reviewed, human-tested, and deployed to production. It is a single-line deletion; I understand the policy.
- [x] Code review: self-reviewed
- [x] Git Hygiene: single atomic commit rebased on `dev`
- [x] Title prefix: **perf**

# Changelog Entry

- ⚡ **Skip redundant refresh on large-chat writes.** `Chats.update_chat_by_id` no longer issues `await db.refresh(chat_item)` after `commit()`. The `chat` table has no server-side defaults, triggers, or computed columns, and every field the method modifies (`chat`, `title`, `updated_at`) is set explicitly from Python values. The refresh was round-tripping the entire `chat.chat` JSON blob over the wire and through the driver's JSON decoder without producing different data.

### Description

Hit during perf work on chats where `chat.chat` had grown to tens of MB (long RAG-heavy conversations). `db.refresh` here is pure overhead:

- No `DEFAULT` clause, no `SERIAL`/`IDENTITY`, no triggers on `chat` (verified on PostgreSQL: `SELECT * FROM pg_trigger WHERE tgrelid = 'chat'::regclass AND NOT tgisinternal` is empty).
- `meta` has `server_default='{}'` but that applies to INSERT only; UPDATE does not re-populate it, and `update_chat_by_id` does not touch `meta`.
- Every column set in the method comes from an explicit Python value above; JSON round-trip through the driver is idempotent for valid JSON.

All callers of `update_chat_by_id` return the resulting `ChatModel` immediately and do not read fields that could change server-side.

### Testing

Patch running in our production fork since 2026-04-20 over a ~35k-row `chat` table, no functional regressions. The tested path was the pre-async (sync) implementation; the single-line removal is semantically identical in the async variant on `dev`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
