### PR TITLE
fix: avoid duplicate allow_redirects in web loader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -521,7 +521,6 @@ class SafeWebBaseLoader(WebBaseLoader):
                     async with session.get(
                         url,
                         **(self.requests_kwargs | kwargs),
-                        allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
                     ) as response:
                         if self.raise_for_status:
                             response.raise_for_status()

--- a/backend/open_webui/test/retrieval/web/test_utils.py
+++ b/backend/open_webui/test/retrieval/web/test_utils.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.env import AIOHTTP_CLIENT_ALLOW_REDIRECTS
+from open_webui.retrieval.web.utils import SafeWebBaseLoader
+
+
+class _FakeResponse:
+    def __init__(self, text: str = 'ok'):
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def text(self):
+        return self._text
+
+
+class _FakeClientSession:
+    last_request = None
+
+    def __init__(self, trust_env=False):
+        self.trust_env = trust_env
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, **kwargs):
+        type(self).last_request = {'url': url, 'kwargs': kwargs}
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_safe_web_base_loader_fetch_merges_redirect_kwargs(monkeypatch):
+    loader = SafeWebBaseLoader.__new__(SafeWebBaseLoader)
+    loader.trust_env = False
+    loader.raise_for_status = True
+    loader.session = SimpleNamespace(
+        headers={'x-test': '1'},
+        cookies=SimpleNamespace(get_dict=lambda: {'cookie': 'value'}),
+        verify=True,
+    )
+    loader.requests_kwargs = {'allow_redirects': AIOHTTP_CLIENT_ALLOW_REDIRECTS}
+
+    monkeypatch.setattr('open_webui.retrieval.web.utils.aiohttp.ClientSession', _FakeClientSession)
+
+    text = await SafeWebBaseLoader._fetch(loader, 'https://example.com')
+
+    assert text == 'ok'
+    assert _FakeClientSession.last_request is not None
+    assert _FakeClientSession.last_request['url'] == 'https://example.com'
+    assert _FakeClientSession.last_request['kwargs']['allow_redirects'] is AIOHTTP_CLIENT_ALLOW_REDIRECTS
+    assert _FakeClientSession.last_request['kwargs']['headers'] == {'x-test': '1'}
+    assert _FakeClientSession.last_request['kwargs']['cookies'] == {'cookie': 'value'}
+    assert 'ssl' in _FakeClientSession.last_request['kwargs']


### PR DESCRIPTION
## Summary
- remove the duplicate `allow_redirects` keyword passed by `SafeWebBaseLoader._fetch`
- keep the redirect policy sourced from `self.requests_kwargs`, which is already initialized for both sync and async fetch paths
- add a regression test for the async fetch request kwargs merge

This addresses the `SafeWebBaseLoader._fetch` TypeError path discussed in #25038.

## Test
- `uv run pytest backend/open_webui/test/retrieval/web/test_utils.py -q`