### PR TITLE
fix: prevent long usernames from overflowing

### DIFF
--- a/src/lib/components/admin/UserPreviewModal.svelte
+++ b/src/lib/components/admin/UserPreviewModal.svelte
@@ -35,14 +35,14 @@
 <Modal size="md" bind:show>
 	<div>
 		<div class=" flex justify-between dark:text-gray-100 px-5 pt-4 mb-1.5">
-			<div class=" text-lg font-medium self-center font-primary">
+			<div class=" text-lg font-medium self-center font-primary min-w-0 truncate">
 				{$i18n.t('User Preview')}
 				{#if userName}
 					<span class="text-sm font-normal text-gray-500 ml-1">{userName}</span>
 				{/if}
 			</div>
 			<button
-				class="self-center"
+				class="self-center flex-shrink-0"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -400,7 +400,7 @@
 								{/if}
 							</div>
 						</td>
-						<td class=" px-3 py-1"> {user.email} </td>
+						<td class=" px-3 py-1 max-w-48 truncate"> {user.email} </td>
 
 						<td class=" px-3 py-1">
 							{dayjs(user.last_active_at * 1000).fromNow()}

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -99,7 +99,7 @@
 								/>
 							</div>
 
-							<div class=" flex-1">
+							<div class=" flex-1 min-w-0">
 								<div class="overflow-hidden w-ful mb-2">
 									<div class=" self-center capitalize font-medium truncate">
 										{selectedUser.name}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1611,7 +1611,7 @@
 							<div
 								class=" flex items-center rounded-2xl py-2 px-1.5 w-full hover:bg-gray-100/50 dark:hover:bg-gray-900/50 transition"
 							>
-								<div class=" self-center mr-3 relative">
+								<div class=" self-center mr-3 relative flex-shrink-0">
 									<img
 										src={`${WEBUI_API_BASE_URL}/users/${$user?.id}/profile/image`}
 										class=" size-7 object-cover rounded-full"
@@ -1631,7 +1631,7 @@
 										</div>
 									{/if}
 								</div>
-								<div class=" self-center font-medium">{$user?.name}</div>
+								<div class=" self-center font-medium truncate">{$user?.name}</div>
 							</div>
 						</UserMenu>
 					{/if}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Long usernames and emails overflow several admin UI components, pushing content beyond container bounds and breaking layouts.

**Edit User Modal** (`EditUserModal.svelte`): The `flex-1` content container lacks `min-w-0`, so the flex item grows unbounded. The `truncate` class on the name `<div>` is already present but has no effect because the parent has no width constraint.

```diff
- <div class=" flex-1">
+ <div class=" flex-1 min-w-0">
```

**User Preview Modal** (`UserPreviewModal.svelte`): The title container grows unbounded, pushing the close (✕) button off-screen.

```diff
- <div class=" text-lg font-medium self-center font-primary">
+ <div class=" text-lg font-medium self-center font-primary min-w-0 truncate">
```
```diff
- <button class="self-center"
+ <button class="self-center flex-shrink-0"
```

**Sidebar username** (`Sidebar.svelte`): The username at the bottom of the expanded sidebar has no truncation, causing long names to wrap across multiple lines. The avatar container also lacks `flex-shrink-0`, causing it to get squeezed.

```diff
- <div class=" self-center mr-3 relative">
+ <div class=" self-center mr-3 relative flex-shrink-0">
```
```diff
- <div class=" self-center font-medium">{$user?.name}</div>
+ <div class=" self-center font-medium truncate">{$user?.name}</div>
```

**Users table — Email column** (`UserList.svelte`): The email `<td>` has no max-width or truncation, so long emails stretch the entire table.

```diff
- <td class=" px-3 py-1"> {user.email} </td>
+ <td class=" px-3 py-1 max-w-48 truncate"> {user.email} </td>
```

### Fixed

- Long usernames no longer overflow the Edit User modal — the existing `truncate` class now takes effect
- User Preview modal close button stays visible with long usernames
- Sidebar avatar no longer gets squeezed by long usernames
- Long usernames in the sidebar are now truncated with ellipsis instead of wrapping
- Long emails in the Users table are now truncated to match the Name column's treatment
---

### Additional Information

- **Files changed:** `EditUserModal.svelte`, `UserPreviewModal.svelte`, `Sidebar.svelte`, `UserList.svelte`
- **Diff:** +6 / −6 (4 files)

### Screenshots or Videos

**Before:**
<img width="919" height="535" alt="image" src="https://github.com/user-attachments/assets/b7cd652a-dc75-4a32-9c70-e320582916b1" />

<img width="423" height="1280" alt="image" src="https://github.com/user-attachments/assets/44d408b0-a6d9-4e82-8627-295002aa91fb" />

**After:**
<img width="520" height="465" alt="image" src="https://github.com/user-attachments/assets/b71f2dd8-4db5-4866-8496-4b3c35345b8a" />

<img width="423" height="1280" alt="image" src="https://github.com/user-attachments/assets/4650b0dc-bbaa-4149-836b-b095f80d262a" />

### Manual Verification Performed

1. Admin → Users → click edit (pencil) on a user with a very long name
   - **Before:** Username overflows the modal, "Remove Initial Gravatar" text wraps vertically
   - **After:** Username is truncated with ellipsis, modal layout is preserved
2. Admin → Users → click eye icon (Preview Access) on a user with a long name
   - **Before:** Username pushes the ✕ close button off-screen
   - **After:** Username truncates, ✕ button stays visible
3. Expand the sidebar with a long username set on your account
   - **Before:** Username wraps across multiple lines, avatar gets squeezed
   - **After:** Username truncates with ellipsis, avatar retains its shape
4. Admin → Users table with a user who has a very long email
   - **Before:** Email stretches the entire table horizontally
   - **After:** Email truncates with ellipsis, matching the Name column's max-width

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.