### PR TITLE
test: cover SafeWebBaseLoader redirect kwargs

### DIFF
--- a/backend/open_webui/test/retrieval/web/test_utils.py
+++ b/backend/open_webui/test/retrieval/web/test_utils.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.retrieval.web.utils import SafeWebBaseLoader
+
+
+class _FakeResponse:
+    def __init__(self, text: str = 'ok'):
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def text(self):
+        return self._text
+
+
+class _FakeClientSession:
+    last_request = None
+
+    def __init__(self, trust_env=False, **kwargs):
+        self.trust_env = trust_env
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, **kwargs):
+        type(self).last_request = {'url': url, 'kwargs': kwargs}
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_safe_web_base_loader_fetch_merges_redirect_kwargs(monkeypatch):
+    loader = SafeWebBaseLoader.__new__(SafeWebBaseLoader)
+    loader.trust_env = False
+    loader.raise_for_status = True
+    loader.session = SimpleNamespace(
+        headers={'x-test': '1'},
+        cookies=SimpleNamespace(get_dict=lambda: {'cookie': 'value'}),
+        verify=True,
+    )
+    loader.requests_kwargs = {'allow_redirects': False}
+
+    monkeypatch.setattr('open_webui.retrieval.web.utils.aiohttp.ClientSession', _FakeClientSession)
+
+    text = await SafeWebBaseLoader._fetch(loader, 'https://example.com')
+
+    assert text == 'ok'
+    assert _FakeClientSession.last_request is not None
+    assert _FakeClientSession.last_request['url'] == 'https://example.com'
+    assert _FakeClientSession.last_request['kwargs']['allow_redirects'] is False
+    assert _FakeClientSession.last_request['kwargs']['headers'] == {'x-test': '1'}
+    assert _FakeClientSession.last_request['kwargs']['cookies'] == {'cookie': 'value'}
+    assert 'ssl' in _FakeClientSession.last_request['kwargs']


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #25038.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [x] **Documentation:** Not applicable; this adds regression coverage only.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Ran the targeted regression test listed below.
- [ ] **Agentic AI Code:** This change was prepared with AI assistance; targeted testing was performed.
- [x] **Self-Review:** The code was reviewed for scope and formatting.
- [x] **Architecture:** No architecture or UX changes.
- [x] **Git Hygiene:** Atomic test-only PR based on `dev`.
- [x] **Title Prefix:** Uses the `test` prefix.

## Summary

This adds regression coverage for `SafeWebBaseLoader._fetch` to ensure async request kwargs are merged once and keep the configured `allow_redirects` value. This protects the web-loader failure mode discussed in #25038, where duplicate redirect kwargs could break source/context loading.

## Test

- `WEBUI_SECRET_KEY=test-secret uv run pytest backend/open_webui/test/retrieval/web/test_utils.py -q`

# Changelog Entry

### Description

- Add regression coverage for `SafeWebBaseLoader._fetch` request kwargs merging.

### Added

- A unit test covering the async web loader request kwargs path.

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Relates to #25038.
- This is a test-only change; the `dev` branch already contains the corresponding `SafeWebBaseLoader._fetch` kwargs behavior.

### Screenshots or Videos

- N/A

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.