### PR TITLE
fix: retain handles + done_callback + shutdown-cancel for pool cleanup tasks

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -679,8 +679,31 @@ async def lifespan(app: FastAPI):
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = THREAD_POOL_SIZE
 
-    asyncio.create_task(periodic_usage_pool_cleanup())
-    asyncio.create_task(periodic_session_pool_cleanup())
+    def _daemon_done_cb(task: asyncio.Task) -> None:
+        # `asyncio.create_task` discards exceptions on unreferenced tasks; without
+        # this callback a dead cleanup loop only surfaces as a delayed
+        # "Task exception was never retrieved" WARNING at GC time, by which point
+        # SESSION_POOL/USAGE_POOL have already been growing without bound for an
+        # unknown interval. Logging at ERROR with exc_info gives operators an
+        # immediate, alertable signal at the moment of death.
+        if not task.cancelled() and task.exception() is not None:
+            log.error(
+                'Background daemon task %s exited unexpectedly: %r '
+                '— pool cleanup has stopped for the remaining lifetime of the process.',
+                task.get_name(),
+                task.exception(),
+                exc_info=task.exception(),
+            )
+
+    app.state.periodic_usage_cleanup_task = asyncio.create_task(
+        periodic_usage_pool_cleanup(), name='periodic_usage_pool_cleanup'
+    )
+    app.state.periodic_usage_cleanup_task.add_done_callback(_daemon_done_cb)
+
+    app.state.periodic_session_cleanup_task = asyncio.create_task(
+        periodic_session_pool_cleanup(), name='periodic_session_pool_cleanup'
+    )
+    app.state.periodic_session_cleanup_task.add_done_callback(_daemon_done_cb)
 
     from open_webui.utils.automations import scheduler_worker_loop
 
@@ -753,6 +776,16 @@ async def lifespan(app: FastAPI):
 
     if hasattr(app.state, 'redis_task_command_listener'):
         app.state.redis_task_command_listener.cancel()
+
+    # Cooperatively cancel the cleanup daemons so their `finally: release_fn()`
+    # blocks run and the Redis lock is freed for the next replica. Without this,
+    # the tasks are destroyed mid-await and asyncio emits a
+    # "Task was destroyed but it is pending!" warning on every clean restart,
+    # which trains operators to ignore that warning and masks real failures.
+    for _attr in ('periodic_usage_cleanup_task', 'periodic_session_cleanup_task'):
+        _t = getattr(app.state, _attr, None)
+        if _t is not None:
+            _t.cancel()
 
 
 app = FastAPI(


### PR DESCRIPTION
## Summary

Closes the second root-cause path named in #25216 (item 2: "`asyncio.create_task` drops the handle — if the task dies for ANY other reason there is no operator signal"). Orthogonal to #21798 — zero file overlap.

#21798 makes the cleanup *loop* internally resilient (it will not exit on Redis lock acquire/renew failure). This PR makes the cleanup *spawn site* observable (if the task dies anyway, the operator knows immediately and the lock is released cooperatively at shutdown).

## Problem

`backend/open_webui/main.py` lines 682-683:

```python
asyncio.create_task(periodic_usage_pool_cleanup())
asyncio.create_task(periodic_session_pool_cleanup())
```

Both return values are discarded. Consequences:

1. **CancelledError escape on clean shutdown.** `asyncio.CancelledError` is `BaseException`, not `Exception`. The three `except Exception` guards inside the `run_with_lock` helper added by #21798 do not catch it. On every clean SIGTERM/SIGINT (which uvicorn/anyio injects into every background task), `CancelledError` propagates through `run_with_lock` to the task boundary. Operator-visible signal: only a delayed *"Task exception was never retrieved"* WARNING emitted at GC time, not at the moment of death.

2. **No real-time signal on unexpected death.** Even for non-cancellation exits (e.g. `MemoryError`, a hypothetical future regression in the outer `while True`), there is no `add_done_callback` to log the exception, no metric to increment, no flag on `app.state` that a healthcheck could surface. Both pools grow unbounded silently.

3. **`"Task was destroyed but it is pending!"` log noise on every restart.** The shutdown block at line 754 cancels only `app.state.redis_task_command_listener`. The cleanup tasks are never cancelled, so they die mid-await on event-loop close, asyncio emits the warning, and operators are trained to ignore that warning — which masks real failures.

## Changes

All three follow the existing `redis_task_command_listener` pattern at lines 676 and 754 — zero invention, just consistency.

1. **Store each cleanup-task handle on `app.state`** and give it a `name=` so log lines identify which daemon died.
2. **Attach a `_daemon_done_cb`** that logs the exception at `ERROR` with `exc_info` at the moment of task death. The callback filters out `task.cancelled()` so normal shutdown produces no noise.
3. **Cancel both tasks in lifespan shutdown** so `CancelledError` is delivered, the inner `finally: release_fn()` in `run_with_lock` runs, and the Redis lock is freed for the next replica.

## Scope notes

- **Out of scope:** `scheduler_worker_loop` at line 687 has the same fire-and-forget pattern but is tracked under a different issue space. Same treatment would apply.
- **Out of scope:** Adding a `/health` endpoint flag for the cleanup state. The `done_callback` already gives operators an alertable ERROR log; a healthcheck flag would be an incremental observability improvement, not a correctness fix.
- **Depends on:** Nothing. Works against current `main` independent of whether #21798 has merged. Once #21798 is in, the combination covers ~95% of the failure surface from #25216.

## Risk

Very low. The change is additive: two `asyncio.create_task()` calls gain names and a done_callback; the shutdown block gains two cancel() calls matching the existing pattern. No logic inside the coroutines is touched. The done_callback only fires when the task exits non-cancelled, so it produces no noise during normal shutdown.

## Test plan

- [ ] Start with `WEBSOCKET_MANAGER=redis`, verify both tasks appear in `app.state` with their `name=` set.
- [ ] Send SIGTERM, verify no `"Task was destroyed but it is pending!"` warning.
- [ ] Inject a synthetic exception inside one cleanup coroutine (e.g. temporary `raise RuntimeError`), verify the ERROR log fires at the moment of death, not at GC time.

Refs: #25216, #21798