### PR TITLE
fix(web): guard xml_element_contents_to_string against None

### DIFF
--- a/backend/open_webui/retrieval/web/yandex.py
+++ b/backend/open_webui/retrieval/web/yandex.py
@@ -19,7 +19,9 @@ from xml.etree.ElementTree import Element
 log = logging.getLogger(__name__)
 
 
-def xml_element_contents_to_string(element: Element) -> str:
+def xml_element_contents_to_string(element: Element | None) -> str:
+    if element is None:
+        return ''
     buffer = [element.text if element.text else '']
 
     for child in element:


### PR DESCRIPTION
## Summary

Fixes #24243

## Bug

In `backend/open_webui/retrieval/web/yandex.py`, the `xml_element_contents_to_string()` helper receives `element: Element` but is called with the result of `group.find('doc/url')`, `group.find('doc/title')`, or `group.find('doc/passages/passage')`, any of which may return `None` when the corresponding XML node is absent.

When `element is None`, accessing `element.text` raises:
```
AttributeError: 'NoneType' object has no attribute 'text'
```

This crashes the entire search function, which then silently returns `[]`, so users see "No results found" even though the Yandex API returned valid results.

Stack trace from the issue:
```
ERROR | open_webui.retrieval.web.yandex:search_yandex:117 - Error in search: 'NoneType' object has no attribute 'text'
ERROR | open_webui.utils.middleware:chat_web_search_handler:1651 - 404: [ERROR: No results found from web search]
```

## Fix

Guard against `None` at the top of the helper:

```python
def xml_element_contents_to_string(element: Element | None) -> str:
    if element is None:
        return ''
    buffer = [element.text if element.text else '']
    ...
```

The function already handles the case of `element.text` being `None` (using `''`), so this change is consistent with the existing pattern.

## Impact

- Search now returns partial results instead of crashing when individual XML nodes are missing
- No behavior change for well-formed Yandex API responses
- The `search_yandex` function already has `try/except` and returns `[]` on error, so this is a defensive improvement
