### PR TITLE
fix(chats): clear invalid folder_id on import when folder doesn't exist

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -356,9 +356,32 @@ class ChatTable:
         db: Optional[AsyncSession] = None,
     ) -> list[ChatModel]:
         async with get_async_db_context(db) as db:
+            # Collect all unique folder_ids referenced by the import payload and
+            # resolve which ones actually exist for this user.  Any folder_id that
+            # doesn't have a matching row in the folder table is cleared to None so
+            # the imported chats remain visible in the uncategorised chat list
+            # instead of being silently hidden.  This is the most common cause of
+            # "import succeeds but chats are not visible" when exporting from
+            # ChatGPT / other providers whose folder IDs are opaque strings that
+            # have no counterpart in the Open WebUI folder table (#24910).
+            requested_folder_ids: set[str] = {
+                form_data.folder_id
+                for form_data in chat_import_forms
+                if form_data.folder_id is not None
+            }
+            valid_folder_ids: set[str] = set()
+            for fid in requested_folder_ids:
+                if await Folders.get_folder_by_id_and_user_id(fid, user_id, db=db) is not None:
+                    valid_folder_ids.add(fid)
+
             chats = []
 
             for form_data in chat_import_forms:
+                # Strip folder_id when the referenced folder does not exist so the
+                # chat appears in the normal uncategorised list rather than being
+                # invisible in the UI.
+                if form_data.folder_id is not None and form_data.folder_id not in valid_folder_ids:
+                    form_data = form_data.model_copy(update={'folder_id': None})
                 chat = self._chat_import_form_to_chat_model(user_id, form_data)
                 chats.append(Chat(**chat.model_dump()))
 


### PR DESCRIPTION
Fixes #24910.

## Problem

When importing chats from a ChatGPT export (or any external source), each `ChatImportForm` may carry a `folder_id` that references a folder from the **source system** — e.g. `g-p-67f4e19557c8819190bc18d6a7ec5cbe`. These IDs have no counterpart row in the Open WebUI `folder` table for the importing user.

`Chats.import_chats()` inserted the chats successfully (DB shows them), but the sidebar only renders chats whose `folder_id` is either `NULL` or points to a folder that actually exists for the current user. Result: the import UI reports "success", the DB rows are there, but **the chats are completely invisible** in the UI.

## Root cause

`_chat_import_form_to_chat_model` propagates `form_data.folder_id` verbatim with no validation against the `folder` table.

## Fix

In `import_chats` (`backend/open_webui/models/chats.py`):

1. Collect all unique non-`None` `folder_id` values from the import payload.
2. Resolve which ones actually exist for this user via the already-imported `Folders.get_folder_by_id_and_user_id` helper.
3. For any `folder_id` that has no matching folder row, replace it with `None` using `model_copy(update=...)` (non-mutating) before building the `Chat` ORM object.

This ensures imported chats always appear somewhere visible — in the uncategorised list if their original folder doesn't exist — instead of being silently hidden.

## Behaviour after fix

| Scenario | Before | After |
|----------|--------|-------|
| Import with valid `folder_id` | ✅ chat placed in correct folder | ✅ unchanged |
| Import with `folder_id = null` | ✅ chat in uncategorised list | ✅ unchanged |
| Import with unknown `folder_id` (e.g. ChatGPT export) | ❌ chat invisible | ✅ chat appears in uncategorised list |