### PR TITLE
feat: add ariaLabel prop to Switch component

### DIFF
--- a/src/lib/components/common/Switch.svelte
+++ b/src/lib/components/common/Switch.svelte
@@ -8,6 +8,7 @@
 	export let state = true;
 	export let id = '';
 	export let ariaLabelledbyId = '';
+	export let ariaLabel = '';
 	export let tooltip = false;
 
 	const i18n = getContext('i18n');
@@ -27,7 +28,8 @@
 	<Switch.Root
 		bind:checked={state}
 		{id}
-		aria-labelledby={ariaLabelledbyId}
+		aria-labelledby={ariaLabelledbyId || undefined}
+		aria-label={ariaLabel || undefined}
 		class="flex h-[1.125rem] min-h-[1.125rem] w-8 shrink-0 cursor-pointer items-center rounded-full px-1 mx-[1px] transition  {($settings?.highContrastMode ??
 		false)
 			? 'focus:outline focus:outline-2 focus:outline-gray-800 focus:dark:outline-gray-200'


### PR DESCRIPTION
- [x] **Linked Issue/Discussion:** See description
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Change described below
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** Confirm this PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Relates to #17150

`Switch.svelte` accepts `ariaLabelledbyId` for associating a visible label via `aria-labelledby`, but has no `aria-label` prop for contexts where no visible label element exists. This leaves standalone switches unlabelled for screen readers.

Adds an `ariaLabel` prop that maps directly to `aria-label` on `Switch.Root`. Both props default to empty string and are only rendered when non-empty (`|| undefined`), so existing usages are unchanged.

```diff
+ export let ariaLabel = '';
  aria-labelledby={ariaLabelledbyId || undefined}
+ aria-label={ariaLabel || undefined}
```

## Changelog Entry

### Added
- `Switch` component now accepts an `ariaLabel` prop for accessible naming where no visible label element is present.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.