### PR TITLE
fix: bundle averaged_perceptron_tagger_eng NLTK resource alongside punkt_tab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -158,7 +158,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -11,7 +11,7 @@ if [[ "${WEB_LOADER_ENGINE,,}" == "playwright" ]]; then
         playwright install-deps chromium
     fi
 
-    python -c "import nltk; nltk.download('punkt_tab')"
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 fi
 
 if [ -n "${WEBUI_SECRET_KEY_FILE}" ]; then

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -14,7 +14,7 @@ IF /I "%WEB_LOADER_ENGINE%" == "playwright" (
         playwright install-deps chromium
     )
 
-    python -c "import nltk; nltk.download('punkt_tab')"
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 )
 
 SET "KEY_FILE=.webui_secret_key"


### PR DESCRIPTION
### Why

`unstructured` 0.18.x partitioning for PPTX/Word/etc. requires **two** NLTK resources at runtime — `punkt_tab` and `averaged_perceptron_tagger_eng` — referenced in `unstructured/nlp/tokenize.py`:

```python
nltk.download("averaged_perceptron_tagger_eng", quiet=True)
nltk.download("punkt_tab", quiet=True)
```

Today only `punkt_tab` is pre-downloaded in the image (PR #21165). The first upload of a `.pptx`/`.docx`/`.pps`/etc. file in a freshly built or recreated container hits:

```
LookupError: Resource 'averaged_perceptron_tagger_eng' not found.
```

The exception path doesn't currently transition `data->>'status'` to `failed`, so the file row stays `pending` indefinitely and the SSE stream `/api/v1/files/{id}/process/status?stream=true` keeps spinning — see #24393 for full reproduction.

After running `nltk.download('averaged_perceptron_tagger_eng', download_dir='/root/nltk_data')` once inside the running container, identical files are processed in ~1.5s. So the dependency graph is the same as the punkt_tab fix, just for one more package.

### What

Add `averaged_perceptron_tagger_eng` to the same one-liner that already bundles `punkt_tab`. Mirrors PR #21165 in scope and intent — keeps airgapped/cold-start environments self-sufficient. Three locations:

- `Dockerfile` (CUDA branch + non-CUDA branch)
- `backend/start.sh` (playwright-engine fallback)
- `backend/start_windows.bat` (playwright-engine fallback)

Net diff: +4/-4.

Closes #24393.

### Test plan

- [ ] Build image and confirm `/root/nltk_data/taggers/averaged_perceptron_tagger_eng/` exists post-build.
- [ ] Upload a `.pptx` to a fresh container without internet access — should reach `status='completed'` and produce chunks.
- [ ] Verify `punkt_tab` behaviour from #21165 is unchanged.