### PR TITLE
fix: parse DEFAULT_MODEL_METADATA from environment variable

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1299,10 +1299,16 @@ MODEL_ORDER_LIST = PersistentConfig(
     [],
 )
 
+try:
+    default_model_metadata = json.loads(os.environ.get('DEFAULT_MODEL_METADATA', '{}'))
+except Exception as e:
+    log.exception(f'Error loading DEFAULT_MODEL_METADATA: {e}')
+    default_model_metadata = {}
+
 DEFAULT_MODEL_METADATA = PersistentConfig(
     'DEFAULT_MODEL_METADATA',
     'models.default_metadata',
-    {},
+    default_model_metadata,
 )
 
 try:


### PR DESCRIPTION
## Summary

Fixes #24319

When ENABLE_PERSISTENT_CONFIG=false, DEFAULT_MODEL_METADATA was not being read from the environment variable because it used a hardcoded empty dict as the default value.

## Changes

Added proper environment variable parsing (same pattern as DEFAULT_MODEL_PARAMS) to read DEFAULT_MODEL_METADATA from environment variable.

## Testing

- I have personally tested ALL changes in this PR
- Tested by setting DEFAULT_MODEL_METADATA env var and verifying it is loaded

## CLA Confirmation

I have read and agree to the Contributor License Agreement.

Generated with Claude Code