### PR TITLE
fix: enforce ollama backend routing policy on caller-supplied url_idx

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -858,6 +858,7 @@ async def embed(
 
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(form_data.model), BYPASS_MODEL_ACCESS_CONTROL)
+    await validate_ollama_backend_idx(request, form_data.model, url_idx, user)
 
     if url_idx is None:
         model = form_data.model
@@ -917,6 +918,7 @@ async def embeddings(
 
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(form_data.model), BYPASS_MODEL_ACCESS_CONTROL)
+    await validate_ollama_backend_idx(request, form_data.model, url_idx, user)
 
     if url_idx is None:
         model = form_data.model
@@ -982,6 +984,7 @@ async def generate_completion(
 
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(form_data.model), BYPASS_MODEL_ACCESS_CONTROL)
+    await validate_ollama_backend_idx(request, form_data.model, url_idx, user)
 
     if url_idx is None:
         await get_all_models(request, user=user)
@@ -1048,7 +1051,23 @@ class GenerateChatCompletionForm(BaseModel):
     )
 
 
-async def get_ollama_url(request: Request, model: str, url_idx: int | None = None):
+async def validate_ollama_backend_idx(request: Request, model: str, url_idx: int | None, user) -> None:
+    # A caller-supplied url_idx must point to a backend the model is actually
+    # served from; the None path is already constrained to that allow-list.
+    if url_idx is None or user is None or getattr(user, 'role', None) == 'admin' or BYPASS_MODEL_ACCESS_CONTROL:
+        return
+
+    models = request.app.state.OLLAMA_MODELS
+    if not models or model not in models:
+        await get_all_models(request, user=user)
+        models = request.app.state.OLLAMA_MODELS
+
+    if url_idx not in (models.get(model) or {}).get('urls', []):
+        raise HTTPException(status_code=403, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
+
+
+async def get_ollama_url(request: Request, model: str, url_idx: int | None = None, user=None):
+    await validate_ollama_backend_idx(request, model, url_idx, user)
     if url_idx is None:
         models = request.app.state.OLLAMA_MODELS
         if model not in models:
@@ -1124,7 +1143,7 @@ async def generate_chat_completion(
     else:
         await check_model_access(user, None, bypass_filter)
 
-    url, url_idx = await get_ollama_url(request, payload['model'], url_idx)
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
         str(url_idx),
         request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),  # Legacy support
@@ -1213,7 +1232,7 @@ async def generate_openai_completion(
     else:
         await check_model_access(user, None)
 
-    url, url_idx = await get_ollama_url(request, payload['model'], url_idx)
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
         str(url_idx),
         request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),  # Legacy support
@@ -1279,7 +1298,7 @@ async def generate_openai_chat_completion(
     else:
         await check_model_access(user, None)
 
-    url, url_idx = await get_ollama_url(request, payload['model'], url_idx)
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
         str(url_idx),
         request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),  # Legacy support
@@ -1331,7 +1350,7 @@ async def generate_anthropic_messages(
     else:
         await check_model_access(user, None)
 
-    url, url_idx = await get_ollama_url(request, payload['model'], url_idx)
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
         str(url_idx),
         request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),  # Legacy support
@@ -1389,7 +1408,7 @@ async def generate_responses(
     else:
         await check_model_access(user, None)
 
-    url, url_idx = await get_ollama_url(request, payload['model'], url_idx)
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = request.app.state.config.OLLAMA_API_CONFIGS.get(
         str(url_idx),
         request.app.state.config.OLLAMA_API_CONFIGS.get(url, {}),  # Legacy support


### PR DESCRIPTION
The indexed data-plane routes (/api/chat, /api/generate, /api/embed, /api/embeddings and the /v1/* proxies) trusted a user-supplied url_idx path parameter and skipped the model-to-backend allow-list, letting a verified user route a request to an admin-disabled backend and have its configured API key attached. Validate the supplied index against the model's enabled backend list before use; admins and bypass mode are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
