### PR TITLE
fix: handle MCP resource content type blob and URI variants

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1158,6 +1158,31 @@ async def process_tool_result(
                             except json.JSONDecodeError:
                                 pass
                             tool_response.append(text)
+                        elif resource.get('blob'):
+                            # Binary resource — surface as image or describe it
+                            mime_type = resource.get('mimeType', 'application/octet-stream')
+                            blob = resource.get('blob', '')
+                            if mime_type.startswith('image/'):
+                                file_url = await get_file_url_from_base64(
+                                    request,
+                                    f'data:{mime_type};base64,{blob}',
+                                    {
+                                        'chat_id': metadata.get('chat_id', None),
+                                        'message_id': metadata.get('message_id', None),
+                                        'session_id': metadata.get('session_id', None),
+                                        'result': item,
+                                    },
+                                    user,
+                                )
+                                tool_result_files.append({'type': 'image', 'url': file_url})
+                            else:
+                                uri = resource.get('uri', 'resource')
+                                tool_response.append(
+                                    f'[Resource: {uri}] (binary data, mimeType: {mime_type})'
+                                )
+                        elif resource.get('uri'):
+                            # URI-only resource — pass the URI as text context
+                            tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
             for item in tool_result:


### PR DESCRIPTION

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** See description
- [x] **Target branch:** Targets `dev`
- [x] **Description:** See below
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Closes #24038

When an MCP tool returns a `resource` content item, only the `text` sub-field was handled. Items with a `blob` (binary data) or a `uri`-only resource were silently dropped, so the model received no information about those resources.

**Changes:**
- `blob` resources: binary image blobs are uploaded and attached as image files (same path as `image`/`audio` items); non-image blobs are described as text so the model knows the resource exists.
- `uri`-only resources: the URI string is appended to the tool response text so the model can reference it.

## Changelog Entry

### Fixed
- MCP tool results with `resource` content items containing `blob` (binary) data or a bare `uri` are no longer silently dropped.


### Contributor License Agreement
- [x] By submitting this PR I confirm I have read and agree to the [CLA](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT).
