### PR TITLE
fix: increase Web API STT inactivity timeout to prevent mid-sentence cut-off

### DIFF
--- a/src/lib/components/chat/MessageInput/VoiceRecording.svelte
+++ b/src/lib/components/chat/MessageInput/VoiceRecording.svelte
@@ -307,7 +307,7 @@
 					speechRecognition.continuous = true;
 
 					// Set the timeout for turning off the recognition after inactivity (in milliseconds)
-					const inactivityTimeout = 2000; // 3 seconds
+					const inactivityTimeout = 5000; // 5 s — allows natural pauses between word batches
 
 					let timeoutId;
 					// Start recognition


### PR DESCRIPTION
## Pull Request Checklist
- [x] Linked Issue/Discussion: See description
- [x] Target branch: `dev`
- [x] Agentic AI Code: This PR has gone through human review and manual testing
- [x] CLA: [agreed](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)

Closes #19727

The Web API STT engine fires `onresult` events in word batches. The 2 s timer starts after each batch, cutting off the user if they speak for more than 2 s without a pause. Increasing to **5 s** gives enough room for natural speech rhythm. Also fixes the incorrect comment (`// 3 seconds` for a 2000 ms value).

**Changed:** `VoiceRecording.svelte` — `inactivityTimeout` 2000 → 5000
