### PR TITLE
fix: handle list-shape data in Firecrawl /search response

### DIFF
--- a/backend/open_webui/retrieval/web/firecrawl.py
+++ b/backend/open_webui/retrieval/web/firecrawl.py
@@ -197,8 +197,11 @@ def search_firecrawl(
             },
             timeout=count * 3 + 10,
         )
+        # Firecrawl /search has historically returned both `{"data": [...]}`
+        # (flat list, what v1 did and what frost19k reported under #23966)
+        # and `{"data": {"web": [...]}}` (current v2). Accept either.
         data = response.get('data') or {}
-        results = data.get('web') or []
+        results = data if isinstance(data, list) else (data.get('web') or [])
 
         if filter_list:
             from open_webui.retrieval.web.main import get_filtered_results


### PR DESCRIPTION
Firecrawl /search returns either `{"data": [...]}` (flat list — v1, and what frost19k reported on #23966) or `{"data": {"web": [...]}}` (v2, current production). The parser only handled the dict shape:

    data = response.get('data') or {}
    results = data.get('web') or []

On a list-shape response, `data.get('web')` raised AttributeError, caught by the function's outer try/except, and `search_firecrawl` silently returned []. Web search worked against v2 endpoints but is one upstream-format-change away from failing closed again. Accept either.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
