### PR TITLE
fix: add blank line separator between serialized output parts to fix raw <details> rendering

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -591,7 +591,7 @@ def serialize_output(output: list) -> str:
                     f'<details type="code_interpreter" done="false"{output_attr}>\n<summary>Analyzing…</summary>\n{display}\n</details>'
                 )
 
-    return '\n'.join(parts).strip()
+    return '\n\n'.join(parts).strip()
 
 
 def deep_merge(target, source):


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Testing:** Perform manual tests to verify the implemented fix works as intended and does not break any other functionality.
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change).
- [x] **Title Prefix:** fix

# Changelog Entry

### Description

Fixes `<details type="reasoning">`, `<details type="tool_calls">`, and `<details type="code_interpreter">` blocks being displayed as raw HTML text in chat instead of being rendered as collapsible UI components.

### Root Cause

In `serialize_output()` in `backend/open_webui/utils/middleware.py`, output parts (text, reasoning, tool calls, code interpreter) are joined with a single newline (`'\n'.join(parts)`). In Markdown, block-level elements must be preceded by a blank line (`\n\n`) to be recognized as a new block. Without it, marked's paragraph tokenizer absorbs the `<details>` tag into the preceding paragraph, preventing the custom `details` marked extension from ever being triggered. The HTML falls through to `HTMLToken.svelte` which renders it as raw text via `{token.text}` (textContent interpolation) instead of `{@html}`.

### Fixed

- Changed `'\n'.join(parts).strip()` to `'\n\n'.join(parts).strip()` in `serialize_output()` to ensure a blank line exists between every block-level element in the serialized output.

### Additional Information

See detailed root cause analysis at https://github.com/open-webui/open-webui/issues/24634#issuecomment-4436505583

Related issues: #24634, #24635
