### PR TITLE
fix: prevent Collapsible onChange from firing on initial mount

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -2,7 +2,7 @@
 	import { decode } from 'html-entities';
 	import { v4 as uuidv4 } from 'uuid';
 
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	const i18n = getContext('i18n');
 
 	import dayjs from '$lib/dayjs';
@@ -55,7 +55,9 @@
 
 	export let onChange: Function = () => {};
 
-	$: onChange(open);
+	let _mounted = false;
+	onMount(() => { _mounted = true; });
+	$: if (_mounted) onChange(open);
 
 	const collapsibleId = uuidv4();
 </script>


### PR DESCRIPTION
- [x] **Linked Issue/Discussion:** See description
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Change described below
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** Confirm this PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Closes #23232

**Root cause:** `Collapsible.svelte` uses `$: onChange(open)` which is a Svelte reactive statement that fires on component initialisation *and* every subsequent change.

`Controls.svelte` passes `onChange={setOpen('advancedParams')}` where `setOpen` writes state to `localStorage`. Because the reactive statement fires on mount, `chatControls.advancedParams` is written to localStorage every time `Controls` mounts — even if the user never interacts with it. The fallback for `advancedParams` is `true`, so any tab that hasn't explicitly closed the section will write `"true"` to localStorage, causing other tabs to auto-expand Advanced Params on mount.

**Fix:** Guard the reactive statement with a `_mounted` flag so `onChange` only fires on user-driven changes, not during initialisation.

```diff
- $: onChange(open);
+ let _mounted = false;
+ onMount(() => { _mounted = true; });
+ $: if (_mounted) onChange(open);
```

## Changelog Entry

### Fixed
- Opening Artifacts panel in one tab no longer causes Advanced Params to auto-expand in other tabs — Collapsible now only writes localStorage on user interaction, not on initial render.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.