### PR TITLE
fix: honour per-user voice setting for Azure TTS

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -460,7 +460,8 @@ async def _tts_azure(request, payload, file_path, file_body_path, user):
     """Generate speech via Azure Cognitive Services TTS."""
     az_region = request.app.state.config.TTS_AZURE_SPEECH_REGION or 'eastus'
     az_base = request.app.state.config.TTS_AZURE_SPEECH_BASE_URL
-    language = request.app.state.config.TTS_VOICE
+    # Honour per-user voice from payload; fall back to admin-configured default.
+    language = payload.get('voice') or request.app.state.config.TTS_VOICE
     locale = '-'.join(language.split('-')[:2])
     output_format = request.app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT
 


### PR DESCRIPTION
Closes #15143

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #15143
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

`_tts_azure` always read `TTS_VOICE` (admin default) and ignored the user's personal voice setting. Every other engine reads `payload.get('voice')` first. One-line fix applying the same pattern.

# Changelog Entry

### Fixed
- Azure TTS now uses the voice set in a user's personal settings.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.