### PR TITLE
fix: wire workspace.skills into the sidebar + workspace-index gates

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -119,7 +119,8 @@
 					$user?.permissions?.workspace?.models ||
 					$user?.permissions?.workspace?.knowledge ||
 					$user?.permissions?.workspace?.prompts ||
-					$user?.permissions?.workspace?.tools
+					$user?.permissions?.workspace?.tools ||
+					$user?.permissions?.workspace?.skills
 				);
 			case 'automations':
 				return (

--- a/src/routes/(app)/workspace/+page.svelte
+++ b/src/routes/(app)/workspace/+page.svelte
@@ -13,6 +13,8 @@
 				goto('/workspace/prompts');
 			} else if ($user?.permissions?.workspace?.tools) {
 				goto('/workspace/tools');
+			} else if ($user?.permissions?.workspace?.skills) {
+				goto('/workspace/skills');
 			} else {
 				goto('/');
 			}


### PR DESCRIPTION
Reported by bwgabrielsusai on #24719: granting a user only `workspace.skills` doesn't show the Workspace menu, and visiting `/workspace` directly bounces them to `/`.

The per-route guard in `/workspace/+layout.svelte` already covered skills, but two earlier gates in the chain didn't:

* `Sidebar.svelte` case 'workspace' OR'd models/knowledge/prompts/tools to decide menu visibility — skills was missing, so the entry never rendered for skills-only users.
* `/workspace/+page.svelte` redirect chain picked the first available section — skills was missing, so the fallback `goto('/')` fired.

Adding skills to both.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
