### PR TITLE
fix: use current dropdown model for sidebar title regeneration (#24745)

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -48,7 +48,8 @@
 		showFileNavPath,
 		showFileNavDir,
 		chatRequestQueues,
-		desktopEvent
+		desktopEvent,
+		selectedChatModels
 	} from '$lib/stores';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
@@ -275,6 +276,10 @@
 	$: if (selectedModels && chatIdProp !== '') {
 		saveSessionSelectedModels();
 	}
+
+	// Expose the active chat's live dropdown selection so the sidebar can
+	// target it for "Current Model" title regeneration (#24745).
+	$: selectedChatModels.set(selectedModels);
 
 	const saveSessionSelectedModels = () => {
 		const selectedModelsString = JSON.stringify(selectedModels);

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -35,7 +35,8 @@
 		currentChatPage,
 		tags,
 		selectedFolder,
-		activeChatIds
+		activeChatIds,
+		selectedChatModels
 	} from '$lib/stores';
 
 	import ChatMenu from './ChatMenu.svelte';
@@ -340,9 +341,10 @@
 
 	const generateTitleHandler = async () => {
 		generating = true;
-		if (!chat) {
-			chat = await getChatById(localStorage.token, id);
-		}
+		// Always refetch: a cached `chat` from an earlier regeneration holds a
+		// stale `history.currentId`/`models`, which made repeated regenerations
+		// reuse a model from an old revision instead of the current one (#24745).
+		chat = await getChatById(localStorage.token, id);
 
 		const chatContent = chat.chat;
 
@@ -363,11 +365,20 @@
 			}));
 		}
 
-		// Resolve the model from the most recent assistant message in the
-		// active branch. This avoids using the stale top-level `models`
-		// array which may reference a model from an older edit.
+		// When this is the active chat, the "Current Model" task model means
+		// the model currently selected in the chat's dropdown, even if it was
+		// changed without sending a new message (#24745). Prefer that live
+		// selection over anything derived from the persisted history.
 		let model = '';
-		if (history?.messages && history?.currentId) {
+		if (id === $chatId) {
+			model = ($selectedChatModels ?? []).find((modelId) => modelId) ?? '';
+		}
+
+		// Otherwise (or for chats that aren't open) resolve the model from the
+		// most recent assistant message in the active branch. This avoids using
+		// the stale top-level `models` array which may reference a model from an
+		// older edit.
+		if (!model && history?.messages && history?.currentId) {
 			let currentId = history.currentId;
 			while (currentId) {
 				const msg = history.messages[currentId];

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -55,6 +55,11 @@ export const TTSWorker = writable(null);
 export const chatId = writable('');
 export const chatTitle = writable('');
 
+// Models currently selected in the active chat's model dropdown.
+// Mirrored from Chat.svelte so sidebar actions (e.g. title regeneration
+// with the "Current Model" task model) can target the live selection.
+export const selectedChatModels = writable<string[]>(['']);
+
 export const channels = writable([]);
 export const channelId = writable(null);
 


### PR DESCRIPTION
When the title task model is "Current Model", regenerating a title from the sidebar (Rename -> sparkles) used a model derived from the chat's message history instead of the model currently selected in the dropdown.

generateTitleHandler reused a cached `chat`, so repeated regenerations resolved the model from a stale history.currentId (the model from an old revision). Even with fresh data it never consulted the live dropdown selection, which the sidebar had no access to.

Add a selectedChatModels store mirrored from Chat.svelte; the handler now always refetches and, for the open chat, prefers the live selection. The history walk remains the fallback for chats that aren't open.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
