### PR TITLE
fix: prevent code block overflow from resizing chat bubbles in widescreen mode

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -407,7 +407,7 @@
 					{/if}
 				</div>
 
-				<div class="flex-auto w-0 pl-2">
+				<div class="flex-auto w-0 min-w-0 pl-2">
 					{#if showUserProfile}
 						<Name>
 							<div class=" self-end text-base shrink-0 font-medium truncate">

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -665,7 +665,7 @@
 			/>
 		</div>
 
-		<div class="flex-auto w-0 pl-1 relative">
+		<div class="flex-auto w-0 min-w-0 pl-1 relative">
 			<Name>
 				<Tooltip content={model?.name ?? message.model} placement="top-start">
 					<span id="response-message-model-name" class="line-clamp-1 text-black dark:text-white">

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -143,7 +143,7 @@
 			/>
 		</div>
 	{/if}
-	<div class="flex-auto w-0 max-w-full pl-1">
+	<div class="flex-auto w-0 min-w-0 max-w-full pl-1">
 		{#if !($settings?.chatBubble ?? true)}
 			<div>
 				<Name>


### PR DESCRIPTION
﻿## Description

Fixes #5975 - Inconsistent Conversation Bubble Sizes with YAML Code Blocks in Widescreen Mode

### Problem
In widescreen mode, when chat messages contain code blocks with long lines (especially YAML), the conversation bubbles change size inconsistently when scrolling up and down. This happens because the code block `<pre>` element has a fixed max-width but its flex parent lacks `min-width: 0`, causing flexbox to grow beyond the intended boundary.

### Solution
Added `min-w-0` to the message content wrapper in `ResponseMessage.svelte`, preventing the flex item from exceeding its container and keeping bubble sizes stable.

### Testing
- Verified YAML code blocks in widescreen mode no longer cause bubble resizing
- Verified normal chat messages are unaffected
- Tested with various code block types (YAML, JSON, Python, JavaScript)

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
