### PR TITLE
fix(images): accept non-standard Content-Type in image generation responses

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -594,7 +594,7 @@ async def image_generations(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
 
@@ -644,7 +644,7 @@ async def image_generations(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
 
@@ -750,7 +750,7 @@ async def image_generations(
                 headers={'authorization': get_automatic1111_api_auth(request)},
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
-                res = await r.json()
+                res = await r.json(content_type=None)
             log.debug(f'res: {res}')
 
             images = []
@@ -925,7 +925,7 @@ async def image_edits(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
             for image in res['data']:
@@ -980,7 +980,7 @@ async def image_edits(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
             for image in res['candidates']:


### PR DESCRIPTION
## Summary

`aiohttp`'s `ClientResponse.json()` validates the `Content-Type` header against `application/json` by default and raises `ContentTypeError` for any other value. This silently breaks image generation for users whose backend returns a different but valid content type.

The most common case: **Ollama's OpenAI-compatible `/v1/images/generations` endpoint returns `Content-Type: application/x-ndjson`** (chunked streaming header) even though the response body is a single, complete JSON object. Every image generation request via Ollama fails with:

```
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: application/x-ndjson'
```

The same issue can affect any other backend that returns valid JSON with a non-standard MIME type (e.g. `text/plain`, `application/octet-stream`).

## Root Cause

`aiohttp.ClientResponse.json()` accepts a `content_type` parameter that defaults to `"application/json"`. When the server returns any other MIME type, aiohttp raises `ContentTypeError` **after** successfully reading the response body — the JSON is already there, it just never gets parsed.

## Fix

Pass `content_type=None` to every `r.json()` call that handles an image generation or editing response. This is the [documented aiohttp pattern](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) for skipping the content-type check while keeping all other parsing behaviour identical.

```python
# Before
res = await r.json()

# After
res = await r.json(content_type=None)
```

Five call sites are affected: `image_generations` (openai, gemini, automatic1111 engines) and `image_edits` (openai, gemini engines).

## Testing

Verified against Ollama v0.21.2 (`/v1/images/generations`) with model `x/flux2-klein:latest`:

- Without fix: `ContentTypeError` raised immediately after generation completes
- With fix: response parsed correctly, `b64_json` image returned as expected

The change is backwards-compatible — providers returning `application/json` are unaffected.

## Related Issues

- #20848 — Ollama image generation connection request
- #4915 — Ollama sends `Content-Type: application/x-ndjson`