### PR TITLE
fix: sanitize null bytes in nested db data

### DIFF
--- a/backend/open_webui/test/utils/test_misc.py
+++ b/backend/open_webui/test/utils/test_misc.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+# Stub lightweight dependencies that misc.py imports at module level so tests
+# can run without a full application bootstrap.
+_env = types.ModuleType('open_webui.env')
+_env.CHAT_STREAM_RESPONSE_CHUNK_MAX_BUFFER_SIZE = 16384
+sys.modules.setdefault('open_webui.env', _env)
+sys.modules.setdefault('mimeparse', types.ModuleType('mimeparse'))
+sys.modules.setdefault('aiohttp', types.ModuleType('aiohttp'))
+
+from open_webui.utils.misc import sanitize_data_for_db  # noqa: E402
+
+
+class TestSanitizeDataForDb:
+    def test_string_null_bytes_removed(self):
+        assert sanitize_data_for_db('a\x00b') == 'ab'
+
+    def test_dict_value_null_bytes_removed(self):
+        result = sanitize_data_for_db({'key': 'val\x00ue'})
+        assert result == {'key': 'value'}
+
+    def test_nested_dict_value_null_bytes_removed(self):
+        result = sanitize_data_for_db({'a': {'b': 'c\x00'}})
+        assert result == {'a': {'b': 'c'}}
+
+    def test_list_value_null_bytes_removed(self):
+        result = sanitize_data_for_db(['a\x00', {'b': 'c\x00'}])
+        assert result == ['a', {'b': 'c'}]
+
+    def test_clean_data_returned_unchanged(self):
+        data = {'key': 'value', 'items': ['a', 'b'], 'num': 42}
+        assert sanitize_data_for_db(data) is data

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -653,7 +653,7 @@ def sanitize_data_for_db(obj):
     # json.dumps is implemented in C and much faster than a Python-level
     # recursive walk over every leaf string.
     try:
-        if '\x00' not in json.dumps(obj, ensure_ascii=False):
+        if '\\u0000' not in json.dumps(obj):
             return obj
     except (TypeError, ValueError):
         pass


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->


# Changelog Entry

### Description

- Fix a silent sanitization bug in `sanitize_data_for_db`: null bytes inside dict/list values were not removed because the fast-path check looked for `'\x00'` in `json.dumps(...)`, while `json.dumps` encodes null bytes as `\u0000`. Changed the check to look for `'\\u0000'` instead.
- Adds focused regression tests for the null-byte sanitization behavior.
- Relates to https://github.com/open-webui/open-webui/discussions/24939

### Added

- `backend/open_webui/test/utils/test_misc.py`: focused regression tests for `sanitize_data_for_db`, covering strings, dict values, nested dict values, list values, and the clean-data fast path.

### Changed

- `backend/open_webui/utils/misc.py`: updated the `sanitize_data_for_db` fast-path to check for `'\\u0000'` instead of `'\x00'` in the `json.dumps` output.

### Fixed

- `sanitize_data_for_db` now correctly strips null bytes from string values inside dicts, nested dicts, and lists.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [×] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
