### PR TITLE
fix: return error message when tool name is not found in tool_call_handler (#25144)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1332,7 +1332,19 @@ async def chat_completion_tools_handler(
 
                 tool_function_name = tool_call.get('name', None)
                 if tool_function_name not in tools:
-                    return body, {}
+                    available_keys = sorted(tools.keys())
+                    available = ', '.join(available_keys) if available_keys else '(none)'
+                    error_msg = f'Tool "{tool_function_name}" not found. Available tools: {available}'
+                    log.warning(error_msg)
+                    sources.append(
+                        {
+                            'source': {'name': str(tool_function_name)},
+                            'document': [error_msg],
+                            'metadata': [{'source': str(tool_function_name), 'parameters': {}}],
+                            'tool_result': True,
+                        }
+                    )
+                    return
 
                 tool_function_params = tool_call.get('parameters', {})
 


### PR DESCRIPTION
When the LLM called a non-existent tool name, `tool_call_handler` silently
returned an empty result. This gave the model no feedback that the tool lookup
failed, causing it to retry the same unknown tool in a loop or continue as if
the call had succeeded.

Append a structured error entry to `sources` instead so the result injected
back into the conversation reads:

  Tool "<name>" not found. Available tools: <list>

This lets the model self-correct on the next turn.

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25144
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Provided above.
- [x] **Changelog:** See below.
- [ ] **Documentation:** No user-facing environment variables or public APIs changed.
- [x] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** Manually verified — with a mock tool set, calling an unknown tool name now injects an error result into the conversation instead of an empty one.
- [x] **Agentic AI Code:** N/A — changes reviewed and manually tested by the PR author.
- [x] **Code review:** Self-reviewed, follows existing code style in `middleware.py`.
- [x] **Design & Architecture:** No architectural change — single targeted guard in the existing early-return path.
- [x] **Git Hygiene:** Single logical change, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

When an LLM called a tool name that did not exist in the available tool set,
`tool_call_handler` in `backend/open_webui/utils/middleware.py` silently
returned `body, {}`. The model received an empty tool result with no indication
the call failed, causing it to loop retrying the same unknown tool name.

### Fixed

- `backend/open_webui/utils/middleware.py`: when `tool_function_name not in tools`,
  instead of silently returning, append a structured error entry to `sources`
  using the same `{source, document, metadata, tool_result: True}` shape used by
  successful tool results. The injected message reads
  `Tool "<name>" not found. Available tools: <sorted list>`, giving the LLM the
  context it needs to self-correct on the next turn. Also emits `log.warning`
  for backend observability.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Root cause identified in issue #25144. Fix is minimal and backwards-compatible —
  only the early-return path for unknown tool names is changed; the happy path
  is unaffected.

### Screenshots or Videos

- N/A

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.