### PR TITLE
docs: fix stray space before period in README troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Encountering connection issues? Our [Open WebUI Documentation](https://docs.open
 
 #### Open WebUI: Server Connection Error
 
-If you're experiencing connection issues, it’s often due to the WebUI docker container not being able to reach the Ollama server at 127.0.0.1:11434 (host.docker.internal:11434) inside the container . Use the `--network=host` flag in your docker command to resolve this. Note that the port changes from 3000 to 8080, resulting in the link: `http://localhost:8080`.
+If you're experiencing connection issues, it’s often due to the WebUI docker container not being able to reach the Ollama server at 127.0.0.1:11434 (host.docker.internal:11434) inside the container. Use the `--network=host` flag in your docker command to resolve this. Note that the port changes from 3000 to 8080, resulting in the link: `http://localhost:8080`.
 
 **Example Docker Command**:
 


### PR DESCRIPTION
## Summary

Removes a stray space between the word "container" and the period in the
"Open WebUI: Server Connection Error" section of the README.

## Change

`README.md`, line 181:

- Before: `inside the container .`
- After:  `inside the container.`

## Type of Change

- [x] Documentation update (typo / formatting)

## Testing

No code changes — Markdown rendering is unaffected. Visually verified
that the surrounding text is unchanged.

## Checklist

- [x] My change targets `main`
- [x] My change is limited to a single, scoped fix
- [x] Commit message follows Conventional Commits (`docs:`)
- [x] I agree to the project's Contributor License Agreement