### PR TITLE
fix(images): accept non-standard Content-Type in image generation responses

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -626,7 +626,7 @@ async def image_generations(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
 
@@ -676,7 +676,7 @@ async def image_generations(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
 
@@ -785,7 +785,7 @@ async def image_generations(
                 headers={'authorization': get_automatic1111_api_auth(request)},
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
-                res = await r.json()
+                res = await r.json(content_type=None)
             log.debug(f'res: {res}')
 
             images = []
@@ -960,7 +960,7 @@ async def image_edits(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
             for image in res['data']:
@@ -1015,7 +1015,7 @@ async def image_edits(
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as r:
                 r.raise_for_status()
-                res = await r.json()
+                res = await r.json(content_type=None)
 
             images = []
             for image in res['candidates']:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #20848
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Added below.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually tested against Ollama v0.21.2 with a Flux image generation model — see details below.
- [x] **Agentic AI Code:** This fix has gone through human review and manual end-to-end testing (image successfully generated and returned).
- [x] **Code review:** Self-reviewed.
- [x] **Git Hygiene:** Single atomic commit.
- [x] **Title Prefix:** `fix`

---

# Changelog Entry

### Description

`aiohttp`'s `ClientResponse.json()` validates the `Content-Type` response header against `"application/json"` by default and raises `ContentTypeError` for any other value. This silently breaks image generation for backends that return valid JSON with a non-standard MIME type.

The immediate trigger: **Ollama v0.21.x returns `Content-Type: application/x-ndjson`** from its OpenAI-compatible `/v1/images/generations` endpoint, even though the response body is a single, fully-formed JSON object. Every image generation request via Ollama therefore fails with:

```
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: application/x-ndjson'
```

The same issue can affect any backend returning valid JSON with a non-standard MIME type (e.g. `text/plain`, `application/x-ndjson`).

### Fixed

- Image generation and editing no longer fail with `ContentTypeError` when a backend returns valid JSON with a non-standard `Content-Type` header (e.g. Ollama returning `application/x-ndjson`). Fix covers the `openai`, `gemini`, and `automatic1111` engines in both `image_generations` and `image_edits`.

---

### Technical Details

`aiohttp.ClientResponse.json()` exposes a `content_type` parameter (default `"application/json"`) for exactly this case. Passing `content_type=None` skips the header check while keeping all other parsing behaviour identical — this is the [documented aiohttp pattern](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) for lenient content-type handling.

**Diff:** 5 lines changed (one per affected `r.json()` call site).

**Reproduction steps (before fix):**
1. Configure Open WebUI image generation engine to `openai`, point `api_base_url` at a local Ollama instance.
2. Select an image generation model (e.g. `x/flux2-klein:latest`).
3. Request an image — generation completes on the Ollama side but Open WebUI returns an error.
4. In logs: `ContentTypeError: Attempt to decode JSON with unexpected mimetype: application/x-ndjson`

**Verification (after fix):**
Tested against Ollama v0.21.2 with model `x/flux2-klein:latest`. The response body (`{"created": ..., "data": [{"b64_json": "..."}]}`) is parsed correctly and the generated image is returned to the client.

### Additional Information

- Related issue: #20848 (Ollama image generation connection)
- Related closed issue: #4915 (Ollama sends `Content-Type: application/x-ndjson`)

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.