### PR TITLE
feat: add OpenAI account auth provider

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
 import re
+import time
 from typing import Optional
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 import aiohttp
 from aiocache import cached
@@ -36,6 +38,7 @@ from open_webui.internal.db import get_async_session
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.models import Models
+from open_webui.models.oauth_sessions import OAuthSessions
 from open_webui.models.users import UserModel
 from open_webui.utils.access_control import check_model_access, has_connection_access
 from open_webui.utils.anthropic import get_anthropic_models, is_anthropic_url
@@ -110,6 +113,12 @@ async def send_get_request(
                 return await response.json()
     except Exception as e:
         # Handle connection error here
+        if is_openai_codex_web_auth_config(config):
+            log.warning(
+                'OpenAI web auth model request failed for host=%s error=%s',
+                urlparse(url).hostname if url else None,
+                e,
+            )
         log.error(f'Connection error: {e}')
         return None
 
@@ -123,7 +132,31 @@ async def get_models_request(
 ):
     if is_anthropic_url(url):
         return await get_anthropic_models(url, key, user=user)
-    return await send_get_request(request, f'{url}/models', key, user=user, config=config)
+    try:
+        return await send_get_request(request, f'{url}/models', key, user=user, config=config)
+    except HTTPException as e:
+        if is_openai_codex_web_auth_config(config):
+            log.warning(
+                'OpenAI web auth model request failed for host=%s status=%s detail=%s',
+                urlparse(url).hostname,
+                e.status_code,
+                e.detail,
+            )
+        raise
+
+
+def is_empty_native_openai_bearer_connection(
+    url: str,
+    key: str = '',
+    config: Optional[dict] = None,
+) -> bool:
+    config = config or {}
+    auth_type = config.get('auth_type')
+    return (
+        urlparse(url).hostname == 'api.openai.com'
+        and not key
+        and (auth_type == 'bearer' or auth_type is None)
+    )
 
 
 def openai_reasoning_model_handler(payload):
@@ -200,6 +233,14 @@ async def get_headers_and_cookies(
         if oauth_token:
             token = f'{oauth_token.get("access_token", "")}'
 
+    elif is_openai_codex_web_auth_config(config):
+        token = await get_openai_web_auth_access_token()
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail='OpenAI web auth credential is not connected or requires reconnection',
+            )
+
     elif auth_type in ('azure_ad', 'microsoft_entra_id'):
         token = get_microsoft_entra_id_access_token()
 
@@ -209,6 +250,15 @@ async def get_headers_and_cookies(
     if config.get('headers') and isinstance(config.get('headers'), dict):
         custom_headers = get_custom_headers(config.get('headers'), user, metadata)
         headers.update(custom_headers)
+
+    if is_openai_codex_web_auth_config(config) and token:
+        headers['Authorization'] = f'Bearer {token}'
+        session = await get_openai_web_auth_session()
+        apply_openai_codex_web_auth_headers(
+            headers,
+            account_id=(session.token or {}).get('account_id') if session else None,
+            metadata=metadata,
+        )
 
     return headers, cookies
 
@@ -235,6 +285,568 @@ def get_microsoft_entra_id_access_token():
 ##########################################
 
 router = APIRouter()
+
+OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER = 'openai_web_auth_device'
+OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER = 'openai_web_auth_credential'
+OPENAI_WEB_AUTH_STORAGE_USER_ID = '__openai_web_auth__'
+OPENAI_WEB_AUTH_ISSUER = 'https://auth.openai.com'
+OPENAI_WEB_AUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+OPENAI_WEB_AUTH_VERIFICATION_URL = f'{OPENAI_WEB_AUTH_ISSUER}/codex/device'
+OPENAI_WEB_AUTH_REDIRECT_URI = f'{OPENAI_WEB_AUTH_ISSUER}/deviceauth/callback'
+OPENAI_WEB_AUTH_DEFAULT_EXPIRES_IN = 3600
+OPENAI_WEB_AUTH_REFRESH_SKEW_SECONDS = 300
+OPENAI_CODEX_WEB_AUTH_TYPE = 'openai_codex_web_auth'
+OPENAI_CODEX_WEB_AUTH_LEGACY_TYPE = 'openai_web_auth'
+OPENAI_CODEX_API_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses'
+OPENAI_CODEX_WEB_AUTH_MODEL_IDS = [
+    'gpt-5.5',
+    'gpt-5.2',
+    'gpt-5.3-codex',
+    'gpt-5.3-codex-spark',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+]
+
+
+class OpenAIWebAuthStartResponse(BaseModel):
+    verification_url: str
+    user_code: str
+    session_id: str
+    interval: int
+    expires_at: int
+
+
+class OpenAIWebAuthCompleteForm(BaseModel):
+    session_id: str
+
+
+class OpenAIWebAuthStatusResponse(BaseModel):
+    credential_type: str
+    connected: bool
+    has_credential: bool
+    status: str
+    expires_at: Optional[int] = None
+
+
+def is_openai_codex_web_auth_config(config: Optional[dict] = None) -> bool:
+    return (config or {}).get('auth_type') in (
+        OPENAI_CODEX_WEB_AUTH_TYPE,
+        OPENAI_CODEX_WEB_AUTH_LEGACY_TYPE,
+    )
+
+
+def build_openai_codex_web_auth_models(url_idx: int) -> dict:
+    return {
+        'object': 'list',
+        'data': [
+            {
+                'id': model_id,
+                'name': model_id,
+                'owned_by': 'openai',
+                'openai': {'id': model_id},
+                'urlIdx': url_idx,
+                'connection_type': 'external',
+                'provider': 'OpenAI Account Auth',
+            }
+            for model_id in OPENAI_CODEX_WEB_AUTH_MODEL_IDS
+        ],
+    }
+
+
+async def build_openai_codex_web_auth_models_if_connected(url_idx: int) -> Optional[dict]:
+    token = await get_openai_web_auth_access_token()
+    if not token:
+        return None
+    return build_openai_codex_web_auth_models(url_idx)
+
+
+def apply_openai_codex_web_auth_headers(headers: dict, account_id: Optional[str] = None, metadata: Optional[dict] = None):
+    if account_id:
+        headers['ChatGPT-Account-Id'] = account_id
+    headers['originator'] = 'open-webui'
+    headers['User-Agent'] = 'Open WebUI'
+    session_id = metadata.get('chat_id') if metadata else None
+    if session_id:
+        headers['session_id'] = str(session_id)
+
+
+def prepare_openai_codex_web_auth_request(
+    payload: dict,
+    is_responses: bool = False,
+) -> tuple[str, dict, bool]:
+    """Return the Codex account-auth endpoint and Responses-compatible payload."""
+
+    responses_payload = payload if is_responses else convert_to_responses_payload(payload)
+    if not responses_payload.get('instructions'):
+        responses_payload['instructions'] = 'You are ChatGPT, a helpful assistant.'
+    responses_payload['store'] = False
+    responses_payload['stream'] = True
+
+    return (
+        OPENAI_CODEX_API_ENDPOINT,
+        responses_payload,
+        True,
+    )
+
+
+def iter_openai_codex_sse_payloads(text: str):
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith('data:'):
+            continue
+        data = line.removeprefix('data:').strip()
+        if not data or data == '[DONE]':
+            continue
+        try:
+            yield json.loads(data)
+        except Exception:
+            continue
+
+
+def parse_openai_codex_sse_response(text: str):
+    last_payload = None
+    for payload in iter_openai_codex_sse_payloads(text):
+        last_payload = payload
+    return last_payload
+
+
+def build_openai_codex_error_payload(payload: Optional[dict]) -> dict:
+    payload = payload or {}
+    details = payload.get('error') or payload.get('status_details') or payload.get('response') or payload
+
+    if isinstance(details, dict):
+        message = details.get('message') or details.get('error') or details.get('detail') or 'OpenAI account auth request failed'
+        code = details.get('code') or payload.get('type') or 'openai_codex_web_auth_error'
+        error_type = details.get('type') or payload.get('type') or 'upstream_error'
+    else:
+        message = str(details) if details else 'OpenAI account auth request failed'
+        code = payload.get('type') or 'openai_codex_web_auth_error'
+        error_type = payload.get('type') or 'upstream_error'
+
+    return {
+        'error': {
+            'message': message,
+            'type': error_type,
+            'code': code,
+        }
+    }
+
+
+def convert_openai_codex_sse_payload(payload: dict) -> Optional[bytes]:
+    event_type = payload.get('type')
+    if event_type == 'response.output_text.delta':
+        delta = payload.get('delta') or payload.get('text') or ''
+        chunk = {
+            'id': payload.get('response_id') or payload.get('id') or '',
+            'object': 'chat.completion.chunk',
+            'model': payload.get('model') or '',
+            'choices': [
+                {
+                    'index': 0,
+                    'delta': {'content': delta},
+                    'finish_reason': None,
+                }
+            ],
+        }
+        return f'data: {json.dumps(chunk)}\n\n'.encode()
+
+    if event_type in ('response.failed', 'response.incomplete'):
+        return (
+            f'data: {json.dumps(build_openai_codex_error_payload(payload))}\n\n'
+            'data: [DONE]\n\n'
+        ).encode()
+
+    if event_type == 'response.completed':
+        return b'data: [DONE]\n\n'
+
+    return None
+
+
+async def openai_codex_stream_chunks_handler(stream: aiohttp.StreamReader):
+    buffer = b''
+    async for data, _ in stream.iter_chunks():
+        if not data:
+            continue
+        lines = (buffer + data).split(b'\n')
+        buffer = lines[-1]
+        for raw_line in lines[:-1]:
+            line = raw_line.decode('utf-8', 'replace').strip()
+            if not line.startswith('data:'):
+                continue
+            event_data = line.removeprefix('data:').strip()
+            if not event_data:
+                continue
+            if event_data == '[DONE]':
+                yield b'data: [DONE]\n\n'
+                continue
+            try:
+                converted = convert_openai_codex_sse_payload(json.loads(event_data))
+            except Exception:
+                converted = None
+            if converted:
+                yield converted
+
+    if buffer:
+        line = buffer.decode('utf-8', 'replace').strip()
+        if line.startswith('data:'):
+            event_data = line.removeprefix('data:').strip()
+            try:
+                converted = convert_openai_codex_sse_payload(json.loads(event_data))
+            except Exception:
+                converted = None
+            if converted:
+                yield converted
+
+
+def _parse_openai_web_auth_positive_int(value, default: int, field_name: str) -> int:
+    if value is None:
+        return default
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=502,
+            detail=f'OpenAI web auth response contained an invalid {field_name}',
+        )
+
+    if parsed < 1:
+        raise HTTPException(
+            status_code=502,
+            detail=f'OpenAI web auth response contained an invalid {field_name}',
+        )
+    return parsed
+
+
+def _decode_jwt_payload(token: str) -> dict:
+    try:
+        payload = token.split('.')[1]
+        payload += '=' * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload.encode()).decode())
+    except Exception:
+        return {}
+
+
+def _extract_openai_account_id(tokens: dict) -> Optional[str]:
+    claims = _decode_jwt_payload(tokens.get('id_token') or tokens.get('access_token') or '')
+    if not claims:
+        return None
+
+    api_auth = claims.get('https://api.openai.com/auth')
+    if isinstance(claims.get('chatgpt_account_id'), str):
+        return claims['chatgpt_account_id']
+    if isinstance(api_auth, dict) and isinstance(api_auth.get('chatgpt_account_id'), str):
+        return api_auth['chatgpt_account_id']
+
+    organizations = claims.get('organizations')
+    if isinstance(organizations, list):
+        for organization in organizations:
+            if isinstance(organization, dict) and isinstance(organization.get('id'), str):
+                return organization['id']
+    return None
+
+
+def _openai_web_auth_status_from_session(session) -> OpenAIWebAuthStatusResponse:
+    if not session:
+        return OpenAIWebAuthStatusResponse(
+            credential_type='none',
+            connected=False,
+            has_credential=False,
+            status='not_configured',
+        )
+
+    status_value = 'connected' if session.expires_at > int(time.time()) else 'reconnect_required'
+    return OpenAIWebAuthStatusResponse(
+        credential_type='web_auth',
+        connected=status_value == 'connected',
+        has_credential=True,
+        status=status_value,
+        expires_at=session.expires_at,
+    )
+
+
+async def _post_openai_web_auth_json(url: str, json_payload: dict) -> tuple[int, dict]:
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        async with session.post(
+            url,
+            json=json_payload,
+            headers={
+                'Content-Type': 'application/json',
+                'User-Agent': 'Open WebUI',
+            },
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        ) as response:
+            try:
+                payload = await response.json()
+            except Exception:
+                payload = {}
+            return response.status, payload
+
+
+async def _post_openai_web_auth_form(url: str, form_payload: dict) -> tuple[int, dict]:
+    async with aiohttp.ClientSession(
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+    ) as session:
+        async with session.post(
+            url,
+            data=urlencode(form_payload),
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        ) as response:
+            try:
+                payload = await response.json()
+            except Exception:
+                payload = {}
+            return response.status, payload
+
+
+async def start_openai_web_auth_device_flow() -> dict:
+    status_code, data = await _post_openai_web_auth_json(
+        f'{OPENAI_WEB_AUTH_ISSUER}/api/accounts/deviceauth/usercode',
+        {'client_id': OPENAI_WEB_AUTH_CLIENT_ID},
+    )
+    if status_code >= 400:
+        raise HTTPException(status_code=502, detail='OpenAI web auth start failed')
+
+    device_auth_id = data.get('device_auth_id')
+    user_code = data.get('user_code')
+    if not isinstance(device_auth_id, str) or not isinstance(user_code, str):
+        raise HTTPException(status_code=502, detail='OpenAI web auth start response was incomplete')
+
+    interval = _parse_openai_web_auth_positive_int(data.get('interval'), 5, 'interval')
+    expires_in = _parse_openai_web_auth_positive_int(data.get('expires_in'), 600, 'expiration')
+    return {
+        'device_auth_id': device_auth_id,
+        'user_code': user_code,
+        'interval': interval,
+        'expires_at': int(time.time()) + expires_in,
+    }
+
+
+async def complete_openai_web_auth_device_flow(device_auth_id: str, user_code: str) -> dict:
+    device_status, device_data = await _post_openai_web_auth_json(
+        f'{OPENAI_WEB_AUTH_ISSUER}/api/accounts/deviceauth/token',
+        {
+            'device_auth_id': device_auth_id,
+            'user_code': user_code,
+        },
+    )
+    if device_status in (403, 404):
+        raise HTTPException(status_code=409, detail='OpenAI authorization is not complete yet')
+    if device_status >= 400:
+        raise HTTPException(status_code=502, detail='OpenAI web auth completion failed')
+
+    authorization_code = device_data.get('authorization_code')
+    code_verifier = device_data.get('code_verifier')
+    if not isinstance(authorization_code, str) or not isinstance(code_verifier, str):
+        raise HTTPException(status_code=502, detail='OpenAI web auth completion response was incomplete')
+
+    token_status, tokens = await _post_openai_web_auth_form(
+        f'{OPENAI_WEB_AUTH_ISSUER}/oauth/token',
+        {
+            'grant_type': 'authorization_code',
+            'code': authorization_code,
+            'redirect_uri': OPENAI_WEB_AUTH_REDIRECT_URI,
+            'client_id': OPENAI_WEB_AUTH_CLIENT_ID,
+            'code_verifier': code_verifier,
+        },
+    )
+    if token_status >= 400:
+        raise HTTPException(status_code=502, detail='OpenAI web auth token exchange failed')
+    if not tokens.get('access_token') or not tokens.get('refresh_token'):
+        raise HTTPException(status_code=502, detail='OpenAI web auth token response was incomplete')
+
+    expires_in = _parse_openai_web_auth_positive_int(
+        tokens.get('expires_in'),
+        OPENAI_WEB_AUTH_DEFAULT_EXPIRES_IN,
+        'expiration',
+    )
+    return {
+        'access_token': tokens['access_token'],
+        'refresh_token': tokens['refresh_token'],
+        'id_token': tokens.get('id_token'),
+        'expires_at': int(time.time()) + expires_in,
+        # Stored server-side only. Not exposed in public status DTOs until product confirms it is safe metadata.
+        'account_id': _extract_openai_account_id(tokens),
+    }
+
+
+async def refresh_openai_web_auth_credential(token: dict) -> Optional[dict]:
+    refresh_token = token.get('refresh_token')
+    if not refresh_token:
+        return None
+
+    token_status, tokens = await _post_openai_web_auth_form(
+        f'{OPENAI_WEB_AUTH_ISSUER}/oauth/token',
+        {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token,
+            'client_id': OPENAI_WEB_AUTH_CLIENT_ID,
+        },
+    )
+    if token_status >= 400 or not tokens.get('access_token'):
+        return None
+
+    try:
+        expires_in = _parse_openai_web_auth_positive_int(
+            tokens.get('expires_in'),
+            OPENAI_WEB_AUTH_DEFAULT_EXPIRES_IN,
+            'expiration',
+        )
+        merged = {
+            **token,
+            'access_token': tokens['access_token'],
+            'refresh_token': tokens.get('refresh_token') or refresh_token,
+            'id_token': tokens.get('id_token') or token.get('id_token'),
+            'expires_at': int(time.time()) + expires_in,
+        }
+    except HTTPException:
+        return None
+    merged['account_id'] = _extract_openai_account_id(merged) or token.get('account_id')
+    return merged
+
+
+async def get_openai_web_auth_session():
+    return await OAuthSessions.get_session_by_provider_and_user_id(
+        OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+        OPENAI_WEB_AUTH_STORAGE_USER_ID,
+    )
+
+
+async def get_openai_web_auth_access_token() -> Optional[str]:
+    session = await get_openai_web_auth_session()
+    if not session:
+        return None
+
+    if session.expires_at <= int(time.time()) + OPENAI_WEB_AUTH_REFRESH_SKEW_SECONDS:
+        refreshed_token = await refresh_openai_web_auth_credential(session.token)
+        if not refreshed_token:
+            return None
+        session = await OAuthSessions.update_session_by_id(session.id, refreshed_token)
+        if not session:
+            return None
+
+    return session.token.get('access_token')
+
+
+async def has_connected_openai_web_auth_credential() -> bool:
+    try:
+        return bool(await get_openai_web_auth_access_token())
+    except HTTPException:
+        return False
+
+
+async def build_openai_web_auth_status() -> OpenAIWebAuthStatusResponse:
+    return _openai_web_auth_status_from_session(await get_openai_web_auth_session())
+
+
+async def invalidate_openai_models_cache(request: Optional[Request] = None, user: Optional[UserModel] = None):
+    """Clear OpenAI model caches after provider credentials or config change.
+
+    The route-level model list is cached per user by ``get_all_models`` and the
+    merged model lookup is also held in ``request.app.state.OPENAI_MODELS`` for
+    routing.  Both can otherwise keep an empty/stale model list after an admin
+    adds, removes, or switches the native OpenAI credential path.
+    """
+
+    cache_keys = ['openai_all_models']
+    if user and getattr(user, 'id', None):
+        cache_keys.append(f'openai_all_models_{user.id}')
+
+    for cache_key in cache_keys:
+        try:
+            await get_all_models.cache.delete(cache_key)
+        except Exception as e:
+            log.debug(f'Failed to invalidate OpenAI models cache key {cache_key}: {e}')
+
+    if request is not None:
+        try:
+            request.app.state.OPENAI_MODELS = {}
+        except Exception as e:
+            log.debug(f'Failed to reset OpenAI app-state model cache: {e}')
+
+
+@router.get('/web-auth/status', response_model=OpenAIWebAuthStatusResponse)
+async def get_web_auth_status(user=Depends(get_admin_user)):
+    return await build_openai_web_auth_status()
+
+
+@router.post('/web-auth/start', response_model=OpenAIWebAuthStartResponse)
+async def start_web_auth(user=Depends(get_admin_user)):
+    started = await start_openai_web_auth_device_flow()
+    created = await OAuthSessions.create_session(
+        user_id=OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        provider=OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER,
+        token={
+            'device_auth_id': started['device_auth_id'],
+            'user_code': started['user_code'],
+            'expires_at': started['expires_at'],
+        },
+    )
+    if not created:
+        raise HTTPException(status_code=500, detail='Failed to store OpenAI web auth session')
+
+    return OpenAIWebAuthStartResponse(
+        verification_url=OPENAI_WEB_AUTH_VERIFICATION_URL,
+        user_code=started['user_code'],
+        session_id=created.id,
+        interval=started['interval'],
+        expires_at=started['expires_at'],
+    )
+
+
+@router.post('/web-auth/complete', response_model=OpenAIWebAuthStatusResponse)
+async def complete_web_auth(
+    form_data: OpenAIWebAuthCompleteForm,
+    request: Request,
+    user=Depends(get_admin_user),
+):
+    device_session = await OAuthSessions.get_session_by_id(form_data.session_id)
+    if not device_session or device_session.provider != OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER:
+        raise HTTPException(status_code=404, detail='OpenAI web auth session not found')
+    if device_session.expires_at <= int(time.time()):
+        await OAuthSessions.delete_session_by_id(device_session.id)
+        raise HTTPException(status_code=409, detail='OpenAI web auth session expired')
+
+    credential = await complete_openai_web_auth_device_flow(
+        device_session.token.get('device_auth_id', ''),
+        device_session.token.get('user_code', ''),
+    )
+
+    await OAuthSessions.delete_sessions_by_user_id_and_provider(
+        OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+    )
+    created = await OAuthSessions.create_session(
+        user_id=OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        provider=OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+        token=credential,
+    )
+    await OAuthSessions.delete_session_by_id(device_session.id)
+    if not created:
+        raise HTTPException(status_code=500, detail='Failed to store OpenAI web auth credential')
+
+    await invalidate_openai_models_cache(request, user)
+
+    return _openai_web_auth_status_from_session(created)
+
+
+@router.post('/web-auth/disconnect', response_model=OpenAIWebAuthStatusResponse)
+async def disconnect_web_auth(request: Request, user=Depends(get_admin_user)):
+    await OAuthSessions.delete_sessions_by_user_id_and_provider(
+        OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+    )
+    await OAuthSessions.delete_sessions_by_user_id_and_provider(
+        OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER,
+    )
+    await invalidate_openai_models_cache(request, user)
+    return await build_openai_web_auth_status()
 
 
 @router.get('/config')
@@ -278,6 +890,8 @@ async def update_config(request: Request, form_data: OpenAIConfigForm, user=Depe
     request.app.state.config.OPENAI_API_CONFIGS = {
         key: value for key, value in request.app.state.config.OPENAI_API_CONFIGS.items() if key in keys
     }
+
+    await invalidate_openai_models_cache(request, user)
 
     return {
         'ENABLE_OPENAI_API': request.app.state.config.ENABLE_OPENAI_API,
@@ -387,6 +1001,10 @@ async def get_all_models_responses(request: Request, user: UserModel) -> list:
     request_tasks = []
     for idx, url in enumerate(api_base_urls):
         if (str(idx) not in api_configs) and (url not in api_configs):  # Legacy support
+            if is_empty_native_openai_bearer_connection(url, api_keys[idx]):
+                log.info('Skipping empty native OpenAI bearer connection at index %s during model listing', idx)
+                request_tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
+                continue
             request_tasks.append(get_models_request(request, url, api_keys[idx], user=user))
         else:
             api_config = api_configs.get(
@@ -398,6 +1016,15 @@ async def get_all_models_responses(request: Request, user: UserModel) -> list:
             model_ids = api_config.get('model_ids', [])
 
             if enable:
+                if is_openai_codex_web_auth_config(api_config):
+                    request_tasks.append(
+                        asyncio.ensure_future(build_openai_codex_web_auth_models_if_connected(idx))
+                    )
+                    continue
+                if is_empty_native_openai_bearer_connection(url, api_keys[idx], api_config):
+                    log.info('Skipping empty native OpenAI bearer connection at index %s during model listing', idx)
+                    request_tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
+                    continue
                 if len(model_ids) == 0:
                     request_tasks.append(get_models_request(request, url, api_keys[idx], user=user, config=api_config))
                 else:
@@ -587,6 +1214,14 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
             request.app.state.config.OPENAI_API_CONFIGS.get(url, {}),  # Legacy support
         )
 
+        if is_empty_native_openai_bearer_connection(url, key, api_config):
+            log.info('Skipping empty native OpenAI bearer connection at index %s during direct model listing', url_idx)
+            return models
+
+        if is_openai_codex_web_auth_config(api_config):
+            models = await build_openai_codex_web_auth_models_if_connected(url_idx)
+            return models or {'data': []}
+
         r = None
         async with aiohttp.ClientSession(
             trust_env=True,
@@ -619,6 +1254,14 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                                     error_detail = f'External Error: {res["error"]}'
                             except Exception:
                                 pass
+
+                            if is_openai_codex_web_auth_config(api_config):
+                                log.warning(
+                                    'OpenAI web auth model request failed for host=%s status=%s detail=%s',
+                                    urlparse(url).hostname,
+                                    r.status,
+                                    error_detail,
+                                )
                             raise Exception(error_detail)
 
                         response_data = await r.json()
@@ -1147,11 +1790,15 @@ async def generate_chat_completion(
         if logit_bias:
             payload['logit_bias'] = json.loads(logit_bias)
 
+    requested_stream = bool(payload.get('stream'))
     headers, cookies = await get_headers_and_cookies(request, url, key, api_config, metadata, user=user)
 
     is_responses = api_config.get('api_type') == 'responses'
+    is_codex_web_auth = is_openai_codex_web_auth_config(api_config)
 
-    if api_config.get('azure') or api_config.get('provider') == 'azure':
+    if is_codex_web_auth:
+        request_url, payload, is_responses = prepare_openai_codex_web_auth_request(payload, is_responses)
+    elif api_config.get('azure') or api_config.get('provider') == 'azure':
         # Only set api-key header if not using Azure Entra ID authentication
         auth_type = api_config.get('auth_type', 'bearer')
         if auth_type not in ('azure_ad', 'microsoft_entra_id'):
@@ -1211,6 +1858,41 @@ async def generate_chat_completion(
             timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
         )
 
+        if is_codex_web_auth and 'text/event-stream' in r.headers.get('Content-Type', ''):
+            if r.status >= 400:
+                error_body = await r.text()
+                log.error(
+                    'OpenAI account auth returned HTTP %d with SSE content-type: %s',
+                    r.status,
+                    error_body[:1000],
+                )
+                parsed_error = parse_openai_codex_sse_response(error_body)
+                error_content = build_openai_codex_error_payload(parsed_error)
+                return JSONResponse(status_code=r.status, content=error_content)
+
+            if requested_stream:
+                streaming = True
+                return StreamingResponse(
+                    stream_wrapper(r, content_handler=openai_codex_stream_chunks_handler),
+                    status_code=r.status,
+                    media_type='text/event-stream',
+                    headers=_clean_proxy_headers(r.headers),
+                )
+
+            response_text = await r.text()
+            parsed_response = parse_openai_codex_sse_response(response_text)
+            if parsed_response is None:
+                raise HTTPException(status_code=502, detail='OpenAI account auth response could not be parsed')
+
+            if parsed_response.get('type') in ('response.failed', 'response.incomplete'):
+                return JSONResponse(
+                    status_code=502,
+                    content=build_openai_codex_error_payload(parsed_response),
+                )
+
+            response = convert_responses_result(parsed_response)
+            return response
+
         # Check if response is SSE
         if 'text/event-stream' in r.headers.get('Content-Type', ''):
             # If the provider returned an error status with SSE content-type,
@@ -1242,8 +1924,20 @@ async def generate_chat_completion(
             try:
                 response = await r.json()
             except Exception as e:
-                log.error(e)
-                response = await r.text()
+                response_text = await r.text()
+                if is_codex_web_auth:
+                    parsed_response = parse_openai_codex_sse_response(response_text)
+                    if parsed_response is not None:
+                        if parsed_response.get('type') in ('response.failed', 'response.incomplete'):
+                            response = build_openai_codex_error_payload(parsed_response)
+                        else:
+                            response = parsed_response
+                    else:
+                        log.error(e)
+                        response = response_text
+                else:
+                    log.error(e)
+                    response = response_text
 
             if r.status >= 400:
                 if isinstance(response, (dict, list)):
@@ -1408,7 +2102,9 @@ async def responses(
     try:
         headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
 
-        if api_config.get('azure') or api_config.get('provider') == 'azure':
+        if is_openai_codex_web_auth_config(api_config):
+            request_url = OPENAI_CODEX_API_ENDPOINT
+        elif api_config.get('azure') or api_config.get('provider') == 'azure':
             auth_type = api_config.get('auth_type', 'bearer')
             if auth_type not in ('azure_ad', 'microsoft_entra_id'):
                 headers['api-key'] = key

--- a/backend/open_webui/test/routers/test_openai_web_auth.py
+++ b/backend/open_webui/test/routers/test_openai_web_auth.py
@@ -1,0 +1,771 @@
+import asyncio
+import os
+import sqlite3
+import tempfile
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+TEST_DATA_DIR = tempfile.mkdtemp(prefix='open-webui-openai-web-auth-')
+TEST_DB_PATH = os.path.join(TEST_DATA_DIR, 'webui.db')
+os.environ.setdefault('DATA_DIR', TEST_DATA_DIR)
+os.environ.setdefault('DATABASE_URL', f'sqlite:///{TEST_DB_PATH}')
+os.environ.setdefault('ENABLE_DB_MIGRATIONS', 'False')
+os.environ.setdefault('VECTOR_DB', 'none')
+
+with sqlite3.connect(TEST_DB_PATH) as conn:
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS config ('
+        'id INTEGER PRIMARY KEY, '
+        'data JSON NOT NULL, '
+        'version INTEGER NOT NULL DEFAULT 0, '
+        'created_at DATETIME DEFAULT CURRENT_TIMESTAMP, '
+        'updated_at DATETIME'
+        ')'
+    )
+
+from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.routers import openai
+
+
+class FakeOAuthSessions:
+    def __init__(self):
+        self.sessions = {}
+        self.created_tokens = []
+        self.next_id = 0
+
+    async def create_session(self, user_id: str, provider: str, token: dict, db=None):
+        self.next_id += 1
+        session_id = f'session-{self.next_id}'
+        session = SimpleNamespace(
+            id=session_id,
+            user_id=user_id,
+            provider=provider,
+            token=token,
+            expires_at=token.get('expires_at') or int(time.time()) + 3600,
+        )
+        self.sessions[session_id] = session
+        self.created_tokens.append(token)
+        return session
+
+    async def get_session_by_id(self, session_id: str, db=None):
+        return self.sessions.get(session_id)
+
+    async def get_session_by_provider_and_user_id(self, provider: str, user_id: str, db=None):
+        matches = [s for s in self.sessions.values() if s.provider == provider and s.user_id == user_id]
+        return matches[-1] if matches else None
+
+    async def update_session_by_id(self, session_id: str, token: dict, db=None):
+        session = self.sessions.get(session_id)
+        if not session:
+            return None
+        session.token = token
+        session.expires_at = token.get('expires_at') or int(time.time()) + 3600
+        self.created_tokens.append(token)
+        return session
+
+    async def delete_session_by_id(self, session_id: str, db=None):
+        return self.sessions.pop(session_id, None) is not None
+
+    async def delete_sessions_by_user_id_and_provider(self, user_id: str, provider: str, db=None):
+        to_delete = [k for k, v in self.sessions.items() if v.user_id == user_id and v.provider == provider]
+        for key in to_delete:
+            del self.sessions[key]
+        return bool(to_delete)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_openai_web_auth_start_returns_safe_fields(monkeypatch):
+    fake_sessions = FakeOAuthSessions()
+    monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+
+    async def fake_start():
+        return {
+            'device_auth_id': 'device-secret',
+            'user_code': 'USER-CODE',
+            'interval': 5,
+            'expires_at': int(time.time()) + 600,
+        }
+
+    monkeypatch.setattr(openai, 'start_openai_web_auth_device_flow', fake_start)
+
+    response = run(openai.start_web_auth(user=SimpleNamespace(role='admin')))
+
+    assert response.verification_url == openai.OPENAI_WEB_AUTH_VERIFICATION_URL
+    assert response.user_code == 'USER-CODE'
+    assert response.session_id == 'session-1'
+    assert response.interval == 5
+    assert not hasattr(response, 'device_auth_id')
+    assert fake_sessions.created_tokens[0]['device_auth_id'] == 'device-secret'
+
+
+def test_openai_web_auth_complete_stores_credential_without_returning_tokens(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        device = await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER,
+            token={
+                'device_auth_id': 'device-secret',
+                'user_code': 'USER-CODE',
+                'expires_at': int(time.time()) + 600,
+            },
+        )
+
+        async def fake_complete(device_auth_id: str, user_code: str):
+            assert device_auth_id == 'device-secret'
+            assert user_code == 'USER-CODE'
+            return {
+                'access_token': 'access-secret',
+                'refresh_token': 'refresh-secret',
+                'expires_at': int(time.time()) + 3600,
+                'account_id': 'acct_123',
+            }
+
+        monkeypatch.setattr(openai, 'complete_openai_web_auth_device_flow', fake_complete)
+
+        response = await openai.complete_web_auth(
+            openai.OpenAIWebAuthCompleteForm(session_id=device.id),
+            request=None,
+            user=SimpleNamespace(role='admin'),
+        )
+
+        payload = response.model_dump()
+        assert payload == {
+            'credential_type': 'web_auth',
+            'connected': True,
+            'has_credential': True,
+            'status': 'connected',
+            'expires_at': payload['expires_at'],
+        }
+        assert 'access_token' not in payload
+        assert 'refresh_token' not in payload
+        assert 'account_id' not in payload
+        credential = await fake_sessions.get_session_by_provider_and_user_id(
+            openai.OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+            openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+        )
+        assert credential.token['access_token'] == 'access-secret'
+        assert credential.token['account_id'] == 'acct_123'
+        assert await fake_sessions.get_session_by_id(device.id) is None
+
+    run(scenario())
+
+
+def test_openai_web_auth_status_and_disconnect_are_redacted(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+            token={
+                'access_token': 'access-secret',
+                'refresh_token': 'refresh-secret',
+                'expires_at': int(time.time()) + 3600,
+                'account_id': 'acct_123',
+            },
+        )
+
+        status_response = await openai.get_web_auth_status(user=SimpleNamespace(role='admin'))
+        assert 'access-secret' not in str(status_response.model_dump())
+        assert 'refresh-secret' not in str(status_response.model_dump())
+        assert 'acct_123' not in str(status_response.model_dump())
+
+        disconnect_response = await openai.disconnect_web_auth(request=None, user=SimpleNamespace(role='admin'))
+        assert disconnect_response.model_dump() == {
+            'credential_type': 'none',
+            'connected': False,
+            'has_credential': False,
+            'status': 'not_configured',
+            'expires_at': None,
+        }
+
+    run(scenario())
+
+
+def test_openai_web_auth_complete_and_disconnect_invalidate_model_caches(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        invalidations = []
+
+        async def fake_invalidate(request=None, user=None):
+            invalidations.append((request, user))
+
+        async def fake_complete(device_auth_id: str, user_code: str):
+            return {
+                'access_token': 'access-secret',
+                'refresh_token': 'refresh-secret',
+                'expires_at': int(time.time()) + 3600,
+            }
+
+        monkeypatch.setattr(openai, 'invalidate_openai_models_cache', fake_invalidate)
+        monkeypatch.setattr(openai, 'complete_openai_web_auth_device_flow', fake_complete)
+
+        device = await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER,
+            token={
+                'device_auth_id': 'device-secret',
+                'user_code': 'USER-CODE',
+                'expires_at': int(time.time()) + 600,
+            },
+        )
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(OPENAI_MODELS={'old': {}})))
+        user = SimpleNamespace(id='admin', role='admin')
+
+        await openai.complete_web_auth(openai.OpenAIWebAuthCompleteForm(session_id=device.id), request=request, user=user)
+        await openai.disconnect_web_auth(request=request, user=user)
+
+        assert invalidations == [(request, user), (request, user)]
+
+    run(scenario())
+
+
+def test_invalidate_openai_models_cache_clears_user_and_app_state(monkeypatch):
+    async def scenario():
+        deleted_keys = []
+
+        async def fake_delete(cache_key: str):
+            deleted_keys.append(cache_key)
+
+        monkeypatch.setattr(openai.get_all_models.cache, 'delete', fake_delete)
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(OPENAI_MODELS={'stale': {}})))
+
+        await openai.invalidate_openai_models_cache(request, SimpleNamespace(id='admin'))
+
+        assert deleted_keys == ['openai_all_models', 'openai_all_models_admin']
+        assert request.app.state.OPENAI_MODELS == {}
+
+    run(scenario())
+
+
+def test_openai_config_update_invalidates_model_caches(monkeypatch):
+    async def scenario():
+        invalidations = []
+
+        async def fake_invalidate(request=None, user=None):
+            invalidations.append((request, user))
+
+        monkeypatch.setattr(openai, 'invalidate_openai_models_cache', fake_invalidate)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=['https://stale.example/v1'],
+                        OPENAI_API_KEYS=['stale'],
+                        OPENAI_API_CONFIGS={},
+                    )
+                )
+            )
+        )
+        user = SimpleNamespace(id='admin', role='admin')
+        form = openai.OpenAIConfigForm(
+            ENABLE_OPENAI_API=True,
+            OPENAI_API_BASE_URLS=['https://api.openai.com/v1'],
+            OPENAI_API_KEYS=[''],
+            OPENAI_API_CONFIGS={'0': {'auth_type': 'openai_web_auth'}, '9': {'enable': True}},
+        )
+
+        response = await openai.update_config(request, form, user=user)
+
+        assert invalidations == [(request, user)]
+        assert response['OPENAI_API_CONFIGS'] == {'0': {'auth_type': 'openai_web_auth'}}
+
+    run(scenario())
+
+
+def test_openai_web_auth_upstream_start_pending_failure_and_invalid_responses(monkeypatch):
+    async def success_json(url: str, payload: dict):
+        return 200, {'device_auth_id': 'device-secret', 'user_code': 'CODE', 'interval': '2', 'expires_in': '30'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', success_json)
+    started = run(openai.start_openai_web_auth_device_flow())
+    assert started['interval'] == 2
+    assert started['expires_at'] > int(time.time())
+
+    async def failing_json(url: str, payload: dict):
+        return 500, {'access_token': 'must-not-leak'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', failing_json)
+    with pytest.raises(HTTPException) as failure:
+        run(openai.start_openai_web_auth_device_flow())
+    assert failure.value.status_code == 502
+    assert 'must-not-leak' not in failure.value.detail
+
+    async def invalid_json(url: str, payload: dict):
+        return 200, {'device_auth_id': 'device-secret', 'user_code': 'CODE', 'interval': 'not-int'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', invalid_json)
+    with pytest.raises(HTTPException) as invalid:
+        run(openai.start_openai_web_auth_device_flow())
+    assert invalid.value.status_code == 502
+    assert 'invalid interval' in invalid.value.detail
+
+
+def test_openai_web_auth_complete_pending_failure_and_invalid_responses(monkeypatch):
+    async def pending_json(url: str, payload: dict):
+        return 403, {}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', pending_json)
+    with pytest.raises(HTTPException) as pending:
+        run(openai.complete_openai_web_auth_device_flow('device', 'CODE'))
+    assert pending.value.status_code == 409
+
+    async def invalid_device_json(url: str, payload: dict):
+        return 200, {'authorization_code': 'auth-code'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', invalid_device_json)
+    with pytest.raises(HTTPException) as invalid_device:
+        run(openai.complete_openai_web_auth_device_flow('device', 'CODE'))
+    assert invalid_device.value.status_code == 502
+
+    async def valid_device_json(url: str, payload: dict):
+        return 200, {'authorization_code': 'auth-code', 'code_verifier': 'verifier'}
+
+    async def token_failure_form(url: str, payload: dict):
+        return 500, {'refresh_token': 'must-not-leak'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_json', valid_device_json)
+    monkeypatch.setattr(openai, '_post_openai_web_auth_form', token_failure_form)
+    with pytest.raises(HTTPException) as token_failure:
+        run(openai.complete_openai_web_auth_device_flow('device', 'CODE'))
+    assert token_failure.value.status_code == 502
+    assert 'must-not-leak' not in token_failure.value.detail
+
+    async def invalid_token_form(url: str, payload: dict):
+        return 200, {'access_token': 'access-secret', 'refresh_token': 'refresh-secret', 'expires_in': 'bad'}
+
+    monkeypatch.setattr(openai, '_post_openai_web_auth_form', invalid_token_form)
+    with pytest.raises(HTTPException) as invalid_token:
+        run(openai.complete_openai_web_auth_device_flow('device', 'CODE'))
+    assert invalid_token.value.status_code == 502
+    assert 'access-secret' not in invalid_token.value.detail
+
+
+def test_openai_web_auth_complete_rejects_expired_sessions(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        device = await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_DEVICE_SESSION_PROVIDER,
+            token={'device_auth_id': 'device', 'user_code': 'CODE', 'expires_at': int(time.time()) - 1},
+        )
+
+        with pytest.raises(HTTPException) as expired:
+            await openai.complete_web_auth(openai.OpenAIWebAuthCompleteForm(session_id=device.id), request=None)
+        assert expired.value.status_code == 409
+        assert await fake_sessions.get_session_by_id(device.id) is None
+
+    run(scenario())
+
+
+def test_openai_web_auth_runtime_refresh_and_codex_headers(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        session = await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+            token={
+                'access_token': 'old-access',
+                'refresh_token': 'refresh-secret',
+                'expires_at': int(time.time()) - 1,
+                'account_id': 'acct_123',
+            },
+        )
+
+        async def fake_refresh(token: dict):
+            assert token['refresh_token'] == 'refresh-secret'
+            return {
+                **token,
+                'access_token': 'new-access',
+                'expires_at': int(time.time()) + 3600,
+            }
+
+        monkeypatch.setattr(openai, 'refresh_openai_web_auth_credential', fake_refresh)
+        request = SimpleNamespace(cookies={}, state=SimpleNamespace())
+
+        headers, cookies = await openai.get_headers_and_cookies(
+            request,
+            openai.OPENAI_CODEX_API_ENDPOINT,
+            key='',
+            config={'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE},
+            metadata={'chat_id': 'chat-1'},
+            user=SimpleNamespace(id='admin'),
+        )
+
+        assert headers['Authorization'] == 'Bearer new-access'
+        assert headers['ChatGPT-Account-Id'] == 'acct_123'
+        assert headers['originator'] == 'open-webui'
+        assert headers['User-Agent'] == 'Open WebUI'
+        assert headers['session_id'] == 'chat-1'
+        assert cookies == {}
+        assert fake_sessions.sessions[session.id].token['access_token'] == 'new-access'
+
+    run(scenario())
+
+
+def test_openai_web_auth_runtime_header_resolution(monkeypatch):
+    async def scenario():
+        fake_sessions = FakeOAuthSessions()
+        monkeypatch.setattr(openai, 'OAuthSessions', fake_sessions)
+        await fake_sessions.create_session(
+            user_id=openai.OPENAI_WEB_AUTH_STORAGE_USER_ID,
+            provider=openai.OPENAI_WEB_AUTH_CREDENTIAL_PROVIDER,
+            token={
+                'access_token': 'access-secret',
+                'refresh_token': 'refresh-secret',
+                'expires_at': int(time.time()) + 3600,
+                'account_id': 'acct_456',
+            },
+        )
+        request = SimpleNamespace(cookies={}, state=SimpleNamespace())
+
+        headers, cookies = await openai.get_headers_and_cookies(
+            request,
+            openai.OPENAI_CODEX_API_ENDPOINT,
+            key='',
+            config={'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE},
+            user=SimpleNamespace(id='admin'),
+        )
+
+        assert headers['Authorization'] == 'Bearer access-secret'
+        assert headers['ChatGPT-Account-Id'] == 'acct_456'
+        assert cookies == {}
+
+    run(scenario())
+
+
+def test_openai_api_key_header_behavior_remains_unchanged():
+    async def scenario():
+        request = SimpleNamespace(cookies={}, state=SimpleNamespace())
+
+        headers, cookies = await openai.get_headers_and_cookies(
+            request,
+            'https://api.openai.com/v1',
+            key='sk-api-key',
+            config={'auth_type': 'bearer'},
+            user=SimpleNamespace(id='admin'),
+        )
+
+        assert headers['Authorization'] == 'Bearer sk-api-key'
+        assert cookies == {}
+
+    run(scenario())
+
+
+def test_empty_native_openai_bearer_models_route_returns_empty_without_upstream_call():
+    async def scenario():
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=['https://api.openai.com/v1'],
+                        OPENAI_API_KEYS=[''],
+                        OPENAI_API_CONFIGS={'0': {'enable': True, 'auth_type': 'bearer'}},
+                    )
+                )
+            )
+        )
+
+        response = await openai.get_models(request, url_idx=0, user=SimpleNamespace(id='admin', role='admin'))
+
+        assert response == {'data': []}
+
+    run(scenario())
+
+
+def test_empty_native_openai_bearer_is_skipped_during_aggregate_model_fetch(monkeypatch):
+    async def scenario():
+        requested = []
+
+        async def fake_models_request(request=None, url=None, key=None, user=None, config=None):
+            requested.append((url, key, config))
+            return {'data': [{'id': 'gpt-test'}]}
+
+        async def fake_get_token():
+            return 'connected-token'
+
+        monkeypatch.setattr(openai, 'get_models_request', fake_models_request)
+        monkeypatch.setattr(openai, 'get_openai_web_auth_access_token', fake_get_token)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=['https://api.openai.com/v1', openai.OPENAI_CODEX_API_ENDPOINT],
+                        OPENAI_API_KEYS=['', ''],
+                        OPENAI_API_CONFIGS={
+                            '0': {'enable': True, 'auth_type': 'bearer'},
+                            '1': {'enable': True, 'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE},
+                        },
+                    )
+                )
+            )
+        )
+
+        responses = await openai.get_all_models_responses(request, user=SimpleNamespace(id='admin', role='admin'))
+
+        assert responses[0] is None
+        assert requested == []
+        assert [model['id'] for model in responses[1]['data']] == openai.OPENAI_CODEX_WEB_AUTH_MODEL_IDS
+        assert responses[1]['data'][0]['urlIdx'] == 1
+
+    run(scenario())
+
+
+def test_codex_web_auth_models_are_hidden_without_connected_credential(monkeypatch):
+    async def scenario():
+        async def fail_models_request(*args, **kwargs):
+            raise AssertionError('Codex account auth must not call /v1/models')
+
+        async def fake_get_token():
+            return None
+
+        monkeypatch.setattr(openai, 'get_models_request', fail_models_request)
+        monkeypatch.setattr(openai, 'get_openai_web_auth_access_token', fake_get_token)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=[openai.OPENAI_CODEX_API_ENDPOINT],
+                        OPENAI_API_KEYS=[''],
+                        OPENAI_API_CONFIGS={'0': {'enable': True, 'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE}},
+                    )
+                )
+            )
+        )
+
+        response = await openai.get_models(request, url_idx=0, user=SimpleNamespace(id='admin', role='admin'))
+
+        assert response == {'data': []}
+
+    run(scenario())
+
+
+def test_codex_web_auth_models_route_returns_static_list_with_connected_credential(monkeypatch):
+    async def scenario():
+        async def fail_models_request(*args, **kwargs):
+            raise AssertionError('Codex account auth must not call /v1/models')
+
+        async def fake_get_token():
+            return 'connected-token'
+
+        monkeypatch.setattr(openai, 'get_models_request', fail_models_request)
+        monkeypatch.setattr(openai, 'get_openai_web_auth_access_token', fake_get_token)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=[openai.OPENAI_CODEX_API_ENDPOINT],
+                        OPENAI_API_KEYS=[''],
+                        OPENAI_API_CONFIGS={'0': {'enable': True, 'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE}},
+                    )
+                )
+            )
+        )
+
+        response = await openai.get_models(request, url_idx=0, user=SimpleNamespace(id='admin', role='admin'))
+
+        assert [model['id'] for model in response['data']] == openai.OPENAI_CODEX_WEB_AUTH_MODEL_IDS
+        assert response['data'][0]['urlIdx'] == 0
+
+    run(scenario())
+
+
+def test_codex_web_auth_aggregate_model_fetch_is_hidden_without_connected_credential(monkeypatch):
+    async def scenario():
+        requested = []
+
+        async def fake_models_request(request=None, url=None, key=None, user=None, config=None):
+            requested.append((url, key, config))
+            return {'data': [{'id': 'gpt-test'}]}
+
+        async def fake_get_token():
+            return None
+
+        monkeypatch.setattr(openai, 'get_models_request', fake_models_request)
+        monkeypatch.setattr(openai, 'get_openai_web_auth_access_token', fake_get_token)
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config=SimpleNamespace(
+                        ENABLE_OPENAI_API=True,
+                        OPENAI_API_BASE_URLS=['https://api.openai.com/v1', openai.OPENAI_CODEX_API_ENDPOINT],
+                        OPENAI_API_KEYS=['', ''],
+                        OPENAI_API_CONFIGS={
+                            '0': {'enable': True, 'auth_type': 'bearer'},
+                            '1': {'enable': True, 'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE},
+                        },
+                    )
+                )
+            )
+        )
+
+        responses = await openai.get_all_models_responses(request, user=SimpleNamespace(id='admin', role='admin'))
+
+        assert responses == [None, None]
+        assert requested == []
+
+    run(scenario())
+
+
+def test_codex_web_auth_request_rewrites_to_responses_endpoint():
+    payload = {
+        'model': 'gpt-5.5',
+        'messages': [{'role': 'user', 'content': 'hello'}],
+        'max_tokens': 10,
+    }
+
+    request_url, converted, is_responses = openai.prepare_openai_codex_web_auth_request(payload, False)
+
+    assert request_url == openai.OPENAI_CODEX_API_ENDPOINT
+    assert is_responses is True
+    assert converted['model'] == 'gpt-5.5'
+    assert converted['instructions'] == 'You are ChatGPT, a helpful assistant.'
+    assert converted['store'] is False
+    assert converted['stream'] is True
+    assert converted['input'][0]['role'] == 'user'
+    assert converted['max_output_tokens'] == 10
+
+
+def test_codex_web_auth_sse_response_parser_uses_last_json_payload():
+    parsed = openai.parse_openai_codex_sse_response(
+        'event: response.created\n'
+        'data: {"type":"response.created"}\n\n'
+        'event: response.completed\n'
+        'data: {"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}\n\n'
+        'data: [DONE]\n'
+    )
+
+    assert parsed['id'] == 'resp_1'
+    assert parsed['output'][0]['content'][0]['text'] == 'ok'
+
+
+def test_codex_web_auth_sse_delta_converter_outputs_chat_chunks():
+    converted = openai.convert_openai_codex_sse_payload(
+        {
+            'type': 'response.output_text.delta',
+            'response_id': 'resp_1',
+            'delta': 'hello',
+            'model': 'gpt-5.5',
+        }
+    )
+
+    assert converted == (
+        b'data: {"id": "resp_1", "object": "chat.completion.chunk", "model": "gpt-5.5", '
+        b'"choices": [{"index": 0, "delta": {"content": "hello"}, "finish_reason": null}]}\n\n'
+    )
+    assert openai.convert_openai_codex_sse_payload({'type': 'response.completed'}) == b'data: [DONE]\n\n'
+def test_codex_web_auth_sse_failure_converter_preserves_error_signal():
+    converted = openai.convert_openai_codex_sse_payload(
+        {
+            'type': 'response.failed',
+            'status_details': {'message': 'permission denied', 'code': 'permission_denied'},
+        }
+    )
+
+    assert converted is not None
+    assert b'permission denied' in converted
+    assert b'data: [DONE]' in converted
+
+
+def test_codex_web_auth_non_2xx_sse_is_forwarded_as_json_error(monkeypatch):
+    async def scenario():
+        async def fake_headers_and_cookies(*args, **kwargs):
+            return {}, {}
+
+        async def fake_check_model_access(*args, **kwargs):
+            return None
+
+        class FakeResponse:
+            status = 502
+            headers = {'Content-Type': 'text/event-stream'}
+
+            async def text(self):
+                return (
+                    'data: {"type":"response.failed","status_details":{"message":"upstream denied","code":"denied"}}\n\n'
+                    'data: [DONE]\n'
+                )
+
+        class FakeSession:
+            async def request(self, *args, **kwargs):
+                return FakeResponse()
+
+        async def fake_get_session():
+            return FakeSession()
+
+        async def fake_cleanup_response(*args, **kwargs):
+            return None
+
+        async def fake_get_model_by_id(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(openai.Models, 'get_model_by_id', staticmethod(fake_get_model_by_id))
+        monkeypatch.setattr(openai, 'check_model_access', fake_check_model_access)
+        monkeypatch.setattr(openai, 'get_headers_and_cookies', fake_headers_and_cookies)
+        monkeypatch.setattr(openai, 'get_session', fake_get_session)
+        monkeypatch.setattr(openai, 'cleanup_response', fake_cleanup_response)
+
+        request = SimpleNamespace(
+            state=SimpleNamespace(bypass_filter=False),
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    OPENAI_MODELS={'gpt-5.5': {'urlIdx': 0}},
+                    config=SimpleNamespace(
+                        OPENAI_API_BASE_URLS=[openai.OPENAI_CODEX_API_ENDPOINT],
+                        OPENAI_API_KEYS=[''],
+                        OPENAI_API_CONFIGS={'0': {'auth_type': openai.OPENAI_CODEX_WEB_AUTH_TYPE}},
+                    ),
+                )
+            ),
+        )
+
+        response = await openai.generate_chat_completion(
+            request,
+            {'model': 'gpt-5.5', 'messages': [{'role': 'user', 'content': 'hello'}], 'stream': True},
+            user=SimpleNamespace(id='admin', role='admin'),
+        )
+
+        assert response.status_code == 502
+        assert b'upstream denied' in response.body
+
+    run(scenario())
+
+
+def test_oauth_sessions_encrypts_persisted_web_auth_tokens():
+    token = {
+        'access_token': 'access-secret',
+        'refresh_token': 'refresh-secret',
+        'expires_at': int(time.time()) + 3600,
+    }
+
+    encrypted = OAuthSessions._encrypt_token(token)
+
+    assert 'access-secret' not in encrypted
+    assert 'refresh-secret' not in encrypted
+    assert OAuthSessions._decrypt_token(encrypted) == token
+
+
+def test_openai_web_auth_routes_require_admin_dependency(monkeypatch):
+    app = FastAPI()
+    app.include_router(openai.router, prefix='/openai')
+    client = TestClient(app)
+
+    response = client.get('/openai/web-auth/status')
+
+    assert response.status_code in (401, 403)

--- a/docs/guides/openai-account-auth-provider-note.md
+++ b/docs/guides/openai-account-auth-provider-note.md
@@ -1,0 +1,19 @@
+# OpenAI Account Auth Provider Note
+
+This branch adds an **OpenAI account-auth connection path** for supported Codex-compatible runtime requests.
+
+## Reviewer Notes
+
+- The browser/device authorization flow follows the de facto Codex account-auth runtime used by developer tooling and is separate from the standard OpenAI API-key path.
+- The implementation currently depends on the observed device-auth issuer at `https://auth.openai.com`.
+- The observed client identifier used for the device flow is `app_EMoamEEZ73f0CkXaXp7hrann`.
+- Runtime requests for this connection path are routed to the observed Codex responses endpoint at `https://chatgpt.com/backend-api/codex/responses`.
+
+## Runtime Scope
+
+Because this mode is distinct from the public OpenAI API-key path, it is implemented as its own runtime mode. The upstream account-auth endpoints and client details are externally controlled, so maintainers should review this path as a Codex-compatible account runtime rather than as normal `/v1` API-key authentication.
+
+## Scope Guardrails
+
+- This mode is intentionally separate from the standard OpenAI API-key connection flow.
+- Existing API-key-based OpenAI connections remain supported and should be preferred when stable API access is required.

--- a/src/lib/apis/openai/index.test.ts
+++ b/src/lib/apis/openai/index.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import {
+	applyOpenAIWebAuthConnection,
+	completeOpenAIWebAuth,
+	createOpenAIWebAuthConfigUpdate,
+	createOpenAIWebAuthConnectionConfig,
+	disconnectOpenAIWebAuth,
+	getSupportedOpenAIConnectionAuthTypes,
+	getOpenAIWebAuthStatus,
+	OPENAI_CODEX_WEB_AUTH_API_BASE_URL,
+	OPENAI_CODEX_WEB_AUTH_TYPE,
+	isEmptyNativeOpenAIBearerConnection,
+	startOpenAIWebAuth
+} from './index';
+
+const mockFetch = (body: unknown, ok = true) => {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok,
+		json: vi.fn().mockResolvedValue(body)
+	});
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('OpenAI web auth API helpers', () => {
+	it('fetches redacted status', async () => {
+		const fetchMock = mockFetch({
+			credential_type: 'web_auth',
+			connected: true,
+			has_credential: true,
+			status: 'connected',
+			expires_at: 1893456000,
+			access_token: 'must-not-return',
+			refresh_token: 'must-not-return',
+			client_secret: 'must-not-return'
+		});
+
+		const status = await getOpenAIWebAuthStatus('test-token');
+
+		expect(fetchMock).toHaveBeenCalledWith('/openai/web-auth/status', expect.any(Object));
+		expect(status).toEqual({
+			credential_type: 'web_auth',
+			connected: true,
+			has_credential: true,
+			status: 'connected',
+			expires_at: 1893456000
+		});
+		expect(JSON.stringify(status)).not.toMatch(
+			/access_token|refresh_token|authorization_code|code_verifier|client_secret/i
+		);
+	});
+
+	it('starts account authorization with safe browser fields', async () => {
+		const fetchMock = mockFetch({
+			verification_url: 'https://auth.openai.com/device',
+			user_code: 'ABCD-EFGH',
+			session_id: 'session-1',
+			interval: 5,
+			expires_at: 1893456000,
+			device_auth_id: 'must-not-return',
+			code_verifier: 'must-not-return',
+			client_id: 'must-not-return'
+		});
+
+		const started = await startOpenAIWebAuth('test-token');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/openai/web-auth/start',
+			expect.objectContaining({ method: 'POST' })
+		);
+		expect(started).toEqual({
+			verification_url: 'https://auth.openai.com/device',
+			user_code: 'ABCD-EFGH',
+			session_id: 'session-1',
+			interval: 5,
+			expires_at: 1893456000
+		});
+		expect(JSON.stringify(started)).not.toMatch(
+			/access_token|refresh_token|authorization_code|code_verifier|client_secret|client_id|device_auth_id/i
+		);
+	});
+
+	it('builds the OpenAI account-auth runtime connection config without public secrets', () => {
+		const config = createOpenAIWebAuthConnectionConfig({ tags: [{ name: 'native' }] });
+
+		expect(config).toEqual({
+			tags: [{ name: 'native' }],
+			enable: true,
+			auth_type: OPENAI_CODEX_WEB_AUTH_TYPE,
+			connection_type: 'external'
+		});
+		expect(JSON.stringify(config)).not.toMatch(/api_key|access_token|refresh_token|client_secret/i);
+	});
+
+	it('does not expose account auth in the generic add-connection auth options', () => {
+		const authTypes = getSupportedOpenAIConnectionAuthTypes();
+
+		expect(authTypes.map(({ value }) => value)).toEqual(['none', 'bearer', 'session', 'system_oauth']);
+		expect(authTypes.map(({ value }) => value)).not.toContain(OPENAI_CODEX_WEB_AUTH_TYPE);
+	});
+
+	it('converts an empty native OpenAI bearer connection to web auth', () => {
+		expect(
+			isEmptyNativeOpenAIBearerConnection('https://api.openai.com/v1', '', {
+				auth_type: 'bearer'
+			})
+		).toBe(true);
+
+		const result = applyOpenAIWebAuthConnection(['https://api.openai.com/v1'], [''], {
+			0: { enable: true, auth_type: 'bearer' }
+		});
+
+		expect(result).toEqual({
+			urls: [OPENAI_CODEX_WEB_AUTH_API_BASE_URL],
+			keys: [''],
+			configs: {
+				0: { enable: true, auth_type: OPENAI_CODEX_WEB_AUTH_TYPE, connection_type: 'external' }
+			}
+		});
+	});
+
+	it('preserves native OpenAI API-key connection and adds separate web auth connection', () => {
+		const result = applyOpenAIWebAuthConnection(['https://api.openai.com/v1'], ['sk-existing'], {
+			0: { enable: true, auth_type: 'bearer' }
+		});
+
+		expect(result.urls).toEqual(['https://api.openai.com/v1', OPENAI_CODEX_WEB_AUTH_API_BASE_URL]);
+		expect(result.keys).toEqual(['sk-existing', '']);
+		expect(result.configs[0]).toEqual({ enable: true, auth_type: 'bearer' });
+		expect(result.configs[1]).toEqual({
+			enable: true,
+			auth_type: OPENAI_CODEX_WEB_AUTH_TYPE,
+			connection_type: 'external'
+		});
+	});
+
+	it('creates an enabled config update for auto-use after successful account auth completion', () => {
+		const result = createOpenAIWebAuthConfigUpdate({
+			ENABLE_OPENAI_API: false,
+			OPENAI_API_BASE_URLS: ['https://api.openai.com/v1'],
+			OPENAI_API_KEYS: ['sk-existing'],
+			OPENAI_API_CONFIGS: { 0: { enable: true, auth_type: 'bearer' } }
+		});
+
+		expect(result.ENABLE_OPENAI_API).toBe(true);
+		expect(result.OPENAI_API_BASE_URLS).toEqual([
+			'https://api.openai.com/v1',
+			OPENAI_CODEX_WEB_AUTH_API_BASE_URL
+		]);
+		expect(result.OPENAI_API_KEYS).toEqual(['sk-existing', '']);
+		expect(result.OPENAI_API_CONFIGS[0]).toEqual({ enable: true, auth_type: 'bearer' });
+		expect(result.OPENAI_API_CONFIGS[1]).toEqual({
+			enable: true,
+			auth_type: OPENAI_CODEX_WEB_AUTH_TYPE,
+			connection_type: 'external'
+		});
+	});
+
+	it('removes duplicate empty native bearer entry when web auth already exists', () => {
+		const result = applyOpenAIWebAuthConnection(
+			['https://api.openai.com/v1', OPENAI_CODEX_WEB_AUTH_API_BASE_URL],
+			['', ''],
+			{
+				0: { enable: true, auth_type: 'bearer' },
+				1: { enable: true, auth_type: OPENAI_CODEX_WEB_AUTH_TYPE }
+			}
+		);
+
+		expect(result.urls).toEqual([OPENAI_CODEX_WEB_AUTH_API_BASE_URL]);
+		expect(result.keys).toEqual(['']);
+		expect(result.configs[0]).toEqual({
+			enable: true,
+			auth_type: OPENAI_CODEX_WEB_AUTH_TYPE,
+			connection_type: 'external'
+		});
+	});
+
+	it('completes with session id and returns redacted status', async () => {
+		const fetchMock = mockFetch({
+			credential_type: 'web_auth',
+			connected: true,
+			has_credential: true,
+			status: 'connected'
+		});
+
+		const status = await completeOpenAIWebAuth('test-token', 'session-1');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/openai/web-auth/complete',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ session_id: 'session-1' })
+			})
+		);
+		expect(status.connected).toBe(true);
+		expect(JSON.stringify(status)).not.toMatch(
+			/access_token|refresh_token|authorization_code|code_verifier|client_secret/i
+		);
+	});
+
+	it('disconnects and returns not connected status', async () => {
+		const fetchMock = mockFetch({
+			credential_type: 'none',
+			connected: false,
+			has_credential: false,
+			status: 'not_configured'
+		});
+
+		const status = await disconnectOpenAIWebAuth('test-token');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/openai/web-auth/disconnect',
+			expect.objectContaining({ method: 'POST' })
+		);
+		expect(status.connected).toBe(false);
+		expect(status.has_credential).toBe(false);
+	});
+});

--- a/src/lib/apis/openai/index.ts
+++ b/src/lib/apis/openai/index.ts
@@ -39,6 +39,292 @@ type OpenAIConfig = {
 	OPENAI_API_CONFIGS: object;
 };
 
+export const OPENAI_WEB_AUTH_API_BASE_URL = 'https://api.openai.com/v1';
+export const OPENAI_CODEX_WEB_AUTH_API_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+export const OPENAI_CODEX_WEB_AUTH_TYPE = 'openai_codex_web_auth';
+export const OPENAI_CODEX_WEB_AUTH_LEGACY_TYPE = 'openai_web_auth';
+
+export const getSupportedOpenAIConnectionAuthTypes = ({
+	direct = false,
+	ollama = false,
+	azure = false
+}: {
+	direct?: boolean;
+	ollama?: boolean;
+	azure?: boolean;
+} = {}) => {
+	const authTypes = [
+		{ value: 'none', label: 'None' },
+		{ value: 'bearer', label: 'Bearer' }
+	];
+
+	if (ollama) {
+		return authTypes;
+	}
+
+	authTypes.push({ value: 'session', label: 'Session' });
+
+	if (!direct) {
+		authTypes.push({ value: 'system_oauth', label: 'OAuth' });
+		if (azure) {
+			authTypes.push({ value: 'microsoft_entra_id', label: 'Entra ID' });
+		}
+	}
+
+	return authTypes;
+};
+
+export const isOpenAICodexWebAuthConfig = (config: Record<string, unknown> = {}) =>
+	config.auth_type === OPENAI_CODEX_WEB_AUTH_TYPE ||
+	config.auth_type === OPENAI_CODEX_WEB_AUTH_LEGACY_TYPE;
+
+export const isEmptyNativeOpenAIBearerConnection = (
+	url: string,
+	key = '',
+	config: Record<string, unknown> = {}
+) =>
+	url.replace(/\/$/, '') === OPENAI_WEB_AUTH_API_BASE_URL &&
+	!key &&
+	(!config.auth_type || config.auth_type === 'bearer');
+
+export const createOpenAIWebAuthConnectionConfig = (
+	existingConfig: Record<string, unknown> = {}
+) => ({
+	...existingConfig,
+	enable: true,
+	auth_type: OPENAI_CODEX_WEB_AUTH_TYPE,
+	connection_type: existingConfig.connection_type ?? 'external'
+});
+
+export const applyOpenAIWebAuthConnection = (
+	urls: string[],
+	keys: string[],
+	configs: Record<string, Record<string, unknown>>
+) => {
+	const normalizedUrls = urls.map((url) => url.replace(/\/$/, ''));
+	const normalizedKeys = [...keys];
+	while (normalizedKeys.length < normalizedUrls.length) {
+		normalizedKeys.push('');
+	}
+
+	const nextUrls: string[] = [];
+	const nextKeys: string[] = [];
+	const nextConfigs: Record<string, Record<string, unknown>> = {};
+	let webAuthIdx = -1;
+	let emptyBearerIdx = -1;
+
+	for (const [idx, url] of normalizedUrls.entries()) {
+		const config = configs[idx] ?? {};
+		const key = normalizedKeys[idx] ?? '';
+		const webAuth = isOpenAICodexWebAuthConfig(config);
+		const emptyBearer = isEmptyNativeOpenAIBearerConnection(url, key, config);
+
+		if (
+			(url === OPENAI_WEB_AUTH_API_BASE_URL || url === OPENAI_CODEX_WEB_AUTH_API_BASE_URL) &&
+			!key &&
+			webAuth
+		) {
+			if (webAuthIdx === -1) {
+				webAuthIdx = nextUrls.length;
+			} else {
+				continue;
+			}
+		}
+
+		if (emptyBearer && emptyBearerIdx === -1) {
+			emptyBearerIdx = nextUrls.length;
+		}
+
+		nextUrls.push(url);
+		nextKeys.push(key);
+		nextConfigs[nextUrls.length - 1] = config;
+	}
+
+	const targetIdx = webAuthIdx >= 0 ? webAuthIdx : emptyBearerIdx;
+	if (targetIdx >= 0) {
+		nextUrls[targetIdx] = OPENAI_CODEX_WEB_AUTH_API_BASE_URL;
+		nextKeys[targetIdx] = '';
+		nextConfigs[targetIdx] = createOpenAIWebAuthConnectionConfig(nextConfigs[targetIdx] ?? {});
+	} else {
+		nextUrls.push(OPENAI_CODEX_WEB_AUTH_API_BASE_URL);
+		nextKeys.push('');
+		nextConfigs[nextUrls.length - 1] = createOpenAIWebAuthConnectionConfig();
+	}
+
+	const finalUrls: string[] = [];
+	const finalKeys: string[] = [];
+	const finalConfigs: Record<string, Record<string, unknown>> = {};
+
+	for (const [idx, url] of nextUrls.entries()) {
+		const config = nextConfigs[idx] ?? {};
+		const key = nextKeys[idx] ?? '';
+		if (isEmptyNativeOpenAIBearerConnection(url, key, config)) {
+			continue;
+		}
+
+		finalUrls.push(url);
+		finalKeys.push(key);
+		finalConfigs[finalUrls.length - 1] = config;
+	}
+
+	return {
+		urls: finalUrls,
+		keys: finalKeys,
+		configs: finalConfigs
+	};
+};
+
+export const createOpenAIWebAuthConfigUpdate = (config: OpenAIConfig): OpenAIConfig => {
+	const next = applyOpenAIWebAuthConnection(
+		config.OPENAI_API_BASE_URLS,
+		config.OPENAI_API_KEYS,
+		config.OPENAI_API_CONFIGS as Record<string, Record<string, unknown>>
+	);
+
+	return {
+		...config,
+		ENABLE_OPENAI_API: true,
+		OPENAI_API_BASE_URLS: next.urls,
+		OPENAI_API_KEYS: next.keys,
+		OPENAI_API_CONFIGS: next.configs
+	};
+};
+
+export type OpenAIWebAuthStatus = {
+	credential_type: 'none' | 'web_auth' | string;
+	connected: boolean;
+	has_credential: boolean;
+	status: 'not_configured' | 'connected' | 'reconnect_required' | string;
+	expires_at?: number | null;
+};
+
+export type OpenAIWebAuthStart = {
+	verification_url: string;
+	user_code: string;
+	session_id: string;
+	interval: number;
+	expires_at: number;
+};
+
+const normalizeOpenAIWebAuthNumber = (value: unknown): number | null => {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return null;
+	}
+	return value;
+};
+
+const normalizeOpenAIWebAuthString = (value: unknown): string => {
+	return typeof value === 'string' ? value : '';
+};
+
+const normalizeOpenAIWebAuthStatus = (body: unknown): OpenAIWebAuthStatus => {
+	const source = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+	const expiresAt = normalizeOpenAIWebAuthNumber(source.expires_at);
+
+	return {
+		credential_type: normalizeOpenAIWebAuthString(source.credential_type) || 'none',
+		connected: source.connected === true,
+		has_credential: source.has_credential === true,
+		status: normalizeOpenAIWebAuthString(source.status) || 'not_configured',
+		...(expiresAt !== null ? { expires_at: expiresAt } : {})
+	};
+};
+
+const normalizeOpenAIWebAuthStart = (body: unknown): OpenAIWebAuthStart => {
+	const source = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+
+	return {
+		verification_url: normalizeOpenAIWebAuthString(source.verification_url),
+		user_code: normalizeOpenAIWebAuthString(source.user_code),
+		session_id: normalizeOpenAIWebAuthString(source.session_id),
+		interval: normalizeOpenAIWebAuthNumber(source.interval) ?? 0,
+		expires_at: normalizeOpenAIWebAuthNumber(source.expires_at) ?? 0
+	};
+};
+
+const handleOpenAIWebAuthResponse = async <T>(
+	response: Response,
+	normalize: (body: unknown) => T
+): Promise<T> => {
+	const body = await response.json().catch(() => ({}));
+	if (!response.ok) {
+		throw body;
+	}
+	return normalize(body);
+};
+
+const normalizeOpenAIWebAuthError = (err: unknown) => {
+	console.error(err);
+	if (err && typeof err === 'object' && 'detail' in err) {
+		return (err as { detail: string }).detail;
+	}
+	return 'Server connection failed';
+};
+
+export const getOpenAIWebAuthStatus = async (token: string = ''): Promise<OpenAIWebAuthStatus> => {
+	try {
+		return await fetch(`${OPENAI_API_BASE_URL}/web-auth/status`, {
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...(token && { authorization: `Bearer ${token}` })
+			}
+		}).then((res) => handleOpenAIWebAuthResponse(res, normalizeOpenAIWebAuthStatus));
+	} catch (err) {
+		throw normalizeOpenAIWebAuthError(err);
+	}
+};
+
+export const startOpenAIWebAuth = async (token: string = ''): Promise<OpenAIWebAuthStart> => {
+	try {
+		return await fetch(`${OPENAI_API_BASE_URL}/web-auth/start`, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...(token && { authorization: `Bearer ${token}` })
+			}
+		}).then((res) => handleOpenAIWebAuthResponse(res, normalizeOpenAIWebAuthStart));
+	} catch (err) {
+		throw normalizeOpenAIWebAuthError(err);
+	}
+};
+
+export const completeOpenAIWebAuth = async (
+	token: string = '',
+	sessionId: string
+): Promise<OpenAIWebAuthStatus> => {
+	try {
+		return await fetch(`${OPENAI_API_BASE_URL}/web-auth/complete`, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...(token && { authorization: `Bearer ${token}` })
+			},
+			body: JSON.stringify({ session_id: sessionId })
+		}).then((res) => handleOpenAIWebAuthResponse(res, normalizeOpenAIWebAuthStatus));
+	} catch (err) {
+		throw normalizeOpenAIWebAuthError(err);
+	}
+};
+
+export const disconnectOpenAIWebAuth = async (token: string = ''): Promise<OpenAIWebAuthStatus> => {
+	try {
+		return await fetch(`${OPENAI_API_BASE_URL}/web-auth/disconnect`, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...(token && { authorization: `Bearer ${token}` })
+			}
+		}).then((res) => handleOpenAIWebAuthResponse(res, normalizeOpenAIWebAuthStatus));
+	} catch (err) {
+		throw normalizeOpenAIWebAuthError(err);
+	}
+};
+
 export const updateOpenAIConfig = async (token: string = '', config: OpenAIConfig) => {
 	let error = null;
 
@@ -133,10 +419,14 @@ export const getOpenAIModels = async (token: string, urlIdx?: number) => {
 
 export const verifyOpenAIConnection = async (
 	token: string = '',
-	connection: dict = {},
+	connection: Record<string, unknown> = {},
 	direct: boolean = false
 ) => {
-	const { url, key, config } = connection;
+	const { url, key, config } = connection as {
+		url?: string;
+		key?: string;
+		config?: Record<string, unknown>;
+	};
 	if (!url) {
 		throw 'OpenAI: URL is required';
 	}

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -4,7 +4,11 @@
 	const i18n = getContext('i18n');
 
 	import { settings } from '$lib/stores';
-	import { verifyOpenAIConnection } from '$lib/apis/openai';
+	import {
+		OPENAI_CODEX_WEB_AUTH_API_BASE_URL,
+		getSupportedOpenAIConnectionAuthTypes,
+		verifyOpenAIConnection
+	} from '$lib/apis/openai';
 	import { verifyOllamaConnection } from '$lib/apis/ollama';
 
 	import Modal from '$lib/components/common/Modal.svelte';
@@ -58,6 +62,14 @@
 	let loading = false;
 	let showDeleteConfirmDialog = false;
 
+	$: authOptions = (() => {
+		const options = getSupportedOpenAIConnectionAuthTypes({ direct, ollama, azure });
+		if (edit && auth_type === 'openai_codex_web_auth') {
+			return [...options, { value: 'openai_codex_web_auth', label: 'OpenAI Account Auth' }];
+		}
+		return options;
+	})();
+
 	const verifyOllamaHandler = async () => {
 		// remove trailing slash from url
 		url = url.replace(/\/$/, '');
@@ -77,6 +89,13 @@
 	const verifyOpenAIHandler = async () => {
 		// remove trailing slash from url
 		url = url.replace(/\/$/, '');
+
+		if (auth_type === 'openai_codex_web_auth') {
+			toast.error(
+				$i18n.t('Verify OpenAI Account Auth from the dedicated OpenAI Account Auth card below the connection list')
+			);
+			return;
+		}
 
 		let _headers = null;
 
@@ -141,6 +160,17 @@
 			return;
 		}
 
+		if (
+			auth_type === 'openai_codex_web_auth' &&
+			url.replace(/\/$/, '') !== OPENAI_CODEX_WEB_AUTH_API_BASE_URL
+		) {
+			loading = false;
+			toast.error(
+				$i18n.t('OpenAI Account Auth is only available for the account-auth runtime URL')
+			);
+			return;
+		}
+
 		if (azure) {
 			if (!apiVersion) {
 				loading = false;
@@ -149,7 +179,10 @@
 				return;
 			}
 
-			if (!key && !['azure_ad', 'microsoft_entra_id'].includes(auth_type)) {
+			if (
+				!key &&
+				!['azure_ad', 'microsoft_entra_id', 'openai_codex_web_auth'].includes(auth_type)
+			) {
 				loading = false;
 
 				toast.error($i18n.t('Key is required'));
@@ -178,6 +211,9 @@
 
 		// remove trailing slash from url
 		url = url.replace(/\/$/, '');
+		if (auth_type === 'openai_codex_web_auth') {
+			key = '';
+		}
 
 		const connection = {
 			url,
@@ -380,24 +416,15 @@
 
 								<div class="flex gap-2">
 									<div class="flex-shrink-0 self-start">
-										<select
-											id="select-bearer-or-session"
-											class={`dark:bg-gray-900 w-full text-sm bg-transparent pr-5 ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
-											bind:value={auth_type}
-										>
-											<option value="none">{$i18n.t('None')}</option>
-											<option value="bearer">{$i18n.t('Bearer')}</option>
-
-											{#if !ollama}
-												<option value="session">{$i18n.t('Session')}</option>
-												{#if !direct}
-													<option value="system_oauth">{$i18n.t('OAuth')}</option>
-													{#if azure}
-														<option value="microsoft_entra_id">{$i18n.t('Entra ID')}</option>
-													{/if}
-												{/if}
-											{/if}
-										</select>
+									<select
+										id="select-bearer-or-session"
+										class={`dark:bg-gray-900 w-full text-sm bg-transparent pr-5 ${($settings?.highContrastMode ?? false) ? 'placeholder:text-gray-700 dark:placeholder:text-gray-100' : 'outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+										bind:value={auth_type}
+									>
+										{#each authOptions as option}
+											<option value={option.value}>{$i18n.t(option.label)}</option>
+										{/each}
+									</select>
 									</div>
 
 									<div class="flex flex-1 items-center">
@@ -412,6 +439,12 @@
 												class={`text-xs self-center translate-y-[1px] ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
 											>
 												{$i18n.t('No authentication')}
+											</div>
+										{:else if auth_type === 'openai_codex_web_auth'}
+											<div
+												class={`text-xs self-center translate-y-[1px] ${($settings?.highContrastMode ?? false) ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500'}`}
+											>
+												{$i18n.t('Uses the connected OpenAI account auth credential')}
 											</div>
 										{:else if auth_type === 'session'}
 											<div

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -5,7 +5,14 @@
 	const dispatch = createEventDispatcher();
 
 	import { getOllamaConfig, updateOllamaConfig } from '$lib/apis/ollama';
-	import { getOpenAIConfig, updateOpenAIConfig, getOpenAIModels } from '$lib/apis/openai';
+	import {
+		createOpenAIWebAuthConfigUpdate,
+		isOpenAICodexWebAuthConfig,
+		isEmptyNativeOpenAIBearerConnection,
+		getOpenAIConfig,
+		updateOpenAIConfig,
+		getOpenAIModels
+	} from '$lib/apis/openai';
 	import { getModels as _getModels, getBackendConfig } from '$lib/apis';
 	import { getConnectionsConfig, setConnectionsConfig } from '$lib/apis/configs';
 
@@ -17,6 +24,7 @@
 	import Plus from '$lib/components/icons/Plus.svelte';
 
 	import OpenAIConnection from './Connections/OpenAIConnection.svelte';
+	import OpenAIWebAuthConnection from './Connections/OpenAIWebAuthConnection.svelte';
 	import AddConnectionModal from '$lib/components/AddConnectionModal.svelte';
 	import OllamaConnection from './Connections/OllamaConnection.svelte';
 
@@ -48,6 +56,13 @@
 	let pipelineUrls = {};
 	let showAddOpenAIConnectionModal = false;
 	let showAddOllamaConnectionModal = false;
+
+	$: openAIWebAuthConfigured = OPENAI_API_BASE_URLS.some((url, idx) => {
+		return (
+			isOpenAICodexWebAuthConfig(OPENAI_API_CONFIGS[idx]) &&
+			(OPENAI_API_CONFIGS[idx]?.enable ?? true)
+		);
+	});
 
 	const updateOpenAIHandler = async () => {
 		if (ENABLE_OPENAI_API !== null) {
@@ -136,6 +151,22 @@
 		await updateOllamaHandler();
 	};
 
+	const useOpenAIWebAuthConnectionHandler = async () => {
+		const next = createOpenAIWebAuthConfigUpdate({
+			ENABLE_OPENAI_API: ENABLE_OPENAI_API ?? true,
+			OPENAI_API_BASE_URLS,
+			OPENAI_API_KEYS,
+			OPENAI_API_CONFIGS
+		});
+
+		ENABLE_OPENAI_API = next.ENABLE_OPENAI_API;
+		OPENAI_API_BASE_URLS = next.OPENAI_API_BASE_URLS;
+		OPENAI_API_KEYS = next.OPENAI_API_KEYS;
+		OPENAI_API_CONFIGS = next.OPENAI_API_CONFIGS;
+
+		await updateOpenAIHandler();
+	};
+
 	onMount(async () => {
 		if ($user?.role === 'admin') {
 			let ollamaConfig = {};
@@ -175,6 +206,15 @@
 				OPENAI_API_BASE_URLS.forEach(async (url, idx) => {
 					OPENAI_API_CONFIGS[idx] = OPENAI_API_CONFIGS[idx] || {};
 					if (!(OPENAI_API_CONFIGS[idx]?.enable ?? true)) {
+						return;
+					}
+					if (
+						isEmptyNativeOpenAIBearerConnection(
+							url,
+							OPENAI_API_KEYS[idx] ?? '',
+							OPENAI_API_CONFIGS[idx]
+						)
+					) {
 						return;
 					}
 					const res = await getOpenAIModels(localStorage.token, idx);
@@ -285,6 +325,11 @@
 										/>
 									{/each}
 								</div>
+
+								<OpenAIWebAuthConnection
+									configured={openAIWebAuthConfigured}
+									onUseCredential={useOpenAIWebAuthConnectionHandler}
+								/>
 							</div>
 						{/if}
 					</div>

--- a/src/lib/components/admin/Settings/Connections/OpenAIWebAuthConnection.svelte
+++ b/src/lib/components/admin/Settings/Connections/OpenAIWebAuthConnection.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import {
+		completeOpenAIWebAuth,
+		disconnectOpenAIWebAuth,
+		getOpenAIWebAuthStatus,
+		startOpenAIWebAuth,
+		type OpenAIWebAuthStart,
+		type OpenAIWebAuthStatus
+	} from '$lib/apis/openai';
+
+	const i18n = getContext<any>('i18n');
+
+	export let configured = false;
+	export let onUseCredential: () => Promise<void> | void = () => {};
+
+	let status: OpenAIWebAuthStatus | null = null;
+	let pendingAuthorization: OpenAIWebAuthStart | null = null;
+	let loading: 'status' | 'start' | 'complete' | 'disconnect' | 'configure' | null = null;
+	let error = '';
+
+	const formatExpiration = (expiresAt?: number | null) => {
+		if (!expiresAt) {
+			return '';
+		}
+		return new Date(expiresAt * 1000).toLocaleString();
+	};
+
+	const refreshStatus = async () => {
+		loading = 'status';
+		error = '';
+		const res = await getOpenAIWebAuthStatus(localStorage.token).catch((err) => {
+			error = `${err}`;
+		});
+		if (res) {
+			status = res;
+		}
+		loading = null;
+	};
+
+	const startHandler = async () => {
+		loading = 'start';
+		error = '';
+		const res = await startOpenAIWebAuth(localStorage.token).catch((err) => {
+			error = `${err}`;
+			toast.error(`${err}`);
+		});
+
+		if (res) {
+			pendingAuthorization = res;
+			status = {
+				credential_type: status?.credential_type ?? 'none',
+				connected: false,
+				has_credential: status?.has_credential ?? false,
+				status: 'awaiting_authorization',
+				expires_at: res.expires_at
+			};
+			toast.success($i18n.t('OpenAI authorization started'));
+		}
+
+		loading = null;
+	};
+
+	const completeHandler = async () => {
+		if (!pendingAuthorization?.session_id) {
+			return;
+		}
+
+		loading = 'complete';
+		error = '';
+		const res = await completeOpenAIWebAuth(
+			localStorage.token,
+			pendingAuthorization.session_id
+		).catch((err) => {
+			error = `${err}`;
+			toast.error(`${err}`);
+		});
+
+		if (res) {
+			status = res;
+			pendingAuthorization = null;
+			if (res.connected) {
+				await Promise.resolve(onUseCredential()).catch((err) => {
+					error = `${err}`;
+					toast.error(`${err}`);
+				});
+				toast.success($i18n.t('OpenAI account auth connected'));
+			} else {
+				toast.error($i18n.t('OpenAI account auth requires reconnect'));
+			}
+		}
+
+		loading = null;
+	};
+
+	const disconnectHandler = async () => {
+		loading = 'disconnect';
+		error = '';
+		const res = await disconnectOpenAIWebAuth(localStorage.token).catch((err) => {
+			error = `${err}`;
+			toast.error(`${err}`);
+		});
+
+		if (res) {
+			status = res;
+			pendingAuthorization = null;
+			toast.success($i18n.t('OpenAI account auth disconnected'));
+		}
+
+		loading = null;
+	};
+
+	const useCredentialHandler = async () => {
+		loading = 'configure';
+		error = '';
+		await Promise.resolve(onUseCredential()).catch((err) => {
+			error = `${err}`;
+			toast.error(`${err}`);
+		});
+		loading = null;
+	};
+
+	onMount(() => {
+		refreshStatus();
+	});
+</script>
+
+<div class="mt-3 rounded-xl border border-gray-100 dark:border-gray-850 p-3 space-y-2">
+	<div class="flex items-start justify-between gap-3">
+		<div>
+			<div class="font-medium text-xs">{$i18n.t('OpenAI Account Auth')}</div>
+			<div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+				{$i18n.t(
+					'Connect OpenAI with an account authorization flow. API-key connections remain available above.'
+				)}
+			</div>
+		</div>
+
+		{#if loading === 'status'}
+			<Spinner />
+		{/if}
+	</div>
+
+	{#if status}
+		<div class="text-xs text-gray-600 dark:text-gray-300">
+			{#if status.connected}
+				{$i18n.t('Status')}: {$i18n.t('Connected')}
+			{:else if status.status === 'reconnect_required'}
+				{$i18n.t('Status')}: {$i18n.t('Reconnect required')}
+			{:else if pendingAuthorization}
+				{$i18n.t('Status')}: {$i18n.t('Awaiting authorization')}
+			{:else}
+				{$i18n.t('Status')}: {$i18n.t('Not connected')}
+			{/if}
+		</div>
+
+		{#if status.expires_at}
+			<div class="text-xs text-gray-500 dark:text-gray-400">
+				{$i18n.t('Expires')}: {formatExpiration(status.expires_at)}
+			</div>
+		{/if}
+
+		{#if status.connected}
+			<div class="text-xs text-gray-500 dark:text-gray-400">
+				{#if configured}
+					{$i18n.t('This account auth is enabled for account-auth compatible OpenAI models.')}
+				{:else}
+					{$i18n.t('Enable it for account-auth compatible OpenAI models before use.')}
+				{/if}
+			</div>
+		{/if}
+	{/if}
+
+	{#if pendingAuthorization}
+		<div class="rounded-lg bg-gray-50 dark:bg-gray-850 p-2 space-y-1.5 text-xs">
+			<div class="flex justify-between gap-2">
+				<span class="text-gray-500 dark:text-gray-400">{$i18n.t('User code')}</span>
+				<span class="font-mono tracking-wide">{pendingAuthorization.user_code}</span>
+			</div>
+
+			<div class="flex justify-between gap-2">
+				<span class="text-gray-500 dark:text-gray-400">{$i18n.t('Authorization page')}</span>
+				<a
+					class="underline font-medium"
+					href={pendingAuthorization.verification_url}
+					target="_blank"
+					rel="noreferrer"
+				>
+					{$i18n.t('Open OpenAI authorization page')}
+				</a>
+			</div>
+
+			<div class="flex justify-between gap-2">
+				<span class="text-gray-500 dark:text-gray-400">{$i18n.t('Check interval')}</span>
+				<span>{$i18n.t('{{seconds}} seconds', { seconds: pendingAuthorization.interval })}</span>
+			</div>
+
+			<div class="flex justify-between gap-2">
+				<span class="text-gray-500 dark:text-gray-400">{$i18n.t('Code expires')}</span>
+				<span>{formatExpiration(pendingAuthorization.expires_at)}</span>
+			</div>
+		</div>
+	{/if}
+
+	{#if error}
+		<div class="text-xs text-red-500">{error}</div>
+	{/if}
+
+	<div class="flex flex-wrap gap-2 pt-1">
+		{#if pendingAuthorization}
+			<button
+				class="px-3 py-1 text-xs font-medium rounded-full bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+				type="button"
+				disabled={loading !== null}
+				on:click={completeHandler}
+			>
+				{$i18n.t('I’ve authorized')}
+				{#if loading === 'complete'}<Spinner />{/if}
+			</button>
+		{:else if status?.connected}
+			{#if !configured}
+				<button
+					class="px-3 py-1 text-xs font-medium rounded-full bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+					type="button"
+					disabled={loading !== null}
+					on:click={useCredentialHandler}
+				>
+					{$i18n.t('Use for account-auth models')}
+					{#if loading === 'configure'}<Spinner />{/if}
+				</button>
+			{/if}
+
+			<button
+				class="px-3 py-1 text-xs font-medium rounded-full border border-gray-200 dark:border-gray-800 disabled:opacity-50"
+				type="button"
+				disabled={loading !== null}
+				on:click={startHandler}
+			>
+				{$i18n.t('Reconnect')}
+				{#if loading === 'start'}<Spinner />{/if}
+			</button>
+		{:else}
+			<button
+				class="px-3 py-1 text-xs font-medium rounded-full bg-black text-white dark:bg-white dark:text-black disabled:opacity-50"
+				type="button"
+				disabled={loading !== null}
+				on:click={startHandler}
+			>
+				{$i18n.t('Connect with OpenAI')}
+				{#if loading === 'start'}<Spinner />{/if}
+			</button>
+		{/if}
+
+		{#if status?.has_credential || pendingAuthorization}
+			<button
+				class="px-3 py-1 text-xs font-medium rounded-full text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 disabled:opacity-50"
+				type="button"
+				disabled={loading !== null}
+				on:click={disconnectHandler}
+			>
+				{$i18n.t('Disconnect')}
+				{#if loading === 'disconnect'}<Spinner />{/if}
+			</button>
+		{/if}
+	</div>
+</div>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/25122
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** See below.
- [x] **Changelog:** Included below.
- [x] **Documentation:** Added `docs/guides/openai-account-auth-provider-note.md` with runtime notes.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Targeted backend/frontend tests passed and manual UI validation was performed.
- [x] **Agentic AI Code:** This PR has gone through additional human review and manual testing.
- [x] **Code review:** Self-review and multi-pass review performed.
- [x] **Design & Architecture:** Account auth is isolated as its own runtime mode and does not replace API-key OpenAI connections.
- [x] **Git Hygiene:** Atomic feature commit based on `dev`.
- [x] **Title Prefix:** Uses `feat:`.

# Changelog Entry

### Description

- Adds an OpenAI Account Auth provider mode for users with compatible account/Codex subscriptions. This mode is separate from standard OpenAI API-key connections and routes supported account-auth models through a Codex-compatible runtime.

### Added

- OpenAI Account Auth admin card with start/complete/status/disconnect actions.
- Server-side OpenAI account-auth device flow and encrypted credential storage through existing OAuth session storage.
- Codex-compatible account-auth runtime mode (`openai_codex_web_auth`) with credential-gated static model listing.
- Streaming translation from Codex Responses events to OpenAI-compatible chat completion SSE chunks.
- Targeted backend and frontend tests for account-auth helpers, model listing, runtime headers, redaction, and API-key regression behavior.
- Reviewer note: `docs/guides/openai-account-auth-provider-note.md`.

### Changed

- OpenAI connection settings now preserve API-key rows while adding a separate account-auth runtime row when account auth is enabled.
- Generic Add Connection no longer exposes account auth as a normal add path; setup is handled through the dedicated admin card.
- OpenAI model cache is invalidated after account-auth and OpenAI config changes.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevents empty native OpenAI bearer rows from blocking model listing.
- Avoids treating account OAuth tokens as normal `/v1` API keys.

### Security

- Account-auth access/refresh tokens remain server-side only and are not placed into public config arrays or frontend-visible state.
- Public status/start/complete/disconnect DTOs are redacted.
- Optional account id is forwarded only as a runtime header when present in stored credential metadata.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- This mode intentionally differs from the standard OpenAI API-key path. Account OAuth tokens are routed through the Codex-compatible responses endpoint rather than `https://api.openai.com/v1`.
- Manual validation confirmed account-auth model listing and responses in the Open WebUI chat UI.

### Screenshots or Videos

- Manual validation was performed locally.
<img width="950" height="503" alt="image" src="https://github.com/user-attachments/assets/ea00aa37-1daa-4fa0-921f-2749a2bcc217" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.