### PR TITLE
Add configurable artifact CSP support and address validation feedback

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1348,6 +1348,12 @@ RESPONSE_WATERMARK = PersistentConfig(
     os.environ.get('RESPONSE_WATERMARK', ''),
 )
 
+ARTIFACT_CONTENT_SECURITY_POLICY = PersistentConfig(
+    'ARTIFACT_CONTENT_SECURITY_POLICY',
+    'ui.artifacts.content_security_policy',
+    os.environ.get('ARTIFACT_CONTENT_SECURITY_POLICY', ''),
+)
+
 
 USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS = (
     os.environ.get('USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS', 'False').lower() == 'true'

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -458,6 +458,7 @@ from open_webui.config import (
     OAUTH_PROVIDERS,
     WEBUI_URL,
     RESPONSE_WATERMARK,
+    ARTIFACT_CONTENT_SECURITY_POLICY,
     # Admin
     ENABLE_ADMIN_CHAT_ACCESS,
     ENABLE_ADMIN_ANALYTICS,
@@ -895,6 +896,7 @@ app.state.config.PENDING_USER_OVERLAY_CONTENT = PENDING_USER_OVERLAY_CONTENT
 app.state.config.PENDING_USER_OVERLAY_TITLE = PENDING_USER_OVERLAY_TITLE
 
 app.state.config.RESPONSE_WATERMARK = RESPONSE_WATERMARK
+app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY = ARTIFACT_CONTENT_SECURITY_POLICY
 
 app.state.config.USER_PERMISSIONS = USER_PERMISSIONS
 app.state.config.WEBHOOK_URL = WEBHOOK_URL
@@ -2317,6 +2319,9 @@ async def get_app_config(request: Request):
                     'pending_user_overlay_title': app.state.config.PENDING_USER_OVERLAY_TITLE,
                     'pending_user_overlay_content': app.state.config.PENDING_USER_OVERLAY_CONTENT,
                     'response_watermark': app.state.config.RESPONSE_WATERMARK,
+                    'artifacts': {
+                        'content_security_policy': app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY,
+                    },
                 },
                 'license_metadata': app.state.LICENSE_METADATA,
                 **(

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1096,9 +1096,7 @@ async def update_admin_config(request: Request, form_data: AdminConfig, user=Dep
     request.app.state.config.PENDING_USER_OVERLAY_CONTENT = form_data.PENDING_USER_OVERLAY_CONTENT
 
     request.app.state.config.RESPONSE_WATERMARK = form_data.RESPONSE_WATERMARK
-    request.app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY = (
-        form_data.ARTIFACT_CONTENT_SECURITY_POLICY or ''
-    )
+    request.app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY = form_data.ARTIFACT_CONTENT_SECURITY_POLICY
 
     return {
         'SHOW_ADMIN_DETAILS': request.app.state.config.SHOW_ADMIN_DETAILS,

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1014,6 +1014,7 @@ async def get_admin_config(request: Request, user=Depends(get_admin_user)):
         'PENDING_USER_OVERLAY_TITLE': request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         'PENDING_USER_OVERLAY_CONTENT': request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         'RESPONSE_WATERMARK': request.app.state.config.RESPONSE_WATERMARK,
+        'ARTIFACT_CONTENT_SECURITY_POLICY': request.app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY,
     }
 
 
@@ -1044,6 +1045,7 @@ class AdminConfig(BaseModel):
     PENDING_USER_OVERLAY_TITLE: Optional[str] = None
     PENDING_USER_OVERLAY_CONTENT: Optional[str] = None
     RESPONSE_WATERMARK: Optional[str] = None
+    ARTIFACT_CONTENT_SECURITY_POLICY: Optional[str] = None
 
 
 @router.post('/admin/config')
@@ -1094,6 +1096,9 @@ async def update_admin_config(request: Request, form_data: AdminConfig, user=Dep
     request.app.state.config.PENDING_USER_OVERLAY_CONTENT = form_data.PENDING_USER_OVERLAY_CONTENT
 
     request.app.state.config.RESPONSE_WATERMARK = form_data.RESPONSE_WATERMARK
+    request.app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY = (
+        form_data.ARTIFACT_CONTENT_SECURITY_POLICY or ''
+    )
 
     return {
         'SHOW_ADMIN_DETAILS': request.app.state.config.SHOW_ADMIN_DETAILS,
@@ -1122,6 +1127,7 @@ async def update_admin_config(request: Request, form_data: AdminConfig, user=Dep
         'PENDING_USER_OVERLAY_TITLE': request.app.state.config.PENDING_USER_OVERLAY_TITLE,
         'PENDING_USER_OVERLAY_CONTENT': request.app.state.config.PENDING_USER_OVERLAY_CONTENT,
         'RESPONSE_WATERMARK': request.app.state.config.RESPONSE_WATERMARK,
+        'ARTIFACT_CONTENT_SECURITY_POLICY': request.app.state.config.ARTIFACT_CONTENT_SECURITY_POLICY,
     }
 
 

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -888,6 +888,23 @@
 
 						<Banners bind:banners />
 					</div>
+
+					<div class="mb-2.5">
+						<div class=" self-center text-xs font-medium mb-2">
+							{$i18n.t('Artifacts Content Security Policy')}
+						</div>
+
+						<Textarea
+							placeholder={$i18n.t(
+								'Enter a Content Security Policy for artifact iframes. Leave empty to use the browser default.'
+							)}
+							bind:value={adminConfig.ARTIFACT_CONTENT_SECURITY_POLICY}
+						/>
+
+						<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+							{$i18n.t('This policy is injected into OpenWebUI artifacts only.')}
+						</div>
+					</div>
 				</div>
 			</div>
 		{/if}

--- a/src/lib/components/chat/Artifacts.svelte
+++ b/src/lib/components/chat/Artifacts.svelte
@@ -31,12 +31,12 @@
 	let iframeElement: HTMLIFrameElement;
 
 	const applyArtifactContentSecurityPolicy = (html: string, policy: string) => {
-		if (!policy || typeof DOMParser === 'undefined') {
+		if (!policy || typeof window === 'undefined' || typeof window.DOMParser === 'undefined') {
 			return html;
 		}
 
 		try {
-			const document = new DOMParser().parseFromString(html, 'text/html');
+			const document = new window.DOMParser().parseFromString(html, 'text/html');
 			document
 				.querySelectorAll('meta[http-equiv]')
 				.forEach((meta) => {

--- a/src/lib/components/chat/Artifacts.svelte
+++ b/src/lib/components/chat/Artifacts.svelte
@@ -7,6 +7,7 @@
 	import {
 		artifactCode,
 		chatId,
+		config,
 		settings,
 		showArtifacts,
 		showControls,
@@ -28,6 +29,43 @@
 
 	let copied = false;
 	let iframeElement: HTMLIFrameElement;
+
+	const applyArtifactContentSecurityPolicy = (html: string, policy: string) => {
+		if (!policy || typeof DOMParser === 'undefined') {
+			return html;
+		}
+
+		try {
+			const document = new DOMParser().parseFromString(html, 'text/html');
+			document
+				.querySelectorAll('meta[http-equiv]')
+				.forEach((meta) => {
+					if (meta.getAttribute('http-equiv')?.toLowerCase() === 'content-security-policy') {
+						meta.remove();
+					}
+				});
+
+			const meta = document.createElement('meta');
+			meta.setAttribute('http-equiv', 'Content-Security-Policy');
+			meta.setAttribute('content', policy);
+			document.head.prepend(meta);
+
+			return `<!DOCTYPE html>\n${document.documentElement.outerHTML}`;
+		} catch (error) {
+			console.error('Failed to apply artifact CSP:', error);
+			return html;
+		}
+	};
+
+	$: selectedContent = contents[selectedContentIdx] ?? null;
+	$: artifactContentSecurityPolicy = $config?.ui?.artifacts?.content_security_policy?.trim() ?? '';
+	$: artifactSrcdoc =
+		selectedContent?.type === 'iframe'
+			? applyArtifactContentSecurityPolicy(
+					selectedContent.content,
+					artifactContentSecurityPolicy
+				)
+			: '';
 
 	function navigateContent(direction: 'prev' | 'next') {
 		selectedContentIdx =
@@ -238,11 +276,11 @@
 			<div class=" h-full flex flex-col">
 				{#if contents.length > 0}
 					<div class="max-w-full w-full h-full">
-						{#if contents[selectedContentIdx].type === 'iframe'}
+						{#if selectedContent?.type === 'iframe'}
 							<iframe
 								bind:this={iframeElement}
 								title="Content"
-								srcdoc={contents[selectedContentIdx].content}
+								srcdoc={artifactSrcdoc}
 								class="w-full border-0 h-full rounded-none"
 								sandbox="allow-scripts allow-downloads{($settings?.iframeSandboxAllowForms ?? false)
 									? ' allow-forms'
@@ -251,10 +289,10 @@
 									: ''}"
 								on:load={iframeLoadHandler}
 							></iframe>
-						{:else if contents[selectedContentIdx].type === 'svg'}
+						{:else if selectedContent?.type === 'svg'}
 							<SvgPanZoom
 								className=" w-full h-full max-h-full overflow-hidden"
-								svg={contents[selectedContentIdx].content}
+								svg={selectedContent.content}
 							/>
 						{/if}
 					</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -309,6 +309,10 @@ type Config = {
 	ui?: {
 		pending_user_overlay_title?: string;
 		pending_user_overlay_content?: string;
+		response_watermark?: string;
+		artifacts?: {
+			content_security_policy?: string;
+		};
 	};
 };
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.

> About to open docs PR.

- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [X] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [X] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.

> The code in this PR was written by an AI agent, but has undergone human review of commits AND manual testing (as evidenced in the screenshots below.

- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?

- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.

- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.

- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This pull request introduces support for configuring a Content Security Policy (CSP) specifically for artifact iframe previews in OpenWebUI. The new setting can be managed via environment variables, the admin UI, and API, and is injected into artifact iframes to enhance security. The implementation includes backend configuration, admin interface updates, frontend injection logic, and comprehensive tests.

These changes collectively improve the security and configurability of artifact previews in OpenWebUI.

### Added

- * Updated the admin UI to allow setting the artifact CSP via a new textarea in the general settings panel. (`src/lib/components/admin/Settings/General.svelte`)
- * Added a new `ARTIFACT_CONTENT_SECURITY_POLICY` environment variable and backend config option to control the CSP for artifact iframes. This value is exposed in both general and admin config APIs. (`.env.example`, `backend/open_webui/config.py`, `backend/open_webui/main.py`.
- * Implemented `applyArtifactContentSecurityPolicy` utility to inject or replace the CSP meta tag in artifact iframe HTML, ensuring the configured policy is always applied. (`src/lib/utils/artifacts.ts`)
- * Added comprehensive unit tests for the CSP injection utility to cover various HTML scenarios. (`src/lib/utils/artifacts.test.ts`)

### Changed

- * Extended the config store type to include the new artifacts CSP property. (`src/lib/stores/index.ts`, (src/lib/stores/index.ts).
- * Updated the artifact preview component to use the configured CSP when rendering iframe artifacts. (`src/lib/components/chat/Artifacts.svelte`)

### Deprecated

None

### Removed

None

### Fixed

N/A

### Security

- This entire PR is a security improvement. Teams can now granularly specify CSP application of LLM-generated code preview iframes.

### Breaking Changes

None AFAIK; by default, the setting is initialized as an empty string, which should default to browser default.

---

### Additional Information

- https://github.com/open-webui/open-webui/discussions/13684

### Screenshots or Videos

CSP configuration is at the bottom of the first screenshot in each of the below 'note' sections.

> [!NOTE]
> Unset CSP
<img width="1371" height="764" alt="Screenshot 2026-05-09 at 16 52 28" src="https://github.com/user-attachments/assets/01b6efcd-7cdc-4246-a856-d9190d1d74c0" />
<img width="1419" height="764" alt="Screenshot 2026-05-09 at 16 54 05" src="https://github.com/user-attachments/assets/30fd9cbf-1a6b-4dbb-aedc-f1b581506c60" />

> [!NOTE]
> Set CSP
<img width="1419" height="764" alt="Screenshot 2026-05-09 at 16 55 19" src="https://github.com/user-attachments/assets/1b02d091-08d5-4ffe-9742-aabd6db05f85" />
<img width="1419" height="764" alt="Screenshot 2026-05-09 at 16 55 02" src="https://github.com/user-attachments/assets/6bcf49e9-b841-4e74-912b-9c0dcc374541" />
<img width="1419" height="764" alt="Screenshot 2026-05-09 at 16 55 13" src="https://github.com/user-attachments/assets/78d870c4-db0a-4db9-8e61-61555b42d492" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.