### PR TITLE
[codex] Optimize YDoc disconnect cleanup with per-user index

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -1,9 +1,9 @@
 import json
 import uuid
-from open_webui.utils.redis import get_redis_connection
-from open_webui.env import REDIS_KEY_PREFIX
-from typing import Optional, List, Tuple
+
 import pycrdt as Y
+from open_webui.env import REDIS_KEY_PREFIX
+from open_webui.utils.redis import get_redis_connection
 
 
 class RedisLock:
@@ -134,10 +134,19 @@ class YdocManager:
         self._redis = redis
         self._redis_key_prefix = redis_key_prefix
 
+    def _updates_key(self, document_id: str) -> str:
+        return f'{self._redis_key_prefix}:{document_id}:updates'
+
+    def _users_key(self, document_id: str) -> str:
+        return f'{self._redis_key_prefix}:{document_id}:users'
+
+    def _user_documents_key(self, user_id: str) -> str:
+        return f'{self._redis_key_prefix}:users:{user_id}:documents'
+
     async def append_to_updates(self, document_id: str, update: bytes):
         document_id = document_id.replace(':', '_')
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             await self._redis.rpush(redis_key, json.dumps(list(update)))
             list_len = await self._redis.llen(redis_key)
             if list_len >= self.COMPACTION_THRESHOLD:
@@ -151,7 +160,7 @@ class YdocManager:
 
     async def _compact_updates_redis(self, document_id: str):
         """Rolling compaction: squash oldest half into one snapshot."""
-        redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+        redis_key = self._updates_key(document_id)
         all_updates = await self._redis.lrange(redis_key, 0, -1)
         if len(all_updates) <= 1:
             return
@@ -176,11 +185,11 @@ class YdocManager:
             ydoc.apply_update(bytes(update))
         self._updates[document_id] = [ydoc.get_update()] + updates[mid:]
 
-    async def get_updates(self, document_id: str) -> List[bytes]:
+    async def get_updates(self, document_id: str) -> list[bytes]:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             updates = await self._redis.lrange(redis_key, 0, -1)
             return [bytes(json.loads(update)) for update in updates]
         else:
@@ -190,16 +199,16 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             return await self._redis.exists(redis_key) > 0
         else:
             return document_id in self._updates
 
-    async def get_users(self, document_id: str) -> List[str]:
+    async def get_users(self, document_id: str) -> list[str]:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
+            redis_key = self._users_key(document_id)
             users = await self._redis.smembers(redis_key)
             return list(users)
         else:
@@ -209,8 +218,8 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
-            await self._redis.sadd(redis_key, user_id)
+            await self._redis.sadd(self._users_key(document_id), user_id)
+            await self._redis.sadd(self._user_documents_key(user_id), document_id)
         else:
             if document_id not in self._users:
                 self._users[document_id] = set()
@@ -220,24 +229,26 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
-            await self._redis.srem(redis_key, user_id)
+            await self._redis.srem(self._users_key(document_id), user_id)
+            await self._redis.srem(self._user_documents_key(user_id), document_id)
         else:
             if document_id in self._users and user_id in self._users[document_id]:
                 self._users[document_id].remove(user_id)
 
     async def remove_user_from_all_documents(self, user_id: str):
         if self._redis:
-            keys = []
-            async for key in self._redis.scan_iter(match=f'{self._redis_key_prefix}:*', count=100):
-                keys.append(key)
-            for key in keys:
-                if key.endswith(':users'):
-                    await self._redis.srem(key, user_id)
+            user_documents_key = self._user_documents_key(user_id)
+            document_ids = await self._redis.smembers(user_documents_key)
+            if not document_ids:
+                document_ids = await self._find_documents_for_user(user_id)
 
-                    document_id = key.split(':')[-2]
-                    if len(await self.get_users(document_id)) == 0:
-                        await self.clear_document(document_id)
+            for document_id in document_ids:
+                await self._redis.srem(self._users_key(document_id), user_id)
+
+                if await self._redis.scard(self._users_key(document_id)) == 0:
+                    await self.clear_document(document_id)
+
+            await self._redis.delete(user_documents_key)
 
         else:
             for document_id in list(self._users.keys()):
@@ -252,12 +263,22 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
-            await self._redis.delete(redis_key)
-            redis_users_key = f'{self._redis_key_prefix}:{document_id}:users'
+            redis_users_key = self._users_key(document_id)
+            users = await self._redis.smembers(redis_users_key)
+            for user_id in users:
+                await self._redis.srem(self._user_documents_key(user_id), document_id)
+
+            await self._redis.delete(self._updates_key(document_id))
             await self._redis.delete(redis_users_key)
         else:
             if document_id in self._updates:
                 del self._updates[document_id]
             if document_id in self._users:
                 del self._users[document_id]
+
+    async def _find_documents_for_user(self, user_id: str) -> set[str]:
+        document_ids = set()
+        async for key in self._redis.scan_iter(match=f'{self._redis_key_prefix}:*:users', count=100):
+            if user_id in await self._redis.smembers(key):
+                document_ids.add(key.split(':')[-2])
+        return document_ids

--- a/backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py
+++ b/backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py
@@ -1,0 +1,89 @@
+import pytest
+from open_webui.socket.utils import YdocManager
+
+
+class FakeAsyncRedis:
+    def __init__(self):
+        self.sets = {}
+        self.lists = {}
+
+    async def sadd(self, key, *values):
+        self.sets.setdefault(key, set()).update(values)
+
+    async def srem(self, key, *values):
+        if key not in self.sets:
+            return 0
+
+        removed = 0
+        for value in values:
+            if value in self.sets[key]:
+                self.sets[key].remove(value)
+                removed += 1
+        return removed
+
+    async def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
+    async def scard(self, key):
+        return len(self.sets.get(key, set()))
+
+    async def rpush(self, key, *values):
+        self.lists.setdefault(key, []).extend(values)
+
+    async def llen(self, key):
+        return len(self.lists.get(key, []))
+
+    async def lrange(self, key, start, end):
+        values = self.lists.get(key, [])
+        if end == -1:
+            return values[start:]
+        return values[start : end + 1]
+
+    async def exists(self, key):
+        return int(key in self.sets or key in self.lists)
+
+    async def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            deleted += int(self.sets.pop(key, None) is not None)
+            deleted += int(self.lists.pop(key, None) is not None)
+        return deleted
+
+    def scan_iter(self, *args, **kwargs):
+        raise AssertionError('YdocManager should use the per-user document index instead of scanning all documents')
+
+
+@pytest.mark.asyncio
+async def test_remove_user_from_all_documents_uses_reverse_index():
+    redis = FakeAsyncRedis()
+    manager = YdocManager(redis=redis, redis_key_prefix='test:ydoc')
+
+    await manager.add_user('note:owned', 'sid-1')
+    await manager.add_user('note:shared', 'sid-1')
+    await manager.add_user('note:shared', 'sid-2')
+    await manager.append_to_updates('note:owned', b'owned-update')
+    await manager.append_to_updates('note:shared', b'shared-update')
+
+    await manager.remove_user_from_all_documents('sid-1')
+
+    assert await manager.get_users('note:shared') == ['sid-2']
+    assert await manager.document_exists('note:shared') is True
+    assert await manager.document_exists('note:owned') is False
+    assert await redis.smembers('test:ydoc:users:sid-1:documents') == set()
+    assert await redis.smembers('test:ydoc:users:sid-2:documents') == {'note_shared'}
+
+
+@pytest.mark.asyncio
+async def test_clear_document_removes_document_from_user_indexes():
+    redis = FakeAsyncRedis()
+    manager = YdocManager(redis=redis, redis_key_prefix='test:ydoc')
+
+    await manager.add_user('note:shared', 'sid-1')
+    await manager.add_user('note:shared', 'sid-2')
+    await manager.append_to_updates('note:shared', b'shared-update')
+
+    await manager.clear_document('note:shared')
+
+    assert await manager.document_exists('note:shared') is False
+    assert await redis.smembers('test:ydoc:users:sid-1:documents') == set()
+    assert await redis.smembers('test:ydoc:users:sid-2:documents') == set()


### PR DESCRIPTION
## Summary
- add a per-user document index to YdocManager
- make disconnect/cleanup remove only the documents a session actually touched
- keep a fallback scan for legacy Redis state with no reverse index yet
- add async unit coverage for the new cleanup path

## Why
The old disconnect path scanned every YDoc key in Redis, which grows linearly with the whole collaborative document set. That makes session teardown slower than it needs to be and couples one user's disconnect to global document volume.

## Validation
- uv run --group dev ruff check backend/open_webui/socket/utils.py backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py
- uv run --group dev pytest backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py -q

This change is intentionally local to Redis bookkeeping and does not alter socket message shapes.