### PR TITLE
Add Perplexity as web search engine

### DIFF
--- a/backend/open_webui/retrieval/web/perplexity.py
+++ b/backend/open_webui/retrieval/web/perplexity.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Literal
 import requests
 
+from open_webui.env import VERSION
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 
 MODELS = Literal[
@@ -64,6 +65,7 @@ def search_perplexity(
         headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json',
+            'X-Pplx-Integration': f'open-webui/{VERSION}',
         }
 
         # Make the API request

--- a/backend/open_webui/retrieval/web/perplexity_search.py
+++ b/backend/open_webui/retrieval/web/perplexity_search.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Literal
 import requests
 
+from open_webui.env import VERSION
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.utils.headers import include_user_info_headers
 
@@ -47,6 +48,7 @@ def search_perplexity_search(
         headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json',
+            'X-Pplx-Integration': f'open-webui/{VERSION}',
         }
 
         # Forward user info headers if user is provided


### PR DESCRIPTION
## Summary

Adds the `X-Pplx-Integration` attribution header to outgoing requests from the existing Perplexity web search integrations (`perplexity.py` chat-completions citation search and `perplexity_search.py` direct Search API). The header follows the standard `slug/version` pattern (`open-webui/<VERSION>`) so Perplexity can attribute traffic to the Open WebUI integration for support, telemetry, and reliability work.

This is a small, no-behavior-change patch: the HTTP call sites are untouched apart from one extra header field, and the version is sourced from the existing `open_webui.env.VERSION` constant so it stays in sync with the package automatically.

## Changes

- `backend/open_webui/retrieval/web/perplexity.py`: import `VERSION`, set `X-Pplx-Integration: open-webui/<VERSION>` on the chat-completions request.
- `backend/open_webui/retrieval/web/perplexity_search.py`: import `VERSION`, set the same header on the Search API request (added before the optional user-info merge so it survives any downstream header munging).

## Testing

- Verified both modules parse cleanly (`ast.parse`).
- No new dependencies; no config or schema changes; no UI surface touched.
- `git diff --stat` shows 2 files changed, 4 insertions(+).

Signed-off-by: James Liounis <james.liounis@perplexity.ai>