### PR TITLE
fix: change menu trigger divs to buttons for keyboard accessibility

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1660,12 +1660,14 @@
 											chatInput?.focus();
 										}}
 									>
-										<div
+										<button
+											type="button"
 											id="input-menu-button"
+											aria-label={$i18n.t('Add files and more')}
 											class="bg-transparent hover:bg-gray-100 text-gray-700 dark:text-white dark:hover:bg-gray-800 rounded-full size-8 flex justify-center items-center outline-hidden focus:outline-hidden"
 										>
 											<PlusAlt className="size-5.5" />
-										</div>
+										</button>
 									</InputMenu>
 
 									{#if showWebSearchButton || showImageGenerationButton || showCodeInterpreterButton || showToolsButton || (toggleFilters && toggleFilters.length > 0)}
@@ -1699,12 +1701,14 @@
 												chatInput?.focus();
 											}}
 										>
-											<div
+											<button
+												type="button"
 												id="integration-menu-button"
+												aria-label={$i18n.t('Integrations')}
 												class="bg-transparent hover:bg-gray-100 text-gray-700 dark:text-white dark:hover:bg-gray-800 rounded-full size-8 flex justify-center items-center outline-hidden focus:outline-hidden"
 											>
 												<Component className="size-4.5" strokeWidth="1.5" />
-											</div>
+											</button>
 										</IntegrationsMenu>
 									{/if}
 


### PR DESCRIPTION
## Pull Request Checklist
- [x] Linked Issue/Discussion: See description
- [x] Target branch: `dev`
- [x] Agentic AI Code: This PR has gone through human review and manual testing
- [x] CLA: [agreed](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)

Closes #24097

Since v0.8.11, the `+` (file upload) and integrations (web search/tools) menu trigger elements are rendered as `<div>` instead of `<button>`. A `<div>` is not natively focusable, so keyboard and screen-reader users cannot Tab to these controls at all — focus jumps straight from the chat input to the send button.

**Fix:** change both `<div id="input-menu-button">` and `<div id="integration-menu-button">` to `<button type="button">` with appropriate `aria-label` attributes. Click behaviour is unchanged since the `InputMenu`/`IntegrationsMenu` wrapper components handle the click event on the outer element.
