### PR TITLE
fix: gate get_image_base64_from_url file_id lookup by caller ownership

### DIFF
--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -19,6 +19,7 @@ from open_webui.models.chats import Chats
 from open_webui.models.files import Files
 from open_webui.routers.files import upload_file_handler
 from open_webui.retrieval.web.utils import validate_url
+from open_webui.utils.access_control.files import has_access_to_file
 
 import asyncio
 import mimetypes
@@ -54,7 +55,7 @@ _IMAGE_MIME_FALLBACK = {
 }
 
 
-async def get_image_base64_from_url(url: str) -> Optional[str]:
+async def get_image_base64_from_url(url: str, user=None) -> Optional[str]:
     try:
         if url.startswith('http'):
             # Validate URL to prevent SSRF attacks against local/private networks.
@@ -77,6 +78,21 @@ async def get_image_base64_from_url(url: str) -> Optional[str]:
             file = await Files.get_file_by_id(url)
 
             if not file:
+                return None
+
+            # Gate file-by-id resolution by ownership. Without this, a caller
+            # can put another user's file_id in an `image_url.url` field, the
+            # server reads the file from disk and inlines it base64 into the
+            # LLM request, and the caller exfiltrates the content via a
+            # describe/OCR prompt. Owner, admin, and explicit read-grant
+            # holders (via shared KBs / channels / shared chats) are allowed.
+            if user is None:
+                return None
+            if (
+                file.user_id != user.id
+                and user.role != 'admin'
+                and not await has_access_to_file(file.id, 'read', user)
+            ):
                 return None
 
             file_path = await asyncio.to_thread(Storage.get_file, file.path)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2110,7 +2110,7 @@ def apply_params_to_form_data(form_data, model):
     return form_data
 
 
-async def convert_url_images_to_base64(form_data):
+async def convert_url_images_to_base64(form_data, user=None):
     messages = form_data.get('messages', [])
 
     for message in messages:
@@ -2131,7 +2131,7 @@ async def convert_url_images_to_base64(form_data):
                 continue
 
             try:
-                base64_data = await get_image_base64_from_url(image_url)
+                base64_data = await get_image_base64_from_url(image_url, user=user)
                 if base64_data:
                     new_content.append(
                         {
@@ -2354,7 +2354,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except Exception:
             pass
 
-    form_data = await convert_url_images_to_base64(form_data)
+    form_data = await convert_url_images_to_base64(form_data, user=user)
 
     event_emitter = await get_event_emitter(metadata)
     event_caller = await get_event_call(metadata)


### PR DESCRIPTION
convert_url_images_to_base64() in utils/middleware.py was calling get_image_base64_from_url(url) without passing the authenticated user. When the url didn't start with http(s):// or data:image/, the helper treated it as a file_id and resolved it via Files.get_file_by_id(url) with no ownership filter — read the file from disk, base64-encoded it, and inlined it into the LLM request as an image_url attachment.

An authenticated user could put another user's file_id (UUIDs leak through shared chats, KB membership, chat exports, etc.) into an image_url.url field on /api/chat/completions and ask the model to describe / OCR the file. The server's read of the victim file went through unchecked; the LLM response carried the file content back to the caller.

Thread `user` through convert_url_images_to_base64() and through get_image_base64_from_url(). Gate the file-by-id branch by the same pattern used at the other file-access call sites: owner, admin under the documented bypass posture, or explicit has_access_to_file('read') grant (covering shared KBs / channels / shared chats). Callers that don't have a user in scope get None back — same as the existing "file not found" code path.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
