### PR TITLE
feat: per-user MCP tool servers

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2236,6 +2236,65 @@ def strip_skill_mentions(messages: list[dict]) -> None:
 
 
 
+async def _open_mcp_connection(
+    connection: dict,
+    *,
+    request,
+    user,
+    server_id: str,
+    metadata: dict,
+    extra_params: dict,
+) -> tuple[MCPClient, list[dict]]:
+    headers, _ = await build_tool_server_headers(
+        connection, request, user,
+        server_id=server_id, metadata=metadata, extra_params=extra_params,
+    )
+
+    client = MCPClient()
+    await client.connect(
+        url=connection.get('url', ''),
+        headers=headers if headers else None,
+    )
+
+    function_name_filter_list = connection.get('config', {}).get('function_name_filter_list', '')
+    if isinstance(function_name_filter_list, str):
+        function_name_filter_list = function_name_filter_list.split(',')
+
+    tool_specs = await client.list_tool_specs()
+    if function_name_filter_list:
+        tool_specs = [
+            spec for spec in tool_specs
+            if is_string_allowed(spec['name'], function_name_filter_list)
+        ]
+    return client, tool_specs
+
+
+def _make_mcp_tool_callable(client: MCPClient, function_name: str):
+    async def tool_function(**kwargs):
+        return await client.call_tool(function_name, function_args=kwargs)
+    return tool_function
+
+
+def _register_mcp_tools(
+    *,
+    client: MCPClient,
+    tool_specs: list[dict],
+    registration_key: str,
+    mcp_clients: dict,
+    tools_dict: dict,
+) -> None:
+    mcp_clients[registration_key] = client
+    for tool_spec in tool_specs:
+        spec_name = f'{registration_key}_{tool_spec["name"]}'
+        tools_dict[spec_name] = {
+            'spec': {**tool_spec, 'name': spec_name},
+            'callable': _make_mcp_tool_callable(client, tool_spec['name']),
+            'type': 'mcp',
+            'client': client,
+            'direct': False,
+        }
+
+
 async def connect_mcp_server(
     request,
     server_id: str,
@@ -2243,7 +2302,7 @@ async def connect_mcp_server(
     metadata: dict,
     extra_params: dict,
 ) -> tuple[MCPClient, list[dict]] | None:
-    """Resolve an MCP server connection, authenticate, and return (client, tool_specs).
+    """Look up an admin MCP server by id, access-check, connect, and return (client, tool_specs).
 
     Returns None if the server is not found or access is denied.
     """
@@ -2264,31 +2323,11 @@ async def connect_mcp_server(
         log.warning(f'Access denied to MCP server {server_id} for user {user.id}')
         return None
 
-    headers, _ = await build_tool_server_headers(
-        mcp_server_connection, request, user,
-        server_id=server_id, metadata=metadata, extra_params=extra_params,
+    return await _open_mcp_connection(
+        mcp_server_connection,
+        request=request, user=user, server_id=server_id,
+        metadata=metadata, extra_params=extra_params,
     )
-
-    client = MCPClient()
-    await client.connect(
-        url=mcp_server_connection.get('url', ''),
-        headers=headers if headers else None,
-    )
-
-    function_name_filter_list = mcp_server_connection.get('config', {}).get(
-        'function_name_filter_list', ''
-    )
-    if isinstance(function_name_filter_list, str):
-        function_name_filter_list = function_name_filter_list.split(',')
-
-    tool_specs = await client.list_tool_specs()
-    if function_name_filter_list:
-        tool_specs = [
-            spec for spec in tool_specs
-            if is_string_allowed(spec['name'], function_name_filter_list)
-        ]
-
-    return client, tool_specs
 
 
 async def process_chat_payload(request, form_data, user, metadata, model):
@@ -2693,40 +2732,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         if tool_ids:
             for tool_id in tool_ids:
                 if tool_id.startswith('server:mcp:'):
+                    server_id = tool_id[len('server:mcp:'):]
                     try:
-                        server_id = tool_id[len('server:mcp:'):]
-
                         result = await connect_mcp_server(
                             request, server_id, user, metadata, extra_params,
                         )
                         if result is None:
                             continue
-
                         client, tool_specs = result
-                        mcp_clients[server_id] = client
-
-                        for tool_spec in tool_specs:
-                            async def make_tool_function(client, function_name):
-                                async def tool_function(**kwargs):
-                                    return await client.call_tool(
-                                        function_name,
-                                        function_args=kwargs,
-                                    )
-
-                                return tool_function
-
-                            tool_function = await make_tool_function(client, tool_spec['name'])
-
-                            mcp_tools_dict[f'{server_id}_{tool_spec["name"]}'] = {
-                                'spec': {
-                                    **tool_spec,
-                                    'name': f'{server_id}_{tool_spec["name"]}',
-                                },
-                                'callable': tool_function,
-                                'type': 'mcp',
-                                'client': client,
-                                'direct': False,
-                            }
+                        _register_mcp_tools(
+                            client=client, tool_specs=tool_specs,
+                            registration_key=server_id,
+                            mcp_clients=mcp_clients, tools_dict=mcp_tools_dict,
+                        )
                     except Exception as e:
                         log.debug(e)
                         if event_emitter:
@@ -2782,6 +2800,41 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
         if direct_tool_servers:
             for tool_server in direct_tool_servers:
+                if tool_server.get('type') == 'mcp':
+                    user_mcp_id = tool_server.get('info', {}).get('id', '')
+                    if not user_mcp_id:
+                        log.warning('skipping user MCP tool server: missing info.id')
+                        if event_emitter:
+                            await event_emitter(
+                                {
+                                    'type': 'chat:message:error',
+                                    'data': {'error': {'content': 'MCP tool server requires an id'}},
+                                }
+                            )
+                        continue
+                    registration_key = f'direct_mcp_{user_mcp_id}'
+                    try:
+                        client, tool_specs = await _open_mcp_connection(
+                            tool_server,
+                            request=request, user=user, server_id=registration_key,
+                            metadata=metadata, extra_params=extra_params,
+                        )
+                        _register_mcp_tools(
+                            client=client, tool_specs=tool_specs,
+                            registration_key=registration_key,
+                            mcp_clients=mcp_clients, tools_dict=tools_dict,
+                        )
+                    except Exception as e:
+                        log.debug(e)
+                        if event_emitter:
+                            await event_emitter(
+                                {
+                                    'type': 'chat:message:error',
+                                    'data': {'error': {'content': f"Failed to connect to MCP server '{user_mcp_id}'"}},
+                                }
+                            )
+                    continue
+
                 system_prompt = tool_server.pop('system_prompt', None)
                 if system_prompt:
                     form_data['messages'] = add_or_update_system_message(

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -432,6 +432,17 @@ export const getToolServersData = async (servers: object[]) => {
 			servers
 				.filter((server) => server?.config?.enable)
 				.map(async (server) => {
+					if (server?.type === 'mcp') {
+						return {
+							...server,
+							info: {
+								...(server?.info ?? {}),
+								title: server?.info?.title ?? server?.info?.name ?? server?.url
+							},
+							specs: []
+						};
+					}
+
 					let error = null;
 
 					let toolServerToken = null;

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -484,26 +484,20 @@
 								<div class=" text-xs text-gray-500">{$i18n.t('Type')}</div>
 
 								<div class="">
-									{#if !direct}
-										<button
-											on:click={() => {
-												type = ['', 'openapi'].includes(type) ? 'mcp' : 'openapi';
-											}}
-											type="button"
-											class=" text-xs text-gray-700 dark:text-gray-300"
-										>
-											{#if ['', 'openapi'].includes(type)}
-												{$i18n.t('OpenAPI')}
-											{:else if type === 'mcp'}
-												{$i18n.t('MCP')}
-												<span class="text-gray-500">{$i18n.t('Streamable HTTP')}</span>
-											{/if}
-										</button>
-									{:else}
-										<div class="text-xs text-gray-700 dark:text-gray-300">
+									<button
+										on:click={() => {
+											type = ['', 'openapi'].includes(type) ? 'mcp' : 'openapi';
+										}}
+										type="button"
+										class=" text-xs text-gray-700 dark:text-gray-300"
+									>
+										{#if ['', 'openapi'].includes(type)}
 											{$i18n.t('OpenAPI')}
-										</div>
-									{/if}
+										{:else if type === 'mcp'}
+											{$i18n.t('MCP')}
+											<span class="text-gray-500">{$i18n.t('Streamable HTTP')}</span>
+										{/if}
+									</button>
 								</div>
 							</div>
 						</div>
@@ -529,7 +523,7 @@
 									/>
 								</div>
 							</div>
-							{#if !direct}
+							{#if !direct || type === 'mcp'}
 								<div class="flex flex-col flex-1">
 									<div class="flex justify-between mb-0.5">
 										<label


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #24620. Relates to #18453 (closed as "intended" — this PR re-opens that discussion with the structural concerns addressed), #19313 (per-user MCP headers — orthogonal but adjacent), and #24432 (MCP tool permissions per workspace — same domain).
- [x] **Target branch:** `dev`.
- [x] **Description:** See changelog entry below.
- [x] **Changelog:** Below.
- [ ] **Documentation:** Not added in this PR — the feature is gated by the existing `features.direct_tool_servers` permission and surfaces in an existing UI panel (Settings → Integrations) that already has docs for the OpenAPI case. Happy to add an MCP-specific note in [open-webui/docs](https://github.com/open-webui/docs) if the maintainer wants it as a follow-up.
- [x] **Dependencies:** None added or upgraded.
- [x] **Testing:** Verified manually via Playwright-driven UI flow (signup → enable permission → add MCP server through the modal → enable in chat integrations menu → send tool-use prompt) against `openai/gpt-oss-120b` over a real LLM gateway. MCP server logs the full session lifecycle including `CallToolRequest` per chat. Edge case tested: missing `info.id` is now refused with an inline error event rather than silently collision-bucketing into a shared namespace.
- [x] **Agentic AI Code:** This PR was drafted with AI assistance and then went through multiple rounds of human review and manual testing (including a Linus-style code review that prompted refactoring the duplicated MCP setup into shared helpers used by both admin and user paths).
- [x] **Code review:** Self-reviewed; refactored the diff to extract three shared module-level helpers (`_open_mcp_connection`, `_make_mcp_tool_callable`, `_register_mcp_tools`) so the admin and user paths share the connect / list / register logic rather than duplicating ~90 lines.
- [x] **Design & Architecture:** No new settings introduced — reuses the existing `features.direct_tool_servers` permission that already gates user OpenAPI tool servers, so admins get per-group control for free. No new endpoints, no DB migrations, no new env vars.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Description

Lets users add MCP tool servers to their personal `Settings → Integrations`, the same way they already can for OpenAPI tool servers. Gated by the existing `features.direct_tool_servers` permission so admins keep per-group control.

The MCP type toggle has been hidden in user-direct mode since the original "experimental mcp support" commit (`777e81f7a`, 2025-09-25) and the backend's `direct_tool_servers` path had no MCP branch — so even if a user had got an MCP entry into their settings, it would have been silently dropped at chat time. This PR wires both ends together.

Closes #24620. Relates to #18453, #19313, #24432.

### Added

- Backend: `_open_mcp_connection`, `_make_mcp_tool_callable`, and `_register_mcp_tools` module-level helpers in `backend/open_webui/utils/middleware.py`, shared by the admin (`server:mcp:<id>`) and user-direct (`direct_mcp_<id>`) tool resolution paths.
- Backend: branch for `type='mcp'` in the `direct_tool_servers` loop of `process_chat_payload` so user-stored MCP entries are actually resolved at chat time.
- Frontend: short-circuit in `getToolServersData` (`src/lib/apis/index.ts`) for `type='mcp'` — the browser can't introspect MCP, so the entry passes through with empty `specs` and a normalized `info.title`; backend resolves specs at chat time.

### Changed

- `backend/open_webui/utils/middleware.py`: refactored the admin MCP loop (formerly ~40 inline lines per call site) to use the new shared helpers — net deletion despite adding the user path.
- `src/lib/components/AddToolServerModal.svelte`: lifted the `{#if !direct}` gate around the OpenAPI↔MCP type toggle, and surfaced the required `ID` field in direct mode when type is MCP. All other admin-only fields (access grants, function-name filter, extra headers, OAuth 2.1 dynamic client registration) remain hidden in direct mode.

### Removed

- _(nothing user-facing)_

### Fixed

- Missing-id case: previously would have silently bucketed all user MCP servers with empty `info.id` into the same namespace and lost the collision protection. Now logs a warning and emits a `chat:message:error` event with `"MCP tool server requires an id"` instead of falling back to `'unnamed'`.

### Security

- `MCPClient` only supports streamable HTTP / SSE transports — there is no stdio transport anywhere in the codebase. User-direct MCP therefore cannot spawn local processes; users can only point at URLs they could already reach from their own browser.
- `features.direct_tool_servers` is `False` by default and is enforced on save in `backend/open_webui/routers/users.py` (the existing check that strips `toolServers` from settings updates for users without the permission). Admins can disable it per-group via the existing permissions UI.
- OAuth surface for user-direct stays narrow: `bearer`, `none`, `session` only. The `system_oauth`, `oauth_2.1`, `oauth_2.1_static` options remain admin-only because they require infrastructure (`__oauth_token__` in extra_params, `oauth_client_manager`) that's tied to admin-defined connections.
- User MCP clients and tool spec names are prefixed `direct_mcp_<id>` so they cannot shadow or be shadowed by admin-defined MCP servers sharing an `info.id`. The prefix uses only characters valid in OpenAI function names (`^[a-zA-Z0-9_-]+$`).

### Breaking Changes

- None.

---

### Additional Information

This PR re-opens the case for #18453, which was closed as "intended" behavior. The reasoning for relaxing the restriction now is in the **Security** section above — the previous concerns (transport sandboxing, OAuth surface, permission gating) are structurally handled or already covered by existing admin controls.

A separate `features.direct_mcp_servers` permission to gate MCP independently of OpenAPI was considered and deliberately skipped (YAGNI for a first cut — the bigger concern was always stdio, which is handled at the transport layer, and the per-group permission already exists). Easy follow-up if a use case appears.

The cloud / hosted-HTTP MCP server case (gitmcp.io, huggingface.co/mcp, future first-party MCP endpoints from model providers) is where this branch is most valuable — running a sidecar `mcpo` proxy per user just to expose an HTTP MCP endpoint as OpenAPI is operational overhead this PR removes.

### Screenshots or Videos

_[Add screenshots if you want — the Settings → Integrations modal with the type toggle visible, the integrations menu in the chat input showing the user's MCP server, and a tool-call round-trip would all make good evidence.]_

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.