### PR TITLE
Fix: Make file content search opt-in in Knowledge Base

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -359,19 +359,28 @@ class KnowledgeTable:
                     permission='read',
                 )
 
-                # Apply filename / content search
-                # Use ->> (as_string) instead of CAST(-> AS TEXT) to avoid
-                # PostgreSQL "invalid memory alloc request size" on large
-                # extracted-content rows (#24670).
-                content_text = File.data['content'].as_string()
                 search_filter = None
                 if filter:
                     q = filter.get('query')
-                    if q:
+                    search_file_content = filter.get('search_file_content')
+                    if q and search_file_content:
+                        print('Applying file name and content search for query:', q)
+                        # Apply filename / content search
+                        # Use ->> (as_string) instead of CAST(-> AS TEXT) to avoid
+                        # PostgreSQL "invalid memory alloc request size" on large
+                        # extracted-content rows (#24670).
+                        content_text = File.data['content'].as_string()
                         search_filter = or_(
                             File.filename.ilike(f'%{q}%'),
                             content_text.ilike(f'%{q}%'),
                         )
+                    elif q:
+                        print('Applying file name search for query:', q)
+                        search_filter = or_(
+                            File.filename.ilike(f'%{q}%'),
+                        )
+
+                    if search_filter is not None:
                         stmt = stmt.filter(search_filter)
 
                 # Order by file changes
@@ -545,7 +554,8 @@ class KnowledgeTable:
 
                 if filter:
                     query_key = filter.get('query')
-                    if query_key:
+                    search_file_content = filter.get('search_file_content')
+                    if query_key and search_file_content:
                         # Use ->> (as_string) instead of CAST(-> AS TEXT) to
                         # avoid PostgreSQL memory allocation failures on large
                         # content (#24670).
@@ -554,6 +564,12 @@ class KnowledgeTable:
                             or_(
                                 File.filename.ilike(f'%{query_key}%'),
                                 content_text.ilike(f'%{query_key}%'),
+                            )
+                        )
+                    elif query_key:
+                        stmt = stmt.filter(
+                            or_(
+                                File.filename.ilike(f'%{query_key}%'),
                             )
                         )
 
@@ -692,7 +708,9 @@ class KnowledgeTable:
         except Exception:
             return False
 
-    async def reset_knowledge_by_id(self, id: str, include_directories: bool = True, db: Optional[AsyncSession] = None) -> Optional[KnowledgeModel]:
+    async def reset_knowledge_by_id(
+        self, id: str, include_directories: bool = True, db: Optional[AsyncSession] = None
+    ) -> Optional[KnowledgeModel]:
         try:
             async with get_async_db_context(db) as db:
                 # Delete all knowledge_file entries for this knowledge_id
@@ -819,9 +837,7 @@ class KnowledgeTable:
     ) -> list[KnowledgeDirectoryModel]:
         """List directories at a given level (parent_id=None for root)."""
         async with get_async_db_context(db) as db:
-            stmt = select(KnowledgeDirectory).filter(
-                KnowledgeDirectory.knowledge_id == knowledge_id
-            )
+            stmt = select(KnowledgeDirectory).filter(KnowledgeDirectory.knowledge_id == knowledge_id)
             if parent_id:
                 stmt = stmt.filter(KnowledgeDirectory.parent_id == parent_id)
             else:
@@ -859,10 +875,7 @@ class KnowledgeTable:
                     .join(KnowledgeFile, File.id == KnowledgeFile.file_id)
                     .filter(KnowledgeFile.knowledge_id == knowledge_id)
                 )
-                return [
-                    (FileModel.model_validate(file), dir_id)
-                    for file, dir_id in result.all()
-                ]
+                return [(FileModel.model_validate(file), dir_id) for file, dir_id in result.all()]
         except Exception:
             return []
 
@@ -870,9 +883,7 @@ class KnowledgeTable:
         self, directory_id: str, db: Optional[AsyncSession] = None
     ) -> Optional[KnowledgeDirectoryModel]:
         async with get_async_db_context(db) as db:
-            result = await db.execute(
-                select(KnowledgeDirectory).filter_by(id=directory_id)
-            )
+            result = await db.execute(select(KnowledgeDirectory).filter_by(id=directory_id))
             directory = result.scalars().first()
             return KnowledgeDirectoryModel.model_validate(directory) if directory else None
 
@@ -892,9 +903,7 @@ class KnowledgeTable:
 
             while current_id and current_id not in seen:
                 seen.add(current_id)
-                result = await db.execute(
-                    select(KnowledgeDirectory).filter_by(id=current_id)
-                )
+                result = await db.execute(select(KnowledgeDirectory).filter_by(id=current_id))
                 directory = result.scalars().first()
                 if not directory:
                     break
@@ -913,9 +922,7 @@ class KnowledgeTable:
         async with get_async_db_context(db) as db:
             try:
                 await db.execute(
-                    update(KnowledgeDirectory)
-                    .filter_by(id=directory_id)
-                    .values(name=name, updated_at=int(time.time()))
+                    update(KnowledgeDirectory).filter_by(id=directory_id).values(name=name, updated_at=int(time.time()))
                 )
                 await db.commit()
                 return await self.get_directory_by_id(directory_id, db=db)
@@ -941,9 +948,7 @@ class KnowledgeTable:
                         if current == directory_id:
                             return None  # Would create a cycle
                         seen.add(current)
-                        result = await db.execute(
-                            select(KnowledgeDirectory.parent_id).filter_by(id=current)
-                        )
+                        result = await db.execute(select(KnowledgeDirectory.parent_id).filter_by(id=current))
                         row = result.first()
                         current = row[0] if row else None
 
@@ -991,9 +996,7 @@ class KnowledgeTable:
         async with get_async_db_context(db) as db:
             try:
                 # Get the directory to find its parent
-                result = await db.execute(
-                    select(KnowledgeDirectory).filter_by(id=directory_id)
-                )
+                result = await db.execute(select(KnowledgeDirectory).filter_by(id=directory_id))
                 directory = result.scalars().first()
                 if not directory:
                     return False
@@ -1003,9 +1006,7 @@ class KnowledgeTable:
                 if move_files_to_parent:
                     # Move files in this directory to its parent (or root)
                     await db.execute(
-                        update(KnowledgeFile)
-                        .filter_by(directory_id=directory_id)
-                        .values(directory_id=parent_id)
+                        update(KnowledgeFile).filter_by(directory_id=directory_id).values(directory_id=parent_id)
                     )
                     # Recursively move files from all subdirectories too
                     await self._move_files_from_subtree(directory_id, parent_id, db=db)
@@ -1014,9 +1015,7 @@ class KnowledgeTable:
                     await self._delete_files_in_subtree(directory_id, db=db)
 
                 # CASCADE on parent_id will handle deleting subdirectories
-                await db.execute(
-                    delete(KnowledgeDirectory).filter_by(id=directory_id)
-                )
+                await db.execute(delete(KnowledgeDirectory).filter_by(id=directory_id))
                 await db.commit()
                 return True
             except Exception as e:
@@ -1030,16 +1029,12 @@ class KnowledgeTable:
         db: AsyncSession,
     ) -> None:
         """Recursively move all files from a directory subtree to the target."""
-        result = await db.execute(
-            select(KnowledgeDirectory.id).filter_by(parent_id=directory_id)
-        )
+        result = await db.execute(select(KnowledgeDirectory.id).filter_by(parent_id=directory_id))
         child_ids = [row[0] for row in result.all()]
 
         for child_id in child_ids:
             await db.execute(
-                update(KnowledgeFile)
-                .filter_by(directory_id=child_id)
-                .values(directory_id=target_directory_id)
+                update(KnowledgeFile).filter_by(directory_id=child_id).values(directory_id=target_directory_id)
             )
             await self._move_files_from_subtree(child_id, target_directory_id, db=db)
 
@@ -1049,12 +1044,8 @@ class KnowledgeTable:
         db: AsyncSession,
     ) -> None:
         """Recursively delete all files from a directory subtree."""
-        await db.execute(
-            delete(KnowledgeFile).filter_by(directory_id=directory_id)
-        )
-        result = await db.execute(
-            select(KnowledgeDirectory.id).filter_by(parent_id=directory_id)
-        )
+        await db.execute(delete(KnowledgeFile).filter_by(directory_id=directory_id))
+        result = await db.execute(select(KnowledgeDirectory.id).filter_by(parent_id=directory_id))
         child_ids = [row[0] for row in result.all()]
         for child_id in child_ids:
             await self._delete_files_in_subtree(child_id, db=db)

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -563,6 +563,7 @@ async def get_knowledge_files_by_id(
     direction: str | None = None,
     directory_id: str | None = Query(None, description='Filter by directory ID. Pass empty string for root.'),
     page: int | None = 1,
+    search_file_content: bool = False,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
@@ -606,6 +607,8 @@ async def get_knowledge_files_by_id(
     # directory_id filtering: present in filter = scope to that directory (None = root)
     if directory_id is not None:
         filter['directory_id'] = directory_id if directory_id else None
+    if search_file_content:
+        filter['search_file_content'] = True
 
     return await Knowledges.search_files_by_id(id, user.id, filter=filter, skip=skip, limit=limit, db=db)
 
@@ -991,9 +994,9 @@ async def reset_knowledge_by_id(
 
 
 class FileManifestEntry(BaseModel):
-    filename: str       # basename: "readme.md"
-    path: str           # relative dir: "docs/api" or "" for root
-    checksum: str       # SHA-256 of raw bytes
+    filename: str  # basename: "readme.md"
+    path: str  # relative dir: "docs/api" or "" for root
+    checksum: str  # SHA-256 of raw bytes
     size: int
 
 
@@ -1002,13 +1005,13 @@ class SyncDiffForm(BaseModel):
 
 
 class SyncDiffResponse(BaseModel):
-    added: list[dict]               # [{filename, path}] — new files
-    modified: list[dict]            # [{filename, path, stale_file_id}] — changed files
-    deleted: list[dict]             # [{file_id, filename}] — files to remove
-    mkdir: list[str]                # directory paths to create
-    rmdir: list[str]                # directory IDs to remove
+    added: list[dict]  # [{filename, path}] — new files
+    modified: list[dict]  # [{filename, path, stale_file_id}] — changed files
+    deleted: list[dict]  # [{file_id, filename}] — files to remove
+    mkdir: list[str]  # directory paths to create
+    rmdir: list[str]  # directory IDs to remove
     unmodified_count: int
-    directory_map: dict[str, str]   # existing path → directory ID
+    directory_map: dict[str, str]  # existing path → directory ID
 
 
 @router.post('/{id}/sync/diff', response_model=SyncDiffResponse)
@@ -1068,11 +1071,13 @@ async def sync_knowledge_diff(
         if key not in indexed_files:
             added.append({'filename': entry.filename, 'path': entry.path})
         elif indexed_files[key]['checksum'] != entry.checksum:
-            modified.append({
-                'filename': entry.filename,
-                'path': entry.path,
-                'stale_file_id': indexed_files[key]['file_id'],
-            })
+            modified.append(
+                {
+                    'filename': entry.filename,
+                    'path': entry.path,
+                    'stale_file_id': indexed_files[key]['file_id'],
+                }
+            )
         else:
             unmodified_count += 1
 
@@ -1086,12 +1091,9 @@ async def sync_knowledge_diff(
         if entry.path:
             segments = entry.path.split('/')
             for depth in range(len(segments)):
-                required_directory_paths.add('/'.join(segments[:depth + 1]))
+                required_directory_paths.add('/'.join(segments[: depth + 1]))
 
-    mkdir = sorted(
-        [p for p in required_directory_paths if p not in directory_id_by_path],
-        key=lambda p: p.count('/')
-    )
+    mkdir = sorted([p for p in required_directory_paths if p not in directory_id_by_path], key=lambda p: p.count('/'))
 
     orphaned_directory_paths = set(directory_id_by_path) - required_directory_paths
     rmdir = [directory_id_by_path[p] for p in orphaned_directory_paths]
@@ -1113,8 +1115,8 @@ async def sync_knowledge_diff(
 
 
 class SyncCleanupForm(BaseModel):
-    file_ids: list[str]         # file IDs to delete
-    dir_ids: list[str] = []     # directory IDs to rmdir
+    file_ids: list[str]  # file IDs to delete
+    dir_ids: list[str] = []  # directory IDs to rmdir
 
 
 @router.post('/{id}/sync/cleanup')
@@ -1139,12 +1141,8 @@ async def sync_knowledge_cleanup(
         await Knowledges.remove_file_from_knowledge_by_id(id, file_id, db=db)
 
         try:
-            await ASYNC_VECTOR_DB_CLIENT.delete(
-                collection_name=id, filter={'file_id': file_id}
-            )
-            await ASYNC_VECTOR_DB_CLIENT.delete(
-                collection_name=id, filter={'hash': file.hash}
-            )
+            await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=id, filter={'file_id': file_id})
+            await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=id, filter={'hash': file.hash})
         except Exception:
             pass
 
@@ -1337,9 +1335,7 @@ class KnowledgeFileMoveForm(BaseModel):
     directory_id: Optional[str] = None
 
 
-async def _verify_knowledge_write_access(
-    id: str, user, db: AsyncSession
-):
+async def _verify_knowledge_write_access(id: str, user, db: AsyncSession):
     """Verify the user has write access to the knowledge base. Returns the knowledge model."""
     knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)
     if not knowledge:
@@ -1489,4 +1485,3 @@ async def move_file_in_knowledge(
             detail='Failed to move file.',
         )
     return {'status': True}
-

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -202,7 +202,8 @@ export const searchKnowledgeFilesById = async (
 	orderBy?: string | null = null,
 	direction?: string | null = null,
 	page: number = 1,
-	directoryId?: string | null = undefined
+	directoryId?: string | null = undefined,
+	searchFileContent: boolean = false
 ) => {
 	let error = null;
 
@@ -216,7 +217,7 @@ export const searchKnowledgeFilesById = async (
 	if (directoryId !== undefined) {
 		searchParams.append('directory_id', directoryId ?? '');
 	}
-
+	if (searchFileContent) searchParams.append('search_file_content', searchFileContent.toString());
 	const res = await fetch(
 		`${WEBUI_API_BASE_URL}/knowledge/${id}/files?${searchParams.toString()}`,
 		{
@@ -545,7 +546,6 @@ export const syncKnowledgeCleanup = async (
 
 export const deleteKnowledgeById = async (token: string, id: string) => {
 	let error = null;
-
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/delete`, {
 		method: 'DELETE',

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -112,6 +112,7 @@
 	let viewOption = null;
 	let sortKey = null;
 	let direction = null;
+	let searchFileContent = false;
 
 	let currentPage = 1;
 	let fileItems = null;
@@ -150,7 +151,8 @@
 		viewOption !== undefined &&
 		sortKey !== undefined &&
 		direction !== undefined &&
-		currentPage !== undefined
+		currentPage !== undefined &&
+		searchFileContent !== undefined
 	) {
 		getItemsPage();
 	}
@@ -159,7 +161,8 @@
 		query !== undefined &&
 		viewOption !== undefined &&
 		sortKey !== undefined &&
-		direction !== undefined
+		direction !== undefined &&
+		searchFileContent !== undefined
 	) {
 		reset();
 	}
@@ -182,7 +185,8 @@
 			sortKey,
 			direction,
 			currentPage,
-			currentDirectoryId
+			currentDirectoryId,
+			searchFileContent
 		).catch(() => {
 			return null;
 		});
@@ -1293,11 +1297,11 @@
 									if (pendingSyncFiles?.length) {
 										showSyncConfirmModal = true;
 									}
-							}}
-							onReset={() => {
-								showResetConfirm = true;
-							}}
-						/>
+								}}
+								onReset={() => {
+									showResetConfirm = true;
+								}}
+							/>
 						</div>
 					{/if}
 				</div>
@@ -1367,6 +1371,14 @@
 								]}
 							/>
 						{/if}
+
+						<div class="flex items-center gap-1.5">
+							<input type="checkbox" bind:checked={searchFileContent} id="searchFileContent" />
+
+							<label for="searchFileContent" class="text-xs text-gray-500">
+								{$i18n.t('Search file content')}
+							</label>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -1543,6 +1555,8 @@
 	}}
 >
 	<div class="text-sm text-gray-700 dark:text-gray-300 flex-1 line-clamp-3">
-		{$i18n.t('This will remove all files and directories from this knowledge base. This action cannot be undone.')}
+		{$i18n.t(
+			'This will remove all files and directories from this knowledge base. This action cannot be undone.'
+		)}
 	</div>
 </ConfirmDialog>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Closes #25082

The content ILIKE search introduced in 11e07681 runs on every keystroke against the full extracted document body. On large deployments this is a seq-scan that can't use any index and gets expensive fast.

d74ee34 fixed a related memory crash but the query still runs by default — this PR makes it opt-in.

Note: this only covers the Workspace KB search box. The # chat picker and model-builder selector call a different path and would need a separate fix, to search on file content.

### Changed

- searchFileContent defaults to false; the backend content scan is only triggered when the flag is explicitly set
- Added a "Search file content" checkbox to the KB search toolbar

### Fixed

Before: every keystroke ran a full content ILIKE seq-scan regardless
After: keystrokes only search filenames by default; content search is opt-in via the checkbox

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Screenshots or Videos

<img width="569" height="226" alt="image" src="https://github.com/user-attachments/assets/4a70ffeb-65a9-457f-b1ab-63dc72d408bc" />
<img width="475" height="278" alt="image" src="https://github.com/user-attachments/assets/d2c4722a-2a18-4e80-8260-d273674c8560" />
<img width="344" height="118" alt="image" src="https://github.com/user-attachments/assets/f67a6339-e13e-4074-a769-11a798cee03e" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
