### PR TITLE
fix: remove duplicate allow_redirects kwarg crashing SafeWebBaseLoader._fetch

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -521,7 +521,6 @@ class SafeWebBaseLoader(WebBaseLoader):
                     async with session.get(
                         url,
                         **(self.requests_kwargs | kwargs),
-                        allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
                     ) as response:
                         if self.raise_for_status:
                             response.raise_for_status()


### PR DESCRIPTION
## Summary

`SafeWebBaseLoader.__init__` stores `AIOHTTP_CLIENT_ALLOW_REDIRECTS` inside `self.requests_kwargs`:

```python
# utils.py line 503-506
self.requests_kwargs = {
    **(self.requests_kwargs or {}),
    'allow_redirects': AIOHTTP_CLIENT_ALLOW_REDIRECTS,
}
```

`_fetch` then unpacks `self.requests_kwargs` **and** passes `allow_redirects` as an explicit keyword argument:

```python
# utils.py line 521-524
async with session.get(
    url,
    **(self.requests_kwargs | kwargs),   # already contains allow_redirects
    allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,  # duplicate → TypeError
) as response:
```

Python raises:

```
TypeError: aiohttp.client.ClientSession.get() got multiple values for keyword argument 'allow_redirects'
```

Because `continue_on_failure=True`, the exception is silently swallowed for **every** URL. Web search always returns zero sources ("no sources found"), regardless of what SearXNG returns.

## Fix

Remove the redundant explicit keyword argument from `session.get()`. `AIOHTTP_CLIENT_ALLOW_REDIRECTS` is already carried by `self.requests_kwargs`, so the SSRF redirect-blocking protection added in v0.9.5 (ref: GHSA-rh5x-h6pp-cjj6) is fully preserved.

## Reproduction

```python
import asyncio, aiohttp

async def test():
    async with aiohttp.ClientSession() as session:
        async with session.get(
            'https://example.com',
            **{'allow_redirects': False},
            allow_redirects=False,   # TypeError here
        ) as r:
            pass

asyncio.run(test())
# TypeError: aiohttp.client.ClientSession.get() got multiple values for keyword argument 'allow_redirects'
```

## Affected version

v0.9.5 — the duplicate was introduced by the SSRF fix that added `allow_redirects` to `requests_kwargs`.