### PR TITLE
fix: reject parser-confusing chars in validate_url to close SSRF bypass

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -69,6 +69,14 @@ def validate_url(url: Union[str, Sequence[str]]):
         if isinstance(validators.url(url), validators.ValidationError):
             raise ValueError(ERROR_MESSAGES.INVALID_URL)
 
+        # Reject parser-confusing chars: urlparse and requests/aiohttp split
+        # on these differently, e.g. http://127.0.0.1\@1.1.1.1 → urlparse
+        # extracts 1.1.1.1 (public, passes filter) while requests connects
+        # to 127.0.0.1 (internal). Same shape with tab/CR/LF.
+        if any(ch in url for ch in ('\\', '\t', '\n', '\r')):
+            log.warning(f'Blocked URL with parser-confusing char: {url!r}')
+            raise ValueError(ERROR_MESSAGES.INVALID_URL)
+
         parsed_url = urllib.parse.urlparse(url)
 
         # Protocol validation - only allow http/https


### PR DESCRIPTION
urllib.parse.urlparse and requests/aiohttp disagree on how to split URLs containing backslash, tab, CR, or LF in or around the netloc. urlparse treats backslash as part of userinfo and uses what follows '@' as the host; requests treats backslash as the start of the path and connects to whatever precedes it. The same URL therefore passes the private-IP filter (urlparse sees a public host) but reaches an internal target (requests connects to e.g. 127.0.0.1). End result is an SSRF that the existing IP block list cannot catch because it's evaluating the wrong host.

PoC: http://127.0.0.1:6666\@1.1.1.1 — urlparse hostname is 1.1.1.1 (global, passes), requests reaches 127.0.0.1 (loopback).

Reject up front any URL containing one of the four documented parser- confusing characters before either parser gets a chance to interpret it. None of these characters is valid in an unencoded URL (\ should always be %5C, whitespace should be %09 / %0A / %0D), so this is a pure defensive rejection with no legitimate-input false positives.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
