### PR TITLE
fix: strip whitespace from embedding model name before API calls

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -682,6 +682,7 @@ def generate_openai_batch_embeddings(
     prefix: str = None,
     user: UserModel = None,
 ) -> list[list[float]]:
+    model = model.strip()
     log.debug(f'generate_openai_batch_embeddings:model {model} batch size: {len(texts)}')
     json_data = {'input': texts, 'model': model}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
@@ -715,6 +716,7 @@ async def agenerate_openai_batch_embeddings(
     prefix: str = None,
     user: UserModel = None,
 ) -> list[list[float]]:
+    model = model.strip()
     log.debug(f'agenerate_openai_batch_embeddings:model {model} batch size: {len(texts)}')
     form_data = {'input': texts, 'model': model}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
@@ -834,6 +836,7 @@ def generate_ollama_batch_embeddings(
     prefix: str = None,
     user: UserModel = None,
 ) -> list[list[float]]:
+    model = model.strip()
     log.debug(f'generate_ollama_batch_embeddings:model {model} batch size: {len(texts)}')
     json_data = {'input': texts, 'model': model, 'truncate': True}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
@@ -870,6 +873,7 @@ async def agenerate_ollama_batch_embeddings(
     prefix: str = None,
     user: UserModel = None,
 ) -> list[list[float]]:
+    model = model.strip()
     log.debug(f'agenerate_ollama_batch_embeddings:model {model} batch size: {len(texts)}')
     form_data = {'input': texts, 'model': model, 'truncate': True}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
@@ -993,6 +997,7 @@ async def generate_embeddings(
     prefix: Union[str, None] = None,
     **kwargs,
 ):
+    model = model.strip()
     url = kwargs.get('url', '')
     key = kwargs.get('key', '')
     user = kwargs.get('user')


### PR DESCRIPTION
## Summary

Fixes #24090 — When the embedding model name is configured with trailing/leading whitespace in the Admin Panel (e.g. `qwen3-embedding-4b `), the padded string is sent verbatim to the embedding endpoint, causing silent 404 errors. File uploads appear successful in the UI but no vectors are stored.

## Root Cause

The model name from the admin settings is used as-is in the API request body without trimming. Extra whitespace causes the embedding provider to return 404 (`Model 'qwen3-embedding-4b  ' not found`).

## Fix

Add `model = model.strip()` at the entry point of all five embedding functions in `retrieval/utils.py`:

- `generate_openai_batch_embeddings`
- `agenerate_openai_batch_embeddings`
- `generate_ollama_batch_embeddings`
- `agenerate_ollama_batch_embeddings`
- `generate_embeddings` (top-level async dispatcher)

This is defense-in-depth — the model name is trimmed regardless of which embedding engine or code path is used.

## Testing

- Model name `qwen3-embedding-4b ` (trailing space) → trimmed to `qwen3-embedding-4b` → embedding succeeds ✅
- Model name `qwen3-embedding-4b` (no whitespace) → unchanged ✅