### PR TITLE
fix: notes is_pinned TypeError on create/get

### DIFF
--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -140,7 +140,7 @@ class NoteTable:
                 }
             )
 
-            new_note = Note(**note.model_dump(exclude={'access_grants'}))
+            new_note = Note(**note.model_dump(exclude={'access_grants', 'is_pinned'}))
 
             db.add(new_note)
             await db.commit()

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -294,7 +294,10 @@ async def get_note_by_id(
     )
 
     pinned_note_ids = await Notes.get_pinned_note_ids(user.id, db=db)
-    return NoteResponse(**note.model_dump(), write_access=write_access, is_pinned=note.id in pinned_note_ids)
+    return NoteResponse(
+        **{**note.model_dump(), 'is_pinned': note.id in pinned_note_ids},
+        write_access=write_access,
+    )
 
 
 ############################


### PR DESCRIPTION
is_pinned exists on the NoteModel pydantic schema but not on the Note SQLAlchemy table (pinning lives in PinnedNote). Two call sites broke after the split:

- models/notes.py: insert_new_note passed model_dump() straight into Note(...), causing 'is_pinned' is an invalid keyword argument for Note.
- routers/notes.py: get_note_by_id passed is_pinned twice to NoteResponse (once via model_dump default, once explicitly), causing got multiple values for keyword argument 'is_pinned'.

Exclude is_pinned from the dump on insert, and override it via dict-spread on the response (matching the pattern already used elsewhere in the same router).

Fixes #24484

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
