### PR TITLE
refactor: remove unused GET /evaluations/feedbacks/all endpoint

### DIFF
--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -10,7 +10,6 @@ from open_webui.models.feedbacks import (
     FeedbackIdResponse,
     FeedbackListResponse,
     FeedbackModel,
-    FeedbackResponse,
     Feedbacks,
     FeedbackUserResponse,
     LeaderboardFeedbackData,
@@ -293,12 +292,6 @@ async def update_config(
 @router.get('/feedbacks/models', response_model=list[str])
 async def get_feedback_model_ids(user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
     return await Feedbacks.get_distinct_model_ids(db=db)
-
-
-@router.get('/feedbacks/all', response_model=list[FeedbackResponse])
-async def get_all_feedbacks(user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
-    feedbacks = await Feedbacks.get_all_feedbacks(db=db)
-    return feedbacks
 
 
 @router.get('/feedbacks/all/ids', response_model=list[FeedbackIdResponse])

--- a/src/lib/apis/evaluations/index.ts
+++ b/src/lib/apis/evaluations/index.ts
@@ -62,37 +62,6 @@ export const updateConfig = async (token: string, config: object) => {
 	return res;
 };
 
-export const getAllFeedbacks = async (token: string = '') => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/evaluations/feedbacks/all`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.then((json) => {
-			return json;
-		})
-		.catch((err) => {
-			error = err.detail;
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const getLeaderboard = async (token: string = '', query: string = '') => {
 	let error = null;
 


### PR DESCRIPTION
GET /evaluations/feedbacks/all returned the entire feedback table in a single response (flagged as a Medium OOM risk for admins in open-webui#22206). Its only frontend wrapper, getAllFeedbacks in src/lib/apis/evaluations/index.ts, is dead: nothing imports or calls it anywhere in the codebase. The endpoint is a redundant view-only twin of GET /evaluations/feedbacks/all/export, which is what the admin Feedbacks UI actually uses.

Removes the endpoint, the now-unused FeedbackResponse import in the evaluations router, and the dead getAllFeedbacks frontend wrapper. The shared Feedbacks.get_all_feedbacks data-layer method is kept, since the live /feedbacks/all/export endpoint still uses it.

Ref: open-webui#22206

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
