### PR TITLE
feat: add keyboard shortcuts for playground and edit last user message

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -97,6 +97,11 @@
 						<!-- {$i18n.t('Only active when the chat input is in focus.')} -->
 						<!-- {$i18n.t('Only active when the chat input is in focus and an LLM is generating a response.')} -->
 						<!-- {$i18n.t('Only can be triggered when the chat input is in focus.')} -->
+						<!-- {$i18n.t('Edit Last User Message')} -->
+						<!-- {$i18n.t('Playground')} -->
+						<!-- {$i18n.t('Run')} -->
+						<!-- {$i18n.t('Add Message')} -->
+						<!-- {$i18n.t('Toggle Role')} -->
 						{#each items as shortcut}
 							<div class="col-span-1 flex items-start">
 								<ShortcutItem {shortcut} {isMac} />

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -288,6 +288,24 @@
 		toast.success($i18n.t('Chat exported successfully'));
 	};
 
+	const handleKeydown = (event: KeyboardEvent) => {
+		const mod = event.ctrlKey || event.metaKey;
+
+		if (mod && !event.shiftKey && event.key === 'Enter') {
+			if (!loading) {
+				event.preventDefault();
+				submitHandler();
+			}
+		} else if (mod && event.shiftKey && event.key.toLowerCase() === 'a') {
+			event.preventDefault();
+			addHandler();
+			role = role === 'user' ? 'assistant' : 'user';
+		} else if (mod && event.shiftKey && event.key.toLowerCase() === 'x') {
+			event.preventDefault();
+			role = role === 'user' ? 'assistant' : 'user';
+		}
+	};
+
 	onMount(async () => {
 		if ($user?.role !== 'admin') {
 			await goto('/');
@@ -303,6 +321,8 @@
 		loaded = true;
 	});
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <div class=" flex flex-col justify-between w-full overflow-y-auto h-full">
 	<div class="mx-auto w-full md:px-0 h-full relative">

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -103,6 +103,17 @@
 		}
 	};
 
+	const handleKeydown = (event: KeyboardEvent) => {
+		const mod = event.ctrlKey || event.metaKey;
+
+		if (mod && !event.shiftKey && event.key === 'Enter') {
+			if (!loading) {
+				event.preventDefault();
+				submitHandler();
+			}
+		}
+	};
+
 	onMount(async () => {
 		if ($user?.role !== 'admin') {
 			await goto('/');
@@ -118,6 +129,8 @@
 		loaded = true;
 	});
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <div class=" flex flex-col justify-between w-full overflow-y-auto h-full">
 	<div class="mx-auto w-full md:px-0 h-full">

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -40,7 +40,13 @@ export enum Shortcut {
 	REGENERATE_RESPONSE = 'regenerateResponse',
 	COPY_LAST_CODE_BLOCK = 'copyLastCodeBlock',
 	COPY_LAST_RESPONSE = 'copyLastResponse',
-	STOP_GENERATING = 'stopGenerating'
+	STOP_GENERATING = 'stopGenerating',
+	EDIT_LAST_MESSAGE = 'editLastMessage',
+
+	//Playground
+	PLAYGROUND_SUBMIT = 'playgroundSubmit',
+	PLAYGROUND_ADD_MESSAGE = 'playgroundAddMessage',
+	PLAYGROUND_TOGGLE_ROLE = 'playgroundToggleRole'
 }
 
 export const shortcuts: ShortcutRegistry = {
@@ -164,5 +170,27 @@ export const shortcuts: ShortcutRegistry = {
 		name: 'Copy Last Code Block',
 		keys: ['mod', 'shift', ';'],
 		category: 'Message'
+	},
+	[Shortcut.EDIT_LAST_MESSAGE]: {
+		name: 'Edit Last User Message',
+		keys: ['mod', 'E'],
+		category: 'Message'
+	},
+
+	//Playground
+	[Shortcut.PLAYGROUND_SUBMIT]: {
+		name: 'Run',
+		keys: ['mod', 'Enter'],
+		category: 'Playground'
+	},
+	[Shortcut.PLAYGROUND_ADD_MESSAGE]: {
+		name: 'Add Message',
+		keys: ['mod', 'shift', 'A'],
+		category: 'Playground'
+	},
+	[Shortcut.PLAYGROUND_TOGGLE_ROLE]: {
+		name: 'Toggle Role',
+		keys: ['mod', 'shift', 'X'],
+		category: 'Playground'
 	}
 };

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -311,6 +311,10 @@
 					console.log('Shortcut triggered: REGENERATE_RESPONSE');
 					event.preventDefault();
 					[...document.getElementsByClassName('regenerate-response-button')]?.at(-1)?.click();
+				} else if (isShortcutMatch(event, shortcuts[Shortcut.EDIT_LAST_MESSAGE])) {
+					console.log('Shortcut triggered: EDIT_LAST_MESSAGE');
+					event.preventDefault();
+					[...document.getElementsByClassName('edit-user-message-button')]?.at(-1)?.click();
 				}
 			});
 		};


### PR DESCRIPTION
 ---                                                
                                            
  Closes #1008                                        
                                              
  Adds keyboard shortcuts to the Playground (which previously had none) and a global shortcut to edit the last user message in the main chat.
                  
  <!--                                                                                                                                                                                                                                                                                         
  ⚠️  CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️ 
  1. Target the `dev` branch. PRs targeting `main` will be automatically closed.                                                                                                                                                                                                               
  2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
  -->             
                                                  
  # Pull Request Checklist                                                                                                                                                                                                                                                                     
                                                   
  - [x] **Target branch:** This PR targets the `dev` branch.                                                                                                                                                                                                                                   
  - [x] **Description:** Provided above and in the changelog below.
  - [x] **Changelog:** See below.                 
  - [x] **Documentation:** No env vars or public APIs changed. New shortcuts are self-documented in the in-app Shortcuts modal (`Ctrl+/`).                                                                                                                                                     
  - [x] **Dependencies:** No new or upgraded dependencies.
  - [x] **Testing:** Manually tested on Windows — all shortcuts verified working (see screenshot below).                                                                                                                                                                                       
  - [x] **Agentic AI Code:** Written and manually reviewed and tested by human contributor.
  - [x] **Code review:** Self-reviewed. Follows existing shortcut patterns in the codebase.
  - [x] **Design & Architecture:** No new settings added. Uses existing `svelte:window` and `getElementsByClassName` patterns already present in the codebase.                                                                                                                                 
  - [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
  - [x] **Title Prefix:** `feat:`                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                               
  # Changelog Entry                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                               
  ### Description                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                               
  - Adds keyboard shortcuts for the Playground (Chat and Completions tabs) which previously had no shortcut support, and adds `Ctrl/Cmd+E` to edit the last user message from anywhere in the main chat. Addresses #1008.                                                                      
                                                                                                                                                                                                                                                                                               
  ### Added                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                               
  - `Ctrl/Cmd+Enter` — Run/submit in Playground Chat and Completions                                                                                                                                                                                                                           
  - `Ctrl/Cmd+Shift+A` — Add message in Playground Chat (mirrors Add button, auto-toggles role)                                                                                                                                                                                                
  - `Ctrl/Cmd+Shift+X` — Toggle user/assistant role in Playground Chat
  - `Ctrl/Cmd+E` — Edit last user message from anywhere in the main chat
  - New **Playground** category visible in the Shortcuts modal (`Ctrl+/`)                                                                                                                                                                                                                      
                                                  
  ### Changed                                                                                                                                                                                                                                                                                  
                                                                  
  - `src/lib/shortcuts.ts` — added `EDIT_LAST_MESSAGE`, `PLAYGROUND_SUBMIT`, `PLAYGROUND_ADD_MESSAGE`, `PLAYGROUND_TOGGLE_ROLE` enum values and registry entries                                                                                                                               
  - `src/routes/(app)/+layout.svelte` — added global `Ctrl/Cmd+E` handler
  - `src/lib/components/playground/Chat.svelte` — added local `svelte:window` keydown handler                                                                                                                                                                                                  
  - `src/lib/components/chat/ShortcutsModal.svelte` — added i18n extraction comments for new strings                                                                                                                                                                                           
                                                                                                    
  ### Screenshots or Videos                                                                                                                                                                                                                                                                    
           
<img width="1021" height="1152" alt="Screenshot 2026-04-28 221453" src="https://github.com/user-attachments/assets/5502ac27-deca-4784-8fcd-f5ef0c09c573" />
                                                       
                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                               
  ### Contributor License Agreement                
                                                                                                                                                                                                                                                                                               
  <!--                                                                                                                                                                                                                                                                                         
  🚨 DO NOT DELETE THE TEXT BELOW 🚨                                                                                                                                                                                                                                                           
  Keep the "Contributor License Agreement" confirmation text intact.                                                                                                                                                                                                                           
  Deleting it will trigger the CLA-Bot to INVALIDATE your PR.       
                                                                                                                                                                                                                                                                                               
  Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
  -->                                                                                                                                  
                                                   
  - [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
                                                                                                                                                                                                                                                                        
  > [!NOTE]                                        
  > Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.                                                                                                                                                                                           
                                                                                                    
  ---           