### PR TITLE
fix: make list_knowledge output lazy to prevent context overflow

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2178,15 +2178,26 @@ async def view_knowledge_file(
 
 
 async def list_knowledge(
+    knowledge_id: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 50,
     __request__: Request = None,
     __user__: dict = None,
     __model_knowledge__: Optional[list[dict]] = None,
 ) -> str:
     """
-    List all knowledge bases, files, and notes attached to the current model.
-    Use this first to discover what knowledge is available before querying or reading files.
+    List knowledge bases, files, and notes attached to the current model.
 
-    :return: JSON with knowledge_bases, files, and notes attached to this model
+    Without knowledge_id: returns KB summaries (name, description, file_count)
+    plus standalone files and notes — no file listing inside KBs.
+
+    With knowledge_id: includes paginated file listing for that specific KB.
+    Use offset/limit to page through large KBs.
+
+    :param knowledge_id: Optional KB ID to get file listing for
+    :param offset: File listing pagination offset (default 0)
+    :param limit: Max files per page (default 50, max 200)
+    :return: JSON with knowledge_bases, files, and notes
     """
     if __request__ is None:
         return json.dumps({'error': 'Request context not available'})
@@ -2238,10 +2249,17 @@ async def list_knowledge(
                         'file_count': file_count,
                     }
 
-                    # Include file listing for each KB
-                    if kb_files:
-                        kb_entry['files'] = [{'id': f.id, 'filename': f.filename} for f in kb_files]
-
+                    # Include file listing only when this KB is targeted
+                    if knowledge_id and knowledge_id == knowledge.id:
+                        if kb_files:
+                            total_files = len(kb_files)
+                            page_limit = min(limit, 200)
+                            sliced = kb_files[offset : offset + page_limit]
+                            kb_entry['files'] = [{'id': f.id, 'filename': f.filename} for f in sliced]
+                            kb_entry['files_offset'] = offset
+                            kb_entry['files_limit'] = page_limit
+                            kb_entry['files_total'] = total_files
+                            kb_entry['files_truncated'] = offset + page_limit < total_files
                     knowledge_bases.append(kb_entry)
 
             elif item_type == 'file':


### PR DESCRIPTION
## Problem

`list_knowledge` currently dumps all file listings inline for every knowledge base attached to a model. When KBs contain hundreds of files, this blows up the model's context window on the very first tool call, leaving little room for the actual user query and response.

## Fix

Add `knowledge_id`, `offset`, and `limit` parameters to `list_knowledge`:

- **Without `knowledge_id`**: returns KB summaries (`name`, `description`, `file_count`) without file listings — lightweight discovery call
- **With `knowledge_id`**: includes paginated file listing for that specific KB with `offset`/`limit`/`total` metadata

This lets the model discover available KBs first, then drill into a specific one without consuming all available context.

## Backward compatibility

All new parameters are optional with sensible defaults. Existing callers that don't pass `knowledge_id` get the same KB metadata minus the file dump (which was the problematic part). The `file_count` field is always returned so callers know files exist without needing the full listing.

## Example

```json
// Without knowledge_id - discovery mode
{"knowledge_bases": [{"id": "kb-1", "name": "Docs", "file_count": 500}], "files": [], "notes": []}

// With knowledge_id="kb-1", offset=0, limit=50
{"knowledge_bases": [{"id": "kb-1", "name": "Docs", "file_count": 500,
  "files": [{"id": "f1", "filename": "doc1.pdf"}, ...],
  "files_offset": 0, "files_limit": 50, "files_total": 500, "files_truncated": true
}], "files": [], "notes": []}
```

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.