### PR TITLE
fix: honor model meta params for native function calling

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,15 @@
+## Summary
+- honor model params stored under `meta.params` as well as `params`
+- also honor `model_item.info.meta.params` from the request payload
+- fixes MCP/native function calling being silently ignored for some model edit paths
+
+## Root cause
+Open WebUI computes `model_info_params` from `Model.params`, but the frontend/request path can carry settings like `function_calling: native` under `model_item.info.meta.params`. In that case the backend ignores the setting and falls back to non-native tool handling.
+
+This showed up as MCP tools being selected in the UI but not being passed through correctly to the model.
+
+## Test plan
+- reproduced with Open WebUI + MCP tool server selected
+- observed request payload containing `model_item.info.meta.params.function_calling = "native"`
+- confirmed backend ignored that value before this patch
+- patched running container with the same change and verified the issue was resolved

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1707,9 +1707,24 @@ async def chat_completion(
 
         # Model params: global defaults as base, per-model overrides win
         default_model_params = getattr(request.app.state.config, 'DEFAULT_MODEL_PARAMS', None) or {}
+
+        db_model_params = model_info.params.model_dump() if model_info and model_info.params else {}
+        db_meta_params = {}
+        if model_info and getattr(model_info, 'meta', None):
+            try:
+                db_meta_params = (
+                    model_info.meta.model_dump() if hasattr(model_info.meta, 'model_dump') else dict(model_info.meta)
+                ).get('params', {}) or {}
+            except Exception:
+                db_meta_params = {}
+
+        payload_meta_params = ((((model_item or {}).get('info') or {}).get('meta') or {}).get('params', {}) or {})
+
         model_info_params = {
             **default_model_params,
-            **(model_info.params.model_dump() if model_info and model_info.params else {}),
+            **db_meta_params,
+            **db_model_params,
+            **payload_meta_params,
         }
 
         # Check base model existence for custom models


### PR DESCRIPTION
## Summary
- honor model params stored under `meta.params` as well as `params`
- also honor `model_item.info.meta.params` from the request payload
- fixes MCP/native function calling being silently ignored for some model edit paths

## Root cause
Open WebUI computes `model_info_params` from `Model.params`, but the frontend/request path can carry settings like `function_calling: native` under `model_item.info.meta.params`. In that case the backend ignores the setting and falls back to non-native tool handling.

This showed up as MCP tools being selected in the UI but not being passed through correctly to the model.

## Test plan
- reproduced with Open WebUI + MCP tool server selected
- observed request payload containing `model_item.info.meta.params.function_calling = "native"`
- confirmed backend ignored that value before this patch
- patched running container with the same change and verified the issue was resolved
