### PR TITLE
fix(images): add null-check in upload_image to prevent crash on SSRF block

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -471,6 +471,16 @@ async def get_image_data(data: str, headers=None):
 
 
 async def upload_image(request, image_data, content_type, metadata, user, db=None):
+    if image_data is None or content_type is None:
+        log.error(
+            f"upload_image called with invalid data: image_data={'present' if image_data is not None else 'None'}, "
+            f"content_type={content_type!r}. This may indicate an SSRF block or network issue."
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Failed to fetch image data. If using a local ComfyUI instance, "
+            "ensure ENABLE_RAG_LOCAL_WEB_FETCH=true in your environment.",
+        )
     image_format = mimetypes.guess_extension(content_type)
     file = UploadFile(
         file=io.BytesIO(image_data),


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) — `Closes #24565`.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits.

# Changelog Entry

### Fixed

- Add null-check in `upload_image` to prevent crash when `get_image_data` returns `(None, None)` due to SSRF block (e.g., ComfyUI on private IP)

### Description

- When `get_image_data` returns `(None, None)` due to an SSRF block (e.g., ComfyUI on private IP like `192.168.x.x`), `upload_image` crashed with `'NoneType' object has no attribute 'lower'` in `mimetypes.guess_extension`
- This is a regression from PR #24518 which added `validate_url()` to prevent SSRF attacks
- Add a null-check at the start of `upload_image` that raises a descriptive `HTTPException` pointing users to the `ENABLE_RAG_LOCAL_WEB_FETCH` workaround

### Related

- Regression from #24518
- Workaround: Set `ENABLE_RAG_LOCAL_WEB_FETCH=true`

---

### Additional Information

- Fixes #24565

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.