### PR TITLE
fix(retrieval): strip embedding model name to avoid silent 404 failures

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -683,7 +683,7 @@ def generate_openai_batch_embeddings(
     user: UserModel = None,
 ) -> list[list[float]]:
     log.debug(f'generate_openai_batch_embeddings:model {model} batch size: {len(texts)}')
-    json_data = {'input': texts, 'model': model}
+    json_data = {'input': texts, 'model': model.strip() if model else model}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
@@ -716,7 +716,7 @@ async def agenerate_openai_batch_embeddings(
     user: UserModel = None,
 ) -> list[list[float]]:
     log.debug(f'agenerate_openai_batch_embeddings:model {model} batch size: {len(texts)}')
-    form_data = {'input': texts, 'model': model}
+    form_data = {'input': texts, 'model': model.strip() if model else model}
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 


### PR DESCRIPTION
## Summary

Fixes #24090

When an embedding model name has trailing/leading whitespace (e.g., `qwen3-embedding-4b `), Open WebUI sends the padded string verbatim to the embedding API, resulting in a silent 404 error. The UI shows the file as "processed" but no vectors are stored.

## Bug

```python
# backend/open_webui/retrieval/utils.py line 686
json_data = {'input': texts, 'model': model}  # No strip!
```

If `model = "qwen3-embedding-4b "`, the API call becomes:
```
POST /v1/embeddings
{"input": [...], "model": "qwen3-embedding-4b "}
```

The API returns 404: `Model 'qwen3-embedding-4b ' not found`, but this error is silently caught and the file appears processed in the UI.

## Fix

Strip whitespace from the model name in both `generate_openai_batch_embeddings` and `agenerate_openai_batch_embeddings`:

```python
# Before
json_data = {'input': texts, 'model': model}

# After
json_data = {'input': texts, 'model': model.strip() if model else model}
```

This ensures that `"qwen3-embedding-4b "` is correctly treated as `"qwen3-embedding-4b"`.

## Testing

1. Set embedding model to `"qwen3-embedding-4b "` (with trailing space) in Admin Panel
2. Upload a file to knowledge base
3. Before: File appears processed but no vectors stored (404 in logs)
4. After: File is properly embedded
