### PR TITLE
fix: handle non-UTF-8 encoded text/CSV files with latin-1 fallback

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -236,7 +236,16 @@ class Loader:
 
     def load(self, filename: str, file_content_type: str, file_path: str) -> list[Document]:
         loader = self._get_loader(filename, file_content_type, file_path)
-        docs = loader.load()
+        try:
+            docs = loader.load()
+        except (UnicodeDecodeError, RuntimeError) as e:
+            # Fallback to latin-1 for text files with non-UTF-8 encoding
+            # latin-1 accepts every byte 0x00-0xFF, so it never fails to decode
+            if isinstance(loader, TextLoader):
+                loader = TextLoader(file_path, encoding="latin-1")
+                docs = loader.load()
+            else:
+                raise
 
         return [Document(page_content=ftfy.fix_text(doc.page_content), metadata=doc.metadata) for doc in docs]
 

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -84,7 +84,14 @@ def _is_text_file(file_path: str, chunk_size: int = 8192) -> bool:
             return False
         chunk.decode('utf-8')
         return True
-    except (UnicodeDecodeError, Exception):
+    except UnicodeDecodeError:
+        # Try latin-1 fallback for files with legacy-encoded non-ASCII bytes
+        try:
+            chunk.decode('latin-1')
+            return True
+        except UnicodeDecodeError:
+            return False
+    except Exception:
         return False
 
 


### PR DESCRIPTION
## Problem

Document upload fails for text/CSV files containing non-UTF-8 encoded characters (e.g. German umlauts encoded in Windows-1252/Latin-1). This is reported in #25172.

Two failure points:

1. **`_is_text_file()` misclassifies non-UTF-8 text as binary** — `chunk.decode('utf-8')` raises `UnicodeDecodeError` and the function returns `False`, causing files with mis-detected content types to fail re-classification.

2. **`TextLoader(autodetect_encoding=True)` fails or times out** — langchain's chardet-based autodetection either returns incorrect low-confidence encodings or hits the 5-second timeout.

## Changes

- **`backend/open_webui/retrieval/loaders/main.py`**: In `Loader.load()`, catch `UnicodeDecodeError` and `RuntimeError` from `TextLoader` and retry with `encoding='latin-1'`. Latin-1 accepts every byte 0x00-0xFF, so it never fails to decode. The existing `ftfy.fix_text()` post-processing (line 241) can then clean up any mojibake.

- **`backend/open_webui/routers/files.py`**: In `_is_text_file()`, add a latin-1 fallback when UTF-8 decode fails, so non-UTF-8 text files are correctly classified as text rather than binary.

## Testing

Files with mixed ASCII + legacy-encoded non-ASCII bytes (common in industrial/exported text from Windows environments) now load successfully instead of timing out or being rejected.

Fixes #25172