### PR TITLE
feat: separate OAUTH_NAME_CLAIM from OAUTH_USERNAME_CLAIM

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -604,6 +604,17 @@ OAUTH_USERNAME_CLAIM = PersistentConfig(
 )
 
 
+# Display name claim — separate from the username so an OIDC provider that
+# distinguishes between e.g. `preferred_username` (login handle) and `name`
+# (full display name) can populate both correctly. Falls back to
+# OAUTH_USERNAME_CLAIM when unset, preserving prior behaviour.
+OAUTH_NAME_CLAIM = PersistentConfig(
+    'OAUTH_NAME_CLAIM',
+    'oauth.oidc.name_claim',
+    os.environ.get('OAUTH_NAME_CLAIM', None),
+)
+
+
 OAUTH_PICTURE_CLAIM = PersistentConfig(
     'OAUTH_PICTURE_CLAIM',
     'oauth.oidc.avatar_claim',

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -53,6 +53,7 @@ from open_webui.config import (
     OAUTH_SUB_CLAIM,
     OAUTH_GROUPS_CLAIM,
     OAUTH_EMAIL_CLAIM,
+    OAUTH_NAME_CLAIM,
     OAUTH_PICTURE_CLAIM,
     OAUTH_USERNAME_CLAIM,
     OAUTH_ALLOWED_ROLES,
@@ -133,6 +134,7 @@ auth_manager_config.OAUTH_GROUPS_CLAIM = OAUTH_GROUPS_CLAIM
 auth_manager_config.OAUTH_EMAIL_CLAIM = OAUTH_EMAIL_CLAIM
 auth_manager_config.OAUTH_PICTURE_CLAIM = OAUTH_PICTURE_CLAIM
 auth_manager_config.OAUTH_USERNAME_CLAIM = OAUTH_USERNAME_CLAIM
+auth_manager_config.OAUTH_NAME_CLAIM = OAUTH_NAME_CLAIM
 auth_manager_config.OAUTH_ALLOWED_ROLES = OAUTH_ALLOWED_ROLES
 auth_manager_config.OAUTH_ADMIN_ROLES = OAUTH_ADMIN_ROLES
 auth_manager_config.OAUTH_ALLOWED_DOMAINS = OAUTH_ALLOWED_DOMAINS
@@ -1642,9 +1644,12 @@ class OAuthManager:
                     user.role = determined_role
 
                 if auth_manager_config.OAUTH_UPDATE_NAME_ON_LOGIN:
-                    username_claim = auth_manager_config.OAUTH_USERNAME_CLAIM
-                    if username_claim:
-                        new_name = user_data.get(username_claim)
+                    name_claim = (
+                        auth_manager_config.OAUTH_NAME_CLAIM
+                        or auth_manager_config.OAUTH_USERNAME_CLAIM
+                    )
+                    if name_claim:
+                        new_name = user_data.get(name_claim)
                         if new_name and new_name != user.name:
                             await Users.update_user_by_id(user.id, {'name': new_name}, db=db)
                             user.name = new_name
@@ -1696,11 +1701,18 @@ class OAuthManager:
                         picture_url = await self._process_picture_url(picture_url, token.get('access_token'))
                     else:
                         picture_url = '/user.png'
-                    username_claim = auth_manager_config.OAUTH_USERNAME_CLAIM
+                    name_claim = (
+                        auth_manager_config.OAUTH_NAME_CLAIM
+                        or auth_manager_config.OAUTH_USERNAME_CLAIM
+                    )
 
-                    name = user_data.get(username_claim)
+                    name = user_data.get(name_claim) if name_claim else None
                     if not name:
-                        log.warning('Username claim is missing, using email as name')
+                        log.warning(
+                            'Name claim is missing (checked OAUTH_NAME_CLAIM '
+                            f'and OAUTH_USERNAME_CLAIM={auth_manager_config.OAUTH_USERNAME_CLAIM!r}), '
+                            'using email as name'
+                        )
                         name = email
 
                     user = await Auths.insert_new_auth(


### PR DESCRIPTION
## Why

OIDC providers commonly distinguish between two distinct user fields:

- **`preferred_username`** — a stable login handle (e.g. `student01`, `j.smith`)
- **`name`** — the human display name (e.g. `Anna Schmidt`, `Jane Smith`)

Today the OAuth user-provisioning code in `backend/open_webui/utils/oauth.py` uses `OAUTH_USERNAME_CLAIM` for **both** the username AND the display name, forcing operators to make a Hobsons choice:

| `OAUTH_USERNAME_CLAIM` set to | Username | Display name |
|---|---|---|
| `preferred_username` | ✅ `student01` | ❌ `student01` (wrong) |
| `name` | ❌ `Anna Schmidt` (URL-unfriendly, contains spaces) | ✅ `Anna Schmidt` |

Neither option is satisfactory for any non-trivial OIDC integration where the IdP returns proper structured profile data.

## What

Add a new `OAUTH_NAME_CLAIM` env var, separate from `OAUTH_USERNAME_CLAIM`. Backwards-compatible: when unset, behaviour is unchanged (falls back to `OAUTH_USERNAME_CLAIM`).

```yaml
# Recommended config for standards-compliant OIDC providers (Authentik,
# Keycloak, Auth0, etc.):
OAUTH_USERNAME_CLAIM: preferred_username   # stable login handle
OAUTH_NAME_CLAIM: name                     # full display name
```

## Where

Two call sites in `backend/open_webui/utils/oauth.py` use the same logic:

- **L1646** — first-time signup: `name = user_data.get(name_claim) ...`
- **L1700** — `OAUTH_UPDATE_NAME_ON_LOGIN` path: `new_name = user_data.get(name_claim) ...`

Both now resolve to `OAUTH_NAME_CLAIM or OAUTH_USERNAME_CLAIM`.

The "using email as name" warning was generalized to mention both env vars so operators can debug missing claims faster.

## Tested

Built locally + tested against Authentik 2024.10. With `OAUTH_NAME_CLAIM=name` set, OIDC provisioning now creates the user with:

- `username`: `student01` (from `preferred_username`)
- `name`: `Anna Schmidt` (from `name` claim)

Without `OAUTH_NAME_CLAIM` set, behaviour is byte-identical to current.

## Diff stats

```
backend/open_webui/config.py      | 11 +++++++++++
backend/open_webui/utils/oauth.py | 24 ++++++++++++++++++------
2 files changed, 29 insertions(+), 6 deletions(-)
```

No DB migrations, no frontend changes, no breaking changes.