### PR TITLE
fix: default WEB_LOADER_ENGINE in start.sh to avoid unbound-variable …

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 # HuggingFace Space deployment, and launches the uvicorn server.
 # ---------------------------------------------------------------------------
 
+# Default optional env vars that we test below with bash's `,,` lowercase
+# expansion. The two can't be combined inline (`${VAR:-default,,}` makes
+# the default literal `,,`), so we normalise once up front and the simple
+# `${VAR,,}` form stays safe under `set -u` everywhere else.
+: "${WEB_LOADER_ENGINE:=}" "${USE_OLLAMA_DOCKER:=}" "${USE_CUDA_DOCKER:=}"
+
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit 1
 


### PR DESCRIPTION
…crash

start.sh runs with `set -euo pipefail`, but the playwright-install branch references `${WEB_LOADER_ENGINE,,}` without a `:-` default. Containers that don't set WEB_LOADER_ENGINE in their env — the default for every deployment that isn't explicitly using playwright/firecrawl/tavily — crash on startup with:

    start.sh: line 15: WEB_LOADER_ENGINE: unbound variable

Introduced by 070ab2650 (refac: reorganize scripts and ci workflows). Every other env-var reference in start.sh already uses `:-`; this one was missed because bash's `,,` lowercase expansion can't be combined with `:-` in a single substitution. Splitting into two steps keeps the lowercase comparison intact.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
