### PR TITLE
fix: enforce per-file ownership when attaching files to folders/KBs

### DIFF
--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -173,6 +173,29 @@ async def update_folder_name_by_id(
                     detail=ERROR_MESSAGES.DEFAULT('Folder already exists'),
                 )
 
+        # Validate read access to every file/collection the caller attaches:
+        # folder.data['files'] is consumed by chat middleware as RAG context.
+        if form_data.data and isinstance(form_data.data.get('files'), list) and user.role != 'admin':
+            for entry in form_data.data['files']:
+                if not isinstance(entry, dict):
+                    continue
+                entry_id = entry.get('id')
+                entry_type = entry.get('type')
+                if not entry_id:
+                    continue
+                if entry_type == 'file':
+                    if not await Files.check_access_by_user_id(entry_id, user.id, 'read', db=db):
+                        raise HTTPException(
+                            status_code=status.HTTP_403_FORBIDDEN,
+                            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                        )
+                elif entry_type == 'collection':
+                    if not await Knowledges.check_access_by_user_id(entry_id, user.id, 'read', db=db):
+                        raise HTTPException(
+                            status_code=status.HTTP_403_FORBIDDEN,
+                            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                        )
+
         try:
             folder = await Folders.update_folder_by_id_and_user_id(id, user.id, form_data, db=db)
             return folder

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -31,6 +31,7 @@ from open_webui.storage.provider import Storage
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.auth import get_verified_user, get_admin_user
 from open_webui.utils.access_control import has_permission, filter_allowed_access_grants
+from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.models.access_grants import AccessGrants
 
 
@@ -656,6 +657,17 @@ async def add_file_to_knowledge_by_id(
             detail=ERROR_MESSAGES.FILE_NOT_PROCESSED,
         )
 
+    # KB write-access is not enough — verify caller can read the file too.
+    if (
+        file.user_id != user.id
+        and user.role != 'admin'
+        and not await has_access_to_file(file.id, 'read', user, db=db)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     # Add content to the vector database
     try:
         await process_file(
@@ -1016,6 +1028,15 @@ async def add_files_to_knowledge_batch(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f'File {missing_ids[0]} not found',
         )
+
+    # Per-file read access — same gate as the single-file endpoint above.
+    if user.role != 'admin':
+        for file in files:
+            if file.user_id != user.id and not await has_access_to_file(file.id, 'read', user, db=db):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                )
 
     # Process files
     try:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -30,6 +30,8 @@ from open_webui.models.oauth_sessions import OAuthSessions
 from open_webui.models.chats import Chats
 from open_webui.models.folders import Folders
 from open_webui.models.users import Users
+from open_webui.models.files import Files
+from open_webui.models.knowledge import Knowledges
 from open_webui.socket.main import (
     get_event_call,
     get_event_emitter,
@@ -2250,6 +2252,31 @@ def strip_skill_mentions(messages: list[dict]) -> None:
                         part['text'] = strip_re.sub('', text).strip()
 
 
+async def _filter_accessible_folder_files(entries, user) -> list:
+    """Drop folder.data['files'] entries the caller can't read. Admins bypass."""
+    if user.role == 'admin':
+        return list(entries) if entries else []
+
+    allowed = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = entry.get('id')
+        entry_type = entry.get('type')
+        if not entry_id:
+            allowed.append(entry)
+            continue
+        if entry_type == 'file':
+            if await Files.check_access_by_user_id(entry_id, user.id, 'read'):
+                allowed.append(entry)
+        elif entry_type == 'collection':
+            if await Knowledges.check_access_by_user_id(entry_id, user.id, 'read'):
+                allowed.append(entry)
+        else:
+            allowed.append(entry)
+    return allowed
+
+
 async def process_chat_payload(request, form_data, user, metadata, model):
     # Pipeline Inlet -> Filter Inlet -> Chat Memory -> Chat Web Search -> Chat Image Generation
     # -> Chat Code Interpreter (Form Data Update) -> (Default) Chat Tools Function Calling
@@ -2407,15 +2434,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             if 'system_prompt' in folder.data:
                 form_data = await apply_system_prompt_to_body(folder.data['system_prompt'], form_data, metadata, user)
             if 'files' in folder.data:
+                # Defensive: filter to files the caller still has read access to.
+                allowed_files = await _filter_accessible_folder_files(folder.data['files'], user)
                 if metadata.get('params', {}).get('function_calling') != 'native':
                     form_data['files'] = [
-                        *folder.data['files'],
+                        *allowed_files,
                         *form_data.get('files', []),
                     ]
                 else:
                     # Native FC: skip RAG injection, builtin tools
                     # will read folder knowledge from metadata.
-                    metadata['folder_knowledge'] = folder.data['files']
+                    metadata['folder_knowledge'] = allowed_files
 
     # Model "Knowledge" handling
     user_message = get_last_user_message(form_data['messages'])


### PR DESCRIPTION
Three writers accept a user-supplied file_id (or list thereof) and attach the referenced file to a resource the caller controls without checking the caller's access to the file itself:

- folders.py update_folder_name_by_id — folder.data['files'] is read by chat middleware as RAG context for the next chat in the folder.
- knowledge.py add_file_to_knowledge_by_id — file becomes reachable via /api/v1/files/{id}/content (read) and /api/v1/files/{id}/data/ content/update (write) once linked to a KB the caller owns, because has_access_to_file treats KB membership as access.
- knowledge.py add_files_to_knowledge_batch — same as above for many.

Add a per-file read-access check at each writer (Files.check_access_by_ user_id for the folder path, has_access_to_file for the knowledge paths). Admins bypass.

Defensive layer in middleware: filter folder.data['files'] down to entries the caller can still read before they enter form_data['files'] as RAG context. Closes the window where a future writer drift, an out-of-band data write, or a revoked grant could turn folder knowledge into an exfiltration primitive at the chat sink.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
