### PR TITLE
fix: drop degenerate empty assistant messages when rebuilding chat history for upstream

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2176,6 +2176,14 @@ def process_messages_with_output(
 
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
+
+    Drops degenerate assistant messages that have no usable payload (empty
+    content, no output that produced messages, no tool_calls). Such rows are
+    persisted when a stream fails before any token is committed (e.g. upstream
+    5xx, connection drop, user-side abort). Forwarding them poisons every
+    subsequent completion on the chat because strict OpenAI-compatible
+    providers reject assistant messages whose content is an empty string and
+    that have no tool_calls.
     """
     processed = []
 
@@ -2189,6 +2197,12 @@ def process_messages_with_output(
             )
             if output_messages:
                 processed.extend(output_messages)
+                continue
+
+        # Drop degenerate assistant messages with no usable payload
+        if message.get('role') == 'assistant' and not message.get('tool_calls'):
+            content = message.get('content')
+            if not content or (isinstance(content, str) and not content.strip()):
                 continue
 
         # Strip 'output' field before adding (LLM shouldn't see it)


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #25083`.
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Entry at the bottom (Keep a Changelog format).
- [x] **Documentation:** N/A — internal behaviour change, no user-facing surface or new config.
- [x] **Dependencies:** None added or changed.
- [x] **Testing:** See "Additional Information" below — verified both via a standalone script that reproduces the poisoned chain from #25083 (8 assertion cases, all pass with the filter, 5 fail without it), and via in-vivo testing where the 5-line filter was applied to a live v0.9.5 container, an empty assistant node was injected into a real chat, and a follow-up message sent through the UI completed normally instead of triggering the original `must not be empty` rejection.
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** Filter is added inside the existing payload-builder function — no new config, no surface change, no state change.
- [x] **Git Hygiene:** Atomic one-file change rebased on `dev`.
- [x] **Title Prefix:** `fix:`.

# Description

Closes #25083.

## What this changes

`process_messages_with_output()` in `backend/open_webui/utils/middleware.py` now skips assistant messages that have:

- no `content` (empty string / whitespace-only / `None` / empty list), **and**
- no `tool_calls`, **and**
- no `output` that successfully produced messages (already handled by the existing branch above; this filter only kicks in when that branch falls through),

before the payload is forwarded to the LLM provider. User, system, and tool messages are never filtered.

## Why

When an assistant generation fails *before any token is committed* — upstream 5xx, connection drop, user-side cancel, `TransferEncodingError`, etc. — Open WebUI persists an assistant row shaped like:

```json
{"role": "assistant", "content": "", "done": false, ...}
```

The history reconstruction path (`load_messages_from_db` → `process_messages_with_output`) currently forwards this row verbatim. Strict OpenAI-compatible providers reject any assistant message with an empty `content` field and no `tool_calls`, with errors like:

```
the message at position 15 with role 'assistant' must not be empty
```

The chat is then **permanently poisoned**: every subsequent prompt fails the same way because the empty row is on the parent chain that `currentId` walks through. Users have to hand-edit `webui.db` to recover.

Full triage with code line references, real DB dump, and a comparison against related closed issues is in #25083.

## What this does **not** try to do

- Does not change how the empty rows are *written*. The frontend persistence path is a separate concern (see #23176 for related work).
- Does not touch `user`, `system`, or `tool` messages — filter is assistant-only.
- Does not modify any DB state. Existing poisoned chats continue to render fine; they just stop being toxic at send-time.

# Changelog Entry

### Fixed

- Filter out empty / `done: false` assistant placeholder messages when rebuilding chat history before sending to the LLM provider. Prevents chats from being permanently broken by a single failed/aborted generation when the upstream provider enforces strict OpenAI message validation (#25083).

---

### Additional Information

A standalone verification script reproduces the poisoned message chain from #25083 and exercises 8 cases. The script inlines the patched function body (the only behaviour change is the new filter clause), so it can be executed without bootstrapping the full `open_webui` import graph.

Output with the patched logic:

```
  OK   passes through normal user + assistant chain
  OK   drops assistant with empty string content (the bug)
  OK   drops assistant with whitespace-only content
  OK   drops assistant with None content
  OK   drops assistant with empty list content
  OK   KEEPS assistant with empty content + tool_calls
  OK   KEEPS user messages even if empty (filter is assistant-only)
  OK   reproduces the real poisoned chain from issue #25083

8/8 checks passed
```

Output with the new filter clause removed (control, simulating current `dev`):

```
  OK   passes through normal user + assistant chain
  FAIL drops assistant with empty string content (the bug):
  FAIL drops assistant with whitespace-only content:
  FAIL drops assistant with None content:
  FAIL drops assistant with empty list content:
  OK   KEEPS assistant with empty content + tool_calls
  OK   KEEPS user messages even if empty (filter is assistant-only)
  FAIL reproduces the real poisoned chain from issue #25083: expected 4 user + 1 healthy assistant, got roles=['user', 'assistant', 'user', 'assistant', 'user', 'assistant', 'user', 'assistant']

3/8 checks passed
```

The 5 failures isolate exactly the regression introduced into chat payloads by an unfiltered empty assistant row, and all clear once the filter is in place. The `KEEPS …` cases confirm the filter does not regress legitimate messages (tool-call assistants, empty user messages).

**In-vivo test**: I additionally applied the 5-line filter to a live `v0.9.5` container by editing `/app/backend/open_webui/utils/middleware.py` in place and restarting `uvicorn`. I then injected a synthetic empty assistant node into a real chat in `webui.db` (matching the row shape that #25083 reports as the failure trigger), refreshed the chat in the browser, and sent a follow-up user message. With the unpatched image this had reliably produced the `the message at position N with role 'assistant' must not be empty` rejection on every send; with the patched image the request completed normally and the upstream returned a regular streamed response. The chat was then restored to its pre-test state.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
