### PR TITLE
fix: consistent conversation bubble sizes with YAML code blocks

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -412,7 +412,7 @@
 									{/if}
 								</Name>
 
-								<div class="mt-1 markdown-prose w-full min-w-full">
+								<div class="mt-1 markdown-prose w-full min-w-0">
 									{#if (message?.content ?? '') === ''}
 										<Skeleton />
 									{:else}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -693,7 +693,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -199,7 +199,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div


### PR DESCRIPTION
## Summary

Fixes #5975 — In widescreen chat bubble mode, YAML code blocks caused conversation bubbles to resize inconsistently when scrolling.

## Root Cause

The message content containers used `min-w-full`, which forced them to be at least the full width of their parent. When code blocks (especially YAML) rendered with varying content widths, this caused the bubble to expand and contract inconsistently during scroll as elements entered/left the viewport.

## Fix

Replace `min-w-full` with `min-w-0` on the markdown-prose wrapper divs in:
- `ResponseMessage.svelte`
- `UserMessage.svelte`
- `MultiResponseMessages.svelte`

`min-w-0` is the standard fix for preventing flex/grid children from overflowing their container. It allows the content to shrink below its intrinsic minimum width, so code blocks use `overflow-x: auto` (already present) instead of pushing the bubble wider.

## Testing

- Verified with YAML code blocks in widescreen + chat bubble mode
- Bubble widths remain stable while scrolling
- No visual regression for normal text messages