### PR TITLE
fix: gate OAuth profile picture MIME at ingestion + storage layer

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -265,6 +265,14 @@ class UsersTable:
         oauth: Optional[dict] = None,
         db: Optional[AsyncSession] = None,
     ) -> Optional[UserModel]:
+        # Storage-layer gate: same allowlist the form validators apply, so any
+        # write path that bypasses Pydantic forms (OAuth signup, LDAP, etc.)
+        # cannot land an SVG / unknown-MIME data URI in the column.
+        try:
+            profile_image_url = validate_profile_image_url(profile_image_url)
+        except Exception:
+            profile_image_url = '/user.png'
+
         async with get_async_db_context(db) as db:
             user = UserModel(
                 **{
@@ -597,6 +605,11 @@ class UsersTable:
         self, id: str, profile_image_url: str, db: Optional[AsyncSession] = None
     ) -> Optional[UserModel]:
         try:
+            # Storage-layer gate: enforce the same allowlist the Pydantic
+            # form validators apply, so any write path that bypasses the
+            # form layer (e.g. OAuth) cannot land an SVG / unknown-MIME
+            # data URI in the column.
+            profile_image_url = validate_profile_image_url(profile_image_url)
             async with get_async_db_context(db) as db:
                 result = await db.execute(select(User).filter_by(id=id))
                 user = result.scalars().first()

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -72,6 +72,7 @@ from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
 from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+    PROFILE_IMAGE_ALLOWED_MIME_TYPES,
     WEBUI_NAME,
     WEBUI_AUTH_COOKIE_SAME_SITE,
     WEBUI_AUTH_COOKIE_SECURE,
@@ -1454,17 +1455,30 @@ class OAuthManager:
                     'Authorization': f'Bearer {access_token}',
                 }
             async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(picture_url, **get_kwargs, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
-                    if resp.ok:
-                        picture = await resp.read()
-                        base64_encoded_picture = base64.b64encode(picture).decode('utf-8')
-                        guessed_mime_type = mimetypes.guess_type(picture_url)[0]
-                        if guessed_mime_type is None:
-                            guessed_mime_type = 'image/jpeg'
-                        return f'data:{guessed_mime_type};base64,{base64_encoded_picture}'
-                    else:
+                async with session.get(
+                    picture_url,
+                    **get_kwargs,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                    allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+                ) as resp:
+                    if not resp.ok:
                         log.warning(f'Failed to fetch profile picture from {picture_url}')
                         return '/user.png'
+
+                    # Use upstream Content-Type (not URL extension) and gate against
+                    # the same allowlist the serving endpoint enforces — keeps SVG
+                    # / unknown MIME types out of profile_image_url at ingestion.
+                    upstream_mime = (resp.headers.get('Content-Type', '') or '').split(';', 1)[0].strip().lower()
+                    if upstream_mime not in PROFILE_IMAGE_ALLOWED_MIME_TYPES:
+                        log.warning(
+                            f"Rejected OAuth profile picture from {picture_url}: "
+                            f"MIME {upstream_mime!r} not in allowlist"
+                        )
+                        return '/user.png'
+
+                    picture = await resp.read()
+                    base64_encoded_picture = base64.b64encode(picture).decode('utf-8')
+                    return f'data:{upstream_mime};base64,{base64_encoded_picture}'
         except Exception as e:
             log.error(f"Error processing profile picture '{picture_url}': {e}")
             return '/user.png'


### PR DESCRIPTION
1. _process_picture_url (utils/oauth.py): MIME was inferred from the URL extension via mimetypes.guess_type, the upstream Content-Type was discarded, and there was no allowlist. An SVG picture URL produced data:image/svg+xml;base64,... in the user's profile_image_url. Switch to the upstream Content-Type and gate it against PROFILE_IMAGE_ALLOWED_MIME_TYPES (the same env var the serving endpoint already uses); fall back to /user.png if the MIME isn't in the allowlist. Also pass allow_redirects=AIOHTTP_CLIENT_ ALLOW_REDIRECTS on the aiohttp session.get — the existing validate_url() only checks the initial URL, redirects to internal targets would otherwise still be followed (same class as the rh5x-h6pp-cjj6 cluster, sixth call site).

2. update_user_profile_image_url_by_id (models/users.py): SQLAlchemy write path bypassed the Pydantic form validators, so anything stored via OAuth or any other non-form caller landed in the column unchallenged. Run validate_profile_image_url at the storage layer before the assignment.

3. insert_new_user (models/users.py): same gap on the new-user path used by Auths.insert_new_auth (OAuth signup, LDAP). Same storage-layer call to validate_profile_image_url, falling back to /user.png if the supplied value doesn't pass.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
