### PR TITLE
Reuse LDAP signup handler and add Feishu env fallbacks

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -623,16 +623,26 @@ FEISHU_CLIENT_SECRET = PersistentConfig(
     os.environ.get('FEISHU_CLIENT_SECRET', ''),
 )
 
+_feishu_oauth_scope = (
+    os.environ.get('FEISHU_SCOPE')
+    or os.environ.get('FEISHU_OAUTH_SCOPE', 'contact:user.base:readonly')
+)
+
 FEISHU_OAUTH_SCOPE = PersistentConfig(
     'FEISHU_OAUTH_SCOPE',
     'oauth.feishu.scope',
-    os.environ.get('FEISHU_OAUTH_SCOPE', 'contact:user.base:readonly'),
+    _feishu_oauth_scope,
+)
+
+_feishu_redirect_uri = (
+    os.environ.get('FEISHU_REDIRECT_URL')
+    or os.environ.get('FEISHU_REDIRECT_URI', '')
 )
 
 FEISHU_REDIRECT_URI = PersistentConfig(
     'FEISHU_REDIRECT_URI',
     'oauth.feishu.redirect_uri',
-    os.environ.get('FEISHU_REDIRECT_URI', ''),
+    _feishu_redirect_uri,
 )
 
 ENABLE_OAUTH_ROLE_MANAGEMENT = PersistentConfig(

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -497,31 +497,13 @@ async def ldap_auth(
             user = await Users.get_user_by_email(email, db=db)
             if not user:
                 try:
-                    # Insert with default role first to avoid TOCTOU race on
-                    # first-user registration.  Matches signup_handler pattern.
-                    user = await Auths.insert_new_auth(
-                        email=email,
-                        password=str(uuid.uuid4()),
-                        name=cn,
-                        role=request.app.state.config.DEFAULT_USER_ROLE,
+                    user = await signup_handler(
+                        request,
+                        email,
+                        str(uuid.uuid4()),
+                        cn,
                         db=db,
                     )
-
-                    if not user:
-                        raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
-
-                    # Atomically check if this is the only user *after* the
-                    # insert.  Only the single user present should become admin.
-                    if await Users.get_num_users(db=db) == 1:
-                        await Users.update_user_role_by_id(user.id, 'admin', db=db)
-                        user = await Users.get_user_by_id(user.id, db=db)
-
-                    await apply_default_group_assignment(
-                        request.app.state.config.DEFAULT_GROUP_ID,
-                        user.id,
-                        db=db,
-                    )
-
                 except HTTPException:
                     raise
                 except Exception as err:


### PR DESCRIPTION
## Summary
- Reuse the shared signup flow in LDAP onboarding so LDAP-created users get webhook dispatching, first-user admin detection, and default-group assignment in a shared path.
- Add backward-compatible fallback support for legacy `FEISHU_SCOPE` and `FEISHU_REDIRECT_URL` environment variables.

## Testing
- Not run (per instruction).
