### PR TITLE
fix: fix in get_sources_from_items collection paths (#195)

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1252,11 +1252,23 @@ async def get_sources_from_items(
                             ],
                         }
             else:
-                # Fallback to collection names
-                if item.get('legacy'):
-                    collection_names.append(f'{item["id"]}')
-                else:
-                    collection_names.append(f'file-{item["id"]}')
+                # Chunked-retrieval fallback. body.metadata.files is client-
+                # controlled, so a caller could attach an arbitrary file id and
+                # query its vector collection. Require read access on the file
+                # before exposing its collection — same posture as the
+                # full-context branch above.
+                file_id = item.get('id')
+                if file_id:
+                    file_object = await Files.get_file_by_id(file_id)
+                    if file_object and (
+                        user.role == 'admin'
+                        or file_object.user_id == user.id
+                        or await has_access_to_file(file_id, 'read', user)
+                    ):
+                        if item.get('legacy'):
+                            collection_names.append(f'{file_id}')
+                        else:
+                            collection_names.append(f'file-{file_id}')
 
         elif item.get('type') == 'collection':
             # Manual Full Mode Toggle for Collection
@@ -1302,9 +1314,25 @@ async def get_sources_from_items(
                             'metadatas': [metadatas],
                         }
                 else:
-                    # Fallback to collection names
                     if item.get('legacy'):
-                        collection_names = item.get('collection_names', [])
+                        # Legacy KB: item.collection_names is client-supplied
+                        # and would otherwise let a caller substitute arbitrary
+                        # vector collection names (e.g. file-<victim_id>) while
+                        # holding access only to the parent KB. Filter the
+                        # supplied names against what the verified KB actually
+                        # owns; drop anything outside that set.
+                        supplied = item.get('collection_names') or []
+                        kb_files = await Knowledges.get_files_by_id(knowledge_base.id)
+                        owned = {f'file-{f.id}' for f in kb_files}
+                        owned.add(knowledge_base.id)
+                        validated = [name for name in supplied if name in owned]
+                        if validated:
+                            collection_names = validated
+                        else:
+                            # Either no names supplied or all were spoofed —
+                            # fall back to the KB id, which the access check
+                            # above already validated.
+                            collection_names.append(knowledge_base.id)
                     else:
                         collection_names.append(item['id'])
 
@@ -1315,8 +1343,19 @@ async def get_sources_from_items(
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
         elif item.get('collection_name'):
-            # Direct Collection Name
-            collection_names.append(item['collection_name'])
+            # WARNING: removed unauthenticated direct-collection-name
+            # passthrough. Previously this branch trusted the client-supplied
+            # `collection_name` field and queried it without any ownership
+            # check, letting a caller read arbitrary vector collections
+            # (e.g. file-<victim_id>) by attaching a bare item to the chat.
+            # Legitimate flows route through type='file' or type='collection'
+            # which carry the proper access checks; items reaching this
+            # branch without a recognized type are no longer trusted.
+            log.debug(
+                'get_sources_from_items: ignoring untrusted direct '
+                "collection_name '%s' on item without type",
+                item.get('collection_name'),
+            )
         elif item.get('collection_names'):
             # Collection Names List
             collection_names.extend(item['collection_names'])


### PR DESCRIPTION
Three caller-controlled paths into get_sources_from_items let an authenticated user query vector collections they don't own by crafting body.metadata.files items in the chat request:

1. Chunked file path (type='file', context!='full'): appended `file-{id}` to the query list without any ownership check on the file id. A caller could attach a victim's file id and read its chunks. Now gated by has_access_to_file, matching the full-context branch already in this function.

2. Legacy collection path (type='collection', legacy=True): read `collection_names` directly from the client-supplied item dict and queried whatever was in it, while only validating access to the parent KB id. A caller could legitimately own a KB and inject ['file-<victim_id>'] into collection_names to read unrelated collections. Now filters the supplied list against what the KB actually owns (its file-{id} collections plus the KB id itself); anything outside that set is dropped, with a fallback to the KB id when nothing legitimate remains.

3. Direct collection_name passthrough (no type, just collection_name): appended an arbitrary client string to the query list with zero validation. Legitimate flows route through the file/collection types which carry their own checks; removed the unauthenticated passthrough and log the rejection.

No behavior change for callers that route through type='file' or type='collection' with legitimate, owner-validated items. Callers that relied on the legacy paths to read collections outside the verified parent's ownership will see those calls drop — that's the intended behavior.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
