### PR TITLE
fix: route YouTube URLs to transcript loader

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -167,11 +167,21 @@ def _is_text_content_type(content_type: str) -> bool:
     return not ct  # empty / missing → assume HTML
 
 
+def _load_url_with_loader(request, url: str) -> tuple[str, list]:
+    loader = get_loader(request, url)
+    docs = loader.load()
+    content = ' '.join([doc.page_content for doc in docs])
+    return content, docs
+
+
 def get_content_from_url(request, url: str) -> str:
     from open_webui.retrieval.web.utils import validate_url
 
     # Validate URL before making any request (blocks private IPs, non-HTTP, filter list)
     validate_url(url)
+
+    if is_youtube_url(url):
+        return _load_url_with_loader(request, url)
 
     # Streamed GET to check Content-Type without downloading the body.
     # allow_redirects=False prevents redirect-based SSRF: validate_url() above is
@@ -190,10 +200,7 @@ def get_content_from_url(request, url: str) -> str:
     if response is None or _is_text_content_type(content_type):
         if response is not None:
             response.close()
-        loader = get_loader(request, url)
-        docs = loader.load()
-        content = ' '.join([doc.page_content for doc in docs])
-        return content, docs
+        return _load_url_with_loader(request, url)
 
     # Binary content (PDF, DOCX, XLSX, PPTX, etc.) — download and extract
     try:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — Closes #24856.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Not applicable; this fixes existing YouTube URL loading behavior.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Validation was performed for the touched backend file.
- [x] **No Unchecked AI Code:** This PR has undergone review and validation.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Keeps redirect-safe content probing for non-YouTube URLs and routes YouTube URLs through the existing `YoutubeLoader`.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Route YouTube URLs directly through the existing transcript loader after URL validation.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `youtu.be` short URLs no longer get misclassified by the content-type probe before `YoutubeLoader` can load the transcript.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

Closes #24856.

Validation:
- `python3 -m py_compile backend/open_webui/retrieval/utils.py`
- `ruff check backend/open_webui/retrieval/utils.py` was attempted, but the file has pre-existing unrelated lint findings.

### Screenshots or Videos

- N/A

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.