### PR TITLE
fix: include reasoning_tags in user settings advanced params save handler

### DIFF
--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -44,6 +44,7 @@
 		stream_response: null,
 		stream_delta_chunk_size: null,
 		function_calling: null,
+		reasoning_tags: null,
 		seed: null,
 		temperature: null,
 		reasoning_effort: null,
@@ -64,7 +65,13 @@
 		num_batch: null,
 		num_keep: null,
 		max_tokens: null,
-		num_gpu: null
+		use_mmap: null,
+		use_mlock: null,
+		num_thread: null,
+		num_gpu: null,
+		think: null,
+		format: null,
+		keep_alive: null
 	};
 
 	const saveHandler = async () => {
@@ -75,6 +82,7 @@
 				stream_delta_chunk_size:
 					params.stream_delta_chunk_size !== null ? params.stream_delta_chunk_size : undefined,
 				function_calling: params.function_calling !== null ? params.function_calling : undefined,
+				reasoning_tags: params.reasoning_tags !== null ? params.reasoning_tags : undefined,
 				seed: (params.seed !== null ? params.seed : undefined) ?? undefined,
 				stop: params.stop ? params.stop.split(',').filter((e) => e) : undefined,
 				temperature: params.temperature !== null ? params.temperature : undefined,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR addresses a gap discovered during a settings audit — `reasoning_tags` is the only advanced parameter with full UI support in `AdvancedParams.svelte` that was missing from `General.svelte`'s save handler.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

`reasoning_tags` is an advanced parameter with full UI support in `AdvancedParams.svelte` (Default / Enabled / Disabled / Custom with start/end tag inputs), but it was missing from `General.svelte`'s `params` initialization and `saveHandler`. This meant the user's Reasoning Tags selection was silently dropped when saving settings under **Settings → General → Advanced Parameters**.

This PR adds `reasoning_tags` to the save handler and also aligns the `params` initialization in `General.svelte` with `AdvancedParams.svelte`'s `defaultParams` by explicitly declaring six additional fields (`use_mmap`, `use_mlock`, `num_thread`, `think`, `format`, `keep_alive`) that were previously only implicit via the `$settings.params` spread on mount. These six fields already persisted correctly through the save handler, but were not declared in the initialization object.

### Fixed

- `reasoning_tags` advanced parameter not being saved in user settings (Settings → General → Advanced Parameters → Reasoning Tags)
- `params` initialization in `General.svelte` now explicitly declares all fields from `AdvancedParams.svelte`'s `defaultParams` for consistency

---

### Additional Information

- Only one file changed: `src/lib/components/chat/Settings/General.svelte`
- `AdvancedParams.svelte` was not modified — the UI support for `reasoning_tags` already existed there

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.