### PR TITLE
fix: set WindowsSelectorEventLoopPolicy before uvicorn on Windows (psycopg v3)

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -34,6 +34,13 @@ def serve(
     port: int = 8080,
 ):
     os.environ['FROM_INIT_PY'] = 'true'
+
+    # psycopg v3 is incompatible with Windows' default ProactorEventLoop.
+    # Set WindowsSelectorEventLoopPolicy before any asyncio/uvicorn init.
+    if sys.platform == 'win32':
+        import asyncio as _asyncio
+        _asyncio.set_event_loop_policy(_asyncio.WindowsSelectorEventLoopPolicy())
+
     if os.getenv('WEBUI_SECRET_KEY') is None:
         typer.echo('Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.')
         if not KEY_FILE.exists():


### PR DESCRIPTION
Closes #24152

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #24152
- [x] **Target branch:** `dev`
- [x] **Testing:** Manually verified
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing
- [x] **Code review:** Self-reviewed
- [x] **Git Hygiene:** Atomic PR

## Description

On Windows, uvicorn may create a `ProactorEventLoop` before `db.py` is imported, locking it in for the process. psycopg v3 cannot use `ProactorEventLoop`. Fix: call `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` at the very top of `serve()`, before any imports that touch asyncio.

# Changelog Entry

### Fixed
- Open WebUI now starts correctly on Windows with a PostgreSQL backend.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.