### PR TITLE
fix: stabilize code block message layout

### DIFF
--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -43,13 +43,21 @@
 	export let readOnly = false;
 	export let editCodeBlock = true;
 	export let topPadding = false;
+
+	const FENCED_CODE_BLOCK_REGEX = /(^|\n)(```|~~~)/;
+
+	$: currentMessage = history.messages?.[messageId];
+	// Fenced code blocks can be much taller than the off-screen intrinsic estimate.
+	$: hasFencedCodeBlock = FENCED_CODE_BLOCK_REGEX.test(currentMessage?.content ?? '');
 </script>
 
 <div
 	role="listitem"
 	class="flex flex-col justify-between px-5 mb-3 w-full {($settings?.widescreenMode ?? null)
 		? 'max-w-full'
-		: 'max-w-5xl'} mx-auto rounded-lg group message-listitem"
+		: 'max-w-5xl'} mx-auto rounded-lg group message-listitem {hasFencedCodeBlock
+		? 'message-listitem-eager'
+		: ''}"
 >
 	{#if history.messages[messageId]}
 		{#if history.messages[messageId].role === 'user'}
@@ -136,5 +144,10 @@
 	.message-listitem {
 		content-visibility: auto;
 		contain-intrinsic-size: auto 150px;
+	}
+
+	.message-listitem-eager {
+		content-visibility: visible;
+		contain-intrinsic-size: none;
 	}
 </style>


### PR DESCRIPTION
## Summary

- keep `content-visibility: auto` for regular chat messages
- render messages containing fenced code blocks eagerly so large YAML/code blocks do not rely on the 150px off-screen intrinsic height estimate
- prevent scroll-time remeasurement from changing message bubble layout in widescreen mode

Closes #5975.

## Testing

- `npx prettier --check src/lib/components/chat/Messages/Message.svelte` passes
- `git diff --check` passes
- `npm run check` was attempted with dependencies installed via `npm install --engine-strict=false`; it fails on existing unrelated project diagnostics (9442 errors, 272 warnings) outside this change
- `npx eslint src/lib/components/chat/Messages/Message.svelte` was attempted; it fails on pre-existing unused imports / Function type warnings already present in this file
