### PR TITLE
feat: add OrcaRouter to OpenAI-compatible provider presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 
 - 🚀 **Effortless Setup**: Install seamlessly using Docker or Kubernetes (kubectl, kustomize or helm) for a hassle-free experience with support for both `:ollama` and `:cuda` tagged images.
 
-- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, and more**.
+- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, OrcaRouter, and more**.
 
 - 🛡️ **Granular Permissions and User Groups**: By allowing administrators to create detailed user roles and permissions, we ensure a secure user environment. This granularity not only enhances security but also allows for customized user experiences, fostering a sense of ownership and responsibility amongst users.
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -163,7 +163,7 @@ async def get_headers_and_cookies(
                 'HTTP-Referer': 'https://openwebui.com/',
                 'X-Title': 'Open WebUI',
             }
-            if 'openrouter.ai' in url
+            if ('openrouter.ai' in url or 'orcarouter.ai' in url)
             else {}
         ),
     }

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -327,6 +327,7 @@
 											<option value="https://api.mistral.ai/v1" />
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
+											<option value="https://api.orcarouter.ai/v1" />
 											<option value="https://api.x.ai/v1" />
 										</datalist>
 									{/if}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #24980
- [x] **Target branch:** `dev`
- [x] **Description:** see below
- [x] **Changelog:** see Added section below
- [x] **Documentation:** Companion docs PR — open-webui/docs#1263
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual end-to-end against `https://api.orcarouter.ai/v1` (model listing via `/v1/models`, streaming chat, attribution headers). The existing OpenRouter connection path was re-verified to be unaffected.
- [x] **Agentic AI Code:** Not authored by an AI agent. Human-written, human-reviewed, and manually tested locally.
- [x] **Code review:** Self-reviewed.
- [x] **Design & Architecture:** Reuses the existing OpenRouter attribution branch and the existing datalist pattern. No new code paths.
- [x] **Git Hygiene:** Single atomic commit on top of `dev`.
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Description

I'm an engineer on the OrcaRouter team.

This PR adds OrcaRouter (https://www.orcarouter.ai) to the OpenAI-compatible provider presets, mirroring the existing OpenRouter entry. OrcaRouter is an OpenAI-compatible LLM router exposing models from multiple upstream providers through `https://api.orcarouter.ai/v1`.

Users can already connect through the generic OpenAI-Compatible connection by typing the URL manually — this just surfaces it the same way OpenRouter is surfaced. Companion docs PR: open-webui/docs#1263.

### Added

- `src/lib/components/AddConnectionModal.svelte`: `https://api.orcarouter.ai/v1` added to the URL autocomplete datalist, right after the existing OpenRouter entry.
- `backend/open_webui/routers/openai.py`: URLs containing `orcarouter.ai` now receive the same `HTTP-Referer` / `X-Title` attribution headers as `openrouter.ai` URLs, by extending the existing branch in `get_headers_and_cookies()`.
- `README.md`: `OrcaRouter` added to the list of example OpenAI-compatible providers next to OpenRouter.

### Screenshots or Videos

URL autocomplete showing the new preset in **Admin Settings → Connections → Add Connection**:
<img width="2559" height="1351" alt="截图1" src="https://github.com/user-attachments/assets/651624a7-db7c-45bc-8e6e-f422a35dc754" />



End-to-end chat through OrcaRouter using `openai/gpt-5.5`:
<img width="2554" height="1355" alt="截图2" src="https://github.com/user-attachments/assets/bdb0b1b7-cd91-4360-bb84-1ee96f3d6033" />



### Contributor License Agreement

By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
