### PR TITLE
feat: open exact PDF citations in source panel

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1043,7 +1043,7 @@ CHUNK_MIN_SIZE_TARGET = int(os.getenv('CHUNK_MIN_SIZE_TARGET', '0'))
 CHUNK_OVERLAP = int(os.getenv('CHUNK_OVERLAP', '100'))
 
 DEFAULT_RAG_TEMPLATE = """### Task:
-Respond to the user query using the provided context, incorporating inline citations in the format [id] **only when the <source> tag includes an explicit id attribute** (e.g., <source id="1">).
+Respond to the user query using the provided context, incorporating inline citations by wrapping the exact <source id="..."> value in brackets **only when the <source> tag includes an explicit id attribute** (e.g., cite <source id="1#0"> as [1#0]).
 
 ### Guidelines:
 - If you don't know the answer, clearly state that.
@@ -1051,17 +1051,17 @@ Respond to the user query using the provided context, incorporating inline citat
 - Respond in the same language as the user's query.
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
-- **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
+- **Only include inline citations using the exact <source id="..."> value in brackets when the <source> tag includes an id attribute.**
 - Do not cite if the <source> tag does not contain an id attribute.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 
 ### Example of Citation:
 If the user asks about a specific topic and the information is found in a source with a provided id attribute, the response should include the citation like in the following example:
-* "According to the study, the proposed method increases efficiency by 20% [1]."
+* "According to the study, the proposed method increases efficiency by 20% [1#0]."
 
 ### Output:
-Provide a clear and direct response to the user's query, including inline citations in the format [id] only when the <source> tag with id attribute is present in the context.
+Provide a clear and direct response to the user's query, including inline citations using the exact <source id="..."> value in brackets only when the <source> tag with id attribute is present in the context.
 
 <context>
 {{CONTEXT}}

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -750,27 +750,39 @@ def handle_responses_streaming_event(
         return current_output, None
 
 
-def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
+def get_source_context(
+    sources: list,
+    source_ids: dict = None,
+    include_content: bool = True,
+    reference_indexes: dict = None,
+) -> str:
     """
     Build <source> tag context string from citation sources.
     """
     context_string = ''
     if source_ids is None:
         source_ids = {}
+    if reference_indexes is None:
+        reference_indexes = {}
     for source in sources:
         for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
             source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
+            group_id = source_ids[source_id]
+            reference_index = reference_indexes.get(source_id, 0)
+            reference_indexes[source_id] = reference_index + 1
+            citation_id = f'{group_id}#{reference_index}'
             src_name = source.get('source', {}).get('name')
             src_type = source.get('source', {}).get('type')
             src_rid = source.get('source', {}).get('id')
             body = doc if include_content else ''
             context_string += (
-                f'<source id="{source_ids[source_id]}"'
+                f'<source id="{citation_id}"'
                 + (f' name="{src_name}"' if src_name else '')
                 + (f' resource-type="{src_type}"' if src_type else '')
                 + (f' resource-id="{src_rid}"' if src_rid else '')
+                + f' source-group-id="{group_id}" reference-index="{reference_index}"'
                 + f'>{body}</source>\n'
             )
     return context_string
@@ -4879,12 +4891,16 @@ async def streaming_chat_response_handler(response, ctx):
                             # Build context: file sources with content,
                             # tool sources as citation markers only.
                             source_ids = {}
+                            reference_indexes = {}
                             source_context = get_source_context(
-                                metadata.get('sources', []), source_ids
+                                metadata.get('sources', []),
+                                source_ids,
+                                reference_indexes=reference_indexes,
                             ) + get_source_context(
                                 all_tool_call_sources,
                                 source_ids,
                                 include_content=False,
+                                reference_indexes=reference_indexes,
                             )
                             source_context = source_context.strip()
                             if source_context:

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -105,6 +105,7 @@
 	import MessageInput from '$lib/components/chat/MessageInput.svelte';
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/chat/Navbar.svelte';
+	import SourcePanel from '$lib/components/chat/SourcePanel.svelte';
 	import ChatControls from './ChatControls.svelte';
 	import EventConfirmDialog from '../common/ConfirmDialog.svelte';
 	import DeleteConfirmDialog from '../common/ConfirmDialog.svelte';
@@ -124,6 +125,7 @@
 	const eventTarget = new EventTarget();
 	let controlPane: Pane | undefined;
 	let controlPaneComponent: ChatControls | undefined;
+	let sourcePanelTarget: any = null;
 
 	let messageInput: MessageInput | undefined;
 	let messagesRef: Messages | undefined;
@@ -3274,6 +3276,9 @@
 										topPadding={true}
 										bottomPadding={files.length > 0}
 										{onSelect}
+										on:openSourcePanel={(e) => {
+											sourcePanelTarget = e.detail;
+										}}
 									/>
 								</div>
 							</div>
@@ -3412,28 +3417,53 @@
 					</div>
 				</Pane>
 
-				<ChatControls
-					bind:this={controlPaneComponent}
-					bind:history
-					bind:chatFiles
-					bind:params
-					bind:files
-					bind:pane={controlPane}
-					chatId={$chatId}
-					modelId={selectedModelIds?.at(0) ?? null}
-					models={selectedModelIds.reduce((a, e, i, arr) => {
-						const model = $models.find((m) => m.id === e);
-						if (model) {
-							return [...a, model];
-						}
-						return a;
-					}, [])}
-					submitPrompt={submitHandler}
-					{stopResponse}
-					{showMessage}
-					{eventTarget}
-					{codeInterpreterEnabled}
-				/>
+				{#if sourcePanelTarget}
+					<PaneResizer
+						class="relative z-20 flex items-center justify-center border-l border-gray-50 transition hover:border-gray-200 dark:border-gray-850/30 dark:hover:border-gray-800"
+					>
+						<div
+							class="absolute -bottom-0 -left-1.5 -right-1.5 -top-0 z-20 cursor-col-resize bg-transparent"
+						/>
+					</PaneResizer>
+					<Pane
+						defaultSize={35}
+						minSize={25}
+						maxSize={50}
+						class="z-10 h-full min-w-0 bg-white dark:bg-gray-850"
+					>
+						<SourcePanel
+							target={sourcePanelTarget}
+							onClose={() => {
+								sourcePanelTarget = null;
+							}}
+						/>
+					</Pane>
+				{/if}
+
+				{#if $showControls}
+					<ChatControls
+						bind:this={controlPaneComponent}
+						bind:history
+						bind:chatFiles
+						bind:params
+						bind:files
+						bind:pane={controlPane}
+						chatId={$chatId}
+						modelId={selectedModelIds?.at(0) ?? null}
+						models={selectedModelIds.reduce((a, e, i, arr) => {
+							const model = $models.find((m) => m.id === e);
+							if (model) {
+								return [...a, model];
+							}
+							return a;
+						}, [])}
+						submitPrompt={submitHandler}
+						{stopResponse}
+						{showMessage}
+						{eventTarget}
+						{codeInterpreterEnabled}
+					/>
+				{/if}
 			</PaneGroup>
 		</div>
 	{:else if loading}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -551,6 +551,9 @@
 								{readOnly}
 								{editCodeBlock}
 								{topPadding}
+								on:openSourcePanel={(e) => {
+									dispatch('openSourcePanel', e.detail);
+								}}
 							/>
 						{/each}
 					</ul>

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { createEventDispatcher, getContext } from 'svelte';
 	import { embed, showControls, showEmbeds } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	import CitationModal from './Citations/CitationModal.svelte';
 
 	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher();
 
 	export let id = '';
 	export let chatId = '';
@@ -22,6 +24,79 @@
 	let showCitationModal = false;
 
 	let selectedCitation: any = null;
+	let sourcePanelRequestId = 0;
+
+	// Exact ids index aligned document/metadata pairs emitted by the backend.
+	const getReferenceCount = (citation: any) =>
+		Math.min(citation?.metadata?.length ?? 0, citation?.document?.length ?? 0);
+
+	const getReferenceIndex = (citation: any, suffix: string | null) => {
+		if (!suffix || !/^\d+$/.test(suffix)) {
+			return null;
+		}
+
+		const index = Number(suffix);
+		const referenceCount = getReferenceCount(citation);
+
+		return index >= 0 && index < referenceCount ? index : null;
+	};
+
+	const getReference = (citation: any, index: number) => {
+		const metadata = citation?.metadata?.[index] ?? {};
+		const source = citation?.source ?? {};
+		const title = metadata?.name ?? source?.name ?? metadata?.source ?? 'Source';
+		const file_id = metadata?.file_id;
+		const url = source?.url?.includes('http') ? source.url : metadata?.url;
+		const page = Number.isInteger(metadata?.page) ? metadata.page : undefined;
+
+		return {
+			index,
+			title,
+			file_id,
+			url,
+			page,
+			page_label: metadata?.page_label,
+			total_pages: metadata?.total_pages,
+			metadata,
+			openInNewTabUrl: file_id
+				? `${WEBUI_API_BASE_URL}/files/${file_id}/content${
+						page !== undefined ? `#page=${page + 1}` : ''
+					}`
+				: url
+		};
+	};
+
+	const getCitationTarget = (citation: any, selectedReferenceIndex = 0, citationGroupIndex = 0) => {
+		const reference = getReference(citation, selectedReferenceIndex);
+		const source = citation?.source ?? {};
+		const contentType =
+			reference?.metadata?.content_type ?? source?.meta?.content_type ?? source?.content_type ?? '';
+		const isPdf =
+			contentType === 'application/pdf' ||
+			reference?.title?.toLowerCase?.().endsWith('.pdf') ||
+			reference?.url?.toLowerCase?.().split('?')[0]?.endsWith('.pdf');
+
+		if (!isPdf || (!reference?.file_id && !reference?.url)) {
+			return null;
+		}
+
+		return {
+			messageId: id,
+			sourceTargetKey: `${id}:${citationGroupIndex}:${selectedReferenceIndex}`,
+			// Bump for repeated clicks on the same citation so PDFViewer scrolls again.
+			scrollRequestId: ++sourcePanelRequestId,
+			citationGroupIndex,
+			selectedReferenceIndex,
+			title: reference.title,
+			file_id: reference.file_id,
+			url: reference.url,
+			page: reference.page,
+			page_label: reference.page_label,
+			total_pages: reference.total_pages,
+			metadata: reference.metadata,
+			openInNewTabUrl: reference.openInNewTabUrl
+		};
+	};
 
 	export const showSourceModal = (sourceId) => {
 		let index;
@@ -40,6 +115,19 @@
 
 		if (citations[index]) {
 			console.log('Showing citation modal for:', citations[index]);
+			const selectedReferenceIndex = getReferenceIndex(citations[index], suffix);
+
+			if (selectedReferenceIndex === null) {
+				selectedCitation = citations[index];
+				showCitationModal = true;
+				return;
+			}
+
+			const target = getCitationTarget(citations[index], selectedReferenceIndex, index);
+			if (target) {
+				dispatch('openSourcePanel', target);
+				return;
+			}
 
 			if (citations[index]?.source?.embed_url) {
 				const embedUrl = citations[index].source.embed_url;

--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -98,6 +98,9 @@
 				{readOnly}
 				{editCodeBlock}
 				{topPadding}
+				on:openSourcePanel={(e) => {
+					dispatch('openSourcePanel', e.detail);
+				}}
 			/>
 		{:else}
 			{#key messageId}
@@ -123,6 +126,9 @@
 					{readOnly}
 					{editCodeBlock}
 					{topPadding}
+					on:openSourcePanel={(e) => {
+						dispatch('openSourcePanel', e.detail);
+					}}
 				/>
 			{/key}
 		{/if}

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -322,6 +322,9 @@
 									{addMessages}
 									{readOnly}
 									{topPadding}
+									on:openSourcePanel={(e) => {
+										dispatch('openSourcePanel', e.detail);
+									}}
 								/>
 							{/if}
 						{/key}
@@ -379,6 +382,9 @@
 										{readOnly}
 										{editCodeBlock}
 										{topPadding}
+										on:openSourcePanel={(e) => {
+											dispatch('openSourcePanel', e.detail);
+										}}
 									/>
 								{/if}
 							{/key}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -895,6 +895,9 @@
 									{chatId}
 									sources={message?.sources ?? message?.citations}
 									{readOnly}
+									on:openSourcePanel={(e) => {
+										dispatch('openSourcePanel', e.detail);
+									}}
 								/>
 							{/if}
 

--- a/src/lib/components/chat/SourcePanel.svelte
+++ b/src/lib/components/chat/SourcePanel.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import PDFViewer from '$lib/components/common/PDFViewer.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+
+	const i18n: Writable<i18nType> = getContext('i18n');
+
+	export let target: {
+		messageId?: string;
+		sourceTargetKey?: string;
+		scrollRequestId?: number;
+		citationGroupIndex?: number;
+		selectedReferenceIndex?: number;
+		title?: string;
+		file_id?: string;
+		url?: string;
+		page?: number;
+		page_label?: string | number;
+		total_pages?: number;
+		metadata?: Record<string, any>;
+		openInNewTabUrl?: string;
+	} | null = null;
+
+	export let onClose: () => void = () => {};
+
+	const decodeString = (str: string) => {
+		try {
+			return decodeURIComponent(str);
+		} catch {
+			return str;
+		}
+	};
+
+	const withPageFragment = (sourceUrl: string | null | undefined, page: number | null) => {
+		if (!sourceUrl || !page) return sourceUrl ?? null;
+
+		const [baseUrl] = sourceUrl.split('#');
+		return `${baseUrl}#page=${page}`;
+	};
+
+	$: title = target?.title ?? $i18n.t('Source');
+	$: fileId = target?.file_id;
+	$: url = target?.url;
+	$: page = target?.page;
+	$: hasPage = Number.isInteger(page);
+	$: initialPage = hasPage ? (page as number) + 1 : null;
+	$: pdfUrl = fileId ? `${WEBUI_API_BASE_URL}/files/${fileId}/content` : null;
+	$: iframeUrl = !fileId ? withPageFragment(url, initialPage) : null;
+	$: openInNewTabUrl = target?.openInNewTabUrl;
+	$: scrollRequestId = target?.scrollRequestId ?? 0;
+</script>
+
+<div
+	class="flex h-full min-h-full w-full min-w-0 flex-col bg-white text-gray-800 dark:bg-gray-850 dark:text-gray-100"
+>
+	<div class="flex shrink-0 items-center justify-between gap-3 px-3 py-2">
+		<div class="min-w-0">
+			<div class="truncate text-sm font-medium">
+				{#if openInNewTabUrl}
+					<Tooltip
+						className="w-fit"
+						content={url?.includes('http') ? $i18n.t('Open link') : $i18n.t('Open file')}
+						placement="top-start"
+						tippyOptions={{ duration: [500, 0] }}
+					>
+						<a
+							class="underline hover:text-gray-500 dark:hover:text-gray-100"
+							href={openInNewTabUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{decodeString(title)}
+						</a>
+					</Tooltip>
+				{:else}
+					{decodeString(title)}
+				{/if}
+			</div>
+		</div>
+
+		<div class="flex shrink-0 items-center gap-1">
+			<button
+				class="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+				aria-label={$i18n.t('Close')}
+				on:click={onClose}
+			>
+				<XMark className="size-4" />
+			</button>
+		</div>
+	</div>
+
+	<div class="min-h-0 flex-1">
+		{#if pdfUrl}
+			{#key pdfUrl}
+				<PDFViewer url={pdfUrl} {initialPage} {scrollRequestId} className="h-full w-full" />
+			{/key}
+		{:else if iframeUrl}
+			{#key `${iframeUrl}:${scrollRequestId}`}
+				<iframe class="h-full w-full border-0" title={decodeString(title)} src={iframeUrl}></iframe>
+			{/key}
+		{:else}
+			<div class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+				{$i18n.t('No source available')}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/common/PDFViewer.svelte
+++ b/src/lib/components/common/PDFViewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy, tick } from 'svelte';
 	import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
 	import panzoom, { type PanZoom } from 'panzoom';
 	import Spinner from './Spinner.svelte';
@@ -7,7 +7,10 @@
 	export let url: string | null = null;
 	export let data: ArrayBuffer | Uint8Array | null = null;
 	export let className = 'w-full h-[70vh]';
+	export let initialPage: number | null = null;
+	export let scrollRequestId = 0;
 
+	let containerElement: HTMLDivElement;
 	let outerContainer: HTMLDivElement;
 	let sceneElement: HTMLDivElement;
 	let loading = true;
@@ -16,10 +19,18 @@
 	let pzInstance: PanZoom | null = null;
 	let zoomLevel = 1;
 	let rerenderTimer: ReturnType<typeof setTimeout> | null = null;
+	let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+	let resizeObserver: ResizeObserver | null = null;
 	let lastRenderedZoom = 1;
+	let lastScrolledPage: number | null = null;
+	let lastScrollRequestId = 0;
+	let lastContainerWidth = 0;
 
 	// Keep a reference to TextLayer instances so we can update/cancel them
 	let textLayerInstances: any[] = [];
+
+	const getContainerWidth = () =>
+		containerElement?.getBoundingClientRect().width || outerContainer?.clientWidth || 800;
 
 	const initPanzoom = () => {
 		if (pzInstance) {
@@ -84,12 +95,30 @@
 		}
 	};
 
+	const scrollToPage = async (page: number | null, requestId = scrollRequestId) => {
+		if (!sceneElement || !outerContainer || !page) return;
+
+		await tick();
+
+		const pageIndex = Math.max(
+			0,
+			Math.min(page - 1, sceneElement.querySelectorAll('[data-page-number]').length - 1)
+		);
+		const pageElement = sceneElement.querySelectorAll('[data-page-number]')[pageIndex];
+
+		if (pageElement) {
+			pageElement.scrollIntoView({ block: 'start' });
+			lastScrolledPage = page;
+			lastScrollRequestId = requestId;
+		}
+	};
+
 	// Re-render existing canvases at a new zoom level (preserves panzoom transform)
 	const rerenderPages = async (forZoom: number) => {
 		if (!pdfDoc || !sceneElement) return;
 		const pdfjs = await import('pdfjs-dist');
 		const dpr = window.devicePixelRatio || 1;
-		const containerWidth = outerContainer?.clientWidth || 800;
+		const containerWidth = getContainerWidth();
 
 		const pageWrappers = sceneElement.querySelectorAll('.pdf-page-wrapper');
 
@@ -112,10 +141,14 @@
 			const wrapper = pageWrappers[i] as HTMLElement;
 			// Update the CSS custom property so textLayer dimensions resolve correctly
 			wrapper.style.setProperty('--scale-factor', String(cssViewport.scale));
+			wrapper.style.width = `${Math.round(cssScale * viewport.width)}px`;
+			wrapper.style.height = `${Math.round(cssScale * viewport.height)}px`;
 
 			const canvas = wrapper.querySelector('canvas')!;
 			canvas.width = scaledViewport.width;
 			canvas.height = scaledViewport.height;
+			canvas.style.width = `${Math.round(cssScale * viewport.width)}px`;
+			canvas.style.height = `${Math.round(cssScale * viewport.height)}px`;
 
 			const ctx = canvas.getContext('2d');
 			if (ctx) {
@@ -138,6 +171,11 @@
 			}
 		}
 		lastRenderedZoom = forZoom;
+		lastContainerWidth = containerWidth;
+
+		if (Math.abs(getContainerWidth() - containerWidth) >= 2) {
+			scheduleResizeRender();
+		}
 	};
 
 	const renderAllPages = async () => {
@@ -162,7 +200,7 @@
 			const viewport = page.getViewport({ scale: 1 });
 
 			// Scale to fit container width
-			const containerWidth = outerContainer?.clientWidth || 800;
+			const containerWidth = getContainerWidth();
 			const cssScale = containerWidth / viewport.width;
 			const renderScale = cssScale * dpr;
 			const scaledViewport = page.getViewport({ scale: renderScale });
@@ -171,6 +209,7 @@
 			// Create page wrapper (positioned container for canvas + text layer)
 			const wrapper = document.createElement('div');
 			wrapper.className = 'pdf-page-wrapper';
+			wrapper.dataset.pageNumber = `${i}`;
 			wrapper.style.position = 'relative';
 			wrapper.style.width = `${Math.round(cssScale * viewport.width)}px`;
 			wrapper.style.height = `${Math.round(cssScale * viewport.height)}px`;
@@ -217,7 +256,22 @@
 		}
 
 		lastRenderedZoom = 1;
+		lastContainerWidth = getContainerWidth();
 		initPanzoom();
+		await scrollToPage(initialPage);
+	};
+
+	const scheduleResizeRender = () => {
+		if (!pdfDoc || !containerElement) return;
+
+		const width = getContainerWidth();
+		if (!width || Math.abs(width - lastContainerWidth) < 2) return;
+
+		if (resizeTimer) clearTimeout(resizeTimer);
+		resizeTimer = setTimeout(() => {
+			resizeTimer = null;
+			rerenderPages(zoomLevel);
+		}, 150);
 	};
 
 	const loadPdf = async () => {
@@ -249,12 +303,30 @@
 		}
 	};
 
-	onMount(() => {
+	onMount(async () => {
 		loadPdf();
+
+		await tick();
+		if (containerElement) {
+			resizeObserver = new ResizeObserver(scheduleResizeRender);
+			resizeObserver.observe(containerElement);
+		}
 	});
+
+	$: if (
+		!loading &&
+		!error &&
+		pdfDoc &&
+		initialPage &&
+		(initialPage !== lastScrolledPage || scrollRequestId !== lastScrollRequestId)
+	) {
+		scrollToPage(initialPage);
+	}
 
 	onDestroy(() => {
 		if (rerenderTimer) clearTimeout(rerenderTimer);
+		if (resizeTimer) clearTimeout(resizeTimer);
+		resizeObserver?.disconnect();
 		pzInstance?.dispose();
 		for (const tl of textLayerInstances) {
 			try {
@@ -269,7 +341,7 @@
 	});
 </script>
 
-<div class="relative {className}">
+<div class="relative min-w-0 overflow-hidden {className}" bind:this={containerElement}>
 	{#if loading}
 		<div class="absolute inset-0 flex items-center justify-center">
 			<Spinner className="size-5" />
@@ -280,7 +352,7 @@
 		</div>
 	{/if}
 
-	<div class="overflow-y-auto h-full" bind:this={outerContainer}>
+	<div class="overflow-y-auto overflow-x-hidden h-full w-full min-w-0" bind:this={outerContainer}>
 		<div bind:this={sceneElement} class="w-full"></div>
 	</div>
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/20829.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [ ] **Documentation:** No docs update included.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manual tests were performed and are listed below.
- [x] **Agentic AI Code:** This PR has gone through additional review and manual testing.
- [x] **Code review:** Self-review performed.
- [x] **Design & Architecture:** Uses existing citation parsing, existing PDFViewer, and local UI state; no new setting added.
- [x] **Git Hygiene:** Atomic branch, rebased on `dev`, no unrelated commits.
- [x] **Title Prefix:** Uses `feat`.

# Changelog Entry

### Description

Adds a right-side SourcePanel for exact PDF citations in classic RAG answers. Clicking an exact PDF citation opens the cited PDF beside the chat and navigates to the cited page when page metadata is available.

### Added

- Classic RAG source context now emits exact source ids such as `<source id="1#0" source-group-id="1" reference-index="0">`.
- Exact PDF citations such as `[1#0]` can open a right-side SourcePanel.
- The existing `PDFViewer` now supports optional initial page navigation and repeated scroll requests.

### Changed

- The default RAG prompt now asks models to cite the exact `<source id="...">` value.
- The citation UI now uses `[N#i]` suffix as a reference index for PDF SourcePanel navigation.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None. Plain `[N]` citations, invalid suffixes, non-PDF citations, unsupported citations, and bottom Sources continue to use the existing CitationModal behavior.

---

### Additional Information

- **Discussion:** https://github.com/open-webui/open-webui/discussions/20829
- This applies to classic RAG/source citations, including uploaded PDF files used as chat context.
- SourcePanel reuses the existing `PDFViewer` component. The PDFViewer changes are limited to optional page navigation, repeated scroll requests, and resize handling needed for the resizable side pane.
- The markdown citation parser already accepted identifiers like `[1#0]`, preserved the raw identifier, and passed it through inline citation clicks. Before this PR, modal logic only used the numeric source group, so `[1#0]` behaved like `[1]`.
- Non-goals: no highlighting, no bbox support and no non-PDF viewers.

### Video

https://github.com/user-attachments/assets/30f56296-20af-44e6-9ba6-916b23248c93


### Manual Validation Checklist

- [x] Exact uploaded PDF citation `[1#0]` opens SourcePanel.
- [x] Exact PDF citation with `metadata.page` navigates to the expected page.
- [x] Exact PDF citation without `metadata.page` opens the PDF normally.
- [x] Re-clicking the same citation after scrolling away re-scrolls to the cited page.
- [x] Same PDF with a different exact citation updates the page without a full reload.
- [x] Plain `[1]` opens CitationModal.
- [x] Invalid suffixes such as `[1#bad]`, `[1#999]`, and `[1#]` fall back to CitationModal.
- [x] Non-PDF citations fall back to CitationModal.
- [x] Bottom Sources clicks continue to open CitationModal.
- [x] Existing PDF file preview still renders, zooms, and resets.
- [x] Existing FileItemModal PDF preview still renders.

### Known Limitations

- Same-page citations may not visibly differ until future highlighting support exists.

### Contributor License Agreement


- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
