### PR TITLE
fix: remove duplicate allow_redirects in SafeWebBaseLoader._fetch

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -521,7 +521,6 @@ class SafeWebBaseLoader(WebBaseLoader):
                     async with session.get(
                         url,
                         **(self.requests_kwargs | kwargs),
-                        allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
                     ) as response:
                         if self.raise_for_status:
                             response.raise_for_status()


### PR DESCRIPTION
Closes #24560

### Description

- Fix TypeError caused by duplicate `allow_redirects` keyword argument in `SafeWebBaseLoader._fetch()`, which broke all web search functionality when `WEB_LOADER_ENGINE` is `safe_web`.

### Fixed

- Removed the explicit `allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS` from the `session.get()` call in `_fetch()`. The value is already present in `self.requests_kwargs` (set in `__init__`), so the explicit parameter causes `aiohttp` to reject the duplicate kwarg.

### Root Cause

In `__init__`, `allow_redirects` is added to `self.requests_kwargs`:
```python
self.requests_kwargs = {
    **(self.requests_kwargs or {}),
    'allow_redirects': AIOHTTP_CLIENT_ALLOW_REDIRECTS,
}
```

Then in `_fetch`, it's passed twice:
```python
async with session.get(
    url,
    **(self.requests_kwargs | kwargs),  # already contains allow_redirects
    allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,  # duplicate!
) as response:
```

### Additional Information

- Introduced by PR #24524
- Confirmed by @farid-abu-issa on Railway deployment (v0.9.5)
- SSRF protection is preserved since the value remains in `self.requests_kwargs`

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.