### PR TITLE
fix: JSON log sink crashes on every exception

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import traceback
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -61,7 +62,9 @@ def _json_sink(message: 'Message') -> None:
         log_entry['extra'] = record['extra']
 
     if record['exception'] is not None:
-        log_entry['error'] = ''.join(record['exception'].format_exception()).rstrip()
+        log_entry['error'] = ''.join(
+            traceback.format_exception(*record['exception'])
+        ).rstrip()
 
     sys.stdout.write(json.dumps(log_entry, ensure_ascii=False, default=str) + '\n')
     sys.stdout.flush()


### PR DESCRIPTION
Closes #25135

## Description

The loguru JSON sink (`LOG_FORMAT=json`) calls `record['exception'].format_exception()`, but loguru's `RecordException` is a `NamedTuple(type, value, traceback)` with no such method. Every `logger.exception(...)` therefore raises `AttributeError` inside the sink and the original traceback is replaced by loguru's `--- Logging error in Loguru Handler ---` freetext block on stderr — which is not valid JSON and is invisible to structured-log filters in Cloud Logging / Datadog / etc.

The stdlib `JSONFormatter` added in the same feature (#21747) already does the right thing in `backend/open_webui/env.py:98` with `traceback.format_exception(*record.exc_info)`. This PR brings the loguru sink in line: `traceback.format_exception(*record['exception'])`.

No new dependency — `traceback` is stdlib and is already imported in several places (`env.py`, `routers/scim.py`, `utils/telemetry/instrumentors.py`).

## Reproduction

With `LOG_FORMAT=json`:

```python
from loguru import logger
try:
    1 / 0
except Exception:
    logger.exception("boom")
```

Before — on stderr, no JSON on stdout:
```
AttributeError: 'RecordException' object has no attribute 'format_exception'
```

After — one JSON line on stdout with the full traceback in the `error` field.

## Testing

- Reproduced in a running container (docker-compose, `LOG_FORMAT=json`) by stopping the database. Before: `SQLAlchemy OperationalError` from a scheduler loop produced the freetext "Logging error" block. After: one well-formed JSON line per error, full traceback in `error`.
- Non-exception log records unaffected.

# Changelog Entry

### Description

- Fix `LOG_FORMAT=json` so exception logs are emitted as a single JSON line with the full traceback, instead of crashing the sink with `AttributeError: 'RecordException' object has no attribute 'format_exception'`.

### Fixed

- JSON log sink (`LOG_FORMAT=json`) crashed on every `logger.exception(...)` call, hiding the original traceback behind a loguru diagnostic block on stderr and breaking structured-log alerting (#25135).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.