### PR TITLE
fix: avoid empty prompt for skill-only messages

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2199,6 +2199,8 @@ def process_messages_with_output(
 
 
 SKILL_MENTION_RE = re.compile(r'<\$([^|>]+)\|?[^>]*>')
+SKILL_ONLY_USER_PROMPT = 'Use the selected skill.'
+UNAVAILABLE_SKILL_ONLY_USER_PROMPT = '.'
 
 
 def _get_text_parts(message: dict) -> list[str]:
@@ -2235,6 +2237,21 @@ def strip_skill_mentions(messages: list[dict]) -> None:
                         part['text'] = strip_re.sub('', text).strip()
 
 
+def ensure_user_selected_skill_has_prompt(
+    messages: list[dict], user_skill_ids: set[str], available_skills: list[Any]
+) -> None:
+    """Avoid sending a blank user message when the user only selected a skill."""
+    if not user_skill_ids:
+        return
+
+    prompt = get_last_user_message(messages)
+    if prompt is None or prompt.strip():
+        return
+
+    active_user_skill_ids = {getattr(skill, 'id', None) for skill in available_skills} & user_skill_ids
+    fallback_prompt = SKILL_ONLY_USER_PROMPT if active_user_skill_ids else UNAVAILABLE_SKILL_ONLY_USER_PROMPT
+    set_last_user_message_content(fallback_prompt, messages)
+
 
 async def connect_mcp_server(
     request,
@@ -2249,10 +2266,7 @@ async def connect_mcp_server(
     """
     mcp_server_connection = None
     for server_connection in request.app.state.config.TOOL_SERVER_CONNECTIONS:
-        if (
-            server_connection.get('type', '') == 'mcp'
-            and server_connection.get('info', {}).get('id') == server_id
-        ):
+        if server_connection.get('type', '') == 'mcp' and server_connection.get('info', {}).get('id') == server_id:
             mcp_server_connection = server_connection
             break
 
@@ -2265,8 +2279,12 @@ async def connect_mcp_server(
         return None
 
     headers, _ = await build_tool_server_headers(
-        mcp_server_connection, request, user,
-        server_id=server_id, metadata=metadata, extra_params=extra_params,
+        mcp_server_connection,
+        request,
+        user,
+        server_id=server_id,
+        metadata=metadata,
+        extra_params=extra_params,
     )
 
     client = MCPClient()
@@ -2275,18 +2293,13 @@ async def connect_mcp_server(
         headers=headers if headers else None,
     )
 
-    function_name_filter_list = mcp_server_connection.get('config', {}).get(
-        'function_name_filter_list', ''
-    )
+    function_name_filter_list = mcp_server_connection.get('config', {}).get('function_name_filter_list', '')
     if isinstance(function_name_filter_list, str):
         function_name_filter_list = function_name_filter_list.split(',')
 
     tool_specs = await client.list_tool_specs()
     if function_name_filter_list:
-        tool_specs = [
-            spec for spec in tool_specs
-            if is_string_allowed(spec['name'], function_name_filter_list)
-        ]
+        tool_specs = [spec for spec in tool_specs if is_string_allowed(spec['name'], function_name_filter_list)]
 
     return client, tool_specs
 
@@ -2639,6 +2652,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     # Strip <$skillId|label> mention tags so the model doesn't see raw markup.
     strip_skill_mentions(form_data.get('messages', []))
+    ensure_user_selected_skill_has_prompt(form_data.get('messages', []), user_skill_ids, available_skills)
 
     prompt = get_last_user_message(form_data['messages'])
     # TODO: re-enable URL extraction from prompt
@@ -2694,10 +2708,14 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             for tool_id in tool_ids:
                 if tool_id.startswith('server:mcp:'):
                     try:
-                        server_id = tool_id[len('server:mcp:'):]
+                        server_id = tool_id[len('server:mcp:') :]
 
                         result = await connect_mcp_server(
-                            request, server_id, user, metadata, extra_params,
+                            request,
+                            server_id,
+                            user,
+                            metadata,
+                            extra_params,
                         )
                         if result is None:
                             continue
@@ -2706,6 +2724,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         mcp_clients[server_id] = client
 
                         for tool_spec in tool_specs:
+
                             async def make_tool_function(client, function_name):
                                 async def tool_function(**kwargs):
                                     return await client.call_tool(


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is a small bug fix for an existing issue.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue or Discussion — Closes #24929.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [ ] **Documentation:** Not applicable; backend bug fix only.
- [ ] **Dependencies:** Not applicable; no dependency changes.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone review and manual validation.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Uses a narrow backend guard after skill mention stripping; no settings added.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Prevents provider API errors when a user submits only a selected skill mention and no additional text.

### Added

- A neutral non-empty fallback for selected-skill messages whose selected skill is no longer active or available.

### Changed

- Skill-only user messages now receive a small fallback prompt after `<$skill|label>` mention stripping, so strict providers do not receive a blank final user message.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed skill-only chat submissions producing an empty user message after backend skill mention stripping.
- Fixed the inactive/unavailable selected-skill edge case so it also cannot leave the final user message blank.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Closes #24929.

This replaces #24968, which was closed because the PR body did not include the required CLA template text. The code also addresses the Copilot review edge case from that PR: if the selected skill is inactive or unavailable, the backend still inserts a neutral non-empty fallback instead of allowing an empty content block through.

Validation:

- `python3 -m py_compile backend/open_webui/utils/middleware.py`
- `uvx ruff format --check backend/open_webui/utils/middleware.py`
- `git diff --check`

Note: `uvx ruff check backend/open_webui/utils/middleware.py` still reports pre-existing import, complexity, and line-length issues across this large file that are unrelated to this change.

### Screenshots or Videos

- Not applicable; backend request-shaping fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
