### PR TITLE
fix: apply RAG_EMBEDDING_QUERY_PREFIX to memory search queries

### DIFF
--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -9,6 +9,7 @@ from open_webui.constants import ERROR_MESSAGES
 from open_webui.internal.db import get_async_session
 from open_webui.models.memories import Memories, MemoryModel
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
+from open_webui.config import RAG_EMBEDDING_QUERY_PREFIX
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_verified_user
 from pydantic import BaseModel
@@ -137,7 +138,7 @@ async def query_memory(
     if not memories:
         raise HTTPException(status_code=404, detail='No memories found for user')
 
-    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, user=user)
+    vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, RAG_EMBEDDING_QUERY_PREFIX, user=user)
 
     results = await ASYNC_VECTOR_DB_CLIENT.search(
         collection_name=f'user-memory-{user.id}',


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to the `RAG_EMBEDDING_QUERY_PREFIX` env var added for instruction-tuned embedding models
- [x] **Target branch:** `dev`
- [x] **Description:** Concise description below
- [x] **Testing:** Manually verified with Qwen3-Embedding; memory search returns semantically correct results with prefix configured, and behaves identically to before when prefix is unset
- [x] **Agentic AI Code:** This PR was not written by an AI agent
- [x] **Code review:** Self-reviewed

## Description

`query_memory` in `routers/memories.py` embeds the search query without applying `RAG_EMBEDDING_QUERY_PREFIX`. Every RAG retrieval path in `retrieval/utils.py` correctly passes this prefix when calling the embedding function, but the memory search path was missed.

Instruction-tuned embedding models (e.g. Qwen3-Embedding) require a task instruction prefix to produce meaningful query embeddings. Without it, memory search returns semantically unrelated results regardless of what the user searches for — the env var has no effect on memory queries.

# Changelog Entry

### Fixed

- Memory search queries now respect `RAG_EMBEDDING_QUERY_PREFIX`, fixing broken semantic search for instruction-tuned embedding models (e.g. Qwen3-Embedding)

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.