### PR TITLE
feat: add optional TOTP two-factor authentication

### DIFF
--- a/backend/open_webui/migrations/versions/f6b90f8a2c1d_add_user_totp_table.py
+++ b/backend/open_webui/migrations/versions/f6b90f8a2c1d_add_user_totp_table.py
@@ -1,0 +1,48 @@
+"""Add user TOTP table
+
+Revision ID: f6b90f8a2c1d
+Revises: 461111b60977
+Create Date: 2026-05-16 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from open_webui.migrations.util import get_existing_tables
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6b90f8a2c1d'
+down_revision: Union[str, None] = '461111b60977'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    existing_tables = set(get_existing_tables())
+
+    if 'user_totp' not in existing_tables:
+        op.create_table(
+            'user_totp',
+            sa.Column(
+                'user_id',
+                sa.String(),
+                sa.ForeignKey('user.id', ondelete='CASCADE'),
+                nullable=False,
+                primary_key=True,
+            ),
+            sa.Column('secret', sa.Text(), nullable=True),
+            sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column('backup_codes', sa.JSON(), nullable=True),
+            sa.Column('last_used_at', sa.BigInteger(), nullable=True),
+            sa.Column('last_used_step', sa.BigInteger(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+        )
+        op.create_index('idx_user_totp_enabled', 'user_totp', ['enabled'])
+
+
+def downgrade() -> None:
+    op.drop_index('idx_user_totp_enabled', table_name='user_totp')
+    op.drop_table('user_totp')

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Optional
 
 from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.models.totp import UserTOTPs
 from open_webui.models.users import User, UserModel, UserProfileImageResponse, Users
 from open_webui.utils.validate import validate_profile_image_url
 from pydantic import BaseModel, field_validator
@@ -198,6 +199,7 @@ class AuthsTable:
                 result = await Users.delete_user_by_id(id, db=db)
 
                 if result:
+                    await UserTOTPs.delete_totp_by_user_id(id, db=db)
                     await db.execute(delete(Auth).filter_by(id=id))
                     await db.commit()
 

--- a/backend/open_webui/models/totp.py
+++ b/backend/open_webui/models/totp.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import time
+
+from open_webui.internal.db import Base, get_async_db_context
+from open_webui.utils.totp import verify_backup_code
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import BigInteger, Boolean, Column, ForeignKey, JSON, String, Text, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class UserTOTP(Base):
+    __tablename__ = 'user_totp'
+
+    user_id = Column(String, ForeignKey('user.id', ondelete='CASCADE'), primary_key=True, unique=True)
+    secret = Column(Text, nullable=True)
+    enabled = Column(Boolean, nullable=False, default=False)
+    backup_codes = Column(JSON, nullable=True)
+    last_used_at = Column(BigInteger, nullable=True)
+    last_used_step = Column(BigInteger, nullable=True)
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+
+class UserTOTPModel(BaseModel):
+    user_id: str
+    secret: str | None = None
+    enabled: bool = False
+    backup_codes: list[str] | None = None
+    last_used_at: int | None = None
+    last_used_step: int | None = None
+    created_at: int
+    updated_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserTOTPsTable:
+    async def get_user_totp_by_user_id(self, user_id: str, db: AsyncSession | None = None) -> UserTOTPModel | None:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                return UserTOTPModel.model_validate(user_totp) if user_totp else None
+        except Exception:
+            return None
+
+    async def is_totp_enabled_by_user_id(self, user_id: str, db: AsyncSession | None = None) -> bool:
+        user_totp = await self.get_user_totp_by_user_id(user_id, db=db)
+        return bool(user_totp and user_totp.enabled and user_totp.secret)
+
+    async def save_pending_secret_by_user_id(
+        self, user_id: str, encrypted_secret: str, db: AsyncSession | None = None
+    ) -> UserTOTPModel | None:
+        try:
+            async with get_async_db_context(db) as db:
+                now = int(time.time())
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+
+                if user_totp:
+                    user_totp.secret = encrypted_secret
+                    user_totp.enabled = False
+                    user_totp.backup_codes = []
+                    user_totp.last_used_step = None
+                    user_totp.updated_at = now
+                else:
+                    user_totp = UserTOTP(
+                        user_id=user_id,
+                        secret=encrypted_secret,
+                        enabled=False,
+                        backup_codes=[],
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    db.add(user_totp)
+
+                await db.commit()
+                await db.refresh(user_totp)
+                return UserTOTPModel.model_validate(user_totp)
+        except Exception:
+            return None
+
+    async def enable_totp_by_user_id(
+        self,
+        user_id: str,
+        backup_codes: list[str],
+        last_used_step: int,
+        db: AsyncSession | None = None,
+    ) -> UserTOTPModel | None:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                if not user_totp or not user_totp.secret:
+                    return None
+
+                now = int(time.time())
+                user_totp.enabled = True
+                user_totp.backup_codes = backup_codes
+                user_totp.last_used_at = now
+                user_totp.last_used_step = last_used_step
+                user_totp.updated_at = now
+
+                await db.commit()
+                await db.refresh(user_totp)
+                return UserTOTPModel.model_validate(user_totp)
+        except Exception:
+            return None
+
+    async def disable_totp_by_user_id(self, user_id: str, db: AsyncSession | None = None) -> bool:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                if not user_totp:
+                    return True
+
+                now = int(time.time())
+                user_totp.secret = None
+                user_totp.enabled = False
+                user_totp.backup_codes = []
+                user_totp.last_used_step = None
+                user_totp.updated_at = now
+
+                await db.commit()
+                return True
+        except Exception:
+            return False
+
+    async def delete_totp_by_user_id(self, user_id: str, db: AsyncSession | None = None) -> bool:
+        try:
+            async with get_async_db_context(db) as db:
+                await db.execute(delete(UserTOTP).filter_by(user_id=user_id))
+                await db.commit()
+                return True
+        except Exception:
+            return False
+
+    async def mark_totp_used_by_user_id(
+        self, user_id: str, last_used_step: int, db: AsyncSession | None = None
+    ) -> bool:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                if not user_totp:
+                    return False
+
+                now = int(time.time())
+                user_totp.last_used_at = now
+                user_totp.last_used_step = last_used_step
+                user_totp.updated_at = now
+
+                await db.commit()
+                return True
+        except Exception:
+            return False
+
+    async def replace_backup_codes_by_user_id(
+        self, user_id: str, backup_codes: list[str], db: AsyncSession | None = None
+    ) -> UserTOTPModel | None:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                if not user_totp or not user_totp.enabled:
+                    return None
+
+                now = int(time.time())
+                user_totp.backup_codes = backup_codes
+                user_totp.updated_at = now
+
+                await db.commit()
+                await db.refresh(user_totp)
+                return UserTOTPModel.model_validate(user_totp)
+        except Exception:
+            return None
+
+    async def consume_backup_code_by_user_id(
+        self, user_id: str, backup_code: str, db: AsyncSession | None = None
+    ) -> bool:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(UserTOTP).filter_by(user_id=user_id))
+                user_totp = result.scalars().first()
+                if not user_totp or not user_totp.enabled:
+                    return False
+
+                backup_codes = list(user_totp.backup_codes or [])
+                for index, hashed_code in enumerate(backup_codes):
+                    if verify_backup_code(backup_code, hashed_code):
+                        remaining = backup_codes[:index] + backup_codes[index + 1 :]
+                        now = int(time.time())
+                        user_totp.backup_codes = remaining
+                        user_totp.last_used_at = now
+                        user_totp.updated_at = now
+                        await db.commit()
+                        return True
+
+                return False
+        except Exception:
+            return False
+
+
+UserTOTPs = UserTOTPsTable()

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -38,7 +38,7 @@ from open_webui.env import (
     WEBUI_AUTH_TRUSTED_NAME_HEADER,
     WEBUI_AUTH_TRUSTED_ROLE_HEADER,
 )
-from open_webui.internal.db import get_async_session
+from open_webui.internal.db import get_async_db_context, get_async_session
 from open_webui.models.auths import (
     AddUserForm,
     ApiKey,
@@ -52,6 +52,7 @@ from open_webui.models.auths import (
 )
 from open_webui.models.groups import Groups
 from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.totp import UserTOTP, UserTOTPs
 from open_webui.models.users import (
     UpdateProfileForm,
     UserModel,
@@ -78,17 +79,27 @@ from open_webui.utils.misc import parse_duration, validate_email_format
 from open_webui.utils.oauth import auth_manager_config
 from open_webui.utils.rate_limit import RateLimiter
 from open_webui.utils.redis import get_redis_client
+from open_webui.utils.totp import (
+    build_otpauth_uri,
+    decrypt_totp_secret,
+    encrypt_totp_secret,
+    generate_backup_codes,
+    generate_totp_secret,
+    hash_backup_code,
+    verify_backup_code,
+    verify_totp,
+)
 from open_webui.utils.webhook import post_webhook
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
 
 log = logging.getLogger(__name__)
 
-# Forgive us our failed attempts, as we forgive those
-# who exceed their allotted rate against this gate.
 signin_rate_limiter = RateLimiter(redis_client=get_redis_client(), limit=5 * 3, window=60 * 3)
+totp_rate_limiter = RateLimiter(redis_client=get_redis_client(), limit=5, window=60 * 5)
 
 
 async def create_session_response(
@@ -143,6 +154,89 @@ async def create_session_response(
     }
 
 
+def create_totp_challenge_response(user) -> dict:
+    mfa_token = create_token(
+        data={'mfa_user_id': user.id, 'purpose': 'totp_login'},
+        expires_delta=datetime.timedelta(minutes=5),
+    )
+    return {
+        'mfa_required': True,
+        'mfa_token': mfa_token,
+        'token_type': 'mfa',
+        'email': user.email,
+    }
+
+
+async def create_session_or_totp_challenge_response(
+    request: Request, user, db, response: Response = None, set_cookie: bool = False
+) -> dict:
+    if await UserTOTPs.is_totp_enabled_by_user_id(user.id, db=db):
+        return create_totp_challenge_response(user)
+
+    return await create_session_response(request, user, db, response, set_cookie=set_cookie)
+
+
+def get_totp_challenge_user_id(mfa_token: str) -> str:
+    data = decode_token(mfa_token)
+    if not data or data.get('purpose') != 'totp_login' or not data.get('mfa_user_id'):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.INVALID_TOKEN,
+        )
+    return data['mfa_user_id']
+
+
+async def verify_totp_or_backup_code(
+    user_id: str,
+    *,
+    code: str | None = None,
+    backup_code: str | None = None,
+    db: AsyncSession | None = None,
+) -> bool:
+    if bool(code) == bool(backup_code):
+        return False
+
+    try:
+        async with get_async_db_context(db) as session:
+            result = await session.execute(select(UserTOTP).filter_by(user_id=user_id).with_for_update())
+            user_totp = result.scalars().first()
+            if not user_totp or not user_totp.enabled or not user_totp.secret:
+                return False
+
+            now = int(time.time())
+
+            if backup_code:
+                backup_codes = list(user_totp.backup_codes or [])
+                for index, hashed_code in enumerate(backup_codes):
+                    if verify_backup_code(backup_code, hashed_code):
+                        user_totp.backup_codes = backup_codes[:index] + backup_codes[index + 1 :]
+                        user_totp.last_used_at = now
+                        user_totp.updated_at = now
+                        await session.commit()
+                        return True
+
+                return False
+
+            try:
+                secret = decrypt_totp_secret(user_totp.secret)
+            except Exception:
+                log.exception('Failed to decrypt TOTP secret')
+                return False
+
+            used_step = verify_totp(secret, code, last_used_step=user_totp.last_used_step)
+            if used_step is None:
+                return False
+
+            user_totp.last_used_at = now
+            user_totp.last_used_step = used_step
+            user_totp.updated_at = now
+            await session.commit()
+            return True
+    except Exception:
+        log.exception('Failed to verify TOTP or backup code')
+        return False
+
+
 ############################
 # GetSessionUser
 ############################
@@ -157,6 +251,54 @@ class SessionUserInfoResponse(SessionUserResponse, UserStatus):
     bio: str | None = None
     gender: str | None = None
     date_of_birth: datetime.date | None = None
+
+
+class TOTPChallengeResponse(BaseModel):
+    mfa_required: bool = True
+    mfa_token: str
+    token_type: str = 'mfa'
+    email: str | None = None
+
+
+class TOTPStatusResponse(BaseModel):
+    enabled: bool
+    created_at: int | None = None
+    last_used_at: int | None = None
+    backup_codes_remaining: int = 0
+
+
+class TOTPSetupResponse(BaseModel):
+    secret: str
+    otpauth_url: str
+
+
+class TOTPEnableForm(BaseModel):
+    code: str
+
+
+class TOTPCodeForm(BaseModel):
+    code: str | None = None
+    backup_code: str | None = None
+
+
+class TOTPLoginForm(TOTPCodeForm):
+    mfa_token: str
+
+
+class TOTPBackupCodesResponse(TOTPStatusResponse):
+    backup_codes: list[str]
+
+
+def get_totp_status_response(user_totp) -> TOTPStatusResponse:
+    if not user_totp or not user_totp.enabled:
+        return TOTPStatusResponse(enabled=False)
+
+    return TOTPStatusResponse(
+        enabled=True,
+        created_at=user_totp.created_at,
+        last_used_at=user_totp.last_used_at,
+        backup_codes_remaining=len(user_totp.backup_codes or []),
+    )
 
 
 @router.get('/', response_model=SessionUserInfoResponse)
@@ -222,6 +364,181 @@ async def get_session_user(
     }
 
     return response_data
+
+
+############################
+# TOTP
+############################
+
+
+@router.get('/totp', response_model=TOTPStatusResponse)
+async def get_totp_status(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    user_totp = await UserTOTPs.get_user_totp_by_user_id(user.id, db=db)
+    return get_totp_status_response(user_totp)
+
+
+@router.post('/totp/setup', response_model=TOTPSetupResponse)
+async def setup_totp(
+    request: Request,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    existing_totp = await UserTOTPs.get_user_totp_by_user_id(user.id, db=db)
+    if existing_totp and existing_totp.enabled:
+        raise HTTPException(400, detail='TOTP is already enabled.')
+
+    secret = generate_totp_secret()
+    encrypted_secret = encrypt_totp_secret(secret)
+    user_totp = await UserTOTPs.save_pending_secret_by_user_id(user.id, encrypted_secret, db=db)
+    if not user_totp:
+        raise HTTPException(500, detail='Failed to start TOTP setup.')
+
+    issuer = request.app.state.WEBUI_NAME or 'Open WebUI'
+    return {
+        'secret': secret,
+        'otpauth_url': build_otpauth_uri(issuer, user.email, secret),
+    }
+
+
+@router.post('/totp/enable', response_model=TOTPBackupCodesResponse)
+async def enable_totp(
+    form_data: TOTPEnableForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if totp_rate_limiter.is_limited(f'enable:{user.id}'):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
+    user_totp = await UserTOTPs.get_user_totp_by_user_id(user.id, db=db)
+    if not user_totp or not user_totp.secret:
+        raise HTTPException(400, detail='TOTP setup has not been started.')
+    if user_totp.enabled:
+        raise HTTPException(400, detail='TOTP is already enabled.')
+
+    try:
+        secret = decrypt_totp_secret(user_totp.secret)
+    except Exception:
+        log.exception('Failed to decrypt TOTP secret')
+        raise HTTPException(500, detail='Failed to enable TOTP.')
+
+    used_step = verify_totp(secret, form_data.code)
+    if used_step is None:
+        raise HTTPException(400, detail='Invalid TOTP code.')
+
+    backup_codes = generate_backup_codes()
+    hashed_backup_codes = [hash_backup_code(code) for code in backup_codes]
+    user_totp = await UserTOTPs.enable_totp_by_user_id(user.id, hashed_backup_codes, used_step, db=db)
+    if not user_totp:
+        raise HTTPException(500, detail='Failed to enable TOTP.')
+
+    status_response = get_totp_status_response(user_totp).model_dump()
+    return {
+        **status_response,
+        'backup_codes': backup_codes,
+    }
+
+
+@router.post('/totp/verify', response_model=SessionUserResponse)
+async def verify_totp_login(
+    request: Request,
+    response: Response,
+    form_data: TOTPLoginForm,
+    db: AsyncSession = Depends(get_async_session),
+):
+    user_id = get_totp_challenge_user_id(form_data.mfa_token)
+    if totp_rate_limiter.is_limited(f'login:{user_id}'):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
+    user = await Users.get_user_by_id(user_id, db=db)
+    if not user:
+        raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
+
+    verified = await verify_totp_or_backup_code(
+        user.id,
+        code=form_data.code,
+        backup_code=form_data.backup_code,
+        db=db,
+    )
+    if not verified:
+        raise HTTPException(400, detail='Invalid TOTP or backup code.')
+
+    return await create_session_response(request, user, db, response, set_cookie=True)
+
+
+@router.post('/totp/disable', response_model=TOTPStatusResponse)
+async def disable_totp(
+    form_data: TOTPCodeForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if totp_rate_limiter.is_limited(f'disable:{user.id}'):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
+    if not await UserTOTPs.is_totp_enabled_by_user_id(user.id, db=db):
+        return TOTPStatusResponse(enabled=False)
+
+    verified = await verify_totp_or_backup_code(
+        user.id,
+        code=form_data.code,
+        backup_code=form_data.backup_code,
+        db=db,
+    )
+    if not verified:
+        raise HTTPException(400, detail='Invalid TOTP or backup code.')
+
+    if not await UserTOTPs.disable_totp_by_user_id(user.id, db=db):
+        raise HTTPException(500, detail='Failed to disable TOTP.')
+
+    return TOTPStatusResponse(enabled=False)
+
+
+@router.post('/totp/backup-codes/regenerate', response_model=TOTPBackupCodesResponse)
+async def regenerate_totp_backup_codes(
+    form_data: TOTPCodeForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if totp_rate_limiter.is_limited(f'backup:{user.id}'):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+        )
+
+    if not await UserTOTPs.is_totp_enabled_by_user_id(user.id, db=db):
+        raise HTTPException(400, detail='TOTP is not enabled.')
+
+    verified = await verify_totp_or_backup_code(
+        user.id,
+        code=form_data.code,
+        backup_code=form_data.backup_code,
+        db=db,
+    )
+    if not verified:
+        raise HTTPException(400, detail='Invalid TOTP or backup code.')
+
+    backup_codes = generate_backup_codes()
+    hashed_backup_codes = [hash_backup_code(code) for code in backup_codes]
+    user_totp = await UserTOTPs.replace_backup_codes_by_user_id(user.id, hashed_backup_codes, db=db)
+    if not user_totp:
+        raise HTTPException(500, detail='Failed to regenerate backup codes.')
+
+    status_response = get_totp_status_response(user_totp).model_dump()
+    return {
+        **status_response,
+        'backup_codes': backup_codes,
+    }
 
 
 ############################
@@ -311,7 +628,7 @@ async def update_password(
 ############################
 # LDAP Authentication
 ############################
-@router.post('/ldap', response_model=SessionUserResponse)
+@router.post('/ldap', response_model=SessionUserResponse | TOTPChallengeResponse)
 async def ldap_auth(
     request: Request,
     response: Response,
@@ -548,7 +865,7 @@ async def ldap_auth(
                     except Exception as e:
                         log.error(f'Failed to sync groups for user {user.id}: {e}')
 
-                return await create_session_response(request, user, db, response, set_cookie=True)
+                return await create_session_or_totp_challenge_response(request, user, db, response, set_cookie=True)
             else:
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
         else:
@@ -563,7 +880,7 @@ async def ldap_auth(
 ############################
 
 
-@router.post('/signin', response_model=SessionUserResponse)
+@router.post('/signin', response_model=SessionUserResponse | TOTPChallengeResponse)
 async def signin(
     request: Request,
     response: Response,
@@ -666,7 +983,7 @@ async def signin(
         )
 
     if user:
-        return await create_session_response(request, user, db, response, set_cookie=True)
+        return await create_session_or_totp_challenge_response(request, user, db, response, set_cookie=True)
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
 
@@ -1285,7 +1602,7 @@ class TokenExchangeForm(BaseModel):
     token: str  # OAuth access token from external provider
 
 
-@router.post('/oauth/{provider}/token/exchange', response_model=SessionUserResponse)
+@router.post('/oauth/{provider}/token/exchange', response_model=SessionUserResponse | TOTPChallengeResponse)
 async def token_exchange(
     request: Request,
     response: Response,
@@ -1386,4 +1703,4 @@ async def token_exchange(
             detail='User not found. Please sign in via the web interface first.',
         )
 
-    return await create_session_response(request, user, db)
+    return await create_session_or_totp_challenge_response(request, user, db)

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -30,6 +30,7 @@ from open_webui.models.access_grants import AccessGrants
 from open_webui.models.knowledge import Knowledges
 from open_webui.models.models import Models
 from open_webui.models.tools import Tools
+from open_webui.models.totp import UserTOTPs
 from open_webui.socket.main import disconnect_user_sessions
 from open_webui.utils.access_control import get_permissions, has_permission
 from open_webui.utils.auth import (
@@ -414,6 +415,13 @@ class UserActiveResponse(UserStatus):
     model_config = ConfigDict(extra='allow')
 
 
+class UserTOTPAdminStatusResponse(BaseModel):
+    enabled: bool
+    created_at: int | None = None
+    last_used_at: int | None = None
+    backup_codes_remaining: int = 0
+
+
 @router.get('/{user_id}', response_model=UserActiveResponse)
 async def get_user_by_id(user_id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
 
@@ -453,6 +461,49 @@ async def get_user_info_by_id(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.USER_NOT_FOUND,
         )
+
+
+@router.get('/{user_id}/totp', response_model=UserTOTPAdminStatusResponse)
+async def get_user_totp_status_by_id(
+    user_id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)
+):
+    target_user = await Users.get_user_by_id(user_id, db=db)
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.USER_NOT_FOUND,
+        )
+
+    user_totp = await UserTOTPs.get_user_totp_by_user_id(user_id, db=db)
+    if not user_totp or not user_totp.enabled:
+        return UserTOTPAdminStatusResponse(enabled=False)
+
+    return UserTOTPAdminStatusResponse(
+        enabled=True,
+        created_at=user_totp.created_at,
+        last_used_at=user_totp.last_used_at,
+        backup_codes_remaining=len(user_totp.backup_codes or []),
+    )
+
+
+@router.delete('/{user_id}/totp', response_model=UserTOTPAdminStatusResponse)
+async def disable_user_totp_by_id(
+    user_id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)
+):
+    target_user = await Users.get_user_by_id(user_id, db=db)
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.USER_NOT_FOUND,
+        )
+
+    if not await UserTOTPs.disable_totp_by_user_id(user_id, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.DEFAULT(),
+        )
+
+    return UserTOTPAdminStatusResponse(enabled=False)
 
 
 @router.get('/{user_id}/oauth/sessions')

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -80,6 +80,7 @@ from open_webui.env import (
 from open_webui.models.auths import Auths
 from open_webui.models.groups import GroupForm, GroupModel, Groups, GroupUpdateForm
 from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.totp import UserTOTPs
 from open_webui.models.users import Users
 from open_webui.retrieval.web.utils import validate_url
 from open_webui.utils.auth import create_token, get_password_hash
@@ -1058,6 +1059,56 @@ class OAuthManager:
             return client._server_metadata_url if hasattr(client, '_server_metadata_url') else None
         return None
 
+    async def _set_oauth_session_cookies(self, response, user_id: str, provider: str, token: dict, cookie_max_age, db=None):
+        if ENABLE_OAUTH_ID_TOKEN_COOKIE:
+            response.set_cookie(
+                key='oauth_id_token',
+                value=token.get('id_token'),
+                httponly=True,
+                samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+                secure=WEBUI_AUTH_COOKIE_SECURE,
+                **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
+            )
+
+        try:
+            _normalize_token_expiry(token)
+
+            # Enforce max concurrent sessions per user/provider to prevent
+            # unbounded growth while allowing multi-device usage.
+            sessions = await OAuthSessions.get_sessions_by_user_id(user_id, db=db)
+            provider_sessions = sorted(
+                [session for session in sessions if session.provider == provider],
+                key=lambda session: session.created_at,
+                reverse=True,
+            )
+
+            if len(provider_sessions) >= OAUTH_MAX_SESSIONS_PER_USER:
+                for old_session in provider_sessions[OAUTH_MAX_SESSIONS_PER_USER - 1 :]:
+                    await OAuthSessions.delete_session_by_id(old_session.id, db=db)
+
+            session = await OAuthSessions.create_session(
+                user_id=user_id,
+                provider=provider,
+                token=token,
+                db=db,
+            )
+
+            if session:
+                response.set_cookie(
+                    key='oauth_session_id',
+                    value=session.id,
+                    httponly=True,
+                    samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
+                    secure=WEBUI_AUTH_COOKIE_SECURE,
+                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
+                )
+
+                log.info(f'Stored OAuth session server-side for user {user_id}, provider {provider}')
+            else:
+                log.warning(f'Failed to create OAuth session for user {user_id}, provider {provider}')
+        except Exception as e:
+            log.error(f'Failed to store OAuth session server-side: {e}')
+
     async def get_oauth_token(self, user_id: str, session_id: str, force_refresh: bool = False):
         """
         Get a valid OAuth token for the user, automatically refreshing if needed.
@@ -1487,6 +1538,11 @@ class OAuthManager:
             raise HTTPException(404)
 
         error_message = None
+        jwt_token = None
+        mfa_token = None
+        mfa_email = None
+        token = None
+        user = None
         try:
             client = self.get_client(provider)
 
@@ -1737,16 +1793,24 @@ class OAuthManager:
                         detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
                     )
 
-            jwt_token = create_token(
-                data={'id': user.id},
-                expires_delta=parse_duration(auth_manager_config.JWT_EXPIRES_IN),
-            )
             if auth_manager_config.ENABLE_OAUTH_GROUP_MANAGEMENT:
                 await self.update_user_groups(
                     user=user,
                     user_data=user_data,
                     default_permissions=request.app.state.config.USER_PERMISSIONS,
                     db=db,
+                )
+
+            if await UserTOTPs.is_totp_enabled_by_user_id(user.id, db=db):
+                mfa_token = create_token(
+                    data={'mfa_user_id': user.id, 'purpose': 'totp_login'},
+                    expires_delta=timedelta(minutes=5),
+                )
+                mfa_email = user.email
+            else:
+                jwt_token = create_token(
+                    data={'id': user.id},
+                    expires_delta=parse_duration(auth_manager_config.JWT_EXPIRES_IN),
                 )
 
         except Exception as e:
@@ -1770,6 +1834,12 @@ class OAuthManager:
         expires_delta = parse_duration(auth_manager_config.JWT_EXPIRES_IN)
         cookie_max_age = int(expires_delta.total_seconds()) if expires_delta else None
 
+        if mfa_token:
+            mfa_params = urllib.parse.urlencode({'mfa_token': mfa_token, 'mfa_email': mfa_email or ''})
+            response = RedirectResponse(url=f'{redirect_url}#{mfa_params}', headers=response.headers)
+            await self._set_oauth_session_cookies(response, user.id, provider, token, cookie_max_age, db=db)
+            return response
+
         # Set the cookie token
         # Redirect back to the frontend with the JWT token
         response.set_cookie(
@@ -1781,55 +1851,7 @@ class OAuthManager:
             **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
         )
 
-        # Legacy cookies for compatibility with older frontend versions
-        if ENABLE_OAUTH_ID_TOKEN_COOKIE:
-            response.set_cookie(
-                key='oauth_id_token',
-                value=token.get('id_token'),
-                httponly=True,
-                samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
-                secure=WEBUI_AUTH_COOKIE_SECURE,
-                **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
-            )
-
-        try:
-            _normalize_token_expiry(token)
-
-            # Enforce max concurrent sessions per user/provider to prevent
-            # unbounded growth while allowing multi-device usage
-            sessions = await OAuthSessions.get_sessions_by_user_id(user.id, db=db)
-            provider_sessions = sorted(
-                [session for session in sessions if session.provider == provider],
-                key=lambda session: session.created_at,
-                reverse=True,
-            )
-            # Keep the newest sessions up to the limit, prune the rest
-            if len(provider_sessions) >= OAUTH_MAX_SESSIONS_PER_USER:
-                for old_session in provider_sessions[OAUTH_MAX_SESSIONS_PER_USER - 1 :]:
-                    await OAuthSessions.delete_session_by_id(old_session.id, db=db)
-
-            session = await OAuthSessions.create_session(
-                user_id=user.id,
-                provider=provider,
-                token=token,
-                db=db,
-            )
-
-            if session:
-                response.set_cookie(
-                    key='oauth_session_id',
-                    value=session.id,
-                    httponly=True,
-                    samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
-                    secure=WEBUI_AUTH_COOKIE_SECURE,
-                    **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
-                )
-
-                log.info(f'Stored OAuth session server-side for user {user.id}, provider {provider}')
-            else:
-                log.warning(f'Failed to create OAuth session for user {user.id}, provider {provider}')
-        except Exception as e:
-            log.error(f'Failed to store OAuth session server-side: {e}')
+        await self._set_oauth_session_cookies(response, user.id, provider, token, cookie_max_age, db=db)
 
         return response
 

--- a/backend/open_webui/utils/totp.py
+++ b/backend/open_webui/utils/totp.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import secrets
+import struct
+import time
+import urllib.parse
+
+import bcrypt
+from cryptography.fernet import Fernet
+from open_webui.env import WEBUI_SECRET_KEY
+
+TOTP_DIGITS = 6
+TOTP_PERIOD = 30
+TOTP_SECRET_BYTES = 20
+BACKUP_CODE_COUNT = 10
+BACKUP_CODE_LENGTH = 10
+BACKUP_CODE_ALPHABET = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+
+
+def _get_fernet() -> Fernet:
+    key_bytes = hashlib.sha256(WEBUI_SECRET_KEY.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(key_bytes))
+
+
+def encrypt_totp_secret(secret: str) -> str:
+    return _get_fernet().encrypt(secret.encode()).decode()
+
+
+def decrypt_totp_secret(encrypted_secret: str) -> str:
+    return _get_fernet().decrypt(encrypted_secret.encode()).decode()
+
+
+def generate_totp_secret() -> str:
+    return base64.b32encode(os.urandom(TOTP_SECRET_BYTES)).decode().rstrip('=')
+
+
+def _decode_base32_secret(secret: str) -> bytes:
+    normalized = secret.strip().replace(' ', '').upper()
+    padding = '=' * ((8 - len(normalized) % 8) % 8)
+    return base64.b32decode(normalized + padding, casefold=True)
+
+
+def hotp(secret: str, counter: int, digits: int = TOTP_DIGITS) -> str:
+    key = _decode_base32_secret(secret)
+    counter_bytes = struct.pack('>Q', counter)
+    digest = hmac.new(key, counter_bytes, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    code = struct.unpack('>I', digest[offset : offset + 4])[0] & 0x7FFFFFFF
+    return str(code % (10**digits)).zfill(digits)
+
+
+def get_totp_step(timestamp: int | None = None, period: int = TOTP_PERIOD) -> int:
+    return int((timestamp if timestamp is not None else time.time()) // period)
+
+
+def verify_totp(
+    secret: str,
+    code: str,
+    *,
+    timestamp: int | None = None,
+    period: int = TOTP_PERIOD,
+    digits: int = TOTP_DIGITS,
+    window: int = 1,
+    last_used_step: int | None = None,
+) -> int | None:
+    normalized_code = ''.join(ch for ch in str(code) if ch.isdigit())
+    if len(normalized_code) != digits:
+        return None
+
+    current_step = get_totp_step(timestamp, period)
+    for step in range(current_step - window, current_step + window + 1):
+        if step < 0:
+            continue
+        if last_used_step is not None and step <= last_used_step:
+            continue
+        if hmac.compare_digest(hotp(secret, step, digits), normalized_code):
+            return step
+
+    return None
+
+
+def build_otpauth_uri(issuer: str, account_name: str, secret: str) -> str:
+    issuer = issuer or 'Open WebUI'
+    label = urllib.parse.quote(f'{issuer}:{account_name}')
+    params = urllib.parse.urlencode(
+        {
+            'secret': secret,
+            'issuer': issuer,
+            'algorithm': 'SHA1',
+            'digits': str(TOTP_DIGITS),
+            'period': str(TOTP_PERIOD),
+        }
+    )
+    return f'otpauth://totp/{label}?{params}'
+
+
+def generate_backup_codes(count: int = BACKUP_CODE_COUNT) -> list[str]:
+    codes = []
+    for _ in range(count):
+        raw = ''.join(secrets.choice(BACKUP_CODE_ALPHABET) for _ in range(BACKUP_CODE_LENGTH))
+        codes.append(f'{raw[:5]}-{raw[5:]}'.lower())
+    return codes
+
+
+def normalize_backup_code(code: str) -> str:
+    return ''.join(ch for ch in str(code).upper() if ch.isalnum())
+
+
+def hash_backup_code(code: str) -> str:
+    normalized = normalize_backup_code(code)
+    return bcrypt.hashpw(normalized.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_backup_code(code: str, hashed_code: str) -> bool:
+    normalized = normalize_backup_code(code)
+    if not normalized or not hashed_code:
+        return False
+    return bcrypt.checkpw(normalized.encode(), hashed_code.encode())

--- a/src/lib/apis/auths/index.ts
+++ b/src/lib/apis/auths/index.ts
@@ -286,6 +286,42 @@ export const userSignIn = async (email: string, password: string) => {
 	return res;
 };
 
+export const verifyTOTPLogin = async (
+	mfaToken: string,
+	code: string | null = null,
+	backupCode: string | null = null
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp/verify`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		credentials: 'include',
+		body: JSON.stringify({
+			mfa_token: mfaToken,
+			code: code,
+			backup_code: backupCode
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const userSignUp = async (
 	name: string,
 	email: string,
@@ -349,6 +385,160 @@ export const userSignOut = async () => {
 	}
 
 	sessionStorage.clear();
+	return res;
+};
+
+export const getTOTPStatus = async (token: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const setupTOTP = async (token: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp/setup`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const enableTOTP = async (token: string, code: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp/enable`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({
+			code: code
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const disableTOTP = async (
+	token: string,
+	code: string | null = null,
+	backupCode: string | null = null
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp/disable`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({
+			code: code,
+			backup_code: backupCode
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const regenerateTOTPBackupCodes = async (
+	token: string,
+	code: string | null = null,
+	backupCode: string | null = null
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/auths/totp/backup-codes/regenerate`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({
+			code: code,
+			backup_code: backupCode
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
 	return res;
 };
 

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -524,6 +524,60 @@ export const updateUserById = async (token: string, userId: string, user: UserUp
 	return res;
 };
 
+export const getUserTOTPStatusById = async (token: string, userId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/users/${userId}/totp`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const disableUserTOTPById = async (token: string, userId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/users/${userId}/totp`, {
+		method: 'DELETE',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getUserGroupsById = async (token: string, userId: string) => {
 	let error = null;
 

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -2,11 +2,18 @@
 	import { toast } from 'svelte-sonner';
 	import dayjs from 'dayjs';
 	import { createEventDispatcher } from 'svelte';
-	import { onMount, getContext } from 'svelte';
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
 
 	import { goto } from '$app/navigation';
 
-	import { updateUserById, getUserGroupsById } from '$lib/apis/users';
+	import {
+		disableUserTOTPById,
+		getUserGroupsById,
+		getUserTOTPStatusById,
+		updateUserById
+	} from '$lib/apis/users';
 
 	import Modal from '$lib/components/common/Modal.svelte';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
@@ -14,7 +21,7 @@
 	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 	import UserProfileImage from '$lib/components/chat/Settings/Account/UserProfileImage.svelte';
 
-	const i18n = getContext('i18n');
+	const i18n: Writable<i18nType> = getContext('i18n');
 	const dispatch = createEventDispatcher();
 	dayjs.extend(localizedFormat);
 
@@ -31,6 +38,7 @@
 			_user = selectedUser;
 			_user.password = '';
 			loadUserGroups();
+			loadTOTPStatus();
 		}
 	};
 
@@ -43,6 +51,7 @@
 	};
 
 	let userGroups: any[] | null = null;
+	let totpStatus: { enabled: boolean; backup_codes_remaining: number } | null = null;
 
 	const submitHandler = async () => {
 		const res = await updateUserById(localStorage.token, selectedUser.id, _user).catch((error) => {
@@ -63,6 +72,29 @@
 			toast.error(`${error}`);
 			return null;
 		});
+	};
+
+	const loadTOTPStatus = async () => {
+		if (!selectedUser?.id) return;
+		totpStatus = await getUserTOTPStatusById(localStorage.token, selectedUser.id).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+	};
+
+	const disableTOTPHandler = async () => {
+		if (!selectedUser?.id) return;
+		if (!confirm($i18n.t('Disable two-factor authentication for this user?'))) return;
+
+		const res = await disableUserTOTPById(localStorage.token, selectedUser.id).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			totpStatus = res;
+			toast.success($i18n.t('Two-factor authentication disabled.'));
+		}
 	};
 </script>
 
@@ -214,6 +246,28 @@
 											/>
 										</div>
 									</div>
+
+									{#if totpStatus?.enabled}
+										<div class="flex flex-col w-full">
+											<div class="mb-1 text-xs text-gray-500">
+												{$i18n.t('Two-factor authentication')}
+											</div>
+
+											<div class="flex items-center justify-between gap-3">
+												<div class="text-xs text-gray-500">
+													{$i18n.t('Backup codes remaining')}: {totpStatus.backup_codes_remaining}
+												</div>
+
+												<button
+													class="text-xs font-medium text-red-500"
+													type="button"
+													on:click={disableTOTPHandler}
+												>
+													{$i18n.t('Disable')}
+												</button>
+											</div>
+										</div>
+									{/if}
 								</div>
 							</div>
 						</div>

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 	import { onMount, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
 
 	import { user, config, settings } from '$lib/stores';
 	import { updateUserProfile, createAPIKey, getAPIKey, getSessionUser } from '$lib/apis/auths';
@@ -16,8 +18,9 @@
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import User from '$lib/components/icons/User.svelte';
 	import UserProfileImage from './Account/UserProfileImage.svelte';
+	import TOTP from './Account/TOTP.svelte';
 
-	const i18n = getContext('i18n');
+	const i18n: Writable<i18nType> = getContext('i18n');
 
 	export let saveHandler: Function;
 	export let saveSettings: Function;
@@ -253,6 +256,10 @@
 				<UpdatePassword />
 			</div>
 		{/if}
+
+		<hr class="border-gray-50 dark:border-gray-850/30 my-4" />
+
+		<TOTP />
 
 		{#if ($config?.features?.enable_api_keys ?? true) && ($user?.role === 'admin' || ($user?.permissions?.features?.api_keys ?? false))}
 			<div class="flex justify-between items-center text-sm mt-2">

--- a/src/lib/components/chat/Settings/Account/TOTP.svelte
+++ b/src/lib/components/chat/Settings/Account/TOTP.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { toast } from 'svelte-sonner';
+
+	import {
+		disableTOTP,
+		enableTOTP,
+		getTOTPStatus,
+		regenerateTOTPBackupCodes,
+		setupTOTP
+	} from '$lib/apis/auths';
+	import { copyToClipboard } from '$lib/utils';
+
+	const i18n: Writable<i18nType> = getContext('i18n');
+
+	type TOTPStatus = {
+		enabled: boolean;
+		created_at?: number | null;
+		last_used_at?: number | null;
+		backup_codes_remaining: number;
+		backup_codes?: string[];
+	};
+
+	type TOTPSetup = {
+		secret: string;
+		otpauth_url: string;
+	};
+
+	let loaded = false;
+	let status: TOTPStatus | null = null;
+	let setup: TOTPSetup | null = null;
+	let setupCode = '';
+	let backupCodes: string[] = [];
+
+	let action: 'disable' | 'regenerate' | '' = '';
+	let actionCode = '';
+	let actionBackupCode = '';
+	let useBackupCode = false;
+
+	const loadStatus = async () => {
+		status = await getTOTPStatus(localStorage.token).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+		loaded = true;
+	};
+
+	const startSetupHandler = async () => {
+		setup = await setupTOTP(localStorage.token).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+		setupCode = '';
+	};
+
+	const enableHandler = async () => {
+		const res = await enableTOTP(localStorage.token, setupCode).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			status = res;
+			setup = null;
+			setupCode = '';
+			backupCodes = res.backup_codes ?? [];
+			toast.success($i18n.t('Two-factor authentication enabled.'));
+		}
+	};
+
+	const resetAction = () => {
+		action = '';
+		actionCode = '';
+		actionBackupCode = '';
+		useBackupCode = false;
+	};
+
+	const disableHandler = async () => {
+		const res = await disableTOTP(
+			localStorage.token,
+			useBackupCode ? null : actionCode,
+			useBackupCode ? actionBackupCode : null
+		).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			status = res;
+			backupCodes = [];
+			resetAction();
+			toast.success($i18n.t('Two-factor authentication disabled.'));
+		}
+	};
+
+	const regenerateBackupCodesHandler = async () => {
+		const res = await regenerateTOTPBackupCodes(
+			localStorage.token,
+			useBackupCode ? null : actionCode,
+			useBackupCode ? actionBackupCode : null
+		).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			status = res;
+			backupCodes = res.backup_codes ?? [];
+			resetAction();
+			toast.success($i18n.t('Backup codes regenerated.'));
+		}
+	};
+
+	const submitActionHandler = async () => {
+		if (action === 'disable') {
+			await disableHandler();
+		} else if (action === 'regenerate') {
+			await regenerateBackupCodesHandler();
+		}
+	};
+
+	const copyBackupCodesHandler = () => {
+		copyToClipboard(backupCodes.join('\n'));
+		toast.success($i18n.t('Copied to clipboard'));
+	};
+
+	onMount(async () => {
+		await loadStatus();
+	});
+</script>
+
+{#if loaded && status}
+	<div class="mt-2">
+		<div class="flex justify-between items-center text-sm">
+			<div class="font-medium">{$i18n.t('Two-factor authentication')}</div>
+
+			{#if status.enabled}
+				<div class="text-xs text-emerald-600 dark:text-emerald-400">{$i18n.t('Enabled')}</div>
+			{:else if !setup}
+				<button
+					class="text-xs font-medium text-gray-500"
+					type="button"
+					on:click={startSetupHandler}>{$i18n.t('Enable')}</button
+				>
+			{/if}
+		</div>
+
+		{#if setup}
+			<div class="mt-3 space-y-2">
+				<a class="text-xs underline" href={setup.otpauth_url}>{$i18n.t('Open authenticator app')}</a>
+
+				<div>
+					<div class="mb-1 text-xs font-medium">{$i18n.t('Setup key')}</div>
+					<div class="flex">
+						<input
+							class="w-full text-sm dark:text-gray-300 bg-transparent outline-hidden"
+							type="text"
+							value={setup.secret}
+							readonly
+							aria-label={$i18n.t('Setup key')}
+						/>
+						<button
+							class="ml-1.5 px-1.5 py-1 dark:hover:bg-gray-850 transition rounded-lg text-xs"
+							type="button"
+							on:click={() => {
+								if (!setup) {
+									return;
+								}
+								copyToClipboard(setup.secret);
+								toast.success($i18n.t('Copied to clipboard'));
+							}}
+						>
+							{$i18n.t('Copy')}
+						</button>
+					</div>
+				</div>
+
+				<div>
+					<label for="totp-setup-code" class="mb-1 text-xs font-medium block"
+						>{$i18n.t('Authenticator code')}</label
+					>
+					<input
+						id="totp-setup-code"
+						class="w-full text-sm dark:text-gray-300 bg-transparent outline-hidden"
+						type="text"
+						inputmode="numeric"
+						autocomplete="one-time-code"
+						bind:value={setupCode}
+						placeholder={$i18n.t('Enter 6-digit code')}
+					/>
+				</div>
+
+				<div class="flex justify-end gap-2">
+					<button
+						class="px-3 py-1.5 text-xs font-medium rounded-full bg-gray-100/70 hover:bg-gray-100 dark:bg-gray-850 dark:hover:bg-gray-800 transition"
+						type="button"
+						on:click={() => {
+							setup = null;
+							setupCode = '';
+						}}
+					>
+						{$i18n.t('Cancel')}
+					</button>
+
+					<button
+						class="px-3 py-1.5 text-xs font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+						type="button"
+						on:click={enableHandler}
+					>
+						{$i18n.t('Verify')}
+					</button>
+				</div>
+			</div>
+		{:else if backupCodes.length > 0}
+			<div class="mt-3 space-y-2">
+				<div class="text-xs font-medium">{$i18n.t('Backup codes')}</div>
+				<div class="grid grid-cols-2 gap-1 text-xs font-mono">
+					{#each backupCodes as code}
+						<div class="py-1">{code}</div>
+					{/each}
+				</div>
+
+				<div class="flex justify-end gap-2">
+					<button
+						class="px-3 py-1.5 text-xs font-medium rounded-full bg-gray-100/70 hover:bg-gray-100 dark:bg-gray-850 dark:hover:bg-gray-800 transition"
+						type="button"
+						on:click={copyBackupCodesHandler}
+					>
+						{$i18n.t('Copy')}
+					</button>
+
+					<button
+						class="px-3 py-1.5 text-xs font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+						type="button"
+						on:click={() => {
+							backupCodes = [];
+							loadStatus();
+						}}
+					>
+						{$i18n.t('Done')}
+					</button>
+				</div>
+			</div>
+		{:else if status.enabled}
+			<div class="mt-2 space-y-2">
+				<div class="text-xs text-gray-500">
+					{$i18n.t('Backup codes remaining')}: {status.backup_codes_remaining}
+				</div>
+
+				<div class="flex gap-2">
+					<button
+						class="text-xs font-medium text-gray-500"
+						type="button"
+						on:click={() => {
+							action = action === 'regenerate' ? '' : 'regenerate';
+						}}
+					>
+						{$i18n.t('New backup codes')}
+					</button>
+
+					<button
+						class="text-xs font-medium text-red-500"
+						type="button"
+						on:click={() => {
+							action = action === 'disable' ? '' : 'disable';
+						}}
+					>
+						{$i18n.t('Disable')}
+					</button>
+				</div>
+
+				{#if action}
+					<div class="space-y-2">
+						{#if useBackupCode}
+							<div>
+								<label for="totp-action-backup" class="mb-1 text-xs font-medium block"
+									>{$i18n.t('Backup code')}</label
+								>
+								<input
+									id="totp-action-backup"
+									class="w-full text-sm dark:text-gray-300 bg-transparent outline-hidden"
+									type="text"
+									autocomplete="one-time-code"
+									bind:value={actionBackupCode}
+									placeholder={$i18n.t('Enter backup code')}
+								/>
+							</div>
+						{:else}
+							<div>
+								<label for="totp-action-code" class="mb-1 text-xs font-medium block"
+									>{$i18n.t('Authenticator code')}</label
+								>
+								<input
+									id="totp-action-code"
+									class="w-full text-sm dark:text-gray-300 bg-transparent outline-hidden"
+									type="text"
+									inputmode="numeric"
+									autocomplete="one-time-code"
+									bind:value={actionCode}
+									placeholder={$i18n.t('Enter 6-digit code')}
+								/>
+							</div>
+						{/if}
+
+						<div class="flex justify-between items-center">
+							<button
+								class="text-xs underline"
+								type="button"
+								on:click={() => {
+									useBackupCode = !useBackupCode;
+									actionCode = '';
+									actionBackupCode = '';
+								}}
+							>
+								{useBackupCode
+									? $i18n.t('Use authenticator code')
+									: $i18n.t('Use backup code')}
+							</button>
+
+							<button
+								class="px-3 py-1.5 text-xs font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+								type="button"
+								on:click={submitActionHandler}
+							>
+								{action === 'disable' ? $i18n.t('Disable') : $i18n.t('Regenerate')}
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -5,6 +5,8 @@
 	import { toast } from 'svelte-sonner';
 
 	import { onMount, getContext, tick } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 
@@ -14,7 +16,8 @@
 		getSessionUser,
 		userSignIn,
 		userSignUp,
-		updateUserTimezone
+		updateUserTimezone,
+		verifyTOTPLogin
 	} from '$lib/apis/auths';
 
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
@@ -25,9 +28,8 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import OnBoarding from '$lib/components/OnBoarding.svelte';
 	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
-	import { redirect } from '@sveltejs/kit';
 
-	const i18n = getContext('i18n');
+	const i18n: Writable<i18nType> = getContext('i18n');
 
 	let loaded = false;
 
@@ -41,6 +43,31 @@
 	let confirmPassword = '';
 
 	let ldapUsername = '';
+	let mfaRequired = false;
+	let mfaToken = '';
+	let mfaCode = '';
+	let mfaBackupCode = '';
+	let useBackupCode = false;
+	let pendingMfaEmail = '';
+
+	const setTOTPChallenge = (challenge: { mfa_token: string; email?: string }) => {
+		mfaRequired = true;
+		mfaToken = challenge.mfa_token;
+		pendingMfaEmail = challenge.email ?? email;
+		mfaCode = '';
+		mfaBackupCode = '';
+		useBackupCode = false;
+		password = '';
+	};
+
+	const clearTOTPChallenge = () => {
+		mfaRequired = false;
+		mfaToken = '';
+		pendingMfaEmail = '';
+		mfaCode = '';
+		mfaBackupCode = '';
+		useBackupCode = false;
+	};
 
 	const setSessionUser = async (sessionUser, redirectPath: string | null = null) => {
 		if (sessionUser) {
@@ -74,6 +101,11 @@
 			return null;
 		});
 
+		if (sessionUser?.mfa_required) {
+			setTOTPChallenge(sessionUser);
+			return;
+		}
+
 		await setSessionUser(sessionUser);
 	};
 
@@ -100,11 +132,31 @@
 			toast.error(`${error}`);
 			return null;
 		});
+		if (sessionUser?.mfa_required) {
+			setTOTPChallenge(sessionUser);
+			return;
+		}
+
+		await setSessionUser(sessionUser);
+	};
+
+	const verifyTOTPHandler = async () => {
+		const sessionUser = await verifyTOTPLogin(
+			mfaToken,
+			useBackupCode ? null : mfaCode,
+			useBackupCode ? mfaBackupCode : null
+		).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
 		await setSessionUser(sessionUser);
 	};
 
 	const submitHandler = async () => {
-		if (mode === 'ldap') {
+		if (mfaRequired) {
+			await verifyTOTPHandler();
+		} else if (mode === 'ldap') {
 			await ldapSignInHandler();
 		} else if (mode === 'signin') {
 			await signInHandler();
@@ -138,6 +190,22 @@
 
 		localStorage.token = token;
 		await setSessionUser(sessionUser, localStorage.getItem('redirectPath') || null);
+	};
+
+	const oauthTOTPChallengeHandler = () => {
+		const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+		const oauthMfaToken = params.get('mfa_token');
+
+		if (!oauthMfaToken) {
+			return false;
+		}
+
+		setTOTPChallenge({
+			mfa_token: oauthMfaToken,
+			email: params.get('mfa_email') ?? undefined
+		});
+		window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+		return true;
 	};
 
 	let onboarding = false;
@@ -180,7 +248,10 @@
 			toast.error(error);
 		}
 
-		await oauthCallbackHandler();
+		const hasOAuthTOTPChallenge = oauthTOTPChallengeHandler();
+		if (!hasOAuthTOTPChallenge) {
+			await oauthCallbackHandler();
+		}
 		form = $page.url.searchParams.get('form');
 
 		loaded = true;
@@ -219,7 +290,7 @@
 			id="auth-container"
 		>
 			<div class="w-full px-10 min-h-screen flex flex-col text-center">
-				{#if ($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false}
+				{#if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) && !mfaRequired}
 					<div class=" my-auto pb-10 w-full sm:max-w-md">
 						<div
 							class="flex items-center justify-center gap-3 text-xl sm:text-2xl text-center font-medium dark:text-gray-200"
@@ -256,7 +327,9 @@
 							>
 								<div class="mb-1">
 									<div class=" text-2xl font-medium">
-										{#if $config?.onboarding ?? false}
+										{#if mfaRequired}
+											{$i18n.t('Verify two-factor code')}
+										{:else if $config?.onboarding ?? false}
 											{$i18n.t(`Get started with {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 										{:else if mode === 'ldap'}
 											{$i18n.t(`Sign in to {{WEBUI_NAME}} with LDAP`, { WEBUI_NAME: $WEBUI_NAME })}
@@ -277,7 +350,64 @@
 									{/if}
 								</div>
 
-								{#if $config?.features.enable_login_form || $config?.features.enable_ldap || form}
+								{#if mfaRequired}
+									<div class="flex flex-col mt-4">
+										<div class="mb-2 text-left text-xs text-gray-500 dark:text-gray-400">
+											{$i18n.t('Account')}: {pendingMfaEmail}
+										</div>
+
+										{#if useBackupCode}
+											<div>
+												<label
+													for="backup-code"
+													class="text-sm font-medium text-left mb-1 block"
+													>{$i18n.t('Backup code')}</label
+												>
+												<input
+													bind:value={mfaBackupCode}
+													type="text"
+													id="backup-code"
+													class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+													autocomplete="one-time-code"
+													name="backup-code"
+													placeholder={$i18n.t('Enter backup code')}
+													required
+												/>
+											</div>
+										{:else}
+											<div>
+												<label for="totp-code" class="text-sm font-medium text-left mb-1 block"
+													>{$i18n.t('Authenticator code')}</label
+												>
+												<input
+													bind:value={mfaCode}
+													type="text"
+													inputmode="numeric"
+													id="totp-code"
+													class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+													autocomplete="one-time-code"
+													name="totp-code"
+													placeholder={$i18n.t('Enter 6-digit code')}
+													required
+												/>
+											</div>
+										{/if}
+
+										<button
+											class="mt-3 text-xs underline text-center"
+											type="button"
+											on:click={() => {
+												useBackupCode = !useBackupCode;
+												mfaCode = '';
+												mfaBackupCode = '';
+											}}
+										>
+											{useBackupCode
+												? $i18n.t('Use authenticator code')
+												: $i18n.t('Use backup code')}
+										</button>
+									</div>
+								{:else if $config?.features.enable_login_form || $config?.features.enable_ldap || form}
 									<div class="flex flex-col mt-4">
 										{#if mode === 'signup'}
 											<div class="mb-2">
@@ -370,7 +500,24 @@
 									</div>
 								{/if}
 								<div class="mt-5">
-									{#if $config?.features.enable_login_form || $config?.features.enable_ldap || form}
+									{#if mfaRequired}
+										<button
+											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
+											type="submit"
+										>
+											{$i18n.t('Verify')}
+										</button>
+
+										<button
+											class="mt-3 text-xs underline text-center"
+											type="button"
+											on:click={() => {
+												clearTOTPChallenge();
+											}}
+										>
+											{$i18n.t('Cancel')}
+										</button>
+									{:else if $config?.features.enable_login_form || $config?.features.enable_ldap || form}
 										{#if mode === 'ldap'}
 											<button
 												class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"

--- a/test/test_totp_utils.py
+++ b/test/test_totp_utils.py
@@ -1,0 +1,50 @@
+from open_webui.utils.totp import (
+    generate_backup_codes,
+    get_totp_step,
+    hash_backup_code,
+    hotp,
+    normalize_backup_code,
+    verify_backup_code,
+    verify_totp,
+)
+
+
+RFC_SECRET = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ'
+
+
+def test_hotp_matches_rfc_4226_vectors():
+    expected = [
+        '755224',
+        '287082',
+        '359152',
+        '969429',
+        '338314',
+        '254676',
+        '287922',
+        '162583',
+        '399871',
+        '520489',
+    ]
+
+    for counter, code in enumerate(expected):
+        assert hotp(RFC_SECRET, counter) == code
+
+
+def test_verify_totp_matches_rfc_6238_sha1_vector():
+    assert verify_totp(RFC_SECRET, '94287082', timestamp=59, digits=8, window=0) == get_totp_step(59)
+
+
+def test_verify_totp_rejects_reused_time_step():
+    step = get_totp_step(59)
+
+    assert verify_totp(RFC_SECRET, '94287082', timestamp=59, digits=8, window=0, last_used_step=step) is None
+
+
+def test_backup_code_hashing_normalizes_user_input():
+    backup_code = generate_backup_codes(1)[0]
+    hashed_code = hash_backup_code(backup_code)
+    spaced_code = f' {backup_code.replace("-", " ")} '
+
+    assert normalize_backup_code(spaced_code) == normalize_backup_code(backup_code)
+    assert verify_backup_code(spaced_code, hashed_code)
+    assert not verify_backup_code('wrong-code', hashed_code)


### PR DESCRIPTION
<!--
Critical Open WebUI PR requirements:
- Target branch: dev
- Keep the CLA section intact
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #1225. Also references #24650, #11953, and #16461.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [ ] **Documentation:** Docs repo update is prepared; see docs draft below.
- [x] **Dependencies:** No new dependencies were added.
- [x] **Testing:** Manual tests were performed. Screenshots are included where applicable.
- [x] **No Unchecked AI Code:** AI-assisted changes have undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are used; TOTP is optional per user and disabled by default.
- [x] **Git Hygiene:** Atomic feature branch based on `upstream/dev`; no unrelated commits intended.
- [x] **Title Prefix:** `feat: add optional TOTP two-factor authentication`

## Description

Adds optional per-user TOTP two-factor authentication for Open WebUI login.

Relates to #1225.
Refs #24650.
Addresses prior feedback from #11953 and #16461 around optional defaults, migration compatibility, metadata, rate limiting, backup-code behavior, and dependency scope.

This PR intentionally keeps QR-code rendering and admin-wide enforcement out of scope so the first TOTP slice stays small, dependency-free, and reviewable. Setup uses an authenticator-app compatible `otpauth://` URI plus a manual setup key.

## Manual Testing

- Verified password login without TOTP remains unchanged.
- Verified TOTP setup from Account settings.
- Verified TOTP login challenge after password login.
- Verified authenticator-code login.
- Verified backup-code login.
- Verified used backup codes cannot be reused.
- Verified backup-code remaining count updates.
- Verified admin can see and reset a user's TOTP status.
- Verified OAuth callback/token-exchange paths return a TOTP challenge when local TOTP is enabled.
- Verified sandbox UI manually.

## Automated / Local Checks

- `git diff --check`
- Backend `py_compile` for touched Python files
- Direct RFC HOTP/TOTP vector checks
- Backup-code normalize/hash/verify checks
- `npm run test:frontend`
- `./node_modules/.bin/vite build`

Note: `npm run build` also passed, but the existing `pyodide:fetch` step pulled a newer `black` wheel and dirtied `static/pyodide/pyodide-lock.json`. That generated change was intentionally excluded from this PR.

## Screenshots or Videos

MFA login challenge screenshot:

`/tmp/open-webui-totp-sandbox/screenshots/totp-login-mfa.png`

Recommended additional PR screenshots before marking ready:

- Account settings before TOTP is enabled.
- TOTP setup key / authenticator URI state.
- Backup codes shown immediately after enable/regenerate.
- Admin user edit modal showing TOTP status/reset.

# Changelog Entry

### Description

- Adds optional per-user TOTP two-factor authentication to protect Open WebUI login for self-hosted instances.

### Added

- Per-user TOTP setup and management in Account settings.
- TOTP challenge support for password, LDAP, trusted-header/no-auth, OAuth callback, and OAuth token-exchange login flows.
- One-time backup codes for account recovery.
- Admin TOTP status and reset control for user recovery.
- TOTP metadata including creation and last-used timestamps.
- TOTP replay protection using the last-used time step, updated in the same locked transaction as verification.
- Rate limiting for TOTP verification flows.

### Changed

- Login responses can now return an MFA challenge when TOTP is enabled for the user.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- TOTP secrets are encrypted with a key derived from `WEBUI_SECRET_KEY`.
- Backup codes are hashed with bcrypt.
- TOTP verification is rate-limited.
- TOTP and backup-code verification update usage state atomically to avoid double-use races.
- TOTP is disabled by default and must be explicitly enabled per user.
- No new dependencies were added.

### Breaking Changes

- None.

---

### Additional Information

- Changing `WEBUI_SECRET_KEY` invalidates encrypted TOTP secrets.
- Multi-instance deployments should use shared rate-limiting state if Open WebUI supports/configures it for the deployment.
- API keys remain bearer credentials and are not changed by login-time TOTP.
- QR-code rendering and admin-wide TOTP enforcement are follow-up scope.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
