### PR TITLE
fix: enforce message ownership in group/DM channel update + delete endpoints

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1368,11 +1368,7 @@ async def update_message_by_id(
     if channel.type in ['group', 'dm']:
         if not await Channels.is_user_channel_member(channel.id, user.id, db=db):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
-        # Channel membership alone does not authorize editing another member's
-        # message — without this check, any group/DM member could overwrite
-        # another member's message content while the server preserves the
-        # original `user_id`, producing tampered content that renders to other
-        # members as the original author's authentic post.
+        # Membership is not authorship — block cross-member edits.
         if user.role != 'admin' and message.user_id != user.id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
     else:
@@ -1576,10 +1572,7 @@ async def delete_message_by_id(
     if channel.type in ['group', 'dm']:
         if not await Channels.is_user_channel_member(channel.id, user.id, db=db):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
-        # Channel membership alone does not authorize deleting another member's
-        # message — without this check, any group/DM member could silently
-        # delete another member's messages, removing them from conversation
-        # history without trace.
+        # Membership is not authorship — block cross-member deletes.
         if user.role != 'admin' and message.user_id != user.id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
     else:

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1368,6 +1368,13 @@ async def update_message_by_id(
     if channel.type in ['group', 'dm']:
         if not await Channels.is_user_channel_member(channel.id, user.id, db=db):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
+        # Channel membership alone does not authorize editing another member's
+        # message — without this check, any group/DM member could overwrite
+        # another member's message content while the server preserves the
+        # original `user_id`, producing tampered content that renders to other
+        # members as the original author's authentic post.
+        if user.role != 'admin' and message.user_id != user.id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
     else:
         if (
             user.role != 'admin'
@@ -1568,6 +1575,12 @@ async def delete_message_by_id(
 
     if channel.type in ['group', 'dm']:
         if not await Channels.is_user_channel_member(channel.id, user.id, db=db):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
+        # Channel membership alone does not authorize deleting another member's
+        # message — without this check, any group/DM member could silently
+        # delete another member's messages, removing them from conversation
+        # history without trace.
+        if user.role != 'admin' and message.user_id != user.id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
     else:
         if (


### PR DESCRIPTION
`update_message_by_id` (channels.py:1348) and `delete_message_by_id` (channels.py:1550) branch on `channel.type`. The `else` branch (standard channels) correctly enforces `message.user_id != user.id` ownership before mutating, but the `if channel.type in ['group', 'dm']` branch only checked `is_user_channel_member` — channel membership alone, with no message ownership verification.

Effect on group/DM channels: any verified member of the conversation could:

- overwrite another member's message content while the server preserved `user_id=victim`, producing tampered content that renders to other members as the original author's authentic post (integrity + authenticity);
- silently delete another member's messages, removing them from conversation history without trace (integrity).

Reproduced end-to-end against v0.9.4 with three users (attacker, victim, viewer) sharing a group channel: attacker overwrites victim's message and deletes another, viewer reads the tampered content as victim-authored.

Two patches, identical shape, mirror the `else` branch's existing ownership semantics:

- `update_message_by_id` group/DM branch: add `if user.role != 'admin' and message.user_id != user.id: raise 403` immediately after the `is_user_channel_member` check.
- `delete_message_by_id` group/DM branch: same.

The standard-channel branch is unchanged (it already enforced ownership). Admins remain able to moderate any message, matching the existing semantic in the standard-channel branch.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
