### PR TITLE
feat: add @internationalized/date to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"@codemirror/theme-one-dark": "^6.1.2",
 		"@floating-ui/dom": "^1.7.2",
 		"@huggingface/transformers": "^3.0.0",
+		"@internationalized/date": "^3.12.1",
 		"@joplin/turndown-plugin-gfm": "^1.0.62",
 		"@mediapipe/tasks-vision": "^0.10.17",
 		"@pyscript/core": "^0.4.32",


### PR DESCRIPTION
Required by bits-ui date components; missing this package causes build error: "Could not resolve @internationalized/date"