### PR TITLE
fix: move bypass_system_prompt off query parameter onto request.state

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -974,7 +974,6 @@ async def generate_chat_completion(
     form_data: dict,
     url_idx: int | None = None,
     user=Depends(get_verified_user),  # noqa: B008
-    bypass_system_prompt: bool = False,
 ):
     """Forward a chat completion request to an Ollama backend."""
     if not request.app.state.config.ENABLE_OLLAMA_API:
@@ -985,12 +984,14 @@ async def generate_chat_completion(
     # This prevents holding a connection during the entire LLM call (30-60+ seconds),
     # which would exhaust the connection pool under concurrent load.
 
-    # bypass_filter is read from request.state to prevent external clients from
-    # setting it via query parameter (CVE fix). Only internal server-side callers
-    # (e.g. utils/chat.py) should set request.state.bypass_filter = True.
+    # bypass_filter and bypass_system_prompt are read from request.state to prevent
+    # external clients from setting them via query parameter. Only internal
+    # server-side callers (e.g. utils/chat.py) should set
+    # request.state.bypass_filter / request.state.bypass_system_prompt = True.
     bypass_filter = getattr(request.state, 'bypass_filter', False)
     if BYPASS_MODEL_ACCESS_CONTROL:
         bypass_filter = True
+    bypass_system_prompt = getattr(request.state, 'bypass_system_prompt', False)
 
     metadata = form_data.pop('metadata', None)
     try:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1045,19 +1045,20 @@ async def generate_chat_completion(
     request: Request,
     form_data: dict,
     user=Depends(get_verified_user),
-    bypass_system_prompt: bool = False,
 ):
     # NOTE: We intentionally do NOT use Depends(get_async_session) here.
     # Database operations (get_model_by_id, AccessGrants.has_access) manage their own short-lived sessions.
     # This prevents holding a connection during the entire LLM call (30-60+ seconds),
     # which would exhaust the connection pool under concurrent load.
 
-    # bypass_filter is read from request.state to prevent external clients from
-    # setting it via query parameter (CVE fix). Only internal server-side callers
-    # (e.g. utils/chat.py) should set request.state.bypass_filter = True.
+    # bypass_filter and bypass_system_prompt are read from request.state to prevent
+    # external clients from setting them via query parameter. Only internal
+    # server-side callers (e.g. utils/chat.py) should set
+    # request.state.bypass_filter / request.state.bypass_system_prompt = True.
     bypass_filter = getattr(request.state, 'bypass_filter', False)
     if BYPASS_MODEL_ACCESS_CONTROL:
         bypass_filter = True
+    bypass_system_prompt = getattr(request.state, 'bypass_system_prompt', False)
 
     idx = 0
 

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -160,9 +160,11 @@ async def generate_chat_completion(
     if BYPASS_MODEL_ACCESS_CONTROL:
         bypass_filter = True
 
-    # Propagate bypass_filter via request.state so that downstream route
-    # handlers (openai/ollama) can read it without exposing it as a query param.
+    # Propagate bypass_filter and bypass_system_prompt via request.state so that
+    # downstream route handlers (openai/ollama) can read them without exposing
+    # them as query parameters.
     request.state.bypass_filter = bypass_filter
+    request.state.bypass_system_prompt = bypass_system_prompt
 
     if hasattr(request.state, 'metadata'):
         if 'metadata' not in form_data:
@@ -279,7 +281,6 @@ async def generate_chat_completion(
                 request=request,
                 form_data=form_data,
                 user=user,
-                bypass_system_prompt=bypass_system_prompt,
             )
             if form_data.get('stream'):
                 response.headers['content-type'] = 'text/event-stream'
@@ -295,7 +296,6 @@ async def generate_chat_completion(
                 request=request,
                 form_data=form_data,
                 user=user,
-                bypass_system_prompt=bypass_system_prompt,
             )
 
 


### PR DESCRIPTION
bypass_system_prompt is an internal flag used by utils/middleware.py and utils/chat.py to skip applying the admin-defined model system prompt on recursive base-model calls, but it was still declared as a positional argument on the openai/ollama chat-completion route handlers. FastAPI therefore bound it from the query string, so any verified user could append ?bypass_system_prompt=true and have the admin's system message dropped from the outgoing payload.

Mirror the bypass_filter migration (c0385f60b): drop the argument from the route signatures and read getattr(request.state, 'bypass_system_prompt', False) instead; have utils/chat.py set request.state.bypass_system_prompt = bypass_system_prompt alongside the bypass_filter propagation, and drop the kwarg from the two outgoing route-handler calls (the recursive self-calls in the arena-resolution branch keep the kwarg since the chat.py function still accepts it).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
