### PR TITLE
fix: set WindowsSelectorEventLoopPolicy before uvicorn on Windows (psycopg v3)

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -34,6 +34,14 @@ def serve(
     port: int = 8080,
 ):
     os.environ['FROM_INIT_PY'] = 'true'
+
+    # psycopg v3 is incompatible with Windows' default ProactorEventLoop.
+    # Set WindowsSelectorEventLoopPolicy *before* any asyncio or uvicorn
+    # initialisation so the selector loop is used from the start.
+    if sys.platform == 'win32':
+        import asyncio as _asyncio
+        _asyncio.set_event_loop_policy(_asyncio.WindowsSelectorEventLoopPolicy())
+
     if os.getenv('WEBUI_SECRET_KEY') is None:
         typer.echo('Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.')
         if not KEY_FILE.exists():


### PR DESCRIPTION
## Pull Request Checklist
- [x] Linked Issue/Discussion: See description
- [x] Target branch: `dev`
- [x] Agentic AI Code: This PR has gone through human review and manual testing
- [x] CLA: [agreed](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)

Closes #24152

On Windows, the default asyncio event loop is `ProactorEventLoop`, which psycopg v3 cannot use for async operations. `db.py` already calls `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` at module load time, but uvicorn may create an event loop *before* `db.py` is imported, locking in `ProactorEventLoop` for the process lifetime.

**Fix:** call `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` at the very top of the `serve()` command in `__init__.py`, before `import open_webui.main` and before `uvicorn.run()`. This guarantees the selector loop policy is active from the first asyncio call.
