### PR TITLE
refactor: remove unused GET /files/ endpoint

### DIFF
--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -105,11 +105,6 @@ class FileMetadataResponse(BaseModel):
     updated_at: int  # timestamp in epoch
 
 
-class FileListResponse(BaseModel):
-    items: list[FileModelResponse]
-    total: int
-
-
 class FileForm(BaseModel):
     id: str
     hash: str | None = None
@@ -243,26 +238,6 @@ class FilesTable:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(File).filter_by(user_id=user_id))
             return [FileModel.model_validate(file) for file in result.scalars().all()]
-
-    async def get_file_list(
-        self,
-        user_id: str | None = None,
-        skip: int = 0,
-        limit: int = 50,
-        db: AsyncSession | None = None,
-    ) -> 'FileListResponse':
-        async with get_async_db_context(db) as db:
-            stmt = select(File)
-            if user_id:
-                stmt = stmt.filter_by(user_id=user_id)
-
-            count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
-            total = count_result.scalar()
-
-            result = await db.execute(stmt.order_by(File.updated_at.desc(), File.id.desc()).offset(skip).limit(limit))
-            items = [FileModelResponse.model_validate(file, from_attributes=True) for file in result.scalars().all()]
-
-            return FileListResponse(items=items, total=total)
 
     @staticmethod
     def _glob_to_like_pattern(glob: str) -> str:

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -28,7 +28,6 @@ from open_webui.models.channels import Channels
 from open_webui.models.chats import Chats
 from open_webui.models.files import (
     FileForm,
-    FileListResponse,
     FileModel,
     FileModelResponse,
     Files,
@@ -336,34 +335,6 @@ async def upload_file_handler(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT('Error uploading file'),
         )
-
-
-############################
-# List Files
-############################
-
-
-PAGE_SIZE = 50
-
-
-@router.get('/', response_model=FileListResponse)
-async def list_files(
-    user=Depends(get_verified_user),
-    page: int = Query(1, ge=1, description='Page number (1-indexed)'),
-    content: bool = Query(True),
-    db: AsyncSession = Depends(get_async_session),
-):
-    skip = (page - 1) * PAGE_SIZE
-    user_id = None if (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL) else user.id
-
-    result = await Files.get_file_list(user_id=user_id, skip=skip, limit=PAGE_SIZE, db=db)
-
-    if not content:
-        for file in result.items:
-            if file.data and 'content' in file.data:
-                del file.data['content']
-
-    return result
 
 
 ############################

--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -144,37 +144,6 @@ export const uploadDir = async (token: string) => {
 	return res;
 };
 
-export const getFiles = async (token: string = '') => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/files/`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.then((json) => {
-			return json;
-		})
-		.catch((err) => {
-			error = err.detail;
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const searchFiles = async (
 	token: string,
 	filename: string = '*',


### PR DESCRIPTION
GET /files/ returned a user's file list with full extracted file content inline by default (content=True), flagged as a High OOM risk in open-webui#22206. It was already paginated server-side (50 per page), but its only frontend wrapper (getFiles in src/lib/apis/files/index.ts) is dead: nothing imports or calls it anywhere in the codebase, and no other code path hits GET /files/. Rather than refactor an endpoint with no callers, remove it.

Drops with it the now-orphaned Files.get_file_list data-layer method and FileListResponse model (both used only by this endpoint), the now-unused PAGE_SIZE constant and FileListResponse import in the files router, and the dead getFiles frontend wrapper.

The paginated GET /files/search endpoint remains the supported way to enumerate a user's files.

Ref: open-webui#22206

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
