### PR TITLE
fix: check destination calendar write access on event update

### DIFF
--- a/backend/open_webui/routers/calendar.py
+++ b/backend/open_webui/routers/calendar.py
@@ -301,6 +301,12 @@ async def update_event(
 
     await _check_calendar_access(event.calendar_id, user, 'write')
 
+    # A new calendar_id in the form moves the event; require write access on the
+    # destination too, mirroring create_event. Without this, write on the source
+    # calendar alone is enough to inject an event into any other calendar.
+    if form_data.calendar_id is not None and form_data.calendar_id != event.calendar_id:
+        await _check_calendar_access(form_data.calendar_id, user, 'write')
+
     updated = await CalendarEvents.update_event_by_id(event_id, form_data)
     if not updated:
         raise HTTPException(status_code=500, detail='Failed to update')


### PR DESCRIPTION
update_event only verified write access on the event's source calendar. CalendarEventUpdateForm accepts a new calendar_id which the model layer applies unconditionally, so a user with write access to their own calendar could move (inject) an event into any other user's calendar. Mirror the destination check create_event already performs.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
