### PR TITLE
fix: bug for API requests for {"detail":"'NoneType' object has no attribute 'startswith'"} response

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1733,6 +1733,7 @@ async def chat_completion(
         #   null   → new chat (root message, no parent)
         #   value  → follow-up (user message's parentId = prev assistant)
         #   absent → legacy caller, no chat management
+        form_data.setdefault('parent_id', None)
         is_new_chat = 'parent_id' in form_data and form_data['parent_id'] is None and not form_data.get('chat_id')
         parent_id = form_data.pop('parent_id', None)
         form_data.pop('new_chat', None)  # Legacy field


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** No new or upgraded dependencies introduced.
- [x] **Testing:** Manual tests performed verifying the fix works as intended and does not break existing functionality. Reproducible steps and context provided below.
- [x] **Agentic AI Code:** This Pull Request was not written by any AI Agent and has gone through human review and manual testing.
- [x] **Code review:** Self-review performed, addressing coding standard issues and ensuring adherence to the project's coding standards.
- [x] **Design & Architecture:** N/A — this is a targeted bug fix with no architectural changes.
- [x] **Git Hygiene:** PR is atomic (one logical change), rebased on `dev`, no unrelated commits included.
- [x] **Title Prefix:** PR title is prefixed with `fix:` as this is a bug fix.

---

# Changelog Entry

### Description

When making API requests without the `parent_id` parameter (as is valid and documented in the [Open WebUI API reference](https://docs.openwebui.com/reference/api-endpoints/)), the server incorrectly forced `is_new_chat` to `false`, which caused a failure inside the `get_event_emitter` function and returned an error to the caller.

This fix ensures that when `parent_id` is absent from the API request payload (a legitimate use case per the official documentation), `is_new_chat` is correctly evaluated rather than being defaulted to `false`, preserving the existing logic for UI-originated requests while also correctly handling direct API calls.

### Added
- N/A

### Changed
- Updated the `is_new_chat` evaluation logic to gracefully handle missing `parent_id` in API request payloads without incorrectly forcing the value to `false`.

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed bug where a missing `parent_id` parameter in an API request caused `is_new_chat` to be incorrectly set to `false`, resulting in an error thrown by `get_event_emitter`.

### Security
- N/A

### Breaking Changes
- N/A

---

### Additional Information

- This bug was reproducible by sending a valid API payload as documented in the [Open WebUI API Endpoints reference](https://docs.openwebui.com/reference/api-endpoints/), which does not require `parent_id` to be present.
- The fix keeps the `is_new_chat` logic fully intact for requests originating from the UI, where `parent_id` is expected to be present.
- No regressions were observed during manual testing of both UI-originated and direct API calls.

### Reproducible Steps (Before Fix)

1. Send a chat completion API request **without** the `parent_id` parameter, using a payload matching the format documented at https://docs.openwebui.com/reference/api-endpoints/
2. Observe that the server sets `is_new_chat = false`
3. Observe that `get_event_emitter` throws an error and the request fails

### After Fix

1. Send the same API request without `parent_id`
2. `is_new_chat` is correctly evaluated based on the actual request context
3. Request completes successfully; UI behavior is unaffected

### Screenshots or Videos

- N/A

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.