### PR TITLE
refactor: remove unused GET /prompts/id/{id}/history/{historyId} endpoint

### DIFF
--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -616,49 +616,6 @@ async def get_prompt_history(
     return history
 
 
-@router.get('/id/{prompt_id}/history/{history_id}', response_model=PromptHistoryModel)
-async def get_prompt_history_entry(
-    prompt_id: str,
-    history_id: str,
-    user=Depends(get_verified_user),
-    db: AsyncSession = Depends(get_async_session),
-):
-    """Get a specific version from history."""
-    prompt = await Prompts.get_prompt_by_id(prompt_id, db=db)
-
-    if not prompt:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    # Check read access
-    if not (
-        user.role == 'admin'
-        or prompt.user_id == user.id
-        or await AccessGrants.has_access(
-            user_id=user.id,
-            resource_type='prompt',
-            resource_id=prompt.id,
-            permission='read',
-            db=db,
-        )
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    history_entry = await PromptHistories.get_history_entry_by_id(history_id, db=db)
-    if not history_entry or history_entry.prompt_id != prompt.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    return history_entry
-
-
 @router.delete('/id/{prompt_id}/history/{history_id}', response_model=bool)
 async def delete_prompt_history_entry(
     prompt_id: str,

--- a/src/lib/apis/prompts/index.ts
+++ b/src/lib/apis/prompts/index.ts
@@ -556,38 +556,6 @@ export const deletePromptHistoryVersion = async (
 	return res;
 };
 
-export const getPromptHistoryEntry = async (
-	token: string,
-	promptId: string,
-	historyId: string
-): Promise<PromptHistoryItem> => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/prompts/id/${promptId}/history/${historyId}`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			error = err.detail;
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const restorePromptFromHistory = async (
 	token: string,
 	promptId: string,


### PR DESCRIPTION
The single-history-version endpoint's only frontend wrapper, getPromptHistoryEntry in src/lib/apis/prompts/index.ts, is dead: nothing imports or calls it, the path is referenced nowhere else, and the route handler has no internal caller. Removes the route handler and the dead wrapper. The shared PromptHistoryModel response model, the PromptHistoryItem frontend type (used by the live history-list wrapper), and the sibling DELETE on the same path are untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
