### PR TITLE
feat: OpenAI Responses API native web_search tool support

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1668,6 +1668,10 @@ async def chat_completion(
                     )
                     else 'default'
                 ),
+                'openai_responses_web_search': (
+                    form_data.get('params', {}).get('openai_responses_web_search') is True
+                    or model_info_params.get('openai_responses_web_search') is True
+                ),
             },
         }
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -847,7 +847,7 @@ def _normalize_stored_item(item: dict) -> dict:
     return {k: v for k, v in item.items() if k in allowed}
 
 
-def convert_to_responses_payload(payload: dict) -> dict:
+def convert_to_responses_payload(payload: dict, metadata: dict | None = None) -> dict:
     """
     Convert Chat Completions payload to Responses API format.
 
@@ -855,6 +855,9 @@ def convert_to_responses_payload(payload: dict) -> dict:
     Responses API: { input: [{type: "message", role, content: [...]}], instructions: "system" }
     """
     messages = payload.pop('messages', [])
+    # Use provided metadata or fallback to payload metadata
+    if metadata is None:
+        metadata = payload.get('metadata', {})
 
     system_content = ''
     input_items = []
@@ -986,6 +989,28 @@ def convert_to_responses_payload(payload: dict) -> dict:
                 converted_tools.append(tool)
         responses_payload['tools'] = converted_tools
 
+    # Determine if native OpenAI web_search should be used
+    if not metadata:
+        metadata = payload.get('metadata', {})
+    web_search_enabled = metadata.get('features', {}).get('web_search', False)
+    using_openai_web_search = metadata.get('params', {}).get('openai_responses_web_search') or payload.get(
+        'openai_responses_web_search'
+    )
+
+    if web_search_enabled and using_openai_web_search:
+        # Strip built-in search_web/fetch_url tools — we only want the native web_search tool
+        tools = responses_payload.get('tools', [])
+        tools = [
+            t for t in tools
+            if not (isinstance(t, dict) and t.get('name') in ('search_web', 'fetch_url'))
+        ]
+        # Inject native web_search tool if not already present
+        has_native_web_search = any(isinstance(t, dict) and t.get('type') == 'web_search' for t in tools)
+        if not has_native_web_search:
+            tools = tools + [{'type': 'web_search'}]
+            log.debug('Injected native web_search tool for Responses API')
+        responses_payload['tools'] = tools
+
     return responses_payload
 
 
@@ -1063,6 +1088,14 @@ async def generate_chat_completion(
 
         if params:
             system = params.pop('system', None)
+
+            # Merge model params into metadata for Responses API processing
+            # Request/runtime params (from metadata) take precedence over model defaults
+            if metadata is not None and isinstance(metadata, dict):
+                metadata['params'] = {
+                    **params,
+                    **metadata.get('params', {})
+                }
 
             payload = apply_model_params_to_body_openai(params, payload)
             if not bypass_system_prompt:
@@ -1146,7 +1179,7 @@ async def generate_chat_completion(
 
         if is_azure_v1:
             if is_responses:
-                payload = convert_to_responses_payload(payload)
+                payload = convert_to_responses_payload(payload, metadata)
                 request_url = f'{url.rstrip("/")}/responses'
             else:
                 request_url = f'{url.rstrip("/")}/chat/completions'
@@ -1156,13 +1189,13 @@ async def generate_chat_completion(
             headers['api-version'] = api_version
 
             if is_responses:
-                payload = convert_to_responses_payload(payload)
+                payload = convert_to_responses_payload(payload, metadata)
                 request_url = f'{request_url}/responses?api-version={api_version}'
             else:
                 request_url = f'{request_url}/chat/completions?api-version={api_version}'
     else:
         if is_responses:
-            payload = convert_to_responses_payload(payload)
+            payload = convert_to_responses_payload(payload, metadata)
             request_url = f'{url}/responses'
         else:
             request_url = f'{url}/chat/completions'

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -73,6 +73,7 @@ def remove_open_webui_params(params: dict) -> dict:
         'function_calling': str,
         'reasoning_tags': list,
         'system': str,
+        'openai_responses_web_search': bool,
     }
 
     for key in list(params.keys()):

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -38,7 +38,8 @@
 		'firecrawl',
 		'external',
 		'yandex',
-		'youcom'
+		'youcom',
+		'model_native'
 	];
 	let webLoaderEngines = ['playwright', 'firecrawl', 'tavily', 'external'];
 
@@ -174,7 +175,18 @@
 					</div>
 
 					{#if webConfig.WEB_SEARCH_ENGINE !== ''}
-						{#if webConfig.WEB_SEARCH_ENGINE === 'ollama_cloud'}
+						{#if webConfig.WEB_SEARCH_ENGINE === 'model_native'}
+							<div class="mb-2.5 flex w-full flex-col">
+								<div class="bg-gray-50 dark:bg-gray-850 rounded-lg p-3">
+									<div class="text-xs font-medium mb-1">{$i18n.t('Model Native Web Search')}</div>
+									<div class="text-xs text-gray-500">
+										{$i18n.t(
+											'This option uses the model\'s native web search capability (e.g., OpenAI Responses API web_search tool). No additional configuration is required, but the model must support native web search and "OpenAI Web Search (Responses API)" must be enabled in the model\'s Advanced Params.'
+										)}
+									</div>
+								</div>
+							</div>
+						{:else if webConfig.WEB_SEARCH_ENGINE === 'ollama_cloud'}
 							<div class="mb-2.5 flex w-full flex-col">
 								<div>
 									<div class=" self-center text-xs font-medium mb-1">

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -17,6 +17,7 @@
 		stream_response: null, // Set stream responses for this model individually
 		stream_delta_chunk_size: null, // Set the chunk size for streaming responses
 		function_calling: null,
+		openai_responses_web_search: null,
 		reasoning_tags: null,
 		seed: null,
 		stop: null,
@@ -170,6 +171,35 @@
 						<span class="ml-2 self-center">{$i18n.t('Native')}</span>
 					{:else}
 						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+					{/if}
+				</button>
+			</div>
+		</Tooltip>
+	</div>
+
+	<div>
+		<Tooltip
+			content={$i18n.t(
+				'Use the OpenAI Responses API native web_search tool instead of built-in search_web and fetch_url tools. Requires Native Function Calling to be enabled.'
+			)}
+			placement="top-start"
+			className="inline-tooltip"
+		>
+			<div class=" py-0.5 flex w-full justify-between">
+				<div class=" self-center text-xs">
+					{$i18n.t('OpenAI Web Search (Responses API)')}
+				</div>
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition"
+					on:click={() => {
+						params.openai_responses_web_search = (params?.openai_responses_web_search ?? null) === null ? true : null;
+					}}
+					type="button"
+				>
+					{#if params.openai_responses_web_search === true}
+						<span class="ml-2 self-center">{$i18n.t('Enabled')}</span>
+					{:else}
+						<span class="ml-2 self-center">{$i18n.t('Disabled')}</span>
 					{/if}
 				</button>
 			</div>


### PR DESCRIPTION
## Description

This PR adds support for OpenAI's native server-side `web_search` tool when using the Responses API (e.g. GPT-5.4). Users can now choose between OpenAI's native web search and OpenWebUI's built-in web search implementations. This addresses the web search support request raised in Discussion #11874.

## How it works

The existing **Web Search capability** (set in Model Editor → Capabilities) acts as the master switch. When enabled, the new **"OpenAI Web Search (Responses API)"** toggle in Advanced Params selects the implementation:

- **Enabled** → Native `{"type": "web_search"}` tool is injected into the Responses API payload; built-in `search_web`/`fetch_url` tools are suppressed
- **Disabled** (default/null) → Existing behavior: built-in `search_web`/`fetch_url` tools are active

## Backend changes

- Added `openai_responses_web_search` to metadata params in `generate_chat_completion`
- Updated `convert_to_responses_payload()` to accept and use metadata for feature/param detection
- Injects native `{"type": "web_search"}` tool into Responses API payload when web_search capability is enabled AND `openai_responses_web_search` is true
- Suppresses built-in `search_web`/`fetch_url` tools when native mode is active
- Added `openai_responses_web_search` to `remove_open_webui_params()` so it is stripped before upstream API calls

## Frontend changes

- Added `model_native` option to Admin → Settings → Web Search engine dropdown
- Added "OpenAI Web Search (Responses API)" toggle to Chat → Advanced Params (Enabled/Disabled button, matches Function Calling UI pattern)

## Testing performed

- [x] Verified with local backend: `openai_responses_web_search=true` correctly injects native `web_search` tool into the Responses API payload
- [x] Verified `openai_responses_web_search=false/null` falls back to built-in `search_web`/`fetch_url` tools
- [x] Verified Web Search capability OFF suppresses both implementations
- [x] Verified `openai_responses_web_search` is stripped from upstream API request
- [x] No new dependencies introduced
- [x] Single atomic commit, rebased onto `dev`

## Related

- Discussion #11874 — [feat: Support for OpenAI's new Responses API](https://github.com/open-webui/open-webui/discussions/11874)

## Changelog

### Added

- **OpenAI Responses API native web_search support.** Added `openai_responses_web_search` parameter (Advanced Params toggle) that routes web search requests through OpenAI's native `web_search` tool in the Responses API instead of the built-in `search_web`/`fetch_url` tools. The existing Web Search capability acts as the master switch; the toggle selects the implementation. ([#11874](https://github.com/open-webui/open-webui/discussions/11874))

---

- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Provided above.
- [x] **Changelog:** Entry added above following Keep a Changelog format.
- [x] **Documentation:** Will be submitted as a follow-up PR to the [Open WebUI Docs Repository](https://github.com/open-webui/docs) documenting the new `model_native` engine option and the Advanced Params toggle.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manual E2E tests performed. Repro steps and results documented above.
- [x] **Agentic AI Code:** This change was AI-assisted. It was manually reviewed and tested on a live local deployment before submitting.
- [x] **Code review:** Self-review performed. Change is scoped to one feature and adheres to project coding standards.
- [x] **Design & Architecture:** Localized to OpenAI Responses API provider-specific handling. No generic message reconstruction changed.
- [x] **Git Hygiene:** Single atomic commit, rebased onto `dev`.
- [x] **Title Prefix:** Uses `feat:` prefix.

---

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


---

Screenshots:

Chat UI:
<img width="882" height="348" alt="Screenshot 2026-04-23 at 4 10 38 PM" src="https://github.com/user-attachments/assets/eab566a1-92c6-499b-8ebe-8993b6586737" />

Admin Web Search:

<img width="830" height="367" alt="Screenshot 2026-04-23 at 4 11 12 PM" src="https://github.com/user-attachments/assets/1606a3b9-08c7-404b-9bc7-4b602f93600a" />

Model Advanced Configs:

<img width="838" height="291" alt="Screenshot 2026-04-23 at 4 10 56 PM" src="https://github.com/user-attachments/assets/336b5fc0-6e6f-4927-bc44-4e34093eb0e0" />

