### PR TITLE
fix: display attached files by chatbot

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -665,7 +665,7 @@
 							<StatusHistory statusHistory={message?.statusHistory} />
 						{/if}
 
-						{#if message?.files && message.files?.filter((f) => f.type === 'image').length > 0}
+						{#if message?.files}
 							<div
 								class="my-1 w-full flex overflow-x-auto gap-2 flex-wrap"
 								dir={$settings?.chatDirection ?? 'auto'}


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** It was bug. It is not required to document, because documentation contains it.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested that attached files by `__event_emitter__` display in chatbot message.
- [x] **Agentic AI Code:** Confirm this Pull Request is not written by any AI Agent.
- [x] **Code review:** Self-reviewed for coding standards.
- [x] **Design & Architecture:** Minimal fix with no new settings.
- [x] **Git Hygiene:** Single atomic commit, rebased on dev.
- [x] **Title Prefix:** fix:

# Changelog Entry

### Description

- Just fixing a old bug related with display of attaching files by chatbot in `ResponseMessage.svetle`. Early it worked only if `__event_emitter__` recieved files (type `file` or something other) with images (type `image`). But after fixing works fine. I noticed this bug 1,5 years ago. I haven't gotten around to it.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Displaying attached files by chatbot. Just I removed second part a condition of displaying attached files and images.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- N/A

### Screenshots or Videos

- 
<img width="2559" height="1276" alt="image" src="https://github.com/user-attachments/assets/78053d0e-0c9d-4d4e-bef2-d5d732964413" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.