### PR TITLE
fix: add missing `import requests` in SafeFireCrawlLoader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -22,6 +22,7 @@ from fastapi.concurrency import run_in_threadpool
 import aiohttp
 import certifi
 import validators
+import requests
 from langchain_community.document_loaders import PlaywrightURLLoader, WebBaseLoader
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document


### PR DESCRIPTION
Good day

## Bug Description

In `backend/open_webui/retrieval/web/utils.py`, the `SafeFireCrawlLoader.lazy_load()` method calls `requests.post()` on line 233, but the `requests` module is never imported. This causes a `NameError: name 'requests' is not defined` at runtime.

## Root Cause

The `requests` library is used for making HTTP calls to the Firecrawl API endpoint (`{self.api_url}/v1/scrape`), but the import statement is missing from the module-level imports.

## Fix Applied

Added `import requests` alongside the other third-party imports (after `import validators`).

## Verification

The fix can be verified by:
1. Importing the `SafeFireCrawlLoader` class
2. Instantiating it with valid API credentials
3. Calling the `lazy_load()` method — it should no longer raise `NameError`

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof