### PR TITLE
fix: resolve undefined session variable in _get_access_grants and _to_prompt_model

### DIFF
--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 import uuid
 from typing import Optional
+
+log = logging.getLogger(__name__)
 
 from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
@@ -90,7 +93,7 @@ class PromptForm(BaseModel):
 
 class PromptsTable:
     async def _get_access_grants(self, prompt_id: str, db: AsyncSession | None = None) -> list[AccessGrantModel]:
-        return await AccessGrants.get_grants_by_resource('prompt', prompt_id, db=session)
+        return await AccessGrants.get_grants_by_resource('prompt', prompt_id, db=db)
 
     async def _to_prompt_model(
         self,
@@ -100,7 +103,7 @@ class PromptsTable:
     ) -> PromptModel:
         prompt_data = PromptModel.model_validate(prompt).model_dump(exclude={'access_grants'})
         prompt_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(prompt_data['id'], db=session)
+            access_grants if access_grants is not None else await self._get_access_grants(prompt_data['id'], db=db)
         )
         return PromptModel.model_validate(prompt_data)
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

`PromptsTable._get_access_grants` and `_to_prompt_model` in
`backend/open_webui/models/prompts.py` both referenced an undefined local
variable `session` instead of the `db` parameter received by each method.

These two helpers are called **outside** of any
`async with get_async_db_context()` context manager, so `session` does not
exist in their local scope. This caused a `NameError` on every call, which
was silently swallowed by the broad `except Exception` handler in
`get_prompt_by_id` — causing it to return `None`.

Because `get_prompt_by_id` returned `None`, the frontend route handler
(`src/routes/(app)/workspace/prompts/[id]/+page.svelte`) treated this as a
missing prompt and immediately called `goto('/workspace/prompts')`, making it
impossible to open any prompt's edit page from the Workspace section.

The same undefined-`session` bug also existed in `_to_prompt_model`, which
falls back to `_get_access_grants` when no pre-fetched grants are passed in —
meaning every code path that lazily loads access grants was equally broken.

Additionally, three methods (`insert_new_prompt`, `update_prompt_version`,
`delete_prompt_by_id`) contained calls to an undefined `log` logger. The
standard Python `logging` import and a module-level `log` instance are added
to resolve the latent `NameError` those calls would produce.

### Added

- `import logging` and `log = logging.getLogger(__name__)` to `prompts.py`, providing the module-level logger that was already referenced by three methods (`insert_new_prompt`, `update_prompt_version`, `delete_prompt_by_id`) but never defined.

### Fixed

- **`PromptsTable._get_access_grants`**: Changed `db=session` → `db=db`. `session` is not a local variable in this method; `db` is the correct parameter to forward.
- **`PromptsTable._to_prompt_model`**: Same fix — changed `db=session` → `db=db` in the fallback call to `_get_access_grants`.
- The combination of these two fixes restores the ability to open any prompt's edit page in Workspace → Prompts. Previously, clicking any prompt card silently redirected back to `/workspace/prompts` because `get_prompt_by_id` always caught the `NameError` and returned `None`.

### Breaking Changes

- None. This is a pure bug fix restoring already-intended behavior with no API or schema changes.

---

### Additional Information

**Root cause chain (for reviewers):**

```
_get_access_grants / _to_prompt_model
  → NameError: name 'session' is not defined
    → caught by `except Exception: return` in get_prompt_by_id
      → returns None
        → 404 raised by the FastAPI router
          → frontend getPromptById() receives null
            → goto('/workspace/prompts')  ← user sees redirect, no error toast
```

The bug is subtle because the `except Exception` clause masks the real error — there is no visible server-side traceback in normal operation and the frontend silently redirects rather than showing an actionable error message.

**Files changed:** 1  
**Lines changed:** +5 / -2  
**New dependencies:** None (standard library `logging` only)

### Screenshots or Videos

**Before:**
<img width="2350" height="249" alt="image" src="https://github.com/user-attachments/assets/99f92c0d-df52-48a0-8fa4-1b11de8d3229" />

**After:**
<img width="2350" height="249" alt="image" src="https://github.com/user-attachments/assets/a1857d1d-4597-4693-934f-f2e7ad23cf85" />

- Verified locally: navigating to any prompt card in Workspace → Prompts now opens the edit page correctly instead of redirecting back to the list.
- Confirmed that saving edits, access grants, and version history all function correctly after the fix.

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.