### PR TITLE
fix: truncate oversized paste to prevent browser freeze

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -172,6 +172,7 @@
 	import FormattingButtons from './RichTextInput/FormattingButtons.svelte';
 
 	import { PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+	import { toast } from 'svelte-sonner';
 	import { createLowlight } from 'lowlight';
 	import hljs from 'highlight.js';
 
@@ -963,10 +964,14 @@
 						event.preventDefault();
 						const { state, dispatch } = view;
 
-						const plainText = (event.clipboardData?.getData('text/plain') ?? '').replace(
+						let plainText = (event.clipboardData?.getData('text/plain') ?? '').replace(
 							/\r\n/g,
 							'\n'
 						);
+						if (plainText.length > PASTED_TEXT_CHARACTER_LIMIT) {
+							plainText = plainText.slice(0, PASTED_TEXT_CHARACTER_LIMIT);
+							toast.warning(`Pasted text truncated to ${PASTED_TEXT_CHARACTER_LIMIT.toLocaleString()} characters.`);
+						}
 
 						const lines = plainText.split('\n');
 						const nodes = [];


### PR DESCRIPTION
Closes #12087

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #12087
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

In plain-text mode, `handlePaste` splits content into individual ProseMirror nodes per line. Pasting megabytes of text creates tens of thousands of nodes synchronously, freezing the browser. Truncates to `PASTED_TEXT_CHARACTER_LIMIT` (1000 chars) with a toast notification.

# Changelog Entry

### Fixed
- Browser no longer freezes when pasting very large text content in the chat input.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.