### PR TITLE
refactor: remove unused GET /evaluations/feedbacks/user endpoint

### DIFF
--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -380,11 +380,6 @@ class FeedbackTable:
             result = await db.execute(select(Feedback).filter_by(type=type).order_by(Feedback.updated_at.desc()))
             return [FeedbackModel.model_validate(feedback) for feedback in result.scalars().all()]
 
-    async def get_feedbacks_by_user_id(self, user_id: str, db: Optional[AsyncSession] = None) -> list[FeedbackModel]:
-        async with get_async_db_context(db) as db:
-            result = await db.execute(select(Feedback).filter_by(user_id=user_id).order_by(Feedback.updated_at.desc()))
-            return [FeedbackModel.model_validate(feedback) for feedback in result.scalars().all()]
-
     async def update_feedback_by_id(
         self, id: str, form_data: FeedbackForm, db: Optional[AsyncSession] = None
     ) -> Optional[FeedbackModel]:

--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -12,7 +12,6 @@ from open_webui.models.feedbacks import (
     FeedbackModel,
     FeedbackResponse,
     Feedbacks,
-    FeedbackUserResponse,
     LeaderboardFeedbackData,
     ModelHistoryEntry,
     ModelHistoryResponse,
@@ -321,12 +320,6 @@ async def export_all_feedbacks(
     feedbacks = await Feedbacks.get_all_feedbacks(db=db)
     if model_id:
         feedbacks = [f for f in feedbacks if f.data and f.data.get('model_id') == model_id]
-    return feedbacks
-
-
-@router.get('/feedbacks/user', response_model=list[FeedbackUserResponse])
-async def get_feedbacks(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    feedbacks = await Feedbacks.get_feedbacks_by_user_id(user.id, db=db)
     return feedbacks
 
 


### PR DESCRIPTION
This endpoint loaded a user's entire feedback table into memory in one response (flagged as a High OOM risk in open-webui#22206), but it has no callers anywhere: nothing in the frontend, backend, tests, or docs invokes it. Rather than add streaming/pagination to dead code, remove it.

Also drops the now-orphaned Feedbacks.get_feedbacks_by_user_id data layer method (its only caller was this endpoint) and the now-unused FeedbackUserResponse import in the evaluations router.

Ref: open-webui#22206

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
