### PR TITLE
fix: respect access_type in shared-chat file authorization branch

### DIFF
--- a/backend/open_webui/utils/access_control/files.py
+++ b/backend/open_webui/utils/access_control/files.py
@@ -66,7 +66,7 @@ async def has_access_to_file(
 
     # Check if the file is associated with any chats the user has access to
     shared_chat_ids = await Chats.get_shared_chat_ids_by_file_id(file_id, db=db)
-    if shared_chat_ids:
+    if access_type == 'read' and shared_chat_ids:
         accessible_ids = await AccessGrants.get_accessible_resource_ids(
             user_id=user.id,
             resource_type='shared_chat',


### PR DESCRIPTION
has_access_to_file granted access whenever the file was attached to a shared chat the user could read, ignoring the requested access_type. A read-only shared-chat recipient therefore satisfied write and delete checks and could delete or mutate the chat owner's attached file. Gate the shared-chat branch on read access, matching the channels branch directly above it.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
