### PR TITLE
fix: prevent details leak from edited assistant content

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -299,6 +299,44 @@ class ChatTable:
 
         return changed
 
+    def _normalize_assistant_content_from_output(self, chat: dict, prior_chat: dict) -> dict:
+        """Rewrite assistant 'content' from 'output' when 'output' has changed.
+
+        Skips messages where the caller also changed 'content', or where the prior
+        'content' differs from 'serialize_output(prior_output)'. Preserves filter
+        outlet rewrites and direct user content edits across saves.
+        """
+        from open_webui.utils.middleware import serialize_output
+
+        history = (chat or {}).get('history') or {}
+        messages = history.get('messages')
+        if not isinstance(messages, dict):
+            return chat
+
+        prior_messages = ((prior_chat or {}).get('history') or {}).get('messages') or {}
+
+        for message_id, message in messages.items():
+            if not (isinstance(message, dict) and message.get('role') == 'assistant'):
+                continue
+            new_output = message.get('output')
+            if not isinstance(new_output, list):
+                continue
+            prior = prior_messages.get(message_id) or {}
+            old_output = prior.get('output')
+            if new_output == old_output:
+                continue
+            prior_content = prior.get('content')
+            if message.get('content') != prior_content:
+                continue
+            try:
+                canonical = serialize_output(old_output) if isinstance(old_output, list) else None
+            except Exception:
+                canonical = None
+            if prior_content != canonical:
+                continue
+            message['content'] = serialize_output(new_output)
+        return chat
+
     async def insert_new_chat(
         self, id: str, user_id: str, form_data: ChatForm, db: AsyncSession | None = None
     ) -> ChatModel | None:
@@ -394,6 +432,7 @@ class ChatTable:
         try:
             async with get_async_db_context(db) as db:
                 chat_item = await db.get(Chat, id)
+                chat = self._normalize_assistant_content_from_output(chat, chat_item.chat)
                 chat_item.chat = self._clean_null_bytes(chat)
                 chat_item.title = self._clean_null_bytes(chat['title']) if 'title' in chat else 'New Chat'
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -32,7 +32,6 @@ from open_webui.models.tags import TagModel, Tags
 from open_webui.socket.main import get_event_emitter
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.middleware import serialize_output
 from open_webui.utils.misc import get_message_list
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -978,14 +977,6 @@ async def update_chat_by_id(
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
         updated_chat = {**chat.chat, **form_data.chat}
-
-        # Re-derive content from output for assistant messages so that
-        # frontend edits to output items are always reflected in content.
-        # serialize_output() is the single source of truth for this conversion.
-        for msg in updated_chat.get('history', {}).get('messages', {}).values():
-            if msg.get('role') == 'assistant' and msg.get('output'):
-                msg['content'] = serialize_output(msg['output'])
-
         chat = await Chats.update_chat_by_id(id, updated_chat, db=db)
         return ChatResponse(**chat.model_dump())
     else:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Deleting a reasoning or tool block in the structured editor updates `output` but leaves `content` with the stale `<details>` HTML. On the next turn, backend paths that fall back to `content` still pass the deleted block to the LLM. The symmetric case: an outlet `Filter` (e.g. "Remove Thinking") that strips `<details>` from `content` is undone on the next save, because the router endpoint unconditionally rewrote `content = serialize_output(output)` before persisting.

To reproduce (editor):

1. Enable a tool on a model and send a message that triggers it.
2. Open the structured editor and remove the tool call block.
3. Send another message.
4. The deleted block is still sent to the AI.

To reproduce (filter):

1. Install an outlet `Filter` that strips `<details>` blocks from `content`.
2. Generate a reasoning response. The block is hidden.
3. Refresh the page once. Still hidden.
4. Refresh again. The block is back.

Root cause: the structured editor updates `output` only, and the save path doesn't reconcile `content` against it. The router-side rewrite that did exist was too aggressive and overwrote intentional content edits.

### Added

- [List any new features, functionalities, or additions]

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- In `update_chat_by_id` (models): rewrite `content = serialize_output(output)` when `output` changes. Skip if `content` also changed, or if the prior `content` didn't match `serialize_output(prior_output)`. This preserves filter `outlet` rewrites and manual edits.
- In `update_chat_by_id` (router): remove the unconditional pre-save rewrite of `content` from `output`, so the model-layer guard is the single decision point.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- The rewrite is diff-aware: only messages whose `output` changed are rewritten. Messages without `output` are skipped, preserving plain text edits and legacy chats.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
