### PR TITLE
refactor: remove unused DELETE /auths/api_key endpoint

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1258,12 +1258,6 @@ async def generate_api_key(
         raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_API_KEY_ERROR)
 
 
-# delete api key
-@router.delete('/api_key', response_model=bool)
-async def delete_api_key(user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)):
-    return await Users.delete_user_api_key_by_id(user.id, db=db)
-
-
 # get api key
 @router.get('/api_key', response_model=ApiKey)
 async def get_api_key(user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)):

--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -688,31 +688,6 @@ export const getAPIKey = async (token: string) => {
 	return res.api_key;
 };
 
-export const deleteAPIKey = async (token: string) => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/api_key`, {
-		method: 'DELETE',
-		headers: {
-			'Content-Type': 'application/json',
-			Authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			console.error(err);
-			error = err.detail;
-			return null;
-		});
-	if (error) {
-		throw error;
-	}
-	return res;
-};
-
 export const deleteOAuthSession = async (token: string, provider: string) => {
 	let error = null;
 


### PR DESCRIPTION
The delete-API-key endpoint's only frontend wrapper, deleteAPIKey in src/lib/apis/auths/index.ts, is dead: nothing imports or calls it, and the route handler has no internal caller. Removes only the DELETE route handler and the dead wrapper. The GET and POST /auths/api_key endpoints on the same path (and their live getAPIKey/createAPIKey wrappers) are deliberately untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
