### PR TITLE
fix: llamacpp load/unload indicator now detects loaded models via /slots

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -39,6 +39,79 @@ log = logging.getLogger(__name__)
 
 async def fetch_ollama_models(request: Request, user: UserModel = None):
     raw_ollama_models = await ollama.get_all_models(request, user=user)
+    models = raw_ollama_models.get('models', [])
+
+    # Initialize capability cache if it doesn't exist
+    if not hasattr(request.app.state, 'supports_slots'):
+        request.app.state.supports_slots = {}
+
+    url_idxs = {
+        url_idx
+        for model in models
+        if not model.get('expires_at')  # Safer check for missing/null expires_at
+        for url_idx in model.get('urls', [])
+    }
+
+    llama_cpp_loaded_model_ids_by_url_idx = {}
+
+    # Helper for async fetching to allow concurrent execution
+    async def fetch_slots_for_url(url_idx):
+        # Skip if we already know this URL doesn't support /slots (e.g., standard Ollama)
+        if request.app.state.supports_slots.get(url_idx) is False:
+            return url_idx, set()
+
+        url = request.app.state.config.OLLAMA_BASE_URLS[url_idx]
+        api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
+            str(url_idx),
+            request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),
+        )
+
+        loaded_model_ids = set()
+        clean_url = url.rstrip('/')
+
+        try:
+            slots = await ollama.send_get_request(
+                f'{clean_url}/slots',
+                api_config.get('key', None),
+                user=user,
+            )
+
+            # If request succeeds, remember that this backend supports /slots
+            request.app.state.supports_slots[url_idx] = True
+
+            prefix_id = api_config.get('prefix_id', None)
+
+            if isinstance(slots, list):
+                for slot in slots:
+                    slot_model_id = slot.get('model')
+                    if slot_model_id:
+                        loaded_model_ids.add(slot_model_id)
+                        if prefix_id:
+                            loaded_model_ids.add(f'{prefix_id}.{slot_model_id}')
+
+        except Exception as e:
+            # 404 means it's likely standard Ollama. Cache the failure to prevent network spam.
+            if "404" in str(e):
+                request.app.state.supports_slots[url_idx] = False
+            else:
+                log.debug(f'Failed to fetch llama.cpp slots for idx {url_idx}: {e}')
+
+        return url_idx, loaded_model_ids
+
+    # Fetch all applicable URLs concurrently
+    if url_idxs:
+        results = await asyncio.gather(*[fetch_slots_for_url(idx) for idx in url_idxs])
+        llama_cpp_loaded_model_ids_by_url_idx = dict(results)
+
+    def is_loaded(model):
+        if model.get('expires_at'):
+            return True
+
+        return any(
+            model['model'] in llama_cpp_loaded_model_ids_by_url_idx.get(url_idx, set())
+            for url_idx in model.get('urls', [])
+        )
+
     return [
         {
             'id': model['model'],
@@ -47,11 +120,11 @@ async def fetch_ollama_models(request: Request, user: UserModel = None):
             'created': int(time.time()),
             'owned_by': 'ollama',
             'ollama': model,
-            'loaded': 'expires_at' in model,
+            'loaded': is_loaded(model),
             'connection_type': model.get('connection_type', 'local'),
             'tags': model.get('tags', []),
         }
-        for model in raw_ollama_models['models']
+        for model in models
     ]
 
 


### PR DESCRIPTION
The current load indicator treats a model as loaded only when `/api/tags` includes `expires_at`, which is standard Ollama behavior. llama.cpp-compatible servers can keep models loaded in `/slots`, but their `/api/tags` response does not include `expires_at`, so open-webui shows those models as unloaded.

This change adds per-backend detection for `/slots` support. During model refresh, open-webui fetches `/api/tags` and, unless the backend is already known not to support it, probes `/slots` concurrently. A `200` response caches that backend as supporting `/slots`; a `404` caches it as not supporting `/slots`; transient failures such as timeouts or 5xx responses are logged but not cached.

The load indicator now treats a model as loaded when either:

1. `/api/tags` includes `expires_at`
2. the same backend's `/slots` response contains that model ID

For llama.cpp `--models-preset`, this matches preset names directly when the same identifier appears in both `/api/tags` and `/slots`. When `prefix_id` is configured, both raw and prefixed model IDs are checked.

This preserves Ollama behavior while correctly showing llama.cpp slot-loaded models as loaded, without repeatedly probing `/slots` on backends that return `404`.

Fixes #24544.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.