### PR TITLE
fix: validate redirect targets during RAG web ingestion

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -174,14 +174,14 @@ def _is_text_content_type(content_type: str) -> bool:
 
 
 def get_content_from_url(request, url: str) -> str:
-    from open_webui.retrieval.web.utils import validate_url
+    from open_webui.retrieval.web.utils import safe_requests_get, validate_url
 
     # Validate URL before making any request (blocks private IPs, non-HTTP, filter list)
     validate_url(url)
 
     # Streamed GET to check Content-Type without downloading the body.
     try:
-        response = requests.get(url, stream=True, timeout=30)
+        response = safe_requests_get(url, stream=True, timeout=30)
         response.raise_for_status()
         content_type = response.headers.get('Content-Type', '')
     except Exception:

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -100,6 +100,41 @@ def validate_url(url: Union[str, Sequence[str]]):
         return False
 
 
+def safe_requests_get(
+    url: str,
+    *,
+    session: requests.Session | None = None,
+    max_redirects: int = 10,
+    **kwargs,
+) -> requests.Response:
+    """Perform a GET request while validating every redirect target.
+
+    validate_url() blocks non-public destinations, but requests follows redirects by
+    default. A public URL can otherwise redirect to localhost/cloud metadata/private
+    infrastructure after the initial validation step.
+    """
+    kwargs.pop('allow_redirects', None)
+    client = session or requests
+    current_url = url
+
+    for _ in range(max_redirects + 1):
+        validate_url(current_url)
+
+        response = client.get(current_url, allow_redirects=False, **kwargs)
+        if not response.is_redirect and not response.is_permanent_redirect:
+            return response
+
+        location = response.headers.get('Location')
+        response.close()
+
+        if not location:
+            raise ValueError(ERROR_MESSAGES.INVALID_URL)
+
+        current_url = urllib.parse.urljoin(response.url, location)
+
+    raise ValueError(ERROR_MESSAGES.INVALID_URL)
+
+
 def safe_validate_urls(url: Sequence[str]) -> Sequence[str]:
     valid_urls = []
     for u in url:
@@ -485,6 +520,20 @@ class SafeWebBaseLoader(WebBaseLoader):
         """
         super().__init__(*args, **kwargs)
         self.trust_env = trust_env
+
+    def _scrape(self, url: str, parser: str | None = None, bs_kwargs: dict | None = None) -> Any:
+        """Synchronously fetch a URL without following unvalidated redirects."""
+        from bs4 import BeautifulSoup
+
+        if parser is None:
+            parser = self.default_parser
+        self._check_parser(parser)
+
+        response = safe_requests_get(url, session=self.session, **self.requests_kwargs)
+        if self.raise_for_status:
+            response.raise_for_status()
+
+        return BeautifulSoup(response.text, parser, **(bs_kwargs or {}))
 
     async def _fetch(self, url: str, retries: int = 3, cooldown: int = 2, backoff: float = 1.5) -> str:
         async with aiohttp.ClientSession(trust_env=self.trust_env) as session:

--- a/backend/open_webui/test/retrieval/web/test_url_validation.py
+++ b/backend/open_webui/test/retrieval/web/test_url_validation.py
@@ -1,0 +1,78 @@
+import pytest
+
+from open_webui.retrieval.web import utils as web_utils
+
+
+class FakeResponse:
+    def __init__(self, url, status_code=200, headers=None):
+        self.url = url
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = 'ok'
+        self.content = b'ok'
+        self.closed = False
+
+    @property
+    def is_redirect(self):
+        return self.status_code in {301, 302, 303, 307, 308}
+
+    @property
+    def is_permanent_redirect(self):
+        return self.status_code in {301, 308}
+
+    def close(self):
+        self.closed = True
+
+    def raise_for_status(self):
+        pass
+
+
+def _mock_public_dns(monkeypatch):
+    def fake_resolve_hostname(hostname):
+        addresses = {
+            'example.com': (['93.184.216.34'], []),
+            'example.org': (['93.184.216.34'], []),
+            '127.0.0.1': (['127.0.0.1'], []),
+            'localhost': (['127.0.0.1'], []),
+        }
+        return addresses[hostname]
+
+    monkeypatch.setattr(web_utils, 'ENABLE_RAG_LOCAL_WEB_FETCH', False)
+    monkeypatch.setattr(web_utils, 'WEB_FETCH_FILTER_LIST', [])
+    monkeypatch.setattr(web_utils, 'resolve_hostname', fake_resolve_hostname)
+
+
+def test_safe_requests_get_blocks_redirect_to_private_network(monkeypatch):
+    _mock_public_dns(monkeypatch)
+    requested_urls = []
+
+    def fake_get(url, **kwargs):
+        requested_urls.append(url)
+        if url == 'https://example.com/start':
+            return FakeResponse(url, 302, {'Location': 'http://127.0.0.1/admin'})
+        raise AssertionError(f'private redirect target was requested: {url}')
+
+    monkeypatch.setattr(web_utils.requests, 'get', fake_get)
+
+    with pytest.raises(ValueError):
+        web_utils.safe_requests_get('https://example.com/start')
+
+    assert requested_urls == ['https://example.com/start']
+
+
+def test_safe_requests_get_allows_public_redirect(monkeypatch):
+    _mock_public_dns(monkeypatch)
+
+    def fake_get(url, **kwargs):
+        if url == 'https://example.com/start':
+            return FakeResponse(url, 302, {'Location': 'https://example.org/final'})
+        if url == 'https://example.org/final':
+            return FakeResponse(url, 200)
+        raise AssertionError(f'unexpected URL requested: {url}')
+
+    monkeypatch.setattr(web_utils.requests, 'get', fake_get)
+
+    response = web_utils.safe_requests_get('https://example.com/start')
+
+    assert response.url == 'https://example.org/final'
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Validate each redirect target during requests-based RAG web URL ingestion instead of only validating the initial URL.
- Route synchronous web-loader and binary-content preflight requests through a safe GET helper.
- Add regression tests covering public URLs that redirect to private network targets.

## Why
Open WebUI already blocks direct private/local URLs when local web fetch is disabled, but requests-based ingestion paths could follow redirects after the initial validation. A public URL could redirect backend ingestion to localhost, private networks, or cloud metadata endpoints.

## Tests
- `PYTHONPATH=backend uv run pytest backend/open_webui/test/retrieval/web/test_url_validation.py -q`
- App smoke test: `/health` and `/ready` returned `200 {"status":true}`