### PR TITLE
fix(markdown): keep structural details out of prose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,12 @@ ARG GID=0
 ######## WebUI frontend ########
 FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
+ARG BUILD_NODE_OPTIONS=""
+ARG BUILD_SOURCEMAP=true
 
 # Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
 # ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS=${BUILD_NODE_OPTIONS}
 
 WORKDIR /app
 
@@ -40,6 +43,7 @@ RUN npm ci --force
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
+ENV VITE_BUILD_SOURCEMAP=${BUILD_SOURCEMAP}
 RUN npm run build
 
 ######## WebUI backend ########

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -180,6 +180,10 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let navigationRequestId = 0;
+	let hasChatMessages = false;
+
+	$: hasChatMessages = !!history?.currentId && !!history?.messages?.[history.currentId];
 
 	$: if (chatIdProp) {
 		navigateHandler();
@@ -192,14 +196,18 @@
 	}
 
 	const navigateHandler = async () => {
+		const targetChatId = chatIdProp;
+		const requestId = ++navigationRequestId;
+
 		// Mark the outgoing chat as read before loading the new one.
 		// $chatId still holds the previous chat here — loadChat() updates it.
-		if ($chatId && $chatId !== chatIdProp && !$temporaryChatEnabled) {
+		if ($chatId && $chatId !== targetChatId && !$temporaryChatEnabled) {
 			updateLastReadAt($chatId);
 		}
 
 		clearTimeout(saveControlsTimer);
 		await saveControls();
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
 		loading = true;
 
 		prompt = '';
@@ -212,10 +220,13 @@
 		imageGenerationEnabled = false;
 
 		const storageChatInput = sessionStorage.getItem(
-			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
+			`chat-input${targetChatId ? `-${targetChatId}` : ''}`
 		);
 
-		if (chatIdProp && (await loadChat())) {
+		const loaded = targetChatId ? await loadChat(targetChatId, requestId) : false;
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
+
+		if (targetChatId && loaded) {
 			await tick();
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
@@ -223,15 +234,15 @@
 			await tick();
 
 			// Mark chat read when initially loading it
-			if (chatIdProp && !$temporaryChatEnabled) {
-				updateLastReadAt(chatIdProp);
+			if (targetChatId && !$temporaryChatEnabled) {
+				updateLastReadAt(targetChatId);
 			}
 
 			// Process any queued requests if the chat is idle
 			const lastMessage = history.currentId ? history.messages[history.currentId] : null;
 			const isIdle = !lastMessage || lastMessage.role !== 'assistant' || lastMessage.done;
 			if (isIdle) {
-				await processNextInQueue(chatIdProp);
+				await processNextInQueue(targetChatId);
 			}
 
 			if (storageChatInput) {
@@ -465,8 +476,6 @@
 	};
 
 	const chatEventHandler = async (event, cb) => {
-		console.log(event);
-
 		if (event.chat_id === $chatId) {
 			await tick();
 			let message = history.messages[event.message_id];
@@ -1362,28 +1371,36 @@
 		setTimeout(() => chatInput?.focus(), 0);
 	};
 
-	const loadChat = async () => {
-		chatId.set(chatIdProp);
+	const loadChat = async (targetChatId = chatIdProp, requestId = navigationRequestId) => {
+		const isStale = () => requestId !== navigationRequestId || targetChatId !== chatIdProp;
+
+		chatId.set(targetChatId);
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);
 		}
 
-		chat = await getChatById(localStorage.token, $chatId).catch(async (error) => {
-			await goto('/');
+		const token = localStorage.token;
+		const chatPromise = getChatById(token, targetChatId).catch(() => {
 			return null;
 		});
+		const tagsPromise = getTagsById(token, targetChatId).catch(() => {
+			return [];
+		});
+		const pendingTaskIdsPromise = getTaskIdsByChatId(token, targetChatId)
+			.then((res) => res?.task_ids ?? [])
+			.catch(() => []);
+
+		chat = await chatPromise;
+		if (isStale()) return undefined;
 
 		if (chat) {
-			tags = await getTagsById(localStorage.token, $chatId).catch(async (error) => {
-				return [];
-			});
+			tags = await tagsPromise;
+			if (isStale()) return undefined;
 
 			const chatContent = chat.chat;
 
 			if (chatContent) {
-				console.log(chatContent);
-
 				selectedModels =
 					(chatContent?.models ?? undefined) !== undefined
 						? chatContent.models
@@ -1432,9 +1449,8 @@
 				// Reconcile active tasks with message state:
 				// If the response is already done, remaining tasks are just background
 				// work (follow-ups, title gen) that shouldn't block the input.
-				const pendingTaskIds = await getTaskIdsByChatId(localStorage.token, $chatId)
-					.then((res) => res?.task_ids ?? [])
-					.catch(() => []);
+				const pendingTaskIds = await pendingTaskIdsPromise;
+				if (isStale()) return undefined;
 				const currentMessage = history.currentId ? history.messages[history.currentId] : null;
 				const responseComplete = currentMessage?.role === 'assistant' && currentMessage?.done;
 
@@ -1452,9 +1468,11 @@
 
 				return true;
 			} else {
-				return null;
+				return false;
 			}
 		}
+
+		return false;
 	};
 
 	const scrollToBottom = async (behavior = 'auto') => {
@@ -3054,7 +3072,7 @@
 					/>
 
 					<div id="chat-pane" class="flex flex-col flex-auto z-10 w-full @container overflow-auto">
-						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || createMessagesList(history, history.currentId).length > 0}
+						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || hasChatMessages}
 							<div
 								class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10 scrollbar-hidden"
 								id="messages-container"

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -192,23 +192,34 @@
 	let saveControlsTimer;
 	$: if (!loading && !$temporaryChatEnabled && $chatId && params && chatFiles) {
 		clearTimeout(saveControlsTimer);
-		saveControlsTimer = setTimeout(saveControls, 400);
+		saveControlsTimer = setTimeout(() => saveControls(), 400);
 	}
 
 	const navigateHandler = async () => {
 		const targetChatId = chatIdProp;
 		const requestId = ++navigationRequestId;
+		const outgoingChatId = $chatId;
+		const outgoingParams = params;
+		const outgoingChatFiles = chatFiles;
 
 		// Mark the outgoing chat as read before loading the new one.
 		// $chatId still holds the previous chat here — loadChat() updates it.
-		if ($chatId && $chatId !== targetChatId && !$temporaryChatEnabled) {
-			updateLastReadAt($chatId);
+		if (outgoingChatId && outgoingChatId !== targetChatId && !$temporaryChatEnabled) {
+			updateLastReadAt(outgoingChatId);
 		}
 
 		clearTimeout(saveControlsTimer);
-		await saveControls();
-		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
 		loading = true;
+		chatId.set(targetChatId);
+		chatTitle.set('');
+		history = { messages: {}, currentId: null };
+
+		if (outgoingChatId && !$temporaryChatEnabled) {
+			saveControls(outgoingChatId, outgoingParams, outgoingChatFiles);
+		}
+
+		await tick();
+		if (requestId !== navigationRequestId || targetChatId !== chatIdProp) return;
 
 		prompt = '';
 		messageInput?.setText('');
@@ -2838,11 +2849,16 @@
 		}
 	};
 
-	const saveControls = async () => {
-		if (!$chatId || $temporaryChatEnabled) return;
-		await updateChatById(localStorage.token, $chatId, { params, files: chatFiles }).catch((err) =>
-			console.error('[controls autosave]', err)
-		);
+	const saveControls = async (
+		targetChatId: string = $chatId,
+		targetParams = params,
+		targetChatFiles = chatFiles
+	) => {
+		if (!targetChatId || $temporaryChatEnabled) return;
+		await updateChatById(localStorage.token, targetChatId, {
+			params: targetParams,
+			files: targetChatFiles
+		}).catch((err) => console.error('[controls autosave]', err));
 	};
 
 	const MAX_DRAFT_LENGTH = 5000;

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -20,10 +20,7 @@
 	import CodeEditor from '$lib/components/common/CodeEditor.svelte';
 	import SvgPanZoom from '$lib/components/common/SVGPanZoom.svelte';
 
-	import ChevronUp from '$lib/components/icons/ChevronUp.svelte';
 	import ChevronUpDown from '$lib/components/icons/ChevronUpDown.svelte';
-	import CommandLine from '$lib/components/icons/CommandLine.svelte';
-	import Cube from '$lib/components/icons/Cube.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
 	const i18n = getContext('i18n');
@@ -39,6 +36,7 @@
 	export let run = true;
 	export let preview = false;
 	export let collapsed = false;
+	export let done = true;
 
 	export let token;
 	export let lang = '';
@@ -65,7 +63,14 @@
 	let renderHTML = null;
 	let renderError = null;
 
-	let highlightedCode = null;
+	const HIGHLIGHT_CODE_MAX_LENGTH = 6000;
+
+	let highlightedCode = '';
+	let highlightedCodeSource = '';
+	let highlightedCodeLang = '';
+	let highlightedCodeDone = true;
+	let displayHighlightedCode = false;
+	let editingCode = false;
 	let executing = false;
 
 	let stdout = null;
@@ -85,6 +90,7 @@
 
 		code = _code;
 		onSave(code);
+		editingCode = false;
 
 		setTimeout(() => {
 			saved = false;
@@ -101,7 +107,56 @@
 	};
 
 	const previewCode = () => {
-		onPreview(code);
+		onPreview(editingCode ? _code : code);
+	};
+
+	const editCode = () => {
+		_code = code;
+		editingCode = true;
+	};
+
+	const cancelEditCode = () => {
+		_code = code;
+		editingCode = false;
+	};
+
+	const escapeHtml = (value = '') => {
+		return value
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+	};
+
+	const updateHighlightedCode = (nextCode: string, nextLang: string, nextDone: boolean) => {
+		const shouldHighlight = nextDone && nextCode.length <= HIGHLIGHT_CODE_MAX_LENGTH;
+		if (
+			nextCode === highlightedCodeSource &&
+			nextLang === highlightedCodeLang &&
+			nextDone === highlightedCodeDone &&
+			shouldHighlight === displayHighlightedCode
+		) {
+			return;
+		}
+
+		highlightedCodeSource = nextCode;
+		highlightedCodeLang = nextLang;
+		highlightedCodeDone = nextDone;
+		displayHighlightedCode = shouldHighlight;
+		if (!shouldHighlight) {
+			highlightedCode = '';
+			return;
+		}
+
+		try {
+			const language = hljs.getLanguage(nextLang) ? nextLang : null;
+			highlightedCode = language
+				? hljs.highlight(nextCode, { language }).value
+				: hljs.highlightAuto(nextCode).value;
+		} catch (error) {
+			highlightedCode = escapeHtml(nextCode);
+		}
 	};
 
 	const checkPythonCode = (str) => {
@@ -401,6 +456,10 @@
 		render();
 	}
 
+	$: if (!collapsed && !editingCode) {
+		updateHighlightedCode(code, lang, done);
+	}
+
 	$: if (attributes) {
 		onAttributesUpdate();
 	}
@@ -505,7 +564,25 @@
 						{/if}
 					{/if}
 
-					{#if save}
+					{#if edit}
+						{#if editingCode}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={cancelEditCode}
+							>
+								{$i18n.t('Cancel')}
+							</button>
+						{:else}
+							<button
+								class="bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
+								on:click={editCode}
+							>
+								{$i18n.t('Edit')}
+							</button>
+						{/if}
+					{/if}
+
+					{#if save && (!edit || editingCode)}
 						<button
 							class="save-code-button bg-none border-none transition rounded-md px-1.5 py-0.5 bg-white dark:bg-black"
 							on:click={saveCode}
@@ -542,9 +619,9 @@
 				<div class=" pt-6.5 bg-white dark:bg-black"></div>
 
 				{#if !collapsed}
-					{#if edit}
+					{#if edit && editingCode}
 						<CodeEditor
-							value={code}
+							value={_code}
 							{id}
 							{lang}
 							onSave={() => {
@@ -563,8 +640,7 @@
 								result) &&
 								'border-bottom-left-radius: 0px; border-bottom-right-radius: 0px;'}"><code
 								class="language-{lang} rounded-t-none whitespace-pre text-sm"
-								>{@html hljs.highlightAuto(code, hljs.getLanguage(lang)?.aliases).value ||
-									code}</code
+								>{#if displayHighlightedCode}{@html highlightedCode}{:else}{code}{/if}</code
 							></pre>
 					{/if}
 				{:else}

--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -9,6 +9,7 @@
 	import { disableSingleTilde } from '$lib/utils/marked/strikethrough-extension';
 	import { mentionExtension } from '$lib/utils/marked/mention-extension';
 	import colonFenceExtension from '$lib/utils/marked/colon-fence-extension';
+	import { normalizeStructuralDetailsBlocks } from '$lib/utils/marked/details-normalization';
 
 	import MarkdownTokens from './Markdown/MarkdownTokens.svelte';
 	import footnoteExtension from '$lib/utils/marked/footnote-extension';
@@ -64,7 +65,9 @@
 		if (content === lastContent) return;
 		lastContent = content;
 
-		const processed = replaceTokens(processResponseContent(content), model?.name, $user?.name);
+		const processed = normalizeStructuralDetailsBlocks(
+			replaceTokens(processResponseContent(content), model?.name, $user?.name)
+		);
 		if (processed === lastParsedContent) return;
 		lastParsedContent = processed;
 

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -92,6 +92,8 @@
 	};
 
 	const getDetailTextContent = (token) => {
+		if (!token) return '';
+
 		return decode(token?.text || '')
 			.replace(/<summary>.*?<\/summary>/gi, '')
 			.trim();
@@ -163,6 +165,7 @@
 				{attributes}
 				{save}
 				{preview}
+				{done}
 				edit={editCodeBlock}
 				stickyButtonsClassName={topPadding ? 'top-10' : 'top-0'}
 				onSave={(value) => {
@@ -376,97 +379,101 @@
 		>
 			<div slot="content" class="space-y-1">
 				{#each token.items as detailToken, detailIdx}
-					{@const textContent = getDetailTextContent(detailToken)}
-
 					{#if detailToken?.attributes?.type === 'tool_calls'}
 						<ToolCallDisplay
 							id={`${id}-${tokenIdx}-${detailIdx}-tc`}
 							attributes={detailToken.attributes}
-							resultContent={getDetailTextContent(detailToken)}
+							resultContent={detailToken?.text ?? ''}
 							grouped={true}
 							open={$settings?.expandDetails ?? false}
 							className="w-full space-y-1"
 						/>
-					{:else if textContent.length > 0}
-						<Collapsible
-							title={detailToken.summary}
-							open={$settings?.expandDetails ?? false}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						>
-							<div class="mb-1.5" slot="content">
-								<svelte:self
-									id={`${id}-${tokenIdx}-${detailIdx}-d`}
-									tokens={marked.lexer(decode(detailToken.text))}
-									attributes={detailToken?.attributes}
-									{done}
-									{editCodeBlock}
-									{onTaskClick}
-									{sourceIds}
-									{onSourceClick}
-								/>
-							</div>
-						</Collapsible>
 					{:else}
-						<Collapsible
-							title={detailToken.summary}
-							open={false}
-							disabled={true}
-							attributes={detailToken?.attributes}
-							messageDone={done}
-							className="w-full space-y-1"
-							dir="auto"
-						/>
+						{@const textContent = getDetailTextContent(detailToken)}
+
+						{#if textContent.length > 0}
+							<Collapsible
+								title={detailToken.summary}
+								open={$settings?.expandDetails ?? false}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							>
+								<div class="mb-1.5" slot="content">
+									<svelte:self
+										id={`${id}-${tokenIdx}-${detailIdx}-d`}
+										tokens={marked.lexer(decode(detailToken.text))}
+										attributes={detailToken?.attributes}
+										{done}
+										{editCodeBlock}
+										{onTaskClick}
+										{sourceIds}
+										{onSourceClick}
+									/>
+								</div>
+							</Collapsible>
+						{:else}
+							<Collapsible
+								title={detailToken.summary}
+								open={false}
+								disabled={true}
+								attributes={detailToken?.attributes}
+								messageDone={done}
+								className="w-full space-y-1"
+								dir="auto"
+							/>
+						{/if}
 					{/if}
 				{/each}
 			</div>
 		</ConsecutiveDetailsGroup>
 	{:else if token.type === 'details'}
-		{@const textContent = getDetailTextContent(token)}
-
 		{#if token?.attributes?.type === 'tool_calls'}
 			<!-- Tool calls have dedicated handling with ToolCallDisplay component -->
 			<ToolCallDisplay
 				id={`${id}-${tokenIdx}-tc`}
 				attributes={token.attributes}
-				resultContent={getDetailTextContent(token)}
+				resultContent={token?.text ?? ''}
 				open={$settings?.expandDetails ?? false}
 				className="w-full space-y-1"
 			/>
-		{:else if textContent.length > 0}
-			<Collapsible
-				title={token.summary}
-				open={$settings?.expandDetails ?? false}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			>
-				<div class=" mb-1.5" slot="content">
-					<svelte:self
-						id={`${id}-${tokenIdx}-d`}
-						tokens={marked.lexer(decode(token.text))}
-						attributes={token?.attributes}
-						{done}
-						{editCodeBlock}
-						{onTaskClick}
-						{sourceIds}
-						{onSourceClick}
-					/>
-				</div>
-			</Collapsible>
 		{:else}
-			<Collapsible
-				title={token.summary}
-				open={false}
-				disabled={true}
-				attributes={token?.attributes}
-				messageDone={done}
-				className="w-full space-y-1"
-				dir="auto"
-			/>
+			{@const textContent = getDetailTextContent(token)}
+
+			{#if textContent.length > 0}
+				<Collapsible
+					title={token.summary}
+					open={$settings?.expandDetails ?? false}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				>
+					<div class=" mb-1.5" slot="content">
+						<svelte:self
+							id={`${id}-${tokenIdx}-d`}
+							tokens={marked.lexer(decode(token.text))}
+							attributes={token?.attributes}
+							{done}
+							{editCodeBlock}
+							{onTaskClick}
+							{sourceIds}
+							{onSourceClick}
+						/>
+					</div>
+				</Collapsible>
+			{:else}
+				<Collapsible
+					title={token.summary}
+					open={false}
+					disabled={true}
+					attributes={token?.attributes}
+					messageDone={done}
+					className="w-full space-y-1"
+					dir="auto"
+				/>
+			{/if}
 		{/if}
 	{:else if token.type === 'html'}
 		<HtmlToken {id} {token} {onSourceClick} />

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -99,6 +99,16 @@
 			.trim();
 	};
 
+	const hasDetailTextContent = (token) => {
+		if (!token) return false;
+
+		return (token?.text || '').replace(/<summary>.*?<\/summary>/gi, '').trim().length > 0;
+	};
+
+	const isPlainTextDetailToken = (token) => {
+		return ['reasoning', 'code_interpreter'].includes(token?.attributes?.type ?? '');
+	};
+
 	$: displayTokens = getDisplayTokens(tokens);
 
 	const exportTableToCSVHandler = (token, tokenIdx = 0) => {
@@ -389,9 +399,9 @@
 							className="w-full space-y-1"
 						/>
 					{:else}
-						{@const textContent = getDetailTextContent(detailToken)}
+						{@const hasTextContent = hasDetailTextContent(detailToken)}
 
-						{#if textContent.length > 0}
+						{#if hasTextContent}
 							<Collapsible
 								title={detailToken.summary}
 								open={$settings?.expandDetails ?? false}
@@ -401,16 +411,25 @@
 								dir="auto"
 							>
 								<div class="mb-1.5" slot="content">
-									<svelte:self
-										id={`${id}-${tokenIdx}-${detailIdx}-d`}
-										tokens={marked.lexer(decode(detailToken.text))}
-										attributes={detailToken?.attributes}
-										{done}
-										{editCodeBlock}
-										{onTaskClick}
-										{sourceIds}
-										{onSourceClick}
-									/>
+									{#if isPlainTextDetailToken(detailToken)}
+										{@const textContent = getDetailTextContent(detailToken)}
+										<div
+											class="whitespace-pre-wrap break-words text-sm text-gray-700 dark:text-gray-300"
+										>
+											{textContent}
+										</div>
+									{:else}
+										<svelte:self
+											id={`${id}-${tokenIdx}-${detailIdx}-d`}
+											tokens={marked.lexer(decode(detailToken.text))}
+											attributes={detailToken?.attributes}
+											{done}
+											{editCodeBlock}
+											{onTaskClick}
+											{sourceIds}
+											{onSourceClick}
+										/>
+									{/if}
 								</div>
 							</Collapsible>
 						{:else}
@@ -439,9 +458,9 @@
 				className="w-full space-y-1"
 			/>
 		{:else}
-			{@const textContent = getDetailTextContent(token)}
+			{@const hasTextContent = hasDetailTextContent(token)}
 
-			{#if textContent.length > 0}
+			{#if hasTextContent}
 				<Collapsible
 					title={token.summary}
 					open={$settings?.expandDetails ?? false}
@@ -451,16 +470,23 @@
 					dir="auto"
 				>
 					<div class=" mb-1.5" slot="content">
-						<svelte:self
-							id={`${id}-${tokenIdx}-d`}
-							tokens={marked.lexer(decode(token.text))}
-							attributes={token?.attributes}
-							{done}
-							{editCodeBlock}
-							{onTaskClick}
-							{sourceIds}
-							{onSourceClick}
-						/>
+						{#if isPlainTextDetailToken(token)}
+							{@const textContent = getDetailTextContent(token)}
+							<div class="whitespace-pre-wrap break-words text-sm text-gray-700 dark:text-gray-300">
+								{textContent}
+							</div>
+						{:else}
+							<svelte:self
+								id={`${id}-${tokenIdx}-d`}
+								tokens={marked.lexer(decode(token.text))}
+								attributes={token?.attributes}
+								{done}
+								{editCodeBlock}
+								{onTaskClick}
+								{sourceIds}
+								{onSourceClick}
+							/>
+						{/if}
 					</div>
 				</Collapsible>
 			{:else}

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -11,7 +11,6 @@
 	import ChevronUp from '../icons/ChevronUp.svelte';
 	import ChevronDown from '../icons/ChevronDown.svelte';
 	import Spinner from './Spinner.svelte';
-	import Markdown from '../chat/Messages/Markdown.svelte';
 	import WrenchSolid from '../icons/WrenchSolid.svelte';
 	import CheckCircle from '../icons/CheckCircle.svelte';
 	import Image from './Image.svelte';
@@ -35,6 +34,7 @@
 	export let className = '';
 
 	const RESULT_PREVIEW_LIMIT = 10000;
+	const TOOL_NAME_PLACEHOLDER = '__OPEN_WEBUI_TOOL_NAME__';
 	let expandedResult = false;
 
 	$: if (!open) expandedResult = false;
@@ -76,17 +76,78 @@
 		}
 	}
 
-	$: args = decode(attributes?.arguments ?? '');
+	function getToolLabelParts(label: string) {
+		const normalized = label.replaceAll(`**${TOOL_NAME_PLACEHOLDER}**`, TOOL_NAME_PLACEHOLDER);
+		const placeholderIndex = normalized.indexOf(TOOL_NAME_PLACEHOLDER);
+
+		if (placeholderIndex === -1) {
+			return { before: `${normalized} `, after: '' };
+		}
+
+		return {
+			before: normalized.slice(0, placeholderIndex),
+			after: normalized.slice(placeholderIndex + TOOL_NAME_PLACEHOLDER.length)
+		};
+	}
+
 	export let resultContent: string = '';
 
-	$: result = resultContent || decode(attributes?.result ?? '');
-	$: files = parseJSONString(decode(attributes?.files ?? ''));
-	$: embeds = parseJSONString(decode(attributes?.embeds ?? ''));
 	$: isDone = attributes?.done === 'true';
 	$: isExecuting = attributes?.done && attributes?.done !== 'true';
 
-	$: parsedArgs = parseArguments(args);
-	$: parsedResult = parseJSONString(result);
+	let args = '';
+	let parsedArgs: Record<string, unknown> | null = null;
+	let files: any = null;
+	let embeds: any = null;
+	let result = '';
+	let parsedResult: unknown = '';
+
+	let lastArguments = '';
+	let lastFiles = '';
+	let lastEmbeds = '';
+	let lastResultContent = '';
+	let lastAttributeResult = '';
+
+	const updateArgs = (nextArguments: string) => {
+		if (nextArguments === lastArguments) return;
+
+		lastArguments = nextArguments;
+		args = decode(nextArguments);
+		parsedArgs = parseArguments(args);
+	};
+
+	const updateFiles = (nextFiles: string) => {
+		if (nextFiles === lastFiles) return;
+
+		lastFiles = nextFiles;
+		files = nextFiles ? parseJSONString(decode(nextFiles)) : null;
+	};
+
+	const updateEmbeds = (nextEmbeds: string) => {
+		if (nextEmbeds === lastEmbeds) return;
+
+		lastEmbeds = nextEmbeds;
+		embeds = nextEmbeds ? parseJSONString(decode(nextEmbeds)) : null;
+	};
+
+	const updateResult = (nextResultContent: string, nextAttributeResult: string) => {
+		if (nextResultContent === lastResultContent && nextAttributeResult === lastAttributeResult) {
+			return;
+		}
+
+		lastResultContent = nextResultContent;
+		lastAttributeResult = nextAttributeResult;
+
+		result = nextResultContent ? decode(nextResultContent) : decode(nextAttributeResult);
+		parsedResult = parseJSONString(result);
+	};
+
+	$: updateArgs(attributes?.arguments ?? '');
+	$: updateFiles(isDone ? (attributes?.files ?? '') : '');
+	$: updateEmbeds(!grouped ? (attributes?.embeds ?? '') : '');
+	$: if (open && isDone) {
+		updateResult(resultContent ?? '', attributes?.result ?? '');
+	}
 </script>
 
 <div {id} class={className}>
@@ -145,19 +206,15 @@
 					<!-- Full label (md and above) -->
 					<span class="hidden @md:inline font-normal">
 						{#if isDone}
-							<Markdown
-								id={`${componentId}-tool-call-title`}
-								content={$i18n.t('View Result from **{{NAME}}**', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('View Result from **{{NAME}}**', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{:else}
-							<Markdown
-								id={`${componentId}-tool-call-executing`}
-								content={$i18n.t('Executing **{{NAME}}**...', {
-									NAME: attributes.name
-								})}
-							/>
+							{@const label = getToolLabelParts(
+								$i18n.t('Executing **{{NAME}}**...', { NAME: TOOL_NAME_PLACEHOLDER })
+							)}
+							{label.before}<strong>{attributes.name}</strong>{label.after}
 						{/if}
 					</span>
 				</div>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -290,19 +290,19 @@
 		allChatsLoaded = false;
 		scrollPaginationEnabled.set(false);
 
-		initFolders();
 		await Promise.all([
-			await (async () => {
+			initFolders().catch(() => {}),
+			(async () => {
 				console.log('Init tags');
 				const _tags = await getAllTags(localStorage.token);
 				tags.set(_tags);
 			})(),
-			await (async () => {
+			(async () => {
 				console.log('Init pinned chats');
 				const _pinnedChats = await getPinnedChatList(localStorage.token);
 				pinnedChats.set(_pinnedChats);
 			})(),
-			await (async () => {
+			(async () => {
 				if (
 					$config?.features?.enable_notes &&
 					($user?.role === 'admin' || ($user?.permissions?.features?.notes ?? true))
@@ -312,7 +312,7 @@
 					pinnedNotes.set(_pinnedNotes);
 				}
 			})(),
-			await (async () => {
+			(async () => {
 				console.log('Init chat list');
 				const _chats = await getChatList(localStorage.token, $currentChatPage);
 				await chats.set(_chats);
@@ -552,13 +552,13 @@
 
 				if (value) {
 					// Only fetch channels if the feature is enabled and user has permission
-					if (
+					const shouldInitChannels =
 						$config?.features?.enable_channels &&
-						($user?.role === 'admin' || ($user?.permissions?.features?.channels ?? true))
-					) {
-						await initChannels();
-					}
-					await initChatList();
+						($user?.role === 'admin' || ($user?.permissions?.features?.channels ?? true));
+					await Promise.all([
+						shouldInitChannels ? initChannels() : Promise.resolve(),
+						initChatList()
+					]);
 
 					// Check which chats have active tasks
 					const allChatIds = [...$chats.map((c) => c.id), ...$pinnedChats.map((c) => c.id)];

--- a/src/lib/utils/marked/details-normalization.test.ts
+++ b/src/lib/utils/marked/details-normalization.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { Marked } from 'marked';
+
+import { normalizeStructuralDetailsBlocks } from './details-normalization';
+import markedExtension from './extension';
+
+const lexerWithDetails = (value: string) => {
+	const parser = new Marked();
+	parser.use(markedExtension());
+
+	return parser.lexer(value);
+};
+
+describe('normalizeStructuralDetailsBlocks', () => {
+	it('separates structural details from adjacent assistant prose', () => {
+		const input = [
+			'<details type="reasoning" done="true">',
+			'<summary>Thought</summary>',
+			'&gt; private notes',
+			'</details>',
+			'Assistant answer',
+			'<details type="tool_calls" done="true" arguments="&quot;{\\&quot;command\\&quot;:\\&quot;echo hi\\&quot;}&quot;">',
+			'<summary>tool</summary>',
+			'{}',
+			'</details>',
+			'Done'
+		].join('\n');
+
+		expect(normalizeStructuralDetailsBlocks(input)).toBe(
+			[
+				'<details type="reasoning" done="true">',
+				'<summary>Thought</summary>',
+				'&gt; private notes',
+				'</details>',
+				'Assistant answer',
+				'',
+				'<details type="tool_calls" done="true" arguments="&quot;{\\&quot;command\\&quot;:\\&quot;echo hi\\&quot;}&quot;">',
+				'<summary>tool</summary>',
+				'{}',
+				'</details>',
+				'Done'
+			].join('\n')
+		);
+	});
+
+	it('does not add separator tokens between consecutive structural details', () => {
+		const input = [
+			'<details type="reasoning" done="true">',
+			'<summary>Thought</summary>',
+			'&gt; private notes',
+			'</details>',
+			'<details type="tool_calls" done="true" arguments="&quot;{}&quot;">',
+			'<summary>tool</summary>',
+			'{}',
+			'</details>'
+		].join('\n');
+
+		expect(normalizeStructuralDetailsBlocks(input)).toBe(input);
+	});
+
+	it('lets marked tokenize structural details that directly follow prose', () => {
+		const toolCallWithMultilineArguments = `<details type="tool_calls" done="true" arguments="&quot;{\\&quot;command\\&quot;:\\&quot;# Analyze each file
+DIR=/tmp/data
+echo ===== file =====\\&quot;}&quot;">`;
+		const input = [
+			'<details type="reasoning" done="true">',
+			'<summary>Thought</summary>',
+			'&gt; private notes',
+			'</details>',
+			'Assistant answer',
+			toolCallWithMultilineArguments,
+			'<summary>tool</summary>',
+			'{}',
+			'</details>',
+			'Done'
+		].join('\n');
+
+		expect(
+			lexerWithDetails(normalizeStructuralDetailsBlocks(input)).some(
+				(token) => token.type === 'details'
+			)
+		).toBe(true);
+	});
+
+	it('leaves ordinary details and unmatched structural details unchanged', () => {
+		const ordinary = '<details>\n<summary>Normal</summary>\ncontent\n</details>\ntext';
+		const unmatched = 'before\n<details type="tool_calls">\nmissing close';
+
+		expect(normalizeStructuralDetailsBlocks(ordinary)).toBe(ordinary);
+		expect(normalizeStructuralDetailsBlocks(unmatched)).toBe(unmatched);
+	});
+});

--- a/src/lib/utils/marked/details-normalization.ts
+++ b/src/lib/utils/marked/details-normalization.ts
@@ -1,0 +1,59 @@
+const structuralDetailsPattern =
+	/<details\b[^>]*\btype="(?:tool_calls|reasoning|code_interpreter)"[^>]*>/g;
+
+const findDetailsBlockEnd = (value: string, startIndex: number) => {
+	let depth = 1;
+	let index = startIndex;
+
+	while (depth > 0 && index < value.length) {
+		const nextOpen = value.indexOf('<details', index);
+		const nextClose = value.indexOf('</details>', index);
+
+		if (nextClose === -1) return -1;
+
+		if (nextOpen !== -1 && nextOpen < nextClose) {
+			depth++;
+			index = nextOpen + '<details'.length;
+		} else {
+			depth--;
+			index = nextClose + '</details>'.length;
+		}
+	}
+
+	return depth === 0 ? index : -1;
+};
+
+const appendBlockBoundary = (value: string) => {
+	if (!value || value.endsWith('\n\n')) return value;
+	return value.endsWith('\n') ? `${value}\n` : `${value}\n\n`;
+};
+
+const hasOnlyWhitespaceBetweenStructuralDetails = (result: string, gap: string) => {
+	return gap.trim().length === 0 && result.trimEnd().endsWith('</details>');
+};
+
+export const normalizeStructuralDetailsBlocks = (value = '') => {
+	let result = '';
+	let cursor = 0;
+
+	structuralDetailsPattern.lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = structuralDetailsPattern.exec(value)) !== null) {
+		const start = match.index;
+		const end = findDetailsBlockEnd(value, start + match[0].length);
+		if (end === -1) continue;
+
+		const gap = value.slice(cursor, start);
+		result += gap;
+		if (!hasOnlyWhitespaceBetweenStructuralDetails(result, gap)) {
+			result = appendBlockBoundary(result);
+		}
+		result += value.slice(start, end);
+
+		cursor = end;
+		structuralDetailsPattern.lastIndex = end;
+	}
+
+	return result + value.slice(cursor);
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -496,8 +496,7 @@
 				executeTool(data, cb, event.chat_id);
 				return;
 			} else if (type === 'request:chat:completion') {
-				console.log(data, $socket.id);
-				const { session_id, channel, form_data, model } = data;
+				const { channel, form_data, model } = data;
 
 				try {
 					const directConnections = $settings?.directConnections ?? {};
@@ -515,11 +514,7 @@
 								form_data['model'] = form_data['model'].replace(`${prefixId}.`, ``);
 							}
 
-							const [res, controller] = await chatCompletion(
-								OPENAI_API_KEY,
-								form_data,
-								OPENAI_API_URL
-							);
+							const [res] = await chatCompletion(OPENAI_API_KEY, form_data, OPENAI_API_URL);
 
 							if (res) {
 								// raise if the response is not ok
@@ -531,7 +526,6 @@
 									cb({
 										status: true
 									});
-									console.log({ status: true });
 
 									// res will either be SSE or JSON
 									const reader = res.body.getReader();
@@ -552,7 +546,6 @@
 											const lines = chunk.split('\n').filter((line) => line.trim() !== '');
 
 											for (const line of lines) {
-												console.log(line);
 												$socket?.emit(channel, line);
 											}
 										}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 		APP_BUILD_HASH: JSON.stringify(process.env.APP_BUILD_HASH || 'dev-build')
 	},
 	build: {
-		sourcemap: true
+		sourcemap: process.env.VITE_BUILD_SOURCEMAP === 'false' ? false : true
 	},
 	worker: {
 		format: 'es'


### PR DESCRIPTION
## Why

Long assistant messages can contain Open WebUI structural `<details>` blocks for reasoning and tool calls. When a structural tool block follows assistant prose without a block boundary, Marked can parse the raw tag and escaped attributes as ordinary markdown, causing broken rendering and excessive DOM text in large chats.

## What changed

- Normalize only Open WebUI structural details blocks before markdown lexing.
- Preserve consecutive structural details so grouped reasoning/tool rendering remains intact.
- Add focused unit coverage for boundary insertion, consecutive blocks, and unmatched/ordinary details.

## Testing

- `npm run test:frontend -- --run`
- Production image build completed successfully.
- Manual logged-in browser checks on a large chat with reasoning/tool details: desktop, mobile viewport, and Chromium with JavaScript JIT disabled. No raw structural `<details>` tags or escaped `&gt;` / `&quot;` entities were visible before or after expanding grouped details.