### PR TITLE
fix: drop degenerate empty assistant messages when rebuilding chat history for upstream

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2176,6 +2176,14 @@ def process_messages_with_output(
 
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
+
+    Drops degenerate assistant messages that have no usable payload (empty
+    content, no output that produced messages, no tool_calls). Such rows are
+    persisted when a stream fails before any token is committed (e.g. upstream
+    5xx, connection drop, user-side abort). Forwarding them poisons every
+    subsequent completion on the chat because strict OpenAI-compatible
+    providers reject assistant messages whose content is an empty string and
+    that have no tool_calls.
     """
     processed = []
 
@@ -2189,6 +2197,12 @@ def process_messages_with_output(
             )
             if output_messages:
                 processed.extend(output_messages)
+                continue
+
+        # Drop degenerate assistant messages with no usable payload
+        if message.get('role') == 'assistant' and not message.get('tool_calls'):
+            content = message.get('content')
+            if not content or (isinstance(content, str) and not content.strip()):
                 continue
 
         # Strip 'output' field before adding (LLM shouldn't see it)


### PR DESCRIPTION
# PR title

`fix: drop degenerate empty assistant messages when rebuilding chat history for upstream`

# PR description (body)

Closes #25083.

## What this changes

`process_messages_with_output()` in `backend/open_webui/utils/middleware.py` now skips assistant messages that have:

- no `content` (or content is empty string / whitespace-only / `None` / empty list), **and**
- no `tool_calls`, **and**
- no `output` that successfully produced messages (already handled by the existing branch above; this filter only kicks in when that branch falls through)

before the payload is forwarded to the LLM provider.

## Why

Whenever an assistant generation fails *before any token is committed* — upstream 5xx, connection drop, user-side cancel, `TransferEncodingError`, etc. — Open WebUI persists an assistant row shaped like:

```json
{"role": "assistant", "content": "", "done": false, ...}
```

The history reconstruction path (`load_messages_from_db` → `process_messages_with_output`) currently forwards this row verbatim. Strict OpenAI-compatible providers (Gemini OpenAI mode, Anthropic compat shims, many cloud APIs) reject any assistant message with an empty `content` field and no `tool_calls`, with errors like:

```
the message at position 15 with role 'assistant' must not be empty
```

The chat is then **permanently poisoned**: every subsequent prompt fails the same way because the empty row is on the parent chain that `currentId` walks through. Users have to hand-edit `webui.db` to recover.

Full triage with code line references, real DB dump, and a comparison against related closed issues is in #25083.

## What this does **not** try to do

- Does not change how the empty rows are *written*. The frontend persistence path is a separate concern (see #23176 for related work).
- Does not touch `user`, `system`, or `tool` messages — filter is assistant-only.
- Does not modify any DB state. Existing poisoned chats continue to render fine; they just stop being toxic at send-time.

## Manual testing

A self-contained verification script that mirrors the patched function logic and exercises 8 scenarios (including the real poisoned chain from #25083) is available at `verify_fix.py` (in #25083 thread). Result:

```
=== Running with PATCHED logic ===
  OK   passes through normal user + assistant chain
  OK   drops assistant with empty string content (the bug)
  OK   drops assistant with whitespace-only content
  OK   drops assistant with None content
  OK   drops assistant with empty list content
  OK   KEEPS assistant with empty content + tool_calls
  OK   KEEPS user messages even if empty (filter is assistant-only)
  OK   reproduces the real poisoned chain from issue #25083
8/8 checks passed

=== Running with UNPATCHED logic (control) ===
  OK   passes through normal user + assistant chain
  FAIL drops assistant with empty string content (the bug)
  FAIL drops assistant with whitespace-only content
  FAIL drops assistant with None content
  FAIL drops assistant with empty list content
  OK   KEEPS assistant with empty content + tool_calls
  OK   KEEPS user messages even if empty (filter is assistant-only)
  FAIL reproduces the real poisoned chain from issue #25083
3/8 checks passed
```

Additionally, against the real poisoned chat described in #25083: after applying this patch, the same chat that previously returned `the message at position 15 with role 'assistant' must not be empty` on every send now completes normally — no DB edit, no chat truncation needed.

## Changelog

### Fixed
- Filter out empty/`done: false` assistant placeholder messages when rebuilding chat history before sending to the LLM provider. Prevents chats from being permanently broken by a single failed/aborted generation when the upstream provider enforces strict OpenAI message validation. ([#25083](https://github.com/open-webui/open-webui/issues/25083))
