### PR TITLE
fix: recover structurally-malformed chat history nodes on load

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1380,6 +1380,47 @@
 						: convertMessagesToHistory(chatContent.messages);
 
 				// Sanitize history: repair orphaned references from failed regenerations (#24424)
+				// and structurally-malformed nodes. A lost assistant placeholder can be persisted
+				// with only its completion fields (content/done/output/usage), missing
+				// id/role/parentId. Such a node still exists under its map key, so the
+				// missing-currentId check below never fires and the chat gets stuck loading.
+				// Reconstruct the graph fields in place from the surrounding message tree so
+				// already-corrupted chats recover the moment they are opened.
+				const parentByChildId = {};
+				for (const [mid, m] of Object.entries(history.messages)) {
+					for (const cid of Array.isArray(m?.childrenIds) ? m.childrenIds : []) {
+						parentByChildId[cid] = mid;
+					}
+				}
+				for (const [mid, message] of Object.entries(history.messages)) {
+					if (!message || typeof message !== 'object') {
+						delete history.messages[mid];
+						continue;
+					}
+					// Well-formed node: id matches its map key, has a role, and an explicit
+					// parentId (null is valid for the root). Leave it untouched.
+					if (message.id === mid && message.role && message.parentId !== undefined) {
+						continue;
+					}
+					message.id = mid;
+					if (message.parentId === undefined) {
+						message.parentId = parentByChildId[mid] ?? null;
+					}
+					if (!Array.isArray(message.childrenIds)) {
+						message.childrenIds = [];
+					}
+					if (!message.role) {
+						const parent = message.parentId ? history.messages[message.parentId] : null;
+						message.role =
+							parent?.role === 'user'
+								? 'assistant'
+								: parent?.role === 'assistant'
+									? 'user'
+									: message.model || message.usage || message.done
+										? 'assistant'
+										: 'user';
+					}
+				}
 				for (const message of Object.values(history.messages)) {
 					if (message.childrenIds) {
 						message.childrenIds = message.childrenIds.filter(
@@ -1387,7 +1428,8 @@
 						);
 					}
 				}
-				if (history.currentId && !history.messages[history.currentId]) {
+				const isUsableNode = (m) => m && m.id && m.role;
+				if (history.currentId && !isUsableNode(history.messages[history.currentId])) {
 					const messageIds = Object.keys(history.messages);
 					let lastMessageId = null;
 					for (const messageId of messageIds) {


### PR DESCRIPTION
A lost assistant placeholder can be persisted with only its completion fields (content/done/output/usage), missing id/role/parentId, while still existing under its map key and being referenced by its parent's childrenIds. The existing #24424 sanitizer only repairs currentId when it points to a *missing* node, so an "exists but malformed" node slips through: the frontend parent-walk dead-ends, Messages keeps the pagination loader visible, and the chat is stuck on "Loading..." forever with no console error and no failed request.

Reconstruct the graph fields in place during the load-time sanitize pass: derive id from the map key, parentId from the back-reference in the tree (null if none), childrenIds to an array, and role from parent alternation with a completion-field fallback. Also widen the currentId guard so an unusable current node falls back to the latest valid leaf.

Strict no-op for well-formed chats (a node whose id matches its key, has a role and an explicit parentId is skipped). Pure frontend and standalone: retroactively un-bricks every already-corrupted chat the moment it is opened, independent of the backend prevention in #24617.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
