### PR TITLE
fix: block private-IP webhook URLs to close SSRF on caller-controlled URL

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -3,7 +3,12 @@ import logging
 import aiohttp
 
 from open_webui.config import WEBUI_FAVICON_URL
-from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT, VERSION
+from open_webui.env import (
+    AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+    AIOHTTP_CLIENT_SESSION_SSL,
+    AIOHTTP_CLIENT_TIMEOUT,
+    VERSION,
+)
 from open_webui.retrieval.web.utils import validate_url
 
 log = logging.getLogger(__name__)
@@ -58,7 +63,12 @@ async def post_webhook(name: str, url: str, message: str, event_data: dict) -> b
         async with aiohttp.ClientSession(
             trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
         ) as session:
-            async with session.post(url, json=payload, ssl=AIOHTTP_CLIENT_SESSION_SSL) as r:
+            async with session.post(
+                url,
+                json=payload,
+                ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+            ) as r:
                 r_text = await r.text()
                 r.raise_for_status()
                 log.debug(f'r.text: {r_text}')

--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -4,6 +4,7 @@ import aiohttp
 
 from open_webui.config import WEBUI_FAVICON_URL
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT, VERSION
+from open_webui.retrieval.web.utils import validate_url
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +14,10 @@ log = logging.getLogger(__name__)
 async def post_webhook(name: str, url: str, message: str, event_data: dict) -> bool:
     try:
         log.debug(f'post_webhook: {url}, {message}, {event_data}')
+        # Block private-IP / loopback / cloud-metadata targets — the URL is
+        # caller-controlled (user notification settings under
+        # ENABLE_USER_WEBHOOKS, automation notification triggers).
+        validate_url(url)
         payload = {}
 
         # Slack and Google Chat Webhooks


### PR DESCRIPTION
post_webhook(url, ...) in utils/webhook.py forwards the URL straight to aiohttp.ClientSession.post with no SSRF gate. The URL is caller-controlled on two surfaces:

- User notification settings under ENABLE_USER_WEBHOOKS=true — any authenticated user can set the URL their notifications POST to.
- Automation notification triggers (calendar alerts, etc.).

Without a gate, the URL can target cloud metadata (169.254.169.254 / fd00:ec2::254), localhost-bound services, RFC1918 internal hosts, or any other private address reachable from the server process. Blind SSRF — no response body returned to the caller — but enough to enumerate internal services via response timing / status codes, and on cloud deployments enough to issue requests against IMDSv1 if available.

Call validate_url() at the top of post_webhook. The function blocks private/reserved IPs when ENABLE_RAG_LOCAL_WEB_FETCH is False (the default), is the project's chosen SSRF gate, and is already applied to the equivalent fetch surfaces (retrieval, image-load, OAuth profile picture). Operators who legitimately need to webhook to private IPs (internal monitoring, self-hosted Slack alternatives, etc.) can set ENABLE_RAG_LOCAL_WEB_FETCH=True — same opt-out as the other gated surfaces.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
