### PR TITLE
fix: use marked.parseInline() in NotificationToast to prevent block-level HTML rendering

### DIFF
--- a/src/lib/components/NotificationToast.svelte
+++ b/src/lib/components/NotificationToast.svelte
@@ -118,7 +118,7 @@
 		{/if}
 
 		<div class=" line-clamp-2 text-xs self-center dark:text-gray-300 font-normal">
-			{@html DOMPurify.sanitize(marked(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
+			{@html DOMPurify.sanitize(marked.parseInline(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Fixes #21860

## Problem

When a model outputs raw HTML or markdown with block-level elements (e.g. `<table>`, `# Heading`, pipe tables), the completion notification renders them as formatted HTML while the chat view displays them as escaped plain text, creating inconsistent rendering.

## Root Cause

`NotificationToast.svelte` passes content through `marked()`, which parses **block-level** markdown (headings, tables, lists, code blocks) and injects the result via `{@html}`. A toast notification is a short 2-line preview and should not render block-level structure.

## Fix

Replace `marked()` with `marked.parseInline()`.

`marked.parseInline()` only handles **inline** markdown (bold, italic, inline code, links) and does not produce block-level HTML. This means:
- `<table>` content is stripped by the existing inner DOMPurify call — no table ever renders
- Markdown pipe tables are not converted to `<table>` HTML  
- Headings are not converted to `<h1>`
- Inline formatting like `**bold**` still works correctly

## Change

```diff
- {@html DOMPurify.sanitize(marked(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
+ {@html DOMPurify.sanitize(marked.parseInline(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
```

Single line in `src/lib/components/NotificationToast.svelte`. No new imports or dependencies — `parseInline` is a method on the already-imported `marked` object (marked v9+, which this project uses).

## Testing

1. Start a chat and prompt the model: `"Output only this HTML: <table><tr><td>Name</td></tr></table>"`
2. Observe the completion notification — it should show plain text, not a rendered table
3. Verify inline formatting like `**bold**` still renders correctly in notifications
