### PR TITLE
refac: scope /api/config disclosure to actual frontend consumers

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2349,9 +2349,7 @@ async def get_app_config(request: Request):
 
     return {
         **({'onboarding': True} if onboarding else {}),
-        'status': True,
         'name': app.state.WEBUI_NAME,
-        'version': VERSION,
         'default_locale': str(DEFAULT_LOCALE),
         'oauth': {'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()}},
         'features': {
@@ -2359,16 +2357,16 @@ async def get_app_config(request: Request):
             'auth_trusted_header': bool(app.state.AUTH_TRUSTED_EMAIL_HEADER),
             'enable_signup_password_confirmation': ENABLE_SIGNUP_PASSWORD_CONFIRMATION,
             'enable_ldap': app.state.config.ENABLE_LDAP,
-            'enable_api_keys': app.state.config.ENABLE_API_KEYS,
             'enable_signup': app.state.config.ENABLE_SIGNUP,
             'enable_login_form': app.state.config.ENABLE_LOGIN_FORM,
-            'enable_password_change_form': app.state.config.ENABLE_PASSWORD_CHANGE_FORM,
             'enable_websocket': ENABLE_WEBSOCKET_SUPPORT,
-            'enable_version_update_check': ENABLE_VERSION_UPDATE_CHECK,
-            'enable_public_active_users_count': ENABLE_PUBLIC_ACTIVE_USERS_COUNT,
-            'enable_easter_eggs': ENABLE_EASTER_EGGS,
             **(
                 {
+                    'enable_api_keys': app.state.config.ENABLE_API_KEYS,
+                    'enable_password_change_form': app.state.config.ENABLE_PASSWORD_CHANGE_FORM,
+                    'enable_version_update_check': ENABLE_VERSION_UPDATE_CHECK,
+                    'enable_public_active_users_count': ENABLE_PUBLIC_ACTIVE_USERS_COUNT,
+                    'enable_easter_eggs': ENABLE_EASTER_EGGS,
                     'enable_direct_connections': app.state.config.ENABLE_DIRECT_CONNECTIONS,
                     'enable_folders': app.state.config.ENABLE_FOLDERS,
                     'folder_max_file_count': app.state.config.FOLDER_MAX_FILE_COUNT,
@@ -2400,12 +2398,13 @@ async def get_app_config(request: Request):
                         else {}
                     ),
                 }
-                if user is not None
+                if user is not None and user.role in ['admin', 'user']
                 else {}
             ),
         },
         **(
             {
+                'version': VERSION,
                 'default_models': app.state.config.DEFAULT_MODELS,
                 'default_pinned_models': app.state.config.DEFAULT_PINNED_MODELS,
                 'default_prompt_suggestions': app.state.config.DEFAULT_PROMPT_SUGGESTIONS,
@@ -2477,7 +2476,7 @@ async def get_app_config(request: Request):
                             'auth_logo_position': app.state.LICENSE_METADATA.get('auth_logo_position', ''),
                         }
                     }
-                    if app.state.LICENSE_METADATA
+                    if user is None and app.state.LICENSE_METADATA
                     else {}
                 ),
             }


### PR DESCRIPTION
/api/config previously disclosed the same payload regardless of caller role, including the exact build version and the full feature-flag matrix to unauthenticated callers, plus the full inner features block to pending users who can only render AccountPending.

Audited every field returned to unauth/pending callers against actual frontend consumers:

- 'status' (hard-coded True) has no readers anywhere — dropped.
- 'version' only consumed by (app)/+layout.svelte changelog gate and ChangelogModal (both admin/user-only) — moved into the admin/user branch.
- enable_api_keys, enable_password_change_form, enable_version_update_check, enable_public_active_users_count, enable_easter_eggs only consumed in admin/user-gated UI — moved into the inner features block.
- The inner features block (enable_direct_connections … enable_memories, OneDrive personal/business) is only consumed in chat/admin UI that pending users never render. Inner-block gate tightened from 'user is not None' to 'user is not None and user.role in [admin, user]'.
- metadata.login_footer / metadata.auth_logo_position only render on /auth, which redirects pending users away. Metadata fallback gated to anonymous callers only.

The /auth page, AccountPending overlay, and the pre-redirect root layout keep every field they actually read. No frontend change required.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
