### PR TITLE
fix: prevent mass-assignment user_id spoofing in POST /api/v1/evaluations/feedback

### DIFF
--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -103,7 +103,14 @@ class FeedbackForm(BaseModel):
     data: Optional[RatingData] = None
     meta: Optional[dict] = None
     snapshot: Optional[SnapshotData] = None
-    model_config = ConfigDict(extra='allow')
+    # extra='ignore' — the form is the public input boundary for
+    # POST /api/v1/evaluations/feedback. Allowing arbitrary extra fields
+    # lets a caller smuggle attributes like `user_id`, `id`, or `version`
+    # into the form payload, which combined with a dict-merge order issue
+    # in insert_new_feedback below could overwrite server-set columns.
+    # Sub-models (RatingData / MetaData / SnapshotData) keep extra='allow'
+    # because their contents are deliberately schema-flexible.
+    model_config = ConfigDict(extra='ignore')
 
 
 class UserResponse(BaseModel):
@@ -145,12 +152,16 @@ class FeedbackTable:
     ) -> Optional[FeedbackModel]:
         async with get_async_db_context(db) as db:
             id = str(uuid.uuid4())
+            # Spread form_data first, then overlay server-controlled fields so
+            # that any client-supplied id / user_id / version / timestamps
+            # cannot win on duplicate keys. Defense-in-depth alongside the
+            # extra='ignore' on FeedbackForm above.
             feedback = FeedbackModel(
                 **{
+                    **form_data.model_dump(),
                     'id': id,
                     'user_id': user_id,
                     'version': 0,
-                    **form_data.model_dump(),
                     'created_at': int(time.time()),
                     'updated_at': int(time.time()),
                 }

--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -103,13 +103,7 @@ class FeedbackForm(BaseModel):
     data: Optional[RatingData] = None
     meta: Optional[dict] = None
     snapshot: Optional[SnapshotData] = None
-    # extra='ignore' — the form is the public input boundary for
-    # POST /api/v1/evaluations/feedback. Allowing arbitrary extra fields
-    # lets a caller smuggle attributes like `user_id`, `id`, or `version`
-    # into the form payload, which combined with a dict-merge order issue
-    # in insert_new_feedback below could overwrite server-set columns.
-    # Sub-models (RatingData / MetaData / SnapshotData) keep extra='allow'
-    # because their contents are deliberately schema-flexible.
+    # ignore: drop client-supplied id/user_id/version/timestamps at parse time.
     model_config = ConfigDict(extra='ignore')
 
 
@@ -152,10 +146,7 @@ class FeedbackTable:
     ) -> Optional[FeedbackModel]:
         async with get_async_db_context(db) as db:
             id = str(uuid.uuid4())
-            # Spread form_data first, then overlay server-controlled fields so
-            # that any client-supplied id / user_id / version / timestamps
-            # cannot win on duplicate keys. Defense-in-depth alongside the
-            # extra='ignore' on FeedbackForm above.
+            # Spread form_data first so server-controlled fields win on duplicate keys.
             feedback = FeedbackModel(
                 **{
                     **form_data.model_dump(),


### PR DESCRIPTION
Two independent gaps in backend/open_webui/models/feedbacks.py let an authenticated caller forge the `user_id` (and `id`, `version`) on a new feedback record submitted to POST /api/v1/evaluations/feedback:

1. `FeedbackForm` declared `model_config = ConfigDict(extra='allow')`, so Pydantic preserved any extra fields supplied in the request body — including `user_id`, `id`, `version`. The form is the public input boundary for the endpoint and should not accept unknown fields.

2. In `insert_new_feedback`, the dict literal placed `**form_data.model_dump()` AFTER `'id': id`, `'user_id': user_id`, `'version': 0`. Python dict-literal duplicate-key resolution is last-wins, so any of those fields present in `form_data` overwrote the server-derived values.

Combined effect: a regular user could POST a feedback record with an arbitrary `user_id`, attributing the rating to any other user. The Elo leaderboard at backend/open_webui/routers/evaluations.py computes model rankings from these records, and the admin export
(GET /api/v1/evaluations/feedbacks/export) and admin list (GET /api/v1/evaluations/feedbacks/all) display the spoofed attribution.

Two fixes, defense-in-depth:

- FeedbackForm: switch `extra='allow'` to `extra='ignore'` so Pydantic drops unknown fields at parse time. Sub-models (RatingData / MetaData / SnapshotData) intentionally keep `extra='allow'` because their contents are deliberately schema-flexible — the spoofing surface was the form, not the sub-payloads.

- insert_new_feedback: spread `form_data.model_dump()` first, then overlay server-controlled fields (`id`, `user_id`, `version`, `created_at`, `updated_at`) so the explicit keys win on duplicate-key resolution regardless of what reaches the function. Matches the secure pattern already used in backend/open_webui/models/functions.py:120.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
