### PR TITLE
perf: reduce heavy chat rendering work

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"format:backend": "ruff format . --exclude .venv --exclude venv",
 		"i18n:parse": "i18next --config i18next-parser.config.ts && prettier --write \"src/lib/i18n/**/*.{js,json}\"",
 		"cy:open": "cypress open",
-		"test:frontend": "vitest --passWithNoTests",
+		"test:frontend": "vitest run --passWithNoTests",
 		"pyodide:fetch": "node scripts/prepare-pyodide.js"
 	},
 	"devDependencies": {

--- a/scripts/renderer-stress-cases.mjs
+++ b/scripts/renderer-stress-cases.mjs
@@ -1,0 +1,237 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const APPROX_CHARS_PER_CONTEXT_TOKEN = 4;
+export const TARGET_LONG_CONTEXT_TOKENS = 1_000_000;
+export const TARGET_LONG_CHAT_CHARS = TARGET_LONG_CONTEXT_TOKENS * APPROX_CHARS_PER_CONTEXT_TOKEN;
+
+const WORDS =
+	'alpha beta gamma delta epsilon zeta eta theta markdown renderer tool call browser context'.split(
+		' '
+	);
+
+const escapeAttr = (value) => {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('"', '&quot;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;');
+};
+
+const paragraph = (idx) => {
+	const words = Array.from({ length: 80 }, (_, wordIdx) => WORDS[(idx + wordIdx) % WORDS.length]);
+	return `### Section ${idx}
+
+${words.join(' ')}.
+
+- [ ] task ${idx}.1
+- [x] task ${idx}.2
+- item ${idx}.3 with \`inline_code_${idx}\`
+
+> quoted markdown with **strong**, _emphasis_, and a [link](https://example.com/${idx}).
+`;
+};
+
+const codeBlock = (idx, lines = 120) => {
+	const body = Array.from({ length: lines }, (_, line) => {
+		return `const value_${idx}_${line} = ${line}; if (value_${idx}_${line} % 7 === 0) console.log("row", value_${idx}_${line});`;
+	}).join('\n');
+
+	return `\n\`\`\`javascript\n${body}\n\`\`\`\n`;
+};
+
+const pythonBlock = (idx, lines = 80) => {
+	const body = Array.from({ length: lines }, (_, line) => {
+		return `value_${idx}_${line} = ${line}\nif value_${idx}_${line} % 5 == 0:\n    print("row", value_${idx}_${line})`;
+	}).join('\n');
+
+	return `\n\`\`\`python\n${body}\n\`\`\`\n`;
+};
+
+const resultRows = (idx, rows = 160) => {
+	return Array.from({ length: rows }, (_, row) => ({
+		row,
+		id: `tool-${idx}-${row}`,
+		title: `Result ${idx}.${row}`,
+		body: 'abcdefghijklmnopqrstuvwxyz '.repeat(6),
+		nested: {
+			score: row / (idx + 1),
+			flags: ['markdown', 'tool_calls', 'long_context', row % 2 ? 'odd' : 'even']
+		}
+	}));
+};
+
+const toolCall = (idx, { rows = 160, done = true, embeds = false } = {}) => {
+	const args = escapeAttr(
+		JSON.stringify({
+			query: `stress renderer tool call ${idx}`,
+			limit: rows,
+			filters: ['markdown', 'tool_calls', 'browser_perf'],
+			nested: {
+				include_code: idx % 2 === 0,
+				include_tables: true,
+				cursor: `cursor-${idx}`
+			}
+		})
+	);
+	const attrs = [
+		'type="tool_calls"',
+		`name="stress_tool_${idx % 11}"`,
+		`arguments="${args}"`,
+		`done="${done ? 'true' : 'false'}"`
+	];
+
+	if (embeds) {
+		attrs.push(
+			`embeds="${escapeAttr(
+				JSON.stringify([{ type: 'iframe', url: 'https://example.com/embed', name: `embed-${idx}` }])
+			)}"`
+		);
+	}
+
+	const result = done
+		? JSON.stringify({ id: idx, rows: resultRows(idx, rows), summary: paragraph(idx) }, null, 2)
+		: '';
+
+	return `<details ${attrs.join(' ')}>
+<summary>Tool call ${idx}</summary>
+${result}
+</details>`;
+};
+
+const markdownKitchenSink = () => {
+	return `# Markdown Kitchen Sink
+
+Text with **bold**, _italic_, ~~strikethrough~~, \`inline code\`, autolinks, and escaped HTML.
+
+| Browser | Renderer path | Expected pressure |
+| --- | --- | --- |
+| Chromium | V8 + DOM | syntax highlighting and layout |
+| Firefox | SpiderMonkey + DOM | parser and DOM churn |
+| Tor Browser | hardened Firefox ESR | JS and DOM work under slower privacy settings |
+
+1. ordered item
+2. ordered item with nested unordered content
+3. ordered item with a long inline segment ${'0123456789 '.repeat(20)}
+
+<details>
+<summary>Regular non-tool details</summary>
+
+${paragraph(7)}
+
+</details>
+
+![image alt](https://example.com/image.png)
+
+${codeBlock(1, 80)}
+
+${pythonBlock(2, 60)}
+
+\`\`\`mermaid
+flowchart TD
+  A[Start] --> B{Renderer}
+  B --> C[Markdown]
+  B --> D[Tool calls]
+\`\`\`
+
+\`\`\`json
+${JSON.stringify({ json: true, rows: resultRows(3, 8) }, null, 2)}
+\`\`\`
+`;
+};
+
+const buildLongChat = (targetChars) => {
+	const chunks = [];
+	let idx = 0;
+	let size = 0;
+
+	while (size < targetChars) {
+		const chunk =
+			paragraph(idx) +
+			(idx % 5 === 0 ? codeBlock(idx, 35) : '') +
+			(idx % 7 === 0 ? toolCall(idx, { rows: 24 }) : '');
+		chunks.push(chunk);
+		size += chunk.length;
+		idx += 1;
+	}
+
+	return chunks.join('\n\n');
+};
+
+export function createRendererStressCases({ longChatChars = TARGET_LONG_CHAT_CHARS } = {}) {
+	const cases = [
+		{
+			name: 'markdown-kitchen-sink',
+			done: true,
+			settings: { expandDetails: true, collapseCodeBlocks: false },
+			description: 'All common markdown constructs plus code, tables, images, details, and diagrams.',
+			content: markdownKitchenSink()
+		},
+		{
+			name: 'tool-calls-collapsed-heavy',
+			done: true,
+			settings: { expandDetails: false, collapseCodeBlocks: false },
+			description: 'Many completed tool calls with large JSON results kept collapsed.',
+			content: Array.from({ length: 160 }, (_, idx) => toolCall(idx, { rows: 120 })).join('\n\n')
+		},
+		{
+			name: 'tool-calls-expanded-heavy',
+			done: true,
+			settings: { expandDetails: true, collapseCodeBlocks: false },
+			description: 'Completed tool calls opened so result decoding and JSON formatting are hot.',
+			content: Array.from({ length: 48 }, (_, idx) => toolCall(idx, { rows: 220, embeds: true })).join(
+				'\n\n'
+			)
+		},
+		{
+			name: 'streaming-code-and-tools',
+			done: false,
+			settings: { expandDetails: false, collapseCodeBlocks: false },
+			description: 'Streaming response with long code blocks and in-flight tool calls.',
+			content:
+				Array.from({ length: 48 }, (_, idx) => codeBlock(idx, 120)).join('\n\n') +
+				Array.from({ length: 80 }, (_, idx) => toolCall(idx, { rows: 0, done: false })).join('\n\n')
+		},
+		{
+			name: 'mixed-long-chat-1m-context',
+			done: true,
+			settings: { expandDetails: false, collapseCodeBlocks: false },
+			description:
+				'Mixed markdown, code, and tool-call content grown to approximately 1M context tokens.',
+			content: buildLongChat(longChatChars)
+		}
+	];
+
+	return cases.map((testCase) => ({
+		...testCase,
+		characters: testCase.content.length,
+		approxContextTokens: Math.ceil(testCase.content.length / APPROX_CHARS_PER_CONTEXT_TOKEN)
+	}));
+}
+
+export function writeRendererStressCases(outputDir, options = {}) {
+	mkdirSync(outputDir, { recursive: true });
+	const cases = createRendererStressCases(options);
+	const manifest = cases.map(({ content, ...metadata }) => metadata);
+
+	writeFileSync(join(outputDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+	for (const testCase of cases) {
+		writeFileSync(join(outputDir, `${testCase.name}.md`), testCase.content);
+	}
+
+	return { cases, manifest };
+}
+
+const isCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCli) {
+	const outputDir = process.argv[2] ?? 'renderer-stress-cases';
+	const longChatChars = Number(
+		process.env.RENDERER_STRESS_LONG_CHARS ??
+			Number(process.env.RENDERER_STRESS_LONG_TOKENS ?? TARGET_LONG_CONTEXT_TOKENS) *
+				APPROX_CHARS_PER_CONTEXT_TOKEN
+	);
+	const { manifest } = writeRendererStressCases(outputDir, { longChatChars });
+	console.log(JSON.stringify(manifest, null, 2));
+}

--- a/scripts/renderer-stress-cases.test.mjs
+++ b/scripts/renderer-stress-cases.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { TARGET_LONG_CHAT_CHARS, createRendererStressCases } from './renderer-stress-cases.mjs';
+
+describe('renderer stress cases', () => {
+	it('covers markdown, collapsed tools, expanded tools, streaming, and long chat payloads', () => {
+		const cases = createRendererStressCases({ longChatChars: TARGET_LONG_CHAT_CHARS });
+		const byName = new Map(cases.map((testCase) => [testCase.name, testCase]));
+
+		expect(byName.has('markdown-kitchen-sink')).toBe(true);
+		expect(byName.has('tool-calls-collapsed-heavy')).toBe(true);
+		expect(byName.has('tool-calls-expanded-heavy')).toBe(true);
+		expect(byName.has('streaming-code-and-tools')).toBe(true);
+		expect(byName.has('mixed-long-chat-1m-context')).toBe(true);
+
+		expect(byName.get('mixed-long-chat-1m-context').characters).toBeGreaterThanOrEqual(
+			TARGET_LONG_CHAT_CHARS
+		);
+		expect(byName.get('mixed-long-chat-1m-context').approxContextTokens).toBeGreaterThanOrEqual(
+			1_000_000
+		);
+		expect(byName.get('streaming-code-and-tools').done).toBe(false);
+		expect(byName.get('tool-calls-expanded-heavy').settings.expandDetails).toBe(true);
+		expect(byName.get('tool-calls-collapsed-heavy').settings.expandDetails).toBe(false);
+	});
+
+	it('escapes tool-call attributes and preserves raw result content for parser stress', () => {
+		const cases = createRendererStressCases({ longChatChars: 20_000 });
+		const collapsedTools = cases.find((testCase) => testCase.name === 'tool-calls-collapsed-heavy');
+
+		expect(collapsedTools.content).toContain('type="tool_calls"');
+		expect(collapsedTools.content).toContain('arguments="{&quot;query&quot;');
+		expect(collapsedTools.content).toContain('"rows": [');
+		expect(collapsedTools.content).not.toContain('arguments="{"query"');
+	});
+});

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -180,6 +180,10 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let navigationRequestId = 0;
+	let hasChatMessages = false;
+
+	$: hasChatMessages = !!history?.currentId && !!history?.messages?.[history.currentId];
 
 	$: if (chatIdProp) {
 		navigateHandler();
@@ -192,14 +196,18 @@
 	}
 
 	const navigateHandler = async () => {
+		const targetChatId = chatIdProp;
+		const requestId = ++navigationRequestId;
+
 		// Mark the outgoing chat as read before loading the new one.
 		// $chatId still holds the previous chat here — loadChat() updates it.
-		if ($chatId && $chatId !== chatIdProp && !$temporaryChatEnabled) {
+		if ($chatId && $chatId !== targetChatId && !$temporaryChatEnabled) {
 			updateLastReadAt($chatId);
 		}
 
 		clearTimeout(saveControlsTimer);
 		await saveControls();
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
 		loading = true;
 
 		prompt = '';
@@ -212,10 +220,13 @@
 		imageGenerationEnabled = false;
 
 		const storageChatInput = sessionStorage.getItem(
-			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
+			`chat-input${targetChatId ? `-${targetChatId}` : ''}`
 		);
 
-		if (chatIdProp && (await loadChat())) {
+		const loaded = targetChatId ? await loadChat(targetChatId, requestId) : false;
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
+
+		if (targetChatId && loaded) {
 			await tick();
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
@@ -223,15 +234,15 @@
 			await tick();
 
 			// Mark chat read when initially loading it
-			if (chatIdProp && !$temporaryChatEnabled) {
-				updateLastReadAt(chatIdProp);
+			if (targetChatId && !$temporaryChatEnabled) {
+				updateLastReadAt(targetChatId);
 			}
 
 			// Process any queued requests if the chat is idle
 			const lastMessage = history.currentId ? history.messages[history.currentId] : null;
 			const isIdle = !lastMessage || lastMessage.role !== 'assistant' || lastMessage.done;
 			if (isIdle) {
-				await processNextInQueue(chatIdProp);
+				await processNextInQueue(targetChatId);
 			}
 
 			if (storageChatInput) {
@@ -465,7 +476,7 @@
 	};
 
 	const chatEventHandler = async (event, cb) => {
-		console.log(event);
+		if (import.meta.env.DEV) console.debug('chat event', event);
 
 		if (event.chat_id === $chatId) {
 			await tick();
@@ -1362,28 +1373,36 @@
 		setTimeout(() => chatInput?.focus(), 0);
 	};
 
-	const loadChat = async () => {
-		chatId.set(chatIdProp);
+	const loadChat = async (targetChatId = chatIdProp, requestId = navigationRequestId) => {
+		const isStale = () => requestId !== navigationRequestId || targetChatId !== chatIdProp;
+
+		chatId.set(targetChatId);
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);
 		}
 
-		chat = await getChatById(localStorage.token, $chatId).catch(async (error) => {
-			await goto('/');
+		const token = localStorage.token;
+		const chatPromise = getChatById(token, targetChatId).catch(async (error) => {
 			return null;
 		});
+		const tagsPromise = getTagsById(token, targetChatId).catch(async (error) => {
+			return [];
+		});
+		const pendingTaskIdsPromise = getTaskIdsByChatId(token, targetChatId)
+			.then((res) => res?.task_ids ?? [])
+			.catch(() => []);
+
+		chat = await chatPromise;
+		if (isStale()) return undefined;
 
 		if (chat) {
-			tags = await getTagsById(localStorage.token, $chatId).catch(async (error) => {
-				return [];
-			});
+			tags = await tagsPromise;
+			if (isStale()) return undefined;
 
 			const chatContent = chat.chat;
 
 			if (chatContent) {
-				console.log(chatContent);
-
 				selectedModels =
 					(chatContent?.models ?? undefined) !== undefined
 						? chatContent.models
@@ -1432,9 +1451,8 @@
 				// Reconcile active tasks with message state:
 				// If the response is already done, remaining tasks are just background
 				// work (follow-ups, title gen) that shouldn't block the input.
-				const pendingTaskIds = await getTaskIdsByChatId(localStorage.token, $chatId)
-					.then((res) => res?.task_ids ?? [])
-					.catch(() => []);
+				const pendingTaskIds = await pendingTaskIdsPromise;
+				if (isStale()) return undefined;
 				const currentMessage = history.currentId ? history.messages[history.currentId] : null;
 				const responseComplete = currentMessage?.role === 'assistant' && currentMessage?.done;
 
@@ -1452,9 +1470,11 @@
 
 				return true;
 			} else {
-				return null;
+				return false;
 			}
 		}
+
+		return false;
 	};
 
 	const scrollToBottom = async (behavior = 'auto') => {
@@ -3054,7 +3074,7 @@
 					/>
 
 					<div id="chat-pane" class="flex flex-col flex-auto z-10 w-full @container overflow-auto">
-						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || createMessagesList(history, history.currentId).length > 0}
+						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || hasChatMessages}
 							<div
 								class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10 scrollbar-hidden"
 								id="messages-container"

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -39,6 +39,7 @@
 	export let run = true;
 	export let preview = false;
 	export let collapsed = false;
+	export let done = true;
 
 	export let token;
 	export let lang = '';
@@ -65,7 +66,14 @@
 	let renderHTML = null;
 	let renderError = null;
 
-	let highlightedCode = null;
+	const HIGHLIGHT_CODE_MAX_LENGTH = 6000;
+
+	let highlightedCode = '';
+	let highlightedCodeSource = '';
+	let highlightedCodeLang = '';
+	let highlightedCodeDone = true;
+	let displayHighlightedCode = false;
+	let editingCode = false;
 	let executing = false;
 
 	let stdout = null;
@@ -85,6 +93,7 @@
 
 		code = _code;
 		onSave(code);
+		editingCode = false;
 
 		setTimeout(() => {
 			saved = false;
@@ -101,7 +110,56 @@
 	};
 
 	const previewCode = () => {
-		onPreview(code);
+		onPreview(editingCode ? _code : code);
+	};
+
+	const editCode = () => {
+		_code = code;
+		editingCode = true;
+	};
+
+	const cancelEditCode = () => {
+		_code = code;
+		editingCode = false;
+	};
+
+	const escapeHtml = (value = '') => {
+		return value
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	};
+
+	const updateHighlightedCode = () => {
+		const shouldHighlight = done && code.length <= HIGHLIGHT_CODE_MAX_LENGTH;
+		if (
+			code === highlightedCodeSource &&
+			lang === highlightedCodeLang &&
+			done === highlightedCodeDone &&
+			shouldHighlight === displayHighlightedCode
+		) {
+			return;
+		}
+
+		highlightedCodeSource = code;
+		highlightedCodeLang = lang;
+		highlightedCodeDone = done;
+		displayHighlightedCode = shouldHighlight;
+		if (!shouldHighlight) {
+			highlightedCode = '';
+			return;
+		}
+
+		try {
+			const language = hljs.getLanguage(lang) ? lang : null;
+			highlightedCode = language
+				? hljs.highlight(code, { language }).value
+				: hljs.highlightAuto(code).value;
+		} catch (error) {
+			highlightedCode = escapeHtml(code);
+		}
 	};
 
 	const checkPythonCode = (str) => {
@@ -401,6 +459,10 @@
 		render();
 	}
 
+	$: if (!collapsed && !editingCode && (code || lang || done !== undefined)) {
+		updateHighlightedCode();
+	}
+
 	$: if (attributes) {
 		onAttributesUpdate();
 	}
@@ -505,7 +567,25 @@
 						{/if}
 					{/if}
 
-					{#if save}
+					{#if edit}
+						{#if editingCode}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={cancelEditCode}
+							>
+								{$i18n.t('Cancel')}
+							</button>
+						{:else}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={editCode}
+							>
+								{$i18n.t('Edit')}
+							</button>
+						{/if}
+					{/if}
+
+					{#if save && (!edit || editingCode)}
 						<button
 							class="save-code-button bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
 							on:click={saveCode}
@@ -542,9 +622,9 @@
 				<div class=" pt-6.5 bg-white dark:bg-black"></div>
 
 				{#if !collapsed}
-					{#if edit}
+					{#if edit && editingCode}
 						<CodeEditor
-							value={code}
+							value={_code}
 							{id}
 							{lang}
 							onSave={() => {
@@ -563,8 +643,7 @@
 								result) &&
 								'border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;'}"><code
 								class="language-{lang} rounded-t-none whitespace-pre text-sm"
-								>{@html hljs.highlightAuto(code, hljs.getLanguage(lang)?.aliases).value ||
-									code}</code
+								>{#if displayHighlightedCode}{@html highlightedCode}{:else}{code}{/if}</code
 							></pre>
 					{/if}
 				{:else}

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -92,6 +92,8 @@
 	};
 
 	const getDetailTextContent = (token) => {
+		if (!token) return '';
+
 		return decode(token?.text || '')
 			.replace(/<summary>.*?<\/summary>/gi, '')
 			.trim();
@@ -163,6 +165,7 @@
 				{attributes}
 				{save}
 				{preview}
+				{done}
 				edit={editCodeBlock}
 				stickyButtonsClassName={topPadding ? 'top-10' : 'top-0'}
 				onSave={(value) => {
@@ -376,97 +379,101 @@
 		>
 			<div slot="content" class="space-y-1">
 				{#each token.items as detailToken, detailIdx}
-					{@const textContent = getDetailTextContent(detailToken)}
-
 					{#if detailToken?.attributes?.type === 'tool_calls'}
 						<ToolCallDisplay
 							id={`${id}-${tokenIdx}-${detailIdx}-tc`}
 							attributes={detailToken.attributes}
-							resultContent={getDetailTextContent(detailToken)}
+							resultContent={detailToken?.text ?? ''}
 							grouped={true}
 							open={$settings?.expandDetails ?? false}
 							className="w-full space-y-1"
 						/>
-					{:else if textContent.length > 0}
-						<Collapsible
-							title={detailToken.summary}
-							open={$settings?.expandDetails ?? false}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						>
-							<div class="mb-1.5" slot="content">
-								<svelte:self
-									id={`${id}-${tokenIdx}-${detailIdx}-d`}
-									tokens={marked.lexer(decode(detailToken.text))}
-									attributes={detailToken?.attributes}
-									{done}
-									{editCodeBlock}
-									{onTaskClick}
-									{sourceIds}
-									{onSourceClick}
-								/>
-							</div>
-						</Collapsible>
 					{:else}
-						<Collapsible
-							title={detailToken.summary}
-							open={false}
-							disabled={true}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						/>
+						{@const textContent = getDetailTextContent(detailToken)}
+
+						{#if textContent.length > 0}
+							<Collapsible
+								title={detailToken.summary}
+								open={$settings?.expandDetails ?? false}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							>
+								<div class="mb-1.5" slot="content">
+									<svelte:self
+										id={`${id}-${tokenIdx}-${detailIdx}-d`}
+										tokens={marked.lexer(decode(detailToken.text))}
+										attributes={detailToken?.attributes}
+										{done}
+										{editCodeBlock}
+										{onTaskClick}
+										{sourceIds}
+										{onSourceClick}
+									/>
+								</div>
+							</Collapsible>
+						{:else}
+							<Collapsible
+								title={detailToken.summary}
+								open={false}
+								disabled={true}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							/>
+						{/if}
 					{/if}
 				{/each}
 			</div>
 		</ConsecutiveDetailsGroup>
 	{:else if token.type === 'details'}
-		{@const textContent = getDetailTextContent(token)}
-
 		{#if token?.attributes?.type === 'tool_calls'}
 			<!-- Tool calls have dedicated handling with ToolCallDisplay component -->
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
-				resultContent={getDetailTextContent(token)}
+				resultContent={token?.text ?? ''}
 				open={$settings?.expandDetails ?? false}
 				className="w-full space-y-1"
 			/>
-		{:else if textContent.length > 0}
-			<Collapsible
-				title={token.summary}
-				open={$settings?.expandDetails ?? false}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			>
-				<div class=" mb-1.5" slot="content">
-					<svelte:self
-						id={`${id}-${tokenIdx}-d`}
-						tokens={marked.lexer(decode(token.text))}
-						attributes={token?.attributes}
-						{done}
-						{editCodeBlock}
-						{onTaskClick}
-						{sourceIds}
-						{onSourceClick}
-					/>
-				</div>
-			</Collapsible>
 		{:else}
-			<Collapsible
-				title={token.summary}
-				open={false}
-				disabled={true}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			/>
+			{@const textContent = getDetailTextContent(token)}
+
+			{#if textContent.length > 0}
+				<Collapsible
+					title={token.summary}
+					open={$settings?.expandDetails ?? false}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				>
+					<div class=" mb-1.5" slot="content">
+						<svelte:self
+							id={`${id}-${tokenIdx}-d`}
+							tokens={marked.lexer(decode(token.text))}
+							attributes={token?.attributes}
+							{done}
+							{editCodeBlock}
+							{onTaskClick}
+							{sourceIds}
+							{onSourceClick}
+						/>
+					</div>
+				</Collapsible>
+			{:else}
+				<Collapsible
+					title={token.summary}
+					open={false}
+					disabled={true}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				/>
+			{/if}
 		{/if}
 	{:else if token.type === 'html'}
 		<HtmlToken {id} {token} {onSourceClick} />

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -11,7 +11,6 @@
 	import ChevronUp from '../icons/ChevronUp.svelte';
 	import ChevronDown from '../icons/ChevronDown.svelte';
 	import Spinner from './Spinner.svelte';
-	import Markdown from '../chat/Messages/Markdown.svelte';
 	import WrenchSolid from '../icons/WrenchSolid.svelte';
 	import CheckCircle from '../icons/CheckCircle.svelte';
 	import Image from './Image.svelte';
@@ -35,6 +34,7 @@
 	export let className = '';
 
 	const RESULT_PREVIEW_LIMIT = 10000;
+	const TOOL_NAME_PLACEHOLDER = '__OPEN_WEBUI_TOOL_NAME__';
 	let expandedResult = false;
 
 	$: if (!open) expandedResult = false;
@@ -76,17 +76,78 @@
 		}
 	}
 
-	$: args = decode(attributes?.arguments ?? '');
+	function getToolLabelParts(label: string) {
+		const normalized = label.replaceAll(`**${TOOL_NAME_PLACEHOLDER}**`, TOOL_NAME_PLACEHOLDER);
+		const placeholderIndex = normalized.indexOf(TOOL_NAME_PLACEHOLDER);
+
+		if (placeholderIndex === -1) {
+			return { before: `${normalized} `, after: '' };
+		}
+
+		return {
+			before: normalized.slice(0, placeholderIndex),
+			after: normalized.slice(placeholderIndex + TOOL_NAME_PLACEHOLDER.length)
+		};
+	}
+
 	export let resultContent: string = '';
 
-	$: result = resultContent || decode(attributes?.result ?? '');
-	$: files = parseJSONString(decode(attributes?.files ?? ''));
-	$: embeds = parseJSONString(decode(attributes?.embeds ?? ''));
 	$: isDone = attributes?.done === 'true';
 	$: isExecuting = attributes?.done && attributes?.done !== 'true';
 
-	$: parsedArgs = parseArguments(args);
-	$: parsedResult = parseJSONString(result);
+	let args = '';
+	let parsedArgs: Record<string, unknown> | null = null;
+	let files: any = null;
+	let embeds: any = null;
+	let result = '';
+	let parsedResult: unknown = '';
+
+	let lastArguments = '';
+	let lastFiles = '';
+	let lastEmbeds = '';
+	let lastResultContent = '';
+	let lastAttributeResult = '';
+
+	const updateArgs = (nextArguments: string) => {
+		if (nextArguments === lastArguments) return;
+
+		lastArguments = nextArguments;
+		args = decode(nextArguments);
+		parsedArgs = parseArguments(args);
+	};
+
+	const updateFiles = (nextFiles: string) => {
+		if (nextFiles === lastFiles) return;
+
+		lastFiles = nextFiles;
+		files = nextFiles ? parseJSONString(decode(nextFiles)) : null;
+	};
+
+	const updateEmbeds = (nextEmbeds: string) => {
+		if (nextEmbeds === lastEmbeds) return;
+
+		lastEmbeds = nextEmbeds;
+		embeds = nextEmbeds ? parseJSONString(decode(nextEmbeds)) : null;
+	};
+
+	const updateResult = (nextResultContent: string, nextAttributeResult: string) => {
+		if (nextResultContent === lastResultContent && nextAttributeResult === lastAttributeResult) {
+			return;
+		}
+
+		lastResultContent = nextResultContent;
+		lastAttributeResult = nextAttributeResult;
+
+		result = nextResultContent ? decode(nextResultContent) : decode(nextAttributeResult);
+		parsedResult = parseJSONString(result);
+	};
+
+	$: updateArgs(attributes?.arguments ?? '');
+	$: updateFiles(isDone ? (attributes?.files ?? '') : '');
+	$: updateEmbeds(!grouped ? (attributes?.embeds ?? '') : '');
+	$: if (open && isDone) {
+		updateResult(resultContent ?? '', attributes?.result ?? '');
+	}
 </script>
 
 <div {id} class={className}>
@@ -145,19 +206,15 @@
 					<!-- Full label (md and above) -->
 					<span class="hidden @md:inline font-normal">
 						{#if isDone}
-							<Markdown
-								id={`${componentId}-tool-call-title`}
-								content={$i18n.t('View Result from **{{NAME}}**', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('View Result from **{{NAME}}**', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{:else}
-							<Markdown
-								id={`${componentId}-tool-call-executing`}
-								content={$i18n.t('Executing **{{NAME}}**...', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('Executing **{{NAME}}**...', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{/if}
 					</span>
 				</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -496,7 +496,7 @@
 				executeTool(data, cb, event.chat_id);
 				return;
 			} else if (type === 'request:chat:completion') {
-				console.log(data, $socket.id);
+				if (import.meta.env.DEV) console.debug('request:chat:completion', data, $socket.id);
 				const { session_id, channel, form_data, model } = data;
 
 				try {
@@ -531,7 +531,7 @@
 									cb({
 										status: true
 									});
-									console.log({ status: true });
+									if (import.meta.env.DEV) console.debug('chat completion stream started');
 
 									// res will either be SSE or JSON
 									const reader = res.body.getReader();
@@ -552,7 +552,7 @@
 											const lines = chunk.split('\n').filter((line) => line.trim() !== '');
 
 											for (const line of lines) {
-												console.log(line);
+												if (import.meta.env.DEV) console.debug('chat completion stream line', line);
 												$socket?.emit(channel, line);
 											}
 										}


### PR DESCRIPTION
## Summary
- Reduce expensive markdown/code/tool-call work during normal chat rendering.
- Add renderer stress fixtures for heavy markdown, tool calls, streaming code, and ~1M-context long chats.
- Parallelize independent chat-load probes and discard stale navigation loads to reduce high-latency stalls.

## Why
This targets pathological chat histories and high-latency browsers, including Tor Browser/Firefox-family sessions where repeated markdown parsing, eager CodeMirror mounts, and nested tool-call rendering can make chats feel frozen.

This PR was prepared by an autonomous AI coding agent at a user's request. Please review it as an ordinary external contribution; no maintainer affiliation is implied.

## Test Plan
- `git diff --check origin/dev...HEAD`
- Svelte compiler smoke checks for:
  - `src/lib/components/chat/Chat.svelte`
  - `src/routes/+layout.svelte`
  - `src/lib/components/chat/Messages/CodeBlock.svelte`
  - `src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte`
  - `src/lib/components/common/ToolCallDisplay.svelte`
- `npm run test:frontend`
- Built a local Open WebUI container image from this branch with `USE_SLIM=true` and verified `/health` on a live local deployment.

## Review Notes
- CodeMirror still mounts for edit mode; read-only code blocks use lighter rendering.
- Large or actively streaming code blocks intentionally skip the expensive highlight path.
- Tool-call payload parsing remains available, but is memoized and delayed so collapsed calls are cheaper.
