### PR TITLE
refactor: remove unused GET /users/user/info endpoint

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -367,17 +367,6 @@ async def update_user_status_by_session_user(
 
 
 ############################
-# GetUserInfoBySessionUser
-############################
-
-
-@router.get('/user/info', response_model=dict | None)
-async def get_user_info_by_session_user(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    # user already fetched by get_verified_user — no need to refetch
-    return user.info
-
-
-############################
 # UpdateUserInfoBySessionUser
 ############################
 

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -357,32 +357,6 @@ export const updateUserStatus = async (token: string, formData: object) => {
 	return res;
 };
 
-export const getUserInfo = async (token: string) => {
-	let error = null;
-	const res = await fetch(`${WEBUI_API_BASE_URL}/users/user/info`, {
-		method: 'GET',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			console.error(err);
-			error = err.detail;
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const updateUserInfo = async (token: string, info: object) => {
 	let error = null;
 


### PR DESCRIPTION
The fetch-own-info endpoint's only frontend wrapper, getUserInfo in src/lib/apis/users/index.ts, is dead: nothing imports or calls it, the path is referenced nowhere else, and the route handler has no internal caller. Removes the route handler, its section header, and the dead wrapper. The sibling POST /users/user/info/update endpoint and its live updateUserInfo wrapper are untouched, as is getUserInfoById.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
