### PR TITLE
feat: configurable aiohttp read_bufsize via AIOHTTP_READ_BUFSIZE env

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -578,6 +578,20 @@ try:
 except ValueError:
     AIOHTTP_POOL_DNS_TTL = 300
 
+# Max size of a single chunk read from an SSE/HTTP stream, in bytes.
+# aiohttp's default is 64 KiB which can be exceeded when an upstream provider
+# emits a single very large SSE chunk (e.g. OpenRouter sometimes batches a
+# reasoning trace or tool-call payload into one chunk, or an image-generation
+# response is returned in one message). Raising this avoids
+# `Got more than N bytes when reading` 400 errors. Default 1 MiB.
+AIOHTTP_READ_BUFSIZE = os.getenv('AIOHTTP_READ_BUFSIZE', str(1024 * 1024))
+try:
+    AIOHTTP_READ_BUFSIZE = int(AIOHTTP_READ_BUFSIZE)
+    if AIOHTTP_READ_BUFSIZE <= 0:
+        AIOHTTP_READ_BUFSIZE = 1024 * 1024
+except ValueError:
+    AIOHTTP_READ_BUFSIZE = 1024 * 1024
+
 RAG_EMBEDDING_TIMEOUT = os.getenv('RAG_EMBEDDING_TIMEOUT', '')
 
 if RAG_EMBEDDING_TIMEOUT == '':

--- a/backend/open_webui/utils/session_pool.py
+++ b/backend/open_webui/utils/session_pool.py
@@ -9,6 +9,11 @@ All pool parameters are configurable via environment variables:
     - AIOHTTP_POOL_CONNECTIONS (default 100) — max total connections
     - AIOHTTP_POOL_CONNECTIONS_PER_HOST (default 30) — per-host limit
     - AIOHTTP_POOL_DNS_TTL (default 300) — DNS cache TTL in seconds
+    - AIOHTTP_READ_BUFSIZE (default 1048576) — per-chunk read buffer size in
+      bytes. Raise this when an upstream emits very large SSE chunks (e.g.
+      reasoning-trace batching by some OpenRouter providers, or single-message
+      image-generation responses) which otherwise fail with
+      "Got more than N bytes when reading".
 
 Usage:
     from open_webui.utils.session_pool import get_session, cleanup_response
@@ -32,6 +37,7 @@ from open_webui.env import (
     AIOHTTP_POOL_CONNECTIONS,
     AIOHTTP_POOL_CONNECTIONS_PER_HOST,
     AIOHTTP_POOL_DNS_TTL,
+    AIOHTTP_READ_BUFSIZE,
 )
 
 log = logging.getLogger(__name__)
@@ -61,12 +67,14 @@ async def get_session() -> aiohttp.ClientSession:
             connector=connector,
             timeout=timeout,
             trust_env=True,
+            read_bufsize=AIOHTTP_READ_BUFSIZE,
         )
         log.info(
-            'Created shared aiohttp session pool (limit=%s, per_host=%s, dns_ttl=%d)',
+            'Created shared aiohttp session pool (limit=%s, per_host=%s, dns_ttl=%d, read_bufsize=%d)',
             AIOHTTP_POOL_CONNECTIONS or 'unlimited',
             AIOHTTP_POOL_CONNECTIONS_PER_HOST or 'unlimited',
             AIOHTTP_POOL_DNS_TTL,
+            AIOHTTP_READ_BUFSIZE,
         )
     return _session
 


### PR DESCRIPTION
## Problem

The shared `aiohttp.ClientSession` in `utils/session_pool.py` is created with the library default `read_bufsize` (64 KiB). Some upstream providers emit a **single** SSE chunk that exceeds this ceiling, causing the stream to fail with:

```
400, message: Got more than 131072 bytes when reading: b'data: {"id":"gen-...","object":"chat.completion.chunk",...
```

(The 131072 = 2 × 64 KiB comes from aiohttp internally doubling the buffer once before raising.)

### Triggers seen in the wild

- **OpenRouter routing reasoning models** (Kimi K2.6, R1-style, etc.) through providers that batch the entire reasoning trace into a single chunk — observed with Novita, WandB, SiliconFlow.
- **Image-generation responses** returned as a single large SSE message — see discussion #24543, which reports the same error signature and is currently unresolved.

There is no current env or config knob to override this; the only workaround is patching the source.

## Fix

Expose `AIOHTTP_READ_BUFSIZE` (default **1 MiB**) and pass it through to `ClientSession(read_bufsize=...)`.

- Default of 1 MiB is conservative — handles every real-world case I've reproduced while still rejecting truly runaway payloads.
- Falls back gracefully on invalid/empty/negative values.
- Logged at session creation alongside the other pool params.

## Files

- `backend/open_webui/env.py` — new env constant with validation.
- `backend/open_webui/utils/session_pool.py` — import it, pass to `ClientSession`, update docstring + log line.

## Validated against

Reproduced the failure with `moonshotai/kimi-k2.6` via OpenRouter (Novita provider) on `v0.9.5`. With the default 64 KiB buffer the stream dies mid-reasoning; with `AIOHTTP_READ_BUFSIZE=1048576` (or the new default) the stream completes cleanly through `data: [DONE]`.

Related: #24543