### PR TITLE
fix: allow clearing calendar event details

### DIFF
--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -103,11 +103,11 @@
 				const result = await updateCalendarEvent(localStorage.token, event.id, {
 					calendar_id: calendarId,
 					title: title.trim(),
-					description: description.trim() || undefined,
+					description: description.trim(),
 					start_at: startNs,
 					end_at: endNs,
 					all_day: allDay,
-					location: location.trim() || undefined,
+					location: location.trim(),
 					meta: { alert_minutes: alertMinutes }
 				});
 				if (result) {


### PR DESCRIPTION
Fixes #25026

## Summary
- Preserve empty description and location strings when updating calendar events
- Keep create-event behavior unchanged, where empty optional fields are omitted

## Testing
- node_modules\.bin\prettier.cmd --check src\lib\components\calendar\CalendarEventModal.svelte
- node_modules\.bin\svelte-check.cmd --workspace src\lib\components\calendar --no-tsconfig --diagnostic-sources "svelte,css" --threshold error