### PR TITLE
fix: remove duplicate allow_redirects in SafeWebBaseLoader._fetch

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -521,7 +521,6 @@ class SafeWebBaseLoader(WebBaseLoader):
                     async with session.get(
                         url,
                         **(self.requests_kwargs | kwargs),
-                        allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
                     ) as response:
                         if self.raise_for_status:
                             response.raise_for_status()


### PR DESCRIPTION
## Description

Fixes a `TypeError` crash in `SafeWebBaseLoader._fetch()` caused by passing `allow_redirects` both in `self.requests_kwargs` and as an explicit keyword argument to `session.get()`.

### Root Cause

In `SafeWebBaseLoader.__init__()`, `allow_redirects` is added to `self.requests_kwargs`. Then in `_fetch()`, `allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS` is also passed explicitly to `session.get()`. Since `self.requests_kwargs` is unpacked with `**`, this creates a duplicate keyword argument that `aiohttp` rejects with a `TypeError`.

### Fix

Remove the explicit `allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS` from the `session.get()` call in `_fetch()`. The value is already present in `self.requests_kwargs` and will be passed via the `**` unpacking.

Fixes #24560