### PR TITLE
fix: forward channel document files to model replies

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -851,6 +851,20 @@ async def send_notification(request, channel, message, active_user_ids, db=None)
     return True
 
 
+def _is_image_attachment(file: dict) -> bool:
+    return file.get('type', '') == 'image' or (file.get('content_type') or '').startswith('image/')
+
+
+def _get_channel_file_key(file: dict) -> str:
+    if file.get('id'):
+        return f'id:{file["id"]}'
+    if file.get('collection_name'):
+        return f'collection:{file["collection_name"]}'
+    if file.get('url'):
+        return f'url:{file["url"]}'
+    return json.dumps(file, sort_keys=True)
+
+
 async def model_response_handler(request, channel, message, user, db=None):
     MODELS = {model['id']: model for model in await get_filtered_models(await get_all_models(request, user=user), user)}
 
@@ -911,6 +925,8 @@ async def model_response_handler(request, channel, message, user, db=None):
 
                 thread_history = []
                 images = []
+                files = []
+                seen_file_keys = set()
 
                 # Batch fetch all users in a single query (fixes N+1 problem)
                 user_ids = list({message.user_id for message in thread_messages})
@@ -931,12 +947,21 @@ async def model_response_handler(request, channel, message, user, db=None):
 
                     thread_message_files = (thread_message.data or {}).get('files', [])
                     for file in thread_message_files:
-                        if file.get('type', '') == 'image':
-                            images.append(file.get('url', ''))
-                        elif file.get('content_type', '').startswith('image/'):
-                            image = await get_image_base64_from_file_id(file.get('id', ''))
-                            if image:
-                                images.append(image)
+                        if not isinstance(file, dict):
+                            continue
+
+                        if _is_image_attachment(file):
+                            if file.get('type', '') == 'image':
+                                images.append(file.get('url', ''))
+                            else:
+                                image = await get_image_base64_from_file_id(file.get('id', ''))
+                                if image:
+                                    images.append(image)
+                        else:
+                            file_key = _get_channel_file_key(file)
+                            if file_key not in seen_file_keys:
+                                seen_file_keys.add(file_key)
+                                files.append(file)
 
                 thread_history_string = '\n\n'.join(thread_history)
                 system_message = {
@@ -1000,6 +1025,8 @@ async def model_response_handler(request, channel, message, user, db=None):
                     form_data['features'] = features
                 if filter_ids:
                     form_data['filter_ids'] = filter_ids
+                if files:
+                    form_data['files'] = files
 
                 # Call the full chat completion pipeline — streaming,
                 # tools, filters, RAG — everything. The pipeline runs as


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24896; related to #23686
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** This PR forwards channel document attachments through the existing chat/RAG file pipeline for channel model replies.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** Not applicable; this is a backend bug fix with no new user-facing configuration or workflow.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual and targeted local tests were performed; details below.
- [x] **No Unchecked AI Code:** This patch was prepared with AI assistance and manually tested. It should still receive maintainer review before merge.
- [x] **Self-Review:** The code path and downstream file/RAG pipeline handoff were reviewed.
- [x] **Architecture:** Uses the existing `form_data["files"]` request shape consumed by the chat completion file/RAG handler. No new settings or architecture changes.
- [x] **Git Hygiene:** Atomic PR, based on `dev`, with no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

## Summary

Channel model replies currently build a synthetic chat completion request from the channel thread. That request collected text and image attachments, but dropped non-image files such as PDFs and DOCX files.

This PR forwards non-image channel attachments as `form_data["files"]`, matching the request shape already used by normal direct chat. That lets the existing chat completion file/RAG pipeline process uploaded channel documents for tagged model replies.

The existing image handling is preserved, and repeated file references are deduplicated before forwarding.

## Root Cause

`backend/open_webui/routers/channels.py` iterated over `thread_message.data.files` inside `model_response_handler`, but only appended image attachments to the model request. Non-image documents were neither added to the image content nor passed through `form_data["files"]`, so the downstream `chat_completion_files_handler` never received them.

Direct chat worked because it already passes uploaded files through `form_data["files"]` into request metadata.

## Testing

- Uploaded PDF/DOCX files to a channel, tagged a model, and confirmed the model could use the uploaded documents instead of asking for them again.
- Ran `python -m py_compile backend/open_webui/routers/channels.py`.
- Ran `uvx ruff format --check backend/open_webui/routers/channels.py`.
- Ran `git diff --check HEAD~1..HEAD`.
- Ran a focused mocked behavior check for `model_response_handler` confirming:
  - PDF and DOCX attachments are forwarded in `form_data["files"]`.
  - Image attachments stay in the existing image path.
  - Duplicate non-image file references are deduplicated.
  - Channel routing still uses `chat_id = "channel:<id>"`.

# Changelog Entry

### Description

- Fix channel model replies so uploaded non-image documents are forwarded to the existing file/RAG context pipeline.

### Added

- N/A

### Changed

- Channel model reply request construction now includes non-image channel attachments in `form_data["files"]`.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Channel model replies no longer ignore uploaded PDF/DOCX and other non-image document attachments.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Closes #24896
- Related to #23686
- No new dependencies or configuration changes.

### Screenshots or Videos

- Manual test confirmed the channel model response can use uploaded documents. A screenshot or recording can be added before marking ready for review if desired.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
