### PR TITLE
feat: add Novita AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 
 - 🚀 **Effortless Setup**: Install seamlessly using Docker or Kubernetes (kubectl, kustomize or helm) for a hassle-free experience with support for both `:ollama` and `:cuda` tagged images.
 
-- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, and more**.
+- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, Novita AI, OpenRouter, and more**.
 
 - 🛡️ **Granular Permissions and User Groups**: By allowing administrators to create detailed user roles and permissions, we ensure a secure user environment. This granularity not only enhances security but also allows for customized user experiences, fostering a sense of ownership and responsibility amongst users.
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -327,6 +327,7 @@
 											<option value="https://api.anthropic.com/v1" />
 											<option value="https://generativelanguage.googleapis.com/v1beta/openai" />
 											<option value="https://api.mistral.ai/v1" />
+											<option value="https://api.novita.ai/openai" />
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />


### PR DESCRIPTION
## Summary

Add Novita AI as an OpenAI-compatible provider option.

## Changes

- Add Novita's OpenAI-compatible base URL to the external connection URL suggestions
- List Novita AI in the README's OpenAI-compatible API examples

## Validation

- `git diff --check origin/dev...HEAD`
- Confirmed the diff is limited to README text and the connection URL datalist

Note: full frontend dependency checks were not run because this environment has Node v24.3.0, while the project declares support for Node >=18.13.0 <=22.x.x.
