### PR TITLE
fix: gate chat-file links by caller access + repair insert_chat_files…

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1624,10 +1624,31 @@ class ChatTable:
             return None
 
         chat_message_file_ids = {
-            item.id for item in await self.get_chat_files_by_chat_id_and_message_id(chat_id, message_id, db=session)
+            item.id for item in await self.get_chat_files_by_chat_id_and_message_id(chat_id, message_id, db=db)
         }
         # Remove duplicates and existing file_ids
         file_ids = list({file_id for file_id in file_ids if file_id and file_id not in chat_message_file_ids})
+        if not file_ids:
+            return None
+
+        # Only link files the caller can read; blocks forging a chat_file row to another user's file.
+        from open_webui.models.files import Files
+        from open_webui.models.users import Users
+        from open_webui.utils.access_control.files import has_access_to_file
+
+        user = await Users.get_user_by_id(user_id, db=db)
+        accessible_file_ids = []
+        for file_id in file_ids:
+            file = await Files.get_file_by_id(file_id, db=db)
+            if not file:
+                continue
+            if (
+                file.user_id == user_id
+                or (user and user.role == 'admin')
+                or (user and await has_access_to_file(file_id, 'read', user, db=db))
+            ):
+                accessible_file_ids.append(file_id)
+        file_ids = accessible_file_ids
         if not file_ids:
             return None
 


### PR DESCRIPTION
… db arg

insert_chat_files() stored any caller-supplied file_id with no ownership check, so a user could attach another user's file to their own chat and then read it through the shared-chat access path in has_access_to_file(). Filter file_ids to those the caller owns, is admin for, or can read.

Also repairs an UnboundLocalError introduced in 260ead64d: the existing duplicate-check referenced `session` before it was assigned (db=session), so the function threw on every call and no chat_file rows were persisted.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
