### PR TITLE
fix: prevent orphaned knowledge files by ensuring atomic upload-process-link chain

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1234,6 +1234,21 @@ async def add_files_to_knowledge_batch(
                     detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
                 )
 
+    # Link all files to the knowledge base FIRST, then process.
+    # This prevents the race condition where a user navigates away before the
+    # final linking step completes, leaving processed files orphaned in the
+    # vector database with no corresponding relational record.
+    linked_file_ids = []
+    try:
+        for file_id in file_ids:
+            await Knowledges.add_file_to_knowledge_by_id(
+                knowledge_id=id, file_id=file_id, user_id=user.id, db=db
+            )
+            linked_file_ids.append(file_id)
+    except Exception as e:
+        log.error(f'add_files_to_knowledge_batch: Failed to link files: {e}', exc_info=True)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     # Process files
     try:
         result = await process_files_batch(
@@ -1243,13 +1258,20 @@ async def add_files_to_knowledge_batch(
             db=db,
         )
     except Exception as e:
+        # Processing failed — rollback all links
+        for file_id in linked_file_ids:
+            await Knowledges.remove_file_from_knowledge_by_id(
+                knowledge_id=id, file_id=file_id, db=db
+            )
         log.error(f'add_files_to_knowledge_batch: Exception occurred: {e}', exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
-    # Only add files that were successfully processed
-    successful_file_ids = [r.file_id for r in result.results if r.status == 'completed']
-    for file_id in successful_file_ids:
-        await Knowledges.add_file_to_knowledge_by_id(knowledge_id=id, file_id=file_id, user_id=user.id, db=db)
+    # Unlink any files that failed to process
+    for file_id in linked_file_ids:
+        if file_id not in {r.file_id for r in result.results if r.status == 'completed'}:
+            await Knowledges.remove_file_from_knowledge_by_id(
+                knowledge_id=id, file_id=file_id, db=db
+            )
 
     # If there were any errors, include them in the response
     if result.errors:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #24807`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** fix: Bug fixes or corrections

Closes #24807

## Description

**Root cause**: Knowledge upload pipeline did linking AFTER processing.
If user navigated away during the slow embedding step (5-60s), files
were orphaned in the vector DB with no relational record.

**Fix** (applied to both endpoints):
- `add_file_to_knowledge_by_id`: Link file to knowledge base FIRST,
  then process. If processing fails, rollback the link.
- `add_files_to_knowledge_batch`: Link all files FIRST, then process.
  If processing fails, rollback all links. After processing, unlink
  any files that failed.

## Changelog

### Fixed

- Prevent orphaned knowledge files by ensuring atomic upload-process-link chain

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.