### PR TITLE
fix: handle MCP resource content type blob and URI variants

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1158,6 +1158,29 @@ async def process_tool_result(
                             except json.JSONDecodeError:
                                 pass
                             tool_response.append(text)
+                        elif resource.get('blob'):
+                            mime_type = resource.get('mimeType', 'application/octet-stream')
+                            blob = resource.get('blob', '')
+                            if mime_type.startswith('image/'):
+                                file_url = await get_file_url_from_base64(
+                                    request,
+                                    f'data:{mime_type};base64,{blob}',
+                                    {
+                                        'chat_id': metadata.get('chat_id', None),
+                                        'message_id': metadata.get('message_id', None),
+                                        'session_id': metadata.get('session_id', None),
+                                        'result': item,
+                                    },
+                                    user,
+                                )
+                                tool_result_files.append({'type': 'image', 'url': file_url})
+                            else:
+                                uri = resource.get('uri', 'resource')
+                                tool_response.append(
+                                    f'[Resource: {uri}] (binary data, mimeType: {mime_type})'
+                                )
+                        elif resource.get('uri'):
+                            tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
             for item in tool_result:


### PR DESCRIPTION
Closes #24038

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #24038
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

MCP tool `resource` items with `blob` (binary) or bare `uri` were silently dropped. Blob images are now uploaded as file attachments; other blobs are described as text; URI-only resources pass the URI as text context.

# Changelog Entry

### Fixed
- MCP resource content items with `blob` or `uri` are no longer silently dropped.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.