### PR TITLE
fix: prevent infinite loading spinner when loadChat() fails

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -215,7 +215,7 @@
 			`chat-input${chatIdProp ? `-${chatIdProp}` : ''}`
 		);
 
-		if (chatIdProp && (await loadChat())) {
+		if (chatIdProp && (await loadChat().catch((e) => { console.error('navigateHandler: loadChat failed', e); loading = false; return false; }))) {
 			await tick();
 			loading = false;
 			window.setTimeout(() => scrollToBottom(), 0);
@@ -255,6 +255,7 @@
 			const chatInput = document.getElementById('chat-input');
 			chatInput?.focus();
 		} else {
+			loading = false;
 			await goto('/');
 		}
 	};


### PR DESCRIPTION
Closes #14806

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #14806
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

If `loadChat()` throws (e.g. on revoked model permissions), neither branch ran and `loading` stayed `true` forever. Added `.catch()` on `loadChat()` and `loading = false` before `goto('/')` in the else branch.

# Changelog Entry

### Fixed
- Switching to a chat with revoked model permissions no longer causes an infinite loading spinner.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.