### PR TITLE
feat: allow '*' wildcard in OAUTH_ALLOWED_ROLES

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1264,7 +1264,7 @@ class OAuthManager:
             if oauth_roles:
                 matched = False
                 for allowed_role in oauth_allowed_roles:
-                    if allowed_role in oauth_roles:
+                    if allowed_role == '*' or allowed_role in oauth_roles:
                         log.debug('Assigned user the user role')
                         role = 'user'
                         matched = True


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Testing:** Manual end-to-end test performed on a real device (Syncloud arm64 box). With the patch, a non-admin OIDC user whose only group is a dynamically-named per-user LDAP group is granted `DEFAULT_USER_ROLE` instead of being 403'd. Without the patch, same user is rejected at `oauth.py:1276` with the WARNING log already present in the function. Repro spec: https://github.com/syncloud/openwebui/blob/fix-oauth-allowed-roles/web/e2e/lam-user-login.spec.ts
- [x] **Self-Review:** Reviewed.
- [x] **Architecture:** Smart default — `*` is only special when explicitly listed; absent `*`, behavior is byte-identical to before. No new env var.
- [x] **Git Hygiene:** Single-commit, atomic, one-line change.
- [x] **Title Prefix:** `feat:`.

# Changelog Entry

### Description

When `ENABLE_OAUTH_ROLE_MANAGEMENT=true`, `get_user_role` requires every authenticated user's `groups`/`roles` claim to contain at least one literal entry from `OAUTH_ALLOWED_ROLES` (default `['user', 'admin']`) or `OAUTH_ADMIN_ROLES`; otherwise the user is rejected with 403.

This works when an admin can enumerate every legal role value. It does **not** work when the OIDC provider emits **dynamic** group names — e.g.:

- LDAP-backed IdPs that auto-create a per-user group named after the user (LDAP Account Manager does this when `DEFAULT_USER_GROUP` does not exist as an LDAP group)
- Multi-tenant providers that prefix groups with a tenant id, project name, etc.
- Provisioning tools that assign each new user a unique synthetic group

A common installer wants:

```
OAUTH_ADMIN_ROLES=my-admin-group   # specific group → admin
OAUTH_ALLOWED_ROLES=*              # everyone else authenticated by OIDC
                                   # gets DEFAULT_USER_ROLE
```

This PR makes `*` in `OAUTH_ALLOWED_ROLES` act as a catch-all match. `OAUTH_ADMIN_ROLES` is intentionally unchanged (still strict-match) so admin auto-mapping keeps working alongside the wildcard.

### Added

- `OAUTH_ALLOWED_ROLES=*` now matches any non-empty roles claim, granting `DEFAULT_USER_ROLE`. `OAUTH_ADMIN_ROLES` behavior is unchanged.

### Changed

- `backend/open_webui/utils/oauth.py:1267` — single condition `if allowed_role in oauth_roles:` extended to `if allowed_role == '*' or allowed_role in oauth_roles:`.

### Fixed

- Operators using IdPs with dynamic per-user group claims (LDAP, multi-tenant, etc.) can no longer be locked out of Open WebUI without manually enumerating every possible group name. Related: #15551, #20518.

---

### Additional Information

Found on the Syncloud platform, where the Syncloud `users` web app (built on LDAP Account Manager) creates a per-user LDAP group for every new account. Authelia (their OIDC provider) returns that group verbatim in the `groups` claim, and Open WebUI then rejects the user with 403 because the group name matches neither `OAUTH_ADMIN_ROLES` nor the default `OAUTH_ALLOWED_ROLES=['user','admin']`.

End-to-end Playwright repro (PR in the Syncloud package): https://github.com/syncloud/openwebui/pull/2

### Screenshots or Videos

Before (rejected, openwebui error toast):

> Screenshot from the end-to-end repro: openwebui shows "You do not have permission to access this resource. Please contact your administrator for assistance." after Authelia completes successfully.

After (with `OAUTH_ALLOWED_ROLES=*`): user lands on the main `/` chat page and gets `DEFAULT_USER_ROLE=user`. Admin user (in `OAUTH_ADMIN_ROLES`) still becomes admin.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
