### PR TITLE
fix: prevent duplicate knowledge batch embeddings

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -151,6 +151,7 @@ class KnowledgeUserModel(KnowledgeModel):
 
 class KnowledgeResponse(KnowledgeModel):
     files: Optional[list[FileMetadataResponse | dict]] = None
+    warnings: Optional[dict] = None
 
 
 class KnowledgeUserResponse(KnowledgeUserModel):
@@ -627,6 +628,14 @@ class KnowledgeTable:
                 return [FileModel.model_validate(file) for file in files]
         except Exception:
             return []
+
+    async def get_file_ids_by_id(self, knowledge_id: str, db: Optional[AsyncSession] = None) -> set[str]:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(KnowledgeFile.file_id).filter_by(knowledge_id=knowledge_id))
+                return set(result.scalars().all())
+        except Exception:
+            return set()
 
     async def get_file_metadatas_by_id(
         self, knowledge_id: str, db: Optional[AsyncSession] = None

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -28,6 +28,8 @@ from open_webui.models.models import ModelForm, Models
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.routers.retrieval import (
     BatchProcessFilesForm,
+    BatchProcessFilesResponse,
+    BatchProcessFilesResult,
     ProcessFileForm,
     process_file,
     process_files_batch,
@@ -662,6 +664,11 @@ async def add_file_to_knowledge_by_id(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.FILE_NOT_PROCESSED,
         )
+    if await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.FILE_EXISTS,
+        )
 
     # KB write-access alone is not enough — caller must also be able to read the file.
     if file.user_id != user.id and user.role != 'admin':
@@ -1169,6 +1176,9 @@ async def sync_knowledge_cleanup(
     return {'status': True}
 
 
+
+
+
 ############################
 # AddFilesToKnowledge
 ############################
@@ -1210,7 +1220,18 @@ async def add_files_to_knowledge_batch(
 
     # Batch-fetch all files to avoid N+1 queries
     log.info(f'files/batch/add - {len(form_data)} files')
-    file_ids = [form.file_id for form in form_data]
+    directory_by_file_id: dict[str, str | None] = {}
+    duplicate_request_ids: set[str] = set()
+    file_ids: list[str] = []
+
+    for form in form_data:
+        if form.file_id in directory_by_file_id:
+            duplicate_request_ids.add(form.file_id)
+            continue
+
+        directory_by_file_id[form.file_id] = form.directory_id
+        file_ids.append(form.file_id)
+
     files = await Files.get_files_by_ids(file_ids, db=db)
 
     # Verify all requested files were found
@@ -1231,22 +1252,54 @@ async def add_files_to_knowledge_batch(
                     detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
                 )
 
-    # Process files
-    try:
-        result = await process_files_batch(
-            request=request,
-            form_data=BatchProcessFilesForm(files=files, collection_name=id),
-            user=user,
-            db=db,
+    existing_file_ids = await Knowledges.get_file_ids_by_id(id, db=db)
+    skipped_results = [
+        BatchProcessFilesResult(
+            file_id=file_id,
+            status='failed',
+            error=ERROR_MESSAGES.FILE_EXISTS,
         )
-    except Exception as e:
-        log.error(f'add_files_to_knowledge_batch: Exception occurred: {e}', exc_info=True)
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        for file_id in sorted(existing_file_ids.intersection(found_ids))
+    ]
+    skipped_results.extend(
+        BatchProcessFilesResult(
+            file_id=file_id,
+            status='failed',
+            error=ERROR_MESSAGES.FILE_EXISTS,
+        )
+        for file_id in sorted(duplicate_request_ids)
+    )
+
+    skipped_file_ids = {result.file_id for result in skipped_results}
+    files_to_process = [file for file in files if file.id not in skipped_file_ids]
+
+    # Process files
+    if files_to_process:
+        try:
+            result = await process_files_batch(
+                request=request,
+                form_data=BatchProcessFilesForm(files=files_to_process, collection_name=id),
+                user=user,
+                db=db,
+            )
+        except Exception as e:
+            log.error(f'add_files_to_knowledge_batch: Exception occurred: {e}', exc_info=True)
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    else:
+        result = BatchProcessFilesResponse(results=[], errors=[])
+
+    result.errors.extend(skipped_results)
 
     # Only add files that were successfully processed
     successful_file_ids = [r.file_id for r in result.results if r.status == 'completed']
     for file_id in successful_file_ids:
-        await Knowledges.add_file_to_knowledge_by_id(knowledge_id=id, file_id=file_id, user_id=user.id, db=db)
+        await Knowledges.add_file_to_knowledge_by_id(
+            knowledge_id=id,
+            file_id=file_id,
+            user_id=user.id,
+            directory_id=directory_by_file_id.get(file_id),
+            db=db,
+        )
 
     # If there were any errors, include them in the response
     if result.errors:
@@ -1489,4 +1542,3 @@ async def move_file_in_knowledge(
             detail='Failed to move file.',
         )
     return {'status': True}
-

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1367,25 +1367,17 @@ def save_docs_to_vector_db(
     log.debug(f'save_docs_to_vector_db: document {_get_docs_info(docs)} {collection_name}')
 
     # Check if entries with the same hash (metadata.hash) already exist
-    if metadata and 'hash' in metadata:
-        result = VECTOR_DB_CLIENT.query(
+    if (
+        metadata
+        and 'hash' in metadata
+        and vector_collection_has_hash_for_other_file(
             collection_name=collection_name,
-            filter={'hash': metadata['hash']},
+            content_hash=metadata['hash'],
+            file_id=metadata.get('file_id'),
         )
-
-        if result is not None and result.ids and len(result.ids) > 0:
-            existing_doc_ids = result.ids[0]
-            if existing_doc_ids:
-                # Check if the existing document belongs to the same file
-                # If same file_id, this is a re-add/reindex - allow it
-                # If different file_id, this is a duplicate - block it
-                existing_file_id = None
-                if result.metadatas and result.metadatas[0]:
-                    existing_file_id = result.metadatas[0][0].get('file_id')
-
-                if existing_file_id != metadata.get('file_id'):
-                    log.info(f'Document with hash {metadata["hash"]} already exists')
-                    raise ValueError(ERROR_MESSAGES.DUPLICATE_CONTENT)
+    ):
+        log.info(f'Document with hash {metadata["hash"]} already exists')
+        raise ValueError(ERROR_MESSAGES.DUPLICATE_CONTENT)
 
     if split:
         if request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER:
@@ -2606,6 +2598,48 @@ class BatchProcessFilesResponse(BaseModel):
     errors: list[BatchProcessFilesResult]
 
 
+def _vector_result_has_ids(result) -> bool:
+    ids_batches = getattr(result, 'ids', None) or []
+    return any(bool(ids) for ids in ids_batches)
+
+
+def vector_result_has_hash_for_other_file(result, file_id: str | None) -> bool:
+    if result is None or not _vector_result_has_ids(result):
+        return False
+
+    metadata_batches = getattr(result, 'metadatas', None) or []
+    ids_batches = getattr(result, 'ids', None) or []
+
+    for batch_index, ids in enumerate(ids_batches):
+        if not ids:
+            continue
+
+        batch_metadatas = []
+        if batch_index < len(metadata_batches) and metadata_batches[batch_index]:
+            batch_metadatas = metadata_batches[batch_index]
+
+        for item_index, _ in enumerate(ids):
+            metadata = {}
+            if item_index < len(batch_metadatas) and isinstance(batch_metadatas[item_index], dict):
+                metadata = batch_metadatas[item_index]
+
+            if metadata.get('file_id') != file_id:
+                return True
+
+    return False
+
+
+def vector_collection_has_hash_for_other_file(collection_name: str, content_hash: str, file_id: str | None) -> bool:
+    if not VECTOR_DB_CLIENT.has_collection(collection_name=collection_name):
+        return False
+
+    result = VECTOR_DB_CLIENT.query(
+        collection_name=collection_name,
+        filter={'hash': content_hash},
+    )
+    return vector_result_has_hash_for_other_file(result, file_id)
+
+
 @router.post('/process/files/batch')
 async def process_files_batch(
     request: Request,
@@ -2629,7 +2663,8 @@ async def process_files_batch(
 
     file_results: list[BatchProcessFilesResult] = []
     file_errors: list[BatchProcessFilesResult] = []
-    file_updates: list[FileUpdateForm] = []
+    file_updates: list[tuple[str, FileUpdateForm]] = []
+    prepared_hashes: dict[str, str] = {}
 
     # Prepare all documents first
     all_docs: list[Document] = []
@@ -2658,6 +2693,35 @@ async def process_files_batch(
                 continue
 
             text_content = file.data.get('content', '')
+            content_hash = calculate_sha256_string(text_content)
+
+            existing_batch_file_id = prepared_hashes.get(content_hash)
+            if existing_batch_file_id and existing_batch_file_id != file.id:
+                file_errors.append(
+                    BatchProcessFilesResult(
+                        file_id=file.id,
+                        status='failed',
+                        error=ERROR_MESSAGES.DUPLICATE_CONTENT,
+                    )
+                )
+                continue
+
+            is_duplicate = await run_in_threadpool(
+                vector_collection_has_hash_for_other_file,
+                collection_name,
+                content_hash,
+                file.id,
+            )
+            if is_duplicate:
+                file_errors.append(
+                    BatchProcessFilesResult(
+                        file_id=file.id,
+                        status='failed',
+                        error=ERROR_MESSAGES.DUPLICATE_CONTENT,
+                    )
+                )
+                continue
+
             docs: list[Document] = [
                 Document(
                     page_content=text_content.replace('<br/>', '\n'),
@@ -2667,16 +2731,21 @@ async def process_files_batch(
                         'created_by': file.user_id,
                         'file_id': file.id,
                         'source': file.filename,
+                        'hash': content_hash,
                     },
                 )
             ]
 
             all_docs.extend(docs)
+            prepared_hashes[content_hash] = file.id
 
             file_updates.append(
-                FileUpdateForm(
-                    hash=calculate_sha256_string(text_content),
-                    data={'content': text_content},
+                (
+                    file.id,
+                    FileUpdateForm(
+                        hash=content_hash,
+                        data={'content': text_content},
+                    ),
                 )
             )
             file_results.append(BatchProcessFilesResult(file_id=file.id, status='prepared'))
@@ -2698,7 +2767,12 @@ async def process_files_batch(
             )
 
             # Update all files with collection name
-            for file_update, file_result in zip(file_updates, file_results):
+            file_updates_by_id = dict(file_updates)
+            for file_result in file_results:
+                file_update = file_updates_by_id.get(file_result.file_id)
+                if not file_update:
+                    continue
+
                 await Files.update_file_by_id(id=file_result.file_id, form_data=file_update, db=db)
                 file_result.status = 'completed'
 

--- a/backend/open_webui/routers/test_retrieval_batch.py
+++ b/backend/open_webui/routers/test_retrieval_batch.py
@@ -1,0 +1,230 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.models.files import FileModel
+from open_webui.routers import knowledge as knowledge_router
+from open_webui.routers import retrieval
+from open_webui.utils.misc import calculate_sha256_string
+
+
+def make_file(file_id: str, content: str, user_id: str = 'user-1') -> FileModel:
+    return FileModel(
+        id=file_id,
+        user_id=user_id,
+        filename=f'{file_id}.txt',
+        path=None,
+        data={'content': content},
+        meta={},
+        created_at=1,
+        updated_at=1,
+    )
+
+
+class User:
+    id = 'user-1'
+    role = 'user'
+
+
+def test_vector_result_duplicate_detection_ignores_same_file():
+    result = SimpleNamespace(
+        ids=[['chunk-1']],
+        metadatas=[[{'file_id': 'file-1'}]],
+    )
+
+    assert retrieval.vector_result_has_hash_for_other_file(result, 'file-1') is False
+
+
+def test_vector_result_duplicate_detection_finds_other_file():
+    result = SimpleNamespace(
+        ids=[['chunk-1', 'chunk-2']],
+        metadatas=[[{'file_id': 'file-1'}, {'file_id': 'file-2'}]],
+    )
+
+    assert retrieval.vector_result_has_hash_for_other_file(result, 'file-1') is True
+
+
+def test_vector_result_duplicate_detection_treats_missing_metadata_as_duplicate():
+    result = SimpleNamespace(ids=[['chunk-1']], metadatas=[[]])
+
+    assert retrieval.vector_result_has_hash_for_other_file(result, 'file-1') is True
+
+
+@pytest.mark.asyncio
+async def test_process_files_batch_skips_existing_collection_hash(monkeypatch):
+    file = make_file('file-1', 'duplicate content')
+
+    async def get_file_by_id(file_id, db=None):
+        return file
+
+    async def validate_collection_access(collection_names, user, access_type='read'):
+        return None
+
+    async def run_in_threadpool(fn, *args, **kwargs):
+        if fn is retrieval.vector_collection_has_hash_for_other_file:
+            return True
+
+        raise AssertionError('duplicate files should not be embedded')
+
+    monkeypatch.setattr(retrieval.Files, 'get_file_by_id', get_file_by_id)
+    monkeypatch.setattr(retrieval, '_validate_collection_access', validate_collection_access)
+    monkeypatch.setattr(retrieval, 'run_in_threadpool', run_in_threadpool)
+
+    result = await retrieval.process_files_batch(
+        request=SimpleNamespace(),
+        form_data=retrieval.BatchProcessFilesForm(files=[file], collection_name='knowledge-1'),
+        user=User(),
+        db=None,
+    )
+
+    assert result.results == []
+    assert len(result.errors) == 1
+    assert result.errors[0].file_id == 'file-1'
+    assert result.errors[0].error == ERROR_MESSAGES.DUPLICATE_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_process_files_batch_adds_hash_metadata_and_updates_files(monkeypatch):
+    first = make_file('file-1', 'first content')
+    second = make_file('file-2', 'second content')
+    saved_docs = []
+    file_updates = {}
+
+    async def get_file_by_id(file_id, db=None):
+        return {'file-1': first, 'file-2': second}[file_id]
+
+    async def update_file_by_id(id, form_data, db=None):
+        file_updates[id] = form_data
+        return None
+
+    async def validate_collection_access(collection_names, user, access_type='read'):
+        return None
+
+    async def run_in_threadpool(fn, *args, **kwargs):
+        if fn is retrieval.vector_collection_has_hash_for_other_file:
+            return False
+        if fn is retrieval.save_docs_to_vector_db:
+            saved_docs.extend(args[1])
+            return True
+
+        raise AssertionError(f'unexpected threaded call: {fn}')
+
+    monkeypatch.setattr(retrieval.Files, 'get_file_by_id', get_file_by_id)
+    monkeypatch.setattr(retrieval.Files, 'update_file_by_id', update_file_by_id)
+    monkeypatch.setattr(retrieval, '_validate_collection_access', validate_collection_access)
+    monkeypatch.setattr(retrieval, 'run_in_threadpool', run_in_threadpool)
+
+    result = await retrieval.process_files_batch(
+        request=SimpleNamespace(),
+        form_data=retrieval.BatchProcessFilesForm(files=[first, second], collection_name='knowledge-1'),
+        user=User(),
+        db=None,
+    )
+
+    assert [item.status for item in result.results] == ['completed', 'completed']
+    assert result.errors == []
+    assert [doc.metadata['hash'] for doc in saved_docs] == [
+        calculate_sha256_string('first content'),
+        calculate_sha256_string('second content'),
+    ]
+    assert file_updates['file-1'].hash == calculate_sha256_string('first content')
+    assert file_updates['file-2'].hash == calculate_sha256_string('second content')
+
+
+@pytest.mark.asyncio
+async def test_process_files_batch_skips_duplicate_hash_inside_same_batch(monkeypatch):
+    first = make_file('file-1', 'same content')
+    second = make_file('file-2', 'same content')
+    saved_docs = []
+
+    async def get_file_by_id(file_id, db=None):
+        return {'file-1': first, 'file-2': second}[file_id]
+
+    async def update_file_by_id(id, form_data, db=None):
+        return None
+
+    async def validate_collection_access(collection_names, user, access_type='read'):
+        return None
+
+    async def run_in_threadpool(fn, *args, **kwargs):
+        if fn is retrieval.vector_collection_has_hash_for_other_file:
+            return False
+        if fn is retrieval.save_docs_to_vector_db:
+            saved_docs.extend(args[1])
+            return True
+
+        raise AssertionError(f'unexpected threaded call: {fn}')
+
+    monkeypatch.setattr(retrieval.Files, 'get_file_by_id', get_file_by_id)
+    monkeypatch.setattr(retrieval.Files, 'update_file_by_id', update_file_by_id)
+    monkeypatch.setattr(retrieval, '_validate_collection_access', validate_collection_access)
+    monkeypatch.setattr(retrieval, 'run_in_threadpool', run_in_threadpool)
+
+    result = await retrieval.process_files_batch(
+        request=SimpleNamespace(),
+        form_data=retrieval.BatchProcessFilesForm(files=[first, second], collection_name='knowledge-1'),
+        user=User(),
+        db=None,
+    )
+
+    assert len(saved_docs) == 1
+    assert result.results[0].file_id == 'file-1'
+    assert result.results[0].status == 'completed'
+    assert len(result.errors) == 1
+    assert result.errors[0].file_id == 'file-2'
+    assert result.errors[0].error == ERROR_MESSAGES.DUPLICATE_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_add_files_to_knowledge_batch_skips_already_linked_files(monkeypatch):
+    file = make_file('file-1', 'already linked')
+    user = User()
+
+    knowledge = SimpleNamespace(
+        id='knowledge-1',
+        user_id=user.id,
+        model_dump=lambda: {
+            'id': 'knowledge-1',
+            'user_id': user.id,
+            'name': 'Knowledge',
+            'description': '',
+            'meta': None,
+            'access_grants': [],
+            'created_at': 1,
+            'updated_at': 1,
+        },
+    )
+
+    async def get_knowledge_by_id(id, db=None):
+        return knowledge
+
+    async def get_files_by_ids(ids, db=None):
+        return [file]
+
+    async def get_file_ids_by_id(id, db=None):
+        return {'file-1'}
+
+    async def get_file_metadatas_by_id(id, db=None):
+        return []
+
+    async def process_files_batch(**kwargs):
+        raise AssertionError('already-linked files should not be reprocessed')
+
+    monkeypatch.setattr(knowledge_router.Knowledges, 'get_knowledge_by_id', get_knowledge_by_id)
+    monkeypatch.setattr(knowledge_router.Knowledges, 'get_file_ids_by_id', get_file_ids_by_id)
+    monkeypatch.setattr(knowledge_router.Knowledges, 'get_file_metadatas_by_id', get_file_metadatas_by_id)
+    monkeypatch.setattr(knowledge_router.Files, 'get_files_by_ids', get_files_by_ids)
+    monkeypatch.setattr(knowledge_router, 'process_files_batch', process_files_batch)
+
+    response = await knowledge_router.add_files_to_knowledge_batch(
+        request=SimpleNamespace(),
+        id='knowledge-1',
+        form_data=[knowledge_router.KnowledgeFileIdForm(file_id='file-1')],
+        user=user,
+        db=None,
+    )
+
+    assert response.warnings == {
+        'message': 'Some files failed to process',
+        'errors': [f'file-1: {ERROR_MESSAGES.FILE_EXISTS}'],
+    }


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

This PR fixes duplicate processing during Knowledge batch adds.

Currently, files that are already linked to a Knowledge base or files with duplicate content can still be processed and embedded again. This leads to unnecessary vector database entries and confusing batch results.

Changes made:

- Skip files that are already linked to the target Knowledge base.
- Detect duplicate content during batch processing using file hashes.
- Return warning details for skipped duplicates while preserving partial-success behavior.
- Add focused backend tests covering duplicate content, duplicate file selection, and already-linked files.

Validation:

- Relevant backend tests pass.
- Syntax checks pass.
- No formatting issues reported by `git diff --check`.

Closes #10679.

# Changelog Entry

### Description

- Fix duplicate processing during Knowledge batch adds by skipping already-linked files and duplicate content before embedding.

### Added

- Focused backend tests covering duplicate content, duplicate file selection, and already-linked Knowledge files.

### Changed

- Knowledge batch add responses now include warning details for skipped duplicates while preserving partial-success behavior.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevented Knowledge batch adds from reprocessing and re-embedding files that are already linked to the target Knowledge base or have duplicate content.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Closes #10679.

### Screenshots or Videos

- Not applicable; backend behavior change covered by tests.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
