### PR TITLE
feat: display per-machine endpoint used for model before response

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
 
 # Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 # Initialize device type args
 # use build args in the docker build command with --build-arg="BUILDARG=true"
+ARG BUILDPLATFORM=linux/amd64
 ARG USE_CUDA=false
 ARG USE_OLLAMA=false
 ARG USE_SLIM=false

--- a/PUBLIC_RELEASE_CHECKLIST.md
+++ b/PUBLIC_RELEASE_CHECKLIST.md
@@ -1,0 +1,34 @@
+# Public Release Checklist
+
+Use this checklist before pushing this repository to a public GitHub repo.
+
+## License
+
+- Keep the upstream `LICENSE` and copyright notices intact.
+- Review the Open WebUI branding restriction before publishing a fork or derivative.
+- Do not remove or replace branding unless your distribution qualifies under the license terms.
+
+## Secrets and Local Data
+
+- Do not commit `.env`, `.env.*`, secret key files, or runtime databases.
+- Keep `open-webui-data/`, cache directories, and model caches out of the public repo.
+- Verify no API keys, tokens, private keys, or session cookies appear in tracked files.
+
+## Network Details
+
+- Remove hardcoded LAN IPs, hostnames, Docker service names, and internal URLs.
+- Prefer placeholders such as `http://<OLLAMA_HOST>:11434` in docs and examples.
+
+## Quick Checks
+
+```bash
+git ls-files | rg '(^|/)(\\.env(\\.|$)|webui\\.db|ollama\\.db|.*secret.*|.*token.*|.*key.*)$'
+git ls-files -z | xargs -0 rg -n '(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36,}|xox[baprs]-[A-Za-z0-9-]+|-----BEGIN (RSA|OPENSSH|PRIVATE) KEY-----|sk-[A-Za-z0-9]{20,})'
+git ls-files -z | xargs -0 rg -n '(192\\.168\\.|10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|localhost:11434|ollama-dify)'
+```
+
+## Before Push
+
+- Run the quick checks above.
+- Review `git status` for any runtime or data files.
+- Push only the sanitized source tree.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,7 +29,7 @@ Open WebUI has a default timeout of 5 minutes for Ollama to finish generating th
 **Troubleshooting Steps**:
 
 1. **Verify Ollama URL Format**:
-   - When running the Web UI container, ensure the `OLLAMA_BASE_URL` is correctly set. (e.g., `http://192.168.1.1:11434` for different host setups).
+   - When running the Web UI container, ensure the `OLLAMA_BASE_URL` is correctly set. (e.g., `http://<OLLAMA_HOST>:11434` for different host setups).
    - In the Open WebUI, navigate to "Settings" > "General".
    - Confirm that the Ollama Server URL is correctly set to `[OLLAMA URL]` (e.g., `http://localhost:11434`).
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -132,6 +132,7 @@ async def send_request(
     stream: bool = False,
     content_type: Optional[str] = None,
     metadata: Optional[dict] = None,
+    response_envelope: Optional[dict] = None,
 ):
     r = None
     streaming = False
@@ -179,14 +180,24 @@ async def send_request(
                 response_headers['Content-Type'] = content_type
 
             streaming = True
+
+            async def prefixed_stream():
+                if response_envelope:
+                    yield f"data: {json.dumps(response_envelope)}\n\n".encode('utf-8')
+                async for chunk in stream_wrapper(r):
+                    yield chunk
+
             return StreamingResponse(
-                stream_wrapper(r),
+                prefixed_stream(),
                 status_code=r.status,
                 headers=response_headers,
             )
         else:
             try:
-                return await r.json()
+                response = await r.json()
+                if response_envelope:
+                    response = {**response_envelope, **response}
+                return response
             except Exception:
                 return None
 
@@ -1151,6 +1162,10 @@ async def generate_chat_completion(
         stream=form_data.stream,
         content_type='application/x-ndjson',
         metadata=metadata,
+        response_envelope={
+            'selected_model_url': url,
+            'selected_model_url_idx': url_idx,
+        },
     )
 
 
@@ -1240,6 +1255,10 @@ async def generate_openai_completion(
         user=user,
         stream=payload.get('stream', False),
         metadata=metadata,
+        response_envelope={
+            'selected_model_url': url,
+            'selected_model_url_idx': url_idx,
+        },
     )
 
 
@@ -1305,6 +1324,10 @@ async def generate_openai_chat_completion(
         user=user,
         stream=payload.get('stream', False),
         metadata=metadata,
+        response_envelope={
+            'selected_model_url': url,
+            'selected_model_url_idx': url_idx,
+        },
     )
 
 
@@ -1357,6 +1380,10 @@ async def generate_anthropic_messages(
         user=user,
         stream=payload.get('stream', False),
         content_type='text/event-stream' if payload.get('stream', False) else None,
+        response_envelope={
+            'selected_model_url': url,
+            'selected_model_url_idx': url_idx,
+        },
     )
 
 
@@ -1415,6 +1442,10 @@ async def generate_responses(
         user=user,
         stream=payload.get('stream', False),
         content_type='text/event-stream' if payload.get('stream', False) else None,
+        response_envelope={
+            'selected_model_url': url,
+            'selected_model_url_idx': url_idx,
+        },
     )
 
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -178,17 +178,16 @@ async def send_request(
             response_headers = _clean_proxy_headers(r.headers)
             if content_type:
                 response_headers['Content-Type'] = content_type
+            if response_envelope:
+                response_headers['X-Selected-Model-Url'] = response_envelope.get('selected_model_url', '')
+                selected_model_url_idx = response_envelope.get('selected_model_url_idx')
+                if selected_model_url_idx is not None:
+                    response_headers['X-Selected-Model-Url-Idx'] = str(selected_model_url_idx)
 
             streaming = True
 
-            async def prefixed_stream():
-                if response_envelope:
-                    yield f"data: {json.dumps(response_envelope)}\n\n".encode('utf-8')
-                async for chunk in stream_wrapper(r):
-                    yield chunk
-
             return StreamingResponse(
-                prefixed_stream(),
+                stream_wrapper(r),
                 status_code=r.status,
                 headers=response_headers,
             )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3391,6 +3391,16 @@ async def non_streaming_chat_response_handler(response, ctx):
                     },
                 )
 
+            if 'selected_model_url' in response_data:
+                await Chats.upsert_message_to_chat_by_id_and_message_id(
+                    metadata['chat_id'],
+                    metadata['message_id'],
+                    {
+                        'selectedModelUrl': response_data['selected_model_url'],
+                        'selectedModelUrlIdx': response_data.get('selected_model_url_idx'),
+                    },
+                )
+
             choices = response_data.get('choices', [])
             if choices and choices[0].get('message', {}).get('content'):
                 content = response_data['choices'][0]['message']['content']
@@ -3881,6 +3891,21 @@ async def streaming_chat_response_handler(response, ctx):
                                         metadata['message_id'],
                                         {
                                             'selectedModelId': model_id,
+                                        },
+                                    )
+                                    await event_emitter(
+                                        {
+                                            'type': 'chat:completion',
+                                            'data': data,
+                                        }
+                                    )
+                                if 'selected_model_url' in data:
+                                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                        metadata['chat_id'],
+                                        metadata['message_id'],
+                                        {
+                                            'selectedModelUrl': data['selected_model_url'],
+                                            'selectedModelUrlIdx': data.get('selected_model_url_idx'),
                                         },
                                     )
                                     await event_emitter(

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3824,6 +3824,35 @@ async def streaming_chat_response_handler(response, ctx):
                         },
                     )
 
+                selected_model_url = response.headers.get('X-Selected-Model-Url')
+                selected_model_url_idx = response.headers.get('X-Selected-Model-Url-Idx')
+                if selected_model_url:
+                    selected_model_url_idx_value = None
+                    try:
+                        selected_model_url_idx_value = int(selected_model_url_idx) if selected_model_url_idx is not None else None
+                    except (TypeError, ValueError):
+                        selected_model_url_idx_value = selected_model_url_idx
+
+                    selected_model_event = {
+                        'selected_model_url': selected_model_url,
+                        'selected_model_url_idx': selected_model_url_idx_value,
+                    }
+
+                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                        metadata['chat_id'],
+                        metadata['message_id'],
+                        {
+                            'selectedModelUrl': selected_model_url,
+                            'selectedModelUrlIdx': selected_model_url_idx_value,
+                        },
+                    )
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': selected_model_event,
+                        }
+                    )
+
                 async def stream_body_handler(response, form_data):
                     nonlocal content
                     nonlocal usage

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1648,7 +1648,19 @@
 	};
 
 	const chatCompletionEventHandler = async (data, message, chatId) => {
-		const { id, done, choices, content, output, sources, selected_model_id, error, usage } = data;
+		const {
+			id,
+			done,
+			choices,
+			content,
+			output,
+			sources,
+			selected_model_id,
+			selected_model_url,
+			selected_model_url_idx,
+			error,
+			usage
+		} = data;
 
 		// Store raw OR-aligned output items from backend
 		if (output) {
@@ -1744,6 +1756,11 @@
 		if (selected_model_id) {
 			message.selectedModelId = selected_model_id;
 			message.arena = true;
+		}
+
+		if (selected_model_url) {
+			message.selectedModelUrl = selected_model_url;
+			message.selectedModelUrlIdx = selected_model_url_idx;
 		}
 
 		if (usage) {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -458,6 +458,10 @@
 						message.statusHistory = [data];
 					}
 				} else if (type === 'chat:completion') {
+					if (data?.selected_model_url) {
+						message.selectedModelUrl = data.selected_model_url;
+						message.selectedModelUrlIdx = data.selected_model_url_idx;
+					}
 					chatCompletionEventHandler(data, message, event.chat_id);
 				} else if (type === 'chat:tasks:cancel') {
 					if (event.message_id === history.currentId) {

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -68,6 +68,8 @@
 		id: string;
 		model: string;
 		content: string;
+		selectedModelUrl?: string;
+		selectedModelUrlIdx?: number;
 		files?: { type: string; url: string }[];
 		timestamp: number;
 		role: string;
@@ -167,7 +169,19 @@
 	let showDeleteConfirm = false;
 
 	let model = null;
+	let selectedModelEndpoint = '';
 	$: model = $models.find((m) => m.id === message.model);
+	$: selectedModelEndpoint = (() => {
+		if (!message?.selectedModelUrl) {
+			return '';
+		}
+
+		try {
+			return new URL(message.selectedModelUrl).host;
+		} catch {
+			return message.selectedModelUrl;
+		}
+	})();
 
 	$: statusEntries = message?.statusHistory ?? [...(message?.status ? [message?.status] : [])];
 	$: hasVisibleStatus =
@@ -634,9 +648,17 @@
 		<div class="flex-auto w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
-					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
-						{model?.name ?? message.model}
-					</span>
+					<div class="flex flex-col min-w-0">
+						<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">
+							{model?.name ?? message.model}
+						</span>
+
+						{#if selectedModelEndpoint}
+							<span class="line-clamp-1 text-[11px] font-normal text-gray-500 dark:text-gray-400">
+								{selectedModelEndpoint}
+							</span>
+						{/if}
+					</div>
 				</Tooltip>
 
 				{#if message.timestamp}


### PR DESCRIPTION
Sanitize a few docs for public release and add a checklist for avoiding secrets and LAN details.