### PR TITLE
fix(oauth): use Protected Resource Metadata scopes in static OAuth 2.1 flow

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -293,6 +293,7 @@ class ProtectedResourceMetadata:
 
     resource: str | None = None
     authorization_servers: list[str] = field(default_factory=list)
+    scopes_supported: list[str] = field(default_factory=list)
 
     def get_discovery_urls(self, server_url: str) -> list[str]:
         """Build all candidate OAuth discovery URLs from this metadata and the server URL."""
@@ -315,6 +316,7 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
     """
     authorization_servers = []
     resource = None
+    scopes = []
     try:
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
@@ -359,6 +361,10 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
                                         log.debug(f'Discovered resource indicator: {resource}')
 
                                     servers = resource_metadata.get('authorization_servers', [])
+                                    scopes = resource_metadata.get('scopes_supported', [])
+                                    if scopes:
+                                        log.debug(f'Discovered resource scopes: {scopes}')
+
                                     if servers:
                                         authorization_servers = servers
                                         log.debug(f'Discovered authorization servers: {servers}')
@@ -369,7 +375,7 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 
-    return ProtectedResourceMetadata(resource=resource, authorization_servers=authorization_servers)
+    return ProtectedResourceMetadata(resource=resource, authorization_servers=authorization_servers, scopes_supported=scopes)
 
 
 def _build_well_known_urls(server_url: str) -> list[str]:
@@ -553,12 +559,11 @@ async def get_oauth_client_info_with_static_credentials(
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        # Let the OAuth provider apply its default scopes.
-        # We intentionally do NOT join all scopes_supported here — that list
-        # represents every scope the server *can* grant, not what the client
-        # should request.  Requesting all of them is almost always wrong and
-        # can break providers like Entra ID that require resource-specific scopes.
-        scope = None
+        # Use scopes from the Protected Resource Metadata (RFC 9728) if available.
+        # Unlike the Authorization Server's scopes_supported (which is a full catalog
+        # of every scope the server can grant), the PRM scopes_supported represents
+        # what this specific resource requires — making it safe to request them all.
+        scope = ' '.join(resource_metadata.scopes_supported) if resource_metadata.scopes_supported else None
 
         # Determine token_endpoint_auth_method
         token_endpoint_auth_method = 'client_secret_post'


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24730 (relates to #23668)
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** N/A — no user-facing documentation change needed.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested against GitHub MCP server's `/.well-known/oauth-protected-resource` endpoint. Confirmed scopes are included in the authorization request.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings. Uses existing PRM discovery flow.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

The static credentials OAuth 2.1 flow (`oauth_2.1_static`) currently sets `scope=None`, relying on the OAuth provider's default scopes. This breaks providers like GitHub that default to minimal/public-only access when no scope is requested — making it impossible to access private resources via MCP tool servers using static OAuth credentials.

This PR reads `scopes_supported` from the Protected Resource Metadata document (RFC 9728) and uses them in the authorization request.

**Why this doesn't break Entra ID:**

The original change (349ea4ea) correctly identified that requesting all scopes from the Authorization Server Metadata breaks providers like Entra ID. However, the Protected Resource Metadata's `scopes_supported` is semantically different:

- **AS Metadata `scopes_supported`**: Full catalog of every scope the authorization server can grant across all resources
- **PRM `scopes_supported`** (RFC 9728 §2): Scopes required by this specific protected resource

Per the MCP spec's Scope Selection Strategy, clients should use `scopes_supported` from the Protected Resource Metadata when no explicit scope is provided in the `WWW-Authenticate` challenge.

### Added

- `scopes_supported` field on `ProtectedResourceMetadata` dataclass

### Changed

- `get_protected_resource_metadata()` now extracts `scopes_supported` from the PRM document
- `get_oauth_client_info_with_static_credentials()` uses PRM scopes instead of `None`

### Fixed

- Static OAuth 2.1 flow now requests appropriate scopes for providers (like GitHub) that require explicit scope requests to grant access to private resources

---

### Additional Information

- Closes #24730 (OAuth scopes missing within authorize_url when using MCP with OAuth2.1 Static — the active issue this PR resolves)
- Relates to #23668 (the original issue that led to removing scope handling; closed by maintainer)
- Relates to #23696 (prior PR attempting to add admin-configurable scopes, closed due to CLA/branch)
- Tested against `github/github-mcp-server` which advertises `repo`, `read:org`, etc. in its PRM `scopes_supported`
- Falls back to `scope=None` when PRM does not include `scopes_supported`, preserving current behavior for Entra ID and similar providers

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
