### PR TITLE
fix: increase Web API STT inactivity timeout to prevent mid-sentence cut-off

### DIFF
--- a/src/lib/components/chat/MessageInput/VoiceRecording.svelte
+++ b/src/lib/components/chat/MessageInput/VoiceRecording.svelte
@@ -307,7 +307,7 @@
 					speechRecognition.continuous = true;
 
 					// Set the timeout for turning off the recognition after inactivity (in milliseconds)
-					const inactivityTimeout = 2000; // 3 seconds
+					const inactivityTimeout = 5000; // 5 seconds — allows natural pauses between word batches
 
 					let timeoutId;
 					// Start recognition


### PR DESCRIPTION
Closes #19727

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #19727
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

The Web API STT engine fires `onresult` in word batches. The 2 s timer started after each batch, cutting off the user if a single batch took >2 s to complete. 5 s gives natural speech room. Also fixes the wrong comment (`// 3 seconds` for 2000 ms).

# Changelog Entry

### Fixed
- Web API STT no longer cuts off recordings mid-sentence after natural pauses.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.