### PR TITLE
fix: use marked.parseInline() in NotificationToast to prevent block-level HTML rendering

### DIFF
--- a/src/lib/components/NotificationToast.svelte
+++ b/src/lib/components/NotificationToast.svelte
@@ -118,7 +118,7 @@
 		{/if}
 
 		<div class=" line-clamp-2 text-xs self-center dark:text-gray-300 font-normal">
-			{@html DOMPurify.sanitize(marked(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
+			{@html DOMPurify.sanitize(marked.parseInline(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Closes #21860

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #21860
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Concise one-line fix described below
- [x] **Dependencies:** No new dependencies — `parseInline` is already on the imported `marked` object (v9+)
- [x] **Testing:** Manually verified — see steps below
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR — single logical change
- [x] **Title Prefix:** `fix:`

---

## Description

When a model outputs raw HTML or markdown with block-level elements (e.g. `<table>`, pipe tables, `# Heading`), the completion notification renders them as formatted HTML while the chat view displays them as escaped plain text — inconsistent behaviour reported in #21860.

**Root cause:** `NotificationToast.svelte` passes content through `marked()`, which parses block-level markdown and injects the result via `{@html}`. A 2-line toast preview should not render block-level structure.

**Fix:** Replace `marked()` with `marked.parseInline()`, which only handles inline markdown (bold, italic, inline code, links) and never produces block-level HTML (`<table>`, `<h1>`, `<ul>`, etc.).

## Changelog Entry

### Fixed

- Completion notification no longer renders block-level HTML (tables, headings, lists) when model output contains raw HTML or markdown — notification now shows a consistent plain-text-style preview.

### Changed

- `NotificationToast.svelte`: replaced `marked()` with `marked.parseInline()` for notification content rendering.

---

### Diff

```diff
- {@html DOMPurify.sanitize(marked(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
+ {@html DOMPurify.sanitize(marked.parseInline(DOMPurify.sanitize(content, { ALLOWED_TAGS: [] })))}
```

Single line in `src/lib/components/NotificationToast.svelte`. No new imports or dependencies needed.

### Testing Steps

1. Start a chat, prompt model: *"Output only this HTML: `<table><tr><td>Name</td><td>Age</td></tr></table>`"*
2. **Before fix:** notification renders a formatted table
3. **After fix:** notification shows plain text content only
4. Verify `**bold**` inline markdown still renders correctly in notifications

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
