### PR TITLE
refactor: remove unused POST /retrieval/reset/uploads endpoint

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2547,29 +2547,6 @@ async def reset_vector_db(user=Depends(get_admin_user), db: AsyncSession = Depen
     await Knowledges.delete_all_knowledge(db=db)
 
 
-@router.post('/reset/uploads')
-async def reset_upload_dir(user=Depends(get_admin_user)) -> bool:
-    folder = f'{UPLOAD_DIR}'
-    try:
-        # Check if the directory exists
-        if os.path.exists(folder):
-            # Iterate over all the files and directories in the specified directory
-            for filename in os.listdir(folder):
-                file_path = os.path.join(folder, filename)
-                try:
-                    if os.path.isfile(file_path) or os.path.islink(file_path):
-                        os.unlink(file_path)  # Remove the file or link
-                    elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)  # Remove the directory
-                except Exception as e:
-                    log.exception(f'Failed to delete {file_path}. Reason: {e}')
-        else:
-            log.warning(f'The directory {folder} does not exist')
-    except Exception as e:
-        log.exception(f'Failed to process the directory {folder}. Reason: {e}')
-    return True
-
-
 if ENV == 'dev':
 
     @router.get('/ef/{text}')

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -479,32 +479,6 @@ export const queryCollection = async (
 	return res;
 };
 
-export const resetUploadDir = async (token: string) => {
-	let error = null;
-
-	const res = await fetch(`${RETRIEVAL_API_BASE_URL}/reset/uploads`, {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			error = err.detail;
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const resetVectorDB = async (token: string) => {
 	let error = null;
 


### PR DESCRIPTION
The reset-upload-dir endpoint's only frontend wrapper, resetUploadDir in src/lib/apis/retrieval/index.ts, is dead: nothing imports or calls it, the route handler has no internal caller, and the path is referenced nowhere else (no other wrapper, test, or doc). Removes the route handler and the dead wrapper. The sibling POST /retrieval/reset/db endpoint and its live resetVectorDB wrapper are untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
