### PR TITLE
fix(chat): recover from malformed history.currentId instead of infinite loading

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -58,6 +58,8 @@
 		copyToClipboard,
 		getMessageContentParts,
 		createMessagesList,
+		findLastRenderableAncestor,
+		isRenderableMessage,
 		getPromptVariables,
 		processDetails,
 		removeAllDetails,
@@ -1348,6 +1350,25 @@
 					(chatContent?.history ?? undefined) !== undefined
 						? chatContent.history
 						: convertMessagesToHistory(chatContent.messages);
+
+				// Defensive recovery: if `history.currentId` points at a malformed
+				// message (e.g. a safety-rejection / content-filter shape from an
+				// upstream OpenAI-compatible provider that lacks `role` /
+				// `childrenIds`), the renderer would otherwise lock up on an
+				// infinite Loading spinner. Walk back to the last valid ancestor
+				// and surface a non-fatal warning instead. See #24157.
+				if (
+					history?.currentId &&
+					history?.messages &&
+					!isRenderableMessage(history.messages[history.currentId])
+				) {
+					const recoveredId = findLastRenderableAncestor(history, history.currentId);
+					console.warn(
+						`[chat] history.currentId ${history.currentId} points at a malformed message; ` +
+							`recovering to last valid ancestor: ${recoveredId ?? '<none>'}`
+					);
+					history.currentId = recoveredId as any;
+				}
 
 				chatTitle.set(chatContent.title);
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1296,6 +1296,52 @@ export const createMessagesList = (history, messageId) => {
 	return list.reverse();
 };
 
+/**
+ * A message is considered "renderable" only if it has the minimum schema fields
+ * downstream components depend on (`role` and `childrenIds`). Upstream OpenAI-
+ * compatible providers occasionally return safety-rejection / content-filter
+ * shapes that get persisted into `chat.history.messages` without these fields.
+ * If `history.currentId` ever points at such a node, the chat renderer locks up
+ * on an infinite Loading spinner. This predicate lets us detect the bad node so
+ * we can fall back to the last valid ancestor instead of rendering it.
+ * See https://github.com/open-webui/open-webui/issues/24157
+ */
+export const isRenderableMessage = (message: unknown): boolean => {
+	if (!message || typeof message !== 'object') {
+		return false;
+	}
+	const m = message as Record<string, unknown>;
+	return typeof m.role === 'string' && Array.isArray(m.childrenIds);
+};
+
+/**
+ * Walk backwards through the parent chain starting at `startId` and return the
+ * first ancestor (inclusive) that satisfies `isRenderableMessage`. Returns
+ * `null` if no renderable ancestor exists.
+ */
+export const findLastRenderableAncestor = (
+	history: { messages: Record<string, any> },
+	startId: string | null | undefined
+): string | null => {
+	if (!startId || !history?.messages) {
+		return null;
+	}
+	const seen = new Set<string>();
+	let currentId: string | null | undefined = startId;
+	while (currentId && !seen.has(currentId)) {
+		seen.add(currentId);
+		const message = history.messages[currentId];
+		if (message === undefined) {
+			return null;
+		}
+		if (isRenderableMessage(message)) {
+			return currentId;
+		}
+		currentId = message?.parentId ?? null;
+	}
+	return null;
+};
+
 export const formatFileSize = (size) => {
 	if (size == null) return 'Unknown size';
 	if (typeof size !== 'number' || size < 0) return 'Invalid size';


### PR DESCRIPTION
## Summary

Fixes #24157 — when an upstream OpenAI-compatible provider returns a safety-rejection or content-filter response that lacks the standard message schema (no `role` / `childrenIds`), the malformed object can end up persisted in `chat.history.messages` and assigned as `history.currentId`. The chat view then locks up on an **infinite Loading spinner** because downstream renderers rely on those fields.

## Approach

Add two small helpers in `src/lib/utils/index.ts`:

- **`isRenderableMessage(message)`** — predicate that requires both `role` (string) and `childrenIds` (array) before treating a node as safe to render.
- **`findLastRenderableAncestor(history, startId)`** — walks the parent chain (cycle-safe via `Set`) and returns the first renderable ancestor, or `null` if none exists.

Wire them into `Chat.svelte#loadChat`: right after the chat content is loaded, if `history.currentId` points at a non-renderable message, log a console warning and reset `history.currentId` to the last valid ancestor (or `null` if no valid ancestor exists). This lets the chat recover automatically and the malformed node is **preserved in `history.messages`** for diagnostics.

## Behavior

| Scenario | Before | After |
|---|---|---|
| `currentId` points at valid message | renders normally | renders normally (no change) |
| `currentId` points at malformed node, valid ancestor exists | infinite Loading | recovers to ancestor + console warning |
| `currentId` points at malformed node, no valid ancestor | infinite Loading | empty chat (renders nothing) + console warning |
| `history.messages` empty / no `currentId` | as before | as before (no change) |

The malformed message is **not deleted** — preserved for forensics. Upstream provider responsibility (returning valid OpenAI-compatible JSON) is unchanged; this just makes Open WebUI defensively robust against bad shapes.

## Verification

- `prettier --check`: ✅
- `npm run check` (svelte-check): ✅ no new errors introduced (existing 9361 errors are preexisting in `main`)
- Unit tests: there is no existing `utils/index.test.ts` to extend; happy to add one if maintainers prefer.

## Refs

- Closes #24157