### PR TITLE
fix: dedupe message files by url when appending (#19518)

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -646,7 +646,12 @@ class ChatTable:
 
             if message_id in history.get('messages', {}):
                 message_files = history['messages'][message_id].get('files', [])
-                message_files = message_files + files
+                # Dedupe by url to avoid double-attaching the same file when
+                # the frontend optimistically persists files via a parallel
+                # POST /chats/{id} before this writer runs. See #19518.
+                existing_urls = {f.get('url') for f in message_files if f.get('url')}
+                new_files = [f for f in files if f.get('url') not in existing_urls]
+                message_files = message_files + new_files
                 history['messages'][message_id]['files'] = message_files
 
             chat['history'] = history


### PR DESCRIPTION
## Summary

Fixes [#19518](https://github.com/open-webui/open-webui/issues/19518) — "Duplicate images displayed in gemini-3-pro-image-preview chats."

That issue was closed as completed but multiple users continue to hit it on 0.7.2+, including with OpenRouter and LiteLLM. Maintainers could not reproduce. This patch identifies the timing-dependent root cause and fixes it.

## Root cause

`Chats.add_message_files_by_id_and_message_id` reads the existing `files` list off the message and unconditionally appends. When the streaming chat completion handler (`utils/middleware.py`, around the `delta.get('images', [])` branch) processes an image returned by an OpenAI-compatible model — e.g. `google/gemini-3.1-flash-image-preview` via OpenRouter, which returns the image in a non-standard `message.images` field — it:

1. Emits a `'files'` event to the frontend with the new file URL
2. Calls `add_message_files_by_id_and_message_id` to persist it

The frontend, on receiving the `'files'` event, optimistically updates its local message state and posts the entire chat back via `POST /api/v1/chats/{id}`, which writes the file into the message's `files` array. If that write lands **before** the backend `add_message_files_by_id_and_message_id` call runs, the backend reads the message (now already containing the file) and appends another copy.

Result: every generated image is stored twice (byte-identical, verified by sha256). The race is wall-clock dependent which is why maintainers couldn't reproduce — fast disks / low concurrency hide it.

## Reproduction

100% reproducible on macOS, Python 3.11, fresh 0.9.5 install, OpenRouter connection, model `google/gemini-3.1-flash-image-preview`, streaming on, any image prompt with an attached input image. SQLite inspection confirms identical hashes:

```
msg b0f39e21 files=2
  [0] type=image url_len=750971 sha256[:12]=b1d87606e2f7
  [1] type=image url_len=750971 sha256[:12]=b1d87606e2f7
```

## Fix

Dedupe incoming files against existing URLs before appending. No behavior change when the frontend race doesn't occur.

## Test plan

- [x] Send an image-edit request through chat with OpenRouter nano-banana → one copy in the DB (verified via direct sqlite3 inspection)
- [x] Before patch: same request reliably produces two byte-identical copies on this machine