### PR TITLE
feat: add Enable All / Disable All actions dropdown to Automations page

### DIFF
--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -28,6 +28,9 @@
 	import Select from '$lib/components/common/Select.svelte';
 	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 	import Check from '$lib/components/icons/Check.svelte';
+	import Dropdown from '$lib/components/common/Dropdown.svelte';
+	import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
+	import Minus from '$lib/components/icons/Minus.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -93,6 +96,24 @@
 		if (res) {
 			automations = (automations ?? []).map((a) => (a.id === res.id ? res : a));
 		}
+	};
+
+	const enableAllHandler = async () => {
+		const toEnable = (automations ?? []).filter((a) => !a.is_active);
+		// Optimistic UI update
+		toEnable.forEach((a) => (a.is_active = true));
+		automations = automations;
+		// Sync with server
+		await Promise.all(toEnable.map((a) => toggleAutomationById(localStorage.token, a.id)));
+	};
+
+	const disableAllHandler = async () => {
+		const toDisable = (automations ?? []).filter((a) => a.is_active);
+		// Optimistic UI update
+		toDisable.forEach((a) => (a.is_active = false));
+		automations = automations;
+		// Sync with server
+		await Promise.all(toDisable.map((a) => toggleAutomationById(localStorage.token, a.id)));
 	};
 
 	const runNowHandler = async (automation: AutomationResponse) => {
@@ -329,6 +350,47 @@
 								</svelte:fragment>
 							</Select>
 						</div>
+
+						<div class="flex-1"></div>
+
+						<Dropdown>
+							<Tooltip content={$i18n.t('Actions')}>
+								<button
+									class="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+									type="button"
+								>
+									<EllipsisHorizontal className="size-4" />
+								</button>
+							</Tooltip>
+
+							<div slot="content">
+								<div
+									class="w-[170px] rounded-xl p-1 border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-sm"
+								>
+									<button
+										class="select-none flex w-full gap-2 items-center px-3 py-1.5 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+										type="button"
+										on:click={() => {
+											enableAllHandler();
+										}}
+									>
+										<CheckCircle className="size-4" />
+										<div class="flex items-center">{$i18n.t('Enable All')}</div>
+									</button>
+
+									<button
+										class="select-none flex w-full gap-2 items-center px-3 py-1.5 text-sm font-medium cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+										type="button"
+										on:click={() => {
+											disableAllHandler();
+										}}
+									>
+										<Minus className="size-4" />
+										<div class="flex items-center">{$i18n.t('Disable All')}</div>
+									</button>
+								</div>
+							</div>
+						</Dropdown>
 					</div>
 
 					{#if automations === null || loading}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #25206`. The Discussion describes the motivation and proposed approach.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new dependencies introduced. All imports (`Dropdown`, `CheckCircle`, `Minus`) already exist in the project.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly and does not introduce regressions. Verification steps are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Reuses the existing `Dropdown` component and follows the same pattern established by the Models workspace page. No new settings or architectural changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Adds a `⋯` (ellipsis) actions dropdown to the Automations page filter bar with **Enable All** and **Disable All** bulk actions.

Currently, the Automations page only supports toggling automations individually via per-row switches. When a user has many automations, there's no quick way to enable or disable all of them at once — for example, when temporarily pausing all scheduled prompts during maintenance or vacation, then re-enabling them afterward.

The Models workspace page already provides this exact pattern via its own `⋯` dropdown. Automations are a natural candidate because they have a single `is_active` toggle per item, making Enable All / Disable All unambiguous (unlike Functions, which have both `is_active` and `is_global` toggles).

**Implementation details:**

- Reuses the existing `Dropdown` component (`$lib/components/common/Dropdown.svelte`)
- Uses the same `CheckCircle` and `Minus` icons as the Models page
- Both handlers use **optimistic UI updates** (toggling local state immediately) followed by parallel `toggleAutomationById` API calls
- All strings are wrapped in `$i18n.t()` for i18n support
- Dropdown is positioned to the right of the status filter (All / Active / Paused), pushed to the far right with a `flex-1` spacer — matching the Models page layout

### Added

- `⋯` actions dropdown to the Automations page filter bar with Enable All and Disable All options

---

### Additional Information

- Only one file changed: `src/routes/(app)/automations/+page.svelte`
- Pattern follows `src/lib/components/workspace/Models.svelte` (lines 231–277, 511–572)
- Relates to #25206

### Screenshots or Videos

**Before:**
<img width="2558" height="1278" alt="image" src="https://github.com/user-attachments/assets/8d27f407-8d70-4f01-8b60-df8d24cd3d3c" />

**After:**
<img width="2558" height="1278" alt="image" src="https://github.com/user-attachments/assets/d0f07c65-1265-4b0b-84e8-5a04d5e72652" />

### Manual Verification Performed

1. Navigate to the **Automations** page
2. Create 2+ automations with varying enabled/disabled states
3. Verify the `⋯` icon appears to the right of the status filter (All / Active / Paused)
4. Hover the `⋯` icon — tooltip shows "Actions"
5. Click it — dropdown appears with "Enable All" and "Disable All"
6. Click **Disable All** — all automation toggles switch off immediately
7. Click **Enable All** — all automation toggles switch on immediately
8. Refresh the page (F5) — verify the states persisted correctly
9. Filter to "Active" or "Paused" — verify the dropdown still works (it operates on the full `automations` array, not the filtered view)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.