### PR TITLE
fix: tag composite pk in migration

### DIFF
--- a/backend/open_webui/migrations/versions/461111b60977_add_missing_primary_keys_to_legacy_.py
+++ b/backend/open_webui/migrations/versions/461111b60977_add_missing_primary_keys_to_legacy_.py
@@ -19,10 +19,12 @@ depends_on: Union[str, Sequence[str], None] = None
 # Tables bootstrapped by the old Peewee migration layer that may have
 # UNIQUE(id) but no PRIMARY KEY constraint.  Fresh Alembic installs
 # already have correct PKs from 7e5b5dc7342b_init.py.
-LEGACY_TABLES = [
-    'auth', 'chat', 'chatidtag', 'document', 'file',
-    'function', 'memory', 'model', 'prompt', 'tag', 'tool', 'user',
-]
+# 'tag' uses a composite PK since the same tag name can exist for multiple users.
+LEGACY_TABLES = {
+    'auth': ['id'], 'chat': ['id'], 'chatidtag': ['id'], 'document': ['id'],
+    'file': ['id'], 'function': ['id'], 'memory': ['id'], 'model': ['id'],
+    'prompt': ['id'], 'tag': ['id', 'user_id'], 'tool': ['id'], 'user': ['id'],
+}
 
 
 def upgrade() -> None:
@@ -30,30 +32,31 @@ def upgrade() -> None:
     inspector = sa.inspect(conn)
     existing_tables = set(inspector.get_table_names())
 
-    for table_name in LEGACY_TABLES:
+    for table_name, pk_columns in LEGACY_TABLES.items():
         if table_name not in existing_tables:
             continue
 
         pk = inspector.get_pk_constraint(table_name)
         pk_cols = pk.get('constrained_columns', [])
 
-        # Already has a proper PK on 'id' — nothing to do
-        if pk_cols == ['id']:
+        # Already has the correct PK — nothing to do
+        if sorted(pk_cols) == sorted(pk_columns):
             continue
 
-        # Check that an 'id' column actually exists
+        # Check that all PK columns exist
         columns = {c['name'] for c in inspector.get_columns(table_name)}
-        if 'id' not in columns:
+        if not all(c in columns for c in pk_columns):
             continue
 
-        print(f"Promoting UNIQUE(id) → PRIMARY KEY for '{table_name}'")
+        print(f"Promoting UNIQUE(id) -> PRIMARY KEY({', '.join(pk_columns)}) for '{table_name}'")
 
+        conn.execute(sa.text(f'DROP TABLE IF EXISTS _alembic_tmp_{table_name}'))
         with op.batch_alter_table(table_name) as batch_op:
             # Drop existing PK if any (e.g. on wrong column)
             if pk_cols and pk.get('name'):
                 batch_op.drop_constraint(pk['name'], type_='primary')
 
-            batch_op.create_primary_key(f'pk_{table_name}_id', ['id'])
+            batch_op.create_primary_key(f'pk_{table_name}', pk_columns)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Migration `461111b60977` failed on Peewee-bootstrapped databases with two errors:

1. `IntegrityError` on `tag`: the migration applied `PK(id)` to all tables, but tag names are not unique across users, so the constraint fails on existing data.
2. `OperationalError` on restart: if a prior run crashed mid-batch, Alembic left `_alembic_tmp_{table}` behind; the replayed migration then fails trying to create it again.

### Added

- [List any new features, functionalities, or additions]

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- `LEGACY_TABLES` changed from a list to a dict. `tag` maps to `['id', 'user_id']` to match the model; all other tables keep `['id']`.
- Added `DROP TABLE IF EXISTS _alembic_tmp_{table_name}` before each `batch_alter_table` to handle leftover temp tables from interrupted runs.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

Tested on legacy DB, fresh DB, idempotency, edge cases, and interrupted migration recovery. Production verified:
```
version: ('461111b60977',)  tmp tables: []
tag PK: [('id', 1), ('user_id', 2)]  auth PK: [('id', 1)]
```

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
