### PR TITLE
fix: load canonical persistent config row

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -93,7 +93,7 @@ def load_json_config():
 def save_to_db(data):
     """Sync save — used ONLY at startup/import time."""
     with get_db() as db:
-        existing_config = db.query(Config).first()
+        existing_config = db.query(Config).order_by(Config.id.asc()).first()
         if not existing_config:
             new_config = Config(data=data, version=0)
             db.add(new_config)
@@ -109,7 +109,7 @@ async def async_save_to_db(data):
     from sqlalchemy import select
 
     async with get_async_db() as db:
-        result = await db.execute(select(Config).limit(1))
+        result = await db.execute(select(Config).order_by(Config.id.asc()).limit(1))
         existing_config = result.scalars().first()
         if not existing_config:
             new_config = Config(data=data, version=0)
@@ -151,7 +151,7 @@ DEFAULT_CONFIG = {
 
 def get_config():
     with get_db() as db:
-        config_entry = db.query(Config).order_by(Config.id.desc()).first()
+        config_entry = db.query(Config).order_by(Config.id.asc()).first()
         return config_entry.data if config_entry else DEFAULT_CONFIG
 
 


### PR DESCRIPTION
## Summary

- make sync config saves select the lowest-id config row explicitly
- make async config saves select the same canonical row explicitly
- make startup config loading read that same canonical row instead of the highest-id duplicate

This keeps load behavior aligned with the row that runtime persistence already updates, preventing later duplicate/default rows from masking saved external connections or model parameters.

Fixes #24743.

## Checks

- `python -m py_compile backend/open_webui/config.py`
- `git diff --check`

Note: I also attempted `uv run --with ruff ruff check backend/open_webui/config.py`, but dependency/tool resolution did not finish within the local timeout.