### PR TITLE
fix(oauth): use Protected Resource Metadata scopes in static OAuth 2.1 flow

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -293,6 +293,7 @@ class ProtectedResourceMetadata:
 
     resource: str | None = None
     authorization_servers: list[str] = field(default_factory=list)
+    scopes_supported: list[str] = field(default_factory=list)
 
     def get_discovery_urls(self, server_url: str) -> list[str]:
         """Build all candidate OAuth discovery URLs from this metadata and the server URL."""
@@ -315,6 +316,7 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
     """
     authorization_servers = []
     resource = None
+    scopes = []
     try:
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
@@ -362,14 +364,19 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
                                     if servers:
                                         authorization_servers = servers
                                         log.debug(f'Discovered authorization servers: {servers}')
-                                        break
+
+                                    scopes = resource_metadata.get('scopes_supported', [])
+                                    if scopes:
+                                        log.debug(f'Discovered resource scopes: {scopes}')
+
+                                    break
                         except Exception as e:
                             log.debug(f'Failed to fetch resource metadata from {resource_metadata_url}: {e}')
                             continue
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 
-    return ProtectedResourceMetadata(resource=resource, authorization_servers=authorization_servers)
+    return ProtectedResourceMetadata(resource=resource, authorization_servers=authorization_servers, scopes_supported=scopes)
 
 
 def _build_well_known_urls(server_url: str) -> list[str]:
@@ -553,12 +560,11 @@ async def get_oauth_client_info_with_static_credentials(
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        # Let the OAuth provider apply its default scopes.
-        # We intentionally do NOT join all scopes_supported here — that list
-        # represents every scope the server *can* grant, not what the client
-        # should request.  Requesting all of them is almost always wrong and
-        # can break providers like Entra ID that require resource-specific scopes.
-        scope = None
+        # Use scopes from the Protected Resource Metadata (RFC 9728) if available.
+        # Unlike the Authorization Server's scopes_supported (which is a full catalog
+        # of every scope the server can grant), the PRM scopes_supported represents
+        # what this specific resource requires — making it safe to request them all.
+        scope = ' '.join(resource_metadata.scopes_supported) if resource_metadata.scopes_supported else None
 
         # Determine token_endpoint_auth_method
         token_endpoint_auth_method = 'client_secret_post'


### PR DESCRIPTION
## Summary

The static credentials OAuth 2.1 flow (`oauth_2.1_static`) currently sets `scope=None`, relying on the OAuth provider's default scopes. This breaks providers like GitHub that default to minimal/public-only access when no scope is requested — making it impossible to access private resources via MCP tool servers using static OAuth credentials.

This PR reads `scopes_supported` from the **Protected Resource Metadata** document (RFC 9728) and uses them in the authorization request.

## Why this doesn't break Entra ID

The original change (349ea4ea) correctly identified that requesting all scopes from the **Authorization Server Metadata** breaks providers like Entra ID. However, the Protected Resource Metadata's `scopes_supported` is semantically different:

- **AS Metadata `scopes_supported`**: Full catalog of every scope the authorization server can grant across all resources
- **PRM `scopes_supported`** (RFC 9728 §2): Scopes required by *this specific protected resource*

Per the MCP spec's [Scope Selection Strategy](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization), clients should use `scopes_supported` from the Protected Resource Metadata when no explicit scope is provided in the `WWW-Authenticate` challenge.

## Changes

1. Added `scopes_supported` field to `ProtectedResourceMetadata` dataclass
2. Extract `scopes_supported` from the PRM document during discovery (it was already being fetched but the field was discarded)
3. Use PRM scopes in the static credentials flow instead of `None`

## Test plan

- [x] Verified GitHub MCP server's `/.well-known/oauth-protected-resource` returns appropriate `scopes_supported` (`repo`, `read:org`, etc.)
- [ ] With this patch, OAuth authorization request includes `scope=repo read:org ...` and GitHub grants access to private org repos
- [ ] Entra ID static OAuth flows continue to work (PRM document from Entra-backed MCP servers typically doesn't include `scopes_supported`, so behavior falls back to `scope=None`)

## Related issues

- #23668 — the original issue that led to removing scope handling
- #23696 — prior PR attempting to add admin-configurable scopes (closed due to CLA/branch)