### PR TITLE
fix: add modern socket.io reason function param

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -805,7 +805,7 @@ async def yjs_awareness_update(sid, data):
 
 
 @sio.event
-async def disconnect(sid):
+async def disconnect(sid, reason=None):
     if sid in SESSION_POOL:
         user = SESSION_POOL[sid]
         del SESSION_POOL[sid]


### PR DESCRIPTION
Fix Socket.IO disconnect handling so the server accepts the optional disconnect reason argument passed by newer Socket.IO/Engine.IO versions. This prevents cleanup from raising `TypeError: disconnect() takes 1 positional argument but 2 were given` during websocket disconnects.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
