### PR TITLE
fix: allow clearing calendar event description and location

### DIFF
--- a/src/lib/apis/calendar/index.ts
+++ b/src/lib/apis/calendar/index.ts
@@ -49,13 +49,13 @@ export type CalendarEventModel = {
 export type CalendarEventForm = {
 	calendar_id: string;
 	title: string;
-	description?: string;
+	description?: string | null;
 	start_at: number;
 	end_at?: number;
 	all_day?: boolean;
 	rrule?: string;
 	color?: string;
-	location?: string;
+	location?: string | null;
 	data?: Record<string, any>;
 	meta?: Record<string, any>;
 	attendees?: { user_id: string; status?: string }[];

--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -103,11 +103,11 @@
 				const result = await updateCalendarEvent(localStorage.token, event.id, {
 					calendar_id: calendarId,
 					title: title.trim(),
-					description: description.trim() || undefined,
+					description: description.trim() || null,
 					start_at: startNs,
 					end_at: endNs,
 					all_day: allDay,
-					location: location.trim() || undefined,
+					location: location.trim() || null,
 					meta: { alert_minutes: alertMinutes }
 				});
 				if (result) {


### PR DESCRIPTION
## Summary
- allow calendar event updates to send `null` for cleared `description` and `location`
- widen the frontend calendar form type so nullable update payloads are type-safe
- keep create behavior unchanged and limit the fix to the existing event update path

## Root Cause
The edit modal was serializing cleared `description` and `location` fields as `undefined`. `JSON.stringify(...)` drops `undefined` keys, and the backend update path only mutates fields that are present in the request body. That meant clearing either field in the UI could not actually clear the stored value.

## Impact
Users can now remove an existing calendar event description and location and have those cleared values persist after saving.

## Validation
- `git diff --check` on the touched files
- `npm run check` currently fails on this checkout due to unrelated pre-existing repo-wide Svelte/TypeScript errors, so it is not a clean gate for this change

Fixes #25026.
