### PR TITLE
Fix GB18030 text loader fallback

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -1,10 +1,10 @@
 import asyncio
-import requests
-import logging
-import ftfy
-import sys
 import json
+import logging
+import sys
 
+import ftfy
+import requests
 from azure.identity import DefaultAzureCredential
 from langchain_community.document_loaders import (
     AzureAIDocumentIntelligenceLoader,
@@ -13,19 +13,15 @@ from langchain_community.document_loaders import (
     Docx2txtLoader,
     OutlookMessageLoader,
     PyPDFLoader,
-    TextLoader,
-    YoutubeLoader,
 )
 from langchain_core.documents import Document
-
-from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
-
-from open_webui.retrieval.loaders.mistral import MistralLoader
+from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, GLOBAL_LOG_LEVEL, REQUESTS_VERIFY
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
+from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
 from open_webui.retrieval.loaders.mineru import MinerULoader
+from open_webui.retrieval.loaders.mistral import MistralLoader
 from open_webui.retrieval.loaders.paddleocr_vl import PaddleOCRVLLoader
-
-from open_webui.env import GLOBAL_LOG_LEVEL, REQUESTS_VERIFY, AIOHTTP_CLIENT_SESSION_SSL
+from open_webui.retrieval.loaders.text import read_text_file
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
@@ -131,6 +127,21 @@ class PptxLoader:
             Document(
                 page_content='\n\n'.join(text_parts),
                 metadata={'source': self.file_path},
+            )
+        ]
+
+
+class RobustTextLoader:
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    def load(self) -> list[Document]:
+        text, encoding = read_text_file(self.file_path)
+
+        return [
+            Document(
+                page_content=text,
+                metadata={'source': self.file_path, 'encoding': encoding},
             )
         ]
 
@@ -277,7 +288,7 @@ class Loader:
             )
         elif self.engine == 'tika' and self.kwargs.get('TIKA_SERVER_URL'):
             if self._is_text_file(file_ext, file_content_type):
-                loader = TextLoader(file_path, autodetect_encoding=True)
+                loader = RobustTextLoader(file_path)
             else:
                 loader = TikaLoader(
                     url=self.kwargs.get('TIKA_SERVER_URL'),
@@ -329,7 +340,7 @@ class Loader:
             )
         elif self.engine == 'docling' and self.kwargs.get('DOCLING_SERVER_URL'):
             if self._is_text_file(file_ext, file_content_type):
-                loader = TextLoader(file_path, autodetect_encoding=True)
+                loader = RobustTextLoader(file_path)
             else:
                 # Build params for DoclingLoader
                 params = self.kwargs.get('DOCLING_PARAMS', {})
@@ -426,7 +437,7 @@ class Loader:
                         'Falling back to plain text loading for .rst file. '
                         'Install it with: pip install unstructured'
                     )
-                    loader = TextLoader(file_path, autodetect_encoding=True)
+                    loader = RobustTextLoader(file_path)
             elif file_ext == 'xml':
                 try:
                     from langchain_community.document_loaders import UnstructuredXMLLoader
@@ -438,11 +449,11 @@ class Loader:
                         'Falling back to plain text loading for .xml file. '
                         'Install it with: pip install unstructured'
                     )
-                    loader = TextLoader(file_path, autodetect_encoding=True)
+                    loader = RobustTextLoader(file_path)
             elif file_ext in ['htm', 'html']:
                 loader = BSHTMLLoader(file_path, open_encoding='unicode_escape')
             elif file_ext == 'md':
-                loader = TextLoader(file_path, autodetect_encoding=True)
+                loader = RobustTextLoader(file_path)
             elif file_content_type == 'application/epub+zip':
                 try:
                     from langchain_community.document_loaders import UnstructuredEPubLoader
@@ -501,8 +512,8 @@ class Loader:
                         'Install it with: pip install unstructured'
                     )
             elif self._is_text_file(file_ext, file_content_type):
-                loader = TextLoader(file_path, autodetect_encoding=True)
+                loader = RobustTextLoader(file_path)
             else:
-                loader = TextLoader(file_path, autodetect_encoding=True)
+                loader = RobustTextLoader(file_path)
 
         return loader

--- a/backend/open_webui/retrieval/loaders/text.py
+++ b/backend/open_webui/retrieval/loaders/text.py
@@ -1,0 +1,95 @@
+import codecs
+from collections.abc import Iterable
+from pathlib import Path
+
+CJK_ENCODING_FALLBACKS = (
+    'gb18030',
+    'gbk',
+    'big5',
+    'big5hkscs',
+    'shift_jis',
+    'euc_jp',
+    'euc_kr',
+)
+
+GB_FAMILY_ENCODINGS = {
+    'gb2312',
+    'gb_2312',
+    'gbk',
+    'gb18030',
+    'hz',
+    'hz-gb-2312',
+}
+
+
+def _normalize_encoding(encoding: str | None) -> str | None:
+    if not encoding:
+        return None
+
+    try:
+        return codecs.lookup(encoding).name
+    except LookupError:
+        return encoding.lower().replace(' ', '-')
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen = set()
+    deduped = []
+
+    for item in items:
+        normalized = _normalize_encoding(item)
+        if not normalized or normalized in seen:
+            continue
+
+        seen.add(normalized)
+        deduped.append(item)
+
+    return deduped
+
+
+def _detect_encoding(data: bytes) -> str | None:
+    try:
+        import chardet
+    except ImportError:
+        return None
+
+    result = chardet.detect(data)
+    encoding = result.get('encoding')
+
+    if encoding:
+        return encoding
+
+    return None
+
+
+def get_text_decoding_candidates(data: bytes) -> list[str]:
+    detected_encoding = _detect_encoding(data)
+    candidates = ['utf-8-sig', 'utf-8']
+
+    if detected_encoding:
+        candidates.append(detected_encoding)
+
+        normalized_detected = _normalize_encoding(detected_encoding)
+        if normalized_detected in GB_FAMILY_ENCODINGS:
+            candidates.extend(('gb18030', 'gbk'))
+
+    candidates.extend(CJK_ENCODING_FALLBACKS)
+    candidates.append('latin-1')
+
+    return _dedupe(candidates)
+
+
+def read_text_file(file_path: str | Path) -> tuple[str, str]:
+    data = Path(file_path).read_bytes()
+    decode_errors: list[UnicodeDecodeError] = []
+
+    for encoding in get_text_decoding_candidates(data):
+        try:
+            return data.decode(encoding), encoding
+        except UnicodeDecodeError as e:
+            decode_errors.append(e)
+
+    if decode_errors:
+        raise decode_errors[-1]
+
+    return data.decode('utf-8'), 'utf-8'

--- a/backend/open_webui/test/retrieval/loaders/test_text.py
+++ b/backend/open_webui/test/retrieval/loaders/test_text.py
@@ -1,0 +1,31 @@
+import sys
+from types import SimpleNamespace
+
+from open_webui.retrieval.loaders.text import (
+    get_text_decoding_candidates,
+    read_text_file,
+)
+
+
+def test_read_text_file_falls_back_to_gb18030(tmp_path):
+    content = '# \u6807\u9898\n\n\U00020000 GB18030 only character\n'
+    file_path = tmp_path / 'gb18030.md'
+    file_path.write_bytes(content.encode('gb18030'))
+
+    text, encoding = read_text_file(file_path)
+
+    assert text == content
+    assert encoding.lower() == 'gb18030'
+
+
+def test_gb2312_detection_adds_gb18030_fallback(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        'chardet',
+        SimpleNamespace(detect=lambda _: {'encoding': 'GB2312', 'confidence': 0.99}),
+    )
+
+    candidates = get_text_decoding_candidates(b'content')
+
+    assert candidates.index('GB2312') < candidates.index('gb18030')
+    assert 'gbk' in candidates


### PR DESCRIPTION
## Summary
- add a robust text decoding helper that retries GB18030/GBK when charset detection reports a GB-family encoding such as GB2312
- use the helper for Markdown and other plain-text ingestion paths instead of LangChain's strict autodetected TextLoader
- add regression coverage for GB18030 Markdown content containing a GB18030-only character

Fixes #24973

## Checks
- `PYTHONPATH=backend; uv run --no-project --with pytest --with typer --with uvicorn --with chardet python -m pytest backend\open_webui\test\retrieval\loaders\test_text.py -q`
- `uv run --no-project --with ruff ruff check --select I,F401 backend\open_webui\retrieval\loaders\main.py backend\open_webui\retrieval\loaders\text.py backend\open_webui\test\retrieval\loaders\test_text.py`