### PR TITLE
fix: keep pending Knowledge uploads visible after reload

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -175,12 +175,18 @@ async def process_uploaded_file(
             knowledge_id = file_metadata.get('knowledge_id')
             if knowledge_id:
                 try:
-                    await Knowledges.add_file_to_knowledge_by_id(
+                    if not await Knowledges.has_file(
                         knowledge_id=knowledge_id,
                         file_id=file_item.id,
-                        user_id=user.id,
-                        directory_id=file_metadata.get('directory_id'),
-                    )
+                        db=db_session,
+                    ):
+                        await Knowledges.add_file_to_knowledge_by_id(
+                            knowledge_id=knowledge_id,
+                            file_id=file_item.id,
+                            user_id=user.id,
+                            directory_id=file_metadata.get('directory_id'),
+                            db=db_session,
+                        )
                     await process_file(
                         request,
                         ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
@@ -201,6 +207,13 @@ async def process_uploaded_file(
                 },
                 db=db_session,
             )
+            knowledge_id = file_metadata.get('knowledge_id')
+            if knowledge_id:
+                await Knowledges.remove_file_from_knowledge_by_id(
+                    knowledge_id=knowledge_id,
+                    file_id=file_item.id,
+                    db=db_session,
+                )
 
     try:
         if db:
@@ -317,6 +330,24 @@ async def upload_file_handler(
             ),
             db=db,
         )
+
+        if process and file_metadata.get('knowledge_id'):
+            # Link the uploaded file to the Knowledge Collection before slow
+            # processing starts. This lets the Knowledge UI restore an
+            # in-progress row after a reload/remount instead of showing an
+            # empty collection while background processing continues.
+            if not await Knowledges.has_file(
+                knowledge_id=file_metadata['knowledge_id'],
+                file_id=file_item.id,
+                db=db,
+            ):
+                await Knowledges.add_file_to_knowledge_by_id(
+                    knowledge_id=file_metadata['knowledge_id'],
+                    file_id=file_item.id,
+                    user_id=user.id,
+                    directory_id=file_metadata.get('directory_id'),
+                    db=db,
+                )
 
         if 'channel_id' in file_metadata:
             channel = await Channels.get_channel_by_id_and_user_id(file_metadata['channel_id'], user.id, db=db)

--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -95,7 +95,11 @@ export const uploadFile = async (
 	return res;
 };
 
-export const getFileProcessStatus = async (token: string, id: string) => {
+export const getFileProcessStatus = async (
+	token: string,
+	id: string,
+	signal: AbortSignal | null = null
+) => {
 	const queryParams = new URLSearchParams();
 	queryParams.append('stream', 'true');
 
@@ -105,10 +109,13 @@ export const getFileProcessStatus = async (token: string, id: string) => {
 		headers: {
 			Accept: 'application/json',
 			authorization: `Bearer ${token}`
-		}
+		},
+		signal: signal ?? undefined
 	}).catch((err) => {
-		error = err.detail;
-		console.error(err);
+		if (err?.name !== 'AbortError') {
+			error = err.detail;
+			console.error(err);
+		}
 		return null;
 	});
 

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -23,7 +23,8 @@
 		uploadFile,
 		deleteFileById,
 		getFileById,
-		renameFileById
+		renameFileById,
+		getFileProcessStatus
 	} from '$lib/apis/files';
 	import {
 		addFileToKnowledgeById,
@@ -43,7 +44,7 @@
 	} from '$lib/apis/knowledge';
 	import { processWeb, processYoutubeVideo } from '$lib/apis/retrieval';
 
-	import { blobToFile, isYoutubeUrl, copyToClipboard } from '$lib/utils';
+	import { blobToFile, isYoutubeUrl, copyToClipboard, splitStream } from '$lib/utils';
 	import { computeFileHash } from '$lib/utils/hash';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
@@ -130,6 +131,123 @@
 		currentPage = 1;
 	};
 
+	let processingFileStatusStreams = new Set<string>();
+	let failedFileCleanupIds = new Set<string>();
+	let processingFileStatusControllers = new Map<string, AbortController>();
+	let processingFileStatusReaders = new Map<string, ReadableStreamDefaultReader<string>>();
+
+	const isFailedFile = (file: any) => file?.data?.status === 'failed' || file?.status === 'failed';
+
+	const isProcessingFile = (file: any) =>
+		file?.status === 'uploading' ||
+		(file?.data?.status &&
+			!['completed', 'failed', 'not_found'].includes(file.data.status));
+
+	const updateFileItemStatus = (fileId: string, status: string, error: string | null = null) => {
+		fileItems = fileItems?.map((item) =>
+			item.id === fileId
+				? {
+						...item,
+						data: {
+							...(item.data ?? {}),
+							status,
+							...(error ? { error } : {})
+						}
+					}
+				: item
+		);
+	};
+
+	const removeFailedFileFromKnowledge = async (fileId: string, message: string | null = null) => {
+		if (failedFileCleanupIds.has(fileId)) return;
+		failedFileCleanupIds.add(fileId);
+
+		toast.error(message ?? $i18n.t('Failed to upload file.'));
+		fileItems = fileItems?.filter((file) => file.id !== fileId);
+
+		if (selectedFileId === fileId) {
+			selectedFileId = null;
+			selectedFile = null;
+			selectedFileContent = '';
+		}
+
+		await removeFileFromKnowledgeById(localStorage.token, id, fileId).catch((e) => {
+			console.error(e);
+			return null;
+		});
+
+		await getItemsPage({ preserveItems: true });
+	};
+
+	const watchProcessingFile = async (fileId: string) => {
+		if (processingFileStatusStreams.has(fileId)) return;
+
+		const controller = new AbortController();
+		processingFileStatusStreams.add(fileId);
+		processingFileStatusControllers.set(fileId, controller);
+
+		try {
+			const status = await getFileProcessStatus(localStorage.token, fileId, controller.signal);
+			if (status && status.ok && status.body) {
+				const reader = status.body
+					.pipeThrough(new TextDecoderStream())
+					.pipeThrough(splitStream('\n'))
+					.getReader();
+				processingFileStatusReaders.set(fileId, reader);
+
+				while (true) {
+					const { value, done } = await reader.read();
+					if (done) break;
+
+					for (const line of value.split('\n')) {
+						if (!line || line === 'data: [DONE]') continue;
+
+						let data = null;
+						try {
+							data = JSON.parse(line.replace(/^data: /, ''));
+						} catch (e) {
+							console.error(e);
+							continue;
+						}
+
+						if (data?.status) {
+							updateFileItemStatus(fileId, data.status, data?.error ?? null);
+
+							if (data.status === 'failed') {
+								await removeFailedFileFromKnowledge(fileId, data?.error ?? null);
+								return;
+							}
+
+							if (['completed', 'not_found'].includes(data.status)) {
+								await getItemsPage({ preserveItems: true });
+								return;
+							}
+						}
+					}
+				}
+			}
+		} catch (e) {
+			if ((e as Error)?.name !== 'AbortError') {
+				console.error(e);
+			}
+		} finally {
+			processingFileStatusReaders.delete(fileId);
+			processingFileStatusControllers.delete(fileId);
+			processingFileStatusStreams.delete(fileId);
+		}
+	};
+
+	onDestroy(() => {
+		processingFileStatusControllers.forEach((controller) => controller.abort());
+		processingFileStatusControllers.clear();
+
+		processingFileStatusReaders.forEach((reader) => {
+			reader.cancel().catch((e) => console.error(e));
+		});
+		processingFileStatusReaders.clear();
+		processingFileStatusStreams.clear();
+	});
+
 	const init = async () => {
 		reset();
 		await getItemsPage();
@@ -164,11 +282,13 @@
 		reset();
 	}
 
-	const getItemsPage = async () => {
+	const getItemsPage = async ({ preserveItems = false }: { preserveItems?: boolean } = {}) => {
 		if (knowledgeId === null) return;
 
-		fileItems = null;
-		fileItemsTotal = null;
+		if (!preserveItems) {
+			fileItems = null;
+			fileItemsTotal = null;
+		}
 
 		if (sortKey === null) {
 			direction = null;
@@ -190,6 +310,13 @@
 		if (res) {
 			fileItems = res.items;
 			fileItemsTotal = res.total;
+			fileItems.forEach((file) => {
+				if (isFailedFile(file)) {
+					void removeFailedFileFromKnowledge(file.id, file?.data?.error ?? null);
+				} else if (isProcessingFile(file)) {
+					void watchProcessingFile(file.id);
+				}
+			});
 			directoryItems = res.directories ?? [];
 			breadcrumbs = res.breadcrumbs ?? [];
 		}
@@ -252,9 +379,15 @@
 						res.content
 					);
 
-					const uploadedFile = await uploadFile(localStorage.token, file, {
-						knowledge_id: knowledge.id
-					}).catch((e) => {
+					const uploadedFile = await uploadFile(
+						localStorage.token,
+						file,
+						{
+							knowledge_id: knowledge.id
+						},
+						undefined,
+						false
+					).catch((e) => {
 						toast.error(`${e}`);
 						return null;
 					});
@@ -270,10 +403,9 @@
 
 						if (uploadedFile.error) {
 							console.warn('File upload warning:', uploadedFile.error);
-							toast.warning(uploadedFile.error);
-							fileItems = fileItems.filter((file) => file.id !== uploadedFile.id);
+							await removeFailedFileFromKnowledge(uploadedFile.id, uploadedFile.error);
 						} else {
-							toast.success($i18n.t('File added successfully.'));
+							toast.success($i18n.t('File added and processing started.'));
 							init();
 						}
 					} else {
@@ -341,7 +473,13 @@
 					: {})
 			};
 
-			const uploadedFile = await uploadFile(localStorage.token, file, metadata).catch((e) => {
+			const uploadedFile = await uploadFile(
+				localStorage.token,
+				file,
+				metadata,
+				undefined,
+				false
+			).catch((e) => {
 				toast.error(`${e}`);
 				return null;
 			});
@@ -357,10 +495,9 @@
 
 				if (uploadedFile.error) {
 					console.warn('File upload warning:', uploadedFile.error);
-					toast.warning(uploadedFile.error);
-					fileItems = fileItems.filter((file) => file.id !== uploadedFile.id);
+					await removeFailedFileFromKnowledge(uploadedFile.id, uploadedFile.error);
 				} else {
-					toast.success($i18n.t('File added successfully.'));
+					toast.success($i18n.t('File added and processing started.'));
 					init();
 				}
 			} else {

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -47,6 +47,11 @@
 		setTimeout(() => editInput?.select(), 0);
 	};
 
+	const isProcessing = (file: any) =>
+		file?.status === 'uploading' ||
+		(file?.data?.status &&
+			!['completed', 'failed', 'not_found'].includes(file.data.status));
+
 	const submitRename = () => {
 		if (editingFileId && editName.trim()) {
 			onRename(editingFileId, editName.trim());
@@ -91,7 +96,7 @@
 			}}
 		>
 			<div class="flex items-center">
-				{#if file?.status !== 'uploading'}
+				{#if !isProcessing(file)}
 					<button
 						class="p-1 rounded-full transition"
 						type="button"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #25031`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

This PR fixes #25031, where an in-progress Knowledge upload can disappear from the Knowledge page after reload/remount.

The backend may still be processing the upload, but the temporary frontend row is lost. During that window, the Knowledge page can appear empty and show `No content found`, making the upload look lost or failed.

This PR keeps the accepted upload visible by linking the file to the Knowledge Collection before slow backend work starts, then restoring the in-progress row from the persisted Knowledge file list.

### Terminology

This PR distinguishes two backend stages:

- **File-level processing:** extraction/chunking/file-level embeddings for the uploaded file.
- **Knowledge-level processing:** making the file available inside the target Knowledge Collection.

This PR does not add a full multi-step progress UI. It only keeps the accepted upload visible while backend work is still in progress.

### Timing

Before:

```text
upload accepted
  -> temporary UI row shown
  -> file-level processing starts
  -> reload/remount
  -> temporary UI row is lost
  -> /knowledge/files returns no row yet
  -> UI may show "No content found"
  -> backend later finishes and links/indexes the file
  -> file finally appears
```

After:

```text
upload accepted
  -> file is linked to Knowledge early
  -> UI row shown
  -> file-level processing starts
  -> reload/remount
  -> /knowledge/files returns pending file row
  -> UI restores spinner/status watching
  -> backend finishes file-level + Knowledge-level work
  -> row refreshes as completed
```



### Added

* Status watching for persisted in-progress Knowledge files after reload/remount.

### Changed

* Knowledge uploads now restore status from persisted Knowledge file rows instead of relying only on the original upload request.
* Knowledge file rows show a spinner for persisted in-progress file states.

### Deprecated

* None.

### Removed

* None.

### Fixed

* In-progress Knowledge uploads disappearing after reload/remount.
* Knowledge page showing `No content found` while an accepted upload is still processing.
* Duplicate Knowledge-file link attempts during backend auto-linking.
* Stale pending Knowledge entries after processing failure.
* Cleanup for active status stream readers/controllers on component destroy.

### Security

* None.

### Breaking Changes

* None.

---

### Additional Information

This is intentionally a minimal bug fix.

It does not add:

* detailed progress labels such as `embedding...`
* per-step progress
* new settings
* a new processing architecture

The goal is only: once a Knowledge upload is accepted, the file should not disappear from the Knowledge page during backend processing.

### Manual Tests

Tested with a Playwright evidence runner using a 120-page PDF (`p120.pdf`) and a reload/remount while backend processing was still running.

* [x] Upload a slow-processing file to a Knowledge Collection.
* [x] Reload the page while backend work is still running.
* [x] Confirm the pending file row remains visible after reload/remount.
* [x] Confirm the pending file row keeps a spinner after reload/remount.
* [x] Confirm the page does not show `No content found` for an accepted upload.
* [x] Wait for completion and confirm the spinner stops and the row returns to a normal file row.
* [x] Navigate away and back during processing; confirm the pending row is restored.
* [x] Confirm no duplicate file row appears.
* [x] Confirm non-Knowledge file uploads are unaffected by keeping the early link behavior scoped to Knowledge uploads.
* [x] Confirm failed processing removes the pre-linked pending row.
* [x] Confirm normal Knowledge upload/delete/rename still works.

Evidence:

* Before, unpatched upstream `dev` image (`ghcr.io/open-webui/open-webui:dev`, commit `5d9a09a88a9094ebfcd249340be3aaee544b34d0`): the same runner left the file outside the Knowledge file list after reload/remount.
  * Upload status: `200`
  * Status stream: sent, `200`, aborted by reload/remount
  * `/api/v1/knowledge/{knowledge_id}/file/add`: not sent by the client before interruption
  * Global Files contained uploaded file: yes
  * Knowledge file list contained uploaded file: no
  * Remount filename visible: no

* After, patched `origin/dev` commit `5d9a09a88a9094ebfcd249340be3aaee544b34d0` with this patch applied locally: reload/remount during processing kept the uploaded file linked to the Knowledge Collection.
  * Upload status: `200`
  * Status stream: sent, `200`, aborted by reload/remount
  * `/api/v1/knowledge/{knowledge_id}/file/add`: not sent by the client before interruption
  * Global Files contained uploaded file: yes
  * Knowledge file list contained uploaded file: yes
  * Remount filename visible: yes
  * Remount spinner active: yes
  * Completion filename visible: yes
  * Completion spinner stopped: yes
  * Completion normal row: yes

### Screenshots or Videos

* Reloading during processing can show `No content found`.

https://github.com/user-attachments/assets/05a0eea3-3f82-4d5e-a8c1-3174a8f59cb8

After:

* The pending file remains visible with a spinner after reload/remount.


https://github.com/user-attachments/assets/f08ab1a6-d3ee-4820-a1e9-4829e6523d9f


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
