### PR TITLE
fix(telemetry): run OTEL metric callbacks synchronously

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from sqlalchemy import select, delete, update, func, or_, case, exists
 from sqlalchemy.ext.asyncio import AsyncSession
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, get_async_db_context, get_db
 
 from open_webui.env import DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL
 
@@ -524,6 +524,11 @@ class UsersTable:
             result = await db.execute(select(func.count()).select_from(User))
             return result.scalar()
 
+    def get_num_users_sync(self) -> Optional[int]:
+        """Synchronous variant for use from non-async contexts (e.g. OTEL metric callbacks)."""
+        with get_db() as db:
+            return db.execute(select(func.count()).select_from(User)).scalar()
+
     async def has_users(self, db: Optional[AsyncSession] = None) -> bool:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(exists(select(User))))
@@ -559,6 +564,15 @@ class UsersTable:
                 select(func.count()).select_from(User).filter(User.last_active_at > today_midnight_timestamp)
             )
             return result.scalar()
+
+    def get_num_users_active_today_sync(self) -> Optional[int]:
+        """Synchronous variant for use from non-async contexts (e.g. OTEL metric callbacks)."""
+        with get_db() as db:
+            current_timestamp = int(datetime.datetime.now().timestamp())
+            today_midnight_timestamp = current_timestamp - (current_timestamp % 86400)
+            return db.execute(
+                select(func.count()).select_from(User).filter(User.last_active_at > today_midnight_timestamp)
+            ).scalar()
 
     async def update_user_role_by_id(
         self, id: str, role: str, db: Optional[AsyncSession] = None
@@ -811,6 +825,14 @@ class UsersTable:
                 select(func.count()).select_from(User).filter(User.last_active_at >= three_minutes_ago)
             )
             return result.scalar()
+
+    def get_active_user_count_sync(self) -> int:
+        """Synchronous variant for use from non-async contexts (e.g. OTEL metric callbacks)."""
+        with get_db() as db:
+            three_minutes_ago = int(time.time()) - 180
+            return db.execute(
+                select(func.count()).select_from(User).filter(User.last_active_at >= three_minutes_ago)
+            ).scalar()
 
     @staticmethod
     def is_active(user: UserModel) -> bool:

--- a/backend/open_webui/utils/telemetry/metrics.py
+++ b/backend/open_webui/utils/telemetry/metrics.py
@@ -124,24 +124,29 @@ def setup_metrics(app: FastAPI, resource: Resource) -> None:
         unit='ms',
     )
 
-    async def observe_active_users(
+    # OTEL observable-gauge callbacks run on the PeriodicExportingMetricReader
+    # thread, which has no running event loop. Use the sync query variants so
+    # the callback returns an iterable of Observations directly instead of a
+    # coroutine (which would trigger `TypeError: 'coroutine' object is not
+    # iterable` on every export cycle).
+    def observe_active_users(
         options: metrics.CallbackOptions,
     ) -> Sequence[metrics.Observation]:
         return [
             metrics.Observation(
-                value=await Users.get_active_user_count(),
+                value=Users.get_active_user_count_sync(),
             )
         ]
 
-    async def observe_total_registered_users(
+    def observe_total_registered_users(
         options: metrics.CallbackOptions,
     ) -> Sequence[metrics.Observation]:
-        # IMPORTANT: Use get_num_users() for efficient COUNT(*) query.
+        # IMPORTANT: Use get_num_users_sync() for efficient COUNT(*) query.
         # Do NOT use len(get_users()["users"]) - it loads ALL user records into memory,
         # causing connection pool exhaustion on high-latency databases (e.g., Aurora).
         return [
             metrics.Observation(
-                value=await Users.get_num_users() or 0,
+                value=Users.get_num_users_sync() or 0,
             )
         ]
 
@@ -159,10 +164,10 @@ def setup_metrics(app: FastAPI, resource: Resource) -> None:
         callbacks=[observe_active_users],
     )
 
-    async def observe_users_active_today(
+    def observe_users_active_today(
         options: metrics.CallbackOptions,
     ) -> Sequence[metrics.Observation]:
-        return [metrics.Observation(value=await Users.get_num_users_active_today())]
+        return [metrics.Observation(value=Users.get_num_users_active_today_sync())]
 
     meter.create_observable_gauge(
         name='webui.users.active.today',


### PR DESCRIPTION
OTEL observable-gauge callbacks run on the `PeriodicExportingMetricReader` thread, which has no event loop. The three async callbacks in `utils/telemetry/metrics.py` (`observe_active_users`, `observe_total_registered_users`, `observe_users_active_today`) returned coroutines instead of iterables of `Observation`, causing `TypeError: 'coroutine' object is not iterable` on every export cycle.

This PR:

- Adds sync `COUNT(*)` variants on `UsersTable` (`get_num_users_sync`, `get_active_user_count_sync`, `get_num_users_active_today_sync`) using the existing sync `SessionLocal` from `open_webui/internal/db.py`.
- Converts the three OTEL callbacks back to plain `def` and points them at the new sync methods.

Sync `SessionLocal` is documented in `db.py` as "used ONLY for startup config loading"; OTEL metric callbacks are the one legitimate runtime exception because OTel's `PeriodicExportingMetricReader` runs them on a worker thread outside any event loop. Option 2 (`asyncio.run_coroutine_threadsafe` against the captured main loop) was considered but would require a lifespan hook plus cross-thread scheduling per export, with no runtime advantage for metrics polled every ~30s.

Closes #23936
Closes #23938

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.