### PR TITLE
fix(images): honor source mime type in Gemini image-edit handler

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -985,25 +985,36 @@ async def image_edits(
             model = f'{model}:generateContent'
             data = {'contents': [{'parts': [{'text': form_data.prompt}]}]}
 
+            def _parse_data_url(s: str):
+                # Accept "data:image/<type>;base64,<payload>" or a bare base64
+                # payload. Returns (mime_type, base64_payload).
+                if s.startswith('data:') and ',' in s:
+                    header, payload = s.split(',', 1)
+                    mt = header[5:].split(';', 1)[0] or 'image/png'
+                    return mt, payload
+                return 'image/png', s
+
             if isinstance(form_data.image, str):
+                mime_type, payload = _parse_data_url(form_data.image)
                 data['contents'][0]['parts'].append(
                     {
                         'inline_data': {
-                            'mime_type': 'image/png',
-                            'data': form_data.image.split(',', 1)[1],
+                            'mime_type': mime_type,
+                            'data': payload,
                         }
                     }
                 )
             elif isinstance(form_data.image, list):
+                parsed = [_parse_data_url(image) for image in form_data.image]
                 data['contents'][0]['parts'].extend(
                     [
                         {
                             'inline_data': {
-                                'mime_type': 'image/png',
-                                'data': image.split(',', 1)[1],
+                                'mime_type': mime_type,
+                                'data': payload,
                             }
                         }
-                        for image in form_data.image
+                        for (mime_type, payload) in parsed
                     ]
                 )
 


### PR DESCRIPTION
## Summary

The Gemini branch of \`image_edits()\` in \`routers/images.py\` hardcodes \`mime_type: 'image/png'\` when forwarding the user-uploaded image to Gemini's \`generateContent\` endpoint. When the user uploads a JPEG (or any non-PNG), Gemini reads the actual bytes, sees a JPEG header, and returns:

\`\`\`
400 INVALID_ARGUMENT: Unhandled generated data mime type: image/jpeg
\`\`\`

Visible to the user as a failed image-edit with that opaque message.

## Fix

Parse the mime type out of the inbound data URL prefix (\`data:image/<type>;base64,...\`) and forward the actual type. Falls back to \`image/png\` when the input isn't a data URL.

No behavior change for PNG inputs. Verified locally with a JPEG upload to \`models/gemini-3.1-flash-image-preview\` via the Image Edit feature — succeeds after patch, fails with the above 400 before.

## Test plan

- [x] JPEG input → returns edited image
- [x] PNG input → still returns edited image (no regression)
- [x] Multiple images (list input) → mime detected per image