### PR TITLE
fix: add voice mode mute shortcut to keyboard shortcuts modal

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -97,6 +97,10 @@
 						<!-- {$i18n.t('Only active when the chat input is in focus.')} -->
 						<!-- {$i18n.t('Only active when the chat input is in focus and an LLM is generating a response.')} -->
 						<!-- {$i18n.t('Only can be triggered when the chat input is in focus.')} -->
+
+						<!-- {$i18n.t('Voice')} -->
+						<!-- {$i18n.t('Toggle Mute')} -->
+						<!-- {$i18n.t('Only active during Voice Mode.')} -->
 						{#each items as shortcut}
 							<div class="col-span-1 flex items-start">
 								<ShortcutItem {shortcut} {isMac} />

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -40,7 +40,10 @@ export enum Shortcut {
 	REGENERATE_RESPONSE = 'regenerateResponse',
 	COPY_LAST_CODE_BLOCK = 'copyLastCodeBlock',
 	COPY_LAST_RESPONSE = 'copyLastResponse',
-	STOP_GENERATING = 'stopGenerating'
+	STOP_GENERATING = 'stopGenerating',
+
+	//Voice
+	TOGGLE_MUTE = 'toggleMute'
 }
 
 export const shortcuts: ShortcutRegistry = {
@@ -164,5 +167,13 @@ export const shortcuts: ShortcutRegistry = {
 		name: 'Copy Last Code Block',
 		keys: ['mod', 'shift', ';'],
 		category: 'Message'
+	},
+
+	//Voice
+	[Shortcut.TOGGLE_MUTE]: {
+		name: 'Toggle Mute',
+		keys: ['M'],
+		category: 'Voice',
+		tooltip: 'Only active during Voice Mode.'
 	}
 };


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #25192`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The Voice Mode mute toggle shortcut (`M` key), introduced in v0.9.3, is not listed in the Keyboard Shortcuts modal (`Ctrl + /`), making it undiscoverable. This PR registers it in the centralized shortcuts registry so it appears in the modal under a new **"Voice"** category with a tooltip indicating it is only active during Voice Mode.

The mute shortcut implementation already exists in `CallOverlay.svelte` — this change only adds it to the shortcuts registry for visibility. No behavioral changes.

*This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

### Fixed

- Voice Mode mute shortcut (`M`) now appears in the Keyboard Shortcuts modal under a new "Voice" category with an asterisk tooltip: "Only active during Voice Mode."

---

### Additional Information

- **Files changed:** 2 files, +16 / -1 lines
- **No new dependencies**
- Relates to #25192
- The existing mute shortcut implementation in `src/lib/components/chat/MessageInput/CallOverlay.svelte` (lines 670–683) was not modified — this PR only registers it in the centralized `src/lib/shortcuts.ts` registry

### Screenshots or Videos

**Before:**
<img width="693" height="716" alt="image" src="https://github.com/user-attachments/assets/f42fd688-fd05-436a-8dea-533ca775b704" />

**After:**
<img width="693" height="716" alt="image" src="https://github.com/user-attachments/assets/2531c0dc-9416-4ed7-b8d3-2a5e6d9e21d7" />

### Manual Verification Performed

1. Open the Keyboard Shortcuts modal via `Ctrl + /`
2. Verify a new **"Voice"** section appears at the bottom
3. Verify it shows **"Toggle Mute"** with the key **M** and a tooltip asterisk
4. Hover over the asterisk to confirm tooltip reads "Only active during Voice Mode."
5. Enter Voice Mode and verify pressing `M` still toggles mute as before
6. Verify no regressions in the existing shortcut categories (Chat, Global, Input, Message)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.