### PR TITLE
fix: apply RAG_EMBEDDING_QUERY_PREFIX to memory search queries

### DIFF
--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from open_webui.utils.access_control import has_permission
 from open_webui.constants import ERROR_MESSAGES
+from open_webui.config import RAG_EMBEDDING_QUERY_PREFIX
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ async def query_memory(
     if not memories:
         raise HTTPException(status_code=404, detail='No memories found for user')
 
-    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, user=user)
+    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, RAG_EMBEDDING_QUERY_PREFIX, user=user)
 
     results = await ASYNC_VECTOR_DB_CLIENT.search(
         collection_name=f'user-memory-{user.id}',


### PR DESCRIPTION
## Summary

- `query_memory` in `routers/memories.py` embeds the search query without the configured `RAG_EMBEDDING_QUERY_PREFIX`
- Every RAG retrieval path in `retrieval/utils.py` correctly passes the prefix when calling the embedding function
- Instruction-tuned embedding models (e.g. Qwen3-Embedding) require a task instruction prefix to produce meaningful embeddings — without it, memory search returns semantically unrelated results regardless of the query

## Test plan

- [ ] Set `RAG_EMBEDDING_QUERY_PREFIX` to an instruction prefix appropriate for your embedding model
- [ ] Add a few memories and search for one by a related term (not an exact string match)
- [ ] Verify results are semantically relevant with the prefix configured
- [ ] Verify behavior is unchanged when `RAG_EMBEDDING_QUERY_PREFIX` is unset (prefix is `None`, no change to existing behavior)