### PR TITLE
perf: reduce chat rendering stalls

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -180,6 +180,10 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let navigationRequestId = 0;
+	let hasChatMessages = false;
+
+	$: hasChatMessages = !!history?.currentId && !!history?.messages?.[history.currentId];
 
 	$: if (chatIdProp) {
 		navigateHandler();
@@ -192,14 +196,18 @@
 	}
 
 	const navigateHandler = async () => {
+		const targetChatId = chatIdProp;
+		const requestId = ++navigationRequestId;
+
 		// Mark the outgoing chat as read before loading the new one.
 		// $chatId still holds the previous chat here — loadChat() updates it.
-		if ($chatId && $chatId !== chatIdProp && !$temporaryChatEnabled) {
+		if ($chatId && $chatId !== targetChatId && !$temporaryChatEnabled) {
 			updateLastReadAt($chatId);
 		}
 
 		clearTimeout(saveControlsTimer);
 		await saveControls();
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
 		loading = true;
 
 		prompt = '';
@@ -212,10 +220,13 @@
 		imageGenerationEnabled = false;
 
 		const storageChatInput = sessionStorage.getItem(
-			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
+			`chat-input${targetChatId ? `-${targetChatId}` : ''}`
 		);
 
-		if (chatIdProp && (await loadChat())) {
+		const loaded = targetChatId ? await loadChat(targetChatId, requestId) : false;
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
+
+		if (targetChatId && loaded) {
 			await tick();
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
@@ -223,15 +234,15 @@
 			await tick();
 
 			// Mark chat read when initially loading it
-			if (chatIdProp && !$temporaryChatEnabled) {
-				updateLastReadAt(chatIdProp);
+			if (targetChatId && !$temporaryChatEnabled) {
+				updateLastReadAt(targetChatId);
 			}
 
 			// Process any queued requests if the chat is idle
 			const lastMessage = history.currentId ? history.messages[history.currentId] : null;
 			const isIdle = !lastMessage || lastMessage.role !== 'assistant' || lastMessage.done;
 			if (isIdle) {
-				await processNextInQueue(chatIdProp);
+				await processNextInQueue(targetChatId);
 			}
 
 			if (storageChatInput) {
@@ -465,8 +476,6 @@
 	};
 
 	const chatEventHandler = async (event, cb) => {
-		console.log(event);
-
 		if (event.chat_id === $chatId) {
 			await tick();
 			let message = history.messages[event.message_id];
@@ -1362,28 +1371,36 @@
 		setTimeout(() => chatInput?.focus(), 0);
 	};
 
-	const loadChat = async () => {
-		chatId.set(chatIdProp);
+	const loadChat = async (targetChatId = chatIdProp, requestId = navigationRequestId) => {
+		const isStale = () => requestId !== navigationRequestId || targetChatId !== chatIdProp;
+
+		chatId.set(targetChatId);
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);
 		}
 
-		chat = await getChatById(localStorage.token, $chatId).catch(async (error) => {
-			await goto('/');
+		const token = localStorage.token;
+		const chatPromise = getChatById(token, targetChatId).catch(() => {
 			return null;
 		});
+		const tagsPromise = getTagsById(token, targetChatId).catch(() => {
+			return [];
+		});
+		const pendingTaskIdsPromise = getTaskIdsByChatId(token, targetChatId)
+			.then((res) => res?.task_ids ?? [])
+			.catch(() => []);
+
+		chat = await chatPromise;
+		if (isStale()) return undefined;
 
 		if (chat) {
-			tags = await getTagsById(localStorage.token, $chatId).catch(async (error) => {
-				return [];
-			});
+			tags = await tagsPromise;
+			if (isStale()) return undefined;
 
 			const chatContent = chat.chat;
 
 			if (chatContent) {
-				console.log(chatContent);
-
 				selectedModels =
 					(chatContent?.models ?? undefined) !== undefined
 						? chatContent.models
@@ -1432,9 +1449,8 @@
 				// Reconcile active tasks with message state:
 				// If the response is already done, remaining tasks are just background
 				// work (follow-ups, title gen) that shouldn't block the input.
-				const pendingTaskIds = await getTaskIdsByChatId(localStorage.token, $chatId)
-					.then((res) => res?.task_ids ?? [])
-					.catch(() => []);
+				const pendingTaskIds = await pendingTaskIdsPromise;
+				if (isStale()) return undefined;
 				const currentMessage = history.currentId ? history.messages[history.currentId] : null;
 				const responseComplete = currentMessage?.role === 'assistant' && currentMessage?.done;
 
@@ -1452,9 +1468,11 @@
 
 				return true;
 			} else {
-				return null;
+				return false;
 			}
 		}
+
+		return false;
 	};
 
 	const scrollToBottom = async (behavior = 'auto') => {
@@ -3054,7 +3072,7 @@
 					/>
 
 					<div id="chat-pane" class="flex flex-col flex-auto z-10 w-full @container overflow-auto">
-						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || createMessagesList(history, history.currentId).length > 0}
+						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || hasChatMessages}
 							<div
 								class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10 scrollbar-hidden"
 								id="messages-container"

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -39,6 +39,7 @@
 	export let run = true;
 	export let preview = false;
 	export let collapsed = false;
+	export let done = true;
 
 	export let token;
 	export let lang = '';
@@ -65,7 +66,14 @@
 	let renderHTML = null;
 	let renderError = null;
 
-	let highlightedCode = null;
+	const HIGHLIGHT_CODE_MAX_LENGTH = 6000;
+
+	let highlightedCode = '';
+	let highlightedCodeSource = '';
+	let highlightedCodeLang = '';
+	let highlightedCodeDone = true;
+	let displayHighlightedCode = false;
+	let editingCode = false;
 	let executing = false;
 
 	let stdout = null;
@@ -85,6 +93,7 @@
 
 		code = _code;
 		onSave(code);
+		editingCode = false;
 
 		setTimeout(() => {
 			saved = false;
@@ -101,7 +110,56 @@
 	};
 
 	const previewCode = () => {
-		onPreview(code);
+		onPreview(editingCode ? _code : code);
+	};
+
+	const editCode = () => {
+		_code = code;
+		editingCode = true;
+	};
+
+	const cancelEditCode = () => {
+		_code = code;
+		editingCode = false;
+	};
+
+	const escapeHtml = (value = '') => {
+		return value
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	};
+
+	const updateHighlightedCode = () => {
+		const shouldHighlight = done && code.length <= HIGHLIGHT_CODE_MAX_LENGTH;
+		if (
+			code === highlightedCodeSource &&
+			lang === highlightedCodeLang &&
+			done === highlightedCodeDone &&
+			shouldHighlight === displayHighlightedCode
+		) {
+			return;
+		}
+
+		highlightedCodeSource = code;
+		highlightedCodeLang = lang;
+		highlightedCodeDone = done;
+		displayHighlightedCode = shouldHighlight;
+		if (!shouldHighlight) {
+			highlightedCode = '';
+			return;
+		}
+
+		try {
+			const language = hljs.getLanguage(lang) ? lang : null;
+			highlightedCode = language
+				? hljs.highlight(code, { language }).value
+				: hljs.highlightAuto(code).value;
+		} catch (error) {
+			highlightedCode = escapeHtml(code);
+		}
 	};
 
 	const checkPythonCode = (str) => {
@@ -401,6 +459,10 @@
 		render();
 	}
 
+	$: if (!collapsed && !editingCode && (code || lang || done !== undefined)) {
+		updateHighlightedCode();
+	}
+
 	$: if (attributes) {
 		onAttributesUpdate();
 	}
@@ -505,7 +567,25 @@
 						{/if}
 					{/if}
 
-					{#if save}
+					{#if edit}
+						{#if editingCode}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={cancelEditCode}
+							>
+								{$i18n.t('Cancel')}
+							</button>
+						{:else}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={editCode}
+							>
+								{$i18n.t('Edit')}
+							</button>
+						{/if}
+					{/if}
+
+					{#if save && (!edit || editingCode)}
 						<button
 							class="save-code-button bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
 							on:click={saveCode}
@@ -542,9 +622,9 @@
 				<div class=" pt-6.5 bg-white dark:bg-black"></div>
 
 				{#if !collapsed}
-					{#if edit}
+					{#if edit && editingCode}
 						<CodeEditor
-							value={code}
+							value={_code}
 							{id}
 							{lang}
 							onSave={() => {
@@ -563,8 +643,7 @@
 								result) &&
 								'border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;'}"><code
 								class="language-{lang} rounded-t-none whitespace-pre text-sm"
-								>{@html hljs.highlightAuto(code, hljs.getLanguage(lang)?.aliases).value ||
-									code}</code
+								>{#if displayHighlightedCode}{@html highlightedCode}{:else}{code}{/if}</code
 							></pre>
 					{/if}
 				{:else}

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -92,6 +92,8 @@
 	};
 
 	const getDetailTextContent = (token) => {
+		if (!token) return '';
+
 		return decode(token?.text || '')
 			.replace(/<summary>.*?<\/summary>/gi, '')
 			.trim();
@@ -163,6 +165,7 @@
 				{attributes}
 				{save}
 				{preview}
+				{done}
 				edit={editCodeBlock}
 				stickyButtonsClassName={topPadding ? 'top-10' : 'top-0'}
 				onSave={(value) => {
@@ -376,97 +379,101 @@
 		>
 			<div slot="content" class="space-y-1">
 				{#each token.items as detailToken, detailIdx}
-					{@const textContent = getDetailTextContent(detailToken)}
-
 					{#if detailToken?.attributes?.type === 'tool_calls'}
 						<ToolCallDisplay
 							id={`${id}-${tokenIdx}-${detailIdx}-tc`}
 							attributes={detailToken.attributes}
-							resultContent={getDetailTextContent(detailToken)}
+							resultContent={detailToken?.text ?? ''}
 							grouped={true}
 							open={$settings?.expandDetails ?? false}
 							className="w-full space-y-1"
 						/>
-					{:else if textContent.length > 0}
-						<Collapsible
-							title={detailToken.summary}
-							open={$settings?.expandDetails ?? false}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						>
-							<div class="mb-1.5" slot="content">
-								<svelte:self
-									id={`${id}-${tokenIdx}-${detailIdx}-d`}
-									tokens={marked.lexer(decode(detailToken.text))}
-									attributes={detailToken?.attributes}
-									{done}
-									{editCodeBlock}
-									{onTaskClick}
-									{sourceIds}
-									{onSourceClick}
-								/>
-							</div>
-						</Collapsible>
 					{:else}
-						<Collapsible
-							title={detailToken.summary}
-							open={false}
-							disabled={true}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						/>
+						{@const textContent = getDetailTextContent(detailToken)}
+
+						{#if textContent.length > 0}
+							<Collapsible
+								title={detailToken.summary}
+								open={$settings?.expandDetails ?? false}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							>
+								<div class="mb-1.5" slot="content">
+									<svelte:self
+										id={`${id}-${tokenIdx}-${detailIdx}-d`}
+										tokens={marked.lexer(decode(detailToken.text))}
+										attributes={detailToken?.attributes}
+										{done}
+										{editCodeBlock}
+										{onTaskClick}
+										{sourceIds}
+										{onSourceClick}
+									/>
+								</div>
+							</Collapsible>
+						{:else}
+							<Collapsible
+								title={detailToken.summary}
+								open={false}
+								disabled={true}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							/>
+						{/if}
 					{/if}
 				{/each}
 			</div>
 		</ConsecutiveDetailsGroup>
 	{:else if token.type === 'details'}
-		{@const textContent = getDetailTextContent(token)}
-
 		{#if token?.attributes?.type === 'tool_calls'}
 			<!-- Tool calls have dedicated handling with ToolCallDisplay component -->
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
-				resultContent={getDetailTextContent(token)}
+				resultContent={token?.text ?? ''}
 				open={$settings?.expandDetails ?? false}
 				className="w-full space-y-1"
 			/>
-		{:else if textContent.length > 0}
-			<Collapsible
-				title={token.summary}
-				open={$settings?.expandDetails ?? false}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			>
-				<div class=" mb-1.5" slot="content">
-					<svelte:self
-						id={`${id}-${tokenIdx}-d`}
-						tokens={marked.lexer(decode(token.text))}
-						attributes={token?.attributes}
-						{done}
-						{editCodeBlock}
-						{onTaskClick}
-						{sourceIds}
-						{onSourceClick}
-					/>
-				</div>
-			</Collapsible>
 		{:else}
-			<Collapsible
-				title={token.summary}
-				open={false}
-				disabled={true}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			/>
+			{@const textContent = getDetailTextContent(token)}
+
+			{#if textContent.length > 0}
+				<Collapsible
+					title={token.summary}
+					open={$settings?.expandDetails ?? false}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				>
+					<div class=" mb-1.5" slot="content">
+						<svelte:self
+							id={`${id}-${tokenIdx}-d`}
+							tokens={marked.lexer(decode(token.text))}
+							attributes={token?.attributes}
+							{done}
+							{editCodeBlock}
+							{onTaskClick}
+							{sourceIds}
+							{onSourceClick}
+						/>
+					</div>
+				</Collapsible>
+			{:else}
+				<Collapsible
+					title={token.summary}
+					open={false}
+					disabled={true}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				/>
+			{/if}
 		{/if}
 	{:else if token.type === 'html'}
 		<HtmlToken {id} {token} {onSourceClick} />

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -11,7 +11,6 @@
 	import ChevronUp from '../icons/ChevronUp.svelte';
 	import ChevronDown from '../icons/ChevronDown.svelte';
 	import Spinner from './Spinner.svelte';
-	import Markdown from '../chat/Messages/Markdown.svelte';
 	import WrenchSolid from '../icons/WrenchSolid.svelte';
 	import CheckCircle from '../icons/CheckCircle.svelte';
 	import Image from './Image.svelte';
@@ -35,6 +34,7 @@
 	export let className = '';
 
 	const RESULT_PREVIEW_LIMIT = 10000;
+	const TOOL_NAME_PLACEHOLDER = '__OPEN_WEBUI_TOOL_NAME__';
 	let expandedResult = false;
 
 	$: if (!open) expandedResult = false;
@@ -76,17 +76,78 @@
 		}
 	}
 
-	$: args = decode(attributes?.arguments ?? '');
+	function getToolLabelParts(label: string) {
+		const normalized = label.replaceAll(`**${TOOL_NAME_PLACEHOLDER}**`, TOOL_NAME_PLACEHOLDER);
+		const placeholderIndex = normalized.indexOf(TOOL_NAME_PLACEHOLDER);
+
+		if (placeholderIndex === -1) {
+			return { before: `${normalized} `, after: '' };
+		}
+
+		return {
+			before: normalized.slice(0, placeholderIndex),
+			after: normalized.slice(placeholderIndex + TOOL_NAME_PLACEHOLDER.length)
+		};
+	}
+
 	export let resultContent: string = '';
 
-	$: result = resultContent || decode(attributes?.result ?? '');
-	$: files = parseJSONString(decode(attributes?.files ?? ''));
-	$: embeds = parseJSONString(decode(attributes?.embeds ?? ''));
 	$: isDone = attributes?.done === 'true';
 	$: isExecuting = attributes?.done && attributes?.done !== 'true';
 
-	$: parsedArgs = parseArguments(args);
-	$: parsedResult = parseJSONString(result);
+	let args = '';
+	let parsedArgs: Record<string, unknown> | null = null;
+	let files: any = null;
+	let embeds: any = null;
+	let result = '';
+	let parsedResult: unknown = '';
+
+	let lastArguments = '';
+	let lastFiles = '';
+	let lastEmbeds = '';
+	let lastResultContent = '';
+	let lastAttributeResult = '';
+
+	const updateArgs = (nextArguments: string) => {
+		if (nextArguments === lastArguments) return;
+
+		lastArguments = nextArguments;
+		args = decode(nextArguments);
+		parsedArgs = parseArguments(args);
+	};
+
+	const updateFiles = (nextFiles: string) => {
+		if (nextFiles === lastFiles) return;
+
+		lastFiles = nextFiles;
+		files = nextFiles ? parseJSONString(decode(nextFiles)) : null;
+	};
+
+	const updateEmbeds = (nextEmbeds: string) => {
+		if (nextEmbeds === lastEmbeds) return;
+
+		lastEmbeds = nextEmbeds;
+		embeds = nextEmbeds ? parseJSONString(decode(nextEmbeds)) : null;
+	};
+
+	const updateResult = (nextResultContent: string, nextAttributeResult: string) => {
+		if (nextResultContent === lastResultContent && nextAttributeResult === lastAttributeResult) {
+			return;
+		}
+
+		lastResultContent = nextResultContent;
+		lastAttributeResult = nextAttributeResult;
+
+		result = nextResultContent ? decode(nextResultContent) : decode(nextAttributeResult);
+		parsedResult = parseJSONString(result);
+	};
+
+	$: updateArgs(attributes?.arguments ?? '');
+	$: updateFiles(isDone ? (attributes?.files ?? '') : '');
+	$: updateEmbeds(!grouped ? (attributes?.embeds ?? '') : '');
+	$: if (open && isDone) {
+		updateResult(resultContent ?? '', attributes?.result ?? '');
+	}
 </script>
 
 <div {id} class={className}>
@@ -145,19 +206,15 @@
 					<!-- Full label (md and above) -->
 					<span class="hidden @md:inline font-normal">
 						{#if isDone}
-							<Markdown
-								id={`${componentId}-tool-call-title`}
-								content={$i18n.t('View Result from **{{NAME}}**', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('View Result from **{{NAME}}**', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{:else}
-							<Markdown
-								id={`${componentId}-tool-call-executing`}
-								content={$i18n.t('Executing **{{NAME}}**...', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('Executing **{{NAME}}**...', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{/if}
 					</span>
 				</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -495,9 +495,8 @@
 				console.log('execute:tool', data);
 				executeTool(data, cb, event.chat_id);
 				return;
-			} else if (type === 'request:chat:completion') {
-				console.log(data, $socket.id);
-				const { session_id, channel, form_data, model } = data;
+				} else if (type === 'request:chat:completion') {
+					const { session_id, channel, form_data, model } = data;
 
 				try {
 					const directConnections = $settings?.directConnections ?? {};
@@ -531,7 +530,6 @@
 									cb({
 										status: true
 									});
-									console.log({ status: true });
 
 									// res will either be SSE or JSON
 									const reader = res.body.getReader();
@@ -552,7 +550,6 @@
 											const lines = chunk.split('\n').filter((line) => line.trim() !== '');
 
 											for (const line of lines) {
-												console.log(line);
 												$socket?.emit(channel, line);
 											}
 										}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #24949`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the listed prefixes.

# Changelog Entry

### Description

- Reduce heavy chat rendering work for markdown, code blocks, tool-call displays, and high-latency chat navigation.

### Added

- None.

### Changed

- Code blocks mount CodeMirror only when editing, and use lighter rendering for large or streaming blocks.
- Tool-call display work is memoized and delayed so collapsed calls avoid nested markdown parsing and eager result decoding.
- Chat loading parallelizes independent metadata probes and discards stale navigation loads.
- Removed noisy chat-path console logging from hot streaming and navigation paths.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Reduced UI stalls caused by eager markdown/highlighting/tool-call work in large chat histories and high-latency browser sessions.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

This PR supersedes #24952 after maintainer feedback. It removes the committed stress-test files and package-script change, leaving only the implementation changes.

This PR was prepared by an autonomous AI coding agent at a user's request, then manually reviewed and tested before marking the checklist item above. Please review it as an ordinary external contribution; no maintainer affiliation is implied.

Validation performed on the cleaned branch:

- `git diff --check origin/dev...HEAD`
- Svelte compiler smoke checks for:
  - `src/lib/components/chat/Chat.svelte`
  - `src/routes/+layout.svelte`
  - `src/lib/components/chat/Messages/CodeBlock.svelte`
  - `src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte`
  - `src/lib/components/common/ToolCallDisplay.svelte`
- `npx vitest run --passWithNoTests`
- Changed-file secret scan over the PR diff.
- Manual local Open WebUI load check in Chromium via Playwright: sign-in page loaded with title `Open WebUI`, no console errors.
