### PR TITLE
fix: guard metadata chat_id None before startswith in middleware

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3059,7 +3059,7 @@ async def background_tasks_handler(ctx):
     messages = []
 
     if (
-        'chat_id' in metadata
+        metadata.get('chat_id')
         and not metadata['chat_id'].startswith('local:')
         and not metadata['chat_id'].startswith('channel:')
     ):
@@ -3424,7 +3424,7 @@ async def non_streaming_chat_response_handler(response, ctx):
 
                 log.error('Provider returned error (non-streaming): %s', error)
 
-                if not metadata['chat_id'].startswith('channel:'):
+                if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                     await Chats.upsert_message_to_chat_by_id_and_message_id(
                         metadata['chat_id'],
                         metadata['message_id'],
@@ -3440,7 +3440,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                         }
                     )
 
-            if 'selected_model_id' in response_data and not metadata['chat_id'].startswith('channel:'):
+            if 'selected_model_id' in response_data and metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                 await Chats.upsert_message_to_chat_by_id_and_message_id(
                     metadata['chat_id'],
                     metadata['message_id'],
@@ -3463,7 +3463,7 @@ async def non_streaming_chat_response_handler(response, ctx):
 
                     title = (
                         await Chats.get_chat_title_by_id(metadata['chat_id'])
-                        if not metadata['chat_id'].startswith('channel:')
+                        if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:')
                         else ''
                     )
 
@@ -3496,7 +3496,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     # Save message in the database
                     usage = normalize_usage(response_data.get('usage', {}) or {})
 
-                    if not metadata['chat_id'].startswith('channel:'):
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             metadata['chat_id'],
                             metadata['message_id'],
@@ -4362,7 +4362,7 @@ async def streaming_chat_response_handler(response, ctx):
                                             if end:
                                                 break
 
-                                        if ENABLE_REALTIME_CHAT_SAVE and not metadata['chat_id'].startswith('channel:'):
+                                        if ENABLE_REALTIME_CHAT_SAVE and metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                                             # Save message in the database
                                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                                 metadata['chat_id'],
@@ -5040,7 +5040,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                 title = (
                     await Chats.get_chat_title_by_id(metadata['chat_id'])
-                    if not metadata['chat_id'].startswith('channel:')
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:')
                     else ''
                 )
                 data = {
@@ -5051,7 +5051,7 @@ async def streaming_chat_response_handler(response, ctx):
                     **({'usage': usage} if usage else {}),
                 }
 
-                if not metadata['chat_id'].startswith('channel:'):
+                if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                     if not ENABLE_REALTIME_CHAT_SAVE:
                         # Save message in the database
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
@@ -5122,7 +5122,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                 async def save_cancelled_state():
                     await event_emitter({'type': 'chat:tasks:cancel'})
-                    if not metadata['chat_id'].startswith('channel:'):
+                    if metadata.get('chat_id') and not metadata['chat_id'].startswith('channel:'):
                         if not ENABLE_REALTIME_CHAT_SAVE:
                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                 metadata['chat_id'],


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #24553 / Relates to #24550, #24554
- [x] **Target branch:** `dev`
- [x] **Description:** Bug fix for `'NoneType' object has no attribute 'startswith'` regression in v0.9.5
- [ ] **Changelog:** See below
- [ ] **Documentation:** No user-facing behaviour change
- [ ] **Dependencies:** None
- [x] **Testing:** Manually verified — calling `POST /api/v1/chat/completions` without `chat_id` now works; web UI chat sessions unaffected
- [x] **Agentic AI Code:** This PR has been reviewed and manually tested by the human author
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Single atomic commit

# Changelog Entry

### Description

`v0.9.5` introduced `channel:` prefix support in `middleware.py`, adding multiple `metadata['chat_id'].startswith('channel:')` calls. When `/api/v1/chat/completions` is called from an external client without a `chat_id` field (IDE extensions, CLI tools, API scripts), `metadata['chat_id']` is `None`, causing:

```
{"detail":"'NoneType' object has no attribute 'startswith'"}
```

The web UI is unaffected because browser sessions always supply `chat_id`. Only headless / programmatic API callers are impacted.

### Fixed

- `middleware.py`: replaced unguarded `metadata['chat_id'].startswith(...)` with `metadata.get('chat_id') and not metadata['chat_id'].startswith(...)` at 9 call sites in `non_streaming_chat_response_handler` and `streaming_chat_response_handler`. A `None` `chat_id` now correctly skips DB persistence, matching the behaviour for requests without a session.

### Reproduce before fix

```bash
curl -X POST http://localhost:3000/api/v1/chat/completions \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"model":"<model>","messages":[{"role":"user","content":"hi"}]}'
# Returns: {"detail":"'NoneType' object has no attribute 'startswith'"}
```

After fix: returns a valid completion response.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.