### PR TITLE
fix: honor model meta params for native function calling

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1689,9 +1689,24 @@ async def chat_completion(
 
         # Model params: global defaults as base, per-model overrides win
         default_model_params = getattr(request.app.state.config, 'DEFAULT_MODEL_PARAMS', None) or {}
+
+        db_model_params = model_info.params.model_dump() if model_info and model_info.params else {}
+        db_meta_params = {}
+        if model_info and getattr(model_info, 'meta', None):
+            try:
+                db_meta_params = (
+                    model_info.meta.model_dump() if hasattr(model_info.meta, 'model_dump') else dict(model_info.meta)
+                ).get('params', {}) or {}
+            except Exception:
+                db_meta_params = {}
+
+        payload_meta_params = ((((model_item or {}).get('info') or {}).get('meta') or {}).get('params', {}) or {})
+
         model_info_params = {
             **default_model_params,
-            **(model_info.params.model_dump() if model_info and model_info.params else {}),
+            **db_meta_params,
+            **db_model_params,
+            **payload_meta_params,
         }
 
         # Check base model existence for custom models


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #25174 (MCP native function calling feature)
- [x] **Target branch:** `dev`
- [x] **Description:** honor model params stored under `meta.params` as well as `params`; also honor `model_item.info.meta.params` from the request payload. Fixes MCP/native function calling being silently ignored when `function_calling=native` is set via the model edit UI.
- [x] **Changelog:** Added under Fixed below
- [x] **Documentation:** No user-facing doc changes — backend bug fix
- [x] **Dependencies:** No new or upgraded dependencies
- [x] **Testing:** Manual test: patched running container, confirmed tools now flow through with MCP + native function calling enabled
- [x] **Agentic AI Code:** This PR is written by a human
- [x] **Code review:** Self-reviewed
- [x] **Design & Architecture:** Minimal change — adds one additional source of model params
- [x] **Git Hygiene:** Single atomic commit, clean diff
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Fixed

- MCP/native function calling was silently ignored when model params were stored under `meta.params` instead of `params`. The backend now correctly merges params from global defaults → `meta.params` → `params` → request payload, ensuring all edit paths for `function_calling` are respected.

---

### Additional Information

**Root cause:** `model_info_params` in `backend/open_webui/main.py` was built only from `Model.params`, ignoring `Model.meta.params` and the request payload `model_item.info.meta.params`. The frontend and some model edit paths persist settings under `meta.params`, so the backend never saw `function_calling=native` and fell back to non-native tool handling.

**Fix:** Merged all four sources of model params with correct precedence:
1. global defaults (`DEFAULT_MODEL_PARAMS`)
2. `model_info.meta.params` (database)
3. `model_info.params` (database)
4. `model_item.info.meta.params` (request payload)

**Test:** Patched running container — confirmed MCP tools flow correctly with native function calling enabled after the fix.

Relates to #25174

### Screenshots or Videos

*(N/A — backend-only fix)*

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
