### PR TITLE
fix: retain handles + done_callback + shutdown-cancel for pool cleanup tasks

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -660,7 +660,7 @@ async def lifespan(app: FastAPI):
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = THREAD_POOL_SIZE
 
-    def _daemon_done_cb(task: asyncio.Task) -> None:
+    def log_unexpected_cleanup_task_exit(task: asyncio.Task) -> None:
         # `asyncio.create_task` discards exceptions on unreferenced tasks; without
         # this callback a dead cleanup loop only surfaces as a delayed
         # "Task exception was never retrieved" WARNING at GC time, by which point
@@ -669,7 +669,7 @@ async def lifespan(app: FastAPI):
         # immediate, alertable signal at the moment of death.
         if not task.cancelled() and task.exception() is not None:
             log.error(
-                'Background daemon task %s exited unexpectedly: %r '
+                'Background cleanup task %s exited unexpectedly: %r '
                 '— pool cleanup has stopped for the remaining lifetime of the process.',
                 task.get_name(),
                 task.exception(),
@@ -679,12 +679,12 @@ async def lifespan(app: FastAPI):
     app.state.periodic_usage_cleanup_task = asyncio.create_task(
         periodic_usage_pool_cleanup(), name='periodic_usage_pool_cleanup'
     )
-    app.state.periodic_usage_cleanup_task.add_done_callback(_daemon_done_cb)
+    app.state.periodic_usage_cleanup_task.add_done_callback(log_unexpected_cleanup_task_exit)
 
     app.state.periodic_session_cleanup_task = asyncio.create_task(
         periodic_session_pool_cleanup(), name='periodic_session_pool_cleanup'
     )
-    app.state.periodic_session_cleanup_task.add_done_callback(_daemon_done_cb)
+    app.state.periodic_session_cleanup_task.add_done_callback(log_unexpected_cleanup_task_exit)
 
     from open_webui.utils.automations import scheduler_worker_loop
 
@@ -763,10 +763,10 @@ async def lifespan(app: FastAPI):
     # the tasks are destroyed mid-await and asyncio emits a
     # "Task was destroyed but it is pending!" warning on every clean restart,
     # which trains operators to ignore that warning and masks real failures.
-    for _attr in ('periodic_usage_cleanup_task', 'periodic_session_cleanup_task'):
-        _t = getattr(app.state, _attr, None)
-        if _t is not None:
-            _t.cancel()
+    if hasattr(app.state, 'periodic_usage_cleanup_task'):
+        app.state.periodic_usage_cleanup_task.cancel()
+    if hasattr(app.state, 'periodic_session_cleanup_task'):
+        app.state.periodic_session_cleanup_task.cancel()
 
 
 app = FastAPI(

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -660,8 +660,31 @@ async def lifespan(app: FastAPI):
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = THREAD_POOL_SIZE
 
-    asyncio.create_task(periodic_usage_pool_cleanup())
-    asyncio.create_task(periodic_session_pool_cleanup())
+    def _daemon_done_cb(task: asyncio.Task) -> None:
+        # `asyncio.create_task` discards exceptions on unreferenced tasks; without
+        # this callback a dead cleanup loop only surfaces as a delayed
+        # "Task exception was never retrieved" WARNING at GC time, by which point
+        # SESSION_POOL/USAGE_POOL have already been growing without bound for an
+        # unknown interval. Logging at ERROR with exc_info gives operators an
+        # immediate, alertable signal at the moment of death.
+        if not task.cancelled() and task.exception() is not None:
+            log.error(
+                'Background daemon task %s exited unexpectedly: %r '
+                '— pool cleanup has stopped for the remaining lifetime of the process.',
+                task.get_name(),
+                task.exception(),
+                exc_info=task.exception(),
+            )
+
+    app.state.periodic_usage_cleanup_task = asyncio.create_task(
+        periodic_usage_pool_cleanup(), name='periodic_usage_pool_cleanup'
+    )
+    app.state.periodic_usage_cleanup_task.add_done_callback(_daemon_done_cb)
+
+    app.state.periodic_session_cleanup_task = asyncio.create_task(
+        periodic_session_pool_cleanup(), name='periodic_session_pool_cleanup'
+    )
+    app.state.periodic_session_cleanup_task.add_done_callback(_daemon_done_cb)
 
     from open_webui.utils.automations import scheduler_worker_loop
 
@@ -734,6 +757,16 @@ async def lifespan(app: FastAPI):
 
     if hasattr(app.state, 'redis_task_command_listener'):
         app.state.redis_task_command_listener.cancel()
+
+    # Cooperatively cancel the cleanup daemons so their `finally: release_fn()`
+    # blocks run and the Redis lock is freed for the next replica. Without this,
+    # the tasks are destroyed mid-await and asyncio emits a
+    # "Task was destroyed but it is pending!" warning on every clean restart,
+    # which trains operators to ignore that warning and masks real failures.
+    for _attr in ('periodic_usage_cleanup_task', 'periodic_session_cleanup_task'):
+        _t = getattr(app.state, _attr, None)
+        if _t is not None:
+            _t.cancel()
 
 
 app = FastAPI(


### PR DESCRIPTION
# Pull Request Checklist

> Replaces closed #25222. Addresses @Classic298's review feedback there: variable naming improved (commit `56ecdb63a`) and the patch is now manually tested with the 3-phase docker compose protocol below (literal log captures included).

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes the spawn-site half of #25216. Complements #21798. Replaces closed #25222.
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** See below + Test Evidence section.
- [x] **Changelog:** Added under `Fixed`.
- [ ] **Documentation:** N/A — internal lifecycle change, no user-facing behavior, no env vars, no public API change.
- [ ] **Dependencies:** No new or upgraded dependencies.
- [x] **Testing:** **Tested locally** with docker compose (open-webui source build + redis:7-alpine, `WEBSOCKET_MANAGER=redis`, `WEBSOCKET_REDIS_LOCK_TIMEOUT=5`). See Test Evidence section. Three-phase test (baseline / #21798 only / #21798 + this patch) all green with literal log captures.
- [x] **Agentic AI Code:** Diff was drafted with AI tooling assistance and **manually tested via the 3-phase docker compose protocol described below** with literal log evidence captured at each stage. Addressing both review concerns from #25222 (variable naming + tested-before-review).
- [x] **Code review:** Self-reviewed; the diff matches the existing `redis_task_command_listener` pattern at lines 657 + 754 exactly.
- [x] **Design & Architecture:** No new settings, no new state shape — reuses `app.state` slot pattern.
- [x] **Git Hygiene:** Two atomic commits, rebased on `dev`, no unrelated commits.
- [x] **Title Prefix:** `fix:`.

# Changelog Entry

### Description

Closes the second root-cause path named in #25216 ("`asyncio.create_task` drops the handle — if the task dies for ANY other reason there is no operator signal"). Orthogonal to #21798: that PR makes the cleanup *loop* internally resilient (it will not exit on Redis lock acquire/renew failure). This PR makes the cleanup *spawn site* observable — if the task dies anyway (e.g. via injected `RuntimeError` or `BaseException`-class exits that bypass `run_with_lock`'s `except Exception` guards), the operator gets an immediate `ERROR` log instead of a delayed asyncio `"Task exception was never retrieved"` WARNING at GC time.

### Added

- `log_unexpected_cleanup_task_exit` callback that logs an `ERROR` with `exc_info` if a cleanup task exits non-cancelled.
- Named tasks (`name='periodic_usage_pool_cleanup'`, `name='periodic_session_pool_cleanup'`) so log lines identify which daemon died.
- Handle retention on `app.state.periodic_usage_cleanup_task` and `app.state.periodic_session_cleanup_task`, mirroring the existing `app.state.redis_task_command_listener` slot.
- Cooperative shutdown cancellation in the `lifespan` finalizer so `CancelledError` is delivered, the `finally: release_fn()` in `run_with_lock` runs, and the Redis lock is freed for the next replica.

### Changed

- The two `asyncio.create_task(...)` calls at `backend/open_webui/main.py:682-683` (previously fire-and-forget) now return references that are stored on `app.state` and have a `done_callback` attached.

### Fixed

- **`USAGE_POOL` / `SESSION_POOL` unbounded growth after silent cleanup-task death (#25216, second root cause).** The only operator-visible signal under the previous code was a delayed `"Task exception was never retrieved"` WARNING fired at asyncio GC time. With a `done_callback`, the failure is logged at `ERROR` at the moment of death, with the task name and `exc_info` traceback.

## Test Evidence

Test environment: Docker compose with open-webui source build + `redis:7-alpine`, `WEBSOCKET_MANAGER=redis`, `WEBSOCKET_REDIS_LOCK_TIMEOUT=5`, Python 3.11, uvicorn 0.34.

### Phase 1 — Baseline (origin/dev, no patches) — confirms the bug

After 8-second `docker pause owui-test-redis` (exceeds 5s lock TTL):

```
2026-05-30 16:16:21.036 | DEBUG | open_webui.socket.main:periodic_usage_pool_cleanup:204 - Running periodic_cleanup
2026-05-30 16:17:02.541 | ERROR | open_webui.socket.main:periodic_usage_pool_cleanup:208 - Unable to renew cleanup lock. Exiting usage pool cleanup.
2026-05-30 16:17:02.541 | ERROR | asyncio.runners:run:118 - Task exception was never retrieved
future: <Task finished name='Task-5' coro=<periodic_usage_pool_cleanup() done, defined at /app/backend/open_webui/socket/main.py:190> exception=Exception('Unable to renew usage pool cleanup lock.')>
    raise Exception('Unable to renew usage pool cleanup lock.')
Exception: Unable to renew usage pool cleanup lock.
```

- Task name: `Task-5` (auto-generated — no `name=` provided).
- Sole operator signal: delayed `Task exception was never retrieved` from asyncio's default exception handler.
- After this point: no further `Running periodic_cleanup` → cleanup is dead for the lifetime of the process.

### Phase 2 — PR #21798 only (cherry-picked onto origin/dev)

Same `docker pause` sequence:

```
2026-05-30 16:22:17.691 | INFO | open_webui.socket.main:run_with_lock:191 - Lock renewal failed. Will re-acquire.
```

Match counts:
| Pattern | Phase 1 | Phase 2 |
|---|---:|---:|
| `Unable to renew cleanup lock` | 1 | **0** |
| `Exiting usage pool cleanup` | 1 | **0** |
| `Task exception was never retrieved` | 1 | **0** |
| `Lock renewal failed. Will re-acquire.` | 0 | **1** |

PR #21798's `run_with_lock` correctly intercepts the renewal-failure path. The first root cause from #25216 is fixed.

### Phase 3 — PR #21798 + this patch

**Test A** — regression check on PR #21798's path:

```
2026-05-30 16:26:15.545 | INFO | open_webui.socket.main:run_with_lock:191 - Lock renewal failed. Will re-acquire.
```

No regression — `run_with_lock` still works.

**Test B** — clean shutdown via SIGTERM:

- Container exited cleanly, exit code 0, 2 seconds after SIGTERM.
- Zero matches for `Task was destroyed but it is pending`, `Task exception was never retrieved`, or any baseline error.
- (Note: Phase 2 also showed zero `Task was destroyed` in this environment — Python 3.11 + recent uvicorn cancels background tasks at loop close. The shutdown-cancel branch in this patch is defensive for older uvicorn / vanilla asyncio runners where the warning does fire.)

**Test C** — injected `RuntimeError('synthetic test of done_callback')` at the top of `periodic_usage_pool_cleanup` (temporary, removed after test, not committed):

```
2026-05-30 16:29:32.760 | ERROR | open_webui.main:log_unexpected_cleanup_task_exit:671 - Background cleanup task periodic_usage_pool_cleanup exited unexpectedly: RuntimeError('synthetic test of done_callback') — pool cleanup has stopped for the remaining lifetime of the process.
    raise RuntimeError('synthetic test of done_callback')
RuntimeError: synthetic test of done_callback
```

- ERROR level — alertable by any log aggregator.
- Named task in log: `periodic_usage_pool_cleanup` (vs Phase 1's auto-generated `Task-5`).
- Exception `repr` in message + `exc_info` traceback included.
- "pool cleanup has stopped" warning — actionable operator signal.

Compared to Phase 1, the operator now has an immediate, attributable, alertable signal at task death — exactly the gap #25216 item 2 asked to close.

### Reproduction recipe (for reviewer)

```bash
git fetch origin pull/21798/head:pr21798
git checkout -b reviewer-test pr21798
git fetch https://github.com/Nexory/open-webui fix/cleanup-task-handle-retention
git cherry-pick FETCH_HEAD~1 FETCH_HEAD

# Then build docker image with WEBSOCKET_MANAGER=redis + WEBSOCKET_REDIS_LOCK_TIMEOUT=5
# Pause Redis 8s, then unpause → expect "Will re-acquire" log.
# Inject `raise RuntimeError('test')` at top of periodic_usage_pool_cleanup → expect "Background cleanup task ... exited unexpectedly" ERROR log.
```

### Additional Information

**Why this is orthogonal to #21798:** Zero file overlap. #21798 modifies `backend/open_webui/socket/main.py` and `backend/open_webui/socket/utils.py`. This PR modifies only `backend/open_webui/main.py`. The two PRs can be reviewed, merged, and reverted independently.

**Addressing review feedback from #25222:**

1. **Variable naming** — fixed in commit `56ecdb63a`. `_daemon_done_cb` → `log_unexpected_cleanup_task_exit` (descriptive, not abbreviated). The shutdown loop with `_attr`/`_t` shorthand → explicit `hasattr` pattern matching the existing `redis_task_command_listener` shutdown at line 754 exactly.
2. **Tested before review** — full 3-phase docker compose test executed with literal log captures (see above). Filing as Draft per your suggestion.

### Screenshots or Videos

N/A — backend lifecycle change with no UI surface.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
