### PR TITLE
fix: validate redirect targets during RAG web ingestion

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -174,14 +174,14 @@ def _is_text_content_type(content_type: str) -> bool:
 
 
 def get_content_from_url(request, url: str) -> str:
-    from open_webui.retrieval.web.utils import validate_url
+    from open_webui.retrieval.web.utils import safe_requests_get, validate_url
 
     # Validate URL before making any request (blocks private IPs, non-HTTP, filter list)
     validate_url(url)
 
     # Streamed GET to check Content-Type without downloading the body.
     try:
-        response = requests.get(url, stream=True, timeout=30)
+        response = safe_requests_get(url, stream=True, timeout=30)
         response.raise_for_status()
         content_type = response.headers.get('Content-Type', '')
     except Exception:

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -100,6 +100,41 @@ def validate_url(url: Union[str, Sequence[str]]):
         return False
 
 
+def safe_requests_get(
+    url: str,
+    *,
+    session: requests.Session | None = None,
+    max_redirects: int = 10,
+    **kwargs,
+) -> requests.Response:
+    """Perform a GET request while validating every redirect target.
+
+    validate_url() blocks non-public destinations, but requests follows redirects by
+    default. A public URL can otherwise redirect to localhost/cloud metadata/private
+    infrastructure after the initial validation step.
+    """
+    kwargs.pop('allow_redirects', None)
+    client = session or requests
+    current_url = url
+
+    for _ in range(max_redirects + 1):
+        validate_url(current_url)
+
+        response = client.get(current_url, allow_redirects=False, **kwargs)
+        if not response.is_redirect and not response.is_permanent_redirect:
+            return response
+
+        location = response.headers.get('Location')
+        response.close()
+
+        if not location:
+            raise ValueError(ERROR_MESSAGES.INVALID_URL)
+
+        current_url = urllib.parse.urljoin(response.url, location)
+
+    raise ValueError(ERROR_MESSAGES.INVALID_URL)
+
+
 def safe_validate_urls(url: Sequence[str]) -> Sequence[str]:
     valid_urls = []
     for u in url:
@@ -485,6 +520,20 @@ class SafeWebBaseLoader(WebBaseLoader):
         """
         super().__init__(*args, **kwargs)
         self.trust_env = trust_env
+
+    def _scrape(self, url: str, parser: str | None = None, bs_kwargs: dict | None = None) -> Any:
+        """Synchronously fetch a URL without following unvalidated redirects."""
+        from bs4 import BeautifulSoup
+
+        if parser is None:
+            parser = self.default_parser
+        self._check_parser(parser)
+
+        response = safe_requests_get(url, session=self.session, **self.requests_kwargs)
+        if self.raise_for_status:
+            response.raise_for_status()
+
+        return BeautifulSoup(response.text, parser, **(bs_kwargs or {}))
 
     async def _fetch(self, url: str, retries: int = 3, cooldown: int = 2, backoff: float = 1.5) -> str:
         async with aiohttp.ClientSession(trust_env=self.trust_env) as session:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** No user-facing behavior, environment variables, public APIs/interfaces, or deployment steps are changed.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manual validation was performed. No test files are included.
- [x] **Agentic AI Code:** This pull request has gone through additional human review and manual testing.
- [x] **Code review:** I performed a self-review of the code and kept the change atomic.
- [x] **Design & Architecture:** This uses existing URL validation behavior and avoids adding new settings.
- [x] **Git Hygiene:** This PR contains one logical change and is based on `dev`.
- [x] **Title Prefix:** The title uses the `fix` prefix.

# Changelog Entry

### Description

- Validates redirect targets during requests-based RAG web URL ingestion, preventing a public URL from redirecting backend ingestion to private/local network resources after the initial URL validation.

### Added

- None.

### Changed

- Requests-based web ingestion now follows redirects manually through a safe helper that validates each redirect destination.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed requests-based RAG URL ingestion paths following redirects without validating each redirect destination.

### Security

- Prevents public URLs from redirecting backend web ingestion to localhost, private networks, or cloud metadata endpoints when local web fetch is disabled.

### Breaking Changes

- None.

---

### Additional Information

Manual validation performed:
- Verified requests-based redirect handling rejects public-to-private redirect targets.
- Verified public-to-public redirect handling continues to work.
- App smoke checks passed:
  - `/health` returned `200 {"status": true}`
  - `/ready` returned `200 {"status": true}`

No test files are included.

### Screenshots or Videos

- Not applicable; backend security fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.