### PR TITLE
fix: enforce file ownership on chat-completion image_url file ids (IDOR)

### DIFF
--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -27,6 +27,7 @@ from open_webui.routers.images import (
     upload_image,
 )
 from open_webui.storage.provider import Storage
+from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.session_pool import get_session
 
 BASE64_IMAGE_URL_PREFIX = re.compile(r'data:image/\w+;base64,', re.IGNORECASE)
@@ -50,7 +51,7 @@ _IMAGE_MIME_FALLBACK = {
 }
 
 
-async def get_image_base64_from_url(url: str) -> Optional[str]:
+async def get_image_base64_from_url(url: str, user) -> Optional[str]:
     try:
         if url.startswith('http'):
             # Validate URL to prevent SSRF attacks against local/private networks.
@@ -73,6 +74,14 @@ async def get_image_base64_from_url(url: str) -> Optional[str]:
             file = await Files.get_file_by_id(url)
 
             if not file:
+                return None
+
+            # url here is a user-supplied file id; enforce the same ownership/access check the file routes use, else any user can read another user's file.
+            if not (
+                file.user_id == user.id
+                or user.role == 'admin'
+                or await has_access_to_file(url, 'read', user)
+            ):
                 return None
 
             file_path = await asyncio.to_thread(Storage.get_file, file.path)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2096,7 +2096,7 @@ def apply_params_to_form_data(form_data, model):
     return form_data
 
 
-async def convert_url_images_to_base64(form_data):
+async def convert_url_images_to_base64(form_data, user):
     messages = form_data.get('messages', [])
 
     for message in messages:
@@ -2117,7 +2117,7 @@ async def convert_url_images_to_base64(form_data):
                 continue
 
             try:
-                base64_data = await get_image_base64_from_url(image_url)
+                base64_data = await get_image_base64_from_url(image_url, user)
                 if base64_data:
                     new_content.append(
                         {
@@ -2340,7 +2340,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except Exception:
             pass
 
-    form_data = await convert_url_images_to_base64(form_data)
+    form_data = await convert_url_images_to_base64(form_data, user)
 
     event_emitter = await get_event_emitter(metadata)
     event_caller = await get_event_call(metadata)


### PR DESCRIPTION
get_image_base64_from_url resolved a user-supplied image_url string as a file id via Files.get_file_by_id with no ownership check, so any verified user could read another user's uploaded image by passing its UUID in a /api/chat/completions request. Thread the authenticated user through convert_url_images_to_base64 and apply the same owner/admin/has_access_to_file check the file routes already use.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
