### PR TITLE
fix: avoid unbound variables in backend/start.sh under set -u

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -12,6 +12,7 @@ cd "$SCRIPT_DIR" || exit 1
 
 # ── Playwright browser installation (if configured) ──────────────────────────
 
+WEB_LOADER_ENGINE="${WEB_LOADER_ENGINE:-}"
 if [[ "${WEB_LOADER_ENGINE,,}" == "playwright" ]]; then
   if [[ -z "${PLAYWRIGHT_WS_URL:-}" ]]; then
     echo "Installing Playwright Chromium browser..."
@@ -41,6 +42,7 @@ fi
 
 # ── Ollama (bundled Docker image) ────────────────────────────────────────────
 
+USE_OLLAMA_DOCKER="${USE_OLLAMA_DOCKER:-}"
 if [[ "${USE_OLLAMA_DOCKER,,}" == "true" ]]; then
   echo "Starting bundled ollama serve..."
   ollama serve &
@@ -48,6 +50,7 @@ fi
 
 # ── CUDA library paths ──────────────────────────────────────────────────────
 
+USE_CUDA_DOCKER="${USE_CUDA_DOCKER:-}"
 if [[ "${USE_CUDA_DOCKER,,}" == "true" ]]; then
   echo "CUDA enabled — extending LD_LIBRARY_PATH for torch/cudnn libraries."
   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/lib/python3.11/site-packages/torch/lib:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** 
- [x] **Target branch:** This PR targets **`dev`**.
- [x] **Description:** See below.
- [x] **Changelog:** Entry included in **Changelog Entry** (mirror into `CHANGELOG.md` if your process requires it).
- [x] **Documentation:** No change to user-facing env contract; variables remain optional. No docs repo update required unless maintainers want a one-line note under deployment troubleshooting.
- [x] **Dependencies:** None.
- [x] **Testing:** See **Additional Information** — confirm container/local start with **unset** `WEB_LOADER_ENGINE`, `USE_OLLAMA_DOCKER`, and `USE_CUDA_DOCKER`.
- [x] **Agentic AI Code:** Confirm per project policy.
- [x] **Code review:** Self-review completed.
- [x] **Design & Architecture:** No new settings; bash-only hardening for `set -u`.
- [x] **Git Hygiene:** Single-file, single-purpose change.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

- 🐚 **backend/start.sh with `set -u`.** Optional environment variables (`WEB_LOADER_ENGINE`, `USE_OLLAMA_DOCKER`, `USE_CUDA_DOCKER`) are defaulted before case-insensitive comparisons so the container entrypoint no longer exits with `unbound variable` when those variables are omitted from the environment.

### Description

`backend/start.sh` uses `set -euo pipefail`. Under **`set -u`**, expanding `${VAR,,}` still requires `VAR` to be **set**. If optional environment variables such as **`WEB_LOADER_ENGINE`**, **`USE_OLLAMA_DOCKER`**, or **`USE_CUDA_DOCKER`** are not passed into the container (or shell), Bash exits with **`unbound variable`** before the server starts.

This PR defaults those variables before lowercasing / comparing, so missing env vars behave as “disabled” instead of crashing startup.

### Changed

- **`backend/start.sh`:** Optional flags are read safely under `set -u` (Playwright branch uses a defaulting assignment in the `if` list; Ollama/CUDA branches default the variable before `${VAR,,}`).

### Fixed

- **Container / script startup:** Avoid start.sh: line 15: `WEB_LOADER_ENGINE: unbound variable` (and the same class of error for `USE_OLLAMA_DOCKER` / `USE_CUDA_DOCKER`) when those variables are unset.

---

### Additional Information

**Root cause:** `set -u` + `${PARAMETER,,}` still references `PARAMETER`; it is not equivalent to `${PARAMETER:-}`.

**Manual test suggestions**

1. Run the entrypoint (or `bash backend/start.sh` in a throwaway env) with **no** `WEB_LOADER_ENGINE` — expect no error and no Playwright install branch unless `WEB_LOADER_ENGINE=playwright`.
2. Same with `USE_OLLAMA_DOCKER` and `USE_CUDA_DOCKER` unset — expect script to continue to uvicorn unless set to `true`.
3. With `WEB_LOADER_ENGINE=playwright` and no `PLAYWRIGHT_WS_URL`, confirm Chromium install path still runs when intended.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.