### PR TITLE
fix: drop dangling folder references when importing chats

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -581,6 +581,19 @@ async def import_chats(
     db: AsyncSession = Depends(get_async_session),
 ):
     try:
+        # Exported chats carry the source instance's folder_id values, but the
+        # export does not include the folders themselves. On a fresh instance
+        # (or after the folders were deleted) those references dangle: the chat
+        # list query hides any chat with a non-null folder_id, and there is no
+        # matching folder to surface it from, so the import reports success yet
+        # the chats are nowhere to be seen. Drop folder references the user does
+        # not own so imported chats land in the main chat list; references that
+        # are still valid (re-importing on the same instance) are preserved.
+        owned_folder_ids = {folder.id for folder in await Folders.get_folders_by_user_id(user.id, db=db)}
+        for chat in form_data.chats:
+            if chat.folder_id is not None and chat.folder_id not in owned_folder_ids:
+                chat.folder_id = None
+
         chats = await Chats.import_chats(user.id, form_data.chats, db=db)
         return chats
     except Exception as e:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24910
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** See below.
- [x] **Changelog:** Added below.
- [ ] **Documentation:** No user-facing docs change required (behaviour fix for an existing endpoint).
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Reproduced and verified manually (steps below).
- [x] **Agentic AI Code:** This PR has gone through additional human review and manual testing.
- [x] **Code review:** Self-reviewed; the diff is a single, atomic change.
- [x] **Design & Architecture:** No new settings; reuses the existing folder-ownership check.
- [x] **Git Hygiene:** Single logical change, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

### Description

Chat exports serialize each chat's `folder_id`, but the export does **not** include the folders themselves (`exportChats()` dumps `getAllChats()`, which returns chats only). When such an export is imported into a different instance — or the same instance after the folders were deleted — those `folder_id` values point at folders that no longer exist for the importing user.

`POST /api/v1/chats/import` stored the values verbatim. Because the chat-list query filters out every chat with a non-null `folder_id` (`get_chat_title_id_list_by_user_id` applies `folder_id IS NULL` when `include_folders=False`) and there is no matching folder to surface the chats from, the imported chats become invisible even though the import reports success — exactly the symptom in #24910.

This PR sanitizes folder references on import:

- Folder IDs the user **actually owns** are preserved, so re-importing on the same instance restores the original grouping.
- **Unknown** folder IDs are reset to `NULL`, so those chats land in the main chat list and are visible again.

The owned-folder set is fetched once per request (a single query), and the check mirrors the existing validation in `POST /api/v1/chats/new`. The `/clone` and `/clone/shared` endpoints are untouched: they call `Chats.import_chats` at the model layer (not this route) and pass an already-owned `folder_id`.

### Reproduction / Verification

1. Create a folder and move one or more chats into it.
2. Settings → export chats (`chat-export-*.json`).
3. Delete the folder (or use a fresh instance / different account), then import that JSON.

**Before:** import toasts "Successfully imported N chats", but the chats appear neither in the chat list nor under any folder (their `folder_id` dangles).
**After:** unknown folder references are dropped on import, so the chats appear in the main chat list; valid references (same instance, folder still present) keep their grouping.

# Changelog Entry

### Description

- Fix imported chats becoming invisible when their `folder_id` references a folder that does not exist for the importing user.

### Fixed

- Chats imported from an export that referenced folders not present on the target instance/account were stored with a dangling `folder_id` and hidden from every chat view. Unknown folder references are now reset to `NULL` on import (owned references are preserved), so the chats are visible in the main chat list again.

---

### Additional Information

- Note on CI: the `Python CI` (Ruff format) check is currently red on `dev` itself for ~48 pre-existing files (a Ruff version bump reformatted them); it is unrelated to this change. This PR adds 13 lines that are already Ruff-formatted (`ruff format --check` reports no change for the added block) and does not touch any of those files.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
