### PR TITLE
fix: validate folder_id ownership on chat create + folder-update endpoints

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -559,6 +559,18 @@ async def create_new_chat(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    # Reject a folder_id that doesn't belong to the caller. Without this the
+    # row is persisted with a dangling foreign reference — no read path
+    # surfaces it across users (all chat reads are user_id-filtered), but
+    # the row state is meaningless and downstream consumers shouldn't have
+    # to assume the column is clean. Also catches non-UUID / nonexistent IDs.
+    if form_data.folder_id is not None:
+        if not await Folders.get_folder_by_id_and_user_id(form_data.folder_id, user.id, db=db):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+
     try:
         chat = await Chats.insert_new_chat(str(uuid4()), user.id, form_data, db=db)
         return ChatResponse(**chat.model_dump())
@@ -1486,6 +1498,15 @@ async def update_chat_folder_id_by_id(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
+        # Same ownership check as the create path — reject foreign / dangling
+        # folder_id values. None is allowed (moves the chat out of any folder).
+        if form_data.folder_id is not None:
+            if not await Folders.get_folder_by_id_and_user_id(form_data.folder_id, user.id, db=db):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=ERROR_MESSAGES.NOT_FOUND,
+                )
+
         chat = await Chats.update_chat_folder_id_by_id_and_user_id(id, user.id, form_data.folder_id, db=db)
         return ChatResponse(**chat.model_dump())
     else:


### PR DESCRIPTION
POST /api/v1/chats/new and POST /api/v1/chats/{id}/folder accepted a caller-supplied folder_id with no validation — neither ownership, nor existence, nor UUID format. The row was persisted with the supplied value verbatim, so the DB ended up with chat rows whose folder_id referenced another user's folder, a non-existent UUID, or even a non-UUID string.

No read path surfaces this across users — every chat-folder read is user_id-filtered on both sides — so this is referential-integrity hardening rather than a security boundary fix. But there's no reason to accept dangling references either, and the downstream consumers shouldn't have to assume the column is clean.

Add a Folders.get_folder_by_id_and_user_id() lookup at both writers: if a folder_id is supplied, it must match a folder owned by the caller. None remains allowed (chat-without-folder is the default). Non-existent and non-UUID values fall through to 404.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
