### PR TITLE
fix: make MCPClient.connect() initialize timeout configurable via env…

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from contextlib import AsyncExitStack
 from typing import Optional
 
@@ -13,6 +14,12 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 from open_webui.env import AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL, AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER
 
+
+# Timeout (in seconds) for the MCP session.initialize() handshake.
+# The handshake performs a list-tools round-trip and can take tens of
+# seconds on cold-start servers or servers exposing many tools. Override
+# via the MCP_INITIALIZE_TIMEOUT environment variable.
+MCP_INITIALIZE_TIMEOUT = float(os.environ.get("MCP_INITIALIZE_TIMEOUT", "60"))
 
 def _build_httpx_client(headers=None, timeout=None, auth=None, verify=True):
     """Create an httpx AsyncClient for MCP transport.
@@ -69,7 +76,7 @@ class MCPClient:
                 self._session_context = ClientSession(read_stream, write_stream)  # pylint: disable=W0201
 
                 self.session = await exit_stack.enter_async_context(self._session_context)
-                with anyio.fail_after(10):
+                with anyio.fail_after(MCP_INITIALIZE_TIMEOUT):
                     await self.session.initialize()
                 self.exit_stack = exit_stack.pop_all()
             except Exception as e:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #25001
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not added in this PR — a follow-up docs PR can add the new `MCP_INITIALIZE_TIMEOUT` env var to the configuration reference once this lands.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed — 15-trial statistical reproduction plus end-to-end deployment in production (OpenWebUI v0.9.5) with a real MCP server (Twinkle Hub, ~60 tools). See the Additional Information section.
- [x] **No Unchecked AI Code:** This PR is human-written and has undergone manual testing in production.
- [x] **Self-Review:** Self-review of the code has been performed.
- [x] **Architecture:** Smart default (60 s) preferred over a new user-facing setting; only an env var is introduced for advanced operators.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`, no unrelated changes.
- [x] **Title Prefix:** Uses `fix:`.

# Changelog Entry

### Description

`MCPClient.connect()` in `backend/open_webui/utils/mcp/client.py` wraps `session.initialize()` in a hardcoded `anyio.fail_after(10)` cancel scope. For MCP servers that perform a list-tools round-trip during initialize, this 10-second budget is frequently insufficient on cold start or when the server exposes many tools, causing a generic `Failed to connect to MCP server '<server_id>'` error even when the server is healthy.

This PR makes the timeout configurable via a new `MCP_INITIALIZE_TIMEOUT` environment variable and raises the default from 10 s to 60 s. The default change is backward compatible.

### Added

- New environment variable `MCP_INITIALIZE_TIMEOUT` (float, seconds) to override the MCP session initialize timeout. Defaults to `60`.

### Changed

- The default timeout for the MCP `session.initialize()` handshake was raised from 10 s to 60 s. Operators wanting the previous behaviour can set `MCP_INITIALIZE_TIMEOUT=10`.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Resolves "Failed to connect to MCP server" failures caused by the previously hardcoded 10 s `anyio.fail_after(10)` budget being too tight for real-world MCP servers exposing many tools. Closes #25001. Also addresses the underlying root cause behind the previously closed reports #19813 and #18889.

### Security

- None.

### Breaking Changes

- None. Behaviour is a strict superset of the previous default; existing deployments continue to work without setting the env var.

---

### Additional Information

**Statistical evidence (15 trials, same code path, same MCP server):**

| `fail_after()` value | Success rate (5 trials per row) |
| -------------------- | --------------------------------- |
| 10 s (current default) | 20 % |
| 30 s                   | 80 % |
| 60 s                   | 100 % |

**Code change (single file, `backend/open_webui/utils/mcp/client.py`, net 9 additions / 1 deletion):**

1. Add `import os`.
2. Add a module-level constant near the existing imports:
   ```python
   # Timeout (in seconds) for the MCP session.initialize() handshake.
   # The handshake performs a list-tools round-trip and can take tens of
   # seconds on cold-start servers or servers exposing many tools. Override
   # via the MCP_INITIALIZE_TIMEOUT environment variable.
   MCP_INITIALIZE_TIMEOUT = float(os.environ.get("MCP_INITIALIZE_TIMEOUT", "60"))
   ```
3. Replace `with anyio.fail_after(10):` with `with anyio.fail_after(MCP_INITIALIZE_TIMEOUT):`.

**Backward compatibility / risk:**

- New env var defaults to 60 s. Operators wanting the old behaviour can set `MCP_INITIALIZE_TIMEOUT=10`.
- No DB / migration / config-schema change. No public API change.
- Worst case: a misbehaving MCP server hangs initialize for up to 60 s before the connect attempt is aborted. The previous 10 s budget was the only thing protecting against that, but it was so tight that real, healthy servers were also being aborted. 60 s remains a finite cap.
- The cancel scope itself is unchanged — only the duration is parameterized.

**Testing performed:**

- 15-trial reproduction (table above) shows 60 s gives 100 % success against a production MCP server (Twinkle Hub, ~60 tools) that previously had a 20 % success rate at 10 s.
- Confirmed `MCP_INITIALIZE_TIMEOUT=5` still triggers `TimeoutError` on the same server, so the override path works in both directions.
- Deployed in production via a ConfigMap subPath overlay on `client.py` against OpenWebUI v0.9.5. End-to-end verification:
  - `MCPClient.connect()` against the same MCP server completed in 0.61 s (warm) — well within the new 60 s budget.
  - `list_tool_specs()` returned all 60 tools in 1.28 s.
  - Browser smoke test through the OpenWebUI UI in Native function-calling mode succeeded — the model invoked `search_datasets`, received a well-formed empty result (`hits: 0, cache_hit: true`), and continued the conversation normally. Previously, the same call failed with `Failed to connect to MCP server`.

**Related issues:**

Closed without root-cause analysis or linked fix — this PR addresses the underlying cause:
- #19813 — "Failed to connect to MCP server, while the connection test works fine"
- #18889 — "Not able to show mcp server fails to connect error message in the chat and silently fail" (adjacent error-visibility bug; out of scope for this PR, can be a follow-up)

Related, complementary in scope (not addressed here):
- #23749 — "perf: MCP tool server reconnects on every message causing 15-20s silent delay". Proposes connection pooling so `initialize()` doesn't run on every chat message. This PR is orthogonal: it raises the per-handshake timeout to a configurable 60 s default so handshakes that do run succeed reliably. Both fixes can land independently and reinforce each other.

**Out of scope (deliberately, suggested follow-up PRs):**

- Promote the timeout exception from `log.debug` to `log.warning` so it appears at default log level (addresses #18889).
- Distinguish `TimeoutError` from generic connect failures in the user-visible error message.
- Add `MCP_INITIALIZE_TIMEOUT` to the configuration documentation in the docs repo.

### Screenshots or Videos

- N/A. This is a server-side timeout configuration change with no UI surface.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

---
