### PR TITLE
feat(anthropic): map advanced thinking and effort params to OpenAI reasoning_effort

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -422,7 +422,7 @@ def convert_openai_to_anthropic_response(openai_response: dict, model: str = '')
         content.append({'type': 'text', 'text': msg_content})
 
     # Tool calls → tool_use blocks
-    tool_calls = message.get('tool_calls', [])
+    tool_calls = message.get('tool_calls') or []
     for tc in tool_calls:
         func = tc.get('function', {})
         try:

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -350,45 +350,75 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     'function': {'name': tc.get('name', '')},
                 }
     # === Add logic to convert Anthropic thinking/reasoning parameters to OpenAI reasoning_effort ===
-    def get_reasoning_effort(effort_value: str) -> str:
-        """Extract reasoning level via fuzzy matching, defaulting to safe compatible 'high' for max values."""
-        effort_lower = str(effort_value).lower()
-        if any(keyword in effort_lower for keyword in ('high', 'max', 'ultra')):
-            return 'high'
-        if 'low' in effort_lower:
+    def convert_budget_to_level(budget: int) -> str | None:
+        """
+        Convert a budget value to the nearest thinking level.
+        
+        Threshold mapping:
+           -1         -> auto
+           0          -> none
+           1-512      -> minimal
+           513-1024   -> low
+           1025-8192  -> medium
+           8193-24576 -> high
+           24577+     -> xhigh
+        """
+        if budget < -1:
+            return None
+        elif budget == -1:
+            return 'auto'
+        elif budget == 0:
+            return 'none'
+        elif budget <= 512:
+            return 'minimal'
+        elif budget <= 1024:
             return 'low'
-        return 'medium'
+        elif budget <= 8192:
+            return 'medium'
+        elif budget <= 24576:
+            return 'high'
+        else:
+            return 'xhigh'
 
-    # 1. Prioritize capturing output_config.effort from the latest Claude Code versions
-    output_config = anthropic_payload.get('output_config')
-    if isinstance(output_config, dict) and 'effort' in output_config:
-        openai_payload['reasoning_effort'] = get_reasoning_effort(output_config['effort'])
+    # Thinking: Convert Claude thinking config to OpenAI reasoning_effort
+    thinking = anthropic_payload.get('thinking')
+    if isinstance(thinking, dict):
+        thinking_type = thinking.get('type')
+        
+        if thinking_type == 'enabled':
+            if 'budget_tokens' in thinking:
+                try:
+                    budget = int(thinking['budget_tokens'])
+                    effort = convert_budget_to_level(budget)
+                    if effort:
+                        openai_payload['reasoning_effort'] = effort
+                except (ValueError, TypeError):
+                    pass
+            else:
+                # No budget_tokens specified, default to "auto" for enabled thinking
+                effort = convert_budget_to_level(-1)
+                if effort:
+                    openai_payload['reasoning_effort'] = effort
+                    
+        elif thinking_type in ('adaptive', 'auto'):
+            # Adaptive thinking can carry an explicit effort in output_config.effort
+            effort = ""
+            output_config = anthropic_payload.get('output_config')
+            if isinstance(output_config, dict):
+                effort_val = output_config.get('effort')
+                if effort_val is not None:
+                    effort = str(effort_val).strip().lower()
             
-    # 2. Compatibility for effort field passed directly at the top level
-    elif 'effort' in anthropic_payload:
-        openai_payload['reasoning_effort'] = get_reasoning_effort(anthropic_payload['effort'])
-
-    # 3. Fallback handling for thinking field (supports both adaptive and legacy budget_tokens)
-    if 'thinking' in anthropic_payload:
-        thinking = anthropic_payload['thinking']
-        if isinstance(thinking, dict):
-            thinking_type = thinking.get('type')
-            
-            # If using the latest adaptive thinking, and effort wasn't caught above
-            if thinking_type == 'adaptive' and 'reasoning_effort' not in openai_payload:
-                openai_payload['reasoning_effort'] = 'high'
+            if effort:
+                openai_payload['reasoning_effort'] = effort
+            else:
+                # Default to xhigh when adaptive but no effort is explicitly set
+                openai_payload['reasoning_effort'] = 'xhigh'
                 
-            # Legacy budget_tokens logic
-            elif 'budget_tokens' in thinking and 'reasoning_effort' not in openai_payload:
-                budget_tokens = thinking.get('budget_tokens', 0)
-                if budget_tokens == 0:
-                    openai_payload['reasoning_effort'] = 'medium'
-                elif budget_tokens < 4000:
-                    openai_payload['reasoning_effort'] = 'low'
-                elif budget_tokens < 8000:
-                    openai_payload['reasoning_effort'] = 'medium'
-                else:
-                    openai_payload['reasoning_effort'] = 'high'
+        elif thinking_type == 'disabled':
+            effort = convert_budget_to_level(0)
+            if effort:
+                openai_payload['reasoning_effort'] = effort
 
     return openai_payload
 

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -350,41 +350,42 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     'function': {'name': tc.get('name', '')},
                 }
     # === Add logic to convert Anthropic thinking/reasoning parameters to OpenAI reasoning_effort ===
-    def map_effort_string(raw_str: str) -> str:
+    def get_reasoning_effort(effort_value: str) -> str:
         """Extract reasoning level via fuzzy matching, defaulting to safe compatible 'high' for max values."""
-        s = raw_str.lower()
-        if any(keyword in s for keyword in ('high', 'max', 'ultra')):
+        effort_lower = str(effort_value).lower()
+        if any(keyword in effort_lower for keyword in ('high', 'max', 'ultra')):
             return 'high'
-        elif 'low' in s:
+        if 'low' in effort_lower:
             return 'low'
-        else:
-            return 'medium'
+        return 'medium'
 
     # 1. Prioritize capturing output_config.effort from the latest Claude Code versions
-    if 'output_config' in anthropic_payload and isinstance(anthropic_payload['output_config'], dict):
-        effort_val = anthropic_payload['output_config'].get('effort')
-        if effort_val:
-            openai_payload['reasoning_effort'] = map_effort_string(str(effort_val))
+    output_config = anthropic_payload.get('output_config')
+    if isinstance(output_config, dict) and 'effort' in output_config:
+        openai_payload['reasoning_effort'] = get_reasoning_effort(output_config['effort'])
             
     # 2. Compatibility for effort field passed directly at the top level
     elif 'effort' in anthropic_payload:
-        openai_payload['reasoning_effort'] = map_effort_string(str(anthropic_payload['effort']))
+        openai_payload['reasoning_effort'] = get_reasoning_effort(anthropic_payload['effort'])
 
     # 3. Fallback handling for thinking field (supports both adaptive and legacy budget_tokens)
     if 'thinking' in anthropic_payload:
-        thinking_cfg = anthropic_payload['thinking']
-        if isinstance(thinking_cfg, dict):
-            # If using the latest adaptive thinking, and effort wasn't caught above, default to high intensity
-            if thinking_cfg.get('type') == 'adaptive' and 'reasoning_effort' not in openai_payload:
+        thinking = anthropic_payload['thinking']
+        if isinstance(thinking, dict):
+            thinking_type = thinking.get('type')
+            
+            # If using the latest adaptive thinking, and effort wasn't caught above
+            if thinking_type == 'adaptive' and 'reasoning_effort' not in openai_payload:
                 openai_payload['reasoning_effort'] = 'high'
+                
             # Legacy budget_tokens logic
-            elif 'budget_tokens' in thinking_cfg and 'reasoning_effort' not in openai_payload:
-                budget = thinking_cfg.get('budget_tokens', 0)
-                if budget == 0:
+            elif 'budget_tokens' in thinking and 'reasoning_effort' not in openai_payload:
+                budget_tokens = thinking.get('budget_tokens', 0)
+                if budget_tokens == 0:
                     openai_payload['reasoning_effort'] = 'medium'
-                elif budget < 4000:
+                elif budget_tokens < 4000:
                     openai_payload['reasoning_effort'] = 'low'
-                elif budget < 8000:
+                elif budget_tokens < 8000:
                     openai_payload['reasoning_effort'] = 'medium'
                 else:
                     openai_payload['reasoning_effort'] = 'high'

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -349,6 +349,45 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     'type': 'function',
                     'function': {'name': tc.get('name', '')},
                 }
+    # === Add logic to convert Anthropic thinking/reasoning parameters to OpenAI reasoning_effort ===
+    def map_effort_string(raw_str: str) -> str:
+        """Extract reasoning level via fuzzy matching, defaulting to safe compatible 'high' for max values."""
+        s = raw_str.lower()
+        if any(keyword in s for keyword in ('high', 'max', 'ultra')):
+            return 'high'
+        elif 'low' in s:
+            return 'low'
+        else:
+            return 'medium'
+
+    # 1. Prioritize capturing output_config.effort from the latest Claude Code versions
+    if 'output_config' in anthropic_payload and isinstance(anthropic_payload['output_config'], dict):
+        effort_val = anthropic_payload['output_config'].get('effort')
+        if effort_val:
+            openai_payload['reasoning_effort'] = map_effort_string(str(effort_val))
+            
+    # 2. Compatibility for effort field passed directly at the top level
+    elif 'effort' in anthropic_payload:
+        openai_payload['reasoning_effort'] = map_effort_string(str(anthropic_payload['effort']))
+
+    # 3. Fallback handling for thinking field (supports both adaptive and legacy budget_tokens)
+    if 'thinking' in anthropic_payload:
+        thinking_cfg = anthropic_payload['thinking']
+        if isinstance(thinking_cfg, dict):
+            # If using the latest adaptive thinking, and effort wasn't caught above, default to high intensity
+            if thinking_cfg.get('type') == 'adaptive' and 'reasoning_effort' not in openai_payload:
+                openai_payload['reasoning_effort'] = 'high'
+            # Legacy budget_tokens logic
+            elif 'budget_tokens' in thinking_cfg and 'reasoning_effort' not in openai_payload:
+                budget = thinking_cfg.get('budget_tokens', 0)
+                if budget == 0:
+                    openai_payload['reasoning_effort'] = 'medium'
+                elif budget < 4000:
+                    openai_payload['reasoning_effort'] = 'low'
+                elif budget < 8000:
+                    openai_payload['reasoning_effort'] = 'medium'
+                else:
+                    openai_payload['reasoning_effort'] = 'high'
 
     return openai_payload
 


### PR DESCRIPTION

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [ ] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [ ] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

### Description
- This PR enhances the Anthropic to OpenAI payload conversion utility by intercepting extended reasoning parameters and translating them to the OpenAI `reasoning_effort` standard.
- AI coding assistants (like Claude Code) frequently update their underlying API payloads to request maximum reasoning effort. Previously, these parameters were silently dropped by the Pydantic/conversion layers. This patch ensures that requests routed through Open WebUI retain their intended reasoning intensity when forwarded to OpenAI-compatible downstream models.
- Also this PR fixes a bug where parsing an OpenAI API response causes a TypeError: 'NoneType' object is not iterable during the conversion to Anthropic's tool_use format.
### Added

**Changes made in `backend/open_webui/utils/anthropic.py`:**
- Added a fuzzy matching helper function to map non-standard effort levels (e.g., `max`, `ultra`, `xhigh`) to the OpenAI-compliant `high` tier.
- Added parsing for the latest Anthropic `output_config.effort` payload structure utilized by updated tools like Claude Code.
- Maintained backward compatibility for top-level `effort` strings.
- Added fallback parsing for the `thinking` object, supporting both the newer `"type": "adaptive"` format and the legacy `"budget_tokens"` format (dynamically mapping token thresholds to low/medium/high).

### Changed

- [List any changes, updates, refactorings, or optimizations]

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Anthropic Compatibility: Fixed a crash (TypeError: 'NoneType' object is not iterable) during OpenAI-to-Anthropic message conversion that occurred when an OpenAI-compatible endpoint returned null for tool_calls.

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

- Verified with payload containing `output_config.effort = "max"` and `thinking.type = "adaptive"`.
- Verified with legacy payload using `thinking.budget_tokens = 8192`.
- Confirmed that payloads correctly map to `"reasoning_effort": "high"` before exiting the conversion function without triggering validation errors.
  - [Reference any related issues, commits, or other relevant information]
- issue #25237 
- Currently, the conversion logic extracts tool calls using tool_calls = message.get('tool_calls', []).
- While this works when the tool_calls key is entirely omitted from the API response, it fails when an OpenAI-compatible API explicitly returns null for the key ({"tool_calls": null}). In Python, json.loads() parses null into None. Because the key actually exists in the dictionary, .get('tool_calls', []) returns None rather than the default empty list. When the code subsequently attempts to iterate over tool_calls, it crashes.
- By changing the extraction logic to tool_calls = message.get('tool_calls') or [], we utilize boolean short-circuiting. If the API returns None (which evaluates to false), Python correctly falls back to the empty list [], allowing the loop to bypass safely and preventing the crash.
### Screenshots or Videos

Tested I mount the modified file in my container.
use the old format to test 
```
curl https://ai.abc.def/api/v1/messages   -H "x-api-key: sk-xxxxxxxxxxxxxxxxx"   -H "anthropic-version: 2023-06-01"   -H "content-type: application/json"   -d '{
    "model": "prx.gemini-pro",
    "max_tokens": 8192,
    "thinking": {
      "type": "enabled",
      "budget_tokens": 4096
    },
    "messages": [
      {
        "role": "user",
        "content": "hi,who are you?"
      }
    ]
  }'
```
And add a filter in OWUI, print the body. You can see the "reasoning_effort": "medium", in the log.
<img width="704" height="769" alt="image" src="https://github.com/user-attachments/assets/00ddf0f8-d96c-4dee-a88f-ba3041c7f0b0" />
Thinking settings are dropped in the current release, without this PR. I also start claude code and point the api to openwebui, which use the new format of anthropic thinking parameters. In upper proxy of my AI apis, I can see the record changed from no effort setting to effort high, when use claude code through OWUI anthropic API endpoint after the PR is applied.
<img width="1704" height="1155" alt="image" src="https://github.com/user-attachments/assets/df334183-7f13-42db-a0bd-ae998585a93c" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.