### PR TITLE
fix: folder landing page delete and create subfolder actions

### DIFF
--- a/src/lib/components/chat/Placeholder/FolderTitle.svelte
+++ b/src/lib/components/chat/Placeholder/FolderTitle.svelte
@@ -11,7 +11,12 @@
 
 	import { selectedFolder } from '$lib/stores';
 
-	import { deleteFolderById, getFolderById, updateFolderById } from '$lib/apis/folders';
+	import {
+		deleteFolderById,
+		getFolderById,
+		updateFolderById,
+		createNewFolder
+	} from '$lib/apis/folders';
 	import { getChatsByFolderId } from '$lib/apis/chats';
 
 	import FolderModal from '$lib/components/layout/Sidebar/Folders/FolderModal.svelte';
@@ -30,6 +35,7 @@
 	export let onDelete: Function = (folderId) => {};
 
 	let showFolderModal = false;
+	let showCreateSubFolderModal = false;
 	let showDeleteConfirm = false;
 	let deleteFolderContents = true;
 
@@ -127,6 +133,39 @@
 
 		saveAs(blob, `folder-${folder.name}-export-${Date.now()}.json`);
 	};
+
+	const createSubFolderHandler = async ({ name, meta, data, parent_id }) => {
+		if (name === '') {
+			toast.error($i18n.t('Folder name cannot be empty.'));
+			return;
+		}
+
+		name = name.trim();
+
+		const res = await createNewFolder(localStorage.token, {
+			name,
+			data,
+			meta,
+			parent_id
+		}).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			toast.success($i18n.t('Folder created successfully'));
+
+			const _folder = await getFolderById(localStorage.token, folder.id).catch((error) => {
+				toast.error(`${error}`);
+				return null;
+			});
+
+			if (_folder) {
+				await selectedFolder.set(_folder);
+			}
+			onUpdate(_folder);
+		}
+	};
 </script>
 
 {#if folder}
@@ -135,6 +174,12 @@
 		edit={true}
 		folderId={folder.id}
 		onSubmit={updateHandler}
+	/>
+
+	<FolderModal
+		bind:show={showCreateSubFolderModal}
+		parentId={folder.id}
+		onSubmit={createSubFolderHandler}
 	/>
 
 	<DeleteConfirmDialog
@@ -146,11 +191,11 @@
 	>
 		<div class=" text-sm text-gray-700 dark:text-gray-300 flex-1 line-clamp-3 mb-2">
 			<!-- {$i18n.t('This will delete <strong>{{NAME}}</strong> and <strong>all its contents</strong>.', {
-				NAME: folders[folderId].name
+				NAME: folder.name
 			})} -->
 
 			{$i18n.t(`Are you sure you want to delete "{{NAME}}"?`, {
-				NAME: folders[folderId].name
+				NAME: folder.name
 			})}
 		</div>
 
@@ -201,6 +246,9 @@
 				}}
 				onExport={() => {
 					exportHandler();
+				}}
+				onCreateSub={() => {
+					showCreateSubFolderModal = true;
 				}}
 			>
 				<button


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

## Description

Two bugs exist in the folder landing page's 3-dot menu (`FolderTitle.svelte`) that don't affect the sidebar's folder menu (`RecursiveFolder.svelte`):

### Bug 1: Delete throws `ReferenceError: folders is not defined`

The `DeleteConfirmDialog` in `FolderTitle.svelte` references `folders[folderId].name`, but the component only has a `folder` prop — neither `folders` nor `folderId` exist in scope. This was likely copy-pasted from `RecursiveFolder.svelte` which does have those variables.

<details>
<summary>Browser console error</summary>

```
Uncaught ReferenceError: folders is not defined
    children FolderTitle.svelte:153
    Ce runtime.js:749
    children FolderTitle.svelte:157
    Nr runtime.js:258
    hn deriveds.js:360
    fr deriveds.js:375
    Q runtime.js:661
    _a effects.js:385
    Nr runtime.js:258
    Ye runtime.js:460
    Y effects.js:136
    _a effects.js:385
    lr async.js:42
    _a effects.js:384
    children FolderTitle.svelte:157
    o slot.js:28
    ve ConfirmDialog.svelte:119
    ensure branches.js:194
    Nr runtime.js:258
    Ye runtime.js:460
    Y effects.js:136
    Ie effects.js:438
    ensure branches.js:194
    h if.js:57
    K if.js:65
    gt ConfirmDialog.svelte:100
    K if.js:63
    Nr runtime.js:258
    Ye runtime.js:460
    Wt batch.js:350
    Gt batch.js:247
    flush batch.js:417
    ensure batch.js:579
    Fn utils.js:47
    Gn task.js:10
    Se task.js:28
    Se task.js:19
    ensure batch.js:573
    ct sources.js:193
    le sources.js:171
    onDelete FolderTitle.svelte:200
    content FolderMenu.svelte:82
```

</details>

**Fix:** Changed `folders[folderId].name` → `folder.name`.

### Bug 2: "Create Folder" does nothing

`FolderMenu` exposes an `onCreateSub` callback, but `FolderTitle.svelte` never passes it, so the button calls a no-op. The sidebar's `RecursiveFolder.svelte` correctly wires this to a `FolderModal`.

**Fix:** Added `createSubFolderHandler` (matching `RecursiveFolder`'s pattern), a `FolderModal` for subfolder creation, and wired `onCreateSub` to open it.

### Changes (1 file)

- `src/lib/components/chat/Placeholder/FolderTitle.svelte` — Fixed both bugs

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Fixed folder landing page Delete and Create Folder menu actions that were broken due to undefined variable references and missing handler wiring.

### Fixed

- Folder landing page "Delete" action no longer throws `ReferenceError: folders is not defined` — now correctly uses the `folder` prop.
- Folder landing page "Create Folder" action now opens the Create Folder modal instead of silently doing nothing.

---

### Additional Information

- No new dependencies added.
- Reuses existing `createNewFolder` API and `FolderModal` component — no new components or APIs introduced.
- Sidebar folder actions (`RecursiveFolder.svelte`) are unaffected — no regression.

### Manual Verification Performed

1. **Delete folder from landing page**: Clicked Delete on the 3-dot menu → Confirm dialog renders correctly showing the folder name → Folder deletes successfully.
2. **Create subfolder from landing page**: Clicked "Create Folder" on the 3-dot menu → Create Folder modal opens → Subfolder is created successfully.
3. **Edit folder from landing page**: Verified no regression — Edit still works.
4. **Export folder from landing page**: Verified no regression — Export still works.
5. **Sidebar folder actions**: Verified no regression — Delete, Create Folder, Edit, and Export all work from the sidebar context menu.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.