### PR TITLE
fix: correct inverted high-contrast text colors for user message timestamp

### DIFF
--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -160,7 +160,7 @@
 						<div
 							class="self-center text-xs font-medium first-letter:capitalize ml-0.5 translate-y-[1px] {($settings?.highContrastMode ??
 							false)
-								? 'dark:text-gray-900 text-gray-100'
+								? 'dark:text-gray-100 text-gray-900'
 								: 'invisible group-hover:visible transition'}"
 						>
 							<Tooltip content={dayjs(message.timestamp * 1000).format('LLLL')}>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to https://github.com/open-webui/open-webui/discussions/25460`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

In non-bubble chat layout with High Contrast Mode enabled, the user message timestamp (e.g., "Today at 2:30 PM") is **invisible** because the Tailwind dark/light text color classes are swapped.

**Root cause:** `UserMessage.svelte` line 163 uses `dark:text-gray-900 text-gray-100` — meaning dark-gray text on dark backgrounds and light-gray text on light backgrounds. Both combinations render the timestamp invisible against its background.

**Fix:** Swap to `dark:text-gray-100 text-gray-900`, which is the correct pattern already used in:
- `ResponseMessage.svelte` line 680 (AI response timestamp)
- `UserMessage.svelte` line 187 (bubble-mode user timestamp)

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Fixed inverted high-contrast text colors for user message timestamp in non-bubble layout (`dark:text-gray-900 text-gray-100` → `dark:text-gray-100 text-gray-900`) in `src/lib/components/chat/Messages/UserMessage.svelte`

---

### Before (High Contrast `On`):

Dark:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/5db60cac-eeab-4c8b-89a6-5668d70aadf9" />

Light:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/536eacda-fcb3-4131-8152-f8223259a3af" />

OLED:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/09c15ade-9106-4eee-a843-140c315c37fe" />

### After (High Contrast `On`):

Dark:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/538633cd-ecc4-487a-8776-e4ba22c6f4d9" />

Light:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/927eca4b-74b2-4b70-abba-30d7c54d9b04" />

OLED:
<img width="2560" height="473" alt="image" src="https://github.com/user-attachments/assets/a9447509-42fd-40e6-8565-089d57bff798" />

### Additional Information

- No new dependencies added.
- No logic changes — only two Tailwind CSS class values are swapped.
- Zero risk of regression — the previous colors rendered the timestamp invisible in both themes.
- The correct pattern is already used in `ResponseMessage.svelte` (line 680) and in the bubble-mode branch of this same file (line 187).

### Manual Verification Performed

1. Enable **High Contrast Mode** in Settings → General
2. Open any chat with messages
3. **Before fix:** User message timestamp is invisible in both dark and light mode
4. **After fix:** User message timestamp is clearly readable in both dark and light mode
5. AI response timestamp remains correctly visible (unaffected by this change)
6. Bubble-mode user timestamp remains correctly visible (unaffected — line 187 was already correct)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
