### PR TITLE
fix: prevent code block overflow from resizing chat bubbles in widescreen mode

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -407,7 +407,7 @@
 					{/if}
 				</div>
 
-				<div class="flex-auto w-0 pl-2">
+				<div class="flex-auto w-0 min-w-0 pl-2">
 					{#if showUserProfile}
 						<Name>
 							<div class=" self-end text-base shrink-0 font-medium truncate">

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -665,7 +665,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -143,7 +143,7 @@
 			/>
 		</div>
 	{/if}
-	<div class="flex-auto w-0 max-w-full pl-1">
+	<div class="flex-auto w-0 min-w-0 max-w-full pl-1">
 		{#if !($settings?.chatBubble ?? true)}
 			<div>
 				<Name>


### PR DESCRIPTION
## Description

Fixes #5975 - Inconsistent Conversation Bubble Sizes with YAML Code Blocks in Widescreen Mode

### Problem
In widescreen mode, when chat messages contain code blocks with long lines (especially YAML), the conversation bubbles change size inconsistently when scrolling up and down. This happens because flex items default to `min-width: auto`, which allows their content to determine the minimum width. When the browser re-calculates layout during scroll events, this causes width fluctuations.

### Root Cause
The flex containers use the classic `flex-auto w-0` pattern for flexbox overflow handling, but CSS still respects `min-width: auto` for flex items unless explicitly overridden. Long code block lines can temporarily expand the flex container width.

### Fix
Added `min-w-0` to flex-auto containers in 3 components:
- `src/lib/components/chat/Messages/ResponseMessage.svelte`
- `src/lib/components/chat/Messages/UserMessage.svelte`
- `src/lib/components/channel/Messages/Message.svelte`

This ensures flex items respect their allocated width regardless of content, preventing code blocks from expanding the message bubbles.

### Testing
- The fix follows the standard CSS flexbox overflow pattern (`min-width: 0`)
- Only one CSS class added per component - minimal, low-risk change
- No visual changes expected in normal usage - code blocks already have `overflow-x-auto` for horizontal scrolling

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.