### PR TITLE
feat: allow '*' wildcard in OAUTH_ALLOWED_ROLES

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1270,7 +1270,7 @@ class OAuthManager:
             if oauth_roles:
                 matched = False
                 for allowed_role in oauth_allowed_roles:
-                    if allowed_role in oauth_roles:
+                    if allowed_role == '*' or allowed_role in oauth_roles:
                         log.debug('Assigned user the user role')
                         role = 'user'
                         matched = True


### PR DESCRIPTION
## Summary

When `ENABLE_OAUTH_ROLE_MANAGEMENT=true`, `oauth.py:get_user_role` requires every authenticated user's `groups`/`roles` claim to contain at least one literal entry from `OAUTH_ALLOWED_ROLES` (default `['user', 'admin']`) or `OAUTH_ADMIN_ROLES`; otherwise the user is rejected with 403.

This works well when an admin can enumerate every legal role value. It does **not** work when the OIDC provider emits **dynamic** group names — e.g.:

- LDAP-backed IdPs that auto-create a per-user group named after the user (LDAP Account Manager does this when `DEFAULT_USER_GROUP` is unset)
- Multi-tenant providers that prefix groups with a tenant id, project name, etc.
- Provisioning tools that assign each new user a unique synthetic group

In those setups operators want:

```
OAUTH_ADMIN_ROLES=my-admin-group   # this specific group → admin
OAUTH_ALLOWED_ROLES=*              # everyone else authenticated via OIDC
                                   # gets DEFAULT_USER_ROLE
```

This PR makes `*` in `OAUTH_ALLOWED_ROLES` act as a catch-all match. `OAUTH_ADMIN_ROLES` is intentionally unchanged (still strict-match) so admin auto-mapping keeps working alongside the wildcard.

## Change

One-line change in `backend/open_webui/utils/oauth.py:1273`:

```diff
-                    if allowed_role in oauth_roles:
+                    if allowed_role == '*' or allowed_role in oauth_roles:
```

## Backward compatibility

Default behavior is preserved — `*` only has special meaning when it is explicitly listed in `OAUTH_ALLOWED_ROLES`. Existing deployments that don't use `*` are unaffected.

## Real-world repro

This bug was reported on the Syncloud forum (https://syncloud.discourse.group/t/616) where Syncloud's `users` web app (which is built on LDAP Account Manager) creates a per-user LDAP group for every new account, and the resulting `groups` claim never matches `OAUTH_ALLOWED_ROLES=user,admin`. End-to-end Playwright repro: https://github.com/syncloud/openwebui/pull/2

## Related issues

Could resolve / help these previously-closed-as-not-planned threads (in spirit):

- open-webui/open-webui#15551 — OAuth Role Management Ignored
- open-webui/open-webui#20518 — Microsoft Entra ID OAuth role mapping not working

(Both could be revisited with `OAUTH_ALLOWED_ROLES=*` as an escape hatch.)