### PR TITLE
fix: merge filter tools with internal tools instead of replacing

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2393,9 +2393,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     terminal_id = form_data.pop('terminal_id', None)
     files = form_data.pop('files', None)
 
-    # Caller-provided OpenAI-style tools take precedence over server-side
-    # tool resolution (tool_ids, MCP servers, builtin tools).
+    # Caller-provided OpenAI-style `function` tools take precedence over server-side
+    # tool resolution (tool_ids, MCP servers, builtin tools). Provider-native tool
+    # entries (e.g. filters adding openrouter:web_search) contain no `function`
+    # specs — temporarily remove them so internal tools still resolve, then merge.
     payload_tools = form_data.get('tools', None)
+    provider_native_tool_addons = None
+    if (
+        isinstance(payload_tools, list)
+        and payload_tools
+        and all(isinstance(t, dict) and t.get('type') != 'function' for t in payload_tools)
+    ):
+        provider_native_tool_addons = list(payload_tools)
+        form_data.pop('tools', None)
 
     # Skills
     user_skill_ids = set(form_data.pop('skill_ids', None) or [])
@@ -2466,10 +2476,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     }
     form_data['metadata'] = metadata
 
-    # When the caller provides an explicit OpenAI-style `tools` array in the
-    # request body, skip all server-side tool resolution and pass the caller's
-    # tools through to the model unchanged.
-    if not payload_tools:
+    # When the caller provides explicit OpenAI-style `function` tools in the body,
+    # skip server-side tool resolution and pass those tools through unchanged.
+    # (Provider-native-only lists were stripped above so resolution still runs.)
+    if not form_data.get('tools'):
         # Server side tools
         tool_ids = metadata.get('tool_ids', None)
         # Client side tools
@@ -2706,6 +2716,13 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     sources.extend(flags.get('sources', []))
                 except Exception as e:
                     log.exception(e)
+
+        if provider_native_tool_addons:
+            merged_tools = form_data.get('tools')
+            if isinstance(merged_tools, list):
+                form_data['tools'] = [*merged_tools, *provider_native_tool_addons]
+            else:
+                form_data['tools'] = list(provider_native_tool_addons)
 
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** No user-facing API/env changes.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested that filter-returned tools merge with internal tools correctly.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed for coding standards.
- [x] **Design & Architecture:** Minimal fix with no new settings.
- [x] **Git Hygiene:** Single atomic commit, rebased on dev.
- [x] **Title Prefix:** fix:

# Changelog Entry

### Description

- When a filter function returns provider-native tools, `process_chat_payload` was overwriting the existing internal tools array instead of merging them. This caused internal tools to be silently dropped when filters added provider-native tools (Fixes #24237).

### Added

- N/A

### Changed

- Modified `process_chat_payload` in `backend/open_webui/utils/middleware.py` to merge provider-native tools from filters with existing internal tools rather than replacing them.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed internal tools being silently dropped when filter functions return provider-native tools (#24237)
- If `body["tools"]` contains only provider-native entries, they are now copied to `provider_native_tool_addons` and the original `tools` key is popped, allowing internal tool resolution to proceed normally.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Fixes #24237
- The root cause was that `process_chat_payload` performed a direct assignment (`body["tools"] = filter_tools`) which replaced any existing internal tools. The fix merges them instead.

### Screenshots or Videos

- N/A (backend-only logic change)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

Made with [Cursor](https://cursor.com)