### PR TITLE
fix(logger): JSON sink crashes on every exception log

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import traceback
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -62,7 +63,9 @@ def _json_sink(message: 'Message') -> None:
         log_entry['extra'] = record['extra']
 
     if record['exception'] is not None:
-        log_entry['error'] = ''.join(record['exception'].format_exception()).rstrip()
+        log_entry['error'] = ''.join(
+            traceback.format_exception(*record['exception'])
+        ).rstrip()
 
     sys.stdout.write(json.dumps(log_entry, ensure_ascii=False, default=str) + '\n')
     sys.stdout.flush()


### PR DESCRIPTION
## Summary

The JSON sink in `backend/open_webui/utils/logger.py` (used when `LOG_FORMAT=json`) calls `record['exception'].format_exception()`, but loguru's `RecordException` is a `NamedTuple(type, value, traceback)` and has no such method. Every `logger.exception(...)` call therefore raises `AttributeError` inside the sink, and the original traceback is lost — replaced by loguru's `--- Logging error in Loguru Handler #1 ---` diagnostic block on stderr (which is not valid JSON and breaks structured-log alerting downstream).

Fix: use stdlib `traceback.format_exception(*record['exception'])` instead — the same approach already used a few lines away in `backend/open_webui/env.py:98` for the stdlib `JSONFormatter` introduced in the same feature (#21747).

## Reproduction

With `LOG_FORMAT=json`:

```python
from loguru import logger
try:
    1 / 0
except Exception:
    logger.exception("boom")
```

**Before** — on stderr (no JSON output at all):
```
--- Logging error in Loguru Handler #1 ---
Record was: ...
Traceback (most recent call last):
  File "/app/backend/open_webui/utils/logger.py", line 65, in _json_sink
    log_entry['error'] = ''.join(record['exception'].format_exception()).rstrip()
AttributeError: 'RecordException' object has no attribute 'format_exception'
--- End of logging error ---
```

**After** — one JSON line on stdout with the full traceback in the `error` field:
```json
{"ts":"…","level":"error","msg":"boom","caller":"…","error":"Traceback (most recent call last):\n  File \"<stdin>\", line 2, in <module>\nZeroDivisionError: division by zero"}
```

## Test plan

- [x] Repro confirmed in a running container: a real `OperationalError` from the calendar scheduler (`open_webui.utils.automations.scheduler_worker_loop`) used to produce the freetext "Logging error in Loguru Handler" block; after this patch it appears as a single well-formed JSON line with the full traceback in `error`.
- [x] Non-exception log records unaffected (no `error` field, no behavior change).
- [x] Stdlib `traceback` is already imported across the codebase (`env.py`, `routers/scim.py`, `utils/telemetry/instrumentors.py`) — no new dependency.

## Notes

- No new dependency: `traceback` is in Python's standard library.
- The change is symmetric with `env.py:98` from #21747; this brings the loguru-based JSON sink in line with the stdlib-based one.
- I could not find an existing issue or PR for this — happy to open one if preferred.