### PR TITLE
fix: handle 'resource' content type in process_tool_result for MCP tools

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1165,7 +1165,9 @@ async def process_tool_result(
                             }
                         )
                     elif item.get('type') == 'resource':
-                        resource = item.get('resource', {})
+                        resource = item.get('resource')
+                        if not isinstance(resource, dict):
+                            resource = {}
                         text = resource.get('text', '')
                         if isinstance(text, str):
                             try:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1164,6 +1164,15 @@ async def process_tool_result(
                                 'url': file_url,
                             }
                         )
+                    elif item.get('type') == 'resource':
+                        resource = item.get('resource', {})
+                        text = resource.get('text', '')
+                        if isinstance(text, str):
+                            try:
+                                text = json.loads(text)
+                            except json.JSONDecodeError:
+                                pass
+                        tool_response.append(text)
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
             for item in tool_result:


### PR DESCRIPTION
MCP servers can return tool results with `type: "resource"` (per the MCP spec), but `process_tool_result()` in `backend/open_webui/utils/middleware.py` only handles `text`, `image`, and `audio`. Resource-type items fall through without being appended to `tool_response`, leaving it empty, so the LLM receives `{"results": []}` and reports that the server returned no data.

This adds an `elif item.get('type') == 'resource'` branch that extracts `resource.text` and attempts a JSON parse — structured payloads (e.g. lists of records) survive as proper data, and plain-text resources fall back to the raw string. The logic mirrors the existing `text` branch.

Closes #24038

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.