### PR TITLE
feat: add admin.analytics permission for analytics-only access

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2778,6 +2778,10 @@ USER_PERMISSIONS_FEATURES_CALENDAR = os.getenv('USER_PERMISSIONS_FEATURES_CALEND
 
 USER_PERMISSIONS_SETTINGS_INTERFACE = os.getenv('USER_PERMISSIONS_SETTINGS_INTERFACE', 'True').lower() == 'true'
 
+USER_PERMISSIONS_ADMIN_ANALYTICS = (
+    os.environ.get('USER_PERMISSIONS_ADMIN_ANALYTICS', 'False').lower() == 'true'
+)
+
 
 DEFAULT_USER_PERMISSIONS = {
     'workspace': {
@@ -2851,6 +2855,9 @@ DEFAULT_USER_PERMISSIONS = {
     },
     'settings': {
         'interface': USER_PERMISSIONS_SETTINGS_INTERFACE,
+    },
+    'admin': {
+        'analytics': USER_PERMISSIONS_ADMIN_ANALYTICS,
     },
 }
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -382,6 +382,7 @@ from open_webui.config import (
     TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
     UPLOAD_DIR,
     USER_PERMISSIONS,
+    DEFAULT_USER_PERMISSIONS,
     VOICE_MODE_PROMPT_TEMPLATE,
     WEB_FETCH_MAX_CONTENT_LENGTH,
     WEB_LOADER_CONCURRENT_REQUESTS,
@@ -632,6 +633,15 @@ async def lifespan(app: FastAPI):
 
     if RESET_CONFIG_ON_START:
         await async_reset_config()
+
+    from open_webui.utils.access_control import fill_missing_permissions
+
+    merged_user_permissions = fill_missing_permissions(
+        json.loads(json.dumps(USER_PERMISSIONS.value)),
+        DEFAULT_USER_PERMISSIONS,
+    )
+    if merged_user_permissions != USER_PERMISSIONS.value:
+        app.state.config.USER_PERMISSIONS = merged_user_permissions
 
     if LICENSE_KEY:
         get_license_data(app, LICENSE_KEY)

--- a/backend/open_webui/migrations/versions/f8a9b0c1d2e3_add_admin_analytics_permissions.py
+++ b/backend/open_webui/migrations/versions/f8a9b0c1d2e3_add_admin_analytics_permissions.py
@@ -1,0 +1,121 @@
+"""Add admin analytics permissions to stored config and groups
+
+Revision ID: f8a9b0c1d2e3
+Revises: f1e2d3c4b5a6
+Create Date: 2026-05-18 12:00:00.000000
+
+"""
+
+from typing import Any, Sequence, Union
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = 'f8a9b0c1d2e3'
+down_revision: Union[str, None] = 'f1e2d3c4b5a6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _ensure_admin_permissions(permissions: dict[str, Any]) -> dict[str, Any]:
+    """Add admin.analytics without importing application config (avoids circular imports)."""
+    updated = dict(permissions)
+    admin = dict(updated.get('admin') or {})
+    admin.setdefault('analytics', False)
+    updated['admin'] = admin
+    return updated
+
+
+def _normalize_permissions(permissions: dict | None) -> dict | None:
+    if permissions is None:
+        return None
+    return _ensure_admin_permissions(permissions)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    # Merge admin.analytics into persisted default user permissions (config table)
+    if 'config' in inspector.get_table_names():
+        config_row = conn.execute(sa.text('SELECT id, data FROM config ORDER BY id DESC LIMIT 1')).fetchone()
+        if config_row and config_row[1]:
+            data = config_row[1]
+            if isinstance(data, str):
+                data = json.loads(data)
+
+            user_section = data.get('user') or {}
+            permissions = user_section.get('permissions')
+            if permissions is not None:
+                normalized = _normalize_permissions(permissions)
+                if normalized != permissions:
+                    user_section['permissions'] = normalized
+                    data['user'] = user_section
+                    conn.execute(
+                        sa.text('UPDATE config SET data = :data WHERE id = :id'),
+                        {'data': data, 'id': config_row[0]},
+                    )
+
+    # Ensure existing group permission JSON includes the new admin section
+    if 'group' in inspector.get_table_names():
+        groups = conn.execute(sa.text('SELECT id, permissions FROM "group" WHERE permissions IS NOT NULL')).fetchall()
+        for group_id, permissions in groups:
+            if not permissions:
+                continue
+            perms = permissions
+            if isinstance(perms, str):
+                perms = json.loads(perms)
+            normalized = _normalize_permissions(perms)
+            if normalized != perms:
+                conn.execute(
+                    sa.text('UPDATE "group" SET permissions = :permissions WHERE id = :id'),
+                    {'permissions': normalized, 'id': group_id},
+                )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    def _strip_admin(permissions: dict | None) -> dict | None:
+        if not permissions or 'admin' not in permissions:
+            return permissions
+        updated = dict(permissions)
+        updated.pop('admin', None)
+        return updated
+
+    if 'config' in inspector.get_table_names():
+        config_row = conn.execute(sa.text('SELECT id, data FROM config ORDER BY id DESC LIMIT 1')).fetchone()
+        if config_row and config_row[1]:
+            data = config_row[1]
+            if isinstance(data, str):
+                data = json.loads(data)
+
+            user_section = data.get('user') or {}
+            permissions = user_section.get('permissions')
+            if permissions and 'admin' in permissions:
+                user_section['permissions'] = _strip_admin(permissions)
+                data['user'] = user_section
+                conn.execute(
+                    sa.text('UPDATE config SET data = :data WHERE id = :id'),
+                    {'data': data, 'id': config_row[0]},
+                )
+
+    if 'group' in inspector.get_table_names():
+        groups = conn.execute(sa.text('SELECT id, permissions FROM "group" WHERE permissions IS NOT NULL')).fetchall()
+        for group_id, permissions in groups:
+            if not permissions:
+                continue
+            perms = permissions
+            if isinstance(perms, str):
+                perms = json.loads(perms)
+            if 'admin' not in perms:
+                continue
+            conn.execute(
+                sa.text('UPDATE "group" SET permissions = :permissions WHERE id = :id'),
+                {'permissions': _strip_admin(perms), 'id': group_id},
+            )

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -248,6 +248,7 @@ class UserUpdateForm(BaseModel):
     email: str | None = None
     profile_image_url: str | None = None
     password: str | None = None
+    permissions: dict | None = None
 
     @field_validator('profile_image_url', mode='before')
     @classmethod

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -10,7 +10,7 @@ from open_webui.models.chats import Chats
 from open_webui.models.feedbacks import Feedbacks
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
-from open_webui.utils.auth import get_admin_user
+from open_webui.utils.auth import get_analytics_user
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -58,7 +58,7 @@ async def get_model_analytics(
     start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
     end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
     group_id: Optional[str] = Query(None, description='Filter by user group ID'),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get message counts per model."""
@@ -78,7 +78,7 @@ async def get_user_analytics(
     end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
     group_id: Optional[str] = Query(None, description='Filter by user group ID'),
     limit: int = Query(50, description='Max users to return'),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get message counts and token usage per user with user info."""
@@ -121,7 +121,7 @@ async def get_messages(
     end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
     skip: int = Query(0),
     limit: int = Query(50, le=100),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Query messages with filters."""
@@ -155,7 +155,7 @@ async def get_summary(
     start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
     end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
     group_id: Optional[str] = Query(None, description='Filter by user group ID'),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get summary statistics for the dashboard."""
@@ -192,7 +192,7 @@ async def get_daily_stats(
     end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
     group_id: Optional[str] = Query(None, description='Filter by user group ID'),
     granularity: str = Query('daily', description="Granularity: 'hourly' or 'daily'"),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get message counts grouped by model for time-series chart."""
@@ -227,7 +227,7 @@ async def get_token_usage(
     start_date: Optional[int] = Query(None),
     end_date: Optional[int] = Query(None),
     group_id: Optional[str] = Query(None, description='Filter by user group ID'),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get token usage aggregated by model."""
@@ -276,7 +276,7 @@ async def get_model_chats(
     end_date: Optional[int] = Query(None),
     skip: int = Query(0),
     limit: int = Query(50, le=100),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get chats that used a specific model, with preview and feedback info."""
@@ -362,7 +362,7 @@ class ModelOverviewResponse(BaseModel):
 async def get_model_overview(
     model_id: str,
     days: int = Query(30, description='Number of days of history (0 for all)'),
-    user=Depends(get_admin_user),
+    user=Depends(get_analytics_user),
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get model overview with feedback history and chat tags."""

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -242,6 +242,10 @@ class SettingsPermissions(BaseModel):
     interface: bool = True
 
 
+class AdminPermissions(BaseModel):
+    analytics: bool = False
+
+
 class UserPermissions(BaseModel):
     workspace: WorkspacePermissions
     sharing: SharingPermissions
@@ -249,6 +253,7 @@ class UserPermissions(BaseModel):
     chat: ChatPermissions
     features: FeaturesPermissions
     settings: SettingsPermissions
+    admin: AdminPermissions
 
 
 @router.get('/default/permissions', response_model=UserPermissions)
@@ -260,6 +265,7 @@ async def get_default_user_permissions(request: Request, user=Depends(get_admin_
         'chat': ChatPermissions(**request.app.state.config.USER_PERMISSIONS.get('chat', {})),
         'features': FeaturesPermissions(**request.app.state.config.USER_PERMISSIONS.get('features', {})),
         'settings': SettingsPermissions(**request.app.state.config.USER_PERMISSIONS.get('settings', {})),
+        'admin': AdminPermissions(**request.app.state.config.USER_PERMISSIONS.get('admin', {})),
     }
 
 
@@ -602,6 +608,25 @@ async def update_user_by_id(
         if form_data.profile_image_url is not None:
             update_data['profile_image_url'] = form_data.profile_image_url
 
+        if form_data.permissions is not None:
+            existing_info = user.info or {}
+            existing_permissions = existing_info.get('permissions', {})
+
+            def combine_permissions(permissions: dict, override: dict) -> dict:
+                for key, value in override.items():
+                    if isinstance(value, dict):
+                        if key not in permissions:
+                            permissions[key] = {}
+                        permissions[key] = combine_permissions(permissions[key], value)
+                    else:
+                        permissions[key] = value
+                return permissions
+
+            update_data['info'] = {
+                **existing_info,
+                'permissions': combine_permissions(existing_permissions, form_data.permissions),
+            }
+
         if update_data:
             updated_user = await Users.update_user_by_id(
                 user_id,
@@ -612,9 +637,12 @@ async def update_user_by_id(
             updated_user = user
 
         if updated_user:
-            # If the role changed, disconnect all socket sessions so stale
+            # If the role or permissions changed, disconnect all socket sessions so stale
             # privileges cached in SESSION_POOL are invalidated.
-            if updated_user.role != user.role:
+            permissions_changed = form_data.permissions is not None and (
+                (user.info or {}).get('permissions') != (updated_user.info or {}).get('permissions')
+            )
+            if updated_user.role != user.role or permissions_changed:
                 await disconnect_user_sessions(user_id)
             return updated_user
 

--- a/backend/open_webui/test/conftest.py
+++ b/backend/open_webui/test/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Ensure `open_webui` and `test` packages are importable when running pytest from repo root or backend/
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+# Isolated data directory and database for tests (before open_webui.config is imported)
+_TEST_DATA_DIR = tempfile.mkdtemp(prefix='open-webui-test-')
+os.environ.setdefault('DATA_DIR', _TEST_DATA_DIR)
+os.environ.setdefault('DATABASE_URL', f'sqlite:///{_TEST_DATA_DIR}/test.db')
+os.environ.setdefault('ENABLE_PERSISTENT_CONFIG', 'False')

--- a/backend/open_webui/test/migrations/test_admin_analytics_permissions_migration.py
+++ b/backend/open_webui/test/migrations/test_admin_analytics_permissions_migration.py
@@ -1,0 +1,68 @@
+import importlib.util
+import json
+from pathlib import Path
+
+LEGACY_STORED_PERMISSIONS = {
+    'workspace': {'models': True},
+    'sharing': {'public_chats': False},
+    'access_grants': {'allow_users': True},
+    'chat': {'controls': True},
+    'features': {'notes': True},
+    'settings': {'interface': True},
+}
+
+
+def _load_migration_module():
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / 'migrations'
+        / 'versions'
+        / 'f8a9b0c1d2e3_add_admin_analytics_permissions.py'
+    )
+    spec = importlib.util.spec_from_file_location('admin_analytics_migration', migration_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_migration = _load_migration_module()
+_normalize_permissions = _migration._normalize_permissions
+_ensure_admin_permissions = _migration._ensure_admin_permissions
+
+
+def test_normalize_permissions_adds_admin_section():
+    result = _normalize_permissions(LEGACY_STORED_PERMISSIONS.copy())
+    assert result is not None
+    assert 'admin' in result
+    assert result['admin']['analytics'] is False
+
+
+def test_normalize_permissions_idempotent():
+    first = _normalize_permissions(LEGACY_STORED_PERMISSIONS.copy())
+    second = _normalize_permissions(first)
+    assert first == second
+
+
+def test_normalize_permissions_none():
+    assert _normalize_permissions(None) is None
+
+
+def test_ensure_admin_preserves_existing_true_flag():
+    perms = {**LEGACY_STORED_PERMISSIONS, 'admin': {'analytics': True}}
+    result = _ensure_admin_permissions(perms)
+    assert result['admin']['analytics'] is True
+
+
+def test_config_payload_shape_after_upgrade():
+    """Simulate pre-upgrade config JSON stored in the database."""
+    data = {
+        'version': 0,
+        'user': {
+            'permissions': LEGACY_STORED_PERMISSIONS.copy(),
+        },
+    }
+    permissions = data['user']['permissions']
+    data['user']['permissions'] = _normalize_permissions(permissions)
+
+    assert data['user']['permissions']['admin']['analytics'] is False
+    assert json.dumps(data['user']['permissions'])

--- a/backend/open_webui/test/util/test_access_control_admin_analytics.py
+++ b/backend/open_webui/test/util/test_access_control_admin_analytics.py
@@ -1,0 +1,187 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from open_webui.config import DEFAULT_USER_PERMISSIONS
+from open_webui.utils.access_control import fill_missing_permissions, get_permissions, has_permission
+
+LEGACY_PERMISSIONS = {
+    'workspace': {'models': False},
+    'sharing': {'public_chats': False},
+    'access_grants': {'allow_users': True},
+    'chat': {'controls': True},
+    'features': {'notes': True},
+    'settings': {'interface': True},
+}
+
+
+def _user(user_id: str, role: str = 'user', info: dict | None = None):
+    return SimpleNamespace(id=user_id, role=role, info=info)
+
+
+@pytest.mark.parametrize(
+    'permissions,expected_analytics',
+    [
+        ({}, False),
+        (LEGACY_PERMISSIONS.copy(), False),
+    ],
+)
+def test_fill_missing_permissions_adds_admin_section(permissions, expected_analytics):
+    result = fill_missing_permissions(permissions, DEFAULT_USER_PERMISSIONS)
+    assert 'admin' in result
+    assert 'analytics' in result['admin']
+    assert result['admin']['analytics'] is expected_analytics
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_admin_always_has_analytics():
+    with (
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user('admin-1', role='admin'),
+        ),
+    ):
+        permissions = await get_permissions('admin-1', LEGACY_PERMISSIONS.copy())
+
+    assert permissions['admin']['analytics'] is True
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_user_info_override():
+    with (
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user(
+                'user-1',
+                role='user',
+                info={'permissions': {'admin': {'analytics': True}}},
+            ),
+        ),
+    ):
+        permissions = await get_permissions('user-1', LEGACY_PERMISSIONS.copy())
+
+    assert permissions['admin']['analytics'] is True
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_group_override():
+    group = SimpleNamespace(permissions={'admin': {'analytics': True}})
+
+    with (
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[group],
+        ),
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user('user-2', role='user'),
+        ),
+    ):
+        permissions = await get_permissions('user-2', LEGACY_PERMISSIONS.copy())
+
+    assert permissions['admin']['analytics'] is True
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_regular_user_default_denied():
+    with (
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user('user-3', role='user'),
+        ),
+    ):
+        permissions = await get_permissions('user-3', LEGACY_PERMISSIONS.copy())
+
+    assert permissions['admin']['analytics'] is False
+
+
+@pytest.mark.asyncio
+async def test_has_permission_admin_role_grants_admin_scope():
+    with (
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user('admin-1', role='admin'),
+        ),
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        allowed = await has_permission('admin-1', 'admin.analytics', LEGACY_PERMISSIONS.copy())
+
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_has_permission_user_info_grants_analytics():
+    with (
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user(
+                'user-1',
+                role='user',
+                info={'permissions': {'admin': {'analytics': True}}},
+            ),
+        ),
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        allowed = await has_permission('user-1', 'admin.analytics', LEGACY_PERMISSIONS.copy())
+
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_has_permission_denied_without_grant():
+    with (
+        patch(
+            'open_webui.models.users.Users.get_user_by_id',
+            new_callable=AsyncMock,
+            return_value=_user('user-2', role='user'),
+        ),
+        patch(
+            'open_webui.utils.access_control.Groups.get_groups_by_member_id',
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        allowed = await has_permission('user-2', 'admin.analytics', LEGACY_PERMISSIONS.copy())
+
+    assert allowed is False
+
+
+def test_get_permissions_template_merges_code_defaults():
+    """Persisted defaults without `admin` must inherit from DEFAULT_USER_PERMISSIONS."""
+    persisted = json.loads(json.dumps(LEGACY_PERMISSIONS))
+    assert 'admin' not in persisted
+
+    template = fill_missing_permissions(persisted, DEFAULT_USER_PERMISSIONS)
+    assert template['admin']['analytics'] is False

--- a/backend/open_webui/test/util/test_analytics_api_integration.py
+++ b/backend/open_webui/test/util/test_analytics_api_integration.py
@@ -1,0 +1,99 @@
+"""Lightweight API integration tests for analytics access control."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from open_webui.internal.db import get_async_session
+from open_webui.routers import analytics
+from open_webui.utils.auth import get_current_user
+
+
+def _build_client(user):
+    app = FastAPI()
+    app.include_router(analytics.router, prefix='/api/v1/analytics')
+    app.state.config = SimpleNamespace(USER_PERMISSIONS={})
+
+    async def _override_current_user():
+        return user
+
+    async def _override_db():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_current_user] = _override_current_user
+    app.dependency_overrides[get_async_session] = _override_db
+
+    return TestClient(app)
+
+
+def test_analytics_summary_allowed_for_admin():
+    user = SimpleNamespace(id='admin-1', role='admin', email='a@test.com', name='Admin')
+
+    with patch(
+        'open_webui.routers.analytics.ChatMessages.get_message_count_by_model',
+        new_callable=AsyncMock,
+        return_value={'m1': 1},
+    ), patch(
+        'open_webui.routers.analytics.ChatMessages.get_message_count_by_user',
+        new_callable=AsyncMock,
+        return_value={'u1': 1},
+    ), patch(
+        'open_webui.routers.analytics.ChatMessages.get_message_count_by_chat',
+        new_callable=AsyncMock,
+        return_value={'c1': 1},
+    ):
+        client = _build_client(user)
+        response = client.get('/api/v1/analytics/summary')
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['total_messages'] == 1
+    assert body['total_users'] == 1
+
+
+def test_analytics_summary_allowed_for_analytics_user():
+    user = SimpleNamespace(id='user-1', role='user', email='u@test.com', name='User')
+
+    with (
+        patch(
+            'open_webui.utils.auth.has_permission',
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            'open_webui.routers.analytics.ChatMessages.get_message_count_by_model',
+            new_callable=AsyncMock,
+            return_value={'m1': 2},
+        ),
+        patch(
+            'open_webui.routers.analytics.ChatMessages.get_message_count_by_user',
+            new_callable=AsyncMock,
+            return_value={'u1': 1, 'u2': 1},
+        ),
+        patch(
+            'open_webui.routers.analytics.ChatMessages.get_message_count_by_chat',
+            new_callable=AsyncMock,
+            return_value={'c1': 1, 'c2': 1},
+        ),
+    ):
+        client = _build_client(user)
+        response = client.get('/api/v1/analytics/summary')
+
+    assert response.status_code == 200
+
+
+def test_analytics_summary_denied_for_regular_user():
+    user = SimpleNamespace(id='user-2', role='user', email='u2@test.com', name='User')
+
+    with patch(
+        'open_webui.utils.auth.has_permission',
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        client = _build_client(user)
+        response = client.get('/api/v1/analytics/summary')
+
+    assert response.status_code == 401

--- a/backend/open_webui/test/util/test_auth_analytics.py
+++ b/backend/open_webui/test/util/test_auth_analytics.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from open_webui.utils.auth import get_analytics_user
+
+
+def _user(role: str = 'user', user_id: str = 'u1'):
+    return SimpleNamespace(id=user_id, role=role, email=f'{user_id}@test.com', name='Test')
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_user_allows_admin():
+    request = MagicMock()
+    request.app.state.config.USER_PERMISSIONS = {}
+
+    user = await get_analytics_user(request=request, user=_user(role='admin'), db=AsyncMock())
+
+    assert user.role == 'admin'
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_user_allows_permission_holder():
+    request = MagicMock()
+    request.app.state.config.USER_PERMISSIONS = {}
+
+    with patch(
+        'open_webui.utils.auth.has_permission',
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        user = await get_analytics_user(request=request, user=_user(role='user'), db=AsyncMock())
+
+    assert user.role == 'user'
+
+
+@pytest.mark.asyncio
+async def test_get_analytics_user_denies_without_permission():
+    request = MagicMock()
+    request.app.state.config.USER_PERMISSIONS = {}
+
+    with patch(
+        'open_webui.utils.auth.has_permission',
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await get_analytics_user(request=request, user=_user(role='user'), db=AsyncMock())
+
+    assert exc.value.status_code == 401

--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -52,17 +52,37 @@ async def get_permissions(
                     permissions[key] = permissions[key] or value  # Use the most permissive value (True > False)
         return permissions
 
+    from open_webui.models.users import Users
+
     user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
 
-    # Deep copy default permissions to avoid modifying the original dict
-    permissions = json.loads(json.dumps(default_permissions))
+    # Merge persisted defaults with code defaults so upgrades keep new permission keys
+    permission_template = fill_missing_permissions(
+        json.loads(json.dumps(default_permissions)),
+        DEFAULT_USER_PERMISSIONS,
+    )
+
+    # Deep copy to avoid modifying the template dict
+    permissions = json.loads(json.dumps(permission_template))
 
     # Combine permissions from all user groups
     for group in user_groups:
         permissions = combine_permissions(permissions, group.permissions or {})
 
-    # Ensure all fields from default_permissions are present and filled in
-    permissions = fill_missing_permissions(permissions, default_permissions)
+    user = await Users.get_user_by_id(user_id, db=db)
+
+    # Merge per-user permissions stored in user.info
+    if user and user.info and user.info.get('permissions'):
+        permissions = combine_permissions(permissions, user.info['permissions'])
+
+    # Ensure all fields from the template are present and filled in
+    permissions = fill_missing_permissions(permissions, permission_template)
+
+    # Admins always have analytics access
+    if user and user.role == 'admin':
+        if 'admin' not in permissions:
+            permissions['admin'] = {}
+        permissions['admin']['analytics'] = True
 
     return permissions
 
@@ -91,11 +111,24 @@ async def has_permission(
 
     permission_hierarchy = permission_key.split('.')
 
+    from open_webui.models.users import Users
+
+    user = await Users.get_user_by_id(user_id, db=db)
+
+    # Admins always have admin-scoped permissions (e.g. analytics)
+    if user and user.role == 'admin' and permission_hierarchy[0] == 'admin':
+        return True
+
     # Retrieve user group permissions
     user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
 
     for group in user_groups:
         if get_permission(group.permissions or {}, permission_hierarchy):
+            return True
+
+    # Check per-user permissions stored in user.info
+    if user and user.info and user.info.get('permissions'):
+        if get_permission(user.info['permissions'], permission_hierarchy):
             return True
 
     # Check default permissions afterward if the group permissions don't allow it

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -19,7 +19,11 @@ from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from fastapi import BackgroundTasks, Depends, HTTPException, Request, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pytz import UTC
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from open_webui.constants import ERROR_MESSAGES
+from open_webui.internal.db import get_async_session
 from open_webui.env import (
     ENABLE_OTEL,
     ENABLE_PASSWORD_VALIDATION,
@@ -37,7 +41,6 @@ from open_webui.env import (
 from open_webui.models.auths import Auths
 from open_webui.models.users import Users
 from open_webui.utils.access_control import has_permission
-from pytz import UTC
 
 log = logging.getLogger(__name__)
 
@@ -465,6 +468,28 @@ def get_admin_user(user=Depends(get_current_user)):
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
     return user
+
+
+async def get_analytics_user(
+    request: Request,
+    user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if user.role == 'admin':
+        return user
+
+    if await has_permission(
+        user.id,
+        'admin.analytics',
+        request.app.state.config.USER_PERMISSIONS,
+        db=db,
+    ):
+        return user
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+    )
 
 
 async def create_admin_user(email: str, password: str, name: str = 'Admin'):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths =
+    backend/open_webui/test
+pythonpath =
+    backend/open_webui
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+filterwarnings =
+    ignore::DeprecationWarning

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -488,6 +488,11 @@ type UserUpdateForm = {
 	email: string;
 	name: string;
 	password: string;
+	permissions?: {
+		admin?: {
+			analytics?: boolean;
+		};
+	};
 };
 
 export const updateUserById = async (token: string, userId: string, user: UserUpdateForm) => {
@@ -504,7 +509,8 @@ export const updateUserById = async (token: string, userId: string, user: UserUp
 			role: user.role,
 			email: user.email,
 			name: user.name,
-			password: user.password !== '' ? user.password : undefined
+			password: user.password !== '' ? user.password : undefined,
+			permissions: user.permissions
 		})
 	})
 		.then(async (res) => {

--- a/src/lib/components/admin/Analytics.svelte
+++ b/src/lib/components/admin/Analytics.svelte
@@ -2,6 +2,7 @@
 	import { onMount, getContext } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { user } from '$lib/stores';
+	import { hasAnalyticsAccess } from '$lib/utils/admin';
 
 	import Dashboard from './Analytics/Dashboard.svelte';
 
@@ -10,8 +11,9 @@
 	let loaded = false;
 
 	onMount(async () => {
-		if ($user?.role !== 'admin') {
+		if (!hasAnalyticsAccess($user)) {
 			await goto('/');
+			return;
 		}
 		loaded = true;
 	});

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -68,7 +68,8 @@
 				access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...loadedPermissions.access_grants },
 				chat: { ...DEFAULT_PERMISSIONS.chat, ...loadedPermissions.chat },
 				features: { ...DEFAULT_PERMISSIONS.features, ...loadedPermissions.features },
-				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings }
+				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings },
+				admin: { ...DEFAULT_PERMISSIONS.admin, ...loadedPermissions.admin }
 			};
 			data = group?.data ?? {};
 

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -24,7 +24,8 @@
 			access_grants: { ...defaults.access_grants, ...obj.access_grants },
 			chat: { ...defaults.chat, ...obj.chat },
 			features: { ...defaults.features, ...obj.features },
-			settings: { ...defaults.settings, ...obj.settings }
+			settings: { ...defaults.settings, ...obj.settings },
+			admin: { ...defaults.admin, ...obj.admin }
 		};
 	}
 
@@ -961,6 +962,28 @@
 				<Switch bind:state={permissions.features.calendar} />
 			</div>
 			{#if defaultPermissions?.features?.calendar && !permissions.features.calendar}
+				<div>
+					<div class="text-xs text-gray-500">
+						{$i18n.t('This is a default user permission and will remain enabled.')}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<hr class=" border-gray-100/30 dark:border-gray-850/30" />
+
+	<div>
+		<div class=" mb-2 text-sm font-medium">{$i18n.t('Admin Permissions')}</div>
+
+		<div class="flex flex-col w-full">
+			<div class="flex w-full justify-between my-1">
+				<div class=" self-center text-xs font-medium">
+					{$i18n.t('Analytics Access')}
+				</div>
+				<Switch bind:state={permissions.admin.analytics} />
+			</div>
+			{#if defaultPermissions?.admin?.analytics && !permissions.admin.analytics}
 				<div>
 					<div class="text-xs text-gray-500">
 						{$i18n.t('This is a default user permission and will remain enabled.')}

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -12,6 +12,7 @@
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
+	import Switch from '$lib/components/common/Switch.svelte';
 	import UserProfileImage from '$lib/components/chat/Settings/Account/UserProfileImage.svelte';
 
 	const i18n = getContext('i18n');
@@ -30,6 +31,7 @@
 		if (selectedUser) {
 			_user = selectedUser;
 			_user.password = '';
+			analyticsAccess = selectedUser?.info?.permissions?.admin?.analytics ?? false;
 			loadUserGroups();
 		}
 	};
@@ -42,10 +44,19 @@
 		password: ''
 	};
 
+	let analyticsAccess = false;
+
 	let userGroups: any[] | null = null;
 
 	const submitHandler = async () => {
-		const res = await updateUserById(localStorage.token, selectedUser.id, _user).catch((error) => {
+		const res = await updateUserById(localStorage.token, selectedUser.id, {
+			..._user,
+			permissions: {
+				admin: {
+					analytics: analyticsAccess
+				}
+			}
+		}).catch((error) => {
 			toast.error(`${error}`);
 		});
 
@@ -130,6 +141,15 @@
 														</a>
 													</span>
 												{/each}
+											</div>
+										</div>
+									{/if}
+
+									{#if _user.role !== 'admin'}
+										<div class="flex flex-col w-full">
+											<div class="flex w-full justify-between my-1">
+												<div class="text-xs text-gray-500">{$i18n.t('Analytics Access')}</div>
+												<Switch bind:state={analyticsAccess} />
 											</div>
 										</div>
 									{/if}

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/stores';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import { hasAnalyticsAccess, isAnalyticsOnlyUser } from '$lib/utils/admin';
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -254,9 +255,9 @@
 				<div class=" self-center truncate">{$i18n.t('Settings')}</div>
 			</button>
 
-			{#if role === 'admin'}
+			{#if hasAnalyticsAccess($user)}
 				<a
-					href="/admin"
+					href={isAnalyticsOnlyUser($user) ? '/admin/analytics' : '/admin'}
 					draggable="false"
 					class="flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer select-none"
 					on:click={async (e) => {
@@ -265,7 +266,7 @@
 						}
 						e.preventDefault();
 						show = false;
-						goto('/admin');
+						goto(isAnalyticsOnlyUser($user) ? '/admin/analytics' : '/admin');
 						if ($mobile) {
 							await tick();
 							showSidebar.set(false);
@@ -275,7 +276,9 @@
 					<div class=" self-center mr-3">
 						<UserGroup className="w-5 h-5" strokeWidth="1.5" />
 					</div>
-					<div class=" self-center truncate">{$i18n.t('Admin Panel')}</div>
+					<div class=" self-center truncate">
+						{isAnalyticsOnlyUser($user) ? $i18n.t('Analytics') : $i18n.t('Admin Panel')}
+					</div>
 				</a>
 			{/if}
 

--- a/src/lib/constants/permissions.ts
+++ b/src/lib/constants/permissions.ts
@@ -68,5 +68,8 @@ export const DEFAULT_PERMISSIONS = {
 	},
 	settings: {
 		interface: true
+	},
+	admin: {
+		analytics: false
 	}
 } as const;

--- a/src/lib/utils/admin.test.ts
+++ b/src/lib/utils/admin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { hasAdminAccess, hasAnalyticsAccess, isAnalyticsOnlyUser } from './admin';
+
+describe('admin access helpers', () => {
+	it('grants analytics to admins regardless of permissions object', () => {
+		expect(hasAnalyticsAccess({ role: 'admin' })).toBe(true);
+		expect(hasAnalyticsAccess({ role: 'admin', permissions: { admin: { analytics: false } } })).toBe(
+			true
+		);
+	});
+
+	it('grants analytics to users with admin.analytics permission', () => {
+		expect(
+			hasAnalyticsAccess({
+				role: 'user',
+				permissions: { admin: { analytics: true } }
+			})
+		).toBe(true);
+	});
+
+	it('denies analytics for regular users without permission', () => {
+		expect(hasAnalyticsAccess({ role: 'user' })).toBe(false);
+		expect(
+			hasAnalyticsAccess({
+				role: 'user',
+				permissions: { admin: { analytics: false } }
+			})
+		).toBe(false);
+	});
+
+	it('identifies analytics-only users', () => {
+		expect(isAnalyticsOnlyUser({ role: 'user', permissions: { admin: { analytics: true } } })).toBe(
+			true
+		);
+		expect(isAnalyticsOnlyUser({ role: 'admin' })).toBe(false);
+	});
+
+	it('hasAdminAccess matches admin role only', () => {
+		expect(hasAdminAccess({ role: 'admin' })).toBe(true);
+		expect(hasAdminAccess({ role: 'user', permissions: { admin: { analytics: true } } })).toBe(
+			false
+		);
+	});
+});

--- a/src/lib/utils/admin.ts
+++ b/src/lib/utils/admin.ts
@@ -1,0 +1,10 @@
+export const hasAdminAccess = (user: { role?: string } | null | undefined) =>
+	user?.role === 'admin';
+
+export const hasAnalyticsAccess = (
+	user: { role?: string; permissions?: { admin?: { analytics?: boolean } } } | null | undefined
+) => hasAdminAccess(user) || (user?.permissions?.admin?.analytics ?? false);
+
+export const isAnalyticsOnlyUser = (
+	user: { role?: string; permissions?: { admin?: { analytics?: boolean } } } | null | undefined
+) => hasAnalyticsAccess(user) && !hasAdminAccess(user);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -192,7 +192,32 @@
 		tools.set(toolsData);
 	};
 
+	const waitForSessionUser = () =>
+		new Promise<void>((resolve) => {
+			if ($user !== undefined && $user !== null) {
+				resolve();
+				return;
+			}
+
+			const timeout = setTimeout(() => {
+				unsubscribe();
+				resolve();
+			}, 15000);
+
+			const unsubscribe = user.subscribe((value) => {
+				if (value !== undefined && value !== null) {
+					clearTimeout(timeout);
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
 	onMount(async () => {
+		if (localStorage.token && ($user === undefined || $user === null)) {
+			await waitForSessionUser();
+		}
+
 		if ($user === undefined || $user === null) {
 			await goto('/auth');
 			return;

--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { onMount, getContext } from 'svelte';
+	import { getContext } from 'svelte';
 	import { goto } from '$app/navigation';
 
 	import { WEBUI_NAME, config, mobile, showSidebar, user } from '$lib/stores';
 	import { page } from '$app/stores';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { hasAdminAccess, hasAnalyticsAccess, isAnalyticsOnlyUser } from '$lib/utils/admin';
 
 	import Sidebar from '$lib/components/icons/Sidebar.svelte';
 
@@ -12,12 +13,19 @@
 
 	let loaded = false;
 
-	onMount(async () => {
-		if ($user?.role !== 'admin') {
-			await goto('/');
+	$: canAccessAdmin = hasAdminAccess($user);
+	$: canAccessAnalytics = hasAnalyticsAccess($user);
+	$: analyticsOnly = isAnalyticsOnlyUser($user);
+
+	$: if ($user?.id) {
+		if (!canAccessAnalytics) {
+			goto('/');
+		} else if (analyticsOnly && !$page.url.pathname.includes('/admin/analytics')) {
+			goto('/admin/analytics');
+		} else {
+			loaded = true;
 		}
-		loaded = true;
-	});
+	}
 </script>
 
 <svelte:head>
@@ -59,15 +67,17 @@
 					<div
 						class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium rounded-full bg-transparent pt-1"
 					>
-						<a
-							draggable="false"
-							class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/users')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
-							href="/admin">{$i18n.t('Users')}</a
-						>
+						{#if canAccessAdmin}
+							<a
+								draggable="false"
+								class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/users')
+									? ''
+									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
+								href="/admin">{$i18n.t('Users')}</a
+							>
+						{/if}
 
-						{#if $config?.features.enable_admin_analytics ?? true}
+						{#if ($config?.features.enable_admin_analytics ?? true) && canAccessAnalytics}
 							<a
 								draggable="false"
 								class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/analytics')
@@ -77,29 +87,31 @@
 							>
 						{/if}
 
-						<a
-							draggable="false"
-							class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/evaluations')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
-							href="/admin/evaluations">{$i18n.t('Evaluations')}</a
-						>
+						{#if canAccessAdmin}
+							<a
+								draggable="false"
+								class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/evaluations')
+									? ''
+									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
+								href="/admin/evaluations">{$i18n.t('Evaluations')}</a
+							>
 
-						<a
-							draggable="false"
-							class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/functions')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
-							href="/admin/functions">{$i18n.t('Functions')}</a
-						>
+							<a
+								draggable="false"
+								class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/functions')
+									? ''
+									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
+								href="/admin/functions">{$i18n.t('Functions')}</a
+							>
 
-						<a
-							draggable="false"
-							class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/settings')
-								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
-							href="/admin/settings">{$i18n.t('Settings')}</a
-						>
+							<a
+								draggable="false"
+								class="min-w-fit p-1.5 {$page.url.pathname.includes('/admin/settings')
+									? ''
+									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition select-none"
+								href="/admin/settings">{$i18n.t('Settings')}</a
+							>
+						{/if}
 					</div>
 				</div>
 			</div>

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
+	import { user } from '$lib/stores';
+	import { hasAdminAccess, hasAnalyticsAccess } from '$lib/utils/admin';
 
 	onMount(() => {
-		goto('/admin/users');
+		if (hasAdminAccess($user)) {
+			goto('/admin/users');
+		} else if (hasAnalyticsAccess($user)) {
+			goto('/admin/analytics');
+		} else {
+			goto('/');
+		}
 	});
 </script>

--- a/src/routes/(app)/admin/analytics/+page.svelte
+++ b/src/routes/(app)/admin/analytics/+page.svelte
@@ -1,12 +1,13 @@
 <script>
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { config } from '$lib/stores';
+	import { config, user } from '$lib/stores';
+	import { hasAdminAccess } from '$lib/utils/admin';
 	import Analytics from '$lib/components/admin/Analytics.svelte';
 
 	onMount(() => {
 		if (!($config?.features.enable_admin_analytics ?? true)) {
-			goto('/admin');
+			goto(hasAdminAccess($user) ? '/admin' : '/');
 		}
 	});
 </script>


### PR DESCRIPTION
﻿## Summary
- Add `admin.analytics` permission for Analytics tab access without full admin role
- Backend: `get_analytics_user`, access control merge, migration for existing configs/groups
- Frontend: analytics-only admin layout, user menu, per-user/group/default permission UI
- Fix Analytics component guard to use effective analytics access instead of admin role only

## Test plan
- [ ] Admin sees Admin Panel with all tabs including Analytics
- [ ] User with only `admin.analytics` sees Analytics menu item and single Analytics tab
- [ ] Direct navigation to `/admin/settings` redirects analytics-only users to `/admin/analytics`
- [ ] Analytics API returns 200 for analytics user, 401 for users without permission
- [ ] Run: `pytest backend/open_webui/test/util/test_auth_analytics.py backend/open_webui/test/util/test_access_control_admin_analytics.py backend/open_webui/test/migrations/`

## Changelog
### Added
- `admin.analytics` user permission for granting Analytics dashboard access without full admin privileges
