### PR TITLE
fix: gate public sharing of skills behind sharing.public_skills on create/update

### DIFF
--- a/backend/open_webui/routers/skills.py
+++ b/backend/open_webui/routers/skills.py
@@ -176,6 +176,19 @@ async def create_new_skill(
             detail=ERROR_MESSAGES.ID_TAKEN,
         )
 
+    # Strip public/user grants the requesting user is not permitted to assign
+    # (matches the channel/notes/calendar pattern). Without this, a user with
+    # workspace.skills permission could attach principal_id='*' read/write
+    # grants in the create payload, bypassing the sharing.public_skills gate
+    # that the dedicated /access/update endpoint already enforces.
+    form_data.access_grants = await filter_allowed_access_grants(
+        request.app.state.config.USER_PERMISSIONS,
+        user.id,
+        user.role,
+        form_data.access_grants,
+        'sharing.public_skills',
+    )
+
     try:
         skill = await Skills.insert_new_skill(user.id, form_data, db=db)
         if skill:
@@ -275,6 +288,19 @@ async def update_skill_by_id(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
+
+    # Strip public/user grants the requesting user is not permitted to assign
+    # (matches the channel/notes/calendar pattern). The access check above only
+    # restricts WHO can write to the skill; this filter restricts WHICH grants
+    # they may set, so a non-admin owner cannot make their own skill publicly
+    # readable/writable without sharing.public_skills permission.
+    form_data.access_grants = await filter_allowed_access_grants(
+        request.app.state.config.USER_PERMISSIONS,
+        user.id,
+        user.role,
+        form_data.access_grants,
+        'sharing.public_skills',
+    )
 
     try:
         updated = {


### PR DESCRIPTION
The /create (L155-193) and /id/{id}/update (L248-297) endpoints in routers/skills.py persisted form_data.access_grants directly to AccessGrants.set_access_grants without filter_allowed_access_grants, while every other shareable resource in the codebase (channels, knowledge, models, notes, prompts, tools, calendars) and the dedicated /id/{id}/access/update endpoint on this same router (L309-348) all do call the filter. A user with workspace.skills permission (default False, but admins can grant it to skill-creating users) could therefore attach {"principal_type":"user","principal_id":"*","permission":"read"|"write"} to the create or update payload and have it persisted unfiltered, bypassing the sharing.public_skills gate that the rest of the cohort enforces.

Two changes:

- create_new_skill: call filter_allowed_access_grants with 'sharing.public_skills' immediately before insert, after the existing permission check and ID-taken check.
- update_skill_by_id: call filter_allowed_access_grants with the same key after the access check, before form_data.model_dump() flows into Skills.update_skill_by_id. The pre-existing access check at L263-277 only restricts WHO may modify the skill; the new filter restricts WHICH grants they may set.

All supporting plumbing was already in place from prior PRs: filter_allowed_access_grants is already imported at L22, the USER_PERMISSIONS_WORKSPACE_SKILLS_ALLOW_PUBLIC_SHARING constant exists, DEFAULT_USER_PERMISSIONS['sharing']['public_skills'] is wired up, SharingPermissions.public_skills is in the Pydantic, and the admin UI already renders the toggle. This is a pure 2-line router fix that closes the cohort-consistency gap.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
