### PR TITLE
fix: stabilize code block message layout

### DIFF
--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -43,13 +43,21 @@
 	export let readOnly = false;
 	export let editCodeBlock = true;
 	export let topPadding = false;
+
+	const FENCED_CODE_BLOCK_REGEX = /(^|\n)(```|~~~)/;
+
+	$: currentMessage = history.messages?.[messageId];
+	// Fenced code blocks can be much taller than the off-screen intrinsic estimate.
+	$: hasFencedCodeBlock = FENCED_CODE_BLOCK_REGEX.test(currentMessage?.content ?? '');
 </script>
 
 <div
 	role="listitem"
 	class="flex flex-col justify-between px-5 mb-3 w-full {($settings?.widescreenMode ?? null)
 		? 'max-w-full'
-		: 'max-w-5xl'} mx-auto rounded-lg group message-listitem"
+		: 'max-w-5xl'} mx-auto rounded-lg group message-listitem {hasFencedCodeBlock
+		? 'message-listitem-eager'
+		: ''}"
 >
 	{#if history.messages[messageId]}
 		{#if history.messages[messageId].role === 'user'}
@@ -136,5 +144,10 @@
 	.message-listitem {
 		content-visibility: auto;
 		contain-intrinsic-size: auto 150px;
+	}
+
+	.message-listitem-eager {
+		content-visibility: visible;
+		contain-intrinsic-size: none;
 	}
 </style>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

## Summary

- Keeps `content-visibility: auto` for regular chat messages.
- Renders messages containing fenced code blocks eagerly so large YAML/code blocks do not rely on the 150px off-screen intrinsic height estimate.
- Prevents scroll-time remeasurement from changing message bubble layout in widescreen mode.

Closes #5975.
Replaces #24643, which targeted `main` by mistake.

# Changelog Entry

### Description

- Stabilizes message layout for chats containing large fenced code blocks in widescreen mode.

### Added

- No new features.

### Changed

- Messages containing fenced code blocks now bypass off-screen content-visibility virtualization.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed scroll-time message bubble resizing caused by large fenced YAML/code blocks using the generic off-screen intrinsic height estimate.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- The change is intentionally scoped to messages containing fenced code blocks (` ``` ` or ` ~~~ `), so normal messages keep the existing `content-visibility: auto` optimization.
- No dependencies were added or changed.

### Screenshots or Videos

- Not attached. Local verification focused on formatting and static checks because a full app repro requires an Open WebUI runtime with the issue's widescreen chat setup.

### Testing

- `npx prettier --check src/lib/components/chat/Messages/Message.svelte` passes.
- `git diff --check upstream/dev..HEAD` passes.
- `npm run check` was attempted with dependencies installed via `npm install --engine-strict=false`; it fails on existing unrelated project diagnostics outside this change.
- `npx eslint src/lib/components/chat/Messages/Message.svelte` was attempted; it fails on pre-existing unused imports / Function type warnings already present in this file.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
