### PR TITLE
fix: prevent STT from blocking the uvicorn event loop

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -1247,7 +1248,7 @@ async def transcription(
         id = uuid.uuid4()
 
         filename = f'{id}.{ext}'
-        contents = file.file.read()
+        contents = await file.read()
 
         file_dir = os.path.join(CACHE_DIR, 'audio', 'transcriptions')
         os.makedirs(file_dir, exist_ok=True)
@@ -1266,7 +1267,7 @@ async def transcription(
             if language:
                 metadata = {'language': language}
 
-            result = transcribe(request, file_path, metadata, user)
+            result = await asyncio.to_thread(transcribe, request, file_path, metadata, user)
 
             return {
                 **result,


### PR DESCRIPTION
@tjbck urgent fix for upcoming version

This was tested and confirmed working in #24196 comments

The transcription endpoint was async but called the synchronous transcribe() function directly, blocking the single-threaded uvicorn event loop for the entire duration of inference. This caused all HTTP and WebSocket connections to stall for every user on the instance during STT processing.

- Add asyncio import

- Use async UploadFile.read() instead of synchronous file.file.read()

- Offload the blocking transcribe() call via asyncio.to_thread()

Closes #24169

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
