### PR TITLE
fix: guard metadata chat_id None before startswith in middleware

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3059,7 +3059,7 @@ async def background_tasks_handler(ctx):
     messages = []
 
     if (
-        'chat_id' in metadata
+        metadata.get('chat_id')
         and not metadata['chat_id'].startswith('local:')
         and not metadata['chat_id'].startswith('channel:')
     ):
@@ -3424,7 +3424,7 @@ async def non_streaming_chat_response_handler(response, ctx):
 
                 log.error('Provider returned error (non-streaming): %s', error)
 
-                if not metadata['chat_id'].startswith('channel:'):
+                if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                     await Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata['chat_id'],
                         metadata['message_id'],
@@ -3440,7 +3440,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                         }
                     )
 
-            if 'selected_model_id' in response_data and not metadata['chat_id'].startswith('channel:'):
+            if 'selected_model_id' in response_data and metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata['chat_id'],
                     metadata['message_id'],
@@ -3463,7 +3463,7 @@ async def non_streaming_chat_response_handler(response, ctx):
 
                     title = (
                         await Chats.get_chat_title_by_id(metadata['chat_id'])
-                        if not metadata['chat_id'].startswith('channel:')
+                        if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:')
                         else ''
                     )
 
@@ -3496,7 +3496,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     # Save message in the database
                     usage = normalize_usage(response_data.get('usage', {}) or {})
 
-                    if not metadata['chat_id'].startswith('channel:'):
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             metadata['chat_id'],
                             metadata['message_id'],
@@ -4362,7 +4362,7 @@ async def streaming_chat_response_handler(response, ctx):
                                             if end:
                                                 break
 
-                                        if ENABLE_REALTIME_CHAT_SAVE and not metadata['chat_id'].startswith('channel:'):
+                                        if ENABLE_REALTIME_CHAT_SAVE and metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                                             # Save message in the database
                                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                                 metadata['chat_id'],
@@ -5040,7 +5040,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                 title = (
                     await Chats.get_chat_title_by_id(metadata['chat_id'])
-                    if not metadata['chat_id'].startswith('channel:')
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:')
                     else ''
                 )
                 data = {
@@ -5051,7 +5051,7 @@ async def streaming_chat_response_handler(response, ctx):
                     **({'usage': usage} if usage else {}),
                 }
 
-                if not metadata['chat_id'].startswith('channel:'):
+                if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                     if not ENABLE_REALTIME_CHAT_SAVE:
                         # Save message in the database
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
@@ -5122,7 +5122,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                 async def save_cancelled_state():
                     await event_emitter({'type': 'chat:tasks:cancel'})
-                    if not metadata['chat_id'].startswith('channel:'):
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                         if not ENABLE_REALTIME_CHAT_SAVE:
                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                 metadata['chat_id'],


### PR DESCRIPTION
## Summary

Fixes `TypeError: 'NoneType' object has no attribute 'startswith'` introduced in v0.9.5, which broke all external `/api/v1/chat/completions` calls that don't supply a `chat_id` (e.g. IDE extensions, CLI tools, API scripts).

Related issues: #24553, #24550, #24554

## Root cause

`v0.9.5` added `channel:` prefix support across `middleware.py`. The new code calls `metadata['chat_id'].startswith('channel:')` in multiple places, but `metadata['chat_id']` is `None` when the caller does not provide a `chat_id`. This causes:

```
{"detail":"'NoneType' object has no attribute 'startswith'"}
```

The affected call sites are in `non_streaming_chat_response_handler` and `streaming_chat_response_handler` (lines 3062–3064, 3427, 3443, 3466, 3499, 4365, 5043, 5054, 5125).

## Fix

Replace unguarded `metadata['chat_id'].startswith(...)` with `metadata.get('chat_id') and not metadata['chat_id'].startswith(...)` so that a `None` `chat_id` is treated as a missing chat session (skip DB persistence), which is the correct behaviour for direct API calls.

## Test plan

- [ ] Call `POST /api/v1/chat/completions` without a `chat_id` field — should return a valid response instead of 500
- [ ] Call via an IDE extension (Continue, OpenCode) — should work as in v0.9.4
- [ ] Normal web UI chat sessions with a `chat_id` — should be unaffected
- [ ] Channel messages (`chat_id` starting with `channel:`) — should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)