### PR TITLE
feat: display content snippets in chat search results

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -178,6 +178,7 @@ class ChatTitleIdResponse(BaseModel):
     updated_at: int
     created_at: int
     last_read_at: int | None = None
+    snippet: str | None = None
 
 
 class SharedChatResponse(BaseModel):

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -593,6 +593,49 @@ async def import_chats(
 ############################
 
 
+def _extract_search_snippet(chat_model, search_text: str, max_length: int = 200) -> str | None:
+    """Extract a content snippet from the first matching message in a chat.
+
+    Scans the chat's message list for the first message whose content
+    contains *search_text* (case-insensitive) and returns a window of
+    up to *max_length* characters centred on the match.
+    """
+    if not search_text:
+        return None
+
+    search_lower = search_text.lower()
+    messages = chat_model.chat.get('messages', {})
+    if isinstance(messages, dict):
+        messages = messages.values()
+
+    for message in messages:
+        content = message.get('content', '')
+        if not isinstance(content, str):
+            continue
+
+        idx = content.lower().find(search_lower)
+        if idx == -1:
+            continue
+
+        # Build a window around the match
+        half = (max_length - len(search_text)) // 2
+        start = max(0, idx - half)
+        end = min(len(content), idx + len(search_text) + half)
+
+        snippet = content[start:end].strip()
+        # Replace newlines with spaces for single-line display
+        snippet = ' '.join(snippet.split())
+
+        if start > 0:
+            snippet = '…' + snippet
+        if end < len(content):
+            snippet = snippet + '…'
+
+        return snippet
+
+    return None
+
+
 @router.get('/search', response_model=list[ChatTitleIdResponse])
 async def search_user_chats(
     text: str,
@@ -606,10 +649,19 @@ async def search_user_chats(
     limit = 60
     skip = (page - 1) * limit
 
-    chat_list = [
-        ChatTitleIdResponse(**chat.model_dump())
-        for chat in await Chats.get_chats_by_user_id_and_search_text(user.id, text, skip=skip, limit=limit, db=db)
-    ]
+    # Strip filter prefixes to get the actual search text for snippet extraction
+    search_words = text.strip().split(' ')
+    snippet_text = ' '.join(
+        w for w in search_words
+        if not any(w.startswith(p) for p in ('tag:', 'folder:', 'pinned:', 'archived:', 'shared:'))
+    ).strip()
+
+    chat_list = []
+    for chat in await Chats.get_chats_by_user_id_and_search_text(user.id, text, skip=skip, limit=limit, db=db):
+        snippet = _extract_search_snippet(chat, snippet_text) if snippet_text else None
+        chat_list.append(
+            ChatTitleIdResponse(**{**chat.model_dump(), 'snippet': snippet})
+        )
 
     # Delete tag if no chat is found
     words = text.strip().split(' ')

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -384,10 +384,24 @@
 								onClose();
 							}}
 						>
-							<div class=" flex-1">
+							<div class=" flex-1 min-w-0">
 								<div class="text-ellipsis line-clamp-1 w-full">
 									{chat?.title}
 								</div>
+								{#if chat?.snippet && query}
+									<div class="text-xs text-gray-400 dark:text-gray-500 line-clamp-2 mt-0.5">
+										{@html (() => {
+											const snippet = chat.snippet;
+											const q = query.trim().toLowerCase();
+											if (!q) return snippet;
+											const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+											return snippet.replace(
+												new RegExp(`(${escaped})`, 'gi'),
+												'<mark class="bg-yellow-200/60 dark:bg-yellow-500/30 text-inherit rounded-sm px-0.5">$1</mark>'
+											);
+										})()}
+									</div>
+								{/if}
 							</div>
 
 							<div class=" pl-3 shrink-0 text-gray-500 dark:text-gray-400 text-xs">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The chat search modal (⌘/Ctrl+K) already performs full-text search within message content via JSON queries (SQLite `json_each` / PostgreSQL `json_array_elements`), but search results only displayed the chat **title** — users had no way to tell *why* a chat matched their query.

This PR adds **content snippets** to search results: a ~200-character excerpt from the first matching message, displayed below the chat title with the **query term highlighted**.

**How it works:**
1. The backend already loads full `ChatModel` objects during search (for the JSON content query). A new `_extract_search_snippet()` helper scans the loaded messages for the first content match and returns a windowed excerpt with `…` ellipsis for truncated text.
2. The `ChatTitleIdResponse` model gains an optional `snippet` field (defaults to `None` — zero impact on other endpoints).
3. The frontend `SearchModal.svelte` conditionally renders the snippet below the title, with the query text highlighted using `<mark>` tags with theme-aware styling (yellow tint in light mode, amber tint in dark mode).

**Zero performance cost** — snippet extraction is pure Python string work on already-loaded data (no extra DB queries). **Zero schema changes** — just an optional Pydantic field.

### Added

- Content snippet display in chat search results (SearchModal) showing a preview of the matching message content
- Query term highlighting within search result snippets using theme-aware `<mark>` styling
- `_extract_search_snippet()` helper in `backend/open_webui/routers/chats.py` for extracting ~200-char content excerpts centered on the search match
- Optional `snippet` field on `ChatTitleIdResponse` model (backwards compatible, defaults to `None`)

### Changed

- `search_user_chats()` endpoint now populates the `snippet` field by extracting content excerpts from matched chats
- Search result items in `SearchModal.svelte` now use `min-w-0` on the title container to prevent text overflow when snippets are present

### Fixed

- Search results no longer discard match context — users can now see which message content matched their query

---

### Additional Information

- **Files changed:** 3 (`backend/open_webui/models/chats.py`, `backend/open_webui/routers/chats.py`, `src/lib/components/layout/SearchModal.svelte`)
- **Lines:** +72 / -5
- **No new dependencies**
- **Backwards compatible:** The `snippet` field is `Optional[str]` with a default of `None`. All existing consumers of `ChatTitleIdResponse` are unaffected.
- The snippet extraction handles both dict-format (current) and list-format (legacy) message stores.
- Filter prefixes (`tag:`, `folder:`, `pinned:`, etc.) are stripped before snippet extraction so only the actual search text is matched.
- [x] **Agentic AI Code**: This Pull Request was prepared with the assistance of an AI copilot and has been thoroughly reviewed and manually tested by the author to ensure quality and adherence to project standards.

### Screenshots or Videos

**Before:**
<img width="1148" height="744" alt="image" src="https://github.com/user-attachments/assets/126810d8-3342-4284-b300-75be80a41d35" />

**After:**
<img width="1148" height="744" alt="image" src="https://github.com/user-attachments/assets/0962a96a-68d3-45a5-867f-29ebc287eeb4" />

### Manual Verification Performed

1. Open the search modal (⌘/Ctrl+K)
2. Type a query that matches message content (not just a title) — e.g., "kubernetes"
3. Verify each matching result shows a snippet below the title with the query term highlighted in yellow/amber
4. Verify title-only matches (where the title contains the query but messages don't) show no snippet
5. Verify filter prefixes still work: `tag:mytag`, `pinned:true`, `folder:Work`
6. Verify long snippets are truncated with `…` ellipsis
7. Verify dark mode: highlight should use amber tint, snippet text should be muted gray
8. Verify arrow-key navigation still works correctly with the taller result items
9. Verify the chat preview panel (right side on desktop) still loads correctly when selecting a result

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.