### PR TITLE
fix: prevent infinite loading spinner when loadChat() fails

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -215,7 +215,7 @@
 			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
 		);
 
-		if (chatIdProp && (await loadChat())) {
+		if (chatIdProp && (await loadChat().catch((e) => { console.error('navigateHandler: loadChat failed', e); loading = false; return false; }))) {
 			await tick();
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
@@ -255,6 +255,7 @@
 			const chatInput = document.getElementById('chat-input');
 			chatInput?.focus();
 		} else {
+			loading = false; // Prevent infinite loading spinner if goto() is slow or fails
 			await goto('/');
 		}
 	};


### PR DESCRIPTION

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** See description
- [x] **Target branch:** Targets `dev`
- [x] **Description:** See below
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Closes #14806

If `loadChat()` throws an unhandled exception (e.g. when model permissions are revoked and downstream validation code throws), neither the `if` nor the `else` branch runs — `loading` stays `true` forever and the UI shows an infinite spinner.

Two minimal changes:
1. Add a `.catch()` on the `loadChat()` call that clears `loading` and returns `false` so the `else` branch runs normally.
2. Set `loading = false` before `goto('/')` in the `else` branch so the spinner disappears immediately even if navigation is slow.

## Changelog Entry

### Fixed
- Switching to a chat whose model permissions were revoked no longer leaves the UI stuck in an infinite loading state.


### Contributor License Agreement
- [x] By submitting this PR I confirm I have read and agree to the [CLA](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT).
