### PR TITLE
feat(retrieval): add X-Pplx-Integration attribution header to Perplexity search modules

### DIFF
--- a/backend/open_webui/retrieval/web/perplexity.py
+++ b/backend/open_webui/retrieval/web/perplexity.py
@@ -2,6 +2,7 @@ import logging
 from typing import Literal, Optional
 
 import requests
+from open_webui.env import VERSION
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 
 MODELS = Literal[
@@ -64,6 +65,7 @@ def search_perplexity(
         headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json',
+            'X-Pplx-Integration': f'open-webui/{VERSION}',
         }
 
         # Make the API request

--- a/backend/open_webui/retrieval/web/perplexity_search.py
+++ b/backend/open_webui/retrieval/web/perplexity_search.py
@@ -2,6 +2,7 @@ import logging
 from typing import Literal, Optional
 
 import requests
+from open_webui.env import VERSION
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.utils.headers import include_user_info_headers
 
@@ -47,6 +48,7 @@ def search_perplexity_search(
         headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json',
+            'X-Pplx-Integration': f'open-webui/{VERSION}',
         }
 
         # Forward user info headers if user is provided


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR re-submits the closed PR #24267 against the required `dev` base branch.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** This PR adds Perplexity attribution headers to the two Perplexity retrieval modules.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** Not applicable; this is a no-behavior-change outbound request header.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Syntax and import verification commands are listed below.
- [x] **No Unchecked AI Code:** This small change has been reviewed for scope and matches the previous submission.
- [x] **Self-Review:** The diff is atomic, limited to two Perplexity retrieval modules, and rebased on `dev`.
- [x] **Architecture:** No architecture or setting changes.
- [x] **Git Hygiene:** The PR contains one logical commit with no unrelated changes.
- [x] **Title Prefix:** The PR title uses the `feat` prefix.

# Changelog Entry

### Description

- Re-submits the Perplexity attribution header change from closed PR #24267 against the required `dev` base branch.

### Added

- Add `X-Pplx-Integration: open-webui/<VERSION>` to outgoing Perplexity requests from `backend/open_webui/retrieval/web/perplexity.py`.
- Add `X-Pplx-Integration: open-webui/<VERSION>` to outgoing Perplexity Search API requests from `backend/open_webui/retrieval/web/perplexity_search.py`.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

The header is set before optional user-info header merging in the Search API path so downstream header handling preserves it. This is a no-behavior-change attribution header only; request payloads, endpoints, and response handling are unchanged.

Verification run:

- `python -c "import ast; paths=['backend/open_webui/retrieval/web/perplexity.py','backend/open_webui/retrieval/web/perplexity_search.py']; [ast.parse(open(path, encoding='utf-8').read()) for path in paths]; print('ast parse ok')"`
- `PYTHONPATH=backend /tmp/openwebui-venv/bin/python -c "from open_webui.env import VERSION; print(f'VERSION={VERSION}')"`

DCO signoff:

Signed-off-by: James Liounis <james.liounis@perplexity.ai>

The CLA was already signed for the original submission.

### Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_
