### PR TITLE
refactor: render from output and derive content at save

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4201,7 +4201,6 @@ async def streaming_chat_response_handler(response, ctx):
 
                                     processed_data = {
                                         'output': full_output(),
-                                        'content': serialize_output(full_output()),
                                     }
 
                                     # print(data)
@@ -4371,7 +4370,7 @@ async def streaming_chat_response_handler(response, ctx):
                                                 )
 
                                             data = {
-                                                'content': serialize_output(full_output() + pending_fc_items),
+                                                'output': full_output() + pending_fc_items,
                                             }
                                             delta_type = 'tool_call'
 
@@ -4429,7 +4428,7 @@ async def streaming_chat_response_handler(response, ctx):
                                                 }
                                             ]
 
-                                        data = {'content': serialize_output(full_output())}
+                                        data = {'output': full_output()}
                                         delta_type = 'content'
 
                                     if value:
@@ -4589,7 +4588,7 @@ async def streaming_chat_response_handler(response, ctx):
                                             )
                                         else:
                                             data = {
-                                                'content': serialize_output(full_output()),
+                                                'output': full_output(),
                                             }
                                             delta_type = 'content'
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1227,9 +1227,17 @@
 		const messages = history ? createMessagesList(history, history.currentId) : [];
 		let contents = [];
 		messages.forEach((message) => {
-			if (message?.role !== 'user' && message?.content) {
+			if (message?.role !== 'user') {
+				let text = message?.content || '';
+				if (!text && message?.output?.length) {
+					text = message.output
+						.filter((i) => i.type === 'message')
+						.flatMap((i) => (i.content ?? []).map((p) => p.text ?? ''))
+						.join('\n');
+				}
+				if (!text) return;
 				const { codeBlocks: codeBlocks, htmlGroups: htmlGroups } = getCodeBlockContents(
-					message.content
+					text
 				);
 
 				if (htmlGroups && htmlGroups.length > 0) {
@@ -1891,9 +1899,35 @@
 	const chatCompletionEventHandler = async (data, message, chatId) => {
 		const { id, done, choices, content, output, sources, selected_model_id, error, usage } = data;
 
+		const extractTextFromOutput = (o) =>
+			o
+				.filter((i) => i.type === 'message')
+				.flatMap((i) => (i.content ?? []).map((p) => (p.text ?? '').trim()))
+				.filter(Boolean)
+				.join('\n');
+
+		const dispatchStreamingTTS = (getText) => {
+			if (!$showCallOverlay) return;
+			const text = getText();
+			const parts = getMessageContentParts(
+				text,
+				$config?.audio?.tts?.split_on ?? 'punctuation'
+			);
+			parts.pop();
+			if (parts.length > 0 && parts[parts.length - 1] !== message.lastSentence) {
+				message.lastSentence = parts[parts.length - 1];
+				eventTarget.dispatchEvent(
+					new CustomEvent('chat', {
+						detail: { id: message.id, content: parts[parts.length - 1] }
+					})
+				);
+			}
+		};
+
 		// Store raw OR-aligned output items from backend
 		if (output) {
 			message.output = output;
+			dispatchStreamingTTS(() => extractTextFromOutput(output));
 		}
 
 		if (error) {
@@ -1904,7 +1938,9 @@
 			message.sources = sources;
 		}
 
-		if (choices) {
+		// Only accumulate content from choices when there's no structured output
+		// (output-based rendering takes priority — avoids redundant serialize/parse round-trip)
+		if (choices && !output) {
 			if (choices[0]?.message?.content) {
 				// Non-stream response
 				message.content += choices[0]?.message?.content;
@@ -1920,30 +1956,7 @@
 						navigator.vibrate(5);
 					}
 
-					// Emit chat event for TTS (only when call overlay is active)
-					if ($showCallOverlay) {
-						const messageContentParts = getMessageContentParts(
-							removeAllDetails(message.content),
-							$config?.audio?.tts?.split_on ?? 'punctuation'
-						);
-						messageContentParts.pop();
-
-						// dispatch only last sentence and make sure it hasn't been dispatched before
-						if (
-							messageContentParts.length > 0 &&
-							messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-						) {
-							message.lastSentence = messageContentParts[messageContentParts.length - 1];
-							eventTarget.dispatchEvent(
-								new CustomEvent('chat', {
-									detail: {
-										id: message.id,
-										content: messageContentParts[messageContentParts.length - 1]
-									}
-								})
-							);
-						}
-					}
+					dispatchStreamingTTS(() => removeAllDetails(message.content));
 				}
 			}
 		}
@@ -1956,30 +1969,7 @@
 				navigator.vibrate(5);
 			}
 
-			// Emit chat event for TTS (only when call overlay is active)
-			if ($showCallOverlay) {
-				const messageContentParts = getMessageContentParts(
-					removeAllDetails(message.content),
-					$config?.audio?.tts?.split_on ?? 'punctuation'
-				);
-				messageContentParts.pop();
-
-				// dispatch only last sentence and make sure it hasn't been dispatched before
-				if (
-					messageContentParts.length > 0 &&
-					messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-				) {
-					message.lastSentence = messageContentParts[messageContentParts.length - 1];
-					eventTarget.dispatchEvent(
-						new CustomEvent('chat', {
-							detail: {
-								id: message.id,
-								content: messageContentParts[messageContentParts.length - 1]
-							}
-						})
-					);
-				}
-			}
+			dispatchStreamingTTS(() => removeAllDetails(message.content));
 		}
 
 		if (selected_model_id) {

--- a/src/lib/components/chat/Messages/OutputRenderer.svelte
+++ b/src/lib/components/chat/Messages/OutputRenderer.svelte
@@ -1,0 +1,405 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { settings } from '$lib/stores';
+
+	import Markdown from './Markdown.svelte';
+	import ConsecutiveDetailsGroup from './Markdown/ConsecutiveDetailsGroup.svelte';
+	import ToolCallDisplay from '$lib/components/common/ToolCallDisplay.svelte';
+	import Collapsible from '$lib/components/common/Collapsible.svelte';
+	import FloatingButtons from '../ContentRenderer/FloatingButtons.svelte';
+
+	import { onDestroy, tick } from 'svelte';
+	import { mobile, chatId, showArtifacts, showControls, artifactCode, showEmbeds } from '$lib/stores';
+
+	const i18n = getContext('i18n');
+
+	export let id: string = '';
+	export let output: any[] = [];
+	export let done: boolean = true;
+	export let model = null;
+	export let sources = null;
+
+	export let save = false;
+	export let preview = false;
+	export let editCodeBlock = true;
+	export let topPadding = false;
+	export let floatingButtons = true;
+
+	export let onSave: Function = () => {};
+	export let onSourceClick: Function = () => {};
+	export let onTaskClick: Function = () => {};
+	export let onSetInputText: Function = () => {};
+
+	let contentContainerElement: HTMLDivElement;
+	let floatingButtonsElement;
+
+	// Build lookup map for function_call_output items by call_id
+	$: toolOutputs = (() => {
+		const map: Record<string, any> = {};
+		for (const item of output) {
+			if (item.type === 'function_call_output') {
+				map[item.call_id] = item;
+			}
+		}
+		return map;
+	})();
+
+	// Source IDs for citation linking (same logic as ContentRenderer)
+	let sourceIds: string[] = [];
+	$: getSourceIds(sources);
+	const getSourceIds = (sources) => {
+		const result: string[] = [];
+		for (const source of sources ?? []) {
+			for (let index = 0; index < (source.document ?? []).length; index++) {
+				if (model?.info?.meta?.capabilities?.citations == false) {
+					result.push('N/A');
+					continue;
+				}
+				const metadata = source.metadata?.[index];
+				const id = metadata?.source ?? 'N/A';
+				if (metadata?.name) {
+					result.push(metadata.name);
+				} else if (id.startsWith('http://') || id.startsWith('https://')) {
+					result.push(id);
+				} else {
+					result.push(source?.source?.name ?? id);
+				}
+			}
+		}
+		sourceIds = [...new Set(result)];
+	};
+
+	const GROUPABLE_TYPES = new Set(['reasoning', 'function_call', 'open_webui:code_interpreter']);
+
+	// Convert an output item to the "detail token" shape that
+	// ConsecutiveDetailsGroup / ToolCallDisplay / Collapsible expect.
+	function toDetailToken(item: any): any {
+		if (item.type === 'function_call') {
+			const resultItem = toolOutputs[item.call_id];
+			const isDone = item.status === 'completed' || !!resultItem;
+			const resultParts =
+				resultItem?.output
+					?.filter((p: any) => p.type !== 'input_image')
+					.map((p: any) => p.text ?? '') ?? [];
+			const resultText = resultParts.join('');
+			return {
+				attributes: {
+					type: 'tool_calls',
+					name: item.name ?? '',
+					done: isDone ? 'true' : 'false',
+					arguments:
+						typeof item.arguments === 'string'
+							? item.arguments
+							: JSON.stringify(item.arguments ?? ''),
+					embeds: resultItem?.embeds ? JSON.stringify(resultItem.embeds) : '',
+					files: resultItem?.files ? JSON.stringify(resultItem.files) : ''
+				},
+				summary: isDone ? 'Tool Executed' : 'Executing...',
+				text: resultText
+			};
+		} else if (item.type === 'reasoning') {
+			const sourceList = item.summary || item.content || [];
+			const text = sourceList.map((p: any) => p.text ?? '').join('');
+			const isDone = item.status === 'completed' || item.duration != null;
+			return {
+				attributes: {
+					type: 'reasoning',
+					done: isDone ? 'true' : 'false',
+					duration: String(item.duration ?? '')
+				},
+				summary: isDone ? `Thought for ${item.duration ?? 0} seconds` : 'Thinking…',
+				text: text
+					.split('\n')
+					.map((l) => (l.startsWith('>') ? l : `> ${l}`))
+					.join('\n')
+			};
+		} else if (item.type === 'open_webui:code_interpreter') {
+			const isDone = item.status === 'completed';
+			const code = item.code ?? '';
+			const lang = item.lang ?? 'python';
+			const text = code ? `\`\`\`${lang}\n${code}\n\`\`\`` : '';
+			return {
+				attributes: {
+					type: 'code_interpreter',
+					done: isDone ? 'true' : 'false',
+					duration: String(item.duration ?? ''),
+					output: item.output ? JSON.stringify(item.output) : ''
+				},
+				summary: isDone ? 'Analyzed' : 'Analyzing…',
+				text
+			};
+		}
+		return null;
+	}
+
+	// Group output items into display items (message blocks and grouped details)
+	$: displayItems = (() => {
+		const items: any[] = [];
+		let currentGroup: any[] = [];
+
+		const flushGroup = () => {
+			if (currentGroup.length > 1) {
+				items.push({ type: 'detail_group', tokens: [...currentGroup] });
+			} else if (currentGroup.length === 1) {
+				items.push({ type: 'detail_single', token: currentGroup[0] });
+			}
+			currentGroup = [];
+		};
+
+		for (const item of output) {
+			if (item.type === 'function_call_output') continue; // handled via function_call
+			if (GROUPABLE_TYPES.has(item.type)) {
+				const token = toDetailToken(item);
+				if (token) currentGroup.push(token);
+			} else if (item.type === 'message') {
+				flushGroup();
+				const text = (item.content ?? []).map((p: any) => p.text ?? '').join('');
+				if (text.trim()) {
+					items.push({ type: 'message', text });
+				}
+			} else {
+				// Unknown type — render as plain text fallback so nothing is silently lost
+				flushGroup();
+				const fallbackText = (item.content ?? []).map((p: any) => p.text ?? '').join('');
+				if (fallbackText.trim()) {
+					items.push({ type: 'message', text: fallbackText });
+				}
+			}
+		}
+		flushGroup();
+		return items;
+	})();
+
+	// Floating button positioning (same as ContentRenderer)
+	const updateButtonPosition = (event: MouseEvent) => {
+		const buttonsContainerElement = document.getElementById(`floating-buttons-${id}`);
+		if (
+			!contentContainerElement?.contains(event.target as Node) &&
+			!buttonsContainerElement?.contains(event.target as Node)
+		) {
+			closeFloatingButtons();
+			return;
+		}
+
+		setTimeout(async () => {
+			await tick();
+			if (!contentContainerElement?.contains(event.target as Node)) return;
+
+			let selection = window.getSelection();
+			if (selection && selection.toString().trim().length > 0) {
+				const range = selection.getRangeAt(0);
+				const rect = range.getBoundingClientRect();
+				const parentRect = contentContainerElement.getBoundingClientRect();
+				const top = rect.bottom - parentRect.top;
+				const left = rect.left - parentRect.left;
+
+				if (buttonsContainerElement) {
+					buttonsContainerElement.style.display = 'block';
+					const spaceOnRight = parentRect.width - left;
+					let halfScreenWidth = $mobile ? window.innerWidth / 2 : window.innerWidth / 3;
+
+					if (spaceOnRight < halfScreenWidth) {
+						const right = parentRect.right - rect.right;
+						buttonsContainerElement.style.right = `${right}px`;
+						buttonsContainerElement.style.left = 'auto';
+					} else {
+						buttonsContainerElement.style.left = `${left}px`;
+						buttonsContainerElement.style.right = 'auto';
+					}
+					buttonsContainerElement.style.top = `${top + 5}px`;
+				}
+			} else {
+				closeFloatingButtons();
+			}
+		}, 0);
+	};
+
+	const closeFloatingButtons = () => {
+		const buttonsContainerElement = document.getElementById(`floating-buttons-${id}`);
+		if (buttonsContainerElement) {
+			buttonsContainerElement.style.display = 'none';
+		}
+		if (floatingButtonsElement && typeof floatingButtonsElement?.closeHandler === 'function') {
+			floatingButtonsElement?.closeHandler();
+		}
+	};
+
+	const keydownHandler = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') closeFloatingButtons();
+	};
+
+	let listenersAttached = false;
+
+	function attachListeners() {
+		if (!listenersAttached && contentContainerElement) {
+			contentContainerElement.addEventListener('mouseup', updateButtonPosition);
+			document.addEventListener('mouseup', updateButtonPosition);
+			document.addEventListener('keydown', keydownHandler);
+			listenersAttached = true;
+		}
+	}
+
+	function detachListeners() {
+		if (listenersAttached) {
+			contentContainerElement?.removeEventListener('mouseup', updateButtonPosition);
+			document.removeEventListener('mouseup', updateButtonPosition);
+			document.removeEventListener('keydown', keydownHandler);
+			listenersAttached = false;
+		}
+	}
+
+	$: if (floatingButtons && contentContainerElement) {
+		attachListeners();
+	} else {
+		detachListeners();
+	}
+
+	onDestroy(() => {
+		detachListeners();
+	});
+</script>
+
+<div bind:this={contentContainerElement}>
+	{#each displayItems as displayItem, idx (displayItem.type + '_' + idx)}
+		{#if displayItem.type === 'message'}
+			<Markdown
+				id={`${id}-msg-${idx}`}
+				content={model?.info?.meta?.capabilities?.citations == false
+					? displayItem.text.replace(
+							/\s*(\[(?:\d+(?:#[^,\]\s]+)?(?:,\s*\d+(?:#[^,\]\s]+)?)*)\])+/g,
+							''
+						)
+					: displayItem.text}
+				{model}
+				{save}
+				{preview}
+				{done}
+				{editCodeBlock}
+				{topPadding}
+				{sourceIds}
+				{onSourceClick}
+				{onTaskClick}
+				{onSave}
+				onUpdate={async (token) => {
+					const { lang, text: code } = token;
+					if (
+						($settings?.detectArtifacts ?? true) &&
+						(['html', 'svg'].includes(lang) || (lang === 'xml' && code.includes('svg'))) &&
+						!$mobile &&
+						$chatId
+					) {
+						await tick();
+						showArtifacts.set(true);
+						showControls.set(true);
+					}
+				}}
+				onPreview={async (value) => {
+					await artifactCode.set(value);
+					await showControls.set(true);
+					await showArtifacts.set(true);
+					await showEmbeds.set(false);
+				}}
+			/>
+		{:else if displayItem.type === 'detail_group'}
+			<ConsecutiveDetailsGroup
+				id={`${id}-group-${idx}`}
+				tokens={displayItem.tokens}
+				messageDone={done}
+			>
+				<div slot="content" class="space-y-1">
+					{#each displayItem.tokens as detailToken, detailIdx}
+						{#if detailToken.attributes?.type === 'tool_calls'}
+							<ToolCallDisplay
+								id={`${id}-group-${idx}-${detailIdx}-tc`}
+								attributes={detailToken.attributes}
+								resultContent={detailToken.text}
+								grouped={true}
+								open={$settings?.expandDetails ?? false}
+								className="w-full space-y-1"
+							/>
+						{:else if detailToken.text?.length > 0}
+							<Collapsible
+								title={detailToken.summary}
+								open={$settings?.expandDetails ?? false}
+								attributes={detailToken.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							>
+								<div class="mb-1.5" slot="content">
+									<Markdown
+										id={`${id}-group-${idx}-${detailIdx}-d`}
+										content={detailToken.text}
+										{done}
+										{editCodeBlock}
+									/>
+								</div>
+							</Collapsible>
+						{:else}
+							<Collapsible
+								title={detailToken.summary}
+								open={false}
+								disabled={true}
+								attributes={detailToken.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							/>
+						{/if}
+					{/each}
+				</div>
+			</ConsecutiveDetailsGroup>
+		{:else if displayItem.type === 'detail_single'}
+			{@const detailToken = displayItem.token}
+			{#if detailToken.attributes?.type === 'tool_calls'}
+				<ToolCallDisplay
+					id={`${id}-single-${idx}-tc`}
+					attributes={detailToken.attributes}
+					resultContent={detailToken.text}
+					open={$settings?.expandDetails ?? false}
+					className="w-full space-y-1"
+				/>
+			{:else if detailToken.text?.length > 0}
+				<Collapsible
+					title={detailToken.summary}
+					open={$settings?.expandDetails ?? false}
+					attributes={detailToken.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				>
+					<div class="mb-1.5" slot="content">
+						<Markdown
+							id={`${id}-single-${idx}-d`}
+							content={detailToken.text}
+							{done}
+							{editCodeBlock}
+						/>
+					</div>
+				</Collapsible>
+			{:else}
+				<Collapsible
+					title={detailToken.summary}
+					open={false}
+					disabled={true}
+					attributes={detailToken.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				/>
+			{/if}
+		{/if}
+	{/each}
+</div>
+
+{#if floatingButtons}
+	<FloatingButtons
+		bind:this={floatingButtonsElement}
+		{id}
+		actions={$settings?.floatingActionButtons ?? []}
+		onSetInputText={(text) => {
+			onSetInputText(text);
+			closeFloatingButtons();
+		}}
+	/>
+{/if}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -55,6 +55,7 @@
 	import Citations from './Citations.svelte';
 	import CodeExecutions from './CodeExecutions.svelte';
 	import ContentRenderer from './ContentRenderer.svelte';
+	import OutputRenderer from './OutputRenderer.svelte';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import FileItem from '$lib/components/common/FileItem.svelte';
 	import FollowUps from './ResponseMessage/FollowUps.svelte';
@@ -125,9 +126,13 @@
 	$: if (history.messages) {
 		const source = history.messages[messageId];
 		if (source) {
-			// Fast path: O(1) check on the fields that change most often (content during streaming, done at end)
-			// Avoids 2x O(n) JSON.stringify calls that are always true during streaming anyway
-			if (message.content !== source.content || message.done !== source.done) {
+			// Fast path: O(1) check on the fields that change most often
+			// (content during streaming, output during output-based streaming, done at end)
+			if (
+				message.content !== source.content ||
+				message.done !== source.done ||
+				message.output?.length !== source.output?.length
+			) {
 				message = structuredClone(source);
 			} else if (!equal(message, source)) {
 				// Slow path: full comparison for infrequent changes (sources, annotations, status, etc.)
@@ -191,6 +196,23 @@
 
 	let showRateComment = false;
 
+	/**
+	 * Extract visible text from output[] (skip reasoning/tool blocks).
+	 * Used for copy and TTS when structured output is available.
+	 */
+	const extractTextFromOutput = (output: any[]): string => {
+		const parts: string[] = [];
+		for (const item of output) {
+			if (item.type === 'message') {
+				for (const part of item.content ?? []) {
+					const text = (part.text ?? '').trim();
+					if (text) parts.push(text);
+				}
+			}
+		}
+		return parts.join('\n');
+	};
+
 	const copyToClipboard = async (text) => {
 		text = removeAllDetails(text);
 
@@ -226,7 +248,11 @@
 			: $config?.audio?.tts?.voice);
 
 	const speak = async () => {
-		if (!(message?.content ?? '').trim().length) {
+		const textForTTS = message.output?.length
+			? extractTextFromOutput(message.output)
+			: (message?.content ?? '');
+
+		if (!textForTTS.trim().length) {
 			toast.info($i18n.t('No content to speak'));
 			return;
 		}
@@ -236,7 +262,7 @@
 		const { signal } = speakAbort;
 
 		speaking = true;
-		const content = removeAllDetails(message.content);
+		const content = message.output?.length ? textForTTS : removeAllDetails(message.content);
 
 		if ($config.audio.tts.engine === '') {
 			let voices = [];
@@ -370,16 +396,6 @@
 		return restoredContent;
 	}
 
-	/** Extract plain text from output items for immediate display after edit.
-	 *  NOT a serialize_output port — just grabs text parts. Backend re-serializes
-	 *  the full rich content (with <details> blocks) on save. */
-	function extractTextFromOutput(output: any[]): string {
-		return output
-			.filter((item) => item.type === 'message')
-			.flatMap((item) => (item.content ?? []).map((p: any) => p.text ?? ''))
-			.join('\n')
-			.trim();
-	}
 
 	const editMessageHandler = async () => {
 		edit = true;
@@ -826,11 +842,66 @@
 							class="w-full flex flex-col relative {edit ? 'hidden' : ''}"
 							id="response-content-container"
 						>
-							{#if message.content === '' && !message.done && !message.error && !hasVisibleStatus}
+							{#if message.output?.length}
+								<!-- Render directly from structured output (no regex parsing needed) -->
+								<OutputRenderer
+									id={`${chatId}-${message.id}`}
+									output={message.output}
+									sources={message.sources}
+									floatingButtons={message?.done &&
+										!readOnly &&
+										($settings?.showFloatingActionButtons ?? true)}
+									save={!readOnly}
+									preview={!readOnly}
+									{editCodeBlock}
+									{topPadding}
+									done={($settings?.chatFadeStreamingText ?? true)
+										? (message?.done ?? false)
+										: true}
+									{model}
+									onTaskClick={async (e) => {
+										console.log(e);
+									}}
+									onSourceClick={async (id) => {
+										console.log(id);
+
+										if (citationsElement) {
+											citationsElement?.showSourceModal(id);
+										}
+									}}
+									onSetInputText={(text) => {
+										setInputText(text);
+									}}
+									onSave={({ raw, oldContent, newContent }) => {
+										// Update the content cache (for DB persistence)
+										history.messages[message.id].content = history.messages[
+											message.id
+										].content.replace(raw, raw.replace(oldContent, newContent));
+
+										// Also update the output item so display stays in sync
+										const outputItems = history.messages[message.id].output;
+										if (outputItems) {
+											for (const item of outputItems) {
+												if (item.type === 'message' && item.content) {
+													for (const part of item.content) {
+														if (part.text && part.text.includes(oldContent)) {
+															part.text = part.text.replace(oldContent, newContent);
+															break;
+														}
+													}
+												}
+											}
+											// Trigger reactivity
+											history.messages[message.id].output = outputItems;
+										}
+
+										updateChat();
+									}}
+								/>
+							{:else if message.content === '' && !message.done && !message.error && !hasVisibleStatus}
 								<Skeleton />
 							{:else if message.content && message.error !== true}
-								<!-- always show message contents even if there's an error -->
-								<!-- unless message.error === true which is legacy error handling, where the error message is stored in message.content -->
+								<!-- Legacy fallback: render from content string for messages without output -->
 								<ContentRenderer
 									id={`${chatId}-${message.id}`}
 									content={message.content}
@@ -1033,7 +1104,11 @@
 											? 'visible'
 											: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition copy-response-button"
 										on:click={() => {
-											copyToClipboard(message.content);
+											copyToClipboard(
+												message.output?.length
+													? extractTextFromOutput(message.output)
+													: message.content
+											);
 										}}
 									>
 										<svg


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing discussion [24885](https://github.com/open-webui/open-webui/discussions/24885). If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Render from `message.output` directly instead of regex-parsing serialized HTML. Removes `serialize_output` from all 4 per-delta streaming call sites. Deduplicates 3 inline TTS blocks into a shared helper.

~44% WS payload reduction for a 500-token response (~976 KB less). Messages without `output` fall through to ContentRenderer unchanged. Content still derived at save time for search/export.

### Added

- `OutputRenderer.svelte` (maps output items by type to existing components)
- `dispatchStreamingTTS` helper in Chat.svelte

### Changed

- `ResponseMessage.svelte` routes to OutputRenderer when output exists
- `Chat.svelte` skips content accumulation when output is present
- `middleware.py` per-delta events send `output` only (save/done unchanged)

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- `serialize_output()` from 4 streaming hot-paths
- 2 duplicate inline TTS blocks

### Fixed

- Literal `<details>` in LLM output no longer misidentified as structural blocks
- Temp chat edits display immediately
- Streaming TTS works during call overlay with output-based messages

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
