### PR TITLE
fix: prevent stored XSS via tool_calls details in channel messages

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1,4 +1,5 @@
 import json
+import re
 import logging
 import base64
 import io
@@ -70,6 +71,28 @@ from sqlalchemy.ext.asyncio import AsyncSession
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# Pattern to match <details> blocks whose attributes contain type="tool_calls".
+# Used to strip potentially dangerous tool-call markup from user-authored
+# channel messages (defense-in-depth against stored XSS via the embeds→iframe
+# rendering path).
+_TOOL_CALL_DETAILS_RE = re.compile(
+    r'<details\b[^>]*\btype\s*=\s*["\']tool_calls["\'][^>]*>.*?</details>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def sanitize_channel_message_content(content: str) -> str:
+    """Strip <details type="tool_calls" ...> blocks from channel message content.
+
+    These blocks are only legitimately produced by assistant tool-call responses
+    in the chat pipeline. In channel messages they would be user-authored and
+    could carry a malicious ``embeds`` attribute that the frontend renders
+    inside an ``allow-scripts`` iframe, leading to stored XSS.
+    """
+    return _TOOL_CALL_DETAILS_RE.sub('', content)
+
 
 
 async def channel_has_access(
@@ -1053,6 +1076,7 @@ async def new_message_handler(request: Request, id: str, form_data: MessageForm,
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
 
     try:
+        form_data.content = sanitize_channel_message_content(form_data.content)
         message = await Messages.insert_new_message(form_data, channel.id, user.id, db=db)
         if message:
             if channel.type in ['group', 'dm']:
@@ -1377,6 +1401,7 @@ async def update_message_by_id(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
 
     try:
+        form_data.content = sanitize_channel_message_content(form_data.content)
         await Messages.update_message_by_id(message_id, form_data, db=db)
         message = await Messages.get_message_by_id(message_id, db=db)
 

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -356,6 +356,7 @@
 							<Markdown
 								id={`${message.id}-reply-to`}
 								content={message?.reply_to_message?.content}
+								untrustedSource={true}
 							/>
 						</div>
 					</button>
@@ -527,6 +528,7 @@
 									id={message.id}
 									content={message.content}
 									paragraphTag="span"
+									untrustedSource={true}
 								/>{#if message.created_at !== message.updated_at && (message?.meta?.model_id ?? null) === null}<span
 										class="text-gray-500 text-[10px] pl-1 self-center">({$i18n.t('edited')})</span
 									>{/if}

--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -25,6 +25,8 @@
 	export let editCodeBlock = true;
 	export let topPadding = false;
 
+	export let untrustedSource = false;
+
 	export let sourceIds = [];
 
 	export let onSave = () => {};
@@ -98,6 +100,7 @@
 		{editCodeBlock}
 		{sourceIds}
 		{topPadding}
+		{untrustedSource}
 		{onTaskClick}
 		{onSourceClick}
 		{onSave}

--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -31,6 +31,8 @@
 
 	export let messageDone = true;
 
+	export let untrustedSource = false;
+
 	let open = $settings?.expandDetails ?? false;
 
 	function parseJSONString(str: string) {
@@ -49,8 +51,12 @@
 
 	$: codeInterpreterCount = tokens.filter((t) => t?.attributes?.type === 'code_interpreter').length;
 
-	// Collect all embeds from tool_calls tokens
+	// Collect all embeds from tool_calls tokens.
+	// When rendering untrusted content (e.g. channel messages), skip entirely
+	// to prevent user-authored embeds from reaching the allow-scripts iframe.
 	$: allEmbeds = (() => {
+		if (untrustedSource) return [];
+
 		const result: Array<{ name: string; embed: string; args: string }> = [];
 		for (const t of tokens) {
 			if (t?.attributes?.type !== 'tool_calls') continue;

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -42,6 +42,8 @@
 	export let editCodeBlock = true;
 	export let topPadding = false;
 
+	export let untrustedSource = false;
+
 	export let onSave: Function = () => {};
 	export let onUpdate: Function = () => {};
 	export let onPreview: Function = () => {};
@@ -371,6 +373,7 @@
 			id={`${id}-${tokenIdx}-detail-group`}
 			tokens={token.items}
 			messageDone={done}
+			{untrustedSource}
 		>
 			<div slot="content" class="space-y-1">
 				{#each token.items as detailToken, detailIdx}


### PR DESCRIPTION
Channel messages are user-authored and must never reach the allow-scripts iframe path used for assistant tool-call rendering.

Frontend: thread an untrustedSource flag from channel Message.svelte through Markdown -> MarkdownTokens -> ConsecutiveDetailsGroup. When true, allEmbeds is forced to an empty array, skipping iframe rendering entirely. Assistant chat messages are unaffected (default is false).

Backend (defense-in-depth): strip <details type=tool_calls> blocks from channel message content in new_message_handler and update_message_by_id before persistence.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
