### PR TITLE
fix(a11y): add descriptive alt text to images with empty alt attributes

### DIFF
--- a/src/lib/components/channel/WebhookItem.svelte
+++ b/src/lib/components/channel/WebhookItem.svelte
@@ -92,7 +92,7 @@
 		<img
 			src={image || `${WEBUI_BASE_URL}/static/favicon.png`}
 			class="rounded-full size-8 object-cover flex-shrink-0"
-			alt=""
+			alt={name}
 		/>
 		<div class="flex-1 text-left min-w-0">
 			<div class="font-medium text-gray-900 dark:text-white truncate">
@@ -126,7 +126,7 @@
 					<img
 						src={image || `${WEBUI_BASE_URL}/static/favicon.png`}
 						class="size-8 object-cover"
-						alt=""
+						alt={name}
 					/>
 				</button>
 				<div class="flex-1">

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -213,7 +213,7 @@
 									: `${WEBUI_API_BASE_URL}/files/${file.url}${file?.content_type ? '/content' : ''}`}
 							<div class={($settings?.chatBubble ?? true) ? 'self-end' : ''}>
 								{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
-									<Image src={fileUrl} imageClassName=" max-h-96 rounded-lg" />
+									<Image src={fileUrl} alt={$i18n.t('Uploaded image')} imageClassName=" max-h-96 rounded-lg" />
 								{:else}
 									<FileItem
 										item={file}

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -247,7 +247,7 @@
 									<img
 										src={`${WEBUI_API_BASE_URL}/users/${$user?.id}/profile/image`}
 										class="size-6 object-cover rounded-full"
-										alt=""
+										alt={$user?.name ? $i18n.t("{{name}}'s avatar", { name: $user.name }) : ""}
 										draggable="false"
 									/>
 								</div>

--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -140,7 +140,7 @@
 									>
 										<img
 											src={image.url}
-											alt=""
+											alt={$i18n.t('Generated image')}
 											class="w-full aspect-square object-cover rounded-lg border border-gray-100/30 dark:border-gray-850/30"
 										/>
 										<div
@@ -184,7 +184,7 @@
 							{#each sourceImages as image, index}
 								<div class=" relative group">
 									<div class="relative flex items-center">
-										<img src={image} alt="" class="size-10 rounded-xl object-cover" />
+										<img src={image} alt={$i18n.t('Source image')} class="size-10 rounded-xl object-cover" />
 									</div>
 									<div class=" absolute -top-1 -right-1">
 										<button

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -595,7 +595,7 @@
 							crossorigin="anonymous"
 							src="{WEBUI_BASE_URL}/static/favicon.png"
 							class=" w-6 rounded-full"
-							alt=""
+							alt="Open WebUI logo"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Several images across the codebase had empty `alt=""` attributes on meaningful images, making them inaccessible to screen reader users (WCAG 2.1 SC 1.1.1).

### Added

- N/A

### Changed

| File | Image | Before | After |
|------|-------|--------|-------|
| `src/lib/components/chat/Navbar.svelte` | User profile photo | `alt=""` | `alt={$user?.name ? $i18n.t("{{name}}'s avatar", { name: $user.name }) : ""}` |
| `src/lib/components/playground/Images.svelte` | AI generated image | `alt=""` | `alt={$i18n.t('Generated image')}` |
| `src/lib/components/playground/Images.svelte` | Source image upload | `alt=""` | `alt={$i18n.t('Source image')}` |
| `src/lib/components/channel/WebhookItem.svelte` | Webhook avatar | `alt=""` | `alt={name}` |
| `src/routes/auth/+page.svelte` | App logo | `alt=""` | `alt="Open WebUI logo"` |
| `src/lib/components/chat/Messages/UserMessage.svelte` | Uploaded image in chat | no alt | `alt={$i18n.t('Uploaded image')}` |


### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Screen reader users can now get meaningful descriptions when navigating images like the user avatar, app logo, and uploaded files.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Discussed in Discord #development before submitting
- Related to issue #24097 (Screen reader navigation on the main web interface is broken)
- Decorative images (e.g. favicon inside buttons with `aria-label`) were intentionally left with `alt=""`

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
