### PR TITLE
fix: add duplicate-content check to batch knowledge file add

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2671,6 +2671,19 @@ async def process_files_batch(
                 )
             ]
 
+            # Duplicate-content guard — mirrors save_docs_to_vector_db for single-file add
+            try:
+                if collection_name and VECTOR_DB_CLIENT.has_collection(collection_name):
+                    dup = VECTOR_DB_CLIENT.query(collection_name=collection_name, filter={'hash': file_hash})
+                    if dup is not None and dup.ids and dup.ids[0]:
+                        ex_fid = dup.metadatas[0][0].get('file_id') if dup.metadatas and dup.metadatas[0] else None
+                        if ex_fid != file.id:
+                            log.info(f'Batch add: skipping duplicate {file.id} (hash exists in {collection_name})')
+                            file_errors.append(BatchProcessFilesResult(file_id=file.id, status='skipped', error=str(ERROR_MESSAGES.DUPLICATE_CONTENT)))
+                            continue
+            except Exception as _dup_err:
+                log.debug(f'Batch add: duplicate check skipped for {file.id}: {_dup_err}')
+
             all_docs.extend(docs)
 
             file_updates.append(


### PR DESCRIPTION
Closes #10679

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #10679
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

The single-file add endpoint checks content hash to prevent duplicates. The batch endpoint skipped this check, allowing duplicate embeddings in the vector DB. Adds the same per-file hash check before each file is queued for embedding.

# Changelog Entry

### Fixed
- Batch knowledge file add no longer creates duplicate embeddings for already-indexed content.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.