### PR TITLE
perf: make /tags fetch only the tags column with SQL access filter

### DIFF
--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -632,12 +632,38 @@ class PromptsTable:
     async def get_tags(self, db: Optional[AsyncSession] = None) -> list[str]:
         try:
             async with get_async_db_context(db) as db:
-                result = await db.execute(select(Prompt).filter_by(is_active=True))
-                prompts = result.scalars().all()
+                result = await db.execute(select(Prompt.tags).filter(Prompt.is_active == True))
                 tags = set()
-                for prompt in prompts:
-                    if prompt.tags:
-                        for tag in prompt.tags:
+                for (tag_list,) in result.all():
+                    if tag_list:
+                        for tag in tag_list:
+                            if tag:
+                                tags.add(tag)
+                return sorted(list(tags))
+        except Exception:
+            return []
+
+    async def get_tags_by_user_id(self, user_id: str, db: Optional[AsyncSession] = None) -> list[str]:
+        try:
+            async with get_async_db_context(db) as db:
+                user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
+                user_group_ids = [group.id for group in user_groups]
+
+                query = select(Prompt.tags).filter(Prompt.is_active == True)
+                query = AccessGrants.has_permission_filter(
+                    db=db,
+                    query=query,
+                    DocumentModel=Prompt,
+                    filter={'user_id': user_id, 'group_ids': user_group_ids},
+                    resource_type='prompt',
+                    permission='read',
+                )
+
+                result = await db.execute(query)
+                tags = set()
+                for (tag_list,) in result.all():
+                    if tag_list:
+                        for tag in tag_list:
                             if tag:
                                 tags.add(tag)
                 return sorted(list(tags))

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -61,13 +61,7 @@ async def get_prompts(user=Depends(get_verified_user), db: AsyncSession = Depend
 async def get_prompt_tags(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
     if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:
         return await Prompts.get_tags(db=db)
-    else:
-        prompts = await Prompts.get_prompts_by_user_id(user.id, 'read', db=db)
-        tags = set()
-        for prompt in prompts:
-            if prompt.tags:
-                tags.update(prompt.tags)
-        return sorted(list(tags))
+    return await Prompts.get_tags_by_user_id(user.id, db=db)
 
 
 @router.get('/list', response_model=PromptAccessListResponse)


### PR DESCRIPTION
Fixes : https://github.com/open-webui/open-webui/discussions/24258

Non-admin GET /api/v1/prompts/tags went through get_prompts_by_user_id, which loaded every active prompt with its full content/data/meta plus owner records and all access grants, then ran one has_access query per prompt that wasn't owned by the caller - all so the endpoint could collapse the result to a sorted tag list. With 600 prompts this took several seconds while the admin path (a single SELECT) returned in <1s.

Add Prompts.get_tags_by_user_id which selects only the tags column and applies the same EXISTS-based access filter used by /list. Also tighten the admin get_tags to project just the tags column instead of full rows. The endpoint is now one DB query (plus one for groups), no row hydration, no N+1.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
