### PR TITLE
fix: broadcast Redis PUBLISH to all primary nodes in cluster mode

### DIFF
--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -77,10 +77,22 @@ async def redis_list_item_tasks(redis: Redis, item_id: str) -> List[str]:
 
 async def redis_send_command(redis: Redis, command: dict):
     command_json = json.dumps(command)
-    # RedisCluster doesn't expose publish() directly, but the
-    # PUBLISH command broadcasts across all cluster nodes server-side.
     if hasattr(redis, 'nodes_manager'):
-        await redis.execute_command('PUBLISH', REDIS_PUBSUB_CHANNEL, command_json)
+        # RedisCluster: PUBLISH is node-local; broadcast to every primary so all
+        # subscribers (on any worker) receive the stop command.
+        try:
+            primaries = redis.get_primaries()
+        except AttributeError:
+            try:
+                await redis.execute_command('PUBLISH', REDIS_PUBSUB_CHANNEL, command_json, target_nodes='all')
+            except TypeError:
+                await redis.execute_command('PUBLISH', REDIS_PUBSUB_CHANNEL, command_json)
+            return
+        for node in primaries:
+            try:
+                await redis.execute_command('PUBLISH', REDIS_PUBSUB_CHANNEL, command_json, target_nodes=node)
+            except Exception as _node_err:
+                log.warning(f'redis_send_command: failed to publish to node {node}: {_node_err}')
     else:
         await redis.publish(REDIS_PUBSUB_CHANNEL, command_json)
 


### PR DESCRIPTION
Closes #19840

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #19840
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

Redis Cluster `PUBLISH` is node-local. The previous fix used `execute_command('PUBLISH')` which only reached one node. Fix: iterate `get_primaries()` and send to each, with fallback to `target_nodes='all'` for older redis-py.

# Changelog Entry

### Fixed
- Task stop commands now reach all workers in Redis Cluster deployments.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.