### PR TITLE
fix: set azure: true for Azure provider on non-azure.* hostnames

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -80,6 +80,11 @@ def _clean_proxy_headers(raw_headers) -> dict:
     return {k: v for k, v in raw_headers.items() if k not in _STRIP_PROXY_HEADERS}
 
 
+def is_azure_openai_config(api_config: dict) -> bool:
+    """True when the connection should use Azure OpenAI-style URL paths."""
+    return bool(api_config.get('azure', False) or api_config.get('provider') == 'azure')
+
+
 async def send_get_request(
     request: Request = None,
     url=None,
@@ -595,7 +600,7 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
             try:
                 headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
-                if api_config.get('azure', False):
+                if is_azure_openai_config(api_config):
                     models = {
                         'data': api_config.get('model_ids', []) or [],
                         'object': 'list',
@@ -681,7 +686,7 @@ async def verify_connection(
         try:
             headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
-            if api_config.get('azure', False):
+            if is_azure_openai_config(api_config):
                 # Only set api-key header if not using Azure Entra ID authentication
                 auth_type = api_config.get('auth_type', 'bearer')
                 if auth_type not in ('azure_ad', 'microsoft_entra_id'):
@@ -1151,7 +1156,7 @@ async def generate_chat_completion(
 
     is_responses = api_config.get('api_type') == 'responses'
 
-    if api_config.get('azure', False):
+    if is_azure_openai_config(api_config):
         # Only set api-key header if not using Azure Entra ID authentication
         auth_type = api_config.get('auth_type', 'bearer')
         if auth_type not in ('azure_ad', 'microsoft_entra_id'):
@@ -1408,7 +1413,7 @@ async def responses(
     try:
         headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
-        if api_config.get('azure', False):
+        if is_azure_openai_config(api_config):
             auth_type = api_config.get('auth_type', 'bearer')
             if auth_type not in ('azure_ad', 'microsoft_entra_id'):
                 headers['api-key'] = key
@@ -1519,7 +1524,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
     try:
         headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
-        if api_config.get('azure', False):
+        if is_azure_openai_config(api_config):
             # Only set api-key header if not using Azure Entra ID authentication
             auth_type = api_config.get('auth_type', 'bearer')
             if auth_type not in ('azure_ad', 'microsoft_entra_id'):

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -101,7 +101,8 @@
 				key,
 				config: {
 					auth_type,
-					...(provider ? { provider } : azure ? { azure: true } : {}),
+					...(azure ? { azure: true } : {}),
+					...(provider ? { provider } : {}),
 					api_version: apiVersion,
 					...(_headers ? { headers: _headers } : {})
 				}
@@ -189,7 +190,8 @@
 				connection_type: connectionType,
 				auth_type,
 				headers: headers ? JSON.parse(headers) : undefined,
-				...(provider ? { provider } : !ollama && azure ? { azure: true } : {}),
+				...(azure ? { azure: true } : {}),
+				...(provider ? { provider } : {}),
 				...(azure ? { api_version: apiVersion } : {}),
 				...(apiType ? { api_type: apiType } : {})
 			}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #24872. Addresses #17121.
- [x] **Target branch:** `dev`
- [x] **Description:** See below.
- [x] **Changelog:** See Changelog Entry below.
- [ ] **Documentation:** Not required — no new user-facing settings; existing Azure OpenAI flow is fixed.
- [x] **Dependencies:** None.
- [x] **Testing:** Manual — Azure OpenAI provider on custom hostname; Verify succeeds; chat returns a reply. Tested against Azure-compatible gateway (DIAL-style deployment API).
- [x] **Agentic AI Code:** Human-reviewed and manually tested.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** Minimal change; no new settings.
- [x] **Git Hygiene:** Single logical fix (UI config + backend routing).
- [x] **Title Prefix:** `fix:`

---

# Changelog Entry

### Description

- Fix Azure OpenAI connections on custom base URLs (hostnames without `azure.` / `cognitive.microsoft.com`). Selecting **Azure OpenAI** in the connection modal now persists `azure: true`, and the backend treats `provider: "azure"` as Azure mode so verify and chat use deployment API paths (`/openai/models`, `/openai/deployments/{model}/chat/completions`).

### Added

- `is_azure_openai_config()` helper in `routers/openai.py` for consistent Azure routing checks.

### Changed

- `AddConnectionModal.svelte`: save `azure: true` whenever Azure mode is active (including when **Provider** is **Azure OpenAI**), not only on URL auto-detection.
- `routers/openai.py`: use `is_azure_openai_config()` instead of `api_config.get('azure', False)` for verify, models, and chat completion routing.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Azure OpenAI provider failing on custom gateway URLs: **Verify** showed “Network error” and chat returned no reply because only `provider: "azure"` was saved without `azure: true`, so requests hit `/models` and `/chat/completions` instead of Azure deployment endpoints ([#24872](https://github.com/open-webui/open-webui/issues/24872)).

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

**Problem**

The **Azure OpenAI** provider in Admin Panel → Settings → Connections is intended for gateways that use the Azure deployment API (APIM, private endpoints) where the hostname does not trigger auto-detection (`azure.` / `cognitive.microsoft.com`).

On save/verify, the UI used:

```js
...(provider ? { provider } : azure ? { azure: true } : {})
```

Choosing **Azure OpenAI** stored `provider: "azure"` but omitted `azure: true`. The backend only checked `api_config.get('azure', False)`, so verify and chat used generic OpenAI paths and failed on Azure-compatible gateways.

**Solution**

1. **Frontend:** Always persist `azure: true` when Azure mode is active; keep `provider: "azure"` when selected.
2. **Backend:** `is_azure_openai_config()` returns true for `azure: true` or `provider === 'azure'` (backward compatibility for existing saved configs).

**Related**

- Closes [#24872](https://github.com/open-webui/open-webui/issues/24872)
- Addresses [#17121](https://github.com/open-webui/open-webui/issues/17121) (custom Azure URLs via explicit provider)

### Screenshots or Videos
<img width="3115" height="1422" alt="image" src="https://github.com/user-attachments/assets/6de31377-54fb-4fb9-be58-365b09ab886b" />

- [ ] Before: Verify → “Network error” on custom host with **Azure OpenAI** provider  
- [X] After: Verify → success; chat receives assistant reply  


### Contributor License Agreement

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
