### PR TITLE
fix: route web uploads through owned Files; drop legacy non-KB fall-open

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1077,9 +1077,12 @@ async def filter_accessible_collections(
       - web-search-*    → ephemeral per-query collections, always allowed
       - knowledge-bases → always denied (system meta-collection)
       - everything else → if the name matches a knowledge base, validated
-                          via Knowledges.check_access_by_user_id; if no
-                          such KB exists, the name is treated as an
-                          ephemeral/legacy collection and allowed
+                          via Knowledges.check_access_by_user_id; otherwise
+                          denied.  The historical "if no such KB exists,
+                          treat as ephemeral/legacy and allow" branch is
+                          gone — web uploads are now stored as owned
+                          Files (gated via has_access_to_file) and the
+                          legacy non-KB namespace is no longer trusted.
     """
     if user.role == 'admin':
         return collection_names
@@ -1102,14 +1105,10 @@ async def filter_accessible_collections(
             # results scoped to the requesting user's session.
             validated.add(name)
         else:
-            # May be a knowledge-base ID or a legacy/ephemeral collection.
-            # If it IS a KB, enforce access control.  If no such KB
-            # exists, treat it as a non-sensitive collection (e.g. legacy
-            # model knowledge, process_text SHA256 collections) and allow.
+            # Only knowledge-base IDs are accepted here; any other unknown
+            # name is denied. Web uploads now register an owned File and
+            # route through the file-* branch above.
             if await Knowledges.check_access_by_user_id(name, user.id, permission=access_type):
-                validated.add(name)
-            elif not await Knowledges.get_knowledge_by_id(name):
-                # Not a KB at all — legacy/ephemeral collection, allow
                 validated.add(name)
     return validated
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -56,7 +56,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
 )
 from open_webui.internal.db import get_async_db, get_async_session
-from open_webui.models.files import FileModel, Files, FileUpdateForm
+from open_webui.models.files import FileForm, FileModel, Files, FileUpdateForm
 from open_webui.models.knowledge import Knowledges
 
 # Document loaders
@@ -1765,47 +1765,6 @@ async def process_file(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
 
 
-class ProcessTextForm(BaseModel):
-    name: str
-    content: str
-    collection_name: str | None = None
-
-
-@router.post('/process/text')
-async def process_text(
-    request: Request,
-    form_data: ProcessTextForm,
-    user=Depends(get_verified_user),
-):
-    collection_name = form_data.collection_name
-    if collection_name is None:
-        collection_name = calculate_sha256_string(form_data.content)
-    else:
-        await _validate_collection_access([collection_name], user, access_type='write')
-
-    docs = [
-        Document(
-            page_content=form_data.content,
-            metadata={'name': form_data.name, 'created_by': user.id},
-        )
-    ]
-    text_content = form_data.content
-    log.debug(f'text_content: {text_content}')
-
-    result = await run_in_threadpool(save_docs_to_vector_db, request, docs, collection_name, user=user)
-    if result:
-        return {
-            'status': True,
-            'collection_name': collection_name,
-            'content': text_content,
-        }
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=ERROR_MESSAGES.DEFAULT(),
-        )
-
-
 @router.post('/process/youtube')
 @router.post('/process/web')
 async def process_web(
@@ -1821,12 +1780,33 @@ async def process_web(
 
         if process:
             collection_name = form_data.collection_name
-            if not collection_name:
-                collection_name = calculate_sha256_string(form_data.url)[:63]
-            else:
-                await _validate_collection_access([collection_name], user, access_type='write')
+            new_file: Optional[FileModel] = None
+            bypass = request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
 
-            if not request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:
+            if collection_name:
+                await _validate_collection_access([collection_name], user, access_type='write')
+            elif not bypass:
+                # No caller-supplied name: register the fetched URL as an owned File so retrieval gates via
+                # has_access_to_file (owner + shared-chat / KB / channel / workspace-model paths) instead of
+                # the legacy unscoped non-KB namespace.
+                file_id = str(uuid.uuid4())
+                collection_name = f'file-{file_id}'
+                new_file = await Files.insert_new_file(
+                    user.id,
+                    FileForm(
+                        id=file_id,
+                        filename=form_data.url,
+                        path='',  # fetched content lives in data.content, no on-disk file
+                        data={'content': content},
+                        meta={
+                            'name': form_data.url,
+                            'source': form_data.url,
+                            'collection_name': collection_name,
+                        },
+                    ),
+                )
+
+            if not bypass:
                 await run_in_threadpool(
                     save_docs_to_vector_db,
                     request,
@@ -1839,19 +1819,20 @@ async def process_web(
             else:
                 collection_name = None
 
+            file_payload = (
+                new_file.model_dump()
+                if new_file is not None
+                else {
+                    'data': {'content': content},
+                    'meta': {'name': form_data.url, 'source': form_data.url},
+                }
+            )
+
             return {
                 'status': True,
                 'collection_name': collection_name,
                 'filename': form_data.url,
-                'file': {
-                    'data': {
-                        'content': content,
-                    },
-                    'meta': {
-                        'name': form_data.url,
-                        'source': form_data.url,
-                    },
-                },
+                'file': file_payload,
             }
         else:
             return {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1034,6 +1034,11 @@
 				if (res) {
 					fileItem.status = 'uploaded';
 					fileItem.collection_name = res.collection_name;
+					// Backend now registers web uploads as owned Files; carry the file id
+					// so chat-save populates ChatFile (drives shared-chat access on clone).
+					if (res.file?.id) {
+						fileItem.id = res.file.id;
+					}
 					fileItem.file = {
 						...res.file,
 						...fileItem.file


### PR DESCRIPTION
/process/web now registers fetched URLs as owned File rows and stores at file-{file_id} instead of the legacy unscoped sha256(url) namespace. Retrieval gates through has_access_to_file, which already handles owner, shared-chat clone, KB / channel / workspace-model paths, so behaviour is preserved without grant copying.

filter_accessible_collections drops the fall-open branch that allowed any unknown non-KB collection name (the BAC primitive). /process/text and ProcessTextForm are removed (no frontend callers, the truly dead legacy surface). Chat.svelte uploadWeb propagates the file id so chat-save populates ChatFile, enabling shared-chat access for cloners.

old chats whose fileItem.collection_name was the legacy sha256(url)[:63] (created before this PR) will silently stop returning RAG results, because filter_accessible_collections will now deny those names. Users have to re-upload the URL in those old chats. No data is destroyed, only the retrieval link is broken. This is the unavoidable price of removing the fail-open without a DB migration.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
