### PR TITLE
fix: return clear error when unknown tool is called instead of silent empty result

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1348,6 +1348,33 @@ async def chat_completion_tools_handler(
 
                 tool_function_name = tool_call.get('name', None)
                 if tool_function_name not in tools:
+                    error_msg = f'Tool "{tool_function_name}" not found. Available tools: {", ".join(sorted(tools.keys()))}'
+                    log.warning(error_msg)
+                    sources.append(
+                        {
+                            'source': {
+                                'name': f'Tool: {tool_function_name}',
+                            },
+                            'document': [error_msg],
+                            'metadata': [
+                                {
+                                    'source': f'Tool: {tool_function_name}',
+                                }
+                            ],
+                            'tool_result': True,
+                        }
+                    )
+                    if event_emitter:
+                        await event_emitter(
+                            {
+                                'type': 'status',
+                                'data': {
+                                    'action': 'tool_call',
+                                    'description': error_msg,
+                                    'done': True,
+                                },
+                            }
+                        )
                     return body, {}
 
                 tool_function_params = tool_call.get('parameters', {})


### PR DESCRIPTION
## Summary

Fixes #25144

When an LLM calls a tool name that does not exist in the available tool set, the \	ool_call_handler\ silently returned an empty dict without adding anything to the conversation sources. The LLM received no feedback and had no way of knowing the call failed, often leading to loops retrying the same nonexistent tool.

## Changes

- When an unknown tool is called, append a descriptive error message to the \sources\ list so the LLM sees it and can self-correct
- Emit a status event so the UI shows the error to the user
- Log a warning for debugging

## Testing

- [ ] Unknown tool name produces an error in the conversation
- [ ] Available tool names are listed in the error message
- [ ] UI shows the error in the tool call block