### PR TITLE
fix: sandbox terminal proxy responses to prevent cross-user XSS via uploaded HTML

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -27,6 +27,15 @@ router = APIRouter()
 STREAMING_CONTENT_TYPES = ('application/octet-stream', 'image/', 'application/pdf')
 STRIPPED_RESPONSE_HEADERS = frozenset(('transfer-encoding', 'connection', 'content-encoding', 'content-length'))
 
+# Sandbox proxied responses into an opaque origin so a terminal-trusted user
+# cannot serve HTML+JS that reads another user's open-webui session storage.
+PROXY_SANDBOX_HEADERS = {
+    'Content-Security-Policy': "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; script-src 'none'",
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+    'X-Frame-Options': 'DENY',
+}
+
 
 def _sanitize_proxy_path(path: str) -> str | None:
     """Sanitize a proxy path to prevent directory traversal / SSRF.
@@ -151,6 +160,8 @@ async def proxy_terminal(
             for key, value in upstream_response.headers.items()
             if key.lower() not in STRIPPED_RESPONSE_HEADERS
         }
+        # Overlay sandbox headers — drop any same-named upstream values.
+        filtered_headers.update(PROXY_SANDBOX_HEADERS)
 
         # Stream binary responses directly
         if any(t in upstream_content_type for t in STREAMING_CONTENT_TYPES):


### PR DESCRIPTION
Terminal proxy at /api/v1/terminals/{server_id}/{path:path} forwarded the upstream Content-Type verbatim with no Content-Security-Policy or X-Content-Type-Options. A terminal-trusted user could host an HTML file on a port reachable through the proxy; another user with access to the same terminal server who opened the proxy URL would render that HTML under open-webui's same origin and a `<script>` payload could read `localStorage.token` for full session theft → ATO.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
