### PR TITLE
feat: auto-redirect to SSO when OAUTH_AUTO_REDIRECT is set

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3435,6 +3435,12 @@ ENABLE_OAUTH_SIGNUP = ConfigVar(
     os.getenv('ENABLE_OAUTH_SIGNUP', 'False').lower() == 'true',
 )
 
+OAUTH_AUTO_REDIRECT = ConfigVar(
+    'OAUTH_AUTO_REDIRECT',
+    'oauth.auto_redirect',
+    os.getenv('OAUTH_AUTO_REDIRECT', 'False').lower() == 'true',
+)
+
 OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE = ConfigVar(
     'OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE',
     'oauth.refresh_token_include_scope',

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -288,6 +288,7 @@ from open_webui.config import (
     MOJEEK_SEARCH_API_KEY,
     OAUTH_ADMIN_ROLES,
     OAUTH_ALLOWED_ROLES,
+    OAUTH_AUTO_REDIRECT,
     OAUTH_EMAIL_CLAIM,
     OAUTH_PICTURE_CLAIM,
     OAUTH_PROVIDERS,
@@ -865,6 +866,7 @@ app.state.BASE_MODELS = []
 app.state.config.WEBUI_URL = WEBUI_URL
 app.state.config.ENABLE_SIGNUP = ENABLE_SIGNUP
 app.state.config.ENABLE_LOGIN_FORM = ENABLE_LOGIN_FORM
+app.state.config.OAUTH_AUTO_REDIRECT = OAUTH_AUTO_REDIRECT
 app.state.config.ENABLE_PASSWORD_CHANGE_FORM = ENABLE_PASSWORD_CHANGE_FORM
 
 app.state.config.ENABLE_API_KEYS = ENABLE_API_KEYS
@@ -2357,7 +2359,10 @@ async def get_app_config(request: Request):
         'name': app.state.WEBUI_NAME,
         'version': VERSION,
         'default_locale': str(DEFAULT_LOCALE),
-        'oauth': {'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()}},
+        'oauth': {
+            'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()},
+            'auto_redirect': app.state.config.OAUTH_AUTO_REDIRECT,
+        },
         'features': {
             # --- Public: required by login/signup page pre-auth ---
             'auth': WEBUI_AUTH,

--- a/backend/open_webui/test/util/test_oauth_auto_redirect.py
+++ b/backend/open_webui/test/util/test_oauth_auto_redirect.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _read_persistent_config(env_value):
+    """Spawn a fresh interpreter so SQLAlchemy's declarative base is not reloaded.
+
+    Returns a dict with keys: value, env_name, config_path.
+    """
+    script = (
+        'import json, sys; '
+        'from open_webui.config import OAUTH_AUTO_REDIRECT as c; '
+        "print(json.dumps({'value': c.value, 'env_name': c.env_name, 'config_path': c.config_path}))"
+    )
+    env = os.environ.copy()
+    env.pop('OAUTH_AUTO_REDIRECT', None)
+    if env_value is not None:
+        env['OAUTH_AUTO_REDIRECT'] = env_value
+    # Ensure the backend package is importable regardless of CWD.
+    backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    existing_path = env.get('PYTHONPATH', '')
+    env['PYTHONPATH'] = backend_dir + (os.pathsep + existing_path if existing_path else '')
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    import json
+
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestOAuthAutoRedirectConfig:
+    """OAUTH_AUTO_REDIRECT env var -> PersistentConfig wiring."""
+
+    def test_defaults_to_false_when_env_unset(self):
+        config = _read_persistent_config(None)
+        assert config['value'] is False
+
+    @pytest.mark.parametrize('truthy', ['true', 'True', 'TRUE'])
+    def test_truthy_env_values_enable_redirect(self, truthy):
+        config = _read_persistent_config(truthy)
+        assert config['value'] is True
+
+    @pytest.mark.parametrize('falsy', ['false', 'False', '0', '', 'yes', 'no'])
+    def test_non_true_env_values_keep_redirect_disabled(self, falsy):
+        config = _read_persistent_config(falsy)
+        assert config['value'] is False
+
+    def test_persistent_config_key_matches_oauth_namespace(self):
+        config = _read_persistent_config(None)
+        assert config['env_name'] == 'OAUTH_AUTO_REDIRECT'
+        assert config['config_path'] == 'oauth.auto_redirect'

--- a/backend/open_webui/test/util/test_oauth_auto_redirect_integration.py
+++ b/backend/open_webui/test/util/test_oauth_auto_redirect_integration.py
@@ -1,0 +1,122 @@
+"""Integration test for OAUTH_AUTO_REDIRECT through the real FastAPI app.
+
+Boots ``open_webui.main`` with an OIDC provider pointed at an in-process mock
+identity provider, then asserts at the HTTP layer that:
+
+  1. GET /api/config        exposes ``oauth.auto_redirect`` and the ``oidc``
+                            provider — i.e. the frontend can see the feature.
+  2. GET /oauth/oidc/login  redirects (302) to the IdP's authorize endpoint —
+                            i.e. the configured SSO entry point actually works.
+
+It runs in a subprocess so the OAuth/OIDC environment is set *before*
+``open_webui.config`` is imported — ``OAUTH_PROVIDERS`` is built at import time.
+
+The mock IdP only needs to serve the OpenID discovery document; ``handle_login``
+fetches that and builds the redirect without ever calling /authorize or /token.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def _probe() -> None:
+    """Runs in the subprocess: boot the app against a mock IdP and assert."""
+    import json
+    import shutil
+    import tempfile
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    issuer: dict = {}
+
+    class _DiscoveryHandler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # silence
+            return
+
+        def do_GET(self):
+            if self.path == '/.well-known/openid-configuration':
+                doc = json.dumps(
+                    {
+                        'issuer': issuer['url'],
+                        'authorization_endpoint': f'{issuer["url"]}/authorize',
+                        'token_endpoint': f'{issuer["url"]}/token',
+                        'jwks_uri': f'{issuer["url"]}/jwks',
+                        'userinfo_endpoint': f'{issuer["url"]}/userinfo',
+                        'response_types_supported': ['code'],
+                        'id_token_signing_alg_values_supported': ['RS256'],
+                        'scopes_supported': ['openid', 'email', 'profile'],
+                    }
+                ).encode()
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.send_header('Content-Length', str(len(doc)))
+                self.end_headers()
+                self.wfile.write(doc)
+            else:
+                self.send_response(404)
+                self.send_header('Content-Length', '0')
+                self.end_headers()
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), _DiscoveryHandler)
+    issuer['url'] = f'http://127.0.0.1:{server.server_address[1]}'
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    # Environment must be in place before open_webui.config is imported.
+    data_dir = tempfile.mkdtemp(prefix='owui-oidc-it-')
+    os.environ.update(
+        {
+            'DATA_DIR': data_dir,
+            'WEBUI_AUTH': 'true',
+            'WEBUI_SECRET_KEY': 'integration-test-secret',
+            'ENABLE_PERSISTENT_CONFIG': 'false',
+            'OAUTH_AUTO_REDIRECT': 'true',
+            'OAUTH_CLIENT_ID': 'integration-test',
+            'OAUTH_CLIENT_SECRET': 'integration-secret',
+            'OAUTH_PROVIDER_NAME': 'SSO',
+            'OPENID_PROVIDER_URL': f'{issuer["url"]}/.well-known/openid-configuration',
+            # Keep app boot offline/fast — irrelevant to the auth flow.
+            'RAG_EMBEDDING_ENGINE': 'ollama',
+            'HF_HUB_OFFLINE': '1',
+        }
+    )
+
+    from fastapi.testclient import TestClient
+    from open_webui.main import app
+
+    try:
+        with TestClient(app) as client:
+            config = client.get('/api/config').json()
+            oauth = config.get('oauth', {})
+            assert oauth.get('auto_redirect') is True, f'/api/config oauth.auto_redirect: {oauth}'
+            assert 'oidc' in oauth.get('providers', {}), f'/api/config oauth.providers: {oauth}'
+
+            resp = client.get('/oauth/oidc/login', follow_redirects=False)
+            assert resp.status_code in (302, 307), f'/oauth/oidc/login status: {resp.status_code}'
+            location = resp.headers.get('location', '')
+            assert location.startswith(f'{issuer["url"]}/authorize'), f'/oauth/oidc/login Location: {location}'
+    finally:
+        server.shutdown()
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+    print('OAUTH_AUTO_REDIRECT integration probe: OK')
+
+
+def test_oauth_auto_redirect_integration():
+    """Boot the app with a mock OIDC provider; verify config exposure + login redirect."""
+    backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    env = {**os.environ, 'PYTHONPATH': backend_dir + os.pathsep + os.environ.get('PYTHONPATH', '')}
+    result = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+    )
+    assert result.returncode == 0, f'integration probe failed\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}'
+    assert 'integration probe: OK' in result.stdout
+
+
+if __name__ == '__main__':
+    _probe()

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -276,6 +276,7 @@ type Document = {
 type Config = {
 	license_metadata: any;
 	status: boolean;
+	onboarding?: boolean;
 	name: string;
 	version: string;
 	default_locale: string;
@@ -305,6 +306,7 @@ type Config = {
 		providers: {
 			[key: string]: string;
 		};
+		auto_redirect: boolean;
 	};
 	ui?: {
 		pending_user_overlay_title?: string;

--- a/src/lib/utils/oauth.test.ts
+++ b/src/lib/utils/oauth.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+	getOAuthAutoRedirectPath,
+	type AutoRedirectConfig,
+	type AutoRedirectContext
+} from './oauth';
+
+// An unauthenticated first visit to /auth with no suppressing signals.
+const baseContext: AutoRedirectContext = {
+	isAuthenticated: false,
+	formParam: null,
+	errorParam: null,
+	hasTokenCookie: false,
+	hasLocalStorageToken: false
+};
+
+// The canonical SSO-only deployment: one provider, auto_redirect on.
+const ssoOnlyConfig: AutoRedirectConfig = {
+	oauth: { providers: { oidc: 'SSO' }, auto_redirect: true },
+	features: { auth: true, auth_trusted_header: false },
+	onboarding: false
+};
+
+describe('getOAuthAutoRedirectPath', () => {
+	it('redirects when one provider is configured and auto_redirect is on', () => {
+		expect(getOAuthAutoRedirectPath(ssoOnlyConfig, baseContext)).toBe('/oauth/oidc/login');
+	});
+
+	it('uses the configured provider key in the path', () => {
+		expect(
+			getOAuthAutoRedirectPath(
+				{ ...ssoOnlyConfig, oauth: { providers: { google: 'Google' }, auto_redirect: true } },
+				baseContext
+			)
+		).toBe('/oauth/google/login');
+	});
+
+	it('does not redirect when auto_redirect is off (default)', () => {
+		expect(
+			getOAuthAutoRedirectPath(
+				{ ...ssoOnlyConfig, oauth: { providers: { oidc: 'SSO' }, auto_redirect: false } },
+				baseContext
+			)
+		).toBeNull();
+	});
+
+	it('does not redirect when multiple providers are configured', () => {
+		expect(
+			getOAuthAutoRedirectPath(
+				{
+					...ssoOnlyConfig,
+					oauth: { providers: { google: 'Google', oidc: 'SSO' }, auto_redirect: true }
+				},
+				baseContext
+			)
+		).toBeNull();
+	});
+
+	it('does not redirect when no providers are configured', () => {
+		expect(
+			getOAuthAutoRedirectPath(
+				{ ...ssoOnlyConfig, oauth: { providers: {}, auto_redirect: true } },
+				baseContext
+			)
+		).toBeNull();
+	});
+
+	it('does not redirect when ?form= is present (escape hatch)', () => {
+		expect(
+			getOAuthAutoRedirectPath(ssoOnlyConfig, { ...baseContext, formParam: 'true' })
+		).toBeNull();
+	});
+
+	it('does not redirect when ?error= is present so the failure stays visible', () => {
+		expect(
+			getOAuthAutoRedirectPath(ssoOnlyConfig, {
+				...baseContext,
+				errorParam: 'Something went wrong'
+			})
+		).toBeNull();
+	});
+
+	it('does not redirect when the user is already authenticated', () => {
+		expect(
+			getOAuthAutoRedirectPath(ssoOnlyConfig, { ...baseContext, isAuthenticated: true })
+		).toBeNull();
+	});
+
+	it('does not redirect when a token cookie is present (OAuth callback in flight)', () => {
+		expect(
+			getOAuthAutoRedirectPath(ssoOnlyConfig, { ...baseContext, hasTokenCookie: true })
+		).toBeNull();
+	});
+
+	it('does not redirect when a localStorage token is present', () => {
+		expect(
+			getOAuthAutoRedirectPath(ssoOnlyConfig, { ...baseContext, hasLocalStorageToken: true })
+		).toBeNull();
+	});
+
+	it('does not redirect when auth is disabled', () => {
+		expect(
+			getOAuthAutoRedirectPath({ ...ssoOnlyConfig, features: { auth: false } }, baseContext)
+		).toBeNull();
+	});
+
+	it('does not redirect in trusted-header auth mode', () => {
+		expect(
+			getOAuthAutoRedirectPath(
+				{ ...ssoOnlyConfig, features: { auth: true, auth_trusted_header: true } },
+				baseContext
+			)
+		).toBeNull();
+	});
+
+	it('does not redirect during first-run onboarding', () => {
+		expect(
+			getOAuthAutoRedirectPath({ ...ssoOnlyConfig, onboarding: true }, baseContext)
+		).toBeNull();
+	});
+
+	it('does not redirect when config is missing', () => {
+		expect(getOAuthAutoRedirectPath(undefined, baseContext)).toBeNull();
+		expect(getOAuthAutoRedirectPath(null, baseContext)).toBeNull();
+	});
+});

--- a/src/lib/utils/oauth.ts
+++ b/src/lib/utils/oauth.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure decision logic for the OAUTH_AUTO_REDIRECT feature, kept out of the
+ * auth page's onMount so it can be unit-tested without a browser.
+ */
+
+/** The subset of the /api/config payload the auto-redirect decision reads. */
+export type AutoRedirectConfig = {
+	oauth?: {
+		providers?: Record<string, string>;
+		auto_redirect?: boolean;
+	};
+	features?: {
+		auth?: boolean;
+		auth_trusted_header?: boolean;
+	};
+	onboarding?: boolean;
+};
+
+/** Per-visit signals that should suppress the auto-redirect. */
+export type AutoRedirectContext = {
+	/** True when a user session already exists ($user !== undefined). */
+	isAuthenticated: boolean;
+	/** The ?form= query param — when present the user explicitly wants the form. */
+	formParam: string | null;
+	/** The ?error= query param — keep the page so the error toast stays visible. */
+	errorParam: string | null;
+	/** A `token` cookie is set (an OAuth callback is mid-flight). */
+	hasTokenCookie: boolean;
+	/** A token is in localStorage (already signed in locally). */
+	hasLocalStorageToken: boolean;
+};
+
+/**
+ * Returns the OAuth provider login path to redirect to from /auth, or null
+ * when the page should render normally.
+ *
+ * Redirects only when SSO is unambiguously the single intended entry point:
+ * OAUTH_AUTO_REDIRECT is on, exactly one OAuth provider is configured, auth is
+ * enabled, the visitor is unauthenticated, and nothing signals the form should
+ * be shown instead (?form=, ?error=, an in-flight/stored token, trusted-header
+ * auth, or first-run onboarding).
+ *
+ * The result is a root-relative path; callers prepend WEBUI_BASE_URL.
+ */
+export const getOAuthAutoRedirectPath = (
+	config: AutoRedirectConfig | null | undefined,
+	context: AutoRedirectContext
+): string | null => {
+	const providers = Object.keys(config?.oauth?.providers ?? {});
+
+	const shouldRedirect =
+		Boolean(config?.oauth?.auto_redirect) &&
+		config?.features?.auth !== false &&
+		providers.length === 1 &&
+		!context.isAuthenticated &&
+		!context.formParam &&
+		!context.errorParam &&
+		!context.hasTokenCookie &&
+		!context.hasLocalStorageToken &&
+		!(config?.features?.auth_trusted_header ?? false) &&
+		!(config?.onboarding ?? false);
+
+	return shouldRedirect ? `/oauth/${providers[0]}/login` : null;
+};

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -21,6 +21,7 @@
 	import { WEBUI_NAME, config, user, socket } from '$lib/stores';
 
 	import { generateInitialsImage, canvasPixelTest, getUserTimezone } from '$lib/utils';
+	import { getOAuthAutoRedirectPath } from '$lib/utils/oauth';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import OnBoarding from '$lib/components/OnBoarding.svelte';
@@ -183,13 +184,44 @@
 		await oauthCallbackHandler();
 		form = $page.url.searchParams.get('form');
 
+		let authConfig = $config;
+		if (!authConfig) {
+			try {
+				authConfig = await getBackendConfig();
+				if (authConfig) {
+					await config.set(authConfig);
+				}
+			} catch (configError) {
+				if ((configError as { authRedirect?: boolean })?.authRedirect) {
+					window.location.href = '/';
+					return;
+				}
+				console.error('Error loading backend config:', configError);
+			}
+		}
+
+		const autoRedirectPath = getOAuthAutoRedirectPath(authConfig, {
+			isAuthenticated: $user !== undefined,
+			formParam: form,
+			errorParam: error,
+			hasTokenCookie: document.cookie.split('; ').some((c) => c.startsWith('token=')),
+			hasLocalStorageToken: Boolean(localStorage.token)
+		});
+		if (autoRedirectPath) {
+			window.location.href = `${WEBUI_BASE_URL}${autoRedirectPath}`;
+			return;
+		}
+
 		loaded = true;
 		setLogoImage();
 
-		if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) {
+		if (
+			(authConfig?.features?.auth_trusted_header ?? false) ||
+			authConfig?.features?.auth === false
+		) {
 			await signInHandler();
 		} else {
-			onboarding = $config?.onboarding ?? false;
+			onboarding = authConfig?.onboarding ?? false;
 		}
 	});
 </script>


### PR DESCRIPTION
## Description

Adds an `OAUTH_AUTO_REDIRECT` environment variable. When enabled **and exactly one OAuth provider is configured**, an unauthenticated visit to `/auth` is redirected straight to that provider's login — removing the extra `Continue with <provider>` click on an otherwise SSO-only login page.

Escape hatch: `/auth?form=true` always renders the local login form, so administrators keep password access if the IdP is unavailable. The redirect is also suppressed after a failed sign-in (`/auth?error=...`), for an already-authenticated session, when a token is present, during first-run onboarding, and under trusted-header auth.

**Why a setting and not a smart default:** auto-redirect cannot be defaulted on — that would break every deployment that uses the local login form or has multiple providers, and would silently change behavior for existing installs. It is therefore opt-in (`Default: False`). The community has requested exactly this opt-in variable across several threads.

Relates to #24421, #7337, #8167, #11612.

## Implementation

- **Backend:** `OAUTH_AUTO_REDIRECT` config variable (`config.py`), wired into `app.state.config` and exposed as `oauth.auto_redirect` in `/api/config` (`main.py`).
- **Frontend:** the redirect decision is a pure function (`src/lib/utils/oauth.ts`) called from the auth page's `onMount`; it redirects to `/oauth/{provider}/login` only when every guard passes.

No new dependencies.

## Documentation

Companion docs PR: open-webui/docs#1260

## Testing

- **Manual:** verified end-to-end in a container — `/auth` redirects to the provider and completes login via the callback; `/auth?form=true` shows the local form; `/auth?error=` keeps the page and surfaces the error.
- **vitest:** `src/lib/utils/oauth.test.ts` covers every guard branch of the redirect decision (runs in the existing `npm run test:frontend` job).
- **pytest:** `test_oauth_auto_redirect.py` (env var to config wiring) and `test_oauth_auto_redirect_integration.py` (boots the app against an in-process mock OIDC provider; asserts `/api/config` exposes `oauth.auto_redirect` and `/oauth/oidc/login` redirects to the IdP).

# Changelog Entry

### Added

- 🔀 **Auto-redirect to SSO.** New `OAUTH_AUTO_REDIRECT` environment variable: when enabled with a single configured OAuth provider, an unauthenticated visit to `/auth` redirects straight to the provider, removing the extra "Continue with" click. Visit `/auth?form=true` to reach the local login form.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.