### PR TITLE
fix: add missing `import requests` in SafeFireCrawlLoader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import ipaddress
 import logging
+import requests
 import socket
 import ssl
 import urllib.parse


### PR DESCRIPTION
Good day,

## Description

In `backend/open_webui/retrieval/web/utils.py`, the `SafeFireCrawlLoader.lazy_load()` method calls `requests.post()` but the `requests` module is not imported. This causes a `NameError: name '\''requests'\'' is not defined` at runtime.

## Fix

Added `import requests` to the imports section of the file.

```diff
+ import requests
```

This is a minimal one-line fix that resolves the `NameError` so that `SafeFireCrawlLoader` can function correctly.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof