### PR TITLE
fix: show existing users and groups as selected in Models settings "Add Access" modal

### DIFF
--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -323,7 +323,20 @@
 	};
 
 	const handleAddAccess = ({ userIds, groupIds }: { userIds: string[]; groupIds: string[] }) => {
-		let next = [...currentGrants()];
+		const userIdSet = new Set(userIds);
+		const groupIdSet = new Set(groupIds);
+
+		// Drop principals the user unchecked in the modal (preserve user:* public grants).
+		let next = currentGrants().filter((grant) => {
+			if (grant.principal_type === 'user') {
+				if (grant.principal_id === '*') return true;
+				return userIdSet.has(grant.principal_id);
+			}
+			if (grant.principal_type === 'group') {
+				return groupIdSet.has(grant.principal_id);
+			}
+			return true;
+		});
 
 		for (const groupId of groupIds) {
 			next = upsertPrincipalGrant('group', groupId, 'read', next);
@@ -442,7 +455,13 @@
 	});
 </script>
 
-<AddAccessModal bind:show={showAddAccessModal} {shareUsers} onAdd={handleAddAccess} />
+<AddAccessModal
+	bind:show={showAddAccessModal}
+	{shareUsers}
+	existingUserIds={selectedUserIds}
+	existingGroupIds={Array.from(new Set([...readGroupIds, ...writeGroupIds]))}
+	onAdd={handleAddAccess}
+/>
 
 <div class=" rounded-lg flex flex-col gap-1">
 	<div class="py-2">
@@ -601,12 +620,10 @@
 			<!-- Users -->
 			{#if shareUsers}
 				{#each selectedUsers as user}
-					<div
-						class="flex items-center gap-3 justify-between text-sm w-full transition border-b border-gray-50 dark:border-gray-850 pb-2 last:border-0"
-					>
+					<div class="flex items-center gap-3 justify-between text-sm w-full transition pb-1">
 						<div class="flex items-center gap-2 w-full flex-1">
 							<img
-								class="rounded-full size-5 object-cover"
+								class="rounded-full size-5 object-cover shrink-0"
 								src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
 								alt={user.name ?? user.id}
 							/>

--- a/src/lib/components/workspace/common/AddAccessModal.svelte
+++ b/src/lib/components/workspace/common/AddAccessModal.svelte
@@ -8,11 +8,22 @@
 
 	export let show = false;
 	export let shareUsers = true;
+	export let existingUserIds: string[] = [];
+	export let existingGroupIds: string[] = [];
 	export let onAdd = (payload: { userIds: string[]; groupIds: string[] }) => {};
 
 	let userIds: string[] = [];
 	let groupIds: string[] = [];
 	let loading = false;
+
+	let prevShow = false;
+	$: {
+		if (show && !prevShow) {
+			userIds = [...existingUserIds];
+			groupIds = [...existingGroupIds];
+		}
+		prevShow = show;
+	}
 
 	const submitHandler = () => {
 		loading = true;

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -84,6 +84,16 @@
 			return [];
 		});
 
+		if (groupIds.length > 0 && groups) {
+			for (const id of groupIds) {
+				const match = groups.find((g) => g.id === id);
+				if (match) {
+					selectedGroup[id] = match;
+				}
+			}
+			selectedGroup = selectedGroup;
+		}
+
 		if (userIds.length > 0) {
 			userIds.forEach(async (id) => {
 				const res = await getUserInfoById(localStorage.token, id).catch((error) => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Users and groups that were already granted on a model weren't showing up as selected in the "Add Access" modal. This prevented to revoke an existing grant from inside the modal, and re-selecting a principal that was already on the list had no useful effect. [picture 1A]
With this fix, principlas already on the access list open with their checkbox ticked. Unckecking a principal and clicking Add now removes their grant. [picture 1B]

In dark mode a thin white border appeared between user rows in the Access Control list. It sat between rows of the same kind and didn't seperate users from groups. [2A]
The border served no purpose, so it has been removed. [2B]

The user avatar in the Access Control list could render as an oval instead of a circle when the row's flex layout squeezed the image. [3A]
Adding `shrink-0` to the avatar prevents flexbox from compressing it, so it stays circular regardless of the surronding text. [3B]

### Fixed

- fix: show existing users and groups as selected in Models settings "Add Access" modal
- fix: remove stray border on user rows in Access List
- fix: keep user avatar circular in Access List

---

### Additional Information

Tested locally against a Docker image built from this branch.

### Screenshots or Videos

1A,
<img width="1631" height="866" alt="Képernyőkép 2026-04-26 202025" src="https://github.com/user-attachments/assets/e2572183-2fb7-408e-b754-8553c487bb3a" />
<img width="1607" height="867" alt="Képernyőkép 2026-04-26 202112" src="https://github.com/user-attachments/assets/20109510-7099-43ec-9a03-9fef93f7ff59" />
1B,
<img width="1610" height="812" alt="Képernyőkép 2026-04-26 203433" src="https://github.com/user-attachments/assets/6046af38-7610-4aa6-803c-85ea57e061d0" />
<img width="1592" height="857" alt="Képernyőkép 2026-04-26 203459" src="https://github.com/user-attachments/assets/f0abffc4-c9a7-4e87-949f-c9615abbccbc" />


2A,
<img width="1631" height="866" alt="Képernyőkép 2026-04-26 202025" src="https://github.com/user-attachments/assets/1b59915f-30cf-4069-8b2a-9480e5965bef" />
2b,
<img width="1585" height="822" alt="Képernyőkép 2026-04-26 203547" src="https://github.com/user-attachments/assets/fab83a27-8a8e-4269-be03-60f21cdf84fa" />


3A,
<img width="1595" height="832" alt="Képernyőkép 2026-04-26 202741" src="https://github.com/user-attachments/assets/6f407839-8e96-48cd-9593-27791b4d3d37" />
3B,
<img width="1585" height="822" alt="Képernyőkép 2026-04-26 203547" src="https://github.com/user-attachments/assets/e17ebf69-ac27-4672-b3d5-d0df874fb8b1" />



### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
