### PR TITLE
fix: auto-link files to Knowledge Collection after processing completes

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -169,6 +169,21 @@ async def process_uploaded_file(
                     db=db_session,
                 )
 
+            # Auto-link to Knowledge Collection if knowledge_id was provided at upload time
+            if 'knowledge_id' in file_metadata:
+                try:
+                    await Knowledges.add_file_to_knowledge_by_id(
+                        knowledge_id=file_metadata['knowledge_id'],
+                        file_id=file_item.id,
+                        user_id=user.id,
+                        db=db_session,
+                    )
+                except Exception as e:
+                    log.warning(
+                        f'Failed to auto-link file {file_item.id} to knowledge '
+                        f'{file_metadata["knowledge_id"]}: {e}'
+                    )
+
         except Exception as e:
             log.error(f'Error processing file: {file_item.id}')
             await Files.update_file_data_by_id(


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** `Closes #24807`
- [x] **Target branch:** `dev`
- [x] **Description:** Concise description down below.
- [x] **Changelog:** Added at the bottom.
- [x] **Documentation:** N/A — backend behavior fix, no new user-facing API or config.
- [x] **Dependencies:** N/A — no new dependencies.
- [x] **Testing:** Locally verified with pytest; backend logic confirmed correct.
- [x] **Agentic AI Code:** Human reviewed and manually verified.
- [x] **Code review:** Performed self-review.
- [x] **Design & Architecture:** Minimal, targeted fix; no new settings or state introduced.
- [x] **Git Hygiene:** Single atomic commit.
- [x] **Title Prefix:** `fix`

---

## Description

When a file is uploaded to a Knowledge Collection, the final linking step previously depended on the frontend calling `POST /knowledge/{id}/file/add` after the SSE processing stream completed. If the user navigated away before that call fired, the file was processed successfully but permanently orphaned — visible in Global Files but absent from the Knowledge Collection.

This change moves the linking operation server-side, inside `process_uploaded_file()`, after `process_file()` finishes. The upload request already carries `knowledge_id` in file metadata, so the backend has all the information needed to complete the association without any frontend participation.

The existing frontend code in `KnowledgeBase.svelte` still calls `addFileHandler()` after upload — for Knowledge Collection uploads this becomes a duplicate call, but `Knowledges.add_file_to_knowledge_by_id()` is idempotent (DB insert is a no-op on duplicate), so no harm is done.

## Validation

```bash
ruff format --check backend/open_webui/routers/files.py

ruff check backend/open_webui/routers/files.py

```

---

## Changelog Entry

### Fixed

- Knowledge upload can leave processed files unlinked when user navigates away before the final linking request fires. Linking is now completed server-side during `process_uploaded_file()`, removing the dependence on the frontend maintaining an active SSE connection.

---

## Screenshots or Videos

Not applicable; backend behavior fix, no UI change.

---

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
