### PR TITLE
fix: handle None chat_id in get_event_emitter channel-mode check

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -898,8 +898,9 @@ async def _make_channel_emitter(request_info):
 
 
 async def get_event_emitter(request_info, update_db=True):
-    # Channel mode: route pipeline output to channel message updates
-    if request_info.get('chat_id', '').startswith('channel:'):
+    # Channel mode: route pipeline output to channel message updates.
+    # `or ''` (not the .get default) because chat_id may be present as None.
+    if (request_info.get('chat_id') or '').startswith('channel:'):
         return await _make_channel_emitter(request_info)
 
     async def __event_emitter__(event_data):


### PR DESCRIPTION
Direct API callers to /api/chat/completions pass no chat_id, so metadata['chat_id'] ends up None. dict.get('chat_id', '') returns None (not '') when the key is present-with-None, so the channels-streaming branch added in v0.9.5 (0037baeb2) crashed with 'NoneType' object has no attribute 'startswith', surfacing as HTTP 400 to the caller.

Fixes #24553.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
