### PR TITLE
docs: fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2641,7 +2641,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - 🌐 **Custom Azure TTS API URL Support Added**: You can now define a custom Azure Text-to-Speech endpoint—enabling flexibility for enterprise deployments and regional compliance.
-- ⚙️ **TOOL_SERVER_CONNECTIONS Environment Variable Suppor**: Easily configure and deploy tool servers via environment variables, streamlining setup and enabling faster enterprise provisioning.
+- ⚙️ **TOOL_SERVER_CONNECTIONS Environment Variable Support**: Easily configure and deploy tool servers via environment variables, streamlining setup and enabling faster enterprise provisioning.
 - 👥 **Enhanced OAuth Group Handling as String or List**: OAuth group data can now be passed as either a list or a comma-separated string, improving compatibility with varied identity provider formats and reducing onboarding friction.
 
 ### Fixed


### PR DESCRIPTION
Summary:
- Fixes a typo in the changelog entry for TOOL_SERVER_CONNECTIONS support.
- Keeps the change text-only with no runtime impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed file; the remaining report is the existing `ue.getWordAtDocPos` identifier.