### PR TITLE
fix: handle ddgs.text() returning None (ddgs >= 9.x API change)

### DIFF
--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -33,9 +33,12 @@ def search_duckduckgo(
 
         # Use the ddgs.text() method to perform the search
         try:
-            search_results = ddgs.text(query, safesearch='moderate', max_results=count, backend=backend)
+            results = ddgs.text(query, safesearch='moderate', max_results=count, backend=backend)
+            # ddgs >= 9.x can return None on error or empty backend
+            search_results = results if results is not None else []
         except RatelimitException as e:
             log.error(f'RatelimitException: {e}')
+            search_results = []
     if filter_list:
         search_results = get_filtered_results(search_results, filter_list)
 


### PR DESCRIPTION
## Summary

ddgs >= 9.x changed the API: `ddgs.text()` now returns `None` instead of an empty list when the backend is unavailable, rate-limited, or encounters other errors. The existing code assumed it always returns a list, causing:

```
TypeError: 'NoneType' object is not iterable
```

## Changes

`backend/open_webui/retrieval/web/duckduckgo.py`:

```python
# Before (buggy)
try:
    search_results = ddgs.text(query, ...)
except RatelimitException as e:
    log.error(f"RatelimitException: {e}")
if filter_list:
    search_results = get_filtered_results(search_results, filter_list)  # crashes if None

# After (fixed)
try:
    results = ddgs.text(query, ...)
    search_results = results if results is not None else []
except RatelimitException as e:
    log.error(f"RatelimitException: {e}")
    search_results = []
if filter_list:
    search_results = get_filtered_results(search_results, filter_list)
```

Closes #24188
