### PR TITLE
fix: pass subscription_key and endpoint in bing.py CLI search_bing() call

### DIFF
--- a/backend/open_webui/retrieval/web/bing.py
+++ b/backend/open_webui/retrieval/web/bing.py
@@ -64,5 +64,14 @@ def main():
 
     args = parser.parse_args()
 
-    results = search_bing(args.locale, args.query, args.count, args.filter)
+    results = search_bing(
+        os.environ.get('BING_SEARCH_V7_SUBSCRIPTION_KEY', ''),
+        os.environ.get(
+            'BING_SEARCH_V7_ENDPOINT', 'https://api.bing.microsoft.com/v7.0/search'
+        ),
+        args.locale,
+        args.query,
+        args.count,
+        args.filter,
+    )
     pprint(results)


### PR DESCRIPTION
The __main__ block called search_bing() with 4 positional arguments, but the function requires 5 (subscription_key, endpoint, locale, query, count). Running `python -m open_webui.retrieval.web.bing` raised a TypeError and, before failing, silently misrouted every argument. Read the key/endpoint from environment variables, matching config.py defaults.

Closes #24765

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
