### PR TITLE
Harden MinerU ZIP result extraction

### DIFF
--- a/backend/open_webui/retrieval/loaders/mineru.py
+++ b/backend/open_webui/retrieval/loaders/mineru.py
@@ -1,12 +1,14 @@
-import os
-import time
-import requests
 import logging
+import os
 import tempfile
+import time
 import zipfile
+from pathlib import PurePosixPath
 from typing import List, Optional
-from langchain_core.documents import Document
+
+import requests
 from fastapi import HTTPException, status
+from langchain_core.documents import Document
 
 log = logging.getLogger(__name__)
 
@@ -36,11 +38,11 @@ class MinerULoader:
 
         # Parse params dict with defaults
         self.params = params or {}
-        self.enable_ocr = params.get('enable_ocr', False)
-        self.enable_formula = params.get('enable_formula', True)
-        self.enable_table = params.get('enable_table', True)
-        self.language = params.get('language', 'en')
-        self.model_version = params.get('model_version', 'pipeline')
+        self.enable_ocr = self.params.get('enable_ocr', False)
+        self.enable_formula = self.params.get('enable_formula', True)
+        self.enable_table = self.params.get('enable_table', True)
+        self.language = self.params.get('language', 'en')
+        self.model_version = self.params.get('model_version', 'pipeline')
 
         self.page_ranges = self.params.pop('page_ranges', '')
 
@@ -434,47 +436,56 @@ class MinerULoader:
                 detail=f'Error downloading results: {str(e)}',
             )
 
-        # Save ZIP to temporary file and extract
+        tmp_zip_path = None
+        markdown_content = None
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp_zip:
                 tmp_zip.write(response.content)
                 tmp_zip_path = tmp_zip.name
 
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                # Extract ZIP
-                with zipfile.ZipFile(tmp_zip_path, 'r') as zip_ref:
-                    zip_ref.extractall(tmp_dir)
+            with zipfile.ZipFile(tmp_zip_path, 'r') as zip_ref:
+                all_files = zip_ref.namelist()
+                unsafe_md_files = []
 
-                # Find markdown file - search recursively for any .md file
-                markdown_content = None
-                found_md_path = None
+                for member in zip_ref.infolist():
+                    if member.is_dir():
+                        continue
 
-                # First, list all files in the ZIP for debugging
-                all_files = []
-                for root, dirs, files in os.walk(tmp_dir):
-                    for file in files:
-                        full_path = os.path.join(root, file)
-                        all_files.append(full_path)
-                        # Look for any .md file
-                        if file.endswith('.md'):
-                            found_md_path = full_path
-                            log.info(f'Found markdown file at: {full_path}')
-                            try:
-                                with open(full_path, 'r', encoding='utf-8') as f:
-                                    markdown_content = f.read()
-                                if markdown_content:  # Use the first non-empty markdown file
-                                    break
-                            except Exception as e:
-                                log.warning(f'Failed to read {full_path}: {e}')
-                    if markdown_content:
-                        break
+                    normalized_name = member.filename.replace('\\', '/')
+                    member_path = PurePosixPath(normalized_name)
+
+                    if member_path.is_absolute() or '..' in member_path.parts:
+                        if member_path.name.endswith('.md'):
+                            unsafe_md_files.append(member.filename)
+                        log.warning(f'Skipping unsafe ZIP member path: {member.filename}')
+                        continue
+
+                    if not member_path.name.endswith('.md'):
+                        continue
+
+                    log.info(f'Found markdown file in ZIP at: {member.filename}')
+                    try:
+                        with zip_ref.open(member) as f:
+                            markdown_content = f.read().decode('utf-8')
+                        if markdown_content:  # Use the first non-empty markdown file
+                            break
+                    except Exception as e:
+                        log.warning(f'Failed to read {member.filename}: {e}')
 
                 if markdown_content is None:
                     log.error(f'Available files in ZIP: {all_files}')
-                    # Try to provide more helpful error message
-                    md_files = [f for f in all_files if f.endswith('.md')]
-                    if md_files:
-                        error_msg = f"Found .md files but couldn't read them: {md_files}"
+                    safe_md_files = [
+                        member.filename
+                        for member in zip_ref.infolist()
+                        if not member.is_dir()
+                        and PurePosixPath(member.filename.replace('\\', '/')).name.endswith('.md')
+                        and not PurePosixPath(member.filename.replace('\\', '/')).is_absolute()
+                        and '..' not in PurePosixPath(member.filename.replace('\\', '/')).parts
+                    ]
+                    if unsafe_md_files:
+                        error_msg = f'Unsafe .md paths found in ZIP: {unsafe_md_files}'
+                    elif safe_md_files:
+                        error_msg = f"Found .md files but couldn't read them: {safe_md_files}"
                     else:
                         error_msg = f'No .md files found in ZIP. Available files: {all_files}'
                     raise HTTPException(
@@ -482,19 +493,21 @@ class MinerULoader:
                         detail=error_msg,
                     )
 
-            # Clean up temporary ZIP file
-            os.unlink(tmp_zip_path)
-
         except zipfile.BadZipFile as e:
             raise HTTPException(
                 status.HTTP_502_BAD_GATEWAY,
                 detail=f'Invalid ZIP file received: {e}',
             )
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f'Error extracting ZIP: {str(e)}',
             )
+        finally:
+            if tmp_zip_path and os.path.exists(tmp_zip_path):
+                os.unlink(tmp_zip_path)
 
         if not markdown_content:
             raise HTTPException(

--- a/backend/open_webui/test/retrieval/loaders/test_mineru.py
+++ b/backend/open_webui/test/retrieval/loaders/test_mineru.py
@@ -1,0 +1,49 @@
+import io
+import zipfile
+
+import pytest
+from fastapi import HTTPException
+from open_webui.retrieval.loaders.mineru import MinerULoader
+
+
+class _Response:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+def _zip_bytes(entries: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w') as zip_file:
+        for name, content in entries.items():
+            zip_file.writestr(name, content)
+    return buffer.getvalue()
+
+
+def test_mineru_zip_loader_reads_safe_markdown_without_extracting(monkeypatch):
+    loader = MinerULoader('input.pdf', api_mode='cloud', api_key='test-key')
+    content = _zip_bytes(
+        {
+            'images/page.png': 'ignored',
+            'nested/result.md': '# Parsed document',
+        }
+    )
+
+    monkeypatch.setattr('open_webui.retrieval.loaders.mineru.requests.get', lambda *_, **__: _Response(content))
+
+    assert loader._download_and_extract_zip('https://example.test/result.zip', 'input.pdf') == '# Parsed document'
+
+
+def test_mineru_zip_loader_rejects_traversal_markdown(monkeypatch):
+    loader = MinerULoader('input.pdf', api_mode='cloud', api_key='test-key')
+    content = _zip_bytes({'../escape.md': '# outside'})
+
+    monkeypatch.setattr('open_webui.retrieval.loaders.mineru.requests.get', lambda *_, **__: _Response(content))
+
+    with pytest.raises(HTTPException) as exc_info:
+        loader._download_and_extract_zip('https://example.test/result.zip', 'input.pdf')
+
+    assert exc_info.value.status_code == 502
+    assert 'Unsafe .md paths' in exc_info.value.detail


### PR DESCRIPTION
This hardens the MinerU cloud ZIP result path by reading Markdown files directly from safe ZIP members instead of extracting the archive to disk. It skips absolute/traversal member paths and returns a clear 502 if only unsafe Markdown paths are present.

I also fixed the params=None constructor path so the documented default continues to work.

Validation:
- python3 -m py_compile backend/open_webui/retrieval/loaders/mineru.py backend/open_webui/test/retrieval/loaders/test_mineru.py
- PYTHONPATH=backend uv run --no-project --with pytest --with fastapi --with langchain-core --with requests --with typer --with uvicorn python -m pytest -q backend/open_webui/test/retrieval/loaders/test_mineru.py
- git diff --check
- uv run --no-project --with ruff ruff check --select I,Q backend/open_webui/retrieval/loaders/mineru.py backend/open_webui/test/retrieval/loaders/test_mineru.py