### PR TITLE
fix(chat): mark chat as read when navigating to new conversation

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -184,6 +184,19 @@
 		navigateHandler();
 	}
 
+	// When navigating away from a chat to a brand-new conversation (chatIdProp
+	// becomes ''), the `$: if (chatIdProp)` block above does not fire, so
+	// navigateHandler() — which marks the previous chat as read — is never called.
+	// Track the previous value and emit last_read_at when transitioning to no-chat.
+	let prevChatIdProp = chatIdProp;
+	$: {
+		const prev = prevChatIdProp;
+		prevChatIdProp = chatIdProp;
+		if (!chatIdProp && prev && $chatId && !$temporaryChatEnabled) {
+			updateLastReadAt($chatId);
+		}
+	}
+
 	let saveControlsTimer;
 	$: if (!loading && !$temporaryChatEnabled && $chatId && params && chatFiles) {
 		clearTimeout(saveControlsTimer);


### PR DESCRIPTION
## Summary

Fixes an issue where unread notification badges reappear after a page refresh even though the user had already viewed the chat.

## Root Cause

When a user clicks **New Chat**, `chatIdProp` transitions to `''`. The existing reactive block:

```svelte
$: if (chatIdProp) {
    navigateHandler();
}
```

does **not** fire on this transition because the condition is falsy — so `navigateHandler()` (which calls `updateLastReadAt`) is never invoked. On the next refresh, the chat still appears as unread.

## Fix

Track the previous value of `chatIdProp`. When it transitions from a real chat ID to `''` (new chat), explicitly call `updateLastReadAt` to mark the current chat as read before leaving.

```svelte
let prevChatIdProp = chatIdProp;
$: {
    const prev = prevChatIdProp;
    prevChatIdProp = chatIdProp;
    if (!chatIdProp && prev && $chatId && !$temporaryChatEnabled) {
        updateLastReadAt($chatId);
    }
}
```

## Testing

1. Open a chat that has unread messages — badge is visible
2. Click **New Chat**
3. Refresh the page
4. Navigate back to the previous chat — badge should **not** reappear

Fixes #25108
