### PR TITLE
fix: run outlet filters before background title, tags, and follow-ups

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3511,13 +3511,13 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 },
                             )
 
-                    await background_tasks_handler(ctx)
                     ctx['assistant_message'] = {
                         'content': content,
                         'output': response_output,
                         **({'usage': usage} if usage else {}),
                     }
                     await outlet_filter_handler(ctx)
+                    await background_tasks_handler(ctx)
 
             response = build_response_object(response, merge_events_into_response(response_data, events))
         except Exception as e:
@@ -5086,13 +5086,13 @@ async def streaming_chat_response_handler(response, ctx):
                     }
                 )
 
-                await background_tasks_handler(ctx)
                 ctx['assistant_message'] = {
                     'content': serialize_output(output),
                     'output': output,
                     **({'usage': usage} if usage else {}),
                 }
                 await outlet_filter_handler(ctx)
+                await background_tasks_handler(ctx)
             except asyncio.CancelledError:
                 log.warning('Task was cancelled!')
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** https://github.com/open-webui/open-webui/discussions/24718
- [x] **Target branch:** This PR targets the **`dev`** branch.
- [x] **Description:** See **Description** and **Changelog Entry** below.
- [x] **Changelog:** Changelog-style notes are included under **Changelog Entry** below (maintainers can mirror into `CHANGELOG.md` if needed).
- [x] **Documentation:** No new env vars or public APIs. Behavior change is internal ordering of post-completion work; docs repo update is optional unless maintainers want it called out in deployment/troubleshooting guides.
- [x] **Dependencies:** None.
- [x] **Testing:** Manual checks listed under **Additional Information** (please run and tick after verifying).
- [x] **Agentic AI Code:** Confirm per project policy (human review + manual testing).
- [x] **Code review:** Self-review completed.
- [x] **Design & Architecture:** No new settings; reorders existing `await` sequence in chat response handlers only.
- [x] **Git Hygiene:** Single logical change (handler ordering + docstring).
- [x] **Title Prefix:** `fix:` — bug fix / correctness for downstream tasks and perceived latency of `chat:outlet`.

# Changelog Entry

- 🧩 **Outlet filters before post-completion background tasks.** In streaming and non-streaming chat handlers (`middleware.py`), `outlet_filter_handler` now runs before `background_tasks_handler` (title, tags, follow-ups). Title/tags/suggestions therefore use the same persisted thread content after outlet edits, and `chat:outlet` is no longer deferred behind those extra LLM calls.

### Description

After a chat completion finishes (streaming and non-streaming), **outlet filters** (`outlet_filter_handler`) now run **before** **`background_tasks_handler`** (title generation, tags generation, follow-up generation).

Previously, background tasks ran first, so title, tags, and follow-ups were built from `messages_map` **before** outlet filters could persist any assistant message edits. That made metadata and suggestions reflect **pre-outlet** text while the UI could later show **post-outlet** content via `chat:outlet`. Outlet also waited behind extra model calls, so **`chat:outlet`** could feel significantly delayed.

**Impact:** Title, tags, and follow-ups now see the same persisted thread content outlet uses; `chat:outlet` is no longer blocked by those background LLM calls. `ctx['assistant_message']` is set before outlet so temp/local chats still work for outlet.

### Changed

- **Chat response handlers** (`backend/open_webui/utils/middleware.py`): execution order is now `outlet_filter_handler` → `background_tasks_handler` after the assistant message is saved and `chat:completion` / `done` is emitted (streaming path unchanged for when `done` fires; only post-emit work is reordered). Non-streaming path sets `ctx['assistant_message']` before outlet, then outlet, then background tasks.

### Fixed

- **Consistency:** Title, tags, and follow-ups are derived from assistant content **after** outlet filters may update it in the database.
- **Latency perception:** `chat:outlet` is emitted before background title/tags/follow-up completions run, instead of after them.

### Breaking Changes

- **BREAKING CHANGE:** None. Custom outlet filters that assumed title/tags/follow-ups were already written before outlet ran would see a different order; that coupling was implicit and uncommon.

---

### Additional Information

- **Files:** `backend/open_webui/utils/middleware.py` (`non_streaming_chat_response_handler`, `streaming_chat_response_handler`, `outlet_filter_handler` docstring).
- **Suggested manual tests:**
  1. Enable title + tags + follow-ups; attach an outlet filter that changes assistant `content`. Confirm DB / UI title and tags reflect edited text (or at least the thread snapshot used for those prompts matches post-outlet).
  2. Confirm `chat:outlet` still arrives and updates the client; observe it is not deferred until after title/tags network activity.
  3. Temp / `local:` chat: confirm outlet still runs with `ctx['assistant_message']` set.
  4. Regression: normal chat without outlet filters — title/tags/follow-ups still run and events still fire.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.