### PR TITLE
fix: gate tool content updates behind workspace.tools to match create endpoint

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -480,15 +480,7 @@ async def update_tools_by_id(
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
 
-    # If the tool's executable Python content is being changed, the caller must
-    # additionally hold the same `workspace.tools` (or `workspace.tools_import`)
-    # permission required by the create endpoint. Without this, a write access
-    # grant on a single tool — which is intended as a metadata-collaboration
-    # primitive — would silently extend to code-execution rights, because
-    # `load_tool_module_by_id` below runs `exec(content)` at module-import time.
-    # Metadata-only edits (name, description, valves config, access grants)
-    # remain available to write-grant collaborators without the workspace
-    # permission.
+    # Content edits trigger exec on load — gate them behind workspace.tools (matches /create).
     if form_data.content != tools.content:
         if user.role != 'admin' and not (
             await has_permission(user.id, 'workspace.tools', request.app.state.config.USER_PERMISSIONS, db=db)

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -480,6 +480,27 @@ async def update_tools_by_id(
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
 
+    # If the tool's executable Python content is being changed, the caller must
+    # additionally hold the same `workspace.tools` (or `workspace.tools_import`)
+    # permission required by the create endpoint. Without this, a write access
+    # grant on a single tool — which is intended as a metadata-collaboration
+    # primitive — would silently extend to code-execution rights, because
+    # `load_tool_module_by_id` below runs `exec(content)` at module-import time.
+    # Metadata-only edits (name, description, valves config, access grants)
+    # remain available to write-grant collaborators without the workspace
+    # permission.
+    if form_data.content != tools.content:
+        if user.role != 'admin' and not (
+            await has_permission(user.id, 'workspace.tools', request.app.state.config.USER_PERMISSIONS, db=db)
+            or await has_permission(
+                user.id, 'workspace.tools_import', request.app.state.config.USER_PERMISSIONS, db=db
+            )
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=ERROR_MESSAGES.UNAUTHORIZED,
+            )
+
     try:
         form_data.content = replace_imports(form_data.content)
         tool_module, frontmatter = await load_tool_module_by_id(id, content=form_data.content)


### PR DESCRIPTION
`update_tools_by_id` (routers/tools.py:452) authorizes a caller as long as they are the tool's owner, hold a `write` access grant on the tool, or are an admin. This means a verified user who has been given a write grant on a tool — typically as part of a metadata-collaboration workflow (edit description, adjust valves, manage access grants) — can also overwrite the tool's Python source. Because `load_tool_module_by_id` further down calls `exec(content, module.__dict__)` at module-import time, anything the new content puts outside the `class Tools:` body executes immediately on the server with the worker's privileges (root in the default Docker deployment).

The `create_new_tools` endpoint already requires
`workspace.tools` (or `workspace.tools_import`) precisely because creating a tool means submitting executable code. The update endpoint did not mirror that check, producing an asymmetric authorization surface in which a write-grantee with no workspace permission can still reach the same exec sink as a workspace.tools-trusted creator. SECURITY.md frames `workspace.tools` as the trust signal an admin uses to delegate code-execution capability; the previous behavior let that signal be bypassed by a per-resource share.

Fix: after the existing ownership / write-grant / admin gate, add a content-change check. If `form_data.content != tools.content`, require `workspace.tools` or `workspace.tools_import` (or admin role). Metadata edits — `name`, `description`, valves config, access grants — continue to flow through the existing gate, so the legitimate share-for- collaboration workflow is unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
