### PR TITLE
fix: handle decoded Ollama tool call arguments

### DIFF
--- a/backend/open_webui/test/utils/test_payload.py
+++ b/backend/open_webui/test/utils/test_payload.py
@@ -1,0 +1,70 @@
+from open_webui.utils.payload import convert_messages_openai_to_ollama
+
+
+def test_convert_messages_openai_to_ollama_parses_tool_call_arguments_string():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup', 'arguments': '{"query": "weather"}'},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result == [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'index': 0,
+                    'id': 'call_1',
+                    'function': {'name': 'lookup', 'arguments': {'query': 'weather'}},
+                }
+            ],
+            'content': '',
+        }
+    ]
+
+
+def test_convert_messages_openai_to_ollama_keeps_decoded_tool_call_arguments():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup', 'arguments': {'query': 'weather'}},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result[0]['tool_calls'][0]['function']['arguments'] == {'query': 'weather'}
+
+
+def test_convert_messages_openai_to_ollama_defaults_missing_tool_call_arguments():
+    messages = [
+        {
+            'role': 'assistant',
+            'tool_calls': [
+                {
+                    'id': 'call_1',
+                    'type': 'function',
+                    'function': {'name': 'lookup'},
+                }
+            ],
+        }
+    ]
+
+    result = convert_messages_openai_to_ollama(messages)
+
+    assert result[0]['tool_calls'][0]['function']['arguments'] == {}

--- a/backend/open_webui/test/utils/test_payload.py
+++ b/backend/open_webui/test/utils/test_payload.py
@@ -1,4 +1,4 @@
-from open_webui.utils.payload import convert_messages_openai_to_ollama
+from open_webui.utils.payload import convert_messages_openai_to_ollama, convert_payload_openai_to_ollama
 
 
 def test_convert_messages_openai_to_ollama_parses_tool_call_arguments_string():
@@ -68,3 +68,30 @@ def test_convert_messages_openai_to_ollama_defaults_missing_tool_call_arguments(
     result = convert_messages_openai_to_ollama(messages)
 
     assert result[0]['tool_calls'][0]['function']['arguments'] == {}
+
+
+def test_convert_payload_openai_to_ollama_forwards_tools_array():
+    tools = [
+        {
+            'type': 'function',
+            'function': {
+                'name': 'get_current_weather_in_city',
+                'description': 'Get the current weather for a city.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {'city': {'type': 'string'}},
+                    'required': ['city'],
+                },
+            },
+        }
+    ]
+    payload = {
+        'model': 'qwen2.5:7b',
+        'messages': [{'role': 'user', 'content': 'Weather in Bountiful?'}],
+        'tools': tools,
+        'stream': False,
+    }
+
+    result = convert_payload_openai_to_ollama(payload)
+
+    assert result['tools'] == tools

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -200,6 +200,13 @@ def apply_model_params_to_body_ollama(params: dict, form_data: dict) -> dict:
 def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
     ollama_messages = []
 
+    def parse_tool_call_arguments(arguments):
+        if arguments is None or arguments == '':
+            return {}
+        if isinstance(arguments, str):
+            return json.loads(arguments)
+        return arguments
+
     for message in messages:
         # Initialize the new message structure with the role
         new_message = {'role': message['role']}
@@ -226,12 +233,13 @@ def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
             # If tool calls are present, add them to the message
             ollama_tool_calls = []
             for tool_call in tool_calls:
+                function = tool_call.get('function') or {}
                 ollama_tool_call = {
                     'index': tool_call.get('index', 0),
                     'id': tool_call.get('id', None),
                     'function': {
-                        'name': tool_call.get('function', {}).get('name', ''),
-                        'arguments': json.loads(tool_call.get('function', {}).get('arguments', {})),
+                        'name': function.get('name', ''),
+                        'arguments': parse_tool_call_arguments(function.get('arguments')),
                     },
                 }
                 ollama_tool_calls.append(ollama_tool_call)


### PR DESCRIPTION
## Summary
- Handle OpenAI tool-call arguments that are already decoded or omitted when converting chat messages to Ollama format.
- Keep root-level OpenAI `tools` forwarded through the full OpenAI-to-Ollama payload conversion path, with regression coverage for the native tool-calling shape from #23907.
- Add focused payload conversion tests for JSON-string, decoded-dict, missing tool-call arguments, and tool array forwarding.

Relates to #23907.

## Why
Some OpenAI-compatible chat/tool flows can produce `function.arguments` as an object or omit it. The Ollama conversion path previously called `json.loads` unconditionally, which raised before the request could be sent.

The full payload regression also covers the native Ollama tool-calling boundary so a resolved `tools: [...]` array remains present when Open WebUI converts an OpenAI-style chat payload for `/api/chat`.

# Changelog Entry

### Description

- Fix Ollama payload conversion for assistant tool calls whose arguments are already decoded or missing.
- Add regression coverage for forwarding the OpenAI `tools` array to Ollama payloads.

### Added

- Unit coverage for tool-call argument conversion in `convert_messages_openai_to_ollama`.
- Unit coverage for `convert_payload_openai_to_ollama` preserving native tool definitions.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevent `json.loads` from raising when tool-call arguments are already a dictionary or are omitted.
- Guard against regressions where native tool definitions are dropped before reaching Ollama.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Validation:
- `python3 -m py_compile backend/open_webui/utils/payload.py backend/open_webui/test/utils/test_payload.py`
- `git diff --check upstream/dev...HEAD`
- `TMPDIR=/tmp PYTHONPATH=$PWD/backend uv run --no-project --python 3.12 --with pytest --with python-mimeparse --with Markdown --with beautifulsoup4 --with cryptography --with-requirements backend/requirements-min.txt pytest backend/open_webui/test/utils/test_payload.py -q` -> `4 passed`
- `TMPDIR=/tmp uv run --no-project --python 3.12 --with 'ruff>=0.15.5' ruff format --check backend/open_webui/utils/payload.py backend/open_webui/test/utils/test_payload.py`
- `TMPDIR=/tmp uv run --no-project --python 3.12 --with 'ruff>=0.15.5' ruff check backend/open_webui/test/utils/test_payload.py`

### Screenshots or Videos

- Not applicable; backend payload conversion change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
