### PR TITLE
feat: add support for legacy .doc files without replacing extraction engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN chown -R $UID:$GID /app $HOME
 # Install common system dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    git build-essential pandoc gcc netcat-openbsd curl jq \
+    git build-essential pandoc gcc netcat-openbsd curl jq antiword \
     libmariadb-dev \
     python3-dev \
     ffmpeg libsm6 libxext6 zstd \

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -487,6 +487,16 @@ class Loader:
                     loader = PptxLoader(file_path)
             elif file_ext == 'msg':
                 loader = OutlookMessageLoader(file_path)
+            elif file_ext == 'doc':
+                try:
+                    from langchain_community.document_loaders import UnstructuredWordDocumentLoader
+
+                    loader = UnstructuredWordDocumentLoader(file_path)
+                except ImportError:
+                    raise ValueError(
+                        "Processing .doc files requires the 'unstructured' package. "
+                        'Install it with: pip install unstructured'
+                    )
             elif file_ext == 'odt':
                 try:
                     from langchain_community.document_loaders import UnstructuredODTLoader


### PR DESCRIPTION
## Summary

- Add `UnstructuredWordDocumentLoader` for legacy `.doc` files (MS Word 97-2003) in the fallback loader logic
- Install `antiword` system dependency in Docker for proper binary Word format parsing

This allows `.doc` file processing while preserving existing extraction engines (Mistral OCR, Tika, etc.) for other formats.

Relates to #2711

---

## Checklist

- [x] **Linked Issue/Discussion:** Relates to #2711
- [x] **Target branch:** `dev`
- [x] **Description:** Provided above
- [x] **Changelog:** See below
- [ ] **Documentation:** N/A - uses existing unstructured package
- [x] **Dependencies:** `antiword` added to Dockerfile apt-get install
- [x] **Testing:** Manual testing with .doc files
- [x] **Agentic AI Code:** Human reviewed and approved
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Follows existing pattern for .odt files
- [x] **Git Hygiene:** Single atomic commit

---

# Changelog Entry

### Description

- Add support for legacy Microsoft Word 97-2003 (.doc) files without replacing the configured content extraction engine

### Added

- `UnstructuredWordDocumentLoader` handler for `.doc` files in `retrieval/loaders/main.py`
- `antiword` system package in Dockerfile for parsing legacy Word binary format

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `.doc` files no longer fail with encoding detection errors

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Follows the same pattern as existing `.odt` file handling (lines 490-499 in main.py)
- `unstructured` package already in requirements.txt (v0.18.31)
- `antiword` is a lightweight (~100KB) utility for extracting text from .doc files

### Screenshots or Videos

N/A - backend-only change

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.