### PR TITLE
feat(chat): citation modal as global singleton via store

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { embed, showControls, showEmbeds } from '$lib/stores';
-
-	import CitationModal from './Citations/CitationModal.svelte';
+	import { openCitation } from '$lib/stores/citations';
 
 	const i18n = getContext('i18n');
 
@@ -16,12 +15,7 @@
 	let showPercentage = false;
 	let showRelevance = true;
 
-	let citationModal = null;
-
 	let showCitations = false;
-	let showCitationModal = false;
-
-	let selectedCitation: any = null;
 
 	export const showSourceModal = (sourceId) => {
 		let index;
@@ -61,12 +55,10 @@
 						});
 					}
 				} else {
-					selectedCitation = citations[index];
-					showCitationModal = true;
+					openCitation(citations[index], { showRelevance, showPercentage });
 				}
 			} else {
-				selectedCitation = citations[index];
-				showCitationModal = true;
+				openCitation(citations[index], { showRelevance, showPercentage });
 			}
 		}
 	};
@@ -151,13 +143,6 @@
 	};
 </script>
 
-<CitationModal
-	bind:show={showCitationModal}
-	citation={selectedCitation}
-	{showPercentage}
-	{showRelevance}
-/>
-
 {#if citations.length > 0}
 	{@const urlCitations = citations.filter((c) => c?.source?.name?.startsWith('http'))}
 	<div class=" py-1 -mx-0.5 w-full flex gap-1 items-center flex-wrap">
@@ -217,8 +202,7 @@
 					})}
 					class="no-toggle outline-hidden flex dark:text-gray-300 bg-transparent text-gray-600 rounded-xl gap-1.5 items-center"
 					on:click={() => {
-						showCitationModal = true;
-						selectedCitation = citation;
+						openCitation(citation, { showRelevance, showPercentage });
 					}}
 				>
 					<div class=" font-medium bg-gray-50 dark:bg-gray-850 rounded-md px-1">

--- a/src/lib/stores/citations.ts
+++ b/src/lib/stores/citations.ts
@@ -1,0 +1,31 @@
+import { writable } from 'svelte/store';
+
+export interface CitationModalState {
+	citation: any | null;
+	show: boolean;
+	showRelevance: boolean;
+	showPercentage: boolean;
+}
+
+export const citationModal = writable<CitationModalState>({
+	citation: null,
+	show: false,
+	showRelevance: true,
+	showPercentage: false
+});
+
+export function openCitation(
+	citation: any,
+	opts: { showRelevance?: boolean; showPercentage?: boolean } = {}
+) {
+	citationModal.set({
+		citation,
+		show: true,
+		showRelevance: opts.showRelevance ?? true,
+		showPercentage: opts.showPercentage ?? false
+	});
+}
+
+export function closeCitation() {
+	citationModal.update((s) => ({ ...s, show: false }));
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -44,6 +44,8 @@
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import SettingsModal from '$lib/components/chat/SettingsModal.svelte';
 	import ChangelogModal from '$lib/components/ChangelogModal.svelte';
+	import CitationModal from '$lib/components/chat/Messages/Citations/CitationModal.svelte';
+	import { citationModal, closeCitation } from '$lib/stores/citations';
 	import AccountPending from '$lib/components/layout/Overlay/AccountPending.svelte';
 	import UpdateInfoToast from '$lib/components/layout/UpdateInfoToast.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
@@ -56,6 +58,10 @@
 	let localDBChats = [];
 
 	let version;
+
+	let citationModalShow = false;
+	$: citationModalShow = $citationModal.show;
+	$: if (!citationModalShow && $citationModal.show) closeCitation();
 
 	const clearChatInputStorage = () => {
 		const chatInputKeys = Object.keys(localStorage).filter((key) => key.startsWith('chat-input'));
@@ -378,6 +384,13 @@
 
 <SettingsModal bind:show={$showSettings} />
 <ChangelogModal bind:show={$showChangelog} />
+
+<CitationModal
+	bind:show={citationModalShow}
+	citation={$citationModal.citation}
+	showRelevance={$citationModal.showRelevance}
+	showPercentage={$citationModal.showPercentage}
+/>
 
 {#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>


### PR DESCRIPTION
Citations.svelte mounts <CitationModal> per instance. A chat with N RAG responses has N modal state machines in the DOM, idle until clicked.

Same shape as the embed/showEmbeds pattern already in $lib/stores. Applied to citations:
- Removes N-instances cost (memory, listeners, lifecycle).
- Markdown citation-marker clicks can call openCitation() directly — no `bind:this` ref hacks into the right <Citations> instance.
- Gives forks an extension point (subscribe to citationModal, render alongside).

### Changes

- NEW `src/lib/stores/citations.ts` — writable + openCitation/closeCitation
- `src/routes/(app)/+layout.svelte` — mount <CitationModal> once, subscribed to store
- `src/lib/components/chat/Messages/Citations.svelte` — dispatch via store instead of local mount; `showSourceModal` export kept as thin wrapper for back-compat

### Bridge note

The +layout bridge is one-way sync (store→local) + close-back handler. The naive `if ($store.show !== local) { sync }` form races itself: the X click writes false to local via `bind:show`, the reactive immediately re-syncs from store (still true), undoes the close. The split form (one `$:` writes local from store, a separate `$:` writes store-close when local goes false) avoids the loop.

### Tested

- Click chip pill → modal opens; X / Esc / backdrop close
- Inline Markdown [n] marker click → modal opens (via showSourceModal wrapper)
- embed_url citation → opens right-side embed panel (unchanged path)
- readOnly mode (shared chat) → opens link in new tab (unchanged)
- Multiple chats in tabs → single global modal, no cross-chat leakage

### Follow-ups (separate PRs if this lands)

Same pattern fits ImagePreview (Image.svelte mounts one per image — 7+ call sites in the chat tree) and CodeExecutionModal. Happy to open those as small PRs after this is reviewed.
