### PR TITLE
fix: handle decoded Ollama tool call arguments

### DIFF
--- a/backend/open_webui/test/utils/test_payload.py
+++ b/backend/open_webui/test/utils/test_payload.py
@@ -1,0 +1,70 @@
+from open_webui.utils.payload import convert_messages_openai_to_ollama
+
+
+def test_convert_messages_openai_to_ollama_parses_tool_call_arguments_string():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup', 'arguments': '{"query": "weather"}'},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result == [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'index': 0,
+                    'id': 'call_1',
+                    'function': {'name': 'lookup', 'arguments': {'query': 'weather'}},
+                }
+            ],
+            'content': '',
+        }
+    ]
+
+
+def test_convert_messages_openai_to_ollama_keeps_decoded_tool_call_arguments():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup', 'arguments': {'query': 'weather'}},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result[0]['tool_calls'][0]['function']['arguments'] == {'query': 'weather'}
+
+
+def test_convert_messages_openai_to_ollama_defaults_missing_tool_call_arguments():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup'},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result[0]['tool_calls'][0]['function']['arguments'] == {}

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -200,6 +200,13 @@ def apply_model_params_to_body_ollama(params: dict, form_data: dict) -> dict:
 def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
     ollama_messages = []
 
+    def parse_tool_call_arguments(arguments):
+        if arguments is None or arguments == '':
+            return {}
+        if isinstance(arguments, str):
+            return json.loads(arguments)
+        return arguments
+
     for message in messages:
         # Initialize the new message structure with the role
         new_message = {'role': message['role']}
@@ -226,12 +233,13 @@ def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
             # If tool calls are present, add them to the message
             ollama_tool_calls = []
             for tool_call in tool_calls:
+                function = tool_call.get('function') or {}
                 ollama_tool_call = {
                     'index': tool_call.get('index', 0),
                     'id': tool_call.get('id', None),
                     'function': {
-                        'name': tool_call.get('function', {}).get('name', ''),
-                        'arguments': json.loads(tool_call.get('function', {}).get('arguments', {})),
+                        'name': function.get('name', ''),
+                        'arguments': parse_tool_call_arguments(function.get('arguments')),
                     },
                 }
                 ollama_tool_calls.append(ollama_tool_call)


### PR DESCRIPTION
## Summary
- Handle OpenAI tool-call arguments that are already decoded or omitted when converting chat messages to Ollama format.
- Add focused payload conversion tests for JSON-string, decoded-dict, and missing tool-call arguments.

Relates to #23907.

## Why
Some OpenAI-compatible chat/tool flows can produce `function.arguments` as an object or omit it. The Ollama conversion path previously called `json.loads` unconditionally, which raised before the request could be sent.

# Changelog Entry

### Description

- Fix Ollama payload conversion for assistant tool calls whose arguments are already decoded or missing.

### Added

- Unit coverage for tool-call argument conversion in `convert_messages_openai_to_ollama`.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevent `json.loads` from raising when tool-call arguments are already a dictionary or are omitted.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Validation:
- `TMPDIR=/tmp PYTHONPATH=/home/ubuntu/gh-pr/open-webui-worker-next/backend uv run --no-project --python 3.12 --with pytest --with python-mimeparse --with Markdown --with beautifulsoup4 --with cryptography --with-requirements backend/requirements-min.txt pytest backend/open_webui/test/utils/test_payload.py -q`
- `TMPDIR=/tmp uv run --no-project --python 3.12 --with ruff ruff format --check backend/open_webui/utils/payload.py backend/open_webui/test/utils/test_payload.py`
- `TMPDIR=/tmp uv run --no-project --python 3.12 --with ruff ruff check backend/open_webui/test/utils/test_payload.py`

### Screenshots or Videos

- Not applicable; backend payload conversion change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.