### PR TITLE
fix: bundle averaged_perceptron_tagger_eng NLTK resource alongside punkt_tab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -158,7 +158,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -11,7 +11,7 @@ if [[ "${WEB_LOADER_ENGINE,,}" == "playwright" ]]; then
         playwright install-deps chromium
     fi
 
-    python -c "import nltk; nltk.download('punkt_tab')"
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 fi
 
 if [ -n "${WEBUI_SECRET_KEY_FILE}" ]; then

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -14,7 +14,7 @@ IF /I "%WEB_LOADER_ENGINE%" == "playwright" (
         playwright install-deps chromium
     )
 
-    python -c "import nltk; nltk.download('punkt_tab')"
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 )
 
 SET "KEY_FILE=.webui_secret_key"


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Targets `dev`.
- [x] **Description:** Below.
- [x] **Changelog:** Below.
- [ ] **Documentation:** N/A — no user-facing behaviour change; restores parity with PR #21165 for the second NLTK resource the same library already requires.
- [x] **Dependencies:** No new or upgraded dependencies. Same `unstructured==0.18.31` / `nltk==3.9.3` already pinned in `backend/requirements.txt`.
- [x] **Testing:** Reproduced the failure end-to-end on `ghcr.io/open-webui/open-webui:v0.9.2`; confirmed identical PPTX file is processed in ~1.5s once `averaged_perceptron_tagger_eng` is present in `/root/nltk_data/`. See #24393 for the full repro and trace.
- [x] **Agentic AI Code:** Patch was drafted with AI assistance and has gone through human review and manual testing on a real running instance — failure reproduced before the change, disappears with the resource bundled, no other behaviour affected.
- [x] **Code review:** Self-reviewed; the change mirrors PR #21165 line-for-line for the second resource that `unstructured/nlp/tokenize.py` requires.
- [x] **Design & Architecture:** No design change.
- [x] **Git Hygiene:** One atomic commit; rebased on `upstream/dev` after the wrong-base auto-close of #24394 and the missing-CLA close of #24395.
- [x] **Title Prefix:** `fix:`.

# Changelog Entry

### Description

`unstructured` 0.18.x partitioning for PPTX/Word/etc. requires both `punkt_tab` and `averaged_perceptron_tagger_eng` (see `unstructured/nlp/tokenize.py`). PR #21165 pre-downloaded `punkt_tab` only. The first upload of any `unstructured`-handled format in a freshly built/recreated container hits `LookupError: Resource 'averaged_perceptron_tagger_eng' not found.`, the file row stays at `data->>'status'='pending'`, and the `/api/v1/files/{id}/process/status?stream=true` SSE keeps spinning. This PR pre-downloads the second resource alongside `punkt_tab` so cold-start / airgapped images work out of the box.

### Fixed

- Knowledge-base ingestion of `.pptx` / `.docx` (and any other format routed through `unstructured` partitioners) hanging at `status=pending` in fresh containers due to the missing `averaged_perceptron_tagger_eng` NLTK resource.

---

### Additional Information

- Closes #24393.
- Replaces #24394 (auto-closed for targeting `main`) and #24395 (auto-closed for missing CLA section).
- Mirrors PR #21165 in scope; same one-liner pattern in both `Dockerfile` branches and in `backend/start.sh` / `backend/start_windows.bat`. Net diff: +4/-4.
- Repro inside a fresh container:
  ```python
  from langchain_community.document_loaders import UnstructuredPowerPointLoader
  UnstructuredPowerPointLoader('/path/to/file.pptx').load()
  # -> LookupError: Resource 'averaged_perceptron_tagger_eng' not found.
  ```
  After this change, the loader returns the parsed document in ~1.5s without any network access at runtime.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.