### PR TITLE
fix: trim leading/trailing whitespace from prompt before submit

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1954,6 +1954,7 @@
 	};
 
 	const submitHandler = async (userPrompt, { _raw = false } = {}) => {
+		userPrompt = userPrompt.trim();
 		console.log('submitHandler', userPrompt, $chatId);
 
 		const _selectedModels = selectedModels.map((modelId) =>


### PR DESCRIPTION
Closes #20198

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #20198
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

The rich-text editor serialiser (turndown) can emit trailing newlines/spaces. `.trim()` at the top of `submitHandler` strips them before the message is stored or sent.

# Changelog Entry

### Fixed
- Messages no longer contain extra whitespace added by the editor serialiser.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.