### PR TITLE
perf: skip redundant function row fetches when warming module cache on /api/models

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -280,16 +280,17 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     functions_by_id = {f.id: f for f in await Functions.get_functions_by_ids(list(all_function_ids))}
 
-    # Pre-warm the function module cache once per unique function ID.
-    # This ensures each function's DB freshness check runs exactly once,
-    # not once per (model × function) pair.
+    # Pre-warm the function module cache once per unique function ID (not once per
+    # model × function). Rows come from the batch query above; pass them into
+    # get_function_module_from_cache to avoid redundant per-id DB reads while
+    # still loading each module body once for this request.
     # Only attempt to load functions that actually exist in the local DB;
     # imported/custom model configs may reference tools or filters the user
     # hasn't installed, and trying to load those would cause persistent
     # "Failed to load function module" log spam on every model refresh.
-    for function_id in functions_by_id:
+    for function_id, function_row in functions_by_id.items():
         try:
-            await get_function_module_from_cache(request, function_id)
+            await get_function_module_from_cache(request, function_id, function=function_row)
         except Exception as e:
             log.debug(f'Failed to load function module for {function_id}: {e}')
 

--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -6,7 +6,7 @@ from importlib import util
 import types
 import tempfile
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from open_webui.env import (
     PIP_OPTIONS,
@@ -14,7 +14,7 @@ from open_webui.env import (
     OFFLINE_MODE,
     ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS,
 )
-from open_webui.models.functions import Functions
+from open_webui.models.functions import FunctionModel, Functions
 from open_webui.models.tools import Tools
 
 log = logging.getLogger(__name__)
@@ -335,16 +335,29 @@ async def get_tool_module_from_cache(request, tool_id, load_from_db=True):
     return tool_module, frontmatter
 
 
-async def get_function_module_from_cache(request, function_id, load_from_db=True):
+async def get_function_module_from_cache(
+    request,
+    function_id,
+    load_from_db=True,
+    function: Optional[FunctionModel] = None,
+):
     if load_from_db:
         # Always load from the database by default
         # This is useful for hooks like "inlet" or "outlet" where the content might change
         # and we want to ensure the latest content is used.
+        #
+        # Callers that already batch-fetched the row (e.g. get_functions_by_ids) may pass
+        # `function=` to avoid a redundant per-id query.
 
-        function = await Functions.get_function_by_id(function_id)
-        if not function:
-            raise Exception(f'Function not found: {function_id}')
-        content = function.content
+        if function is not None:
+            if function.id != function_id:
+                raise ValueError(f'function row id {function.id!r} does not match {function_id!r}')
+            content = function.content
+        else:
+            function = await Functions.get_function_by_id(function_id)
+            if not function:
+                raise Exception(f'Function not found: {function_id}')
+            content = function.content
 
         new_content = replace_imports(content)
         if new_content != content:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps. *(N/A: internal backend optimization only; no user-facing API or env changes.)*
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash. *(None.)*
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**. *(Automated unit tests added; recommend quick manual smoke: load app, model list, actions/filters still work.)*
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes. *(Optional `function=` argument; defaults preserve existing behavior.)*
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:

# Changelog Entry

### Description

- When building the model list, Open WebUI batch-loads function rows with `get_functions_by_ids`, then warms the function module cache by calling `get_function_module_from_cache` once per function ID. Previously, each of those calls issued another `get_function_by_id` (primary-key `SELECT`) even though the row was already loaded. This change allows callers to pass the preloaded `FunctionModel` so the warmup path avoids redundant per-ID database round-trips. Behavior for callers that omit the new argument is unchanged.

### Changed

- `get_function_module_from_cache(..., function: Optional[FunctionModel] = None)`: when `function` is provided with `load_from_db=True`, use the row’s `content` and skip `Functions.get_function_by_id`.
- `get_all_models` warmup loop: pass `function=function_row` from `functions_by_id` into `get_function_module_from_cache`; comment updated to describe batch row reuse.
---

### Additional Information

- **Motivation:** Traces on `GET /api/models` showed many short, sequential PostgreSQL lookups on `function` by primary key after an `IN (...)` batch load. Removing the duplicate reads reduces latency and connection-pool pressure when multiple actions/filters are referenced.
- **Semantics:** The preloaded row is the same snapshot as the batch query in that request. Call sites that do not pass `function=` still re-fetch from the DB as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.