### PR TITLE
fix(chat): mark chat as read when navigating to new conversation

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -185,6 +185,23 @@
 		navigateHandler();
 	}
 
+	// When navigating away from a chat to a brand-new conversation (chatIdProp
+	// becomes ''), the `$: if (chatIdProp)` block above does not fire, so
+	// navigateHandler() — which marks the previous chat as read — is never called.
+	// Track the previous chatIdProp *and* the previous $chatId so we always pass
+	// the correct outgoing chat ID to updateLastReadAt, even if $chatId has
+	// already been cleared by the time the reactive block runs.
+	let prevChatIdProp = chatIdProp;
+	let prevChatId = $chatId;
+	$: if (chatIdProp !== prevChatIdProp) {
+		const outgoing = prevChatId;
+		prevChatIdProp = chatIdProp;
+		prevChatId = $chatId;
+		if (!chatIdProp && outgoing && !$temporaryChatEnabled) {
+			updateLastReadAt(outgoing);
+		}
+	}
+
 	let saveControlsTimer;
 	$: if (!loading && !$temporaryChatEnabled && $chatId && params && chatFiles) {
 		clearTimeout(saveControlsTimer);


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25108
- [x] **Target branch:** `dev`
- [x] **Description:** Provided below
- [x] **Testing:** Manual steps provided below
- [x] **Code review:** Self-reviewed

---

## Summary

Fixes an issue where unread notification badges reappear on a chat after a page refresh, even though the user already viewed it.

## Root Cause

When a user clicks **New Chat**, `chatIdProp` transitions to `''`. The existing reactive block:

```svelte
$: if (chatIdProp) {
    navigateHandler();
}
```

does **not** fire on this transition because the condition is falsy — so `navigateHandler()` (which calls `updateLastReadAt`) is never invoked. On the next refresh, the chat still appears as unread.

## Fix

Track the previous value of `chatIdProp` with an explicit change guard to avoid Svelte re-run loops. Also capture the previous `$chatId` snapshot so we always pass the correct outgoing chat ID to `updateLastReadAt`, even if `$chatId` has already been updated by the time the reactive block runs.

```svelte
let prevChatIdProp = chatIdProp;
let prevChatId = $chatId;
$: if (chatIdProp !== prevChatIdProp) {
    const outgoing = prevChatId;
    prevChatIdProp = chatIdProp;
    prevChatId = $chatId;
    if (!chatIdProp && outgoing && !$temporaryChatEnabled) {
        updateLastReadAt(outgoing);
    }
}
```

## Testing

1. Open a chat that has unread messages — badge is visible in the sidebar
2. Click **New Chat**
3. Refresh the page
4. Navigate back to the previous chat — badge should **not** reappear

---

# Changelog Entry

### Description

Fixes unread notification badge persisting after navigating to a new chat and refreshing the page.

### Fixed

- Unread notification badge on a chat no longer reappears after clicking "New Chat" and refreshing the page (#25108)

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
