### PR TITLE
fix: prefer source_url for document citation links

### DIFF
--- a/backend/open_webui/retrieval/source.py
+++ b/backend/open_webui/retrieval/source.py
@@ -1,0 +1,95 @@
+import ipaddress
+import re
+from urllib.parse import urlparse
+
+
+SOURCE_URL_METADATA_KEYS = ('source_url', 'source-url', 'sourceUrl', 'sourceURL')
+HOST_LABEL_RE = re.compile(r'^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$')
+
+
+def is_valid_url_hostname(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+
+    try:
+        ipaddress.ip_address(hostname)
+        return True
+    except ValueError:
+        pass
+
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError:
+        return False
+
+    if hostname.endswith('.'):
+        hostname = hostname[:-1]
+
+    if not hostname or len(hostname) > 253:
+        return False
+
+    return all(HOST_LABEL_RE.match(label) for label in hostname.split('.'))
+
+
+def normalize_source_url(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    value = value.strip()
+    if not value or '\\' in value or any(char.isspace() or ord(char) < 32 for char in value):
+        return None
+
+    try:
+        parsed = urlparse(value)
+        parsed.port
+    except ValueError:
+        return None
+
+    if (
+        parsed.scheme not in {'http', 'https'}
+        or not parsed.netloc
+        or not is_valid_url_hostname(parsed.hostname)
+        or parsed.username
+        or parsed.password
+    ):
+        return None
+
+    return value
+
+
+def get_source_url_from_metadata(metadata: dict | None) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+
+    nested_metadata = metadata.get('data') if isinstance(metadata.get('data'), dict) else {}
+
+    for values in (metadata, nested_metadata):
+        for key in SOURCE_URL_METADATA_KEYS:
+            source_url = normalize_source_url(values.get(key))
+            if source_url:
+                return source_url
+
+    return None
+
+
+def get_source_url_metadata(metadata: dict | None) -> dict:
+    source_url = get_source_url_from_metadata(metadata)
+    return {'source_url': source_url} if source_url else {}
+
+
+def get_first_source_url_metadata(*metadata_items: dict | None) -> dict:
+    for metadata in metadata_items:
+        source_url = get_source_url_from_metadata(metadata)
+        if source_url:
+            return {'source_url': source_url}
+
+    return {}
+
+
+def get_file_source_url_metadata(file) -> dict:
+    return get_source_url_metadata(getattr(file, 'meta', None))
+
+
+def merge_source_url_metadata(metadata: dict | None, source_metadata: dict | None) -> dict:
+    metadata = metadata if isinstance(metadata, dict) else {}
+    return {**get_source_url_metadata(source_metadata), **metadata}

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -39,6 +39,7 @@ from open_webui.models.knowledge import Knowledges
 from open_webui.models.notes import Notes
 from open_webui.models.users import UserModel
 from open_webui.retrieval.loaders.youtube import YoutubeLoader
+from open_webui.retrieval.source import get_file_source_url_metadata, get_first_source_url_metadata
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.main import GetResult
@@ -1208,6 +1209,14 @@ async def get_sources_from_items(
                 if item.get('file', {}).get('data', {}).get('content', ''):
                     # Manual Full Mode Toggle
                     # Used from chat file modal, we can assume that the file content will be available from item.get("file").get("data", {}).get("content")
+                    file_metadata = item.get('file', {}).get('meta', {}) or {}
+                    content_metadata = item.get('file', {}).get('data', {}).get('metadata', {}) or {}
+                    file_metadata = file_metadata if isinstance(file_metadata, dict) else {}
+                    content_metadata = content_metadata if isinstance(content_metadata, dict) else {}
+                    source_url_metadata = get_first_source_url_metadata(
+                        file_metadata,
+                        content_metadata,
+                    )
                     query_result = {
                         'documents': [[item.get('file', {}).get('data', {}).get('content', '')]],
                         'metadatas': [
@@ -1215,7 +1224,8 @@ async def get_sources_from_items(
                                 {
                                     'file_id': item.get('id'),
                                     'name': item.get('name'),
-                                    **item.get('file').get('data', {}).get('metadata', {}),
+                                    **content_metadata,
+                                    **source_url_metadata,
                                 }
                             ]
                         ],
@@ -1235,6 +1245,7 @@ async def get_sources_from_items(
                                         'file_id': item.get('id'),
                                         'name': file_object.filename,
                                         'source': file_object.filename,
+                                        **get_file_source_url_metadata(file_object),
                                     }
                                 ]
                             ],
@@ -1282,6 +1293,7 @@ async def get_sources_from_items(
                                     'file_id': file.id,
                                     'name': file.filename,
                                     'source': file.filename,
+                                    **get_file_source_url_metadata(file),
                                 }
                             )
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -73,6 +73,7 @@ from open_webui.retrieval.utils import (
     query_doc,
     query_doc_with_hybrid_search,
 )
+from open_webui.retrieval.source import get_file_source_url_metadata, merge_source_url_metadata
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.utils import filter_metadata
@@ -119,6 +120,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
+
 
 ##########################################
 #
@@ -1556,6 +1558,7 @@ async def process_file(
     if file:
         try:
             collection_name = form_data.collection_name
+            file_source_url_metadata = get_file_source_url_metadata(file)
 
             if collection_name is None:
                 collection_name = f'file-{file.id}'
@@ -1582,6 +1585,7 @@ async def process_file(
                             'created_by': file.user_id,
                             'file_id': file.id,
                             'source': file.filename,
+                            **file_source_url_metadata,
                         },
                     )
                 ]
@@ -1599,7 +1603,10 @@ async def process_file(
                     docs = [
                         Document(
                             page_content=result.documents[0][idx],
-                            metadata=result.metadatas[0][idx],
+                            metadata=merge_source_url_metadata(
+                                result.metadatas[0][idx],
+                                file.meta,
+                            ),
                         )
                         for idx, id in enumerate(result.ids[0])
                     ]
@@ -1613,6 +1620,7 @@ async def process_file(
                                 'created_by': file.user_id,
                                 'file_id': file.id,
                                 'source': file.filename,
+                                **file_source_url_metadata,
                             },
                         )
                     ]
@@ -1637,6 +1645,7 @@ async def process_file(
                                 'created_by': file.user_id,
                                 'file_id': file.id,
                                 'source': file.filename,
+                                **file_source_url_metadata,
                             },
                         )
                         for doc in docs
@@ -1651,6 +1660,7 @@ async def process_file(
                                 'created_by': file.user_id,
                                 'file_id': file.id,
                                 'source': file.filename,
+                                **file_source_url_metadata,
                             },
                         )
                     ]
@@ -2645,6 +2655,7 @@ async def process_files_batch(
                 continue
 
             text_content = file.data.get('content', '')
+            file_source_url_metadata = get_file_source_url_metadata(file)
             docs: list[Document] = [
                 Document(
                     page_content=text_content.replace('<br/>', '\n'),
@@ -2654,6 +2665,7 @@ async def process_files_batch(
                         'created_by': file.user_id,
                         'file_id': file.id,
                         'source': file.filename,
+                        **file_source_url_metadata,
                     },
                 )
             ]

--- a/backend/open_webui/test/retrieval/test_source.py
+++ b/backend/open_webui/test/retrieval/test_source.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+
+import pytest
+
+from open_webui.retrieval.source import (
+    get_first_source_url_metadata,
+    get_file_source_url_metadata,
+    get_source_url_from_metadata,
+    get_source_url_metadata,
+    is_valid_url_hostname,
+    merge_source_url_metadata,
+    normalize_source_url,
+)
+
+
+def _file(meta, filename='uploaded.pdf'):
+    return SimpleNamespace(meta=meta, filename=filename)
+
+
+def test_get_source_url_from_metadata_uses_nested_api_source_url_metadata():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+
+    assert get_source_url_from_metadata({'data': {'source_url': source_url}}) == source_url
+
+
+def test_get_source_url_from_metadata_prefers_explicit_source_url_keys():
+    meta = {
+        'sourceUrl': 'https://example.com/top-level-source-url',
+        'data': {
+            'source_url': 'https://example.com/nested-source-url',
+        },
+    }
+
+    assert get_source_url_from_metadata(meta) == 'https://example.com/top-level-source-url'
+
+
+def test_get_source_url_metadata_returns_empty_dict_for_missing_source_url():
+    meta = {
+        'source_url': '   ',
+        'url': 'https://example.com/generic-url-is-not-source-url',
+    }
+
+    assert get_source_url_metadata(meta) == {}
+
+
+@pytest.mark.parametrize(
+    'source_url',
+    [
+        None,
+        '',
+        '   ',
+        123,
+        [],
+        {},
+        '/relative/path',
+        '//example.com/missing-scheme',
+        'gitlab.example.com/group/project',
+        'https:///missing-host',
+        'https://exa mple.com/path',
+        'https://example.com/path with spaces',
+        'https://example.com\\@evil.example/path',
+        'https://example.com\\path',
+        'https://[::1',
+        'https://%zz',
+        'https://example.com:bad/path',
+        'https://user@example.com/path',
+        'https://user:pass@example.com/path',
+        'https://.com',
+        'https://example..com',
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'file:///etc/passwd',
+        'blob:https://example.com/source-id',
+        'mailto:user@example.com',
+    ],
+)
+def test_normalize_source_url_rejects_invalid_or_non_http_urls(source_url):
+    assert normalize_source_url(source_url) is None
+    assert get_source_url_metadata({'source_url': source_url}) == {}
+
+
+def test_normalize_source_url_accepts_http_https_and_preserves_encoded_characters():
+    http_url = 'http://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+    encoded_url = 'https://gitlab.example.com/docs/spec%20file.pdf?ref=%3Cmain%3E'
+
+    assert normalize_source_url(http_url) == http_url
+    assert normalize_source_url(encoded_url) == encoded_url
+
+
+def test_normalize_source_url_trims_and_accepts_source_url_alias():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+
+    assert normalize_source_url(f'  {source_url}  ') == source_url
+    assert get_source_url_from_metadata({'sourceURL': source_url}) == source_url
+
+
+def test_normalize_source_url_accepts_local_and_ip_hosts():
+    localhost_url = 'https://localhost/docs/spec.pdf'
+    ipv4_url = 'http://192.168.1.10/docs/spec.pdf'
+    ipv6_url = 'https://[2001:db8::1]/docs/spec.pdf'
+
+    assert normalize_source_url(localhost_url) == localhost_url
+    assert normalize_source_url(ipv4_url) == ipv4_url
+    assert normalize_source_url(ipv6_url) == ipv6_url
+
+
+def test_is_valid_url_hostname_handles_idn_hostnames():
+    assert is_valid_url_hostname('münich.example')
+
+
+def test_get_first_source_url_metadata_preserves_upload_meta_when_content_metadata_exists():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+    file_metadata = {'data': {'source_url': source_url}}
+    content_metadata = {'source': 'uploaded.pdf'}
+
+    assert get_first_source_url_metadata(file_metadata, content_metadata) == {
+        'source_url': source_url
+    }
+
+
+def test_get_first_source_url_metadata_falls_back_to_content_metadata():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+
+    assert get_first_source_url_metadata({}, {'source_url': source_url}) == {
+        'source_url': source_url
+    }
+
+
+def test_get_file_source_url_metadata_promotes_nested_source_url():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+
+    assert get_file_source_url_metadata(_file({'data': {'source_url': source_url}})) == {
+        'source_url': source_url
+    }
+
+
+def test_merge_source_url_metadata_adds_missing_source_url_without_overwriting_existing_metadata():
+    source_url = 'https://gitlab.example.com/group/project/-/blob/main/docs/spec.pdf'
+    existing_source_url = 'https://example.com/already-indexed'
+
+    assert merge_source_url_metadata({'name': 'spec.pdf'}, {'source_url': source_url}) == {
+        'name': 'spec.pdf',
+        'source_url': source_url,
+    }
+    assert merge_source_url_metadata(
+        {'source_url': existing_source_url},
+        {'source_url': source_url},
+    ) == {'source_url': existing_source_url}

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -23,6 +23,24 @@
 
 	let selectedCitation: any = null;
 
+	const getHttpUrl = (url: string | null | undefined) => {
+		if (typeof url !== 'string') {
+			return null;
+		}
+
+		const value = url.trim();
+		try {
+			const parsedUrl = new URL(value);
+			return (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') && parsedUrl.hostname
+				? value
+				: null;
+		} catch {
+			return null;
+		}
+	};
+
+	const isHttpUrl = (url: string | null | undefined) => getHttpUrl(url) !== null;
+
 	export const showSourceModal = (sourceId) => {
 		let index;
 		let suffix = null;
@@ -113,8 +131,12 @@
 					_source = { ..._source, name: metadata.name };
 				}
 
-				if (id.startsWith('http://') || id.startsWith('https://')) {
-					_source = { ..._source, name: id, url: id };
+				const sourceUrl = getHttpUrl(metadata?.source_url);
+				const sourceIdUrl = getHttpUrl(id);
+				if (sourceUrl) {
+					_source = { ..._source, source_url: sourceUrl, url: sourceUrl };
+				} else if (sourceIdUrl) {
+					_source = { ..._source, name: sourceIdUrl, url: sourceIdUrl };
 				}
 
 				const existingSource = acc.find((item) => item.id === id);
@@ -159,7 +181,9 @@
 />
 
 {#if citations.length > 0}
-	{@const urlCitations = citations.filter((c) => c?.source?.name?.startsWith('http'))}
+	{@const urlCitations = citations.filter(
+		(c) => !c?.source?.source_url && isHttpUrl(c?.source?.url ?? c?.source?.name)
+	)}
 	<div class=" py-1 -mx-0.5 w-full flex gap-1 items-center flex-wrap">
 		<button
 			class="text-xs font-medium text-gray-600 dark:text-gray-300 px-3.5 h-8 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-1 border border-gray-50 dark:border-gray-850/30"
@@ -175,7 +199,7 @@
 				<div class="flex -space-x-1 items-center">
 					{#each urlCitations.slice(0, 3) as citation, idx}
 						<img
-							src="https://www.google.com/s2/favicons?sz=32&domain={citation.source.name}"
+							src="https://www.google.com/s2/favicons?sz=32&domain={citation.source.url ?? citation.source.name}"
 							alt="favicon"
 							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-white dark:bg-gray-900"
 							on:error={(e) => {

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -64,16 +64,41 @@
 		}
 	};
 
-	const getTextFragmentUrl = (doc: any): string | null => {
-		const { metadata, source, document: content } = doc ?? {};
-		const { file_id, page } = metadata ?? {};
-		const sourceUrl = source?.url;
+	const getHttpUrl = (url: string | null | undefined) => {
+		if (typeof url !== 'string') {
+			return null;
+		}
 
-		const baseUrl = file_id
-			? `${WEBUI_API_BASE_URL}/files/${file_id}/content${page !== undefined ? `#page=${page + 1}` : ''}`
-			: sourceUrl?.includes('http')
-				? sourceUrl
+		const value = url.trim();
+		try {
+			const parsedUrl = new URL(value);
+			return (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') && parsedUrl.hostname
+				? value
 				: null;
+		} catch {
+			return null;
+		}
+	};
+
+	const isHttpUrl = (url: string | null | undefined) => getHttpUrl(url) !== null;
+
+	const getDocumentUrl = (doc: any): string | null => {
+		const { metadata, source } = doc ?? {};
+		const { file_id, page } = metadata ?? {};
+		const sourceUrl = getHttpUrl(metadata?.source_url ?? source?.url);
+
+		if (sourceUrl) {
+			return sourceUrl;
+		}
+
+		return file_id
+			? `${WEBUI_API_BASE_URL}/files/${file_id}/content${page !== undefined ? `#page=${page + 1}` : ''}`
+			: null;
+	};
+
+	const getTextFragmentUrl = (doc: any): string | null => {
+		const { document: content } = doc ?? {};
+		const baseUrl = getDocumentUrl(doc);
 
 		if (!baseUrl || !content) return baseUrl;
 
@@ -101,23 +126,19 @@
 			<div class=" text-lg font-medium self-center flex items-center">
 				{#if citation?.source?.name}
 					{@const document = mergedDocuments?.[0]}
-					{#if document?.metadata?.file_id || document.source?.url?.includes('http')}
+					{@const documentUrl = getDocumentUrl(document)}
+					{#if documentUrl}
 						<Tooltip
 							className="w-fit"
-							content={document.source?.url?.includes('http')
-								? $i18n.t('Open link')
-								: $i18n.t('Open file')}
+							content={isHttpUrl(documentUrl) ? $i18n.t('Open link') : $i18n.t('Open file')}
 							placement="top-start"
 							tippyOptions={{ duration: [500, 0] }}
 						>
 							<a
 								class="hover:text-gray-500 dark:hover:text-gray-100 underline grow line-clamp-1"
-								href={document?.metadata?.file_id
-									? `${WEBUI_API_BASE_URL}/files/${document?.metadata?.file_id}/content${document?.metadata?.page !== undefined ? `#page=${document.metadata.page + 1}` : ''}`
-									: document.source?.url?.includes('http')
-										? document.source.url
-										: `#`}
+								href={documentUrl}
 								target="_blank"
+								rel="noopener noreferrer"
 							>
 								{decodeString(citation?.source?.name)}
 							</a>
@@ -161,12 +182,13 @@
 							<div
 								class=" text-sm font-medium dark:text-gray-300 flex items-center gap-2 w-fit mb-1"
 							>
-								{#if document.source?.url?.includes('http')}
+								{#if isHttpUrl(getDocumentUrl(document))}
 									{@const snippetUrl = getTextFragmentUrl(document)}
 									{#if snippetUrl}
 										<a
 											href={snippetUrl}
 											target="_blank"
+											rel="noopener noreferrer"
 											class="underline hover:text-gray-500 dark:hover:text-gray-100"
 											>{$i18n.t('Content')}</a
 										>

--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -108,7 +108,7 @@
 				const id = metadata?.source ?? 'N/A';
 				if (metadata?.name) {
 					result.push(metadata.name);
-				} else if (id.startsWith('http://') || id.startsWith('https://')) {
+				} else if (typeof id === 'string' && (id.startsWith('http://') || id.startsWith('https://'))) {
 					result.push(id);
 				} else {
 					result.push(source?.source?.name ?? id);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: A discussion has been opened before this PR: https://github.com/open-webui/open-webui/discussions/24773

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue or Discussion — Closes #24775; Relates to https://github.com/open-webui/open-webui/discussions/24773.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Documentation impact is described below. This uses existing document metadata and introduces no new public API endpoint.
- [x] **Dependencies:** No new or updated dependencies are introduced.
- [x] **Testing:** Manual/container tests were performed and edge cases are listed below.
- [x] **No Unchecked AI Code:** This PR was AI-assisted, but the changes were manually reviewed and manually tested.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** This keeps existing fallback behavior and treats `source_url` only as citation presentation metadata.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

## Description

This PR updates citation URL resolution so API-uploaded documents can preserve their authoritative source URL.

When citation metadata includes a source URL, Open WebUI now prefers that URL for citation links before falling back to the internal file endpoint. This keeps current behavior for normal file uploads while improving API ingestion workflows where documents originate from another system.

No new dependencies are added.

## Reproduction

Before this change:

1. Upload a document through the API with metadata:
   `{"source_url": "https://gitlab.example.com/group/project/-/blob/main/docs/spec.md"}`
2. Process the file and use it in chat/RAG.
3. Open the generated citation.

Expected: the citation opens the provided `source_url`.
Actual: the citation can fall back to Open WebUI's internal file endpoint.

## Changed

- Adds a small source URL resolver for citation metadata.
- Preserves existing internal file citation fallback behavior when `source_url` is absent or invalid.
- Uses `source_url` only as a presentation hint for citation links.

## Testing

Tested locally with:

- Podman build:
  - `podman build --env NODE_OPTIONS=--max-old-space-size=4096 --build-arg USE_SLIM=true --build-arg BUILD_HASH=023b1e735 -t localhost/open-webui-source-url:source-url-citations .`
- Runtime:
  - `OLLAMA_BASE_URL=http://host.containers.internal:11434`
- Healthcheck:
  - `GET /health`
  - result: `{"status": true}`
- Unit tests inside the container:
  - `cd /app/backend && python -m pytest open_webui/test/retrieval/test_source.py`
  - result: `37 passed`
- Edge cases covered by tests:
  - absent, empty, null, and non-string source URL metadata
  - valid `http` and `https` source URLs
  - local, IPv4, IPv6, and IDN hostnames
  - relative URLs and missing-host URLs
  - rejected raw whitespace, invalid ports, userinfo, parser-confusing backslashes, and malformed hosts
  - rejected `javascript:`, `data:`, `file:`, `blob:`, and `mailto:` URLs
  - encoded URL characters

## Documentation

- Documentation impact: this uses the existing document metadata convention `source_url` when present.
- No new public API endpoint is introduced.
- Existing citation fallback behavior remains unchanged when `source_url` is absent or invalid.

## Security Considerations

- `source_url` is only used as a citation presentation hint.
- Only absolute `http` and `https` URLs with a valid host are accepted.
- Invalid or unsupported schemes fall back to existing citation behavior.
- `source_url` is never used for authorization, file lookup, deletion, backend fetches, or access decisions.
- External links use the existing Svelte rendering path and `rel="noopener noreferrer"` when opened with `target="_blank"`.
- No new automatic external requests are introduced; document citations using `source_url` are excluded from the Google favicon lookup used for regular URL citations.

## AI-assisted Code Note

This PR was AI-assisted, but the changes were manually reviewed and manually tested by the author. The implementation was verified in a running Open WebUI container, including the steps listed above.

# Changelog Entry

### Description

- Prefer provided source URLs for document citation links before falling back to internal file links.

### Added

- Source URL resolution helper and tests.

### Changed

- Citation rendering now uses resolved source URLs when available.

### Deprecated

- None.

### Removed

- None.

### Fixed

- API-uploaded documents with source URLs can now show citations that link to the original source instead of only the internal file endpoint.

### Security

- No new automatic external requests are introduced by this change.
- Document citations that use `source_url` are not added to the Google favicon lookup used for regular URL citations.

### Breaking Changes

- None.

---

### Additional Information

- This PR targets `dev`.
- No new dependencies.
- Related discussion: https://github.com/open-webui/open-webui/discussions/24773
- Closes #24775

### Screenshots or Videos

No screenshot included. This is citation metadata resolution behavior rather than a new UI surface.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
