### PR TITLE
feat: auto-fill name, id, and description for tools and functions from frontmatter

### DIFF
--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -4,7 +4,7 @@
 
 	const i18n = getContext('i18n');
 
-	import { nameToId } from '$lib/utils';
+	import { extractFrontmatter, nameToId } from '$lib/utils';
 	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Badge from '$lib/components/common/Badge.svelte';
@@ -28,6 +28,11 @@
 	export let content = '';
 	let _content = '';
 
+	let hasManualName = false;
+	let hasManualId = false;
+	let hasManualDescription = false;
+	let isFrontmatterDetected = false;
+
 	$: if (content) {
 		updateContent();
 	}
@@ -36,7 +41,27 @@
 		_content = content;
 	};
 
-	$: if (name && !edit && !clone) {
+	// Auto-detect frontmatter and fill name/description in create mode
+	const handleContentChange = (newContent) => {
+		if (edit) return;
+		const fm = extractFrontmatter(newContent);
+		if (fm.title) {
+			isFrontmatterDetected = true;
+			if (!hasManualName) {
+				name = fm.title.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+			}
+			if (!hasManualId) {
+				id = nameToId(fm.title);
+			}
+		} else {
+			isFrontmatterDetected = false;
+		}
+		if (fm.description && !hasManualDescription) {
+			meta = { ...meta, description: fm.description };
+		}
+	};
+
+	$: if (name && !edit && !clone && !isFrontmatterDetected) {
 		id = nameToId(name);
 	}
 
@@ -323,6 +348,7 @@ class Pipe:
 									type="text"
 									placeholder={$i18n.t('Function Name')}
 									bind:value={name}
+									on:input={() => { hasManualName = true; }}
 									required
 								/>
 							</Tooltip>
@@ -345,6 +371,7 @@ class Pipe:
 									type="text"
 									placeholder={$i18n.t('Function ID')}
 									bind:value={id}
+									on:input={() => { hasManualId = true; }}
 									required
 									disabled={edit}
 								/>
@@ -361,6 +388,7 @@ class Pipe:
 								type="text"
 								placeholder={$i18n.t('Function Description')}
 								bind:value={meta.description}
+								on:input={() => { hasManualDescription = true; }}
 								required
 							/>
 						</Tooltip>
@@ -375,6 +403,7 @@ class Pipe:
 						{boilerplate}
 						onChange={(e) => {
 							_content = e;
+							handleContentChange(e);
 						}}
 						onSave={async () => {
 							if (formElement) {

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { extractFrontmatter, nameToId } from '$lib/utils';
 	import { toast } from 'svelte-sonner';
 	import { getContext, onMount, tick } from 'svelte';
 
@@ -8,7 +9,7 @@
 	import { user } from '$lib/stores';
 	import { updateToolAccessGrants } from '$lib/apis/tools';
 
-	import { nameToId } from '$lib/utils';
+
 	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
@@ -35,6 +36,11 @@
 	export let content = '';
 	export let accessGrants = [];
 
+	let hasManualName = false;
+	let hasManualId = false;
+	let hasManualDescription = false;
+	let isFrontmatterDetected = false;
+
 	let _content = '';
 
 	$: if (content) {
@@ -45,7 +51,27 @@
 		_content = content;
 	};
 
-	$: if (name && !edit && !clone) {
+	// Auto-detect frontmatter and fill name/description in create mode
+	const handleContentChange = (newContent) => {
+		if (edit) return;
+		const fm = extractFrontmatter(newContent);
+		if (fm.title) {
+			isFrontmatterDetected = true;
+			if (!hasManualName) {
+				name = fm.title.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+			}
+			if (!hasManualId) {
+				id = nameToId(fm.title);
+			}
+		} else {
+			isFrontmatterDetected = false;
+		}
+		if (fm.description && !hasManualDescription) {
+			meta = { ...meta, description: fm.description };
+		}
+	};
+
+	$: if (name && !edit && !clone && !isFrontmatterDetected) {
 		id = nameToId(name);
 	}
 
@@ -246,6 +272,7 @@ class Tools:
 									placeholder={$i18n.t('Tool Name')}
 									aria-label={$i18n.t('Tool Name')}
 									bind:value={name}
+									on:input={() => { hasManualName = true; }}
 									required
 								/>
 							</Tooltip>
@@ -281,6 +308,7 @@ class Tools:
 									placeholder={$i18n.t('Tool ID')}
 									aria-label={$i18n.t('Tool ID')}
 									bind:value={id}
+									on:input={() => { hasManualId = true; }}
 									required
 									disabled={edit}
 								/>
@@ -298,6 +326,7 @@ class Tools:
 								placeholder={$i18n.t('Tool Description')}
 								aria-label={$i18n.t('Tool Description')}
 								bind:value={meta.description}
+								on:input={() => { hasManualDescription = true; }}
 								required
 							/>
 						</Tooltip>
@@ -312,6 +341,7 @@ class Tools:
 						{boilerplate}
 						onChange={(e) => {
 							_content = e;
+							handleContentChange(e);
 						}}
 						onSave={async () => {
 							if (formElement) {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to [#24648](https://github.com/open-webui/open-webui/discussions/24648). If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

**Problem:** When creating a new **Tool** or **Function** in Open WebUI, users must manually type the Name, ID, and Description fields even when the pasted code already contains this metadata in its frontmatter header. This is inconsistent with the **Skill** editor, which already auto-fills these fields from the skill's YAML frontmatter when code is pasted.

**Solution:** This PR extends the same auto-fill behavior to the Tool and Function editors. When a user pastes (or types) Python code containing a valid `"""` triple-quote frontmatter block into a new Tool or Function, the `title:` and `description:` fields are automatically extracted and used to populate:

- **Name** — title-cased from the `title:` frontmatter key
- **ID** — slugified from the `title:` frontmatter key using the existing `nameToId()` utility
- **Description** — directly from the `description:` frontmatter key

This reuses the existing `extractFrontmatter()` utility from `$lib/utils` (the same function already used by the `ImportModal` and the create/edit page wrappers for version checking), so no new utilities or dependencies are introduced.

**Key design decisions:**

- **Manual override tracking:** Each field (Name, ID, Description) tracks whether the user has manually typed into it via `on:input` handlers. Once a field is manually edited, the frontmatter auto-fill stops overwriting it — giving the user full control.
- **Create-mode only:** The auto-fill logic is skipped entirely in edit mode, preventing accidental overwrites of existing metadata.
- **Clone-safe:** The `handleContentChange` function is only invoked from the CodeEditor's `onChange` callback (user-initiated edits), not from the initial prop-based content assignment, so cloning a Tool or Function does not trigger unwanted auto-fill overwrites.
- **Consistent with Skills:** The pattern mirrors the existing `SkillEditor.svelte` implementation (which uses `parseFrontmatter()` for `---` YAML headers), adapted for the Python `"""` triple-quote format that Tools and Functions use.

### Added

- Auto-fill of Name, ID, and Description fields in the **ToolkitEditor** (`src/lib/components/workspace/Tools/ToolkitEditor.svelte`) from Python triple-quote frontmatter when creating a new Tool.
- Auto-fill of Name, ID, and Description fields in the **FunctionEditor** (`src/lib/components/admin/Functions/FunctionEditor.svelte`) from Python triple-quote frontmatter when creating a new Function.
- Manual override detection (`hasManualName`, `hasManualId`, `hasManualDescription` flags) on all three input fields in both editors to prevent auto-fill from overwriting user edits.

### Changed

- The reactive `nameToId` derivation in both editors is now additionally guarded by `!isFrontmatterDetected` to prevent the name-based ID from fighting with the frontmatter-derived ID.
- The import statement in `ToolkitEditor.svelte` was consolidated to import both `extractFrontmatter` and `nameToId` from `$lib/utils` in a single import.

---

### Additional Information

- **No new dependencies** were added. This feature exclusively uses the existing `extractFrontmatter()` and `nameToId()` utilities already present in `$lib/utils/index.ts`.
- **Scope:** 2 files changed, 63 insertions, 4 deletions. Single atomic commit.
- **Frontmatter format supported:** The standard Open WebUI Python frontmatter format enclosed in triple quotes (`"""`), e.g.:
  ```python
  """
  title: My Cool Tool
  description: A tool that does something useful
  author: username
  version: 1.0
  """
  ```

### Screenshots or Videos

[Screencast from 2026-05-13 03-49-25.webm](https://github.com/user-attachments/assets/42afc1e8-8200-40de-a81c-d2c504fd94fc)

### Manual Verification Performed

1. **Tool auto-fill:** Navigate to Workspace → Tools → Create New Tool. Paste a Python tool with valid `"""` frontmatter containing `title:` and `description:` keys. Verify the Name, ID, and Description fields auto-populate.
2. **Function auto-fill:** Navigate to Admin → Functions → Create New Function. Paste a Python function with valid `"""` frontmatter. Verify the same auto-population behavior.
3. **Manual override:** After auto-fill, manually type into the Name field. Verify that subsequent code edits no longer overwrite the manually-entered name (same for ID and Description).
4. **No frontmatter:** Paste Python code without a `"""` frontmatter block. Verify the fields remain empty and the fallback `nameToId` derivation from the Name field still works as before.
5. **Edit mode:** Open an existing Tool/Function for editing. Verify the auto-fill does NOT trigger and existing metadata is preserved.
6. **Clone mode:** Clone an existing Tool/Function. Verify the cloned Name/ID/Description are preserved and not overwritten by frontmatter.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.