### PR TITLE
fix: Task generation (title, tags, etc.) failing for direct connection chats

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -157,28 +157,26 @@ async def generate_title(request: Request, form_data: dict, user=Depends(get_ver
             content={'detail': 'Title generation is disabled'},
         )
 
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
 
@@ -234,28 +232,26 @@ async def generate_follow_ups(request: Request, form_data: dict, user=Depends(ge
             content={'detail': 'Follow-up generation is disabled'},
         )
 
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating chat title using model {task_model_id} for user {user.email} ')
 
@@ -302,28 +298,26 @@ async def generate_chat_tags(request: Request, form_data: dict, user=Depends(get
             content={'detail': 'Tags generation is disabled'},
         )
 
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating chat tags using model {task_model_id} for user {user.email} ')
 
@@ -364,28 +358,26 @@ async def generate_chat_tags(request: Request, form_data: dict, user=Depends(get
 
 @router.post('/image_prompt/completions')
 async def generate_image_prompt(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating image prompt using model {task_model_id} for user {user.email} ')
 
@@ -444,28 +436,26 @@ async def generate_queries(request: Request, form_data: dict, user=Depends(get_v
         log.info(f'Reusing cached queries: {request.state.cached_queries}')
         return request.state.cached_queries
 
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating {type} queries using model {task_model_id} for user {user.email}')
 
@@ -522,28 +512,26 @@ async def generate_autocompletion(request: Request, form_data: dict, user=Depend
                 detail=ERROR_MESSAGES.INPUT_TOO_LONG(request.app.state.config.AUTOCOMPLETE_GENERATION_INPUT_MAX_LENGTH),
             )
 
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating autocompletion using model {task_model_id} for user {user.email}')
 
@@ -584,28 +572,26 @@ async def generate_autocompletion(request: Request, form_data: dict, user=Depend
 
 @router.post('/emoji/completions')
 async def generate_emoji(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
-    if model_id not in models:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
-        )
 
-    # Check if the user has a custom task model
-    # If the user has a custom task model, use that model
+    # Resolve the task model before validating — the configured task model
+    # may differ from the chat model (e.g., when users chat via direct
+    # connections, the chat model may not be in the server's MODELS registry,
+    # but the configured task model is).
     task_model_id = get_task_model_id(
         model_id,
         request.app.state.config.TASK_MODEL,
         request.app.state.config.TASK_MODEL_EXTERNAL,
         models,
     )
+
+    if task_model_id not in models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.MODEL_NOT_FOUND(),
+        )
 
     log.debug(f'generating emoji using model {task_model_id} for user {user.email} ')
 
@@ -649,12 +635,7 @@ async def generate_emoji(request: Request, form_data: dict, user=Depends(get_ver
 
 @router.post('/moa/completions')
 async def generate_moa_response(request: Request, form_data: dict, user=Depends(get_verified_user)):
-    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
-        models = {
-            request.state.model['id']: request.state.model,
-        }
-    else:
-        models = request.app.state.MODELS
+    models = request.app.state.MODELS
 
     model_id = form_data['model']
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3006,6 +3006,17 @@ async def background_tasks_handler(ctx):
     tasks = ctx['tasks']
     event_emitter = ctx['event_emitter']
 
+    # Background task generation (titles, tags, follow-ups) should always use
+    # the server-side task model, not the user's direct connection. Clear the
+    # direct flag so generate_chat_completion routes through the standard
+    # server-side path instead of generate_direct_chat_completion, which
+    # requires an active WebSocket session that doesn't exist in this context.
+    original_direct = getattr(request.state, 'direct', False)
+    original_model = getattr(request.state, 'model', None)
+    request.state.direct = False
+    if hasattr(request.state, 'model'):
+        del request.state.model
+
     message = None
     messages = []
 
@@ -3199,6 +3210,11 @@ async def background_tasks_handler(ctx):
                             )
                         except Exception as e:
                             pass
+
+    # Restore original direct connection state
+    request.state.direct = original_direct
+    if original_model is not None:
+        request.state.model = original_model
 
 
 async def outlet_filter_handler(ctx):


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No user-facing configuration changes; existing `ENABLE_DIRECT_CONNECTIONS` and `TASK_MODEL` settings work correctly after this fix.
- [x] **Dependencies:** No new or changed dependencies.
- [x] **Testing:** Manually tested on a production AWS Fargate deployment (3 ECS tasks, Aurora PostgreSQL, ALB) with 28 models via LiteLLM gateway. Before/after results documented below.
- [x] **Agentic AI Code:** Code was authored with AI assistance (Claude Code) and has been thoroughly reviewed and manually tested by a human on a live production deployment.
- [x] **Code review:** Self-reviewed. Changes are minimal and targeted.
- [x] **Design & Architecture:** No new settings, no architectural changes. Fixes existing code paths to work as intended.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

When `ENABLE_DIRECT_CONNECTIONS=true` and users chat via their own API keys, all background task generation (auto-title, tags, follow-ups, emoji, etc.) fails with either a 404 or `TypeError: 'NoneType' object is not callable`. This PR fixes two related code paths so the configured server-side task model is used correctly.

### Fixed

- Task generation endpoints (`/api/v1/tasks/*/completions`) no longer return 404 when the chat model is from a direct connection and a server-side task model is configured
- Background task handler (`background_tasks_handler`) no longer crashes with `TypeError` when generating titles/tags after a direct connection chat completion

---

### Additional Information

**Two root causes addressed:**

1. **HTTP endpoint path (`tasks.py`):** The model existence check validated the *chat* model against `request.app.state.MODELS` before `get_task_model_id()` could resolve to the configured task model. Direct connection models aren't in the server's MODELS registry, so this raised a 404 — even though the configured task model was available. **Fix:** Task endpoints now always use `request.app.state.MODELS` and validate the resolved `task_model_id` after `get_task_model_id()` runs.

2. **Internal middleware path (`middleware.py`):** After a chat completion, `background_tasks_handler` called `generate_title`/`generate_chat_tags` with the original request that still had `request.state.direct = True`. This routed task generation through `generate_direct_chat_completion`, which required an active WebSocket session unavailable in the background task context — causing `event_caller` to be `None`. **Fix:** `background_tasks_handler` temporarily clears `request.state.direct` so task generation routes through the standard server-side path, then restores the original state.

**Error traceback (before fix):**
```
middleware.py:5020 → await background_tasks_handler(ctx)
  middleware.py:3112 → res = await generate_title(request, {...}, user)
    tasks.py:220     → return await generate_direct_chat_completion(...)
      chat.py:140    → res = await event_caller({...})
TypeError: 'NoneType' object is not callable
```

- Related issues: #24092, #24095

### Screenshots or Videos

**Before fix** — server logs show TypeError on every chat via direct connection:
```
ERROR | open_webui.routers.tasks:generate_title:222 - Exception occurred
  File "/app/backend/open_webui/utils/middleware.py", line 5020, in response_handler
TypeError: 'NoneType' object is not callable
ERROR | open_webui.routers.tasks:generate_chat_tags:358 - Error generating chat completion: 'NoneType' object is not callable
```

**After fix** — title generation succeeds, zero errors:
```
INFO | "POST /api/v1/tasks/title/completions HTTP/1.1" 200
```
(No TypeError or 404 errors in logs after deploying the patched image to production)

**Test environment:**
- Open WebUI v0.9.2 on AWS Fargate (ARM64), 3 ECS tasks
- `ENABLE_DIRECT_CONNECTIONS=true`, `ENABLE_OLLAMA_API=False`
- Server-level OpenAI connection via LiteLLM gateway (28 models)
- Task Model set to "Amazon Nova Micro" in Admin Settings
- Users chatting via direct connections to Claude, GPT, Gemini, and other models

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.