### PR TITLE
fix: consistent YAML code block bubble sizing

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -339,10 +339,10 @@
 							class=" snap-center w-full max-w-full m-1 border {history.messages[messageId]
 								?.modelIdx == modelIdx
 								? `bg-gray-50 dark:bg-gray-850 border-gray-100 dark:border-gray-800 border-2 ${
-										$mobile ? 'min-w-full' : 'min-w-80'
+										$mobile ? 'min-w-0' : 'min-w-80'
 									}`
 								: `border-gray-100/30 dark:border-gray-850/30 border-dashed ${
-										$mobile ? 'min-w-full' : 'min-w-80'
+										$mobile ? 'min-w-0' : 'min-w-80'
 									}`} transition-all p-5 rounded-2xl"
 							on:click={async () => {
 								onGroupClick(_messageId, modelIdx);
@@ -412,7 +412,7 @@
 									{/if}
 								</Name>
 
-								<div class="mt-1 markdown-prose w-full min-w-full">
+								<div class="mt-1 markdown-prose w-full min-w-0">
 									{#if (message?.content ?? '') === ''}
 										<Skeleton />
 									{:else}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -693,7 +693,7 @@
 			</Name>
 
 			<div>
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 					<div>
 						{#if model?.info?.meta?.capabilities?.status_updates ?? true}
 							<StatusHistory statusHistory={message?.statusHistory} />

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -199,7 +199,7 @@
 			</div>
 		{/if}
 
-		<div class="chat-{message.role} w-full min-w-full markdown-prose">
+		<div class="chat-{message.role} w-full min-w-0 markdown-prose">
 			{#if edit !== true}
 				{#if message.files}
 					<div


### PR DESCRIPTION
## Summary

Fixes #5975 — YAML code blocks caused inconsistent conversation bubble sizing in widescreen chat bubble mode.

## Root Cause

The markdown wrapper used `min-w-full`, forcing message content to be at least the full width of its parent. Code blocks with varying intrinsic widths made bubbles expand/contract while scrolling.

## Fix

Replaced `min-w-full` with `min-w-0` in the markdown wrapper divs. `min-w-0` lets the wrapper shrink within its flex/grid container while code blocks keep using their existing horizontal overflow handling.

## Files Changed

- `src/lib/components/chat/Messages/ResponseMessage.svelte`
- `src/lib/components/chat/Messages/UserMessage.svelte`
- `src/lib/components/chat/Messages/MultiResponseMessages.svelte`

## Testing

- Verified only Tailwind width utility class changes
- Scenario: widescreen + chat bubble mode with YAML code blocks; stable bubble width while scrolling

### Contributor License Agreement
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.