### PR TITLE
fix(images): add null-check in upload_image to prevent crash on SSRF block

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -472,6 +472,16 @@ async def get_image_data(data: str, headers=None):
 
 
 async def upload_image(request, image_data, content_type, metadata, user, db=None):
+    if image_data is None or content_type is None:
+        log.error(
+            f"upload_image called with invalid data: image_data={'present' if image_data is not None else 'None'}, "
+            f"content_type={content_type!r}. This may indicate an SSRF block or network issue."
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Failed to fetch image data. If using a local ComfyUI instance, "
+            "ensure ENABLE_RAG_LOCAL_WEB_FETCH=true in your environment.",
+        )
     image_format = mimetypes.guess_extension(content_type)
     file = UploadFile(
         file=io.BytesIO(image_data),


### PR DESCRIPTION
## Summary

When `get_image_data` returns `(None, None)` due to an SSRF block (e.g., ComfyUI on private IP like `192.168.x.x`), `upload_image` crashes with `'NoneType' object has no attribute 'lower'` in `mimetypes.guess_extension`.

This is a regression from PR #24518 which added `validate_url()` to prevent SSRF attacks. While the security fix is important, it broke ComfyUI deployments on private networks.

## Fix

Add a null-check at the start of `upload_image` that raises a descriptive `HTTPException` pointing users to the `ENABLE_RAG_LOCAL_WEB_FETCH` workaround.

## Changes

- `backend/open_webui/routers/images.py`: Added null-check in `upload_image()` function

## Testing

- Verified that `upload_image` now raises a 400 error with a helpful message instead of crashing
- The error message guides users to set `ENABLE_RAG_LOCAL_WEB_FETCH=true`

## Related

- Regression from #24518
- Workaround: Set `ENABLE_RAG_LOCAL_WEB_FETCH=true`

Fixes #24565