### PR TITLE
fix: populate OAuth scopes from RFC 9728 protected resource metadata in static MCP flow (#24730)

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -293,6 +293,7 @@ class ProtectedResourceMetadata:
 
     resource: str | None = None
     authorization_servers: list[str] = field(default_factory=list)
+    scopes_supported: list[str] = field(default_factory=list)
 
     def get_discovery_urls(self, server_url: str) -> list[str]:
         """Build all candidate OAuth discovery URLs from this metadata and the server URL."""
@@ -315,6 +316,7 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
     """
     authorization_servers = []
     resource = None
+    scopes_supported = []
     try:
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(
@@ -358,6 +360,15 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
                                     if resource:
                                         log.debug(f'Discovered resource indicator: {resource}')
 
+                                    # RFC 9728: scopes_supported here is the per-resource
+                                    # scope list — what the client should request to access
+                                    # THIS resource server. Safe to use directly, unlike the
+                                    # IdP-wide catalog from RFC 8414 oauth-authorization-server.
+                                    discovered_scopes = resource_metadata.get('scopes_supported') or []
+                                    if discovered_scopes:
+                                        scopes_supported = discovered_scopes
+                                        log.debug(f'Discovered resource scopes: {scopes_supported}')
+
                                     servers = resource_metadata.get('authorization_servers', [])
                                     if servers:
                                         authorization_servers = servers
@@ -369,7 +380,11 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 
-    return ProtectedResourceMetadata(resource=resource, authorization_servers=authorization_servers)
+    return ProtectedResourceMetadata(
+        resource=resource,
+        authorization_servers=authorization_servers,
+        scopes_supported=scopes_supported,
+    )
 
 
 def _build_well_known_urls(server_url: str) -> list[str]:
@@ -553,12 +568,16 @@ async def get_oauth_client_info_with_static_credentials(
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
-        # Let the OAuth provider apply its default scopes.
-        # We intentionally do NOT join all scopes_supported here — that list
-        # represents every scope the server *can* grant, not what the client
-        # should request.  Requesting all of them is almost always wrong and
-        # can break providers like Entra ID that require resource-specific scopes.
-        scope = None
+        # Use scopes from the Protected Resource Metadata (RFC 9728) when available.
+        # Unlike the auth-server's scopes_supported (an IdP-wide catalog of every
+        # scope the server *can* grant), the protected-resource document advertises
+        # the scopes specifically required to access THIS resource server, so it is
+        # safe — and required by providers like Entra v2 — to request them.
+        scope = (
+            ' '.join(resource_metadata.scopes_supported)
+            if resource_metadata.scopes_supported
+            else None
+        )
 
         # Determine token_endpoint_auth_method
         token_endpoint_auth_method = 'client_secret_post'


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixes the OAuth 2.1 (Static) authorize URL for MCP connections, which was missing the `scope` parameter. The `scopes_supported` array advertised in the RFC 9728 `.well-known/oauth-protected-resource` metadata document is now parsed and forwarded into the authorize request, resolving sign-in failures with providers like Microsoft Entra v2 that reject `scope`-less authorization requests (`AADSTS900144`).

### Added

- `scopes_supported: list[str]` field on the `ProtectedResourceMetadata` dataclass in `backend/open_webui/utils/oauth.py`, populated from the protected-resource metadata document during OAuth discovery.

### Changed

- `get_protected_resource_metadata()` now reads `scopes_supported` from the `.well-known/oauth-protected-resource` JSON response and returns it on the resulting `ProtectedResourceMetadata`.
- `get_oauth_client_info_with_static_credentials()` no longer hardcodes `scope = None`. When the discovered `ProtectedResourceMetadata.scopes_supported` is non-empty, scopes are joined into a space-separated `scope` value on the resulting `OAuthClientInformationFull`. When absent, the previous behaviour (`scope = None`) is preserved.

### Deprecated

- None

### Removed

- None

### Fixed

- OAuth 2.1 (Static) authorize URL for MCP connections was missing the `scope` parameter, causing sign-in to fail with `AADSTS900144: The request body must contain the following parameter: 'scope'` on Microsoft Entra v2 and similar providers that require explicit scopes. (#24730)

### Security

- None

### Breaking Changes

- None

---

### Additional Information

**Testing notes:** Did not add automated unit tests in this PR. Importing `backend/open_webui/utils/oauth.py` triggers database initialization at module load, which would require non-trivial test-infrastructure mocking outside the scope of this fix. Happy to add tests in a follow-up if maintainers can point to the recommended test setup for this module.

### Screenshots or Videos

- None

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
