### PR TITLE
chore: remove dead code

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -16,8 +16,6 @@ import markdown
 from bs4 import BeautifulSoup
 from cryptography.hazmat.primitives import serialization
 
-from open_webui.constants import ERROR_MESSAGES
-
 ####################################
 # Load .env file
 ####################################
@@ -603,9 +601,10 @@ ENABLE_SIGNUP_PASSWORD_CONFIRMATION = os.getenv('ENABLE_SIGNUP_PASSWORD_CONFIRMA
 ####################################
 
 # WEBUI_JWT_SECRET_KEY is deprecated; use WEBUI_SECRET_KEY instead.
+# No hardcoded fallback by design: the supported start scripts set/auto-generate it; unset is rejected below.
 WEBUI_SECRET_KEY = os.getenv(
     'WEBUI_SECRET_KEY',
-    os.getenv('WEBUI_JWT_SECRET_KEY', 't0p-s3cr3t'),
+    os.getenv('WEBUI_JWT_SECRET_KEY', ''),
 )
 
 WEBUI_SESSION_COOKIE_SAME_SITE = os.getenv('WEBUI_SESSION_COOKIE_SAME_SITE', 'lax')
@@ -620,7 +619,14 @@ WEBUI_AUTH_COOKIE_SECURE = (
 )
 
 if WEBUI_AUTH and WEBUI_SECRET_KEY == '':
-    raise ValueError(ERROR_MESSAGES.ENV_VAR_NOT_FOUND)
+    raise SystemExit(
+        'WEBUI_SECRET_KEY is not set. It is a hard requirement when authentication is enabled.\n'
+        'The supported start methods set or auto-generate it for you: use start.sh (Linux/macOS), '
+        'start_windows.bat (Windows), or `open-webui serve`.\n'
+        'If you start the backend another way (e.g. invoking uvicorn directly, which is unsupported), '
+        'you must set WEBUI_SECRET_KEY yourself to a long random value.\n'
+        'See https://docs.openwebui.com/reference/env-configuration#webui_secret_key'
+    )
 
 ENABLE_COMPRESSION_MIDDLEWARE = os.getenv('ENABLE_COMPRESSION_MIDDLEWARE', 'True').lower() == 'true'
 


### PR DESCRIPTION
It was only ever reachable by invoking uvicorn directly, which is unsupported and unsafe (the app would then sign tokens/cookies with a public, hardcoded key). Drop the fallback (default to '') so an unset key is caught by the existing WEBUI_AUTH guard, and replace the vague error with a clear, actionable message explaining that the key is a hard requirement and how the supported start methods provide it. Exit cleanly via SystemExit instead of raising a ValueError traceback.
WEBUI_AUTH=False keeps working unchanged (key defaults to '').

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
