### PR TITLE
fix: make MCPClient.connect() initialize timeout configurable via env…

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -1,5 +1,7 @@
+
 import asyncio
 import logging
+import os
 from typing import Optional
 from contextlib import AsyncExitStack
 
@@ -13,6 +15,12 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 import httpx
 from open_webui.env import AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL, AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER
+
+# Timeout (in seconds) for the MCP session.initialize() handshake.
+# The handshake performs a list-tools round-trip and can take tens of
+# seconds on cold-start servers or servers exposing many tools. Override
+# via the MCP_INITIALIZE_TIMEOUT environment variable.
+MCP_INITIALIZE_TIMEOUT = float(os.environ.get("MCP_INITIALIZE_TIMEOUT", "60"))
 
 
 def _build_httpx_client(headers=None, timeout=None, auth=None, verify=True):
@@ -70,7 +78,7 @@ class MCPClient:
                 self._session_context = ClientSession(read_stream, write_stream)  # pylint: disable=W0201
 
                 self.session = await exit_stack.enter_async_context(self._session_context)
-                with anyio.fail_after(10):
+                with anyio.fail_after(MCP_INITIALIZE_TIMEOUT):
                     await self.session.initialize()
                 self.exit_stack = exit_stack.pop_all()
             except Exception as e:


### PR DESCRIPTION
  ### Summary

  The `session.initialize()` handshake in `MCPClient.connect()` is wrapped in a
  hardcoded `anyio.fail_after(10)` cancel scope. For MCP servers that perform a
  list-tools round-trip during initialize, this 10-second budget is frequently
  insufficient on cold start or when the server exposes many tools, causing a
  generic `Failed to connect to MCP server '<server_id>'` error even when the
  server is healthy.

  This PR makes the timeout configurable via the new `MCP_INITIALIZE_TIMEOUT`
  environment variable and raises the default from 10 s to 60 s. The default
  change is backward compatible — connections that previously succeeded under
  10 s still succeed; connections that previously failed at the 10 s edge now
  get a realistic budget.

  Fixes: #25001

  See also (closed without root cause / linked PR — this change addresses the
  underlying cause):

  - #19813 — Failed to connect to MCP server, while the connection test works fine
  - #18889 — Not able to show mcp server fails to connect error message in the chat (adjacent log-level / UI-message follow-up listed in the Out-of-scope section below)

  Related, complementary in scope (not addressed here):

  - #23749 — perf: MCP tool server reconnects on every message causing 15-20s silent delay. Proposes connection pooling so the `initialize()` handshake doesn't run on every chat message. This PR is orthogonal:
   it raises the per-handshake timeout to a configurable 60s default so handshakes that do run succeed reliably. Both fixes can land independently and reinforce each other.

  ### Statistical evidence (from the linked issue)

  | `fail_after()` value | Success rate (5 trials per row) |
  | -------------------- | --------------------------------- |
  | 10 s (current default) | 20 % |
  | 30 s                   | 80 % |
  | 60 s                   | 100 % |

  ### Changes

  Single file: `backend/open_webui/utils/mcp/client.py`

  1. Add `import os` at the top of the file.
  2. Add a module-level constant near the other imports:
     ```python
     # Timeout (in seconds) for the MCP session.initialize() handshake.
     # The handshake performs a list-tools round-trip and can take tens of
     # seconds on cold-start servers or servers exposing many tools. Override
     # via the MCP_INITIALIZE_TIMEOUT environment variable.
     MCP_INITIALIZE_TIMEOUT = float(os.environ.get("MCP_INITIALIZE_TIMEOUT", "60"))
  3. Replace
  with anyio.fail_after(10):
      await self.session.initialize()
  3. with
  with anyio.fail_after(MCP_INITIALIZE_TIMEOUT):
      await self.session.initialize()

  Net diff: 1 import + 5 comment lines + 1 constant + 1 changed line.

  Backward Compatibility

  - New env var defaults to 60 s. If administrators want to retain the previous
  10-second behaviour, they can set MCP_INITIALIZE_TIMEOUT=10.
  - No DB / migration / config-schema change.
  - No public API surface change. Only internal behaviour.

  Risk

  Very low.

  - Worst case: a misbehaving MCP server hangs its initialize for up to 60 s
  before the connect attempt is aborted. The previous 10 s budget was the
  only thing protecting against that, but it was so tight that real, healthy
  servers were also being aborted (see statistical evidence). 60 s is still a
  finite, generous cap.
  - The cancel scope itself is unchanged — only the duration is parameterized.

  Testing

  - Manual: 15-trial reproduction (table above) shows 60 s gives 100 % success
  against a production MCP server (Twinkle Hub, ~60 tools) that previously
  had a 20 % success rate at 10 s.
  - Manual: confirmed MCP_INITIALIZE_TIMEOUT=5 still triggers TimeoutError
  on the same server, so the override path works in both directions.
  - Deployed in production via a ConfigMap subPath overlay on client.py
  against OpenWebUI v0.9.5. End-to-end verification:
    - MCPClient.connect() against the same MCP server completed in 0.61 s
  (warm) — well within the new 60 s budget.
    - list_tool_specs() returned all 60 tools in 1.28 s.
    - Browser smoke test through the OpenWebUI UI in Native function-calling
  mode succeeded — the model invoked search_datasets, received a
  well-formed empty result (hits: 0, cache_hit: true), and continued
  the conversation normally. Previously, the same call failed with
  Failed to connect to MCP server.

  Out of scope (deliberately)

  To keep this PR minimal and easy to review, the following adjacent
  improvements are not included. Happy to follow up with separate PRs if
  maintainers want them:

  - Promote the timeout exception from log.debug to log.warning so it
  appears at default log level.
  - Distinguish TimeoutError from generic connect failures in the user-
  visible error message (e.g. Failed to connect to MCP server '<server_id>' (initialize timed out after Ns)).

  Checklist

  - Single-file change, minimal diff
  - Backward compatible default behaviour preserved via env var override
  - No new dependencies
  - No migrations
  - Linked issue describes user-facing symptom and statistical reproduction