### PR TITLE
feat(anthropic): map advanced thinking and effort params to OpenAI re…

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -349,6 +349,45 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     'type': 'function',
                     'function': {'name': tc.get('name', '')},
                 }
+    # === Add logic to convert Anthropic thinking/reasoning parameters to OpenAI reasoning_effort ===
+    def map_effort_string(raw_str: str) -> str:
+        """Extract reasoning level via fuzzy matching, defaulting to safe compatible 'high' for max values."""
+        s = raw_str.lower()
+        if any(keyword in s for keyword in ('high', 'max', 'ultra')):
+            return 'high'
+        elif 'low' in s:
+            return 'low'
+        else:
+            return 'medium'
+
+    # 1. Prioritize capturing output_config.effort from the latest Claude Code versions
+    if 'output_config' in anthropic_payload and isinstance(anthropic_payload['output_config'], dict):
+        effort_val = anthropic_payload['output_config'].get('effort')
+        if effort_val:
+            openai_payload['reasoning_effort'] = map_effort_string(str(effort_val))
+            
+    # 2. Compatibility for effort field passed directly at the top level
+    elif 'effort' in anthropic_payload:
+        openai_payload['reasoning_effort'] = map_effort_string(str(anthropic_payload['effort']))
+
+    # 3. Fallback handling for thinking field (supports both adaptive and legacy budget_tokens)
+    if 'thinking' in anthropic_payload:
+        thinking_cfg = anthropic_payload['thinking']
+        if isinstance(thinking_cfg, dict):
+            # If using the latest adaptive thinking, and effort wasn't caught above, default to high intensity
+            if thinking_cfg.get('type') == 'adaptive' and 'reasoning_effort' not in openai_payload:
+                openai_payload['reasoning_effort'] = 'high'
+            # Legacy budget_tokens logic
+            elif 'budget_tokens' in thinking_cfg and 'reasoning_effort' not in openai_payload:
+                budget = thinking_cfg.get('budget_tokens', 0)
+                if budget == 0:
+                    openai_payload['reasoning_effort'] = 'medium'
+                elif budget < 4000:
+                    openai_payload['reasoning_effort'] = 'low'
+                elif budget < 8000:
+                    openai_payload['reasoning_effort'] = 'medium'
+                else:
+                    openai_payload['reasoning_effort'] = 'high'
 
     return openai_payload
 


### PR DESCRIPTION
…asoning_effort

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

### Description
- This PR enhances the Anthropic to OpenAI payload conversion utility by intercepting extended reasoning parameters and translating them to the OpenAI `reasoning_effort` standard.
- AI coding assistants (like Claude Code) frequently update their underlying API payloads to request maximum reasoning effort. Previously, these parameters were silently dropped by the Pydantic/conversion layers. This patch ensures that requests routed through Open WebUI retain their intended reasoning intensity when forwarded to OpenAI-compatible downstream models.
### Added

**Changes made in `backend/open_webui/utils/anthropic.py`:**
- Added a fuzzy matching helper function to map non-standard effort levels (e.g., `max`, `ultra`, `xhigh`) to the OpenAI-compliant `high` tier.
- Added parsing for the latest Anthropic `output_config.effort` payload structure utilized by updated tools like Claude Code.
- Maintained backward compatibility for top-level `effort` strings.
- Added fallback parsing for the `thinking` object, supporting both the newer `"type": "adaptive"` format and the legacy `"budget_tokens"` format (dynamically mapping token thresholds to low/medium/high).

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- [List any fixes, corrections, or bug fixes]

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- Verified with payload containing `output_config.effort = "max"` and `thinking.type = "adaptive"`.
- Verified with legacy payload using `thinking.budget_tokens = 8192`.
- Confirmed that payloads correctly map to `"reasoning_effort": "high"` before exiting the conversion function without triggering validation errors.
  - [Reference any related issues, commits, or other relevant information]
- issue #25237 
### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
