### PR TITLE
fix: honor SSL verification setting for OpenAI STT

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -749,6 +749,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                         files={'file': (filename, audio_file)},
                         data=payload,
                         timeout=AIOHTTP_CLIENT_TIMEOUT,
+                        verify=AIOHTTP_CLIENT_SESSION_SSL,
                     )
 
                 if r.status_code == 200:

--- a/test/backend/routers/test_audio.py
+++ b/test/backend/routers/test_audio.py
@@ -1,0 +1,33 @@
+import ast
+from pathlib import Path
+
+
+def test_openai_stt_transcription_uses_configured_ssl_verification():
+    audio_router = Path(__file__).parents[3] / 'backend' / 'open_webui' / 'routers' / 'audio.py'
+    tree = ast.parse(audio_router.read_text())
+
+    matching_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == 'post'
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == 'requests'
+        and any(
+            keyword.arg == 'url'
+            and isinstance(keyword.value, ast.JoinedStr)
+            and any(
+                isinstance(value, ast.Constant) and value.value == '/audio/transcriptions'
+                for value in keyword.value.values
+            )
+            for keyword in node.keywords
+        )
+    ]
+
+    assert matching_calls, 'Expected OpenAI STT transcription request to be present'
+
+    verify_keywords = [keyword.value for call in matching_calls for keyword in call.keywords if keyword.arg == 'verify']
+
+    assert len(verify_keywords) == len(matching_calls)
+    assert all(isinstance(value, ast.Name) and value.id == 'AIOHTTP_CLIENT_SESSION_SSL' for value in verify_keywords)


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24568.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Self-Review:** The code and regression test were reviewed for scope and consistency.
- [x] **Architecture:** Reuses the existing global SSL verification setting; no new setting or flow.
- [x] **Git Hygiene:** Atomic branch from current `dev` with one logical change.
- [x] **Title Prefix:** Uses the `fix:` prefix.

# Changelog Entry

### Description

- Honor `AIOHTTP_CLIENT_SESSION_SSL` for OpenAI-compatible speech-to-text transcription requests made from the audio router.

### Fixed

- Added `verify=AIOHTTP_CLIENT_SESSION_SSL` to the synchronous `requests.post` call for `{STT_OPENAI_API_BASE_URL}/audio/transcriptions`, so deployments using self-signed OpenAI-compatible STT endpoints can disable certificate verification consistently with the rest of the backend HTTP clients.
- Added a focused regression test that ensures the OpenAI STT transcription request continues to pass the configured SSL verification value.

---

### Additional Information

Validated with:

- `python3 -m pytest test/backend/routers/test_audio.py -q`
- `python3 -m py_compile backend/open_webui/routers/audio.py test/backend/routers/test_audio.py`
- `uvx ruff check test/backend/routers/test_audio.py`
- `uvx ruff format --check test/backend/routers/test_audio.py`
- `git diff --check`

Full-file Ruff on `backend/open_webui/routers/audio.py` currently reports pre-existing issues unrelated to this change, so this PR keeps the production diff to the single missing `verify` keyword.

### Screenshots or Videos

- Backend-only fix; no UI screenshots.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
