### PR TITLE
fix: reconcile chat_message via explicit deletions

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -133,6 +133,8 @@ class ChatFileModel(BaseModel):
 class ChatForm(BaseModel):
     chat: dict
     folder_id: str | None = None
+    # Explicit deletions to prune; absent => upsert-only.
+    deleted_message_ids: list[str] | None = None
 
 
 class ChatImportForm(ChatForm):
@@ -496,22 +498,42 @@ class ChatTable:
                 log.warning('Backfill failed for message %s in chat %s: %s', message_id, chat_id, e)
 
     async def reconcile_messages_by_chat_id(
-        self, chat_id: str, user_id: str, messages: dict[str, dict]
+        self,
+        chat_id: str,
+        user_id: str,
+        messages: dict[str, dict],
+        deleted_message_ids: list[str] | None = None,
     ) -> None:
-        """Sync ``chat_message`` rows with the committed JSON blob.
+        """Upsert blob messages, then prune only the IDs the client explicitly
+        deleted (plus their now-orphaned descendants).
 
-        Upserts current messages via ``backfill_messages_by_chat_id``
-        and deletes orphaned rows whose message_id no longer appears
-        in the blob.  Best-effort: errors are logged but never raised.
+        Rows merely missing from the blob are never inferred as deletions — a
+        lost write race would otherwise drop a still-valid message permanently.
+        Best-effort: errors are logged, not raised.
         """
         try:
             await self.backfill_messages_by_chat_id(chat_id, user_id, messages)
 
-            existing_map = await ChatMessages.get_messages_map_by_chat_id(chat_id)
-            if existing_map is not None:
-                orphaned_ids = set(existing_map.keys()) - set(messages.keys())
-                if orphaned_ids:
-                    await ChatMessages.delete_message_ids_by_chat_id(chat_id, orphaned_ids)
+            dead_ids = set(deleted_message_ids or [])
+            if not dead_ids:
+                return
+
+            existing_map = await ChatMessages.get_messages_map_by_chat_id(chat_id) or {}
+
+            # Reparented children reappear in the blob and survive; truly orphaned ones go with the parent.
+            changed = True
+            while changed:
+                changed = False
+                for message_id, message in existing_map.items():
+                    if message_id in dead_ids or message_id in messages:
+                        continue
+                    if message.get('parentId') in dead_ids:
+                        dead_ids.add(message_id)
+                        changed = True
+
+            dead_ids &= set(existing_map.keys())
+            if dead_ids:
+                await ChatMessages.delete_message_ids_by_chat_id(chat_id, dead_ids)
         except Exception as e:
             log.warning('Failed to reconcile chat_message rows for chat %s: %s', chat_id, e)
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -982,7 +982,9 @@ async def update_chat_by_id(
         # history with potential edits, deletions, or new branches.
         messages = (updated_chat.get('history') or {}).get('messages') or {}
         if messages:
-            await Chats.reconcile_messages_by_chat_id(id, user.id, messages)
+            await Chats.reconcile_messages_by_chat_id(
+                id, user.id, messages, deleted_message_ids=form_data.deleted_message_ids
+            )
 
         return ChatResponse(**chat.model_dump())
     else:

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -1039,7 +1039,12 @@ export const getChatAccessGrants = async (token: string, id: string) => {
 	return res;
 };
 
-export const updateChatById = async (token: string, id: string, chat: object) => {
+export const updateChatById = async (
+	token: string,
+	id: string,
+	chat: object,
+	deletedMessageIds: string[] | null = null
+) => {
 	let error = null;
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}`, {
@@ -1050,7 +1055,11 @@ export const updateChatById = async (token: string, id: string, chat: object) =>
 			...(token && { authorization: `Bearer ${token}` })
 		},
 		body: JSON.stringify({
-			chat: chat
+			chat: chat,
+			// Omit when empty so ordinary saves stay upsert-only.
+			...(deletedMessageIds && deletedMessageIds.length
+				? { deleted_message_ids: deletedMessageIds }
+				: {})
 		})
 	})
 		.then(async (res) => {

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -164,14 +164,24 @@
 		}
 	};
 
+	// Deletions buffered since the last save; the backend prunes exactly these.
+	let deletedMessageIds = new Set();
+
 	const updateChat = async () => {
 		if (!$temporaryChatEnabled) {
 			history = history;
 			await tick();
-			const res = await updateChatById(localStorage.token, chatId, {
-				history: history,
-				messages: messages
-			});
+			const res = await updateChatById(
+				localStorage.token,
+				chatId,
+				{
+					history: history,
+					messages: messages
+				},
+				Array.from(deletedMessageIds)
+			);
+			// Reached only on success (updateChatById throws otherwise); keep IDs for retry on failure.
+			deletedMessageIds.clear();
 
 			// Refresh local message content from backend (e.g. re-derived via serialize_output)
 			if (res?.chat?.history?.messages) {
@@ -461,9 +471,11 @@
 		// Delete the message and its children
 		[messageId, ...childMessageIds].forEach((id) => {
 			delete history.messages[id];
+			deletedMessageIds.add(id);
 		});
 
 		showMessage({ id: parentMessageId }, false);
+		await updateChat();
 	};
 
 	const triggerScroll = () => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** Verify that the pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** Provide a concise description of the changes made in this pull request down below.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Documentation:** Add docs in [Open WebUI Docs Repository](https://github.com/open-webui/docs). Document user-facing behavior, environment variables, public APIs/interfaces, or deployment steps.
- [x] **Dependencies:** Are there any new or upgraded dependencies? If so, explain why, update the changelog/docs, and include any compatibility notes. Actually run the code/function that uses updated library to ensure it doesn't crash.
- [x] **Testing:** Perform manual tests to **verify the implemented fix/feature works as intended AND does not break any other functionality**. Include reproducible steps to demonstrate the issue before the fix. Test edge cases (URL encoding, HTML entities, types). Take this as an opportunity to **make screenshots of the feature/fix and include them in the PR description**.
- [x] **Agentic AI Code:** Confirm this Pull Request is **not written by any AI Agent** or has at least **gone through additional human review AND manual testing**. If any AI Agent is the co-author of this PR, it may lead to immediate closure of the PR.
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Design & Architecture:** Prefer smart defaults over adding new settings; use local state for ephemeral UI logic. Open a Discussion for major architectural or UX changes.
- [x] **Git Hygiene:** Keep PRs atomic (one logical change). Clean up commits and rebase on `dev` to ensure no unrelated commits (e.g. from `main`) are included. Push updates to the existing PR branch instead of closing and reopening.
- [x] **Title Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Stop reconcile from inferring deletions. Prune only what the client explicitly reports.

Chat messages live in two places: the `chat.chat` JSON blob and the `chat_message` table. Reads prefer the table, and the table feeds the next turn's LLM context.

`reconcile_messages_by_chat_id` currently infers deletions by diffing the incoming history against existing rows (`orphaned = existing - blob`, then delete). With no locking on the chat row and several writers doing full read/modify/write of the blob (frontend full-history POST, completion saves, title and follow-up tasks), one of them can save a stale history that omits a valid message. Reconcile reads that as a deletion and deletes the row. It is then missing from reads and context, with no way back, since the self-heal path only fires on a dangling `parentId` and a deleted leaf leaves nothing dangling.

This removes the inference. Reconcile is upsert-only unless the client says what was deleted. A real deletion and a stale omission look identical on the server, so the client tells it directly.

### Added

- Optional `deleted_message_ids` on `ChatForm` and `POST /api/v1/chats/{id}`. Missing or empty means upsert-only, so older clients are unaffected.
- Frontend buffers deletions in `Messages.svelte` and passes them to `updateChatById`, which only sends the field when non-empty. The buffer clears only after a successful save, so deletions survive a failed save and retry.

### Changed

- `Chats.reconcile_messages_by_chat_id(..., deleted_message_ids=None)`: prunes exactly the listed ids plus orphaned descendants; reparented messages still in the pushed history are kept.
- Trade-off: with no deletion signal (older clients), a deleted message's row persists until a client reports it. Intentional, since a stale row is recoverable and a deleted valid message is not.

### Deprecated

- [List any deprecated functionality or features that have been removed]

### Removed

- [List any removed features, files, or functionalities]

### Fixed

- Valid messages no longer vanish on a stale or concurrent save (multiple tabs, overlapping writes in a turn, or a background task saving old state).

### Security

- [List any new or updated security-related changes, including vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]

---

### Additional Information

Repro on `dev`: open a chat, send a couple of turns, then force two overlapping saves of the same chat (two tabs, or an edit during a running completion). A valid message disappears from the chat and from the model's context. On this branch it stays.

Real deletions, cascades, reparenting, and regeneration behave exactly as before. The only change is that a message missing from a stale or concurrent save is no longer treated as deleted.

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
