### PR TITLE
chore: add validate_url() to get_image_data() for cohort consistency hardening

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -442,16 +442,7 @@ GenerateImageForm = CreateImageForm  # Alias for backward compatibility
 async def get_image_data(data: str, headers=None):
     try:
         if data.startswith('http://') or data.startswith('https://'):
-            # Defense-in-depth: validate the URL before fetching, mirroring the
-            # check on the sibling load_url_image() path. The URL here normally
-            # comes from the admin-configured image generation API response, so
-            # an exploitable SSRF additionally requires either a misconfigured
-            # / untrusted upstream image API or a custom OpenAI-compatible
-            # server that reflects user-supplied input into response URLs —
-            # both admin-side concerns. This validate_url() call closes the
-            # consistency gap so any future code path that begins to call
-            # get_image_data() with caller-influenced input is gated by the
-            # same private-IP / loopback / metadata-IP filter.
+            # Defense-in-depth: gate before fetch (mirrors load_url_image).
             validate_url(data)
             session = await get_session()
             async with session.get(

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -442,6 +442,17 @@ GenerateImageForm = CreateImageForm  # Alias for backward compatibility
 async def get_image_data(data: str, headers=None):
     try:
         if data.startswith('http://') or data.startswith('https://'):
+            # Defense-in-depth: validate the URL before fetching, mirroring the
+            # check on the sibling load_url_image() path. The URL here normally
+            # comes from the admin-configured image generation API response, so
+            # an exploitable SSRF additionally requires either a misconfigured
+            # / untrusted upstream image API or a custom OpenAI-compatible
+            # server that reflects user-supplied input into response URLs —
+            # both admin-side concerns. This validate_url() call closes the
+            # consistency gap so any future code path that begins to call
+            # get_image_data() with caller-influenced input is gated by the
+            # same private-IP / loopback / metadata-IP filter.
+            validate_url(data)
             session = await get_session()
             async with session.get(
                 data,


### PR DESCRIPTION
`get_image_data()` in `backend/open_webui/routers/images.py` fetches the URL returned by the configured image generation API directly via `session.get(data)` without first calling `validate_url()`. The sibling `load_url_image()` in the same file (called from /images/edit) calls `validate_url(data)` first — that gate was added under GHSA-jgx9-jr5x-mvpv. The two functions handle structurally identical input (an attacker-or-server-supplied URL string) and should enforce the same SSRF gate as a matter of code hygiene.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
