### PR TITLE
fix: trim whitespace from prompt before submit

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1954,6 +1954,7 @@
 	};
 
 	const submitHandler = async (userPrompt, { _raw = false } = {}) => {
+		userPrompt = userPrompt.trim(); // strip leading/trailing whitespace (#20198)
 		console.log('submitHandler', userPrompt, $chatId);
 
 		const _selectedModels = selectedModels.map((modelId) =>


### PR DESCRIPTION

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** See description
- [x] **Target branch:** Targets `dev`
- [x] **Description:** See below
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Closes #20198

The rich-text editor (via turndown) can produce trailing newlines/spaces in the markdown output. These are passed as-is to `submitHandler`, stored in the message, and echoed back as extra blank lines in the chat view.

Adds a single `.trim()` call at the top of `submitHandler` so any leading or trailing whitespace is stripped before the prompt is stored or sent.

## Changelog Entry

### Fixed
- Messages no longer contain extra leading/trailing spaces or newlines added by the editor's markdown serialiser.


### Contributor License Agreement
- [x] By submitting this PR I confirm I have read and agree to the [CLA](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT).
