### PR TITLE
fix: honor SSL setting for STT requests

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -745,6 +745,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                         files={'file': (filename, audio_file)},
                         data=payload,
                         timeout=AIOHTTP_CLIENT_TIMEOUT,
+                        verify=AIOHTTP_CLIENT_SESSION_SSL,
                     )
 
                 if r.status_code == 200:
@@ -806,6 +807,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                     params=params,
                     data=file_data,
                     timeout=AIOHTTP_CLIENT_TIMEOUT,
+                    verify=AIOHTTP_CLIENT_SESSION_SSL,
                 )
 
                 if r.status_code == 200:
@@ -914,6 +916,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                         'Ocp-Apim-Subscription-Key': api_key,
                     },
                     timeout=AIOHTTP_CLIENT_TIMEOUT,
+                    verify=AIOHTTP_CLIENT_SESSION_SSL,
                 )
 
             r.raise_for_status()
@@ -1067,6 +1070,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                         'Content-Type': 'application/json',
                     },
                     timeout=AIOHTTP_CLIENT_TIMEOUT,
+                    verify=AIOHTTP_CLIENT_SESSION_SSL,
                 )
 
                 r.raise_for_status()
@@ -1106,6 +1110,7 @@ def transcription_handler(request, file_path, metadata, user=None):
                             'Authorization': f'Bearer {api_key}',
                         },
                         timeout=AIOHTTP_CLIENT_TIMEOUT,
+                        verify=AIOHTTP_CLIENT_SESSION_SSL,
                     )
 
                 r.raise_for_status()


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — Closes #24568.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Not applicable; this fixes existing SSL configuration behavior.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone review and validation.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Reuses the existing `AIOHTTP_CLIENT_SESSION_SSL` configuration.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Honor the existing SSL verification setting for synchronous speech-to-text provider requests.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- STT requests made through `requests.post` now pass `verify=AIOHTTP_CLIENT_SESSION_SSL`, allowing self-signed certificate setups when SSL verification is disabled.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

Closes #24568.

Validation:
- `python3 -m py_compile backend/open_webui/routers/audio.py`
- `ruff check backend/open_webui/routers/audio.py` was attempted, but the file has pre-existing unrelated lint findings.

### Screenshots or Videos

- N/A

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.