### PR TITLE
fix: use configured voice for OpenAI TTS requests

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -53,6 +53,7 @@ from open_webui.env import (
     ENV,
 )
 from open_webui.utils.access_control import has_permission
+from open_webui.utils.audio import apply_openai_tts_config
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.utils.misc import strict_match_mime_type
@@ -388,9 +389,6 @@ async def _write_tts_cache(
 
 async def _tts_openai(request, payload, file_path, file_body_path, user):
     """Generate speech via an OpenAI-compatible TTS endpoint."""
-    payload['model'] = request.app.state.config.TTS_MODEL
-    payload = {**payload, **(request.app.state.config.TTS_OPENAI_PARAMS or {})}
-
     headers = {
         'Content-Type': 'application/json',
         'Authorization': f'Bearer {request.app.state.config.TTS_OPENAI_API_KEY}',
@@ -591,9 +589,29 @@ async def speech(request: Request, user=Depends(get_verified_user)):
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    body = await request.body()
+    try:
+        body = await request.body()
+        payload = json.loads(body)
+    except Exception as exc:
+        log.exception(exc)
+        raise HTTPException(status_code=400, detail='Invalid JSON payload')
+
+    handler = _TTS_ENGINES.get(engine)
+    if handler is None:
+        raise HTTPException(status_code=400, detail=f'Unsupported TTS engine: {engine}')
+
+    cache_body = body
+    if engine == 'openai':
+        payload = apply_openai_tts_config(
+            payload,
+            request.app.state.config.TTS_MODEL,
+            request.app.state.config.TTS_VOICE,
+            request.app.state.config.TTS_OPENAI_PARAMS,
+        )
+        cache_body = json.dumps(payload, sort_keys=True).encode('utf-8')
+
     name = hashlib.sha256(
-        body
+        cache_body
         + str(engine).encode('utf-8')
         + str(request.app.state.config.TTS_MODEL).encode('utf-8')
     ).hexdigest()
@@ -604,16 +622,6 @@ async def speech(request: Request, user=Depends(get_verified_user)):
     # Return cached result if available
     if file_path.is_file():
         return FileResponse(file_path)
-
-    try:
-        payload = json.loads(body)
-    except Exception as exc:
-        log.exception(exc)
-        raise HTTPException(status_code=400, detail='Invalid JSON payload')
-
-    handler = _TTS_ENGINES.get(engine)
-    if handler is None:
-        raise HTTPException(status_code=400, detail=f'Unsupported TTS engine: {engine}')
 
     return await handler(request, payload, file_path, file_body_path, user)
 

--- a/backend/open_webui/test/routers/test_audio.py
+++ b/backend/open_webui/test/routers/test_audio.py
@@ -1,0 +1,51 @@
+from open_webui.utils.audio import apply_openai_tts_config
+
+
+def test_apply_openai_tts_config_injects_configured_voice():
+    payload = apply_openai_tts_config(
+        {'input': 'hello'},
+        model='tts-1-hd',
+        voice='nova',
+        params=None,
+    )
+
+    assert payload == {
+        'input': 'hello',
+        'model': 'tts-1-hd',
+        'voice': 'nova',
+    }
+
+
+def test_apply_openai_tts_config_keeps_client_voice():
+    payload = apply_openai_tts_config(
+        {'input': 'hello', 'voice': 'alloy'},
+        model='tts-1-hd',
+        voice='nova',
+        params=None,
+    )
+
+    assert payload['voice'] == 'alloy'
+
+
+def test_apply_openai_tts_config_replaces_empty_client_voice():
+    payload = apply_openai_tts_config(
+        {'input': 'hello', 'voice': ''},
+        model='tts-1-hd',
+        voice='nova',
+        params=None,
+    )
+
+    assert payload['voice'] == 'nova'
+
+
+def test_apply_openai_tts_config_allows_params_to_override_payload():
+    payload = apply_openai_tts_config(
+        {'input': 'hello', 'voice': 'alloy'},
+        model='tts-1-hd',
+        voice='nova',
+        params={'voice': 'echo', 'response_format': 'mp3'},
+    )
+
+    assert payload['model'] == 'tts-1-hd'
+    assert payload['voice'] == 'echo'
+    assert payload['response_format'] == 'mp3'

--- a/backend/open_webui/utils/audio.py
+++ b/backend/open_webui/utils/audio.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+
+def apply_openai_tts_config(
+    payload: dict[str, Any],
+    model: str,
+    voice: str,
+    params: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Apply OpenAI TTS config defaults to a request payload."""
+    payload = {**payload, 'model': model}
+    if not payload.get('voice'):
+        payload['voice'] = voice
+    return {**payload, **(params or {})}


### PR DESCRIPTION
<!--
CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE)
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - `Closes #25035`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this fixes server-side behavior for an existing documented/configured TTS setting.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI assistance and is submitted as a draft for human review before it is marked ready.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Fill missing or empty OpenAI TTS `voice` values from the configured `TTS_VOICE` so third-party clients that omit `voice` can still use `/api/v1/audio/speech`.
- Normalize the OpenAI TTS payload before cache lookup so cached audio reflects the effective model, voice, and custom OpenAI params.

### Added

- Focused regression coverage for missing, empty, client-provided, and custom-param OpenAI TTS voice handling.

### Changed

- OpenAI TTS request payload normalization now happens before cache-key generation.

### Deprecated

- None.

### Removed

- None.

### Fixed

- `Closes #25035`: OpenAI-compatible TTS requests without a `voice` now fall back to the configured server voice instead of being forwarded upstream without the required field.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Validation performed:

- `python -m py_compile backend/open_webui/routers/audio.py backend/open_webui/utils/audio.py backend/open_webui/test/routers/test_audio.py`
- `PYTHONPATH=backend uv run --no-project --python 3.12 --with pytest --with typer --with uvicorn python -m pytest backend/open_webui/test/routers/test_audio.py -q`
- `uv run --no-project --python 3.12 --with ruff ruff format --check backend/open_webui/utils/audio.py backend/open_webui/test/routers/test_audio.py`
- `git diff --check`

This was prepared with AI assistance and local validation, then opened as a draft for review.

### Screenshots or Videos

- Not applicable; backend TTS request handling only.

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
