### PR TITLE
BREAKING/perf/feat: cache-optimal file context in native FC mode

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1413,13 +1413,16 @@ Respond to the user query using the provided context, incorporating inline citat
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
 - **For `<source>` tags in the context: only include inline citations using [id] (e.g., [1], [2]) when the `<source>` tag includes an id attribute, and do not cite from `<source>` tags that lack an id attribute.**
 - **For tool result chunks (which do not arrive wrapped in `<source>` tags):** cite using the chunk's source identifier in square brackets — typically the `source` filename, e.g. `[contract.pdf]`. Do not invent numeric `[N]` citations for tool result content that doesn't carry one.
-- If the context lists items as available for retrieval but does not include their content (for example, inventory-style entries), do not cite them directly — call the appropriate tool to fetch their content first, then cite from the returned chunks.
+- If the context lists items as available for retrieval but does not include their content, do not cite them directly — call the appropriate tool to fetch their content first, then cite from the returned chunks.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 
 ### Example of Citation:
 If the user asks about a specific topic and the information is found in a source with a provided id attribute, the response should include the citation like in the following example:
 * "According to the study, the proposed method increases efficiency by 20% [1]."
+
+Or in the example of you retrieving the information through a tool call in a tool result, you can cite like so:
+* "The emergency server room access code is stored in the key box [emergency_handbook.pdf]."
 
 ### Output:
 Provide a clear and direct response to the user's query. Use inline citations in [id] format when an `<source id="...">` tag is present in the context, or in [source-name] format when citing a chunk returned by a tool result.

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1403,7 +1403,7 @@ CHUNK_OVERLAP = ConfigVar(
 )
 
 DEFAULT_RAG_TEMPLATE = """### Task:
-Respond to the user query using the provided context, incorporating inline citations in the format [id] **only when the <source> tag includes an explicit id attribute** (e.g., <source id="1">).
+Respond to the user query using the provided context, citing sources inline by name in square brackets (e.g., `[contract.pdf]` or `[wikipedia.org]`).
 
 ### Guidelines:
 - If you don't know the answer, clearly state that.
@@ -1411,21 +1411,21 @@ Respond to the user query using the provided context, incorporating inline citat
 - Respond in the same language as the user's query.
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
-- **For `<source>` tags in the context: only include inline citations using [id] (e.g., [1], [2]) when the `<source>` tag includes an id attribute, and do not cite from `<source>` tags that lack an id attribute.**
-- **For tool result chunks (which do not arrive wrapped in `<source>` tags):** cite using the chunk's source identifier in square brackets — typically the `source` filename, e.g. `[contract.pdf]`. Do not invent numeric `[N]` citations for tool result content that doesn't carry one.
-- If the context lists items as available for retrieval but does not include their content, do not cite them directly — call the appropriate tool to fetch their content first, then cite from the returned chunks.
+- **Cite each `<source>` tag in the context by the value of its `name` attribute**, in square brackets — e.g. `<source name="contract.pdf">` → `[contract.pdf]`, `<source name="https://wikipedia.org">` → `[https://wikipedia.org]` or `[wikipedia.org]` (URL protocol is optional in the citation).
+- **For content returned by tool calls** (web search, page fetch, attached-file or knowledge search): cite by the source's primary name as it appears in the result — a web result's title, a file chunk's source filename, or, for a directly fetched page, its URL. Prefer the title/name when one is present. Use the same `[identifier]` format.
+- If the context lists items as available for retrieval but does not include their content (for example, `<retrievable_file>` entries inside `<retrievable_files>`), do not cite them directly — call the appropriate tool to fetch their content first, then cite the returned sources by name.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 
 ### Example of Citation:
-If the user asks about a specific topic and the information is found in a source with a provided id attribute, the response should include the citation like in the following example:
-* "According to the study, the proposed method increases efficiency by 20% [1]."
+* "According to the study, the proposed method increases efficiency by 20% [research_paper.pdf]."
+* "The official documentation confirms this behavior [docs.python.org]."
 
 Or in the example of you retrieving the information through a tool call in a tool result, you can cite like so:
 * "The emergency server room access code is stored in the key box [emergency_handbook.pdf]."
 
 ### Output:
-Provide a clear and direct response to the user's query. Use inline citations in [id] format when an `<source id="...">` tag is present in the context, or in [source-name] format when citing a chunk returned by a tool result.
+Provide a clear and direct response to the user's query, including inline `[source-name]` citations matched to the `name` attribute of `<source>` tags in the context, or to the source identifier of chunks returned by tool calls.
 
 <context>
 {{CONTEXT}}

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1411,8 +1411,9 @@ Respond to the user query using the provided context, incorporating inline citat
 - Respond in the same language as the user's query.
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
-- **Only include inline citations using [id] (e.g., [1], [2]) when the <source> tag includes an id attribute.**
-- Do not cite if the <source> tag does not contain an id attribute.
+- **For `<source>` tags in the context: only include inline citations using [id] (e.g., [1], [2]) when the `<source>` tag includes an id attribute, and do not cite from `<source>` tags that lack an id attribute.**
+- **For tool result chunks (which do not arrive wrapped in `<source>` tags):** cite using the chunk's source identifier in square brackets — typically the `source` filename, e.g. `[contract.pdf]`. Do not invent numeric `[N]` citations for tool result content that doesn't carry one.
+- If the context lists items as available for retrieval but does not include their content (for example, inventory-style entries), do not cite them directly — call the appropriate tool to fetch their content first, then cite from the returned chunks.
 - Do not use XML tags in your response.
 - Ensure citations are concise and directly related to the information provided.
 
@@ -1421,7 +1422,7 @@ If the user asks about a specific topic and the information is found in a source
 * "According to the study, the proposed method increases efficiency by 20% [1]."
 
 ### Output:
-Provide a clear and direct response to the user's query, including inline citations in the format [id] only when the <source> tag with id attribute is present in the context.
+Provide a clear and direct response to the user's query. Use inline citations in [id] format when an `<source id="...">` tag is present in the context, or in [source-name] format when citing a chunk returned by a tool result.
 
 <context>
 {{CONTEXT}}

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -567,6 +567,7 @@ from open_webui.utils.models import (
     get_all_models,
     get_filtered_models,
 )
+from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
 from open_webui.utils.oauth import (
     OAuthClientInformationFull,
     OAuthClientManager,
@@ -1047,6 +1048,7 @@ app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT = RAG_EXTERNAL_RERANKER_TIMEOUT
 app.state.config.RAG_RERANKING_BATCH_SIZE = RAG_RERANKING_BATCH_SIZE
 
 app.state.config.RAG_TEMPLATE = RAG_TEMPLATE
+warn_if_deprecated_rag_template_placeholders(app.state.config.RAG_TEMPLATE)
 
 app.state.config.RAG_OPENAI_API_BASE_URL = RAG_OPENAI_API_BASE_URL
 app.state.config.RAG_OPENAI_API_KEY = RAG_OPENAI_API_KEY

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -567,7 +567,6 @@ from open_webui.utils.models import (
     get_all_models,
     get_filtered_models,
 )
-from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
 from open_webui.utils.oauth import (
     OAuthClientInformationFull,
     OAuthClientManager,
@@ -1048,7 +1047,14 @@ app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT = RAG_EXTERNAL_RERANKER_TIMEOUT
 app.state.config.RAG_RERANKING_BATCH_SIZE = RAG_RERANKING_BATCH_SIZE
 
 app.state.config.RAG_TEMPLATE = RAG_TEMPLATE
-warn_if_deprecated_rag_template_placeholders(app.state.config.RAG_TEMPLATE)
+if app.state.config.RAG_TEMPLATE and (
+    '{{QUERY}}' in app.state.config.RAG_TEMPLATE or '[query]' in app.state.config.RAG_TEMPLATE
+):
+    log.warning(
+        "RAG_TEMPLATE contains {{QUERY}}/[query] placeholders, which are no "
+        "longer substituted (the user's message is already in the messages "
+        'array) and will be stripped to empty. Remove them from your template.'
+    )
 
 app.state.config.RAG_OPENAI_API_BASE_URL = RAG_OPENAI_API_BASE_URL
 app.state.config.RAG_OPENAI_API_KEY = RAG_OPENAI_API_KEY

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -718,9 +718,15 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
     request.app.state.config.RAG_TEMPLATE = (
         form_data.RAG_TEMPLATE if form_data.RAG_TEMPLATE is not None else request.app.state.config.RAG_TEMPLATE
     )
-    from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
-
-    warn_if_deprecated_rag_template_placeholders(request.app.state.config.RAG_TEMPLATE)
+    if request.app.state.config.RAG_TEMPLATE and (
+        '{{QUERY}}' in request.app.state.config.RAG_TEMPLATE
+        or '[query]' in request.app.state.config.RAG_TEMPLATE
+    ):
+        log.warning(
+            "RAG_TEMPLATE contains {{QUERY}}/[query] placeholders, which are no "
+            "longer substituted (the user's message is already in the messages "
+            'array) and will be stripped to empty. Remove them from your template.'
+        )
     request.app.state.config.TOP_K = form_data.TOP_K if form_data.TOP_K is not None else request.app.state.config.TOP_K
     request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL = (
         form_data.BYPASS_EMBEDDING_AND_RETRIEVAL

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -718,6 +718,9 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
     request.app.state.config.RAG_TEMPLATE = (
         form_data.RAG_TEMPLATE if form_data.RAG_TEMPLATE is not None else request.app.state.config.RAG_TEMPLATE
     )
+    from open_webui.utils.task import warn_if_deprecated_rag_template_placeholders
+
+    warn_if_deprecated_rag_template_placeholders(request.app.state.config.RAG_TEMPLATE)
     request.app.state.config.TOP_K = form_data.TOP_K if form_data.TOP_K is not None else request.app.state.config.TOP_K
     request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL = (
         form_data.BYPASS_EMBEDDING_AND_RETRIEVAL

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -61,11 +61,15 @@ async def _has_read_access_to_file(
         for item in model_knowledge
     ):
         return True
+    from open_webui.models.users import Users
     from open_webui.utils.access_control.files import has_access_to_file
-    return await has_access_to_file(
-        file_id=file.id, access_type='read',
-        user=UserModel(**{'id': user_id, 'role': user_role}),
-    )
+
+    # Fetch the real user (cheap PK lookup); a synthesized partial UserModel
+    # fails validation on the required email/name/timestamp fields.
+    user = await Users.get_user_by_id(user_id)
+    if not user:
+        return False
+    return await has_access_to_file(file_id=file.id, access_type='read', user=user)
 
 # =============================================================================
 # TIME UTILITIES
@@ -2322,9 +2326,11 @@ async def query_knowledge_files(
         if knowledge_ids.lower() in ('none', 'null', ''):
             knowledge_ids = None
         else:
-            # Try to parse as JSON array if it looks like one
+            # Wrap scalar parse results (e.g. '"abc"' -> 'abc') in a list so
+            # membership checks stay list-shaped, not substring/dict-key matching.
             try:
-                knowledge_ids = json.loads(knowledge_ids)
+                parsed = json.loads(knowledge_ids)
+                knowledge_ids = parsed if isinstance(parsed, list) else [parsed]
             except json.JSONDecodeError:
                 # Treat as single ID
                 knowledge_ids = [knowledge_ids]
@@ -2449,10 +2455,11 @@ async def query_knowledge_files(
                 distances = query_results.get('distances', [[]])[0]
 
                 for idx, doc in enumerate(documents):
+                    meta = (metadatas[idx] if idx < len(metadatas) else None) or {}
                     chunk_info = {
                         'content': doc,
-                        'source': metadatas[idx].get('source', metadatas[idx].get('name', 'Unknown')),
-                        'file_id': metadatas[idx].get('file_id', ''),
+                        'source': meta.get('source') or meta.get('name') or 'Unknown',
+                        'file_id': meta.get('file_id', ''),
                     }
                     if idx < len(distances):
                         chunk_info['distance'] = distances[idx]
@@ -2464,6 +2471,178 @@ async def query_knowledge_files(
         return json.dumps(chunks, ensure_ascii=False)
     except Exception as e:
         log.exception(f'query_knowledge_files error: {e}')
+        return json.dumps({'error': str(e)})
+
+
+async def query_attached_files(
+    query: str,
+    ids: Optional[list[str]] = None,
+    count: Optional[int] = None,
+    __request__: Request = None,
+    __user__: dict = None,
+    __attached_files__: list[dict] = None,
+) -> str:
+    """
+    Search files and knowledge bases the user attached to this chat.
+
+    The system context lists each retrievable item inside <retrievable_files>
+    as a <retrievable_file id="..."> entry. Call this tool to fetch
+    semantically relevant chunks; cite from the returned chunks rather than
+    the inventory entries themselves. Distinct from query_knowledge_files
+    (which searches model-attached knowledge).
+
+    :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
+    :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on a `<retrievable_file id="...">` entry in the system context (for example "abc123" for `<retrievable_file id="abc123" ...>`, not the whole tag).
+    :param count: Optional. Maximum number of result chunks to return. When omitted, defaults to the admin-configured retrieval TOP_K. When supplied, values above that limit are clamped down.
+    :return: JSON list of chunks with content, source, file_id, distance
+    """
+    if __request__ is None:
+        return json.dumps({'error': 'Request context not available'})
+
+    if not __user__:
+        return json.dumps({'error': 'User context not available'})
+
+    if not __attached_files__:
+        return json.dumps({'error': 'No retrievable files are attached to this chat.'})
+
+    admin_top_k = __request__.app.state.config.TOP_K
+
+    if isinstance(count, str):
+        try:
+            count = int(count)
+        except ValueError:
+            count = None
+
+    if not isinstance(count, int) or count <= 0:
+        count = admin_top_k
+    else:
+        count = min(count, admin_top_k)
+
+    if isinstance(ids, str):
+        if ids.lower() in ('none', 'null', ''):
+            ids = None
+        else:
+            try:
+                parsed = json.loads(ids)
+                # Wrap non-list parses in a list so `id in ids` stays a list
+                # membership check (not substring/dict-key matching).
+                ids = parsed if isinstance(parsed, list) else [parsed]
+            except json.JSONDecodeError:
+                ids = [ids]
+
+    try:
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.models.files import Files
+        from open_webui.models.knowledge import Knowledges
+        from open_webui.retrieval.utils import query_collection
+
+        embedding_function = __request__.app.state.EMBEDDING_FUNCTION
+        if not embedding_function:
+            return json.dumps({'error': 'Embedding function not configured'})
+
+        user_id = __user__.get('id')
+        user_role = __user__.get('role', 'user')
+        user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
+
+        # Empty list and missing field both mean "no scoping" — search every
+        # attached item. Only an explicit non-empty list that resolves to
+        # nothing is treated as a model error.
+        if ids:
+            scoped_items = [item for item in __attached_files__ if item.get('id') in ids]
+            if not scoped_items:
+                return json.dumps({
+                    'error': 'None of the requested ids match an attached file. '
+                    'Check the <retrievable_file id="..."> entries in <retrievable_files>, '
+                    'or omit `ids` to search every attached item.'
+                })
+        else:
+            scoped_items = list(__attached_files__)
+
+        # Resolve each attached item to collection names AFTER verifying the
+        # caller can read it. Items the user can't access are silently skipped
+        # (same posture as query_knowledge_files).
+        collection_names = []
+        for attached_item in scoped_items:
+            # Belt-and-suspenders: callers already filter context == 'full'.
+            if attached_item.get('context') == 'full':
+                continue
+            item_type = attached_item.get('type')
+            item_id = attached_item.get('id')
+            if not item_id:
+                continue
+
+            if item_type == 'file':
+                file_record = await Files.get_file_by_id(item_id)
+                if not file_record:
+                    continue
+                # Chat scope: deliberately do not pass __model_knowledge__ —
+                # this tool only reads items the user attached to *this* chat.
+                if not await _has_read_access_to_file(file_record, user_id, user_role):
+                    continue
+                collection_names.append(f'file-{item_id}')
+
+            elif item_type == 'collection':
+                knowledge_record = await Knowledges.get_knowledge_by_id(item_id)
+                user_owns_kb = knowledge_record and (
+                    user_role == 'admin'
+                    or knowledge_record.user_id == user_id
+                    or await AccessGrants.has_access(
+                        user_id=user_id,
+                        resource_type='knowledge',
+                        resource_id=knowledge_record.id,
+                        permission='read',
+                        user_group_ids=set(user_group_ids),
+                    )
+                )
+                if not user_owns_kb:
+                    continue
+                # Use the access-checked KB id directly (matches
+                # query_knowledge_files). Trusting client-supplied
+                # collection_names here would be a BOLA.
+                collection_names.append(item_id)
+
+        if not collection_names:
+            return json.dumps({
+                'error': 'No accessible retrievable collections resolved from the attached items.'
+            })
+
+        collection_names = list(dict.fromkeys(collection_names))
+
+        chunks: list[dict] = []
+        query_results = await query_collection(
+            __request__,
+            collection_names=collection_names,
+            queries=[query],
+            embedding_function=embedding_function,
+            k=count,
+        )
+
+        if query_results and 'documents' in query_results:
+            chunk_documents = query_results.get('documents', [[]])[0]
+            chunk_metadatas = query_results.get('metadatas', [[]])[0]
+            chunk_distances = query_results.get('distances', [[]])[0]
+
+            for chunk_index, document in enumerate(chunk_documents):
+                # Some query_collection paths can return None in the
+                # metadatas list (e.g. partial hybrid-search failures).
+                chunk_metadata = (
+                    chunk_metadatas[chunk_index]
+                    if chunk_index < len(chunk_metadatas)
+                    else None
+                ) or {}
+                chunk_info = {
+                    'content': document,
+                    'source': chunk_metadata.get('source') or chunk_metadata.get('name') or 'Unknown',
+                    'file_id': chunk_metadata.get('file_id', ''),
+                }
+                if chunk_index < len(chunk_distances):
+                    chunk_info['distance'] = chunk_distances[chunk_index]
+                chunks.append(chunk_info)
+
+        chunks = chunks[:count]
+        return json.dumps(chunks, ensure_ascii=False)
+    except Exception as e:
+        log.exception(f'query_attached_files error: {e}')
         return json.dumps({'error': str(e)})
 
 

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2483,13 +2483,13 @@ async def query_attached_files(
     __attached_files__: list[dict] = None,
 ) -> str:
     """
-    Search files and knowledge bases the user attached to this chat.
+    Search files and knowledge bases the user manually attached to this chat.
 
-    The system context lists each retrievable item inside <retrievable_files>
+    If the user manually attached files or knowledge bases to this chat, the
+    system context will list each retrievable item inside <retrievable_files>
     as a <retrievable_file id="..."> entry. Call this tool to fetch
     semantically relevant chunks; cite from the returned chunks rather than
-    the inventory entries themselves. Distinct from query_knowledge_files
-    (which searches model-attached knowledge).
+    the inventory entries themselves.
 
     :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
     :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on a `<retrievable_file id="...">` entry in the system context (for example "abc123" for `<retrievable_file id="abc123" ...>`, not the whole tag).

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2483,13 +2483,13 @@ async def query_attached_files(
     __attached_files__: list[dict] = None,
 ) -> str:
     """
-    Search files and knowledge bases the user manually attached to this chat.
+    Search files and knowledge bases the user attached to this chat.
 
-    If the user manually attached files or knowledge bases to this chat, the
-    system context will list each retrievable item inside <retrievable_files>
+    The system context lists each retrievable item inside <retrievable_files>
     as a <retrievable_file id="..."> entry. Call this tool to fetch
     semantically relevant chunks; cite from the returned chunks rather than
-    the inventory entries themselves.
+    the inventory entries themselves. Distinct from query_knowledge_files
+    (which searches model-attached knowledge).
 
     :param query: Required. Natural-language search query used for semantic / hybrid retrieval over the attached items' content.
     :param ids: Optional. When omitted, the search runs against every file and knowledge base attached to this chat (the default). To narrow the search to a subset, supply a list of plain attached-item id strings — each id is the literal value of the `id` attribute on a `<retrievable_file id="...">` entry in the system context (for example "abc123" for `<retrievable_file id="abc123" ...>`, not the whole tag).

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -216,7 +216,7 @@ def get_citation_source_from_tool_result(
 
     Returns a list of sources (usually one, but query_knowledge_files may return multiple).
     """
-    _EXPECTS_LIST = {'search_web', 'query_knowledge_files'}
+    _EXPECTS_LIST = {'search_web', 'query_knowledge_files', 'query_attached_files'}
     _EXPECTS_DICT = {'view_knowledge_file', 'view_file'}
 
     try:
@@ -305,7 +305,7 @@ def get_citation_source_from_tool_result(
                 }
             ]
 
-        elif tool_name == 'query_knowledge_files':
+        elif tool_name in ('query_knowledge_files', 'query_attached_files'):
             chunks = tool_result
 
             # Group chunks by source for better citation display
@@ -928,30 +928,76 @@ def handle_responses_streaming_event(
         return current_output, None
 
 
+_ROSTER_HINT = 'Use query_attached_files with this id to inspect or search this item.'
+
+
+def _format_tag_attrs(pairs: list[tuple[str, str | None]]) -> str:
+    """Render space-prefixed XML attributes, skipping any with falsy values.
+
+    Values are HTML-escaped so user-controlled fields (filenames, KB names,
+    arbitrary metadata) can't break out of the attribute and inject sibling
+    tags into the rendered context.
+    """
+    return ''.join(
+        f' {key}="{html.escape(str(value), quote=True)}"'
+        for key, value in pairs
+        if value
+    )
+
+
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
-    Build <source> tag context string from citation sources.
+    Render sources for the RAG <context> block.
+
+    Citeable sources -> <source id="N">body</source>. Roster-only sources
+    (roster_only=True, no body) -> <retrievable_file ...> inside <retrievable_files>.
+    Citeable-only input stays bare (no wrapper, backward compatible); mixed
+    input wraps citeable sources under <full_context_files>.
     """
-    context_string = ''
     if source_ids is None:
         source_ids = {}
+
+    citeable_parts: list[str] = []
+    roster_parts: list[str] = []
+
     for source in sources:
-        for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
+        source_info = source.get('source') or {}
+        source_name = source_info.get('name')
+        source_type = source_info.get('type')
+        source_resource_id = source_info.get('id')
+
+        if source.get('roster_only'):
+            attrs = _format_tag_attrs([
+                ('id', source_resource_id),
+                ('name', source_name),
+                ('resource-type', source_type),
+            ])
+            roster_parts.append(
+                f'<retrievable_file{attrs}>{_ROSTER_HINT}</retrievable_file>\n'
+            )
+            continue
+
+        for document_chunk, chunk_meta in zip(source.get('document', []), source.get('metadata', [])):
+            source_id = (chunk_meta or {}).get('source') or source_resource_id or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
-            src_name = source.get('source', {}).get('name')
-            src_type = source.get('source', {}).get('type')
-            src_rid = source.get('source', {}).get('id')
-            body = doc if include_content else ''
-            context_string += (
-                f'<source id="{source_ids[source_id]}"'
-                + (f' name="{src_name}"' if src_name else '')
-                + (f' resource-type="{src_type}"' if src_type else '')
-                + (f' resource-id="{src_rid}"' if src_rid else '')
-                + f'>{body}</source>\n'
-            )
-    return context_string
+            attrs = _format_tag_attrs([
+                ('id', str(source_ids[source_id])),
+                ('name', source_name),
+                ('resource-type', source_type),
+                ('resource-id', source_resource_id),
+            ])
+            body = document_chunk if include_content else ''
+            citeable_parts.append(f'<source{attrs}>{body}</source>\n')
+
+    if not roster_parts:
+        return ''.join(citeable_parts)
+
+    parts: list[str] = []
+    if citeable_parts:
+        parts.append('<full_context_files>\n' + ''.join(citeable_parts) + '</full_context_files>\n')
+    parts.append('<retrievable_files>\n' + ''.join(roster_parts) + '</retrievable_files>\n')
+    return ''.join(parts)
 
 
 async def apply_source_context_to_messages(
@@ -960,14 +1006,15 @@ async def apply_source_context_to_messages(
     sources: list,
     user_message: str,
     include_content: bool = True,
+    force_system_message: bool = False,
 ) -> list:
     """
-    Build source context from citation sources and apply to messages.
-    Uses RAG template to format context for model consumption.
+    Render sources via RAG template and inject into messages.
 
-    When include_content is False, emit <source> tags with id/name but no
-    document body — useful when the content is already present elsewhere
-    (e.g. in a tool result message) and only citation markers are needed.
+    include_content=False emits citation-only <source> tags (content lives
+    elsewhere, e.g. tool results). force_system_message=True overrides
+    RAG_SYSTEM_CONTEXT and pins the template to the system prompt — used by
+    native FC mode to keep file context in a cache-stable prefix.
     """
     if not sources or not user_message:
         return messages
@@ -978,7 +1025,7 @@ async def apply_source_context_to_messages(
     if not context:
         return messages
 
-    if RAG_SYSTEM_CONTEXT:
+    if RAG_SYSTEM_CONTEXT or force_system_message:
         return add_or_update_system_message(
             await rag_template(request.app.state.config.RAG_TEMPLATE, context, user_message),
             messages,
@@ -1933,17 +1980,63 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
 
 
 async def chat_completion_files_handler(
-    request: Request, body: dict, extra_params: dict, user: UserModel
+    request: Request,
+    body: dict,
+    extra_params: dict,
+    user: UserModel,
+    native_function_calling_with_builtins: bool = False,
 ) -> tuple[dict, dict[str, list]]:
+    """
+    Resolve body.metadata.files into sources for the RAG template.
+
+    Default mode: every item runs through get_sources_from_items (unchanged).
+    Native FC mode: chunked file/collection items skip retrieval and become
+    roster-only entries; the model fetches them via query_attached_files.
+    Full-context items still retrieve normally.
+    """
     __event_emitter__ = extra_params['__event_emitter__']
     sources = []
 
     if files := body.get('metadata', {}).get('files', None):
-        # Check if all files are in full context mode
-        all_full_context = all(item.get('context') == 'full' for item in files)
+        force_full_context = (
+            request.app.state.config.RAG_FULL_CONTEXT
+            or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+        )
+        # Only chunked file / collection items get diverted to the roster;
+        # everything else (full-context items, natively-full types, unknown
+        # types) stays in the retrieval pipeline.
+        RETRIEVABLE_TYPES = {'file', 'collection'}
+        should_partition = native_function_calling_with_builtins and not force_full_context
+
+        def is_retrievable(item):
+            return (
+                item.get('context') != 'full'
+                and item.get('type') in RETRIEVABLE_TYPES
+            )
+
+        if should_partition:
+            # Sort by id so the rendered blocks (and source_ids numbering) stay
+            # byte-stable across turns regardless of frontend file ordering.
+            retrievable_items = sorted(
+                (item for item in files if is_retrievable(item)),
+                key=lambda item: item.get('id') or '',
+            )
+            full_context_items = sorted(
+                (item for item in files if not is_retrievable(item)),
+                key=lambda item: item.get('id') or '',
+            )
+        else:
+            retrievable_items = []
+            full_context_items = list(files)
+
+        retrieval_all_full_context = all(
+            item.get('context') == 'full' for item in full_context_items
+        )
 
         queries = []
-        if not all_full_context:
+        needs_query_generation = bool(full_context_items) and not retrieval_all_full_context
+
+        if needs_query_generation:
             try:
                 queries_response = await generate_queries(
                     request,
@@ -1987,36 +2080,57 @@ async def chat_completion_files_handler(
         if len(queries) == 0:
             queries = [get_last_user_message(body['messages']) or '']
 
-        try:
-            # Directly await async get_sources_from_items (no thread needed - fully async now)
-            sources = await get_sources_from_items(
-                request=request,
-                items=files,
-                queries=queries,
-                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
-                    query, prefix=prefix, user=user
-                ),
-                k=request.app.state.config.TOP_K,
-                reranking_function=(
-                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
-                    if request.app.state.RERANKING_FUNCTION
-                    else None
-                ),
-                k_reranker=request.app.state.config.TOP_K_RERANKER,
-                r=request.app.state.config.RELEVANCE_THRESHOLD,
-                hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
-                hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
-                full_context=all_full_context or request.app.state.config.RAG_FULL_CONTEXT,
-                user=user,
+        if full_context_items:
+            try:
+                # Directly await async get_sources_from_items (no thread needed - fully async now)
+                sources = await get_sources_from_items(
+                    request=request,
+                    items=full_context_items,
+                    queries=queries,
+                    embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                        query, prefix=prefix, user=user
+                    ),
+                    k=request.app.state.config.TOP_K,
+                    reranking_function=(
+                        (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                        if request.app.state.RERANKING_FUNCTION
+                        else None
+                    ),
+                    k_reranker=request.app.state.config.TOP_K_RERANKER,
+                    r=request.app.state.config.RELEVANCE_THRESHOLD,
+                    hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
+                    hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
+                    full_context=retrieval_all_full_context or force_full_context,
+                    user=user,
+                )
+            except Exception as e:
+                log.exception(e)
+
+        # Roster entries for the <retrievable_files> block (no retrieval).
+        # Consumers short-circuit on roster_only before touching document/metadata.
+        for item in retrievable_items:
+            sources.append(
+                {
+                    'source': {
+                        'type': item.get('type'),
+                        'id': item.get('id'),
+                        'name': item.get('name'),
+                    },
+                    'roster_only': True,
+                }
             )
-        except Exception as e:
-            log.exception(e)
 
         log.debug(f'rag_contexts:sources: {sources}')
 
         unique_ids = set()
         for source in sources or []:
             if not source or len(source.keys()) == 0:
+                continue
+
+            if source.get('roster_only'):
+                _id = (source.get('source') or {}).get('id')
+                if _id:
+                    unique_ids.add(_id)
                 continue
 
             documents = source.get('document') or []
@@ -2676,6 +2790,16 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # When the caller provides an explicit OpenAI-style `tools` array in the
     # request body, skip all server-side tool resolution and pass the caller's
     # tools through to the model unchanged.
+    capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
+    builtin_tools_enabled = capabilities.get('builtin_tools', True)
+    file_context_enabled = capabilities.get('file_context', True)
+    is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'
+    # query_attached_files lives in the knowledge builtin category; if it's
+    # disabled the tool isn't registered, so the native-FC path must revert too.
+    knowledge_builtins_enabled = (
+        model.get('info', {}).get('meta', {}).get('builtinTools', {}).get('knowledge', True)
+    )
+
     if not payload_tools:
         # Server side tools
         tool_ids = metadata.get('tool_ids', None)
@@ -2803,20 +2927,25 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             metadata['mcp_clients'] = mcp_clients
 
         # Inject builtin tools for native function calling based on enabled features and model capability
-        # Check if builtin_tools capability is enabled for this model (defaults to True if not specified)
-        builtin_tools_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
-            'builtin_tools', True
-        )
-        if metadata.get('params', {}).get('function_calling') == 'native' and builtin_tools_enabled:
-            # Add file context to user messages
+        if is_native_fc and builtin_tools_enabled:
+            # add_file_context injects URL pointers (not content), so it runs
+            # regardless of the file_context capability — pre-PR behavior.
             chat_id = metadata.get('chat_id')
             form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            # query_attached_files exposes content, so gate its input list on
+            # the file_context capability.
+            attached_files_for_tools = (
+                form_data.get('metadata', {}).get('files', []) or []
+                if file_context_enabled
+                else []
+            )
             builtin_tools = await get_builtin_tools(
                 request,
                 {
                     **extra_params,
                     '__event_emitter__': event_emitter,
                     '__skill_ids__': [s.id for s in available_skills if s.id not in user_skill_ids],
+                    '__attached_files__': attached_files_for_tools,
                 },
                 features,
                 model,
@@ -2830,7 +2959,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             # (e.g. pipe functions) can access all tools including MCP and builtins.
             metadata['tools'] = tools_dict
 
-            if metadata.get('params', {}).get('function_calling') == 'native':
+            if is_native_fc:
                 # If the function calling is native, then call the tools function calling handler
                 form_data['tools'] = [
                     {'type': 'function', 'function': tool.get('spec', {})} for tool in tools_dict.values()
@@ -2847,12 +2976,47 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 except Exception as e:
                     log.exception(e)
 
-    # Check if file context extraction is enabled for this model (default True)
-    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
+    # Admin-forced full content (either flag) means no chunked retrieval to
+    # partition — keep pre-PR behavior.
+    force_full_context = (
+        request.app.state.config.RAG_FULL_CONTEXT
+        or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+    )
+
+    # Only activate when there's a chunked file/collection to route through
+    # the tool; otherwise the gate would needlessly regress citation handling
+    # for unrelated native tool calls in no-file / full-context-only chats.
+    attached_files_list = (form_data.get('metadata') or {}).get('files') or []
+    has_retrievable_attached_files = any(
+        item.get('context') != 'full'
+        and item.get('type') in ('file', 'collection')
+        for item in attached_files_list
+    )
+
+    # `not payload_tools` because builtin tools (incl. query_attached_files)
+    # only get registered in that branch — otherwise the roster would point
+    # at a tool the model doesn't have.
+    native_fc_with_builtins = (
+        not payload_tools
+        and is_native_fc
+        and builtin_tools_enabled
+        and knowledge_builtins_enabled
+        and file_context_enabled
+        and not force_full_context
+        and has_retrievable_attached_files
+    )
+    # Read by the tool-call loop to skip per-iteration RAG re-application.
+    metadata['native_fc_with_builtins'] = native_fc_with_builtins
 
     if file_context_enabled:
         try:
-            form_data, flags = await chat_completion_files_handler(request, form_data, extra_params, user)
+            form_data, flags = await chat_completion_files_handler(
+                request,
+                form_data,
+                extra_params,
+                user,
+                native_function_calling_with_builtins=native_fc_with_builtins,
+            )
             sources.extend(flags.get('sources', []))
         except Exception as e:
             log.exception(e)
@@ -2863,17 +3027,29 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     system_message = get_system_message(form_data['messages'])
     metadata['system_prompt'] = get_content_from_message(system_message) if system_message else None
     metadata['user_prompt'] = get_last_user_message(form_data['messages'])
-    metadata['sources'] = sources[:] if sources else []
+    # Roster-only entries are chat-level inventory, not evidence — exclude
+    # them from metadata['sources'] so pipe functions / outlet filters don't
+    # have to special-case the missing document/metadata fields.
+    metadata['sources'] = [s for s in sources if not s.get('roster_only')] if sources else []
 
     # If context is not empty, insert it into the messages
     if sources and prompt:
-        form_data['messages'] = await apply_source_context_to_messages(request, form_data['messages'], sources, prompt)
+        form_data['messages'] = await apply_source_context_to_messages(
+            request,
+            form_data['messages'],
+            sources,
+            prompt,
+            force_system_message=native_fc_with_builtins,
+        )
 
-    # If there are citations, add them to the data_items
+    # If there are citations, add them to the data_items. Roster-only entries
+    # are chat-level inventory, not evidence the model cited — exclude them so
+    # the frontend citation panel doesn't display empty-content pseudo-sources.
     sources = [
         source
         for source in sources
-        if source.get('source', {}).get('name', '') or source.get('source', {}).get('id', '')
+        if not source.get('roster_only')
+        and (source.get('source', {}).get('name', '') or source.get('source', {}).get('id', ''))
     ]
 
     if len(sources) > 0:
@@ -4601,6 +4777,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 'view_file',
                                 'view_knowledge_file',
                                 'query_knowledge_files',
+                                'query_attached_files',
                             ]
                             and tool_result
                         ):
@@ -4681,7 +4858,8 @@ async def streaming_chat_response_handler(response, ctx):
                         # Restoring to pre-RAG original prevents duplicating
                         # the RAG template across file and tool sources.
                         all_tool_call_sources.extend(tool_call_sources)
-                        if all_tool_call_sources and user_message:
+                        skip_rag_reapply = metadata.get('native_fc_with_builtins', False)
+                        if not skip_rag_reapply and all_tool_call_sources and user_message:
                             # Restore pre-RAG message state before re-applying
                             # to prevent RAG template duplication.
                             original_user_message = metadata.get('user_prompt') or user_message

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -945,18 +945,17 @@ def _format_tag_attrs(pairs: list[tuple[str, str | None]]) -> str:
     )
 
 
-def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
+def get_source_context(sources: list, include_content: bool = True) -> str:
     """
     Render sources for the RAG <context> block.
 
-    Citeable sources -> <source id="N">body</source>. Roster-only sources
+    Citeable sources -> <source name="...">body</source>. Roster-only sources
     (roster_only=True, no body) -> <retrievable_file ...> inside <retrievable_files>.
     Citeable-only input stays bare (no wrapper, backward compatible); mixed
-    input wraps citeable sources under <full_context_files>.
+    input wraps citeable sources under <full_context_files>. The model cites
+    sources by their `name` attribute (or URL for web results) — see
+    DEFAULT_RAG_TEMPLATE.
     """
-    if source_ids is None:
-        source_ids = {}
-
     citeable_parts: list[str] = []
     roster_parts: list[str] = []
 
@@ -978,12 +977,17 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
             continue
 
         for document_chunk, chunk_meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = (chunk_meta or {}).get('source') or source_resource_id or 'N/A'
-            if source_id not in source_ids:
-                source_ids[source_id] = len(source_ids) + 1
+            # Per-chunk citation handle: chunk metadata `source` (often the
+            # filename or URL) takes priority, falling back to the top-level
+            # source name, then the resource id.
+            citation_name = (
+                (chunk_meta or {}).get('source')
+                or source_name
+                or source_resource_id
+                or 'Unknown'
+            )
             attrs = _format_tag_attrs([
-                ('id', str(source_ids[source_id])),
-                ('name', source_name),
+                ('name', citation_name),
                 ('resource-type', source_type),
                 ('resource-id', source_resource_id),
             ])
@@ -2015,8 +2019,8 @@ async def chat_completion_files_handler(
             )
 
         if should_partition:
-            # Sort by id so the rendered blocks (and source_ids numbering) stay
-            # byte-stable across turns regardless of frontend file ordering.
+            # Sort by id so the rendered blocks stay byte-stable across
+            # turns regardless of frontend file ordering.
             retrievable_items = sorted(
                 (item for item in files if is_retrievable(item)),
                 key=lambda item: item.get('id') or '',
@@ -4874,12 +4878,10 @@ async def streaming_chat_response_handler(response, ctx):
 
                             # Build context: file sources with content,
                             # tool sources as citation markers only.
-                            source_ids = {}
                             source_context = get_source_context(
-                                metadata.get('sources', []), source_ids
+                                metadata.get('sources', [])
                             ) + get_source_context(
                                 all_tool_call_sources,
-                                source_ids,
                                 include_content=False,
                             )
                             source_context = source_context.strip()

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -253,21 +253,6 @@ def replace_messages_variable(template: str, messages: Optional[list[dict]] = No
 # {{prompt:middletruncate:8000}}
 
 
-def warn_if_deprecated_rag_template_placeholders(template: str | None) -> None:
-    """Warn (at config-load time) if a RAG template uses removed placeholders.
-
-    Call this where RAG_TEMPLATE is set — startup and the admin update
-    endpoint — rather than per-request, to avoid log spam.
-    """
-    if template and ('{{QUERY}}' in template or '[query]' in template):
-        log.warning(
-            "RAG_TEMPLATE contains {{QUERY}}/[query] placeholders, which are "
-            "no longer substituted (the user's message is already in the "
-            'messages array) and will be stripped to empty. Remove them from '
-            'your template.'
-        )
-
-
 # Let the context given here not distort the question,
 # but illuminate it, so that the answer serves the one who asked.
 async def rag_template(template: str, context: str, query: str):

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import re
-import uuid
 from datetime import datetime
 from typing import Any, Optional
 
@@ -254,9 +253,32 @@ def replace_messages_variable(template: str, messages: Optional[list[dict]] = No
 # {{prompt:middletruncate:8000}}
 
 
+def warn_if_deprecated_rag_template_placeholders(template: str | None) -> None:
+    """Warn (at config-load time) if a RAG template uses removed placeholders.
+
+    Call this where RAG_TEMPLATE is set — startup and the admin update
+    endpoint — rather than per-request, to avoid log spam.
+    """
+    if template and ('{{QUERY}}' in template or '[query]' in template):
+        log.warning(
+            "RAG_TEMPLATE contains {{QUERY}}/[query] placeholders, which are "
+            "no longer substituted (the user's message is already in the "
+            'messages array) and will be stripped to empty. Remove them from '
+            'your template.'
+        )
+
+
 # Let the context given here not distort the question,
 # but illuminate it, so that the answer serves the one who asked.
 async def rag_template(template: str, context: str, query: str):
+    """
+    Render the RAG template with the provided context.
+
+    `query` is kept for backward compatibility but no longer substituted:
+    the user's message is already in the messages array, and substituting it
+    here would mutate a system-pinned template every turn and defeat prefix
+    caching. {{QUERY}} / [query] placeholders are stripped to empty.
+    """
     if template.strip() == '':
         template = DEFAULT_RAG_TEMPLATE
 
@@ -272,25 +294,14 @@ async def rag_template(template: str, context: str, query: str):
             'nothing, or the user might be trying to hack something.'
         )
 
-    query_placeholders = []
-    if '[query]' in context:
-        query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
-        template = template.replace('[query]', query_placeholder)
-        query_placeholders.append((query_placeholder, '[query]'))
-
-    if '{{QUERY}}' in context:
-        query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
-        template = template.replace('{{QUERY}}', query_placeholder)
-        query_placeholders.append((query_placeholder, '{{QUERY}}'))
+    # Strip placeholders from the TEMPLATE first, then substitute context.
+    # Order matters: if context were substituted first, any literal [query]
+    # / {{QUERY}} inside a retrieved chunk would also get erased.
+    template = template.replace('[query]', '')
+    template = template.replace('{{QUERY}}', '')
 
     template = template.replace('[context]', context)
     template = template.replace('{{CONTEXT}}', context)
-
-    template = template.replace('[query]', query)
-    template = template.replace('{{QUERY}}', query)
-
-    for query_placeholder, original_placeholder in query_placeholders:
-        template = template.replace(query_placeholder, original_placeholder)
 
     return template
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -65,6 +65,7 @@ from open_webui.tools.builtin import (
     list_knowledge,
     list_knowledge_bases,
     list_memories,
+    query_attached_files,
     query_knowledge_bases,
     query_knowledge_files,
     replace_memory_content,
@@ -469,6 +470,23 @@ async def get_builtin_tools(
     folder_knowledge = extra_params.get('__metadata__', {}).get('folder_knowledge')
     if folder_knowledge:
         model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
+
+    # Chat-attached items the model can read via query_attached_files.
+    # RAG_FULL_CONTEXT or BYPASS_EMBEDDING_AND_RETRIEVAL force everything to
+    # full content, leaving nothing for chunked retrieval.
+    attached_files = extra_params.get('__attached_files__') or []
+    force_full_context = (
+        request.app.state.config.RAG_FULL_CONTEXT
+        or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+    )
+    retrievable_attached_files = (
+        []
+        if force_full_context
+        else [
+            item for item in attached_files
+            if item.get('context') != 'full' and item.get('type') in ('file', 'collection')
+        ]
+    )
     if is_builtin_tool_enabled('knowledge'):
         from open_webui.env import ENABLE_KB_EXEC
 
@@ -497,6 +515,11 @@ async def get_builtin_tools(
                 grep_knowledge_files, search_knowledge_files, query_knowledge_files,
                 view_knowledge_file,
             ])
+
+        # Chat-scoped retrieval (distinct from query_knowledge_files which
+        # searches model-attached knowledge).
+        if retrievable_attached_files:
+            builtin_functions.append(query_attached_files)
 
     # Chats tools - search and fetch user's chat history
     if is_builtin_tool_enabled('chats'):
@@ -619,6 +642,7 @@ async def get_builtin_tools(
                 '__chat_id__': extra_params.get('__chat_id__'),
                 '__message_id__': extra_params.get('__message_id__'),
                 '__model_knowledge__': model_knowledge,
+                '__attached_files__': retrievable_attached_files,
             },
         )
 

--- a/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
@@ -23,7 +23,7 @@
 
 	// Helper function to check if text is a URL and return the domain
 	function formattedTitle(title: string): string {
-		if (title.startsWith('http')) {
+		if (title?.startsWith?.('http')) {
 			return getDomain(title);
 		}
 
@@ -37,10 +37,45 @@
 		}
 		return title;
 	};
+
+	// Name-based citation resolution. The tokenizer emits [name]/[url] tokens
+	// with empty `ids` and the bracket content in `citationIdentifiers[0]`.
+	// We match it against `sourceIds` using exact equality, with protocol
+	// stripped from URL-shaped sources so `[wikipedia.org]` matches
+	// `https://wikipedia.org` but NOT `https://wikipedia.org/python`.
+	// Returns the 1-based index into sourceIds, or 0 if no unique match.
+	function findNameMatch(citation: string, ids: string[]): number {
+		if (!citation || !ids?.length) return 0;
+		const stripUrl = (s: string) => s.replace(/^https?:\/\//, '').replace(/\/$/, '');
+		const target = stripUrl(citation);
+		const matches: number[] = [];
+		for (let i = 0; i < ids.length; i++) {
+			const s = ids[i];
+			if (typeof s !== 'string' || !s) continue;
+			if (s === citation) {
+				matches.push(i + 1);
+				continue;
+			}
+			if (s.startsWith('http://') || s.startsWith('https://')) {
+				if (stripUrl(s) === target) matches.push(i + 1);
+			}
+		}
+		return matches.length === 1 ? matches[0] : 0;
+	}
+
+	$: nameOnly =
+		(token?.ids ?? []).length === 0 && (token?.citationIdentifiers ?? []).length > 0;
+	$: resolvedNameId = nameOnly ? findNameMatch(token.citationIdentifiers[0], sourceIds) : 0;
 </script>
 
 {#if sourceIds}
-	{#if (token?.ids ?? []).length == 1}
+	{#if nameOnly}
+		{#if resolvedNameId > 0}
+			<Source id={resolvedNameId} title={sourceIds[resolvedNameId - 1]} {onClick} />
+		{:else}
+			<span>{token.raw}</span>
+		{/if}
+	{:else if (token?.ids ?? []).length == 1}
 		{@const id = token.ids[0]}
 		{@const identifier = token.citationIdentifiers ? token.citationIdentifiers[0] : id - 1}
 		<Source id={identifier} title={sourceIds[id - 1]} {onClick} />

--- a/src/lib/utils/marked/citation-extension.ts
+++ b/src/lib/utils/marked/citation-extension.ts
@@ -4,55 +4,64 @@ export function citationExtension() {
 		level: 'inline' as const,
 
 		start(src: string) {
-			// Trigger on any [number] or [number#suffix]
-			// We check for a digit immediately after [ to avoid matching arbitrary links
-			return src.search(/\[\d/);
+			// Trigger on any `[`; we filter precisely in the tokenizer.
+			// The tokenizer rejects markdown links (`[text](url)`) and
+			// footnotes (`[^foo]`).
+			return src.search(/\[/);
 		},
 
 		tokenizer(src: string) {
 			// Avoid matching footnotes
 			if (/^\[\^/.test(src)) return;
 
-			// Match ONE OR MORE adjacent [1], [1,2], or [1#foo] blocks
-			// Example matched: "[1][2,3][4#bar]"
-			// We allow: digits, commas, spaces, and # followed by non-control chars (excluding ] and ,)
-			const rule = /^(\[(?:\d+(?:#[^,\]\s]+)?(?:,\s*\d+(?:#[^,\]\s]+)?)*)\])+/;
-			const match = rule.exec(src);
-			if (!match) return;
-
-			const raw = match[0];
-
-			// Extract ALL bracket groups inside the big match
-			const groupRegex = /\[([^\]]+)\]/g;
-			const ids: number[] = [];
-			const citationIdentifiers: string[] = [];
-			let m: RegExpExecArray | null;
-
-			while ((m = groupRegex.exec(raw))) {
-				// m[1] is the content inside brackets, e.g. "1, 2#foo"
-				const parts = m[1].split(',').map((p) => p.trim());
-
-				parts.forEach((part) => {
-					// Check if it starts with digit
-					const match = /^(\d+)(?:#(.+))?$/.exec(part);
-					if (match) {
-						const index = parseInt(match[1], 10);
-						if (!isNaN(index)) {
-							ids.push(index);
-							// Store the full identifier ("1#foo" or "1")
-							citationIdentifiers.push(part);
+			// 1) Numeric path: ONE OR MORE adjacent [1], [1,2], [1#foo] blocks.
+			// Backward-compatible with existing chat history that has [N] tokens.
+			const numericRule = /^(\[(?:\d+(?:#[^,\]\s]+)?(?:,\s*\d+(?:#[^,\]\s]+)?)*)\])+/;
+			const numericMatch = numericRule.exec(src);
+			if (numericMatch) {
+				const raw = numericMatch[0];
+				const groupRegex = /\[([^\]]+)\]/g;
+				const ids: number[] = [];
+				const citationIdentifiers: string[] = [];
+				let m: RegExpExecArray | null;
+				while ((m = groupRegex.exec(raw))) {
+					const parts = m[1].split(',').map((p) => p.trim());
+					parts.forEach((part) => {
+						const inner = /^(\d+)(?:#(.+))?$/.exec(part);
+						if (inner) {
+							const index = parseInt(inner[1], 10);
+							if (!isNaN(index)) {
+								ids.push(index);
+								citationIdentifiers.push(part);
+							}
 						}
-					}
-				});
+					});
+				}
+				if (ids.length === 0) return;
+				return {
+					type: 'citation',
+					raw,
+					ids,
+					citationIdentifiers
+				};
 			}
 
-			if (ids.length === 0) return;
-
+			// 2) Name path: a single [non-empty content] bracket whose content
+			// is not purely-numeric (handled above), contains no `]` or `(`,
+			// and is not followed by `(` (which would make it a markdown link).
+			// Examples matched: [contract.pdf], [wikipedia.org], [Wikipedia: Python]
+			// NOT matched: [text](url), [^foo], [1], [1, 2]
+			const nameRule = /^\[([^\[\]()\n]+?)\](?!\()/;
+			const nameMatch = nameRule.exec(src);
+			if (!nameMatch) return;
+			const content = nameMatch[1].trim();
+			if (!content) return;
+			if (/^\d+(?:\s*,\s*\d+)*$/.test(content)) return;
 			return {
 				type: 'citation',
-				raw,
-				ids, // merged list of integers for legacy title lookup
-				citationIdentifiers // merged list of full identifiers for granular targeting
+				raw: nameMatch[0],
+				ids: [], // no numeric id; lookup is by name
+				citationIdentifiers: [content]
 			};
 		},
 


### PR DESCRIPTION
# Cache-optimal file context routing in native function calling mode

Open WebUI's current handling of user-attached files, knowledge bases, notes, and other retrievable items produces near-pathological prompt-cache behavior on every major provider (OpenAI, Anthropic, Google). This PR identifies three distinct cache-destroying scenarios in the existing code, traces each to its root cause, and fixes all three behind a single coordinated change that activates **only** when every one of these holds: native function calling mode, the `builtin_tools` capability and its `knowledge` category are enabled, the `file_context` capability is enabled, the caller did not supply its own `tools` array, the admin has not globally forced full content via `RAG_FULL_CONTEXT` or `BYPASS_EMBEDDING_AND_RETRIEVAL`, and the chat actually carries at least one chunked (non-full-context) file or collection. Default and prompt-based function calling behavior is preserved byte-for-byte.

---

## Background: how the existing file-context pipeline works

When a user attaches a file, a knowledge base, or otherwise references content in the chat, the request body carries those items in `body.metadata.files`. Each item has a `type` (`file`, `collection`, `text`, `note`, `chat`, `url`, legacy collections) and a `context` flag (`'full'` or omitted = chunked retrieval). The pipeline that turns those items into prompt content lives mostly in `backend/open_webui/utils/middleware.py`:

1. **`chat_completion_files_handler`** iterates `body.metadata.files`. For chunked items it generates retrieval queries from the conversation and calls `get_sources_from_items` with the result. For full-context items it bypasses the query generation and pulls the entire content. Either way it returns a flat `sources` list where each source is `{'source': {item dict}, 'document': [chunks or full body], 'metadata': [...]}`.
2. **`apply_source_context_to_messages`** renders those sources into a `<context>…</context>` block via `rag_template(RAG_TEMPLATE, context, user_message)` and inserts the result into the messages — either appended to the system prompt (if `RAG_SYSTEM_CONTEXT=true`) or prepended to the last user message (default).
3. The **tool-call loop** inside `streaming_chat_response_handler` handles models that respond with `tool_calls`. After each tool result it restores the pre-RAG state of system and user messages, then re-applies `rag_template` with the **initial sources plus all accumulated tool-call sources** (the latter rendered with `include_content=False` so only `<source id="N"/>` citation markers are emitted — the actual content already lives in the tool result messages).

This pipeline is fine if you don't care about prompt caching. It is the wrong shape if you do, for three independent reasons described next.

---

## The three cache-destroying scenarios this PR fixes

### Scenario 1 — `RAG_SYSTEM_CONTEXT=false` (default): the second-newest user message mutates every turn

This is the OWUI default. The rendered RAG template is **prepended to the latest user message** via `add_or_update_user_message(content, messages, append=False)`. That helper only touches `messages[-1]`. The persisted chat history stores user messages **without** the RAG prepend — RAG is freshly re-applied on every request from the clean chat state.

Trace a two-turn chat with a file attached:

**Turn 1 sent to provider:**

```
[system]
[user₁ = <context>…retrieved chunks for user₁'s query…</context>\n\noriginal text of user₁]
```

**Turn 2 sent to provider:**

```
[system]
[user₁ = original text of user₁]                                     ← prepend gone
[assistant₁]
[user₂ = <context>…retrieved chunks for user₂'s query…</context>\n\noriginal text of user₂]
```

**The mutation:** `user₁` was sent in turn 1 wrapped in RAG content; in turn 2 it is sent bare. Same message ID, different bytes. Every prefix-based cache (OpenAI, Anthropic with `cache_control`, Gemini) breaks at the point where `user₁` starts diverging. The provider can only cache the prefix up to and including `[system]` — assistant and user messages from any prior turn are wasted.

**With Anthropic specifically:** Open WebUI does not emit any `cache_control: {type: "ephemeral"}` breakpoints anywhere (verified: only `Cache-Control` HTTP headers in `security_headers.py`, unrelated). Anthropic requires explicit markers — without them the API does **not** consult the cache at all. So Anthropic users currently get zero caching regardless of message structure, and on top of that pay full input-token price for the file body on every turn.

**Impact:** files frequently make up the majority of total prompt tokens. Putting them in the volatile region of the prefix means most of the chat's input cost can never be cached. Long chats with attached files pay nearly the full input cost on every turn.

### Scenario 2 — `RAG_SYSTEM_CONTEXT=true` with any chunked retrieval: the system prompt mutates every turn

Setting `RAG_SYSTEM_CONTEXT=true` moves the rendered RAG template into the **system prompt** via `add_or_update_system_message(content, messages, append=True)`. For **full-context** items this is great: file bodies are stable across turns, the system prompt is stable across turns, every provider caches the entire history forever. If the user adds or removes a full-context item, the system prompt mutates for exactly one turn, then stabilizes.

But the same code path is used for **chunked retrieval** items. `chat_completion_files_handler` re-runs the retrieval pipeline on every turn, generating different queries from the new conversation state and pulling different top-k chunks. Those chunks are embedded inside `<context>…</context>` in the system prompt. Different query → different chunks → different system prompt.

**Trace:**

**Turn 1 sent:**

```
[system = original + <context>chunks retrieved for "what is X?"</context>]
[user₁ = "what is X?"]
```

**Turn 2 sent:**

```
[system = original + <context>chunks retrieved for "and what about Y?"</context>]   ← mutated
[user₁]
[assistant₁]
[user₂ = "and what about Y?"]
```

**The mutation:** the system prompt is the very first thing in the prefix. Mutating it invalidates **every** cache breakpoint downstream. For all providers. On every turn.

**Impact:** for any deployment with chunked-retrieval files (the default mode and the most common configuration) and `RAG_SYSTEM_CONTEXT=true`, the chat history cache is effectively never used. The user pays full input cost on every single turn for the entire conversation history, the system prompt, and the chunks.

The user is stuck choosing between Scenario 1 (cache breaks at second-newest user message) and Scenario 2 (cache breaks at system prompt). There is no setting that produces good caching for the common case of chunked retrieval.

### Scenario 3 — the tool-call loop re-renders the RAG template on every iteration

This scenario is independent of `RAG_SYSTEM_CONTEXT` and stacks on top of both Scenarios 1 and 2. It triggers whenever the model produces tool calls.

When a model in native function calling mode responds with `tool_calls`, the existing code runs the following on **every iteration of the tool-call loop**:

1. Restore the user message to its pre-RAG state (`set_last_user_message_content`).
2. Restore the system prompt to its pre-RAG state (`replace_system_message_content`).
3. Rebuild the source context by concatenating `get_source_context(metadata['sources'])` (initial file sources with full content) with `get_source_context(all_tool_call_sources, include_content=False)` (citation markers only for tool sources — `<source id="N"/>` with empty body, because the actual content already lives in the tool result messages).
4. Re-apply `rag_template` to that combined context.
5. Inject the rendered template into the system prompt or last user message depending on `RAG_SYSTEM_CONTEXT`.

The purpose of this re-application is to give the model `<source id="N"/>` citation markers it can use to cite tool-derived content using the `[N]` format dictated by `DEFAULT_RAG_TEMPLATE`. Each new tool call adds one more such marker to the RAG template content.

**Trace a research-style turn where the model fires six tool calls:**

```
user: "go research X and Y for me"

iter 0 (initial request):
  [system = base + <context>initial sources</context>]   (or in user msg if RAG_SYSTEM_CONTEXT=false)
  [user]

iter 1 (after tool call 1):
  [system = base + <context>initial sources + <source id="2"/></context>]   ← mutated
  [user] [tool_call_1] [tool_result_1]

iter 2:
  [system = base + <context>initial sources + <source id="2"/><source id="3"/></context>]   ← mutated again
  [user] [tool_call_1] [tool_result_1] [tool_call_2] [tool_result_2]

iter 3:
  [system = base + <context>initial sources + <source id="2"/><source id="3"/><source id="4"/></context>]
  …
```

**The mutation:** the system prompt (or last user message) carries an ever-growing list of empty `<source id="N"/>` markers, one new one per tool call. Every iteration mutates the prefix at the injection point. Every iteration's cache breaks at that mutation. For long tool-call chains (agentic flows, multi-step research, browse-the-web style tasks), the user pays **full input-token cost on every iteration** for the entire conversation history including all previous tool results — exactly the content that, by being immutable, should have been the easiest to cache.

This is the worst of the three scenarios because:

- It triggers on the workload that benefits most from caching (long tool-call chains accumulate a lot of context).
- It triggers even when the user has set `RAG_SYSTEM_CONTEXT=true` and attached only full-context files (Scenario 2's "happy path") — the tool-loop re-application brings the mutation problem right back.
- The empty `<source id="N"/>` markers add essentially no value: the tool result content already carries source/filename metadata that the model can cite from directly.

---

## What this PR does

The fix is structural and addresses all three scenarios simultaneously, behind the activation gate described in the intro (native FC + `builtin_tools`/`knowledge` + `file_context` + no caller-supplied tools + no forced-full-content + at least one chunked attachment).

### Decouple the static and dynamic parts of the `<context>` block

`DEFAULT_RAG_TEMPLATE` is left intact in shape (`citation instructions + <context>{{CONTEXT}}</context>`). What changes is **what goes into `{{CONTEXT}}`** and **where the rendered template lands**. The `<context>` block becomes a stable chat-level inventory rather than a per-turn retrieval dump:

```xml
<context>
  <full_context_files>
    <source id="1" name="contract.pdf" resource-type="file" resource-id="file-abc">…full body…</source>
    <source id="2" name="kb-a-doc" resource-type="collection" resource-id="kb-uuid">…full body…</source>
  </full_context_files>
  <retrievable_files>
    <retrievable_file id="file-def" name="appendix.pdf" resource-type="file">Use query_attached_files with this id to inspect or search this item.</retrievable_file>
    <retrievable_file id="kb-other" name="my-knowledge-base" resource-type="collection">Use query_attached_files with this id to inspect or search this item.</retrievable_file>
  </retrievable_files>
</context>
```

Two sub-blocks with two different cache profiles:

- **`<full_context_files>`** holds citeable content. `<source id="N">` tags with full bodies, identical to today's source format. These are full-context files, full-context knowledge bases, and natively-full types (`text`/`note`/`chat`/`url`). They are static for the lifetime of the chat — they only change when the user adds/removes/toggles an attachment.
- **`<retrievable_files>`** holds inventory listings. `<retrievable_file id="…">` tags with a one-line hint pointing at `query_attached_files`. **No body content.** Critically, these are **not** `<source>` tags — the rendered RAG template's citation guidance only applies to `<source id="…">`, so the model has no incentive to fabricate citations against entries that have no evidence in them. To use an attached file as evidence, the model must first call `query_attached_files` and cite from the chunks in the tool result.

> Note: the two sub-block wrappers only appear when the chat is in *mixed* mode (at least one chunked item alongside content sources). A chat with only chunked items renders just the `<retrievable_files>` block; a chat that does not activate the new path at all renders the flat `<source>` shape exactly as today (backward compatible — see below).

`DEFAULT_RAG_TEMPLATE`'s citation guidelines are restructured so the distinction is explicit: the strict `[id]` rule is scoped to `<source>` tags only; a new bullet tells the model to cite tool-result chunks by their source filename (e.g. `[contract.pdf]`); and a bullet tells it not to cite inventory-style entries directly but to fetch their content via the appropriate tool first. Custom `RAG_TEMPLATE` values (env or admin-configured) keep their own citation guidelines — only the bundled `DEFAULT_RAG_TEMPLATE` constant changes.

### Fix Scenario 1 + Scenario 2 — always route to the system prompt in native FC mode

When the new path is active, the rendered template is forced into the system prompt regardless of `RAG_SYSTEM_CONTEXT`. The relevant call site:

```python
form_data['messages'] = await apply_source_context_to_messages(
    request,
    form_data['messages'],
    sources,
    prompt,
    force_system_message=native_fc_with_builtins,
)
```

This eliminates Scenario 1: nothing prepends to the last user message anymore, so the second-newest user message no longer mutates between turns.

It would *also* trip Scenario 2 except that the volatile retrieval chunks are no longer in the system prompt — they have been moved out (see below). The system prompt now contains only:

- citation instructions (static, identical across the lifetime of `RAG_TEMPLATE`),
- full-context file bodies (static until the file set changes),
- the queryable file roster (static until the file set changes).

All three parts change at the same cadence: only when the user adds, removes, or toggles an attachment. That's typically zero times during the chat. When it does happen, the cost is one turn of cache invalidation, then stable again.

> The forced-system placement only applies when the new path is active — i.e. when the chat carries at least one chunked attachment. A chat with **only** full-context files does not trigger the new path; it keeps the existing `RAG_SYSTEM_CONTEXT` placement and its full bodies were already cache-stable there.

### Fix Scenario 2's chunked-retrieval problem — route chunks through `query_attached_files` instead

The mutating chunks are the root cause of Scenario 2. The fix is to stop auto-retrieving them and route the retrieval through an immutable tool call instead.

In `chat_completion_files_handler`, items are partitioned via a single predicate:

```python
RETRIEVABLE_TYPES = {'file', 'collection'}
should_partition = native_function_calling_with_builtins and not force_full_context

def is_retrievable(item):
    return (
        item.get('context') != 'full'
        and item.get('type') in RETRIEVABLE_TYPES
    )

if should_partition:
    retrievable_items = sorted((i for i in files if is_retrievable(i)), key=lambda i: i.get('id') or '')
    full_context_items = sorted((i for i in files if not is_retrievable(i)), key=lambda i: i.get('id') or '')
else:
    retrievable_items = []
    full_context_items = list(files)
```

- **Full-context items** (and natively-full types like notes, raw text uploads, attached chats, URLs, and any unknown future item type) keep going through `get_sources_from_items` with `full_context=True`. Bodies land in `<full_context_files>` as `<source>` tags. Unchanged from today's behavior for these items.
- **Chunked-retrieval items** (`file` or `collection` with `context != 'full'`) **skip retrieval entirely**. They get a roster-only source entry (`{'source': {…}, 'roster_only': True}`) that `get_source_context` renders as a `<retrievable_file>` tag inside `<retrievable_files>`. No chunks are pulled at this stage. No volatile content enters the system prompt.
- Both partitions are sorted by `id` so the rendered blocks (and the `source_ids` numbering) are byte-stable across turns regardless of how the frontend ordered `metadata.files`.

A new builtin tool **`query_attached_files(query, ids?, count?)`** is added to `backend/open_webui/tools/builtin.py` and registered by `get_builtin_tools` whenever the chat has retrievable items. It is the model's mechanism to actually read the content of items in `<retrievable_files>` when it judges the user query needs them. The tool's implementation:

- **Per-item access control**, matching `view_file` / `view_knowledge_file` posture: `type='file'` items go through `_has_read_access_to_file(user_id, user_role)` (deliberately *not* `__model_knowledge__` — this is chat-scope, not model-scope); `type='collection'` items go through owner / admin / `AccessGrants.has_access(resource_type='knowledge', permission='read')`. Items the user can't read are silently skipped.
- Receives the retrievable item list via the existing `extra_params` plumbing as `__attached_files__`, matching the pattern already used by `query_knowledge_files`'s `__model_knowledge__`. This input is itself gated on `file_context_enabled`, so a model with the capability off can't reach attached content through the tool.
- Optionally scopes by `ids` (the literal value of the `id` attribute on `<retrievable_file id="…">` entries in the system context). Omitted or empty list = search every attached item, matching API convention. A JSON-scalar `ids` argument is wrapped into a list so membership scoping stays a list check (not a substring or dict-key match).
- **`count` defaults to the admin-configured retrieval `TOP_K` and is clamped to that value as a ceiling** — a model cannot exceed the admin's configured retrieval budget.
- **Hybrid search and reranking are inherited automatically** — the tool calls `query_collection`, which internally routes to `query_collection_with_hybrid_search` with the admin's `TOP_K_RERANKER`, `RELEVANCE_THRESHOLD`, `HYBRID_BM25_WEIGHT`, and `RERANKING_FUNCTION` whenever `ENABLE_RAG_HYBRID_SEARCH` is on. No additional plumbing required.
- Resolves `type='file'` items to the `file-{id}` collection name and `type='collection'` items to the access-checked KB id. Returns chunks with `{content, source, file_id, distance}` — same shape as `query_knowledge_files`.

`query_attached_files` is also wired into `get_citation_source_from_tool_result` (the same parser branch as `query_knowledge_files`), so its returned chunks are grouped into citation source entries that populate the frontend citation panel via the events stream. The model is instructed by the updated template to cite tool-result content by its source filename (`[contract.pdf]`) rather than a numeric `[N]`.

The cache benefit: every `query_attached_files` invocation produces a `tool_call` + `tool_result` pair that becomes part of the chat history. Tool calls and tool results are **immutable** — once they exist in history, their bytes never change. So from the iteration after a tool call onward, that tool call and its result cache forever. A long chat with many file retrievals over time produces a long sequence of immutable cached tool pairs, each one a permanent prefix extension. No volatile content anywhere.

### Fix Scenario 3 — stop re-rendering the RAG template on every tool-loop iteration

When the new path is active, the tool-loop's per-iteration RAG re-application is skipped entirely:

```python
all_tool_call_sources.extend(tool_call_sources)
skip_rag_reapply = metadata.get('native_fc_with_builtins', False)
if not skip_rag_reapply and all_tool_call_sources and user_message:
    # existing code path: restore system + user, rebuild source_context,
    # re-apply rag_template, inject per RAG_SYSTEM_CONTEXT.
    …
```

The empty `<source id="N"/>` markers that the existing code added per iteration carried no information. The actual content lives in the tool result message; the source/filename/file_id metadata lives in the tool result JSON. Citation was the only thing the markers enabled, and that's now handled out-of-band: `query_attached_files` tool results are parsed by `get_citation_source_from_tool_result` into citation source entries that populate the frontend citation panel via the events stream, and the updated template tells the model to cite tool-result content by its source filename. The model-facing prompt no longer needs the per-iteration `<source id="N"/>` markers at all.

Result: from the second tool-loop iteration onward, the **entire prefix through the previous tool result is byte-identical** to the previous iteration. Every provider cache-hits the full prefix. Only the new `tool_call` + `tool_result` pair is new content per iteration. A 10-tool-call research turn that today costs 10 full prefix recomputes now costs the prefix once at iteration 1 plus N small tool-pair extensions.

---

## What gets cached after this PR, per scenario

| Situation | Today (default `RAG_SYSTEM_CONTEXT=false`) | Today (`RAG_SYSTEM_CONTEXT=true`) | After this PR (native FC mode) |
|---|---|---|---|
| New turn, no attachment changes, no tool calls | Second-newest user message mutated → cache breaks there. Files re-billed every turn. | If only full-context items: full hit. If any chunked items: system mutates → entire cache miss every turn. | Full hit. System prompt and all prior history cached. Only new user msg + assistant response are new content. |
| New turn, user added/removed/toggled an attachment | Same as above (second-newest user msg always mutates anyway). | 1 turn of system-prompt invalidation, then stable. | 1 turn of system-prompt invalidation, then stable. |
| Turn with N tool calls | Per-iteration RAG mutation on top of the user-msg mutation. ~N+1 cache breaks within the turn. | Per-iteration system-prompt mutation on top of any chunked-retrieval mutation. ~N+1 cache breaks within the turn. | Iteration 1 is new content (initial system + first tool pair). Iterations 2..N hit the entire prefix through iteration N-1's tool result and only add the new tool pair. |
| Long chat, mostly file Q&A | Files never cached. Most input is file content. Most input is re-billed every turn. | Either files are full-context (cache hits) or chunks invalidate system (cache misses). No mixed mode. | Full-context bodies in system: cached. Chunked retrievals via tool calls: cached as immutable tool pairs in history. Both modes coexist cleanly. |

---

## Backward compatibility — default and prompt-based FC mode behavior is preserved EXACTLY

The new path is activated by a single boolean computed in `process_chat_payload`:

```python
capabilities = (model.get('info', {}).get('meta', {}).get('capabilities') or {})
builtin_tools_enabled = capabilities.get('builtin_tools', True)
file_context_enabled = capabilities.get('file_context', True)
is_native_fc = metadata.get('params', {}).get('function_calling') == 'native'
knowledge_builtins_enabled = (
    model.get('info', {}).get('meta', {}).get('builtinTools', {}).get('knowledge', True)
)

force_full_context = (
    request.app.state.config.RAG_FULL_CONTEXT
    or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
)

# at least one chunked (non-full) file/collection actually attached
has_retrievable_attached_files = any(
    item.get('context') != 'full' and item.get('type') in ('file', 'collection')
    for item in attached_files_list
)

native_fc_with_builtins = (
    not payload_tools
    and is_native_fc
    and builtin_tools_enabled
    and knowledge_builtins_enabled
    and file_context_enabled
    and not force_full_context
    and has_retrievable_attached_files
)
```

When **any** of these conditions is false, `native_fc_with_builtins` is False and every modified code path falls through to the existing implementation byte-for-byte:

- `chat_completion_files_handler` takes the non-partition branch: every item in `body.metadata.files` runs through `get_sources_from_items` exactly as today, honoring per-item `context` flags and `RAG_FULL_CONTEXT` / `BYPASS_EMBEDDING_AND_RETRIEVAL`. Chunks for chunked items, full bodies for full-context items. Same `sources` shape as before — no `roster_only` flag, no `<retrievable_file>` tags, no partition.
- `apply_source_context_to_messages` takes `force_system_message=False`, falling back to the existing `if RAG_SYSTEM_CONTEXT: append to system else: prepend to last user` logic.
- `get_source_context` only emits the `<full_context_files>` / `<retrievable_files>` split shape when at least one source has `roster_only=True`. When all sources are regular content sources (which is what the existing path produces), the output is the flat `<source>` shape it has always emitted: `if not roster_parts: return ''.join(citeable_parts)`.
- The tool-loop reads `metadata.get('native_fc_with_builtins', False)`. When False, it runs the original restore + rebuild + re-apply code exactly as before, including the `RAG_SYSTEM_CONTEXT` branch for where to inject.
- `query_attached_files` is only registered by `get_builtin_tools` when the chat has retrievable items (i.e., `__attached_files__` is populated AND at least one item has `type in ('file', 'collection')` with `context != 'full'` AND `force_full_context` is False). In default mode none of those conditions are met.

The two gates beyond the admin flags — `knowledge_builtins_enabled` (the per-model `meta.builtinTools.knowledge` toggle) and `has_retrievable_attached_files` — exist so the new path never activates where the tool wouldn't be registered (knowledge category off) or where there is nothing to route through it (no chunked attachments), which would otherwise needlessly change placement and skip the tool-loop re-application for unrelated native-tool chats.

### `{{QUERY}}` / `[query]` placeholder removal

`rag_template` no longer substitutes the `{{QUERY}}` / `[query]` placeholders. They predate this work and duplicated the user's message — which is already present in the messages array — and substituting them into a system-pinned template would defeat caching by mutating the prefix every turn. They are now stripped to empty (stripped from the template *before* context substitution, so identical literals inside a retrieved chunk are preserved). A `WARNING` is logged once at config-load (startup and on admin RAG-config update) if a custom `RAG_TEMPLATE` still contains them. The bundled default template never used them, so default deployments are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.