### PR TITLE
refac(audio,cache): allowlist audio extensions and harden cache file …

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2776,7 +2776,15 @@ async def serve_cache_file(
         raise HTTPException(status_code=404, detail='File not found')
     if not os.path.isfile(file_path):
         raise HTTPException(status_code=404, detail='File not found')
-    return FileResponse(file_path)
+
+    mime, _ = mimetypes.guess_type(file_path)
+    inline_safe = mime and mime.split('/', 1)[0] in {'image', 'audio', 'video'}
+
+    headers = {'X-Content-Type-Options': 'nosniff'}
+    if not inline_safe:
+        headers['Content-Disposition'] = f'attachment; filename="{os.path.basename(file_path)}"'
+
+    return FileResponse(file_path, headers=headers)
 
 
 def swagger_ui_html(*args, **kwargs):

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1242,7 +1242,14 @@ async def transcription(
 
     try:
         safe_name = os.path.basename(file.filename) if file.filename else ''
-        ext = safe_name.rsplit('.', 1)[-1] if '.' in safe_name else ''
+        ext = safe_name.rsplit('.', 1)[-1].lower() if '.' in safe_name else ''
+
+        allowed_audio_extensions = {'mp3', 'wav', 'm4a', 'webm', 'ogg', 'flac', 'mp4', 'mpga', 'mpeg'}
+        if ext not in allowed_audio_extensions:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Invalid audio file extension',
+            )
 
         id = uuid.uuid4()
 


### PR DESCRIPTION
…serving

Audio transcription upload: validate file extension against a strict allowlist of known audio formats before persisting to disk. Rejects non-audio extensions with HTTP 400.

Cache route: add X-Content-Type-Options: nosniff to all responses. Force Content-Disposition: attachment for file types outside image/audio/video to prevent inline rendering of potentially dangerous content.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
