### PR TITLE
fix(retrieval): detect OOXML files before loader selection

### DIFF
--- a/backend/open_webui/retrieval/loaders/file_type.py
+++ b/backend/open_webui/retrieval/loaders/file_type.py
@@ -1,0 +1,21 @@
+import zipfile
+
+
+OOXML_FILE_TYPES = {
+    'word/document.xml': 'docx',
+    'xl/workbook.xml': 'xlsx',
+    'ppt/presentation.xml': 'pptx',
+}
+
+
+def detect_ooxml_file_type(file_path: str) -> str | None:
+    try:
+        with zipfile.ZipFile(file_path) as archive:
+            names = set(archive.namelist())
+    except (OSError, zipfile.BadZipFile):
+        return None
+
+    for marker, file_type in OOXML_FILE_TYPES.items():
+        if marker in names:
+            return file_type
+    return None

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -19,6 +19,7 @@ from langchain_community.document_loaders import (
 from langchain_core.documents import Document
 
 from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
+from open_webui.retrieval.loaders.file_type import detect_ooxml_file_type
 
 from open_webui.retrieval.loaders.mistral import MistralLoader
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
@@ -262,6 +263,9 @@ class Loader:
 
     def _get_loader(self, filename: str, file_content_type: str, file_path: str):
         file_ext = filename.split('.')[-1].lower()
+        detected_ooxml_type = detect_ooxml_file_type(file_path)
+        if detected_ooxml_type:
+            file_ext = detected_ooxml_type
 
         if (
             self.engine == 'external'

--- a/backend/open_webui/test/retrieval/loaders/test_main_loader.py
+++ b/backend/open_webui/test/retrieval/loaders/test_main_loader.py
@@ -1,0 +1,23 @@
+import zipfile
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from open_webui.retrieval.loaders.file_type import detect_ooxml_file_type
+
+
+def test_detects_word_ooxml_file_with_legacy_doc_extension(tmp_path):
+    file_path = tmp_path / 'legacy.doc'
+    with zipfile.ZipFile(file_path, 'w') as archive:
+        archive.writestr('[Content_Types].xml', '')
+        archive.writestr('word/document.xml', '<w:document />')
+
+    assert detect_ooxml_file_type(str(file_path)) == 'docx'
+
+
+def test_ignores_non_zip_files(tmp_path):
+    file_path = tmp_path / 'legacy.doc'
+    file_path.write_bytes(b'not a zip file')
+
+    assert detect_ooxml_file_type(str(file_path)) is None


### PR DESCRIPTION
## Summary\n- Detect OOXML package markers before choosing the retrieval loader\n- Route ZIP-based Word, Excel, and PowerPoint files to the existing docx/xlsx/pptx loader branches even when their extension or uploaded MIME type is misleading\n- Add focused tests for legacy .doc filenames that contain Word OOXML packages and for non-ZIP files\n\n## Why\nSome valid Office files are uploaded with legacy extensions such as .doc or browser-provided MIME types such as application/msword even though the file is actually an OOXML package. The current loader selection trusts filename extension and content_type, so these files can miss the Docx2txtLoader branch and fall through to text loading.\n\nThis keeps the change narrow by sniffing only known OOXML ZIP package entries:\n- word/document.xml -> docx\n- xl/workbook.xml -> xlsx\n- ppt/presentation.xml -> pptx\n\n## Tests\n- PYTHONPATH=backend uv run --no-sync pytest backend/open_webui/test/retrieval/loaders/test_main_loader.py -q