### PR TITLE
fix: truncate oversized paste to prevent browser freeze

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -172,6 +172,7 @@
 	import FormattingButtons from './RichTextInput/FormattingButtons.svelte';
 
 	import { PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+	import { toast } from 'svelte-sonner';
 	import { createLowlight } from 'lowlight';
 	import hljs from 'highlight.js';
 
@@ -963,10 +964,15 @@
 						event.preventDefault();
 						const { state, dispatch } = view;
 
-						const plainText = (event.clipboardData?.getData('text/plain') ?? '').replace(
+						let plainText = (event.clipboardData?.getData('text/plain') ?? '').replace(
 							/\r\n/g,
 							'\n'
 						);
+						// Truncate before node creation to prevent browser freeze on huge pastes
+						if (plainText.length > PASTED_TEXT_CHARACTER_LIMIT) {
+							plainText = plainText.slice(0, PASTED_TEXT_CHARACTER_LIMIT);
+							toast.warning(`Pasted text truncated to ${PASTED_TEXT_CHARACTER_LIMIT} characters.`);
+						}
 
 						const lines = plainText.split('\n');
 						const nodes = [];


### PR DESCRIPTION
## Pull Request Checklist
- [x] Linked Issue/Discussion: See description
- [x] Target branch: `dev`
- [x] Agentic AI Code: This PR has gone through human review and manual testing
- [x] CLA: [agreed](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)

Closes #12087

In plain-text (non-richText) mode, the `handlePaste` handler splits the pasted content into lines and creates a ProseMirror text node per line. Pasting megabytes of text creates tens of thousands of DOM nodes synchronously, freezing the browser tab.

Fix: truncate `plainText` to `PASTED_TEXT_CHARACTER_LIMIT` (1000 chars) before splitting into nodes, and show a toast notification so the user knows the paste was truncated.
