### PR TITLE
feat: Optional auto-redirect to SSO for single-provider setups

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -3433,6 +3433,12 @@ ENABLE_OAUTH_SIGNUP = ConfigVar(
     os.getenv('ENABLE_OAUTH_SIGNUP', 'False').lower() == 'true',
 )
 
+OAUTH_AUTO_REDIRECT = ConfigVar(
+    'OAUTH_AUTO_REDIRECT',
+    'oauth.auto_redirect',
+    os.getenv('OAUTH_AUTO_REDIRECT', 'False').lower() == 'true',
+)
+
 OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE = ConfigVar(
     'OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE',
     'oauth.refresh_token_include_scope',

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -288,6 +288,7 @@ from open_webui.config import (
     MOJEEK_SEARCH_API_KEY,
     OAUTH_ADMIN_ROLES,
     OAUTH_ALLOWED_ROLES,
+    OAUTH_AUTO_REDIRECT,
     OAUTH_EMAIL_CLAIM,
     OAUTH_PICTURE_CLAIM,
     OAUTH_PROVIDERS,
@@ -858,6 +859,7 @@ app.state.BASE_MODELS = []
 app.state.config.WEBUI_URL = WEBUI_URL
 app.state.config.ENABLE_SIGNUP = ENABLE_SIGNUP
 app.state.config.ENABLE_LOGIN_FORM = ENABLE_LOGIN_FORM
+app.state.config.OAUTH_AUTO_REDIRECT = OAUTH_AUTO_REDIRECT
 app.state.config.ENABLE_PASSWORD_CHANGE_FORM = ENABLE_PASSWORD_CHANGE_FORM
 
 app.state.config.ENABLE_API_KEYS = ENABLE_API_KEYS
@@ -2350,7 +2352,10 @@ async def get_app_config(request: Request):
         'name': app.state.WEBUI_NAME,
         'version': VERSION,
         'default_locale': str(DEFAULT_LOCALE),
-        'oauth': {'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()}},
+        'oauth': {
+            'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()},
+            'auto_redirect': app.state.config.OAUTH_AUTO_REDIRECT,
+        },
         'features': {
             # --- Public: required by login/signup page pre-auth ---
             'auth': WEBUI_AUTH,

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -276,6 +276,7 @@ type Document = {
 type Config = {
 	license_metadata: any;
 	status: boolean;
+	onboarding?: boolean;
 	name: string;
 	version: string;
 	default_locale: string;
@@ -305,6 +306,7 @@ type Config = {
 		providers: {
 			[key: string]: string;
 		};
+		auto_redirect: boolean;
 	};
 	ui?: {
 		pending_user_overlay_title?: string;

--- a/src/lib/utils/oauth.ts
+++ b/src/lib/utils/oauth.ts
@@ -1,0 +1,68 @@
+/**
+ * Decision logic for the OAUTH_AUTO_REDIRECT feature
+ */
+
+/** The subset of the /api/config payload the auto-redirect decision reads. */
+export type AutoRedirectConfig = {
+	oauth?: {
+		providers?: Record<string, string>;
+		auto_redirect?: boolean;
+	};
+	features?: {
+		auth?: boolean;
+		auth_trusted_header?: boolean;
+		enable_login_form?: boolean;
+		enable_ldap?: boolean;
+	};
+	onboarding?: boolean;
+};
+
+/** Per-visit signals that should suppress the auto-redirect. */
+export type AutoRedirectContext = {
+	/** True when a user session already exists ($user !== undefined). */
+	isAuthenticated: boolean;
+	/** The ?form= query param — when present the user explicitly wants the form. */
+	formParam: string | null;
+	/** The ?error= query param — keep the page so the error toast stays visible. */
+	errorParam: string | null;
+	/** A `token` cookie is set (an OAuth callback is mid-flight). */
+	hasTokenCookie: boolean;
+	/** A token is in localStorage (already signed in locally). */
+	hasLocalStorageToken: boolean;
+};
+
+/**
+ * Returns the OAuth provider login path to redirect to from /auth, or null
+ * when the page should render normally.
+ *
+ * Redirects only when SSO is unambiguously the single intended entry point:
+ * OAUTH_AUTO_REDIRECT is on, exactly one OAuth provider is configured, the
+ * local login form and LDAP are both disabled, auth is enabled, the visitor
+ * is unauthenticated, and nothing signals the form should be shown instead
+ * (?form=, ?error=, an in-flight/stored token, trusted-header auth, or
+ * first-run onboarding).
+ *
+ * The result is a root-relative path; callers prepend WEBUI_BASE_URL.
+ */
+export const getOAuthAutoRedirectPath = (
+	config: AutoRedirectConfig | null | undefined,
+	context: AutoRedirectContext
+): string | null => {
+	const providers = Object.keys(config?.oauth?.providers ?? {});
+
+	const shouldRedirect =
+		Boolean(config?.oauth?.auto_redirect) &&
+		config?.features?.auth !== false &&
+		providers.length === 1 &&
+		config?.features?.enable_login_form === false &&
+		config?.features?.enable_ldap === false &&
+		!context.isAuthenticated &&
+		!context.formParam &&
+		!context.errorParam &&
+		!context.hasTokenCookie &&
+		!context.hasLocalStorageToken &&
+		!(config?.features?.auth_trusted_header ?? false) &&
+		!(config?.onboarding ?? false);
+
+	return shouldRedirect ? `/oauth/${providers[0]}/login` : null;
+};

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -21,6 +21,7 @@
 	import { WEBUI_NAME, config, user, socket } from '$lib/stores';
 
 	import { generateInitialsImage, canvasPixelTest, getUserTimezone } from '$lib/utils';
+	import { getOAuthAutoRedirectPath } from '$lib/utils/oauth';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import OnBoarding from '$lib/components/OnBoarding.svelte';
@@ -183,10 +184,37 @@
 		await oauthCallbackHandler();
 		form = $page.url.searchParams.get('form');
 
+		if (!$config) {
+			try {
+				await config.set(await getBackendConfig());
+			} catch (configError) {
+				if ((configError as { authRedirect?: boolean })?.authRedirect) {
+					window.location.href = '/';
+					return;
+				}
+				console.error('Error loading backend config:', configError);
+			}
+		}
+
+		const autoRedirectPath = getOAuthAutoRedirectPath($config, {
+			isAuthenticated: $user !== undefined,
+			formParam: form,
+			errorParam: error,
+			hasTokenCookie: document.cookie.split('; ').some((c) => c.startsWith('token=')),
+			hasLocalStorageToken: Boolean(localStorage.token)
+		});
+		if (autoRedirectPath) {
+			window.location.href = `${WEBUI_BASE_URL}${autoRedirectPath}`;
+			return;
+		}
+
 		loaded = true;
 		setLogoImage();
 
-		if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) {
+		if (
+			($config?.features?.auth_trusted_header ?? false) ||
+			$config?.features?.auth === false
+		) {
 			await signInHandler();
 		} else {
 			onboarding = $config?.onboarding ?? false;


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to discussions #24421, #7337, #8167, and #11612, which request an opt-in auto-redirect when SSO is the only configured sign-in option.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Adds an `OAUTH_AUTO_REDIRECT` environment variable that redirects an unauthenticated `/auth` visit straight to the configured OAuth provider when the deployment is SSO-only. Details below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** Companion docs PR — open-webui/docs#1260.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual end-to-end verification performed in a container with Keycloak. Video below.
- [x] **No Unchecked AI Code:** The change has undergone human review and manual end-to-end testing.
- [x] **Self-Review:** The diff is scoped to the OAuth auto-redirect feature and is rebased on `dev`.
- [x] **Architecture:** Introduces one opt-in setting; auto-redirect cannot be a safe default (rationale below).
- [x] **Git Hygiene:** Single feature commit, rebased on `dev`, with no unrelated changes.
- [x] **Title Prefix:** The PR title uses the `feat` prefix.

# Changelog Entry

### Description

- Adds an `OAUTH_AUTO_REDIRECT` environment variable. When enabled and the deployment is SSO-only — exactly one OAuth provider configured, `ENABLE_LOGIN_FORM=false`, `ENABLE_LDAP=false` — an unauthenticated visit to `/auth` is redirected straight to the provider's login, removing the extra "Continue with" click on an otherwise SSO-only login page. `/auth?form=true` reaches the local login form as an admin-recovery escape hatch.

### Added

- 🔀 **Auto-redirect to SSO.** New `OAUTH_AUTO_REDIRECT` environment variable: when enabled on an SSO-only deployment (single configured OAuth provider, local login form and LDAP both off), an unauthenticated visit to `/auth` redirects straight to the provider, removing the extra "Continue with" click. Visit `/auth?form=true` to reach the local login form.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

**Behavior.** When all of the following are true, an unauthenticated visit to `/auth` redirects straight to `/oauth/{provider}/login`:

- `OAUTH_AUTO_REDIRECT=true`
- exactly one OAuth provider configured
- `ENABLE_LOGIN_FORM=false`
- `ENABLE_LDAP=false`

The redirect is suppressed when the local login form is explicitly requested (`/auth?form=true`), after a failed sign-in (`/auth?error=...`), for an already-authenticated session, when a token is present, during first-run onboarding, and under trusted-header auth. If any precondition is unmet, `OAUTH_AUTO_REDIRECT=true` is a no-op — the page renders as it does today.

**Why a setting and not a smart default.** Auto-redirect cannot be defaulted on — it would silently change behavior for every existing install. It is therefore opt-in (`Default: False`), and additionally guarded on the deployment shape being unambiguously SSO-only so admins who enable it can't accidentally hide a local form or LDAP they meant to keep reachable.

**Implementation.**

- Backend: `OAUTH_AUTO_REDIRECT` config variable ([backend/open_webui/config.py](backend/open_webui/config.py)), wired into `app.state.config` and exposed as `oauth.auto_redirect` in `/api/config` ([backend/open_webui/main.py](backend/open_webui/main.py)).
- Frontend: the redirect decision is a pure function ([src/lib/utils/oauth.ts](src/lib/utils/oauth.ts)) called from the auth page's `onMount` ([src/routes/auth/+page.svelte](src/routes/auth/+page.svelte)).

**Manual verification.** End-to-end in a container against a mock OIDC provider:

- `/auth` on a deployment satisfying all preconditions → immediate redirect to the IdP; full callback round-trip lands signed in.
- `/auth?form=true` on the same deployment → local login form rendered, no redirect (escape hatch).
- `/auth?error=...` → page held, error surfaced, no redirect loop.
- Already-authenticated session visiting `/auth` → existing redirect to `/`, not a fresh SSO round-trip.
- Two providers configured + `OAUTH_AUTO_REDIRECT=true` → both buttons rendered, no redirect (single-provider guard holds).
- One provider + `OAUTH_AUTO_REDIRECT=true` + `ENABLE_LOGIN_FORM=true` → no redirect; local form remains the primary entry point.
- One provider + `OAUTH_AUTO_REDIRECT=true` + `ENABLE_LDAP=true` → no redirect; LDAP entry point remains reachable.
- `OAUTH_AUTO_REDIRECT` unset → unchanged behavior.

### Screenshots or Videos

End-to-end against a real OIDC flow — Open WebUI built from this branch, with an OIDC client pointed at Keycloak. The deployment satisfies all four preconditions (`OAUTH_AUTO_REDIRECT=true`, single configured OAuth provider, `ENABLE_LOGIN_FORM=false`, `ENABLE_LDAP=false`). Visiting `/auth` auto-redirects straight to the Keycloak login (no "Continue with …" interstitial); after typing credentials the OAuth callback lands the user on the actual Open WebUI dashboard signed in.

https://github.com/user-attachments/assets/ebfe7544-d8aa-4ae4-97b1-4dd23224e4b3

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

