### PR TITLE
fix: hide hidden base models in the automations model selector

### DIFF
--- a/src/lib/components/automations/ModelDropdown.svelte
+++ b/src/lib/components/automations/ModelDropdown.svelte
@@ -24,13 +24,19 @@
 		? $models.find((m) => m.id === model_id)?.name || model_id
 		: $i18n.t('Select model');
 
+	// Hidden base models are returned by the API for resolving Workspace Models,
+	// but should not be user-selectable here (consistent with the chat, notes and
+	// pinned-model selectors). The label above intentionally still resolves a
+	// hidden model so existing automations keep showing the correct name.
+	$: selectableModels = $models.filter((m) => !(m?.info?.meta?.hidden ?? false));
+
 	$: filteredModels = modelSearch
-		? $models.filter(
+		? selectableModels.filter(
 				(m) =>
 					m.name.toLowerCase().includes(modelSearch.toLowerCase()) ||
 					m.id.toLowerCase().includes(modelSearch.toLowerCase())
 			)
-		: $models;
+		: selectableModels;
 </script>
 
 <Dropdown bind:show={showDropdown} {side} {align}>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24869
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** See below.
- [x] **Changelog:** Added below.
- [ ] **Documentation:** No user-facing docs change required (UI consistency fix).
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Reproduced and verified manually (steps below).
- [x] **Agentic AI Code:** This PR has gone through additional human review and manual testing.
- [x] **Code review:** Self-reviewed; the diff is a single, atomic change.
- [x] **Design & Architecture:** No new settings; reuses the existing hidden-model predicate.
- [x] **Git Hygiene:** Single logical change, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

### Description

The `/api/models` response intentionally includes base models marked as hidden (`info.meta.hidden`) because they may still be required to resolve Workspace Models. Every user-facing model selector therefore filters them out on the client side, e.g.:

- `chat/ModelSelector/Selector.svelte` — `.filter((item) => !(item.model?.info?.meta?.hidden ?? false))`
- `chat/Chat.svelte`, `notes/NoteEditor/Controls.svelte`, `layout/Sidebar/PinnedModelList.svelte` — same predicate.

The **Automations** model dropdown (`automations/ModelDropdown.svelte`) was the one selector that listed the raw `$models` store, so hidden base models were offered for selection there.

This PR applies the same `!(model?.info?.meta?.hidden ?? false)` filter to the dropdown's selectable list. The label lookup (`modelLabel`) is deliberately left reading from `$models` so an automation that was already configured with a hidden model continues to display the correct name.

### Reproduction / Verification

1. Workspace → Models → edit a base model and enable **Hidden**.
2. Open the Automations editor and click the model dropdown.

**Before:** the hidden base model appears in the list and can be selected.
**After:** the hidden base model is no longer listed (matching the chat/notes/pinned selectors); an automation already pointing at a hidden model still shows that model's name on the button.

# Changelog Entry

### Description

- Hide hidden base models in the Automations model selector, consistent with every other model selector.

### Fixed

- The Automations model dropdown listed base models marked as hidden (`info.meta.hidden`), unlike the chat, notes and pinned-model selectors. It now filters them out while still resolving the display name of an already-selected hidden model.

---

### Additional Information

- Note on CI: the `Frontend Build` check is currently red on `dev` itself because `npm run format` rewrites the vendored `backend/open_webui/static/swagger-ui/swagger-ui-bundle.js` (it is not covered by `.prettierignore`, which only excludes the root `/static/*`), making the subsequent `git diff --exit-code` fail. That is pre-existing and unrelated to this change. The single file touched here is Prettier-clean (`prettier --check` passes with the repo config).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
