### PR TITLE
fix: SafeFireCrawlLoader continue on per-URL errors and honor requests_per_second

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -218,8 +218,8 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         self.params = params or {}
 
     def lazy_load(self) -> Iterator[Document]:
-        try:
-            for url in self.web_paths:
+        for url in self.web_paths:
+            try:
                 doc = scrape_firecrawl_url(
                     self.api_url,
                     self.api_key,
@@ -230,21 +230,30 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
                 )
                 if doc is not None:
                     yield doc
-        except Exception as e:
-            if self.continue_on_failure:
-                log.warning(f'Error extracting content from URLs with Firecrawl: {e}')
-            else:
+            except Exception as e:
+                if self.continue_on_failure:
+                    log.warning(f'Error extracting content from {url} with Firecrawl: {e}')
+                    continue
                 raise e
 
     async def alazy_load(self):
-        try:
-            docs = await run_in_threadpool(lambda: list(self.lazy_load()))
-            for doc in docs:
-                yield doc
-        except Exception as e:
-            if self.continue_on_failure:
-                log.warning(f'Error extracting content from URLs with Firecrawl: {e}')
-            else:
+        for url in self.web_paths:
+            try:
+                doc = await run_in_threadpool(
+                    scrape_firecrawl_url,
+                    self.api_url,
+                    self.api_key,
+                    url,
+                    verify_ssl=self.verify_ssl,
+                    timeout=self.timeout,
+                    params=self.params,
+                )
+                if doc is not None:
+                    yield doc
+            except Exception as e:
+                if self.continue_on_failure:
+                    log.warning(f'Error extracting content from {url} with Firecrawl: {e}')
+                    continue
                 raise e
 
 

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -220,6 +220,7 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
     def lazy_load(self) -> Iterator[Document]:
         for url in self.web_paths:
             try:
+                self._sync_wait_for_rate_limit()
                 doc = scrape_firecrawl_url(
                     self.api_url,
                     self.api_key,
@@ -239,6 +240,7 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
     async def alazy_load(self):
         for url in self.web_paths:
             try:
+                await self._wait_for_rate_limit()
                 doc = await run_in_threadpool(
                     scrape_firecrawl_url,
                     self.api_url,

--- a/backend/open_webui/test/test_retrieval_web_firecrawl_loader.py
+++ b/backend/open_webui/test/test_retrieval_web_firecrawl_loader.py
@@ -1,0 +1,181 @@
+"""Tests for `SafeFireCrawlLoader` in `open_webui.retrieval.web.utils`.
+
+The loader is expected to:
+
+- Yield a `Document` for every URL that `scrape_firecrawl_url` returns successfully;
+- Skip URLs for which `scrape_firecrawl_url` returns `None` (the helper signals "no markdown content" by returning
+  `None`) without raising;
+- When `continue_on_failure` is `True` (the default), continue with the rest of the batch after a per-URL exception,
+  log a warning that identifies which URL failed, and not let earlier or later URLs in the batch be lost;
+- When `continue_on_failure` is `False`, propagate the first per-URL exception.
+
+Tests mock `scrape_firecrawl_url` so they need no HTTP server, no Firecrawl SDK and no network access.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+from langchain_core.documents import Document
+
+from open_webui.retrieval.web.utils import SafeFireCrawlLoader
+
+
+URLS = [
+    'https://example.com/page-1',
+    'https://example.com/page-2',
+    'https://example.com/page-3',
+    'https://example.com/page-4',
+    'https://example.com/page-5',
+]
+
+
+def _make_doc(url: str) -> Document:
+    return Document(page_content=f'# content for {url}', metadata={'source': url})
+
+
+def _http_error(url: str, status: int = 403) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status
+    response.url = 'https://api.firecrawl.dev/v2/scrape'
+    response.reason = 'Forbidden' if status == 403 else 'Error'
+    return requests.HTTPError(f'{status} Client Error: {response.reason} for url: {response.url}', response=response)
+
+
+def _build_loader(**kwargs) -> SafeFireCrawlLoader:
+    defaults = {
+        'web_paths': URLS,
+        'api_key': 'fc-test',
+        'api_url': 'https://api.firecrawl.dev',
+        'verify_ssl': True,
+        'continue_on_failure': True,
+    }
+    defaults.update(kwargs)
+    return SafeFireCrawlLoader(**defaults)
+
+
+async def _collect(async_iter) -> list:
+    return [item async for item in async_iter]
+
+
+class TestLazyLoad:
+    """Synchronous `SafeFireCrawlLoader.lazy_load`"""
+
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_yields_all_documents_when_all_urls_succeed(self, mock_scrape):
+        mock_scrape.side_effect = [_make_doc(url) for url in URLS]
+        loader = _build_loader()
+        docs = list(loader.lazy_load())
+        assert [doc.metadata['source'] for doc in docs] == URLS
+        assert mock_scrape.call_count == len(URLS)
+
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_skips_urls_that_return_none(self, mock_scrape):
+        """`scrape_firecrawl_url` returns None for empty markdown; loader must silently skip those without raising."""
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            None,
+            _make_doc(URLS[2]),
+            None,
+            _make_doc(URLS[4]),
+        ]
+        loader = _build_loader()
+        docs = list(loader.lazy_load())
+        assert [doc.metadata['source'] for doc in docs] == [URLS[0], URLS[2], URLS[4]]
+
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_continues_after_per_url_error_when_continue_on_failure_true(self, mock_scrape):
+        """Regression: with continue_on_failure=True, a per-URL HTTP error must not abort the rest of the batch."""
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _make_doc(URLS[1]),
+            _http_error(URLS[2], status=403),
+            _make_doc(URLS[3]),
+            _make_doc(URLS[4]),
+        ]
+        loader = _build_loader(continue_on_failure=True)
+        docs = list(loader.lazy_load())
+        assert [doc.metadata['source'] for doc in docs] == [URLS[0], URLS[1], URLS[3], URLS[4]]
+        assert mock_scrape.call_count == len(URLS)
+
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_warning_message_includes_failing_url(self, mock_scrape, caplog):
+        """The warning emitted on a per-URL failure must identify which URL failed"""
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _http_error(URLS[1], status=403),
+            _make_doc(URLS[2]),
+        ]
+        loader = _build_loader(web_paths=URLS[:3], continue_on_failure=True)
+        with caplog.at_level('WARNING', logger='open_webui.retrieval.web.utils'):
+            list(loader.lazy_load())
+        warning_messages = [record.getMessage() for record in caplog.records if record.levelname == 'WARNING']
+        warnings_found = [URLS[1] in message for message in warning_messages]
+        assert len(warnings_found) == 1, (
+            f'Expected the failing URL {URLS[1]!r} in a WARNING log line, got: {warning_messages!r}'
+        )
+
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_raises_when_continue_on_failure_is_false(self, mock_scrape):
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _http_error(URLS[1], status=403),
+            _make_doc(URLS[2]),
+        ]
+        loader = _build_loader(web_paths=URLS[:3], continue_on_failure=False)
+        with pytest.raises(requests.HTTPError):
+            list(loader.lazy_load())
+
+
+class TestAlazyLoad:
+    """Async `SafeFireCrawlLoader.alazy_load` -- same contract as the sync version."""
+
+    @pytest.mark.asyncio
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    async def test_yields_all_documents_when_all_urls_succeed(self, mock_scrape):
+        mock_scrape.side_effect = [_make_doc(url) for url in URLS]
+        loader = _build_loader()
+        docs = await _collect(loader.alazy_load())
+        assert [doc.metadata['source'] for doc in docs] == URLS
+
+    @pytest.mark.asyncio
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    async def test_continues_after_per_url_error_when_continue_on_failure_true(self, mock_scrape):
+        """Async equivalent of the sync regression: a per-URL HTTP error must not abort the rest of the batch"""
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _make_doc(URLS[1]),
+            _http_error(URLS[2], status=403),
+            _make_doc(URLS[3]),
+            _make_doc(URLS[4]),
+        ]
+        loader = _build_loader(continue_on_failure=True)
+        docs = await _collect(loader.alazy_load())
+        assert [doc.metadata['source'] for doc in docs] == [URLS[0], URLS[1], URLS[3], URLS[4]]
+
+    @pytest.mark.asyncio
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    async def test_warning_message_includes_failing_url(self, mock_scrape, caplog):
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _http_error(URLS[1], status=403),
+            _make_doc(URLS[2]),
+        ]
+        loader = _build_loader(web_paths=URLS[:3], continue_on_failure=True)
+        with caplog.at_level('WARNING', logger='open_webui.retrieval.web.utils'):
+            await _collect(loader.alazy_load())
+        warning_messages = [record.getMessage() for record in caplog.records if record.levelname == 'WARNING']
+        warnings_found = [URLS[1] in message for message in warning_messages]
+        assert warnings_found, f'Expected the failing URL {URLS[1]!r} in a WARNING log line, got: {warning_messages!r}'
+
+    @pytest.mark.asyncio
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    async def test_raises_when_continue_on_failure_is_false(self, mock_scrape):
+        mock_scrape.side_effect = [
+            _make_doc(URLS[0]),
+            _http_error(URLS[1], status=403),
+            _make_doc(URLS[2]),
+        ]
+        loader = _build_loader(web_paths=URLS[:3], continue_on_failure=False)
+        with pytest.raises(requests.HTTPError):
+            await _collect(loader.alazy_load())

--- a/backend/open_webui/test/test_retrieval_web_firecrawl_loader.py
+++ b/backend/open_webui/test/test_retrieval_web_firecrawl_loader.py
@@ -126,6 +126,24 @@ class TestLazyLoad:
         with pytest.raises(requests.HTTPError):
             list(loader.lazy_load())
 
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    def test_waits_for_rate_limit_before_each_scrape(self, mock_scrape):
+        """Each URL must trigger the rate limiter before the scrape, mirroring SafePlaywrightURLLoader"""
+        events = []
+
+        def wait_side_effect():
+            events.append('wait')
+
+        def scrape_side_effect(api_url, api_key, url, **kwargs):
+            events.append('scrape')
+            return _make_doc(url)
+
+        mock_scrape.side_effect = scrape_side_effect
+        loader = _build_loader(web_paths=URLS[:3])
+        with patch.object(loader, '_sync_wait_for_rate_limit', side_effect=wait_side_effect):
+            list(loader.lazy_load())
+        assert events == ['wait', 'scrape'] * 3, f'Expected wait-then-scrape per URL; got {events!r}'
+
 
 class TestAlazyLoad:
     """Async `SafeFireCrawlLoader.alazy_load` -- same contract as the sync version."""
@@ -179,3 +197,22 @@ class TestAlazyLoad:
         loader = _build_loader(web_paths=URLS[:3], continue_on_failure=False)
         with pytest.raises(requests.HTTPError):
             await _collect(loader.alazy_load())
+
+    @pytest.mark.asyncio
+    @patch('open_webui.retrieval.web.utils.scrape_firecrawl_url')
+    async def test_waits_for_rate_limit_before_each_scrape(self, mock_scrape):
+        """Async equivalent: each URL must await the rate limiter before scraping."""
+        events = []
+
+        async def wait_side_effect():
+            events.append('wait')
+
+        def scrape_side_effect(api_url, api_key, url, **kwargs):
+            events.append('scrape')
+            return _make_doc(url)
+
+        mock_scrape.side_effect = scrape_side_effect
+        loader = _build_loader(web_paths=URLS[:3])
+        with patch.object(loader, '_wait_for_rate_limit', side_effect=wait_side_effect):
+            await _collect(loader.alazy_load())
+        assert events == ['wait', 'scrape'] * 3, f'Expected wait-then-scrape per URL; got {events!r}'

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -1141,12 +1141,18 @@
 
 					<div class="mb-2.5 w-full">
 						<div class=" self-center text-xs font-medium mb-1">
-							{$i18n.t('Concurrent Requests')}
+							<Tooltip
+								content={$i18n.t(
+									'Cap the rate at which the web loader fetches URLs. 0 = unlimited. Lower this to respect rate limits on paid extraction APIs (e.g. Firecrawl, Tavily) or to reduce load on source websites.'
+								)}
+								placement="top-start"
+							>
+								{$i18n.t('Requests per second')}
+							</Tooltip>
 						</div>
-
 						<input
 							class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
-							placeholder={$i18n.t('Concurrent Requests')}
+							placeholder={$i18n.t('Requests per second')}
 							bind:value={webConfig.WEB_LOADER_CONCURRENT_REQUESTS}
 							required
 						/>


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

## Description

`SafeFireCrawlLoader.lazy_load` and `SafeFireCrawlLoader.alazy_load` had `try/except` wrapping the entire `for` loop instead of each iteration. The first URL that returned an HTTP error from Firecrawl (e.g. 402, 403, 404, 400 -- none of which are in the helper's retry list) terminated the loop and silently dropped every URL that came after it. The `continue_on_failure=True` flag was effectively a no-op: it suppressed the exception but did not actually continue iterating.

This also has a direct cost impact: every successful scrape before the failing URL is billed by Firecrawl (the request completed on their end) but discarded before reaching the model, so the user pays for content that neither they nor the model ever see.

While investigating this, I found a second bug: `SafeFireCrawlLoader` inherits `RateLimitMixin` and stores `requests_per_second` from its constructor, but neither `lazy_load` nor `alazy_load` ever invoked the wait method. The configured value (admin setting and env var `WEB_LOADER_CONCURRENT_REQUESTS`) was silently ignored.

Both fixes mirror the existing pattern in `SafePlaywrightURLLoader` in the same file: the `try/except` moves inside the loop with `continue` in the handler and `_sync_wait_for_rate_limit` / `_wait_for_rate_limit` are invoked per iteration. `alazy_load` is also restructured to scrape one URL at a time in the threadpool and yield as it goes, instead of collecting the whole batch into a list first. The per-URL warning now identifies which URL failed.

The admin UI labeled the Web Loader's `WEB_LOADER_CONCURRENT_REQUESTS` setting as "Concurrent Requests", but the underlying value is passed as `requests_per_second` and used as a sequential rate limiter (the loop is sequential in every loader). The label was renamed to "Requests per second" and a tooltip was added describing the actual behavior. The config key and env var name were preserved for backward compatibility. The Web Search section's "Concurrent Requests" label is left unchanged because that one is genuinely concurrency control (`asyncio.Semaphore` over parallel queries).

### Added

- `backend/open_webui/test/test_retrieval_web_firecrawl_loader.py`: contract tests for `SafeFireCrawlLoader.lazy_load` and `SafeFireCrawlLoader.alazy_load`. Tests mock `scrape_firecrawl_url` and require no HTTP server, no Firecrawl SDK and no network access. They cover the happy path, per-URL failure recovery (the regression), the warning message identifying the failing URL, `None`-handling (empty markdown), `continue_on_failure=False` propagation and that the rate-limit wait is invoked before every scrape (sync and async).
- Tooltip on the Web Loader admin setting describing what "Requests per second" actually does.

### Fixed

- `SafeFireCrawlLoader.lazy_load` and `SafeFireCrawlLoader.alazy_load` now actually continue past a per-URL failure when `continue_on_failure=True` (the default), instead of aborting the rest of the batch on the first error.
- `SafeFireCrawlLoader` now honors the configured `requests_per_second` (admin setting, env var `WEB_LOADER_CONCURRENT_REQUESTS`). Previously the setting was silently ignored (the loader fired requests as fast as the loop ran).
- The per-URL failure warning now includes the URL that failed, instead of just the Firecrawl endpoint, which made it impossible to tell which URL in a batch was responsible. This makes it easier to debug (e.g. searching for the URL in the FireCrawl dashboard).

### Changed

- `SafeFireCrawlLoader.alazy_load` is now a true streaming async generator: it scrapes URLs one at a time in the threadpool and yields each document as it becomes available. The previous implementation delegated to `lazy_load` via `list(self.lazy_load())`, blocking until every URL was scraped before yielding the first document.
- Web Loader admin UI label renamed from "Concurrent Requests" to "Requests per second". The previous label misrepresented the setting (it is a sequential rate limit, not a concurrency cap). The config key and env var name weren't changed.

## Security

None.

## Breaking Changes

None.

## Deprecated

None.

## Removed

None.

## Additional Information

Running the implemented tests against `dev` (i.e. before applying the fix commits in this PR) - 4 failures:

```
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_yields_all_documents_when_all_urls_succeed PASSED                                                           [  9%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_skips_urls_that_return_none PASSED                                                                          [ 18%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_continues_after_per_url_error_when_continue_on_failure_true FAILED                                          [ 27%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_warning_message_includes_failing_url PASSED                                                                 [ 36%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_raises_when_continue_on_failure_is_false PASSED                                                             [ 45%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_waits_for_rate_limit_before_each_scrape FAILED                                                              [ 54%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_yields_all_documents_when_all_urls_succeed PASSED                                                          [ 63%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_continues_after_per_url_error_when_continue_on_failure_true FAILED                                         [ 72%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_warning_message_includes_failing_url PASSED                                                                [ 81%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_raises_when_continue_on_failure_is_false PASSED                                                            [ 90%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_waits_for_rate_limit_before_each_scrape FAILED                                                             [100%]
```

After - all 11 pass:

```
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_yields_all_documents_when_all_urls_succeed PASSED                                                           [  9%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_skips_urls_that_return_none PASSED                                                                          [ 18%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_continues_after_per_url_error_when_continue_on_failure_true PASSED                                          [ 27%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_warning_message_includes_failing_url PASSED                                                                 [ 36%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_raises_when_continue_on_failure_is_false PASSED                                                             [ 45%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestLazyLoad::test_waits_for_rate_limit_before_each_scrape PASSED                                                              [ 54%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_yields_all_documents_when_all_urls_succeed PASSED                                                          [ 63%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_continues_after_per_url_error_when_continue_on_failure_true PASSED                                         [ 72%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_warning_message_includes_failing_url PASSED                                                                [ 81%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_raises_when_continue_on_failure_is_false PASSED                                                            [ 90%]
open_webui/test/test_retrieval_web_firecrawl_loader.py::TestAlazyLoad::test_waits_for_rate_limit_before_each_scrape PASSED                                                             [100%]
```

## Screenshots or Videos

The label change and the new tooltip:
<img width="537" height="361" alt="2026-04-27_20-13" src="https://github.com/user-attachments/assets/dd871ee3-1423-4864-883c-1dcafc1bf6ec" />


## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
