### PR TITLE
feat(chat): citation modal as global singleton via store

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { embed, showControls, showEmbeds } from '$lib/stores';
-
-	import CitationModal from './Citations/CitationModal.svelte';
+	import { openCitation } from '$lib/stores/citations';
 
 	const i18n = getContext('i18n');
 
@@ -16,12 +15,7 @@
 	let showPercentage = false;
 	let showRelevance = true;
 
-	let citationModal = null;
-
 	let showCitations = false;
-	let showCitationModal = false;
-
-	let selectedCitation: any = null;
 
 	export const showSourceModal = (sourceId) => {
 		let index;
@@ -61,12 +55,10 @@
 						});
 					}
 				} else {
-					selectedCitation = citations[index];
-					showCitationModal = true;
+					openCitation(citations[index], { showRelevance, showPercentage });
 				}
 			} else {
-				selectedCitation = citations[index];
-				showCitationModal = true;
+				openCitation(citations[index], { showRelevance, showPercentage });
 			}
 		}
 	};
@@ -151,13 +143,6 @@
 	};
 </script>
 
-<CitationModal
-	bind:show={showCitationModal}
-	citation={selectedCitation}
-	{showPercentage}
-	{showRelevance}
-/>
-
 {#if citations.length > 0}
 	{@const urlCitations = citations.filter((c) => c?.source?.name?.startsWith('http'))}
 	<div class=" py-1 -mx-0.5 w-full flex gap-1 items-center flex-wrap">
@@ -217,8 +202,7 @@
 					})}
 					class="no-toggle outline-hidden flex dark:text-gray-300 bg-transparent text-gray-600 rounded-xl gap-1.5 items-center"
 					on:click={() => {
-						showCitationModal = true;
-						selectedCitation = citation;
+						openCitation(citation, { showRelevance, showPercentage });
 					}}
 				>
 					<div class=" font-medium bg-gray-50 dark:bg-gray-850 rounded-md px-1">

--- a/src/lib/stores/citations.ts
+++ b/src/lib/stores/citations.ts
@@ -1,0 +1,31 @@
+import { writable } from 'svelte/store';
+
+export interface CitationModalState {
+	citation: any | null;
+	show: boolean;
+	showRelevance: boolean;
+	showPercentage: boolean;
+}
+
+export const citationModal = writable<CitationModalState>({
+	citation: null,
+	show: false,
+	showRelevance: true,
+	showPercentage: false
+});
+
+export function openCitation(
+	citation: any,
+	opts: { showRelevance?: boolean; showPercentage?: boolean } = {}
+) {
+	citationModal.set({
+		citation,
+		show: true,
+		showRelevance: opts.showRelevance ?? true,
+		showPercentage: opts.showPercentage ?? false
+	});
+}
+
+export function closeCitation() {
+	citationModal.update((s) => ({ ...s, show: false }));
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -44,6 +44,8 @@
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import SettingsModal from '$lib/components/chat/SettingsModal.svelte';
 	import ChangelogModal from '$lib/components/ChangelogModal.svelte';
+	import CitationModal from '$lib/components/chat/Messages/Citations/CitationModal.svelte';
+	import { citationModal, closeCitation } from '$lib/stores/citations';
 	import AccountPending from '$lib/components/layout/Overlay/AccountPending.svelte';
 	import UpdateInfoToast from '$lib/components/layout/UpdateInfoToast.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
@@ -56,6 +58,10 @@
 	let localDBChats = [];
 
 	let version;
+
+	let citationModalShow = false;
+	$: citationModalShow = $citationModal.show;
+	$: if (!citationModalShow && $citationModal.show) closeCitation();
 
 	const clearChatInputStorage = () => {
 		const chatInputKeys = Object.keys(localStorage).filter((key) => key.startsWith('chat-input'));
@@ -378,6 +384,13 @@
 
 <SettingsModal bind:show={$showSettings} />
 <ChangelogModal bind:show={$showChangelog} />
+
+<CitationModal
+	bind:show={citationModalShow}
+	citation={$citationModal.citation}
+	showRelevance={$citationModal.showRelevance}
+	showPercentage={$citationModal.showPercentage}
+/>
 
 {#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** `dev`
- [x] **Description:** Below
- [x] **Changelog:** Below
- [x] **Documentation:** No user-facing API change, no env vars, no deployment steps
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manual coverage across open/close paths, multi-chat, embed_url branch, readOnly mode (see below)
- [x] **Agentic AI Code:** AI-assisted authorship. Code has been reviewed line by line by the author, manually tested across multiple scenarios, and has been running in a downstream fork in production for several days without regression.
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Follows the existing `embed` / `showEmbeds` store pattern. No new settings, no UX change.
- [x] **Git Hygiene:** 3 atomic commits, rebased on `dev`
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

`Citations.svelte` mounts `<CitationModal>` per instance. A chat with N RAG responses has N modal state machines in the DOM, idle until clicked.

This PR applies the same singleton pattern already used by `embed` / `showEmbeds` / `showControls` (writable stores in `$lib/stores`, sink mounted once at app level, any caller dispatches via store action). Three benefits:

1. Removes N-instances cost (memory, listeners, lifecycle).
2. Markdown citation-marker clicks can call `openCitation()` directly — no `bind:this` ref hacks back into the right `<Citations>` instance.
3. Gives forks an extension point (subscribe to `citationModal`, render alongside the modal).

### Added

- `src/lib/stores/citations.ts` — `citationModal` writable store + `openCitation` / `closeCitation` actions.
- Global `<CitationModal>` mount in `src/routes/(app)/+layout.svelte` subscribed to the store.

### Changed

- `src/lib/components/chat/Messages/Citations.svelte` — dispatches via `openCitation()` instead of a local `<CitationModal bind:show>` mount. `showSourceModal` export kept as a thin wrapper for back-compat with external callers (e.g. `ResponseMessage.svelte` which still calls `citationsElement.showSourceModal(id)` from a Markdown click handler).

### Deprecated

_N/A_

### Removed

- Per-instance modal mount and local state (`showCitationModal`, `selectedCitation`) in `Citations.svelte`.

### Fixed

_N/A — pure refactor, no bug fix._

### Security

_N/A_

### Breaking Changes

None. Existing consumers of `Citations.svelte` keep working without modification; `showSourceModal` external API preserved.

---

### Additional Information

**Bridge note.** The `+layout` bridge between the store and `<CitationModal bind:show={local}>` uses one-way sync (store → local) plus a close-back handler:

```svelte
let citationModalShow = false;
$: citationModalShow = $citationModal.show;
$: if (!citationModalShow && $citationModal.show) closeCitation();
```

The naive `if ($store.show !== local) { sync }` form races itself: the X click writes `false` to `local` via `bind:show`, then the reactive immediately re-syncs from the store (still `true`), undoing the close. The split form above avoids the loop because the first `$:` only writes `local`, never reads it; the second `$:` only triggers when `local` transitions to `false` while the store is still open.

**Manual tests performed.**

- Click chip pill → modal opens; X / Esc / backdrop close.
- Inline Markdown `[n]` marker click → modal opens (via `showSourceModal` wrapper, the existing path through `ResponseMessage.svelte`).
- `embed_url` citation → opens right-side embed panel (unchanged path, the `showSourceModal` wrapper preserves the embed branch).
- `readOnly` mode (shared chat) → opens link in new tab (unchanged).
- Multiple chats in tabs → single global modal instance, no cross-chat leakage.

**Follow-ups.** The same pattern fits `ImagePreview` (`Image.svelte` currently mounts one per image — 7+ call sites in the chat tree) and `CodeExecutionModal`. Happy to open those as separate small PRs after this is reviewed.

### Screenshots or Videos

Refactor with no UX change; visual behavior is identical to current `main`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
