### PR TITLE
perf: index YDoc memberships for disconnect cleanup

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -6,9 +6,10 @@ import json
 import uuid
 
 import pycrdt as Y
-from open_webui.utils.redis import get_redis_connection
 from open_webui.env import REDIS_KEY_PREFIX
-YDOC_KEY_PREFIX = f"{REDIS_KEY_PREFIX}:ydoc:documents"
+from open_webui.utils.redis import get_redis_connection
+
+YDOC_KEY_PREFIX = f'{REDIS_KEY_PREFIX}:ydoc:documents'
 
 class RedisLock:
     """Distributed lock backed by a Redis SET with NX/EX semantics."""
@@ -140,10 +141,19 @@ class YdocManager:
         self._redis = redis
         self._redis_key_prefix = redis_key_prefix
 
+    def _updates_key(self, document_id: str) -> str:
+        return f'{self._redis_key_prefix}:{document_id}:updates'
+
+    def _users_key(self, document_id: str) -> str:
+        return f'{self._redis_key_prefix}:{document_id}:users'
+
+    def _user_documents_key(self, user_id: str) -> str:
+        return f'{self._redis_key_prefix}:users:{user_id}:documents'
+
     async def append_to_updates(self, document_id: str, update: bytes):
         document_id = document_id.replace(':', '_')
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             await self._redis.rpush(redis_key, json.dumps(list(update)))
             list_len = await self._redis.llen(redis_key)
             if list_len >= self.COMPACTION_THRESHOLD:
@@ -157,7 +167,7 @@ class YdocManager:
 
     async def _compact_updates_redis(self, document_id: str):
         """Rolling compaction: squash oldest half into one snapshot."""
-        redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+        redis_key = self._updates_key(document_id)
         all_updates = await self._redis.lrange(redis_key, 0, -1)
         if len(all_updates) <= 1:
             return
@@ -186,7 +196,7 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             updates = await self._redis.lrange(redis_key, 0, -1)
             return [bytes(json.loads(update)) for update in updates]
         else:
@@ -196,7 +206,7 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
+            redis_key = self._updates_key(document_id)
             return await self._redis.exists(redis_key) > 0
         else:
             return document_id in self._updates
@@ -205,7 +215,7 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
+            redis_key = self._users_key(document_id)
             users = await self._redis.smembers(redis_key)
             return list(users)
         else:
@@ -215,8 +225,8 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
-            await self._redis.sadd(redis_key, user_id)
+            await self._redis.sadd(self._users_key(document_id), user_id)
+            await self._redis.sadd(self._user_documents_key(user_id), document_id)
         else:
             if document_id not in self._users:
                 self._users[document_id] = set()
@@ -226,24 +236,26 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:users'
-            await self._redis.srem(redis_key, user_id)
+            await self._redis.srem(self._users_key(document_id), user_id)
+            await self._redis.srem(self._user_documents_key(user_id), document_id)
         else:
             if document_id in self._users and user_id in self._users[document_id]:
                 self._users[document_id].remove(user_id)
 
     async def remove_user_from_all_documents(self, user_id: str):
         if self._redis:
-            keys = []
-            async for key in self._redis.scan_iter(match=f'{self._redis_key_prefix}:*', count=100):
-                keys.append(key)
-            for key in keys:
-                if key.endswith(':users'):
-                    await self._redis.srem(key, user_id)
+            user_documents_key = self._user_documents_key(user_id)
+            document_ids = await self._redis.smembers(user_documents_key)
+            if not document_ids:
+                document_ids = await self._find_documents_for_user(user_id)
 
-                    document_id = key.split(':')[-2]
-                    if len(await self.get_users(document_id)) == 0:
-                        await self.clear_document(document_id)
+            for document_id in document_ids:
+                await self._redis.srem(self._users_key(document_id), user_id)
+
+                if await self._redis.scard(self._users_key(document_id)) == 0:
+                    await self.clear_document(document_id)
+
+            await self._redis.delete(user_documents_key)
 
         else:
             for document_id in list(self._users.keys()):
@@ -258,12 +270,22 @@ class YdocManager:
         document_id = document_id.replace(':', '_')
 
         if self._redis:
-            redis_key = f'{self._redis_key_prefix}:{document_id}:updates'
-            await self._redis.delete(redis_key)
-            redis_users_key = f'{self._redis_key_prefix}:{document_id}:users'
+            redis_users_key = self._users_key(document_id)
+            users = await self._redis.smembers(redis_users_key)
+            for user_id in users:
+                await self._redis.srem(self._user_documents_key(user_id), document_id)
+
+            await self._redis.delete(self._updates_key(document_id))
             await self._redis.delete(redis_users_key)
         else:
             if document_id in self._updates:
                 del self._updates[document_id]
             if document_id in self._users:
                 del self._users[document_id]
+
+    async def _find_documents_for_user(self, user_id: str) -> set[str]:
+        document_ids = set()
+        async for key in self._redis.scan_iter(match=f'{self._redis_key_prefix}:*:users', count=100):
+            if user_id in await self._redis.smembers(key):
+                document_ids.add(key.split(':')[-2])
+        return document_ids

--- a/backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py
+++ b/backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py
@@ -1,0 +1,89 @@
+import pytest
+from open_webui.socket.utils import YdocManager
+
+
+class FakeAsyncRedis:
+    def __init__(self):
+        self.sets = {}
+        self.lists = {}
+
+    async def sadd(self, key, *values):
+        self.sets.setdefault(key, set()).update(values)
+
+    async def srem(self, key, *values):
+        if key not in self.sets:
+            return 0
+
+        removed = 0
+        for value in values:
+            if value in self.sets[key]:
+                self.sets[key].remove(value)
+                removed += 1
+        return removed
+
+    async def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
+    async def scard(self, key):
+        return len(self.sets.get(key, set()))
+
+    async def rpush(self, key, *values):
+        self.lists.setdefault(key, []).extend(values)
+
+    async def llen(self, key):
+        return len(self.lists.get(key, []))
+
+    async def lrange(self, key, start, end):
+        values = self.lists.get(key, [])
+        if end == -1:
+            return values[start:]
+        return values[start : end + 1]
+
+    async def exists(self, key):
+        return int(key in self.sets or key in self.lists)
+
+    async def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            deleted += int(self.sets.pop(key, None) is not None)
+            deleted += int(self.lists.pop(key, None) is not None)
+        return deleted
+
+    def scan_iter(self, *args, **kwargs):
+        raise AssertionError('YdocManager should use the per-user document index instead of scanning all documents')
+
+
+@pytest.mark.asyncio
+async def test_remove_user_from_all_documents_uses_reverse_index():
+    redis = FakeAsyncRedis()
+    manager = YdocManager(redis=redis, redis_key_prefix='test:ydoc')
+
+    await manager.add_user('note:owned', 'sid-1')
+    await manager.add_user('note:shared', 'sid-1')
+    await manager.add_user('note:shared', 'sid-2')
+    await manager.append_to_updates('note:owned', b'owned-update')
+    await manager.append_to_updates('note:shared', b'shared-update')
+
+    await manager.remove_user_from_all_documents('sid-1')
+
+    assert await manager.get_users('note:shared') == ['sid-2']
+    assert await manager.document_exists('note:shared') is True
+    assert await manager.document_exists('note:owned') is False
+    assert await redis.smembers('test:ydoc:users:sid-1:documents') == set()
+    assert await redis.smembers('test:ydoc:users:sid-2:documents') == {'note_shared'}
+
+
+@pytest.mark.asyncio
+async def test_clear_document_removes_document_from_user_indexes():
+    redis = FakeAsyncRedis()
+    manager = YdocManager(redis=redis, redis_key_prefix='test:ydoc')
+
+    await manager.add_user('note:shared', 'sid-1')
+    await manager.add_user('note:shared', 'sid-2')
+    await manager.append_to_updates('note:shared', b'shared-update')
+
+    await manager.clear_document('note:shared')
+
+    assert await manager.document_exists('note:shared') is False
+    assert await redis.smembers('test:ydoc:users:sid-1:documents') == set()
+    assert await redis.smembers('test:ydoc:users:sid-2:documents') == set()


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Add a Redis reverse index from socket user/session IDs to collaborative YDoc document IDs so disconnect cleanup can remove a user's memberships without scanning every document membership set.
- Keep the reverse index synchronized when users join, disconnect, or when a document is cleared.
- Add focused async tests covering disconnect cleanup and document cleanup index maintenance.

### Added

- Redis-backed per-user document membership index for `YdocManager`.
- Regression tests for reverse-index cleanup behavior.

### Changed

- `remove_user_from_all_documents()` now reads the user's document set directly and only falls back to a scan when the index is absent, preserving compatibility with existing Redis state.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Avoids an O(number of active YDoc documents) Redis key scan on each user disconnect in the common indexed path.
- Removes cleared documents from every associated user's reverse index so future disconnect cleanup does not chase stale document IDs.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

Validation:

- `uv run pytest backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py`
- `uv run ruff check backend/open_webui/socket/utils.py backend/open_webui/test/apps/webui/socket/test_ydoc_manager.py`
- `git diff --check`

This is the same fix as the earlier PR, retargeted to `dev` and updated to the repository template/title requirements.

### Screenshots or Videos

- Not applicable; backend WebSocket state cleanup only.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
