### PR TITLE
fix: support Azure AI Foundry OpenAI v1 with Entra ID

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -596,10 +596,29 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                 headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
                 if api_config.get('azure') or api_config.get('provider') == 'azure':
-                    models = {
-                        'data': api_config.get('model_ids', []) or [],
-                        'object': 'list',
-                    }
+                    if is_azure_openai_v1_url(url):
+                        async with session.get(
+                            f'{url.rstrip("/")}/models',
+                            headers=headers,
+                            cookies=cookies,
+                            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                        ) as r:
+                            if r.status != 200:
+                                error_detail = f'HTTP Error: {r.status}'
+                                try:
+                                    res = await r.json()
+                                    if 'error' in res:
+                                        error_detail = f'External Error: {res["error"]}'
+                                except Exception:
+                                    pass
+                                raise Exception(error_detail)
+
+                            models = await r.json()
+                    else:
+                        models = {
+                            'data': api_config.get('model_ids', []) or [],
+                            'object': 'list',
+                        }
                 elif is_anthropic_url(url):
                     models = await get_anthropic_models(url, key, user=user)
                     if models is None:
@@ -687,9 +706,14 @@ async def verify_connection(
                 if auth_type not in ('azure_ad', 'microsoft_entra_id'):
                     headers['api-key'] = key
 
-                api_version = api_config.get('api_version', '') or '2023-03-15-preview'
+                if is_azure_openai_v1_url(url):
+                    models_url = f'{url.rstrip("/")}/models'
+                else:
+                    api_version = api_config.get('api_version', '') or '2023-03-15-preview'
+                    models_url = f'{url}/openai/models?api-version={api_version}'
+
                 async with session.get(
-                    url=f'{url}/openai/models?api-version={api_version}',
+                    url=models_url,
                     headers=headers,
                     cookies=cookies,
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
@@ -807,6 +831,11 @@ def _sanitize_model_for_url(model: str) -> str:
             detail='Invalid model name: must not be empty or contain path separators or traversal sequences',
         )
     return quote(model, safe='')
+
+
+def is_azure_openai_v1_url(url: str) -> bool:
+    """Return True when an Azure connection uses the OpenAI-compatible v1 API."""
+    return bool(re.search(r'/openai/v1(?:/|$)', url.rstrip('/')))
 
 
 def convert_to_azure_payload(url, payload: dict, api_version: str):
@@ -1159,7 +1188,7 @@ async def generate_chat_completion(
 
         # Azure v1 format: base URL already ends with /openai/v1,
         # model stays in the payload, no deployment URL rewriting.
-        is_azure_v1 = bool(re.search(r'/openai/v1(?:/|$)', url))
+        is_azure_v1 = is_azure_openai_v1_url(url)
 
         if is_azure_v1:
             if is_responses:
@@ -1413,7 +1442,7 @@ async def responses(
             if auth_type not in ('azure_ad', 'microsoft_entra_id'):
                 headers['api-key'] = key
 
-            is_azure_v1 = bool(re.search(r'/openai/v1(?:/|$)', url))
+            is_azure_v1 = is_azure_openai_v1_url(url)
 
             if is_azure_v1:
                 request_url = f'{url.rstrip("/")}/responses'
@@ -1525,7 +1554,7 @@ async def proxy(path: str, request: Request, user=Depends(get_verified_user)):
             if auth_type not in ('azure_ad', 'microsoft_entra_id'):
                 headers['api-key'] = key
 
-            is_azure_v1 = bool(re.search(r'/openai/v1(?:/|$)', url))
+            is_azure_v1 = is_azure_openai_v1_url(url)
 
             if is_azure_v1:
                 qs = request.url.query

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -42,6 +42,7 @@
 		((url.includes('azure.') || url.includes('cognitive.microsoft.com')) &&
 			!direct &&
 			provider === '');
+	$: azureOpenAIV1 = azure && /\/openai\/v1\/?$/.test(url.replace(/\/$/, ''));
 
 	let prefixId = '';
 	let enable = true;
@@ -103,7 +104,7 @@
 					auth_type,
 					...(provider ? { provider } : {}),
 					...(azure ? { azure: true } : {}),
-					api_version: apiVersion,
+					...(apiVersion ? { api_version: apiVersion } : {}),
 					...(_headers ? { headers: _headers } : {})
 				}
 			},
@@ -142,7 +143,7 @@
 		}
 
 		if (azure) {
-			if (!apiVersion) {
+			if (!azureOpenAIV1 && !apiVersion) {
 				loading = false;
 
 				toast.error($i18n.t('API Version is required'));
@@ -156,7 +157,7 @@
 				return;
 			}
 
-			if (modelIds.length === 0) {
+			if (!azureOpenAIV1 && modelIds.length === 0) {
 				loading = false;
 				toast.error($i18n.t('Deployment names are required for Azure OpenAI'));
 				return;
@@ -192,7 +193,7 @@
 				headers: headers ? JSON.parse(headers) : undefined,
 				...(provider ? { provider } : {}),
 				...(!ollama && azure ? { azure: true } : {}),
-				...(azure ? { api_version: apiVersion } : {}),
+				...(azure && apiVersion ? { api_version: apiVersion } : {}),
 				...(apiType ? { api_type: apiType } : {})
 			}
 		};
@@ -517,7 +518,7 @@
 							</div>
 						{/if}
 
-						{#if azure}
+						{#if azure && !azureOpenAIV1}
 							<div class="flex gap-2 mt-2">
 								<div class="flex flex-col w-full">
 									<label
@@ -624,10 +625,16 @@
 											url: url
 										})}
 									{:else if azure}
-										{$i18n.t('Deployment names are required for Azure OpenAI')}
-										<!-- {$i18n.t('Leave empty to include all models from "{{url}}" endpoint', {
-											url: `${url}/openai/deployments`
-										})} -->
+										{#if azureOpenAIV1}
+											{$i18n.t('Leave empty to include all models from "{{url}}/models" endpoint', {
+												url: url
+											})}
+										{:else}
+											{$i18n.t('Deployment names are required for Azure OpenAI')}
+											<!-- {$i18n.t('Leave empty to include all models from "{{url}}" endpoint', {
+												url: `${url}/openai/deployments`
+											})} -->
+										{/if}
 									{:else}
 										{$i18n.t('Leave empty to include all models from "{{url}}/models" endpoint', {
 											url: url


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — Fixes #24761.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** Description is provided below.
- [x] **Changelog:** Changelog entry is provided below.
- [ ] **Documentation:** No docs PR yet. This updates connection behavior for Azure AI Foundry OpenAI-compatible v1 endpoints.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Focused syntax, formatting, and whitespace checks are listed below.
- [x] **Agentic AI Code:** This Pull Request has gone through additional human review and focused validation.
- [x] **Code review:** Self-review completed.
- [x] **Design & Architecture:** Uses existing Azure provider/auth configuration and v1 URL detection instead of adding a new setting.
- [x] **Git Hygiene:** Atomic PR with one logical change.
- [x] **Title Prefix:** Title uses an accepted prefix.

## Summary

Adds the remaining Azure AI Foundry / OpenAI-compatible v1 handling needed for Azure connections that use Microsoft Entra ID.

- Detects Azure OpenAI-compatible v1 base URLs ending in `/openai/v1`
- Verifies Azure v1 connections with `GET /models` instead of classic Azure deployment model listing
- Uses the v1 `/models` endpoint for model discovery when no explicit model IDs are configured
- Allows the connection modal to save Azure v1 connections without a classic `api-version`
- Allows Azure v1 model IDs to be discovered instead of requiring deployment names up front
- Keeps classic Azure OpenAI deployment API behavior unchanged

## Why

Azure AI Foundry OpenAI-compatible v1 endpoints use `/openai/v1/...` routes and pass the deployment/model in the request body. Open WebUI already has Entra ID auth support on the Azure provider and partial v1 request routing, but the connection flow still forced classic Azure API-version/deployment assumptions and verification still called the classic Azure `/openai/models?api-version=...` endpoint.

This lets administrators configure Foundry v1 endpoints as Azure connections and keep Microsoft Entra ID / DefaultAzureCredential authentication.

Fixes #24761.

## Validation

- `python3 -m py_compile backend/open_webui/routers/openai.py`
- `npx prettier --check src/lib/components/AddConnectionModal.svelte`
- `git diff --check`

Note: `npm run check` currently fails on unrelated existing Svelte/TS diagnostics across the repo; the touched Svelte file passes Prettier.

# Changelog Entry

### Description

- Support Azure AI Foundry OpenAI-compatible v1 endpoint verification and model discovery for Azure OpenAI connections.

### Added

- Azure OpenAI v1 `/models` discovery for base URLs ending in `/openai/v1`.

### Changed

- Azure v1 connection setup no longer requires classic Azure API version or deployment names up front.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed Azure AI Foundry v1 verification and model discovery using classic Azure deployment model routes.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Related issue: #24761.

### Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
