### PR TITLE
refactor: remove unused GET /analytics/messages endpoint

### DIFF
--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -112,37 +112,6 @@ async def get_user_analytics(
     return UserAnalyticsResponse(users=users)
 
 
-@router.get('/messages', response_model=list[ChatMessageModel])
-async def get_messages(
-    model_id: Optional[str] = Query(None, description='Filter by model ID'),
-    user_id: Optional[str] = Query(None, description='Filter by user ID'),
-    chat_id: Optional[str] = Query(None, description='Filter by chat ID'),
-    start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
-    end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
-    skip: int = Query(0),
-    limit: int = Query(50, le=100),
-    user=Depends(get_admin_user),
-    db: AsyncSession = Depends(get_async_session),
-):
-    """Query messages with filters."""
-    if chat_id:
-        return await ChatMessages.get_messages_by_chat_id(chat_id=chat_id, db=db)
-    elif model_id:
-        return await ChatMessages.get_messages_by_model_id(
-            model_id=model_id,
-            start_date=start_date,
-            end_date=end_date,
-            skip=skip,
-            limit=limit,
-            db=db,
-        )
-    elif user_id:
-        return await ChatMessages.get_messages_by_user_id(user_id=user_id, skip=skip, limit=limit, db=db)
-    else:
-        # Return empty if no filter specified
-        return []
-
-
 class SummaryResponse(BaseModel):
     total_messages: int
     total_chats: int

--- a/src/lib/apis/analytics/index.ts
+++ b/src/lib/apis/analytics/index.ts
@@ -78,52 +78,6 @@ export const getUserAnalytics = async (
 	return res;
 };
 
-export const getMessages = async (
-	token: string = '',
-	modelId: string | null = null,
-	userId: string | null = null,
-	chatId: string | null = null,
-	startDate: number | null = null,
-	endDate: number | null = null,
-	skip: number = 0,
-	limit: number = 50
-) => {
-	let error = null;
-
-	const searchParams = new URLSearchParams();
-	if (modelId) searchParams.append('model_id', modelId);
-	if (userId) searchParams.append('user_id', userId);
-	if (chatId) searchParams.append('chat_id', chatId);
-	if (startDate) searchParams.append('start_date', startDate.toString());
-	if (endDate) searchParams.append('end_date', endDate.toString());
-	if (skip) searchParams.append('skip', skip.toString());
-	if (limit) searchParams.append('limit', limit.toString());
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/analytics/messages?${searchParams.toString()}`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			error = err.detail;
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const getSummary = async (
 	token: string = '',
 	startDate: number | null = null,


### PR DESCRIPTION
The message-query analytics endpoint's only frontend wrapper, getMessages in src/lib/apis/analytics/index.ts, is dead: nothing imports or calls it (the apparent name collisions are unrelated backend snake_case get_messages_by_* model methods), the route handler has no internal caller, and the path is referenced nowhere else. Removes the route handler and the dead wrapper. The shared ChatMessageModel response model and ChatMessages.get_messages_by_* data methods are untouched, as are the sibling /analytics endpoints.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
