### PR TITLE
refactor: remove unused POST /api/v1/utils/markdown endpoint

### DIFF
--- a/backend/open_webui/routers/utils.py
+++ b/backend/open_webui/routers/utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 import black
-import markdown
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from open_webui.config import DATA_DIR, ENABLE_ADMIN_EXPORT
 from open_webui.constants import ERROR_MESSAGES
@@ -71,15 +70,6 @@ async def execute_code(request: Request, form_data: CodeForm, user=Depends(get_v
             status_code=400,
             detail=ERROR_MESSAGES.DEFAULT('Code execution engine not supported'),
         )
-
-
-class MarkdownForm(BaseModel):
-    md: str
-
-
-@router.post('/markdown')
-async def get_html_from_markdown(form_data: MarkdownForm, user=Depends(get_verified_user)):
-    return {'html': markdown.markdown(form_data.md)}
 
 
 class ChatForm(BaseModel):

--- a/src/lib/apis/utils/index.ts
+++ b/src/lib/apis/utils/index.ts
@@ -122,32 +122,6 @@ export const downloadChatAsPDF = async (token: string, title: string, messages: 
 	return blob;
 };
 
-export const getHTMLFromMarkdown = async (token: string, md: string) => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/utils/markdown`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		},
-		body: JSON.stringify({
-			md: md
-		})
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			console.error(err);
-			error = err;
-			return null;
-		});
-
-	return res.html;
-};
-
 export const downloadDatabase = async (token: string) => {
 	let error = null;
 


### PR DESCRIPTION
POST /utils/markdown rendered a markdown string to HTML server-side. Its only frontend wrapper, getHTMLFromMarkdown in src/lib/apis/utils/index.ts, is dead: nothing imports or calls it, the route is hit by no other code path, and the path string appears nowhere else in the repo (no direct fetch, no test, no docs). Markdown is rendered client-side in the UI, so this endpoint was redundant.

Fully self-contained removal: the endpoint, its MarkdownForm model, the now-orphaned 'import markdown' in the utils router (used only here), and the dead getHTMLFromMarkdown wrapper. Nothing else depends on any of them.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
