### PR TITLE
feat: optional HS256 JWT for forwarded user identity headers

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -784,6 +784,16 @@ FORWARD_SESSION_INFO_HEADER_MESSAGE_ID = os.getenv(
 )
 FORWARD_SESSION_INFO_HEADER_CHAT_ID = os.getenv('FORWARD_SESSION_INFO_HEADER_CHAT_ID', 'X-OpenWebUI-Chat-Id')
 
+# If set while ENABLE_FORWARD_USER_INFO_HEADERS is True, send one signed HS256 JWT
+# (FORWARD_USER_JWT_HEADER) instead of separate X-OpenWebUI-User-* headers.
+FORWARD_USER_JWT_SECRET = (os.environ.get('FORWARD_USER_JWT_SECRET') or '').strip() or None
+FORWARD_USER_JWT_HEADER = os.environ.get('FORWARD_USER_JWT_HEADER', 'X-OpenWebUI-User-Jwt')
+try:
+    FORWARD_USER_JWT_EXPIRES_SECONDS = int(os.environ.get('FORWARD_USER_JWT_EXPIRES_SECONDS', '300'))
+except ValueError:
+    FORWARD_USER_JWT_EXPIRES_SECONDS = 300
+
+
 ####################################
 # Progressive Web App
 ####################################

--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -1,14 +1,52 @@
+import logging
+import time
+from typing import Any, Optional
 from urllib.parse import quote
 
+import jwt
+
 from open_webui.env import (
-    FORWARD_USER_INFO_HEADER_USER_NAME,
-    FORWARD_USER_INFO_HEADER_USER_ID,
     FORWARD_USER_INFO_HEADER_USER_EMAIL,
+    FORWARD_USER_INFO_HEADER_USER_ID,
+    FORWARD_USER_INFO_HEADER_USER_NAME,
     FORWARD_USER_INFO_HEADER_USER_ROLE,
+    FORWARD_USER_JWT_EXPIRES_SECONDS,
+    FORWARD_USER_JWT_HEADER,
+    FORWARD_USER_JWT_SECRET,
 )
 
+log = logging.getLogger(__name__)
 
-def include_user_info_headers(headers, user):
+
+def _mint_forward_user_jwt(user: Any) -> str:
+    now = int(time.time())
+    payload = {
+        'sub': str(user.id),
+        'email': str(user.email),
+        'name': str(user.name),
+        'role': str(user.role),
+        'iss': 'open-webui',
+        'iat': now,
+        'exp': now + FORWARD_USER_JWT_EXPIRES_SECONDS,
+    }
+    return jwt.encode(payload, FORWARD_USER_JWT_SECRET, algorithm='HS256')
+
+
+def include_user_info_headers(headers: dict, user: Optional[Any] = None) -> dict:
+    """
+    Forward user identity to external backends: signed JWT in FORWARD_USER_JWT_HEADER if
+    FORWARD_USER_JWT_SECRET is set; otherwise the legacy X-OpenWebUI-User-* headers.
+    """
+    if user is None:
+        return headers
+
+    if FORWARD_USER_JWT_SECRET:
+        try:
+            token = _mint_forward_user_jwt(user)
+            return {**headers, FORWARD_USER_JWT_HEADER: token}
+        except Exception:
+            log.exception('Failed to mint %s; using plain user info headers.', FORWARD_USER_JWT_HEADER)
+
     return {
         **headers,
         FORWARD_USER_INFO_HEADER_USER_NAME: quote(user.name, safe=' '),


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to Discussion (https://github.com/open-webui/open-webui/discussions/24627)
- [x] **Target branch:** This PR targets **`dev`** (not `main`).
- [x] **Description:** See “Changelog Entry” / “Description” below.
- [x] **Changelog:** Keep a Changelog–style entry included below under “Changelog Entry”.
- [ ] **Documentation:** Open WebUI docs 
- [x] **Dependencies:** No new dependencies. Uses existing `PyJWT` (`import jwt`) already used elsewhere in the backend.
- [x] **Testing:** Manual verification: with `ENABLE_FORWARD_USER_INFO_HEADERS=true` and `FORWARD_USER_JWT_SECRET` set, outbound requests include `FORWARD_USER_JWT_HEADER` (default `X-OpenWebUI-User-Jwt`) with HS256 JWT; claims `sub`, `email`, `name`, `role`, `iss` (`open-webui`), `iat`, `exp`. Without secret, legacy `X-OpenWebUI-User-*` headers unchanged. Gateway decode with shared secret succeeds.
- [x] **Agentic AI Code:** Confirm per your process (human review + manual testing).
- [x] **Code review:** Self-reviewed; follows existing `env.py` int-parse patterns and centralizes behavior in `include_user_info_headers` so all existing call sites pick it up.
- [x] **Design & Architecture:** Opt-in via env only; default behavior unchanged when `FORWARD_USER_JWT_SECRET` is unset.
- [x] **Git Hygiene:** Single logical feature (forwarded user identity as optional signed JWT).
- [x] **Title Prefix:** **feat**: optional signed JWT for forwarded user identity to external backends

# Changelog Entry

- 🔐 **Signed JWT for forwarded user identity.** When `"ENABLE_FORWARD_USER_INFO_HEADERS"` is enabled, setting `"FORWARD_USER_JWT_SECRET"` sends a short-lived HS256 JWT in `"FORWARD_USER_JWT_HEADER"` instead of the separate `"X-OpenWebUI-User-*"` headers, so OpenAI-compatible gateways and tool backends can verify user context with a shared secret. 

### Description

When `ENABLE_FORWARD_USER_INFO_HEADERS` is enabled, operators can optionally set `FORWARD_USER_JWT_SECRET` so Open WebUI sends **one** HS256 JWT (header name configurable) carrying `sub`, `email`, `name`, and `role` instead of the four separate `X-OpenWebUI-User-*` headers. This lets upstream gateways verify user context cryptographically with a shared secret instead of trusting plain header strings alone which should prevent spoofing of headers by bad actors. If minting fails, behavior falls back to the legacy headers.

### Added

- Environment variables: `FORWARD_USER_JWT_SECRET`, `FORWARD_USER_JWT_HEADER` (default `X-OpenWebUI-User-Jwt`), `FORWARD_USER_JWT_EXPIRES_SECONDS` (default `300`, invalid values fall back to `300`).
- JWT claims: `sub` (user id), `email`, `name`, `role`, `iss` (`open-webui`), `iat`, `exp` (HS256).

### Changed

- `include_user_info_headers`: when `FORWARD_USER_JWT_SECRET` is non-empty, adds only the configured JWT header and omits the four legacy user info headers for that request path.

### Security

- Optional signed user context for trusted hops to external OpenAI-compatible backends, RAG, tools, TTS/STT, etc. (same call sites as existing forwarded headers). Operators should use a dedicated secret and short TTL appropriate to their gateway; `iss` is fixed to `open-webui` for verification pinning.

### Breaking Changes

- **Behavioral (env-driven):** If `FORWARD_USER_JWT_SECRET` is set, upstreams that previously relied only on `X-OpenWebUI-User-Name` / `Id` / `Email` / `Role` will no longer receive those four headers from this path; they must accept the JWT header instead. Unset `FORWARD_USER_JWT_SECRET` to restore legacy behavior.

---

### Additional Information

- Implementation: `backend/open_webui/env.py` (env wiring), `backend/open_webui/utils/headers.py` (`_mint_forward_user_jwt` + branch in `include_user_info_headers`).
- Session / login JWT (`WEBUI_SECRET_KEY`) is unchanged; this is a separate optional secret for gateway-facing assertions.
- JWT is not exposed to the browser by default; it is attached to **server-side** outbound requests that already use `include_user_info_headers`.

### Screenshots or Videos

- N/A (no UI change; verification via gateway / proxy logs or test upstream).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.