### PR TITLE
Add shortcut to edit last user message

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -90,6 +90,7 @@
 						<!-- {$i18n.t('Regenerate Response')} -->
 						<!-- {$i18n.t('Stop Generating')} -->
 						<!-- {$i18n.t('Edit Last Message')} -->
+						<!-- {$i18n.t('Edit Last User Message')} -->
 						<!-- {$i18n.t('Copy Last Response')} -->
 						<!-- {$i18n.t('Copy Last Code Block')} -->
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -38,6 +38,7 @@ export enum Shortcut {
 	//Message
 	GENERATE_MESSAGE_PAIR = 'generateMessagePair',
 	REGENERATE_RESPONSE = 'regenerateResponse',
+	EDIT_LAST_USER_MESSAGE = 'editLastUserMessage',
 	COPY_LAST_CODE_BLOCK = 'copyLastCodeBlock',
 	COPY_LAST_RESPONSE = 'copyLastResponse',
 	STOP_GENERATING = 'stopGenerating'
@@ -141,6 +142,11 @@ export const shortcuts: ShortcutRegistry = {
 	[Shortcut.REGENERATE_RESPONSE]: {
 		name: 'Regenerate Response',
 		keys: ['mod', 'R'],
+		category: 'Message'
+	},
+	[Shortcut.EDIT_LAST_USER_MESSAGE]: {
+		name: 'Edit Last User Message',
+		keys: ['mod', 'shift', 'E'],
 		category: 'Message'
 	},
 	[Shortcut.STOP_GENERATING]: {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -263,6 +263,12 @@
 					console.log('Shortcut triggered: COPY_LAST_RESPONSE');
 					event.preventDefault();
 					[...document.getElementsByClassName('copy-response-button')]?.at(-1)?.click();
+				} else if (isShortcutMatch(event, shortcuts[Shortcut.EDIT_LAST_USER_MESSAGE])) {
+					console.log('Shortcut triggered: EDIT_LAST_USER_MESSAGE');
+					event.preventDefault();
+					const editButtons =
+						document.querySelectorAll<HTMLButtonElement>('.edit-user-message-button');
+					editButtons.item(editButtons.length - 1)?.click();
 				} else if (isShortcutMatch(event, shortcuts[Shortcut.TOGGLE_SIDEBAR])) {
 					console.log('Shortcut triggered: TOGGLE_SIDEBAR');
 					event.preventDefault();


### PR DESCRIPTION
## Summary
- Adds a Ctrl/Cmd + Shift + E shortcut for editing the most recent user message.
- Registers the shortcut in the shortcuts registry and shortcuts modal translation hints.

## Test plan
- Started the frontend dev server with npm run dev.
- Checked the touched files with IDE diagnostics; no new lint errors were reported.
- Ran npm run check, but it fails on existing unrelated Svelte/TypeScript issues in AdvancedParams.svelte.