### PR TITLE
fix(ollama): keep prefixed model names consistent

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -375,6 +375,13 @@ async def get_all_models(request: Request, user: UserModel = None):
                 for model in response.get('models', []):
                     if prefix_id:
                         model['model'] = f'{prefix_id}.{model["model"]}'
+                        original_model = model['model']
+                        prefixed_model = f'{prefix_id}.{original_model}'
+
+                        model['model'] = prefixed_model
+
+                        if model.get('name') in (None, '', original_model):
+                            model['name'] = prefixed_model
 
                     if tags:
                         model['tags'] = tags


### PR DESCRIPTION
## Summary

Fix Ollama model list entries when `prefix_id` is configured.

Open WebUI already prefixes `model`, but left `name` unchanged. Since the UI and Ollama-compatible clients may use `name` as the display/model identifier, prefixed Ollama backends could appear ambiguous or inconsistent.

## Fix

When applying `prefix_id` in `get_all_models()`, keep `name` in sync with the prefixed `model` value if the upstream name is empty or still equal to the original Ollama model name.

This preserves custom names while making automatically generated Ollama list entries consistent.

Related: #18752

# Changelog Entry

### Description

Fix inconsistent Ollama model names when `prefix_id` is configured.

### Fixed

- Fixed Ollama model list entries so automatically generated `name` values stay consistent with prefixed `model` values.

### Additional Information

- No new dependencies.
- No breaking changes.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.