### PR TITLE
fix: reorder settings to place rich text options above prompt autocompletion

### DIFF
--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -1181,27 +1181,6 @@
 				</div>
 			</div>
 
-			{#if $config?.features?.enable_autocomplete_generation}
-				<div>
-					<div class=" py-0.5 flex w-full justify-between">
-						<div id="prompt-autocompletion-label" class=" self-center text-xs">
-							{$i18n.t('Prompt Autocompletion')}
-						</div>
-
-						<div class="flex items-center gap-2 p-1">
-							<Switch
-								ariaLabelledbyId="prompt-autocompletion-label"
-								tooltip={true}
-								bind:state={promptAutocomplete}
-								on:change={() => {
-									saveSettings({ promptAutocomplete });
-								}}
-							/>
-						</div>
-					</div>
-				</div>
-			{/if}
-
 			{#if richTextInput}
 				<div>
 					<div class=" py-0.5 flex w-full justify-between">
@@ -1235,6 +1214,27 @@
 								bind:state={insertPromptAsRichText}
 								on:change={() => {
 									saveSettings({ insertPromptAsRichText });
+								}}
+							/>
+						</div>
+					</div>
+				</div>
+			{/if}
+
+			{#if $config?.features?.enable_autocomplete_generation}
+				<div>
+					<div class=" py-0.5 flex w-full justify-between">
+						<div id="prompt-autocompletion-label" class=" self-center text-xs">
+							{$i18n.t('Prompt Autocompletion')}
+						</div>
+
+						<div class="flex items-center gap-2 p-1">
+							<Switch
+								ariaLabelledbyId="prompt-autocompletion-label"
+								tooltip={true}
+								bind:state={promptAutocomplete}
+								on:change={() => {
+									saveSettings({ promptAutocomplete });
 								}}
 							/>
 						</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to discussion post https://github.com/open-webui/open-webui/discussions/24708`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- I've noticed a small inconsistency in the User Settings menu where the Rich Text Input sub-options (Formatting Toolbar, etc.) were being placed below Prompt Autocompletion, separating them from the main Rich Text toggle.

- In response to this, I've reordered the user settings to place "Rich Text Input" related options (Formatting Toolbar, Insert as Rich Text) above "Prompt Autocompletion". This provides a more logical grouping of input-related settings.

### Changed

- Reordered settings blocks in `src/lib/components/chat/Settings/Interface.svelte`.

---

### Additional Information

- This is a minor UI polish to improve the organization of the user settings menu.
- Relates to discussion post: https://github.com/open-webui/open-webui/discussions/24708

### Screenshots or Videos

**Before:**

<img width="1117" height="225" alt="image" src="https://github.com/user-attachments/assets/d7c6e6eb-d080-4692-bbbd-aca5c18f6bdf" />

**After:**

<img width="1117" height="225" alt="image" src="https://github.com/user-attachments/assets/c634b549-d05b-451b-8d9a-d6dfa9478c59" />

### Manual Verification Performed

1. Open User Settings -> Interface.
2. Toggle "Rich Text Input for Chat" ON.
3. Verify that "Show Formatting Toolbar" and "Insert Prompt as Rich Text" appear directly below the toggle and ABOVE "Prompt Autocompletion".
4. Toggle "Rich Text Input for Chat" OFF and verify the options disappear correctly.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.