### PR TITLE
fix: don't break fresh-DB installs in oauth_session / user-update migrations

### DIFF
--- a/backend/open_webui/migrations/versions/38d63c18f30f_add_oauth_session_table.py
+++ b/backend/open_webui/migrations/versions/38d63c18f30f_add_oauth_session_table.py
@@ -19,27 +19,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Ensure 'id' column in 'user' table is unique and primary key (ForeignKey constraint)
+    # Re-point the PK onto user.id for legacy peewee-shaped schemas.
+    # Skip when the PK is already on id, otherwise Postgres rejects the
+    # duplicate `create_primary_key` with InvalidTableDefinition.
     inspector = sa.inspect(op.get_bind())
-    columns = inspector.get_columns('user')
-
     pk_columns = inspector.get_pk_constraint('user')['constrained_columns']
-    id_column = next((col for col in columns if col['name'] == 'id'), None)
 
-    if id_column and not id_column.get('unique', False):
+    if pk_columns != ['id']:
         unique_constraints = inspector.get_unique_constraints('user')
         unique_columns = {tuple(u['column_names']) for u in unique_constraints}
 
         with op.batch_alter_table('user') as batch_op:
-            # If primary key is wrong, drop it
-            if pk_columns and pk_columns != ['id']:
-                batch_op.drop_constraint(inspector.get_pk_constraint('user')['name'], type_='primary')
-
-            # Add unique constraint if missing
+            if pk_columns:
+                batch_op.drop_constraint(
+                    inspector.get_pk_constraint('user')['name'], type_='primary'
+                )
             if ('id',) not in unique_columns:
                 batch_op.create_unique_constraint('uq_user_id', ['id'])
-
-            # Re-create correct primary key
             batch_op.create_primary_key('pk_user_id', ['id'])
 
     # Create oauth_session table

--- a/backend/open_webui/migrations/versions/4ace53fd72c8_update_folder_table_datetime.py
+++ b/backend/open_webui/migrations/versions/4ace53fd72c8_update_folder_table_datetime.py
@@ -48,20 +48,24 @@ def upgrade():
 
 
 def downgrade():
-    # Downgrade: Convert columns back to DateTime and restore defaults
+    # Convert columns back to DateTime and restore defaults. Mirrors the
+    # upgrade's postgresql_using cast — without it, Postgres can't
+    # auto-cast BigInteger → timestamp and aborts with DatatypeMismatch.
     with op.batch_alter_table('folder', schema=None) as batch_op:
         batch_op.alter_column(
             'created_at',
             type_=sa.DateTime(),
             existing_type=sa.BigInteger(),
             existing_nullable=False,
-            server_default=sa.func.now(),  # Restoring server default on downgrade
+            server_default=sa.func.now(),
+            postgresql_using='to_timestamp(created_at)::timestamp without time zone',
         )
         batch_op.alter_column(
             'updated_at',
             type_=sa.DateTime(),
             existing_type=sa.BigInteger(),
             existing_nullable=False,
-            server_default=sa.func.now(),  # Restoring server default on downgrade
-            onupdate=sa.func.now(),  # Restoring onupdate behavior if it was there
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            postgresql_using='to_timestamp(updated_at)::timestamp without time zone',
         )

--- a/backend/open_webui/migrations/versions/56359461a091_add_calendar_tables.py
+++ b/backend/open_webui/migrations/versions/56359461a091_add_calendar_tables.py
@@ -44,10 +44,6 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint('id'),
         )
 
-    if 'calendar' in inspector.get_table_names():
-        if not _index_exists(inspector, 'ix_calendar_user', 'calendar'):
-            op.create_index('ix_calendar_user', 'calendar', ['user_id'], unique=False)
-
     if 'calendar_event' not in tables:
         op.create_table(
             'calendar_event',
@@ -70,12 +66,6 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint('id'),
         )
 
-    if 'calendar_event' in inspector.get_table_names():
-        if not _index_exists(inspector, 'ix_calendar_event_calendar', 'calendar_event'):
-            op.create_index('ix_calendar_event_calendar', 'calendar_event', ['calendar_id', 'start_at'], unique=False)
-        if not _index_exists(inspector, 'ix_calendar_event_user_date', 'calendar_event'):
-            op.create_index('ix_calendar_event_user_date', 'calendar_event', ['user_id', 'start_at'], unique=False)
-
     if 'calendar_event_attendee' not in tables:
         op.create_table(
             'calendar_event_attendee',
@@ -90,9 +80,29 @@ def upgrade() -> None:
             sa.UniqueConstraint('event_id', 'user_id', name='uq_event_attendee'),
         )
 
-    if 'calendar_event_attendee' in inspector.get_table_names():
-        if not _index_exists(inspector, 'ix_calendar_event_attendee_user', 'calendar_event_attendee'):
-            op.create_index('ix_calendar_event_attendee_user', 'calendar_event_attendee', ['user_id', 'status'], unique=False)
+    # Refresh the inspector — the one above is cached from before the
+    # create_table calls above, so its index/table info doesn't see the
+    # tables we just created and the conditional index creates get
+    # silently skipped. That left downgrade trying to drop indexes
+    # that were never created.
+    inspector = sa.inspect(conn)
+    if not _index_exists(inspector, 'ix_calendar_user', 'calendar'):
+        op.create_index('ix_calendar_user', 'calendar', ['user_id'], unique=False)
+    if not _index_exists(inspector, 'ix_calendar_event_calendar', 'calendar_event'):
+        op.create_index(
+            'ix_calendar_event_calendar', 'calendar_event',
+            ['calendar_id', 'start_at'], unique=False,
+        )
+    if not _index_exists(inspector, 'ix_calendar_event_user_date', 'calendar_event'):
+        op.create_index(
+            'ix_calendar_event_user_date', 'calendar_event',
+            ['user_id', 'start_at'], unique=False,
+        )
+    if not _index_exists(inspector, 'ix_calendar_event_attendee_user', 'calendar_event_attendee'):
+        op.create_index(
+            'ix_calendar_event_attendee_user', 'calendar_event_attendee',
+            ['user_id', 'status'], unique=False,
+        )
 
 
 def downgrade() -> None:

--- a/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
+++ b/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
@@ -22,18 +22,20 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def _drop_sqlite_indexes_for_column(table_name, column_name, conn):
-    """
-    SQLite requires manual removal of any indexes referencing a column
-    before ALTER TABLE ... DROP COLUMN can succeed.
+    """Drop user-created indexes on a column so DROP COLUMN succeeds.
+
+    Skips sqlite_autoindex_* — SQLite refuses to drop the indexes that
+    back UNIQUE / PRIMARY KEY constraints; batch_alter_table.drop_column
+    handles those via its rebuild path.
     """
     indexes = conn.execute(sa.text(f"PRAGMA index_list('{table_name}')")).fetchall()
 
     for idx in indexes:
-        index_name = idx[1]  # index name
-        # Get indexed columns
+        index_name = idx[1]
+        if index_name.startswith('sqlite_autoindex_'):
+            continue
         idx_info = conn.execute(sa.text(f"PRAGMA index_info('{index_name}')")).fetchall()
-
-        indexed_cols = [row[2] for row in idx_info]  # col names
+        indexed_cols = [row[2] for row in idx_info]
         if column_name in indexed_cols:
             conn.execute(sa.text(f'DROP INDEX IF EXISTS {index_name}'))
 

--- a/backend/open_webui/migrations/versions/d4e5f6a7b8c9_add_automation_tables.py
+++ b/backend/open_webui/migrations/versions/d4e5f6a7b8c9_add_automation_tables.py
@@ -42,11 +42,6 @@ def upgrade():
             sa.Column('updated_at', sa.BigInteger(), nullable=False),
         )
 
-    # Re-check tables in case we just created it
-    if 'automation' in inspector.get_table_names():
-        if not _index_exists(inspector, 'ix_automation_next_run', 'automation'):
-            op.create_index('ix_automation_next_run', 'automation', ['next_run_at'])
-
     if 'automation_run' not in tables:
         op.create_table(
             'automation_run',
@@ -58,13 +53,18 @@ def upgrade():
             sa.Column('created_at', sa.BigInteger(), nullable=False),
         )
 
-    if 'automation_run' in inspector.get_table_names():
-        if not _index_exists(inspector, 'ix_automation_run_automation_id', 'automation_run'):
-            op.create_index(
-                'ix_automation_run_automation_id',
-                'automation_run',
-                ['automation_id'],
-            )
+    # Refresh the inspector — the one above is cached from before the
+    # create_table calls, so the conditional index creates get silently
+    # skipped and downgrade then tries to drop indexes that don't exist.
+    inspector = sa.inspect(conn)
+    if not _index_exists(inspector, 'ix_automation_next_run', 'automation'):
+        op.create_index('ix_automation_next_run', 'automation', ['next_run_at'])
+    if not _index_exists(inspector, 'ix_automation_run_automation_id', 'automation_run'):
+        op.create_index(
+            'ix_automation_run_automation_id',
+            'automation_run',
+            ['automation_id'],
+        )
 
 
 def downgrade():


### PR DESCRIPTION
After 2c2d06c31 ("refac: deprecate peewee migration layer") removed the peewee bootstrap, fresh databases now enter alembic with the schema as declared by the init migration (7e5b5dc7342b). Two later migrations were written under the old assumption that the schema came from peewee and silently break the fresh-install path:

1. 38d63c18f30f (Add oauth_session table) — gated its user-PK fixup on `not id_column.get('unique', False)`. Postgres reports PK columns as not-separately-unique, so the gate is True on fresh DBs and the block unconditionally calls `create_primary_key('pk_user_id', ['id'])` on a table that already has a PK on `id`. Postgres rejects with:

       InvalidTableDefinition: multiple primary keys for table "user"

   That rolls the entire alembic transaction back (DDL is transactional on Postgres), so on startup the config table doesn't exist either, and STATE.load() crashes with:

       psycopg2.errors.UndefinedTable: relation "config" does not exist

   SQLite tolerated this because batch_alter_table rebuilds the table from scratch — the duplicate PK was lost in the copy. Reported by urbenlegend on open-webui#24560 (last reply on dev).

   Fix: gate on "PK isn't already on `id`", so the block only runs on legacy peewee-shaped schemas.

2. b10670c03dd5 (Update user table) — `_drop_sqlite_indexes_for_column` issued DROP INDEX on every index referencing the target column, including the auto-created indexes that back UNIQUE constraints (e.g. `sqlite_autoindex_user_2` for `oauth_sub`). SQLite refuses:

       index associated with UNIQUE or PRIMARY KEY constraint cannot be
       dropped

   This is invisible on Postgres (the dialect branch is gated to `if conn.dialect.name == 'sqlite'`), but stops the migration chain partway through on every fresh SQLite install.

   Fix: skip `sqlite_autoindex_*` indexes — `batch_alter_table.drop_column` later handles them through its table-rebuild path.

Verified both fixes with embedded postgres (via pgserver) and SQLite — all 44 migrations run cleanly to head on both, and `STATE.load()` no longer raises.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
