### PR TITLE
docs: fix stray space before period in README troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Encountering connection issues? Our [Open WebUI Documentation](https://docs.open
 
 #### Open WebUI: Server Connection Error
 
-If you're experiencing connection issues, it’s often due to the WebUI docker container not being able to reach the Ollama server at 127.0.0.1:11434 (host.docker.internal:11434) inside the container . Use the `--network=host` flag in your docker command to resolve this. Note that the port changes from 3000 to 8080, resulting in the link: `http://localhost:8080`.
+If you're experiencing connection issues, it’s often due to the WebUI docker container not being able to reach the Ollama server at 127.0.0.1:11434 (host.docker.internal:11434) inside the container. Use the `--network=host` flag in your docker command to resolve this. Note that the port changes from 3000 to 8080, resulting in the link: `http://localhost:8080`.
 
 **Example Docker Command**:
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This is a single-character documentation typo fix (an extra space before a period). Opening a separate Issue or Discussion for a 1-character correction felt excessive, but happy to open one if maintainers prefer.
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** A concise description is included below.
- [x] **Changelog:** Entry added below under `Fixed`.
- [x] **Documentation:** No external docs change needed; this is a typo fix in `README.md`.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Visually inspected the rendered Markdown — surrounding text and formatting are unchanged.
- [x] **Agentic AI Code:** Disclosure — this fix was prepared with AI assistance, then reviewed and explicitly approved by the repository owner of the contributor account before submission. The change is a 1-character documentation correction with no logic impact.
- [x] **Code review:** Self-reviewed; the diff is a single-character whitespace removal.
- [x] **Design & Architecture:** N/A — documentation typo.
- [x] **Git Hygiene:** Single atomic commit on a fresh branch off `upstream/dev`.
- [x] **Title Prefix:** `docs:`

# Changelog Entry

### Description

- Removes a stray space between the word "container" and the period in the "Open WebUI: Server Connection Error" troubleshooting section of the `README.md`.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Stray space before period in the README troubleshooting section (`inside the container .` → `inside the container.`).

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- File: `README.md`, line 181, section `#### Open WebUI: Server Connection Error`.
- Diff: 1 insertion, 1 deletion.

### Screenshots or Videos

- Not applicable for whitespace-only Markdown change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
