### PR TITLE
fix: prevent redirect-based SSRF in OAuth picture URL fetch

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1454,7 +1454,12 @@ class OAuthManager:
                     'Authorization': f'Bearer {access_token}',
                 }
             async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(picture_url, **get_kwargs, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
+                async with session.get(
+                    picture_url,
+                    **get_kwargs,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                    allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+                ) as resp:
                     if resp.ok:
                         picture = await resp.read()
                         base64_encoded_picture = base64.b64encode(picture).decode('utf-8')


### PR DESCRIPTION
## Summary

Add `allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS` to the `session.get()` call in `_process_picture_url()`.

## Details

The `_process_picture_url()` method in `oauth.py:1457` calls `validate_url()` to guard against SSRF but does not pass `allow_redirects=False` to the aiohttp client. This means a URL that passes `validate_url()` can 302-redirect to an internal address (e.g., `169.254.169.254`) and the redirect is followed.

## Fix

This matches the existing pattern already used in:
- OAuth preflight check (`oauth.py:744`)
- Image fetch pipeline (`images.py:820`)
- Web retrieval pipeline (`retrieval/utils.py:189`)
- File processing pipeline (`files.py:61-64`)

The `AIOHTTP_CLIENT_ALLOW_REDIRECTS` variable defaults to `False` and is already imported at line 74 of the same file.

## Testing

Verified locally with a redirect server PoC. Without the fix, aiohttp follows a 302 redirect from a public URL to `127.0.0.1:PORT/internal`. With the fix, the redirect is correctly blocked.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)