### PR TITLE
refactor: remove unused GET /users/groups endpoint

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -137,16 +137,6 @@ async def search_users(
 
 
 ############################
-# User Groups
-############################
-
-
-@router.get('/groups')
-async def get_user_groups(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    return await Groups.get_groups_by_member_id(user.id, db=db)
-
-
-############################
 # User Permissions
 ############################
 

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -1,33 +1,6 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { getUserPosition } from '$lib/utils';
 
-export const getUserGroups = async (token: string) => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/users/groups`, {
-		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			console.error(err);
-			error = err.detail;
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const getUserDefaultPermissions = async (token: string) => {
 	let error = null;
 


### PR DESCRIPTION
The endpoint's only frontend wrapper, getUserGroups in src/lib/apis/users/index.ts, is dead: nothing imports or calls it. The only other `users/groups` references are SvelteKit page routes (/admin/users/groups), not this API path, and the route handler has no internal caller. Removes the route handler, its section header, and the dead wrapper. The shared Groups.get_groups_by_member_id data-layer method (used by prompt/knowledge access checks) is untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
