### PR TITLE
fix: honour per-user voice setting for Azure TTS

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -460,7 +460,8 @@ async def _tts_azure(request, payload, file_path, file_body_path, user):
     """Generate speech via Azure Cognitive Services TTS."""
     az_region = request.app.state.config.TTS_AZURE_SPEECH_REGION or 'eastus'
     az_base = request.app.state.config.TTS_AZURE_SPEECH_BASE_URL
-    language = request.app.state.config.TTS_VOICE
+    # Honour the per-user voice from the request payload; fall back to admin default.
+    language = payload.get('voice') or request.app.state.config.TTS_VOICE
     locale = '-'.join(language.split('-')[:2])
     output_format = request.app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT
 


### PR DESCRIPTION
## Pull Request Checklist
- [x] Linked Issue/Discussion: See description
- [x] Target branch: `dev`
- [x] Agentic AI Code: This PR has gone through human review and manual testing
- [x] CLA: [agreed](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)

Closes #15143

`_tts_azure` always used `TTS_VOICE` (admin default), ignoring the user's selected voice. Every other engine reads `payload.get('voice')` first. One-line fix: `payload.get('voice') or request.app.state.config.TTS_VOICE`.
