### PR TITLE
fix: apply OAUTH_TIMEOUT to MCP tool server OAuth 2.1 path

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -62,6 +62,7 @@ from open_webui.config import (
     OAUTH_ACCESS_TOKEN_REQUEST_INCLUDE_CLIENT_ID,
     OAUTH_AUDIENCE,
     OAUTH_AUTHORIZE_PARAMS,
+    OAUTH_TIMEOUT,
     WEBHOOK_URL,
     JWT_EXPIRES_IN,
     AppConfig,
@@ -597,6 +598,7 @@ class OAuthClientManager:
             'client_secret': oauth_client_info.client_secret,
             'client_kwargs': {
                 'follow_redirects': True,
+                **({'timeout': int(OAUTH_TIMEOUT.value)} if OAUTH_TIMEOUT.value else {}),
                 **({'scope': oauth_client_info.scope} if oauth_client_info.scope else {}),
                 **(
                     {'token_endpoint_auth_method': oauth_client_info.token_endpoint_auth_method}


### PR DESCRIPTION
## Summary

Fixes #24138 — `OAUTH_TIMEOUT` has no effect on the MCP tool server OAuth 2.1 path, causing `httpx.ReadTimeout` for token endpoints that respond in >5 seconds.

## Root Cause

PR #15366 added `OAUTH_TIMEOUT` to OIDC SSO login flows in `config.py`, but the MCP tool server OAuth 2.1 path in `oauth.py`'s `add_client()` was not updated. The `client_kwargs` dict is built without reading `OAUTH_TIMEOUT`, so the default httpx timeout (5s) applies regardless of the env var.

## Fix

Import `OAUTH_TIMEOUT` from `config` and apply the same timeout pattern used in all OIDC `client_kwargs` entries:

```python
'client_kwargs': {
    'follow_redirects': True,
    **({'timeout': int(OAUTH_TIMEOUT.value)} if OAUTH_TIMEOUT.value else {}),
    ...
}
```

## Testing

- MCP tool server with slow token endpoint (~5.7s) + `OAUTH_TIMEOUT=60` → succeeds ✅
- No `OAUTH_TIMEOUT` set → default httpx timeout applies (unchanged behavior) ✅
- OIDC SSO path → unchanged ✅