### PR TITLE
fix: preserve citation-like brackets inside code

### DIFF
--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { replaceOutsideCode } from './index';
+
+const removeCitationMarkers = (content: string) =>
+	replaceOutsideCode(content, (segment) =>
+		segment.replace(/\s*(\[(?:\d+(?:#[^,\]\s]+)?(?:,\s*\d+(?:#[^,\]\s]+)?)*)\])+/g, '')
+	);
+
+describe('replaceOutsideCode', () => {
+	it('applies replacements outside code', () => {
+		expect(removeCitationMarkers('Alpha [1] beta [2, 3#page].')).toBe('Alpha beta.');
+	});
+
+	it('preserves citation-like brackets inside fenced code blocks', () => {
+		const content = ['Before [1]', '```python', 'data = [0]', 'values = [1, 2, 3]', '```'].join(
+			'\n'
+		);
+
+		expect(removeCitationMarkers(content)).toBe(
+			['Before', '```python', 'data = [0]', 'values = [1, 2, 3]', '```'].join('\n')
+		);
+	});
+
+	it('preserves citation-like brackets inside tilde fenced code blocks', () => {
+		const content = ['Before [1]', '~~~python', 'data = [0]', 'values = [1, 2, 3]', '~~~'].join(
+			'\n'
+		);
+
+		expect(removeCitationMarkers(content)).toBe(
+			['Before', '~~~python', 'data = [0]', 'values = [1, 2, 3]', '~~~'].join('\n')
+		);
+	});
+
+	it('preserves citation-like brackets inside inline code', () => {
+		expect(removeCitationMarkers('Use `data = [0]` here [1].')).toBe('Use `data = [0]` here.');
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -46,9 +46,11 @@ function escapeRegExp(string: string): string {
 // Replace tokens outside code blocks only
 export const replaceOutsideCode = (content: string, replacer: (str: string) => string) => {
 	return content
-		.split(/(```[\s\S]*?```|`[\s\S]*?`)/)
+		.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~|`[\s\S]*?`)/)
 		.map((segment) => {
-			return segment.startsWith('```') || segment.startsWith('`') ? segment : replacer(segment);
+			return segment.startsWith('```') || segment.startsWith('~~~') || segment.startsWith('`')
+				? segment
+				: replacer(segment);
 		})
 		.join('');
 };


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #25195.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Not applicable; this preserves existing rendering behavior and adds no user-facing setting, public API, environment variable, or deployment step.
- [x] **Dependencies:** No dependencies added or updated.
- [x] **Testing:** Added focused unit coverage for prose citation removal plus fenced/inline code preservation, and ran the targeted frontend test.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Move citation-marker removal into a small utility that skips markdown code segments.
- Preserve citation-like bracket expressions inside fenced code blocks and inline code when a model disables citations.
- Add focused Vitest coverage for prose marker removal, fenced code blocks, and inline code.

### Added

- Unit tests for citation cleanup behavior.

### Changed

- `ContentRenderer` now removes disabled citation markers only outside markdown code spans/fences.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Code examples such as `data = [0]` are no longer stripped when citations are disabled for a model.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

Validation:

- `npx prettier --write src/lib/utils/citations.ts src/lib/utils/citations.test.ts src/lib/components/chat/Messages/ContentRenderer.svelte`
- `npm run test:frontend -- --run src/lib/utils/citations.test.ts`
- `git diff --check`

### Screenshots or Videos

- Not applicable; markdown text-cleanup behavior covered by unit tests.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.