### PR TITLE
refactor: remove unused GET /prompts/command/{command} endpoint

### DIFF
--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -189,50 +189,6 @@ async def create_new_prompt(
 
 
 ############################
-# GetPromptByCommand
-############################
-
-
-@router.get('/command/{command}', response_model=PromptAccessResponse | None)
-async def get_prompt_by_command(
-    command: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
-):
-    prompt = await Prompts.get_prompt_by_command(command, db=db)
-
-    if prompt:
-        if (
-            user.role == 'admin'
-            or prompt.user_id == user.id
-            or await AccessGrants.has_access(
-                user_id=user.id,
-                resource_type='prompt',
-                resource_id=prompt.id,
-                permission='read',
-                db=db,
-            )
-        ):
-            return PromptAccessResponse(
-                **prompt.model_dump(),
-                write_access=(
-                    (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
-                    or user.id == prompt.user_id
-                    or await AccessGrants.has_access(
-                        user_id=user.id,
-                        resource_type='prompt',
-                        resource_id=prompt.id,
-                        permission='write',
-                        db=db,
-                    )
-                ),
-            )
-
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail=ERROR_MESSAGES.NOT_FOUND,
-    )
-
-
-############################
 # GetPromptById
 ############################
 

--- a/src/lib/apis/prompts/index.ts
+++ b/src/lib/apis/prompts/index.ts
@@ -226,40 +226,6 @@ export const getPromptList = async (token: string = '') => {
 	return res;
 };
 
-export const getPromptByCommand = async (token: string, command: string) => {
-	let error = null;
-
-	command = command.charAt(0) === '/' ? command.slice(1) : command;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/prompts/command/${command}`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.then((json) => {
-			return json;
-		})
-		.catch((err) => {
-			error = err.detail;
-
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const getPromptById = async (token: string, promptId: string) => {
 	let error = null;
 


### PR DESCRIPTION
The lookup-prompt-by-command endpoint's only frontend wrapper, getPromptByCommand, is dead: nothing imports or calls it, the path is referenced nowhere else, and the route handler has no internal caller (slash-command resolution happens client-side from the loaded prompt list). Removes the route handler, its section header, and the dead wrapper.

The shared Prompts.get_prompt_by_command data-layer method is kept: it is still used by create/update prompt validation (prompts.py:175, 275, 340). PromptAccessResponse and AccessGrants are untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
