### PR TITLE
fix: accept documented Feishu OAuth env aliases

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -37,6 +37,7 @@ from open_webui.env import (
     log,
 )
 from open_webui.internal.db import Base, get_db, get_async_db
+from open_webui.utils.env_vars import get_env_with_aliases
 from open_webui.utils.redis import get_redis_connection
 
 
@@ -624,15 +625,19 @@ FEISHU_CLIENT_SECRET = PersistentConfig(
 )
 
 FEISHU_OAUTH_SCOPE = PersistentConfig(
-    'FEISHU_OAUTH_SCOPE',
+    'FEISHU_CLIENT_SCOPE',
     'oauth.feishu.scope',
-    os.environ.get('FEISHU_OAUTH_SCOPE', 'contact:user.base:readonly'),
+    get_env_with_aliases(
+        'FEISHU_CLIENT_SCOPE',
+        'FEISHU_OAUTH_SCOPE',
+        default='contact:user.base:readonly',
+    ),
 )
 
 FEISHU_REDIRECT_URI = PersistentConfig(
-    'FEISHU_REDIRECT_URI',
+    'FEISHU_CLIENT_REDIRECT_URI',
     'oauth.feishu.redirect_uri',
-    os.environ.get('FEISHU_REDIRECT_URI', ''),
+    get_env_with_aliases('FEISHU_CLIENT_REDIRECT_URI', 'FEISHU_REDIRECT_URI'),
 )
 
 ENABLE_OAUTH_ROLE_MANAGEMENT = PersistentConfig(

--- a/backend/open_webui/test/utils/test_env_vars.py
+++ b/backend/open_webui/test/utils/test_env_vars.py
@@ -1,0 +1,43 @@
+from open_webui.utils.env_vars import get_env_with_aliases
+
+
+def test_get_env_with_aliases_prefers_documented_env_name():
+    environ = {
+        'FEISHU_CLIENT_REDIRECT_URI': 'https://example.test/oauth/feishu/callback',
+        'FEISHU_REDIRECT_URI': 'https://legacy.example.test/oauth/feishu/callback',
+    }
+
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_REDIRECT_URI',
+            'FEISHU_REDIRECT_URI',
+            environ=environ,
+        )
+        == 'https://example.test/oauth/feishu/callback'
+    )
+
+
+def test_get_env_with_aliases_falls_back_to_legacy_alias():
+    environ = {'FEISHU_OAUTH_SCOPE': 'contact:user.email:readonly'}
+
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_SCOPE',
+            'FEISHU_OAUTH_SCOPE',
+            default='contact:user.base:readonly',
+            environ=environ,
+        )
+        == 'contact:user.email:readonly'
+    )
+
+
+def test_get_env_with_aliases_returns_default_when_missing():
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_SCOPE',
+            'FEISHU_OAUTH_SCOPE',
+            default='contact:user.base:readonly',
+            environ={},
+        )
+        == 'contact:user.base:readonly'
+    )

--- a/backend/open_webui/test/utils/test_env_vars.py
+++ b/backend/open_webui/test/utils/test_env_vars.py
@@ -31,6 +31,23 @@ def test_get_env_with_aliases_falls_back_to_legacy_alias():
     )
 
 
+def test_get_env_with_aliases_prefers_documented_scope_env_name():
+    environ = {
+        'FEISHU_CLIENT_SCOPE': 'contact:user.base:readonly',
+        'FEISHU_OAUTH_SCOPE': 'contact:user.email:readonly',
+    }
+
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_SCOPE',
+            'FEISHU_OAUTH_SCOPE',
+            default='contact:user.base:readonly',
+            environ=environ,
+        )
+        == 'contact:user.base:readonly'
+    )
+
+
 def test_get_env_with_aliases_skips_empty_documented_env_name():
     environ = {
         'FEISHU_CLIENT_SCOPE': '',

--- a/backend/open_webui/test/utils/test_env_vars.py
+++ b/backend/open_webui/test/utils/test_env_vars.py
@@ -31,6 +31,40 @@ def test_get_env_with_aliases_falls_back_to_legacy_alias():
     )
 
 
+def test_get_env_with_aliases_skips_empty_documented_env_name():
+    environ = {
+        'FEISHU_CLIENT_SCOPE': '',
+        'FEISHU_OAUTH_SCOPE': 'contact:user.email:readonly',
+    }
+
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_SCOPE',
+            'FEISHU_OAUTH_SCOPE',
+            default='contact:user.base:readonly',
+            environ=environ,
+        )
+        == 'contact:user.email:readonly'
+    )
+
+
+def test_get_env_with_aliases_skips_empty_aliases_before_default():
+    environ = {
+        'FEISHU_CLIENT_SCOPE': '',
+        'FEISHU_OAUTH_SCOPE': '',
+    }
+
+    assert (
+        get_env_with_aliases(
+            'FEISHU_CLIENT_SCOPE',
+            'FEISHU_OAUTH_SCOPE',
+            default='contact:user.base:readonly',
+            environ=environ,
+        )
+        == 'contact:user.base:readonly'
+    )
+
+
 def test_get_env_with_aliases_returns_default_when_missing():
     assert (
         get_env_with_aliases(

--- a/backend/open_webui/utils/env_vars.py
+++ b/backend/open_webui/utils/env_vars.py
@@ -12,7 +12,7 @@ def get_env_with_aliases(
 
     for name in (env_name, *aliases):
         value = values.get(name)
-        if value is not None:
+        if value is not None and value != '':
             return value
 
     return default

--- a/backend/open_webui/utils/env_vars.py
+++ b/backend/open_webui/utils/env_vars.py
@@ -1,0 +1,18 @@
+import os
+from collections.abc import Mapping
+
+
+def get_env_with_aliases(
+    env_name: str,
+    *aliases: str,
+    default: str = '',
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    values = os.environ if environ is None else environ
+
+    for name in (env_name, *aliases):
+        value = values.get(name)
+        if value is not None:
+            return value
+
+    return default


### PR DESCRIPTION
## Pull Request Checklist

- [x] Target branch: this PR targets `dev`.
- [x] Description: Feishu OAuth now accepts the documented `FEISHU_CLIENT_SCOPE` and `FEISHU_CLIENT_REDIRECT_URI` env vars, while retaining `FEISHU_OAUTH_SCOPE` and `FEISHU_REDIRECT_URI` as legacy fallbacks.
- [x] Changelog: included below.
- [x] Documentation: existing docs already use the documented names; this makes code match them.
- [x] Dependencies: no dependency changes.
- [x] Testing: focused automated tests and compile checks are listed below.
- [ ] Agentic AI Code: not checked here; Genmin should confirm this according to project policy if needed.
- [x] Code review: reviewed the diff for compatibility with existing persistent config paths.
- [x] Design & Architecture: preserves existing config paths and adds only a small env alias helper.
- [x] Git Hygiene: rebased onto `dev`; one logical change.
- [x] Title Prefix: uses `fix:`.

## Changelog Entry

### Description

- Accept documented Feishu OAuth env names while preserving legacy aliases.

### Added

- Focused tests for documented env precedence, legacy fallback, and default behavior.

### Changed

- `FEISHU_CLIENT_SCOPE` now takes precedence over `FEISHU_OAUTH_SCOPE`.
- `FEISHU_CLIENT_REDIRECT_URI` now takes precedence over `FEISHU_REDIRECT_URI`.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed Feishu OAuth deployments following the docs so explicit redirect URIs are passed to Authlib instead of falling back to request URL inference.

### Security

- None.

### Breaking Changes

- None. Legacy env vars remain supported.

---

### Additional Information

Fixes #24094.

Validation run:

- `PYTHONPATH=backend uv run --no-sync --with pytest --with typer --with uvicorn pytest backend/open_webui/test/utils/test_env_vars.py -q`
- `uv run --no-sync --with ruff ruff check backend/open_webui/utils/env_vars.py backend/open_webui/test/utils/test_env_vars.py`
- `PYTHONPATH=backend uv run --no-sync --with typer --with uvicorn python -m compileall -q backend/open_webui/config.py backend/open_webui/utils/env_vars.py backend/open_webui/test/utils/test_env_vars.py`
- `git diff --check`

### Screenshots or Videos

- Not applicable; backend env parsing fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
