### PR TITLE
fix: source overflow "+N" badge wraps for 2-digit values

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -185,7 +185,7 @@
 					{/each}
 					{#if citations.length > 3}
 						<div
-							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-[8px] font-semibold text-gray-500 dark:text-gray-400"
+							class="min-w-4 h-4 px-1 rounded-full shrink-0 border border-white dark:border-gray-850 bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-[8px] font-semibold text-gray-500 dark:text-gray-400 whitespace-nowrap"
 							aria-hidden="true"
 						>
 							+{citations.length - Math.min(urlCitations.length, 3)}


### PR DESCRIPTION
## Bug

When a chat response cites 10 or more web sources, the `+N` overflow badge in the citations row wraps the second digit onto a new line.

The badge container in `src/lib/components/chat/Messages/Citations.svelte` was hard-sized at `size-4` (16×16 px), which can't fit two-digit overflows at the `text-[8px]` font size used.

Reproduces on `0.9.2` and current `dev`.

## Fix

One CSS class change on `Citations.svelte:188`:

- `size-4` → `min-w-4 h-4 px-1`
- Added `whitespace-nowrap` for safety

This keeps the perfect-circle look for single-digit overflows (visually consistent with the favicon row above) and lets the pill grow horizontally for multi-digit values.

## Testing

Tested locally; the badge renders correctly for both single-digit and multi-digit overflow values. Pure CSS change, no JS or API impact.