### PR TITLE
fix: prevent redirect-based SSRF and enforce collecton write access

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1567,6 +1567,8 @@ async def process_file(
 
             if collection_name is None:
                 collection_name = f'file-{file.id}'
+            else:
+                await _validate_collection_access([collection_name], user, access_type='write')
 
             if form_data.content:
                 # Update the content in the file

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2619,6 +2619,9 @@ async def process_files_batch(
 
     collection_name = form_data.collection_name
 
+    if collection_name:
+        await _validate_collection_access([collection_name], user, access_type='write')
+
     file_results: List[BatchProcessFilesResult] = []
     file_errors: List[BatchProcessFilesResult] = []
     file_updates: List[FileUpdateForm] = []

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -26,7 +26,11 @@ import base64
 import io
 import re
 
-from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, ENABLE_IMAGE_CONTENT_TYPE_EXTENSION_FALLBACK
+from open_webui.env import (
+    AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+    AIOHTTP_CLIENT_SESSION_SSL,
+    ENABLE_IMAGE_CONTENT_TYPE_EXTENSION_FALLBACK,
+)
 from open_webui.utils.session_pool import get_session
 
 BASE64_IMAGE_URL_PREFIX = re.compile(r'data:image/\w+;base64,', re.IGNORECASE)
@@ -53,11 +57,17 @@ _IMAGE_MIME_FALLBACK = {
 async def get_image_base64_from_url(url: str) -> Optional[str]:
     try:
         if url.startswith('http'):
-            # Validate URL to prevent SSRF attacks against local/private networks
+            # Validate URL to prevent SSRF attacks against local/private networks.
+            # allow_redirects=False prevents redirect-based SSRF: validate_url() is
+            # called only on the originally-submitted URL; following 3xx redirects
+            # without re-validation would let an attacker reach private IPs via a
+            # public host that redirects internally (e.g. cloud-metadata exfil).
             validate_url(url)
             # Download the image from the URL
             session = await get_session()
-            async with session.get(url, ssl=AIOHTTP_CLIENT_SESSION_SSL) as response:
+            async with session.get(
+                url, ssl=AIOHTTP_CLIENT_SESSION_SSL, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS
+            ) as response:
                 response.raise_for_status()
                 image_data = await response.read()
                 encoded_string = base64.b64encode(image_data).decode('utf-8')


### PR DESCRIPTION
Cohort follow-up to PR #24491. That PR patched three call sites (SafeWebBaseLoader._scrape, get_content_from_url, load_url_image) to pass allow_redirects=False on the underlying HTTP client; this fourth call site in utils/files.py was missed.

get_image_base64_from_url() is invoked from convert_url_images_to_base64 in utils/middleware.py on every /api/chat/completions request whose message content includes an image_url part. validate_url() is called on the originally-submitted URL only; the aiohttp session.get() call had no allow_redirects argument and the shared session pool does not override the aiohttp default (allow_redirects=True). An authenticated user sending a chat message with image_url pointing at an attacker host that 302-redirects to 169.254.169.254 / 127.0.0.1 / RFC1918 reached the internal target. This is the most reachable variant in the redirect cluster: no special endpoint, no admin permission, no feature flag.

Apply the same one-line fix as the other three call sites: pass allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS (defaults to False).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
