### PR TITLE
fix: skip legacy RAG files handler when native function calling is enabled

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2850,7 +2850,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Check if file context extraction is enabled for this model (default True)
     file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
 
-    if file_context_enabled:
+    if file_context_enabled and metadata.get('params', {}).get('function_calling') != 'native':
         try:
             form_data, flags = await chat_completion_files_handler(request, form_data, extra_params, user)
             sources.extend(flags.get('sources', []))


### PR DESCRIPTION
## Summary

`chat_completion_files_handler` is missing the `function_calling != 'native'` guard that every other handler in `process_chat_payload` already has.

When a file is uploaded in "Focused Retrieval" mode to a chat with native function calling enabled, **both** `add_file_context()` (correct — injects `<file>` tags) **and** the legacy RAG pipeline (`generate_queries` → vector search → RAG template injection) fire, producing redundant/conflicting context and an unnecessary task-model LLM call.

## The fix

Add the same guard all other handlers use:

```python
# Before
if file_context_enabled:

# After
if file_context_enabled and metadata.get('params', {}).get('function_calling') != 'native':
```

## Consistency check

| Handler | Guard | 
|---|---|
| Folder files (line 2247) | `if function_calling != 'native'` ✅ |
| Model knowledge (line 2261) | `if function_calling != 'native'` ✅ |
| Memory (line 2338) | `if function_calling != 'native'` ✅ |
| Web search (line 2343) | `if function_calling != 'native'` ✅ |
| Image generation (line 2348) | `if function_calling != 'native'` ✅ |
| Code interpreter (line 2356) | `if function_calling != 'native'` ✅ |
| **chat_completion_files_handler** | **Missing** ❌ → **Fixed** ✅ |

Fixes #25101

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.