### PR TITLE
fix: persist any base64 image mime type in get_image_urls

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1680,7 +1680,11 @@ async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
         if not url:
             continue
 
-        if url.startswith('data:image/png;base64'):
+        # Persist any base64-encoded image type (image/png, image/jpeg, image/webp, ...)
+        # to disk and replace the data URL with a /api/v1/files/... reference. Without
+        # this, non-PNG images returned by models (e.g. nano-banana 2 via OpenRouter
+        # returns JPEG) stay inlined as multi-MB data URLs in chat history.
+        if url.startswith('data:image/') and ';base64,' in url:
             url = await get_image_url_from_base64(request, url, metadata, user)
 
         image_urls.append(url)


### PR DESCRIPTION
## Summary

\`get_image_urls\` in \`utils/middleware.py\` only invokes \`get_image_url_from_base64\` when the image URL starts with \`data:image/png;base64\`. Models that return JPEG inline — notably \`google/gemini-3.1-flash-image-preview\` (nano-banana 2) via OpenRouter, which returns Google's C2PA-signed JPEGs — emit \`data:image/jpeg;base64,...\` and bypass the disk-persistence path.

Effect: the image is stored as a multi-MB \`data:\` URL directly in the chat row's JSON column. Every chat render re-ships the full base64 payload to the frontend, and the SQLite chat row balloons with each generated image.

## Fix

Match any \`data:image/<type>;base64,\` prefix so PNG, JPEG, WebP, etc. all get persisted consistently and the message stores a small \`/api/v1/files/<id>/content\` reference.

## Test plan

- [x] PNG image-output model → persisted as before (no regression)
- [x] JPEG image-output model (nano-banana 2 / OpenRouter) → now persisted to disk, chat row stores 58-char URL instead of ~1 MB inline base64