### PR TITLE
perf(chats): skip deep copy in sanitize_data_for_db when input has no null bytes or surrogates

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -608,8 +608,39 @@ def sanitize_text_for_db(text: str) -> str:
     return text
 
 
+_SANITIZE_BAD_CHARS_RE = re.compile(r'[\x00\ud800-\udfff]')
+
+
+def _sanitize_needs_copy(obj) -> bool:
+    """Return True if any string in the structure needs sanitization.
+
+    A string "needs sanitization" if it contains a NUL byte or a lone UTF-16
+    surrogate code point (U+D800..U+DFFF) — exactly the characters that
+    ``sanitize_text_for_db`` rewrites. Valid JSON-decoded payloads almost
+    never contain these, so real-world chats take the zero-copy fast path in
+    ``sanitize_data_for_db`` below. The walk mirrors that function and visits
+    only dict values (keys were not rewritten by the original implementation
+    either).
+    """
+    if isinstance(obj, str):
+        return _SANITIZE_BAD_CHARS_RE.search(obj) is not None
+    if isinstance(obj, dict):
+        return any(_sanitize_needs_copy(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_sanitize_needs_copy(v) for v in obj)
+    return False
+
+
 def sanitize_data_for_db(obj):
     """Recursively sanitize all strings in a data structure for database storage."""
+    # Fast path: if nothing looks dirty, return the object as-is (zero-copy).
+    # The original implementation always rebuilt the entire structure, which
+    # is wasteful once a chat's ``chat`` JSON grows past a few megabytes — the
+    # deep copy dominates CPU time and allocates a duplicate of the full tree
+    # for no reason. Data read back from the database is always clean because
+    # PostgreSQL text/jsonb cannot store NUL bytes or lone surrogates.
+    if not _sanitize_needs_copy(obj):
+        return obj
     if isinstance(obj, str):
         return sanitize_text_for_db(obj)
     elif isinstance(obj, dict):


### PR DESCRIPTION
# Pull Request Checklist

- [x] Target branch: `dev`
- [x] Description + measurements below
- [x] Changelog entry at bottom
- [x] No docs changes (backend-only, no user-facing behaviour)
- [x] No new or upgraded dependencies
- [x] Testing: correctness verified by running both implementations against every row (34 780) in our production chat table, 0 mismatches. Patch is running in our production fork since 2026-04-20. Tested on the pre-0.9 (sync) implementation of the caller; the patch itself is caller-agnostic — it modifies a pure-Python helper that sanitizes in-memory structures.
- [x] Agentic AI Code: change drafted with AI assistance, then human-reviewed, human-tested, and deployed to production. The patch is ~30 lines and the invariant was verified exhaustively.
- [x] Code review: self-reviewed
- [x] Git Hygiene: single atomic commit rebased on `dev`
- [x] Title prefix: **perf**

# Changelog Entry

- ⚡ **Zero-copy fast path for `sanitize_data_for_db`.** The chat write path no longer rebuilds the entire chat structure on every call to `sanitize_data_for_db`. A lightweight scan now checks whether any string actually contains the characters that `sanitize_text_for_db` would rewrite (NUL or lone UTF-16 surrogates); if not, the input is returned as-is. This eliminates a deep copy of the chat JSON on effectively every real-world write.

### Description

`sanitize_data_for_db` is called on every chat payload before persisting. The existing implementation always rebuilds the whole structure recursively — new dicts, new lists, re-sanitized strings — even when the input is already clean. That allocates a parallel copy of the entire chat tree, which becomes tens of MB on long RAG-heavy conversations.

In practice the characters that `sanitize_text_for_db` rewrites (NUL and lone UTF-16 surrogate code points) *cannot* be stored in PostgreSQL `text` or `jsonb` columns, so data read back from the database is always clean. The only path that produces dirty input is inbound untrusted content on ingest, which is extremely rare.

This PR adds a `_sanitize_needs_copy` helper that scans for exactly the code points `sanitize_text_for_db` would modify. If nothing matches, `sanitize_data_for_db` returns the input object as-is (zero copy). If anything matches, it falls back to the existing recursive-copy path. The behaviour is semantically identical for all inputs.

### Measurements on real data

Against a 34 780-row production chat table (with `pg_column_size(chat)` up to 80 MB):

| Shape | Leaves | old time | new time | old peak alloc | new peak alloc |
|---|---|---|---|---|---|
| Active chat, 28 MB on disk (274k leaves, avg 154 chars) | 274,817 | 394 ms | 217 ms | 96 MB | 0 MB |
| Active chat, 9 MB (131k leaves) | 131,185 | 109 ms | 95 ms | 34 MB | 0 MB |
| Active chat, 2 MB (7.7k leaves) | 7,667 | 24 ms | 14 ms | ~8 MB | 0 MB |
| Pathological: 80 MB on disk, 230 huge leaves | 230 | 103 ms | 220 ms | 90 MB | 0 MB |

Typical chats (many short leaves, deep nesting) are 1.5–1.8× faster and allocate nothing on sanitize. Pathological shapes with a handful of huge leaf strings get slower CPU-wise (regex scan vs C-level `str.replace` + `encode`/`decode`) but still save on memory.

### Correctness

Invariant: `new_sanitize(x) == old_sanitize(x)` for every `x`.

Verified by running both implementations against every chat in our production database (34,780 rows) and deep-comparing outputs. **0 mismatches.** 99.98% of chats took the fast path; the 7 that fell through to the slow path all contained legacy NUL bytes (binary pasted into messages, or ZIP bytes from pre-Tika document uploads before `sanitize_data_for_db` was introduced in #20072) and produced identical results in both implementations.

### Testing

Running in our production fork since 2026-04-20. The patch only changes the pre-check and preserves the original recursive path verbatim, so behaviour for any dirty input is unchanged.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
