### PR TITLE
fix(retrieval): detect OOXML files before loader selection

### DIFF
--- a/backend/open_webui/retrieval/loaders/file_type.py
+++ b/backend/open_webui/retrieval/loaders/file_type.py
@@ -1,0 +1,21 @@
+import zipfile
+
+
+OOXML_FILE_TYPES = {
+    'word/document.xml': 'docx',
+    'xl/workbook.xml': 'xlsx',
+    'ppt/presentation.xml': 'pptx',
+}
+
+
+def detect_ooxml_file_type(file_path: str) -> str | None:
+    try:
+        with zipfile.ZipFile(file_path) as archive:
+            names = set(archive.namelist())
+    except (OSError, zipfile.BadZipFile):
+        return None
+
+    for marker, file_type in OOXML_FILE_TYPES.items():
+        if marker in names:
+            return file_type
+    return None

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -18,6 +18,7 @@ from langchain_community.document_loaders import (
 )
 from langchain_core.documents import Document
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, GLOBAL_LOG_LEVEL, REQUESTS_VERIFY
+from open_webui.retrieval.loaders.file_type import detect_ooxml_file_type
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
 from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
 from open_webui.retrieval.loaders.mineru import MinerULoader
@@ -259,6 +260,9 @@ class Loader:
 
     def _get_loader(self, filename: str, file_content_type: str, file_path: str):
         file_ext = filename.split('.')[-1].lower()
+        detected_ooxml_type = detect_ooxml_file_type(file_path)
+        if detected_ooxml_type:
+            file_ext = detected_ooxml_type
 
         if (
             self.engine == 'external'

--- a/backend/open_webui/test/retrieval/loaders/test_main_loader.py
+++ b/backend/open_webui/test/retrieval/loaders/test_main_loader.py
@@ -1,0 +1,23 @@
+import zipfile
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from open_webui.retrieval.loaders.file_type import detect_ooxml_file_type
+
+
+def test_detects_word_ooxml_file_with_legacy_doc_extension(tmp_path):
+    file_path = tmp_path / 'legacy.doc'
+    with zipfile.ZipFile(file_path, 'w') as archive:
+        archive.writestr('[Content_Types].xml', '')
+        archive.writestr('word/document.xml', '<w:document />')
+
+    assert detect_ooxml_file_type(str(file_path)) == 'docx'
+
+
+def test_ignores_non_zip_files(tmp_path):
+    file_path = tmp_path / 'legacy.doc'
+    file_path.write_bytes(b'not a zip file')
+
+    assert detect_ooxml_file_type(str(file_path)) is None


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references existing issues. Relates to #3264 and #2710.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Not applicable; this is internal loader selection behavior.
- [x] **Dependencies:** Are there any new or upgraded dependencies? No new dependencies.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Included below.
- [ ] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the listed prefixes.

# Changelog Entry

### Description

- Detect OOXML package markers before retrieval loader selection so valid Office files with misleading legacy extensions or browser MIME types are routed to the correct existing loader branch.

### Added

- Added a small ZIP package marker detector for OOXML Word, Excel, and PowerPoint files.
- Added focused tests for legacy `.doc` filenames that contain Word OOXML packages and for non-ZIP files.

### Changed

- Retrieval loader selection now treats ZIP packages containing `word/document.xml`, `xl/workbook.xml`, or `ppt/presentation.xml` as `docx`, `xlsx`, or `pptx` respectively before falling through to extension/MIME based selection.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed valid OOXML documents uploaded with misleading metadata such as `.doc` / `application/msword` missing the `Docx2txtLoader` path and falling through to plain text loading.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- This keeps detection narrow and only checks standard OOXML package entries:
  - `word/document.xml` -> `docx`
  - `xl/workbook.xml` -> `xlsx`
  - `ppt/presentation.xml` -> `pptx`
- This avoids routing genuine Word 97-2003 binary `.doc` files to the docx loader.

### Testing

- `PYTHONPATH=backend uv run --no-sync pytest backend/open_webui/test/retrieval/loaders/test_main_loader.py -q`
- Manual importlib check against a legacy `.doc` filename containing Word OOXML returned `docx`.

### Screenshots or Videos

- Not applicable; backend loader selection fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
