### PR TITLE
fix: harden file serving endpoints against stored XSS

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -57,6 +57,40 @@ log = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Content types that are safe to serve inline (not executable in browsers).
+# Everything else must be forced to attachment with application/octet-stream.
+SAFE_INLINE_CONTENT_TYPES = {
+    'application/pdf',
+    'text/plain',
+    'text/csv',
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/svg+xml',
+    'image/bmp',
+    'image/tiff',
+    'audio/mpeg',
+    'audio/ogg',
+    'audio/wav',
+    'audio/webm',
+    'video/mp4',
+    'video/webm',
+    'video/ogg',
+}
+
+
+def _safe_content_type(content_type: str | None) -> tuple[str, bool]:
+    """Return a (content_type, is_safe_inline) tuple.
+
+    If the content_type is in the safe allowlist it is returned as-is.
+    Otherwise it is replaced with application/octet-stream to prevent
+    browsers from interpreting uploaded files as executable HTML/JS.
+    """
+    if content_type and content_type.lower() in SAFE_INLINE_CONTENT_TYPES:
+        return content_type, True
+    return 'application/octet-stream', False
+
 
 from open_webui.utils.access_control.files import has_access_to_file
 
@@ -631,16 +665,25 @@ async def get_file_content_by_id(
                 content_type = file.meta.get('content_type')
                 filename = file.meta.get('name', file.filename)
                 encoded_filename = quote(filename)
-                headers = {}
+                headers = {
+                    'X-Content-Type-Options': 'nosniff',
+                }
 
-                if attachment:
+                # Normalize content type from file extension when appropriate
+                if filename.lower().endswith('.pdf'):
+                    content_type = 'application/pdf'
+
+                # Validate content type against the safe allowlist to prevent
+                # XSS via user-controlled Content-Type (e.g. uploading a file
+                # with Content-Type: text/html containing malicious scripts).
+                content_type, is_safe = _safe_content_type(content_type)
+
+                if attachment or not is_safe:
                     headers['Content-Disposition'] = f"attachment; filename*=UTF-8''{encoded_filename}"
+                elif content_type == 'text/plain':
+                    headers['Content-Disposition'] = f"inline; filename*=UTF-8''{encoded_filename}"
                 else:
-                    if content_type == 'application/pdf' or filename.lower().endswith('.pdf'):
-                        headers['Content-Disposition'] = f"inline; filename*=UTF-8''{encoded_filename}"
-                        content_type = 'application/pdf'
-                    elif content_type != 'text/plain':
-                        headers['Content-Disposition'] = f"attachment; filename*=UTF-8''{encoded_filename}"
+                    headers['Content-Disposition'] = f"inline; filename*=UTF-8''{encoded_filename}"
 
                 return FileResponse(file_path, headers=headers, media_type=content_type)
 
@@ -692,7 +735,14 @@ async def get_html_file_content_by_id(
             # Check if the file already exists in the cache
             if file_path.is_file():
                 log.info(f'file_path: {file_path}')
-                return FileResponse(file_path)
+                # Serve with Content-Security-Policy sandbox to prevent
+                # script execution even though the content is HTML.
+                # Also force nosniff to stop browsers from second-guessing.
+                headers = {
+                    'Content-Security-Policy': "sandbox; default-src 'none'; style-src 'unsafe-inline'; img-src data:",
+                    'X-Content-Type-Options': 'nosniff',
+                }
+                return FileResponse(file_path, headers=headers, media_type='text/html')
             else:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
@@ -732,7 +782,10 @@ async def get_file_content_by_id(
         # Handle Unicode filenames
         filename = file.meta.get('name', file.filename)
         encoded_filename = quote(filename)  # RFC5987 encoding
-        headers = {'Content-Disposition': f"attachment; filename*=UTF-8''{encoded_filename}"}
+        headers = {
+            'Content-Disposition': f"attachment; filename*=UTF-8''{encoded_filename}",
+            'X-Content-Type-Options': 'nosniff',
+        }
 
         if file_path:
             file_path = await asyncio.to_thread(Storage.get_file, file_path)
@@ -740,7 +793,7 @@ async def get_file_content_by_id(
 
             # Check if the file already exists in the cache
             if file_path.is_file():
-                return FileResponse(file_path, headers=headers)
+                return FileResponse(file_path, headers=headers, media_type='application/octet-stream')
             else:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -67,7 +67,6 @@ SAFE_INLINE_CONTENT_TYPES = {
     'image/jpeg',
     'image/gif',
     'image/webp',
-    'image/svg+xml',
     'image/bmp',
     'image/tiff',
     'audio/mpeg',
@@ -87,8 +86,10 @@ def _safe_content_type(content_type: str | None) -> tuple[str, bool]:
     Otherwise it is replaced with application/octet-stream to prevent
     browsers from interpreting uploaded files as executable HTML/JS.
     """
-    if content_type and content_type.lower() in SAFE_INLINE_CONTENT_TYPES:
-        return content_type, True
+    if content_type:
+        base_type = content_type.split(';')[0].strip().lower()
+        if base_type in SAFE_INLINE_CONTENT_TYPES:
+            return base_type, True
     return 'application/octet-stream', False
 
 
@@ -658,13 +659,9 @@ async def get_file_content_by_id(
 
             # Check if the file already exists in the cache
             if file_path.is_file():
-                # Handle Unicode filenames
-                filename = file.meta.get('name', file.filename)
-                encoded_filename = quote(filename)  # RFC5987 encoding
-
                 content_type = file.meta.get('content_type')
                 filename = file.meta.get('name', file.filename)
-                encoded_filename = quote(filename)
+                encoded_filename = quote(filename)  # RFC5987 encoding
                 headers = {
                     'X-Content-Type-Options': 'nosniff',
                 }
@@ -680,8 +677,6 @@ async def get_file_content_by_id(
 
                 if attachment or not is_safe:
                     headers['Content-Disposition'] = f"attachment; filename*=UTF-8''{encoded_filename}"
-                elif content_type == 'text/plain':
-                    headers['Content-Disposition'] = f"inline; filename*=UTF-8''{encoded_filename}"
                 else:
                     headers['Content-Disposition'] = f"inline; filename*=UTF-8''{encoded_filename}"
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No user-facing config changes; no docs needed.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified that PDFs, images, and text/plain files still serve inline. HTML and SVG files are now forced to download. The `/content/html` endpoint still renders HTML but with CSP sandbox blocking script execution.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed; also ran an agent code review that caught SVG in the allowlist (fixed) and dead code (cleaned up).
- [x] **Design & Architecture:** No new settings or UI changes.
- [x] **Git Hygiene:** Atomic PR, rebased on `dev`, two clean commits.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Harden file-serving endpoints against stored XSS by validating content types against a safe allowlist and adding security headers. Previously, an attacker could upload a file with `Content-Type: text/html` containing malicious scripts, and any authenticated user viewing the file would execute the scripts under the app's origin.

### Added

- `SAFE_INLINE_CONTENT_TYPES` allowlist for content types safe to serve inline (images, PDF, plain text, audio, video)
- `_safe_content_type()` helper that validates and normalizes content types against the allowlist

### Changed

- `GET /{id}/content` now validates content type against allowlist; unsafe types forced to `application/octet-stream` + attachment download
- `GET /{id}/content/html` now includes `Content-Security-Policy: sandbox` header blocking script execution
- `GET /{id}/content/{file_name}` now explicitly sets `media_type=application/octet-stream`
- All three endpoints now include `X-Content-Type-Options: nosniff`

### Deprecated

- N/A

### Removed

- Removed duplicate variable assignments (dead code cleanup)

### Fixed

- **Stored XSS via user-controlled Content-Type**: uploading files with `Content-Type: text/html` no longer results in inline HTML rendering
- **Stored XSS via HTML preview endpoint**: admin-uploaded HTML files can no longer execute scripts when viewed by other users
- **SVG script execution**: SVGs served as direct document responses can no longer execute JavaScript (excluded from inline allowlist)

### Security

- Content-type allowlist prevents browsers from executing uploaded files as HTML/JavaScript
- CSP sandbox on HTML preview endpoint blocks script execution
- `X-Content-Type-Options: nosniff` prevents MIME-sniffing attacks
- MIME parameters stripped before allowlist comparison to prevent bypasses

### Breaking Changes

- SVG files served via `/{id}/content` will now download instead of displaying inline. SVGs loaded via `<img>` tags in the frontend are unaffected since browsers disable scripting in that context.
- Files with exotic content types (e.g. `text/html`, `application/javascript`) will now force-download instead of rendering inline.

---

### Additional Information

- The `/content/html` endpoint is already restricted to files owned by admin-role users (line 724 check), but in multi-admin deployments a compromised admin could target other admins. The CSP sandbox provides defense-in-depth.
- The `users.py` and `channels.py` profile image endpoints also decode data URIs with user-controlled media types — these are out of scope for this PR but could be addressed separately.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.