### PR TITLE
fix: gate cross-origin postMessage prompt control behind iframe same-origin opt-in

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -640,13 +640,22 @@
 		const isSameOrigin = event.origin === window.origin;
 		const type = event.data?.type;
 
-		// Prompt-related message types only submit text to the chat input —
-		// functionally equivalent to the user typing.  When same-origin is
-		// enabled they go through immediately.  When it is disabled (opaque
-		// origin) we show a confirmation dialog so the user stays in control.
+		// Prompt-related message types let an embedding page drive the chat
+		// input / submission. They are only honored from a trusted context:
+		// genuinely same-origin, or the user has explicitly opted in via the
+		// "iframe Sandbox Allow Same Origin" interface setting (same setting
+		// that controls whether rendered iframes get allow-same-origin). A
+		// cross-origin page (e.g. an external site that window.open()s this app
+		// and postMessages it) must not be able to set or submit prompts in the
+		// victim's authenticated session without that opt-in.
 		const iframePromptTypes = ['input:prompt', 'input:prompt:submit', 'action:submit'];
+		const allowEmbedPrompts = isSameOrigin || ($settings?.iframeSandboxAllowSameOrigin ?? false);
 
 		if (!isSameOrigin && !iframePromptTypes.includes(type)) {
+			return;
+		}
+
+		if (iframePromptTypes.includes(type) && !allowEmbedPrompts) {
 			return;
 		}
 


### PR DESCRIPTION
The chat window message listener honored input:prompt and action:submit from any origin, while only input:prompt:submit enforced a cross-origin check. A cross-origin page could window.open() the app and postMessage input:prompt + action:submit to set and submit a prompt in the victim's authenticated session without consent, bypassing the embed confirmation.

Honor the three prompt message types only when same-origin or when the user has explicitly enabled the "iframe Sandbox Allow Same Origin" interface setting (the same setting that already gates allow-same-origin on rendered iframes). Default-off means cross-origin prompt injection is blocked out of the box.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
