### PR TITLE
fix: exact-time calendar alerts by adding scheduler grace window

### DIFF
--- a/backend/open_webui/models/calendar.py
+++ b/backend/open_webui/models/calendar.py
@@ -696,6 +696,7 @@ class CalendarEventTable:
         self,
         now_ns: int,
         default_lookahead_ns: int,
+        grace_ns: int = 0,
         db: Optional[AsyncSession] = None,
     ) -> list[tuple[CalendarEventModel, Optional[str]]]:
         """Events starting between now and now + lookahead, for alert processing.
@@ -716,7 +717,7 @@ class CalendarEventTable:
                 .outerjoin(UserRow, UserRow.id == CalendarEvent.user_id)
                 .filter(
                     CalendarEvent.is_cancelled == False,
-                    CalendarEvent.start_at >= now_ns,
+                    CalendarEvent.start_at >= now_ns - grace_ns,
                     CalendarEvent.start_at <= upper,
                 )
             )

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -501,9 +501,10 @@ async def _check_calendar_alerts(app) -> None:
 
     now_ns = int(time.time_ns())
     default_lookahead_ns = CALENDAR_ALERT_LOOKAHEAD_MINUTES * 60 * 1_000_000_000
+    grace_ns = SCHEDULER_POLL_INTERVAL * 1_000_000_000
 
     async with get_async_db() as db:
-        upcoming = await CalendarEvents.get_upcoming_events(now_ns, default_lookahead_ns, db=db)
+        upcoming = await CalendarEvents.get_upcoming_events(now_ns, default_lookahead_ns,grace_ns=grace_ns, db=db)
 
     if not upcoming:
         return


### PR DESCRIPTION
# Pull Request Checklist

* [x] **Linked Issue/Discussion:** Closes #24589
* [x] **Target branch:** `dev`
* [x] **Description:** Added scheduler grace window for exact-time calendar reminders.
* [x] **Changelog:** Added below.
* [x] **Documentation:** Not required (internal bug fix, no user-facing config change).
* [x] **Dependencies:** No new dependencies.
* [x] **Testing:** Manually tested exact-time and 5-minute reminders.
* [x] **Agentic AI Code:** Manually reviewed and tested.
* [x] **Code review:** Self-reviewed.
* [x] **Design & Architecture:** No architectural changes.
* [x] **Git Hygiene:** Atomic change, rebased on `dev`.
* [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Fixes a bug where calendar reminders configured as **"At time of event"** could be skipped when the scheduler polled slightly after the event start time.

### Added

* Grace window based on `SCHEDULER_POLL_INTERVAL` for exact-time reminder detection.

### Changed

* Updated calendar alert lookup logic to include recently-started events inside the scheduler polling window.

### Deprecated

* None

### Removed

* None

### Fixed

* "At time of event" reminders now trigger correctly for:

  * UI notifications
  * Webhook notifications

### Security

* None

### Breaking Changes

* None

---

### Additional Information

Root cause:
`get_upcoming_events()` filtered only `start_at >= now_ns`, so if scheduler ran a few seconds late, the event was missed permanently.

Fix:
Allow a small backward grace window (`now_ns - SCHEDULER_POLL_INTERVAL`) during event lookup.

### Screenshots or Videos

* N/A (backend-only fix)

### Contributor License Agreement

* [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
