### PR TITLE
fix: polyfill ReadableStream async iteration for Safari PDFs

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1688,7 +1688,42 @@ export const parseJsonValue = (value: string): any => {
 	return value;
 };
 
+type ReadableStreamWithAsyncIterator<T> = ReadableStream<T> & {
+	[Symbol.asyncIterator]?: () => AsyncIterableIterator<T>;
+};
+
+function ensureReadableStreamAsyncIterator() {
+	if (typeof ReadableStream === 'undefined') {
+		return;
+	}
+
+	const prototype = ReadableStream.prototype as ReadableStreamWithAsyncIterator<unknown>;
+	if (prototype[Symbol.asyncIterator]) {
+		return;
+	}
+
+	Object.defineProperty(prototype, Symbol.asyncIterator, {
+		value: async function* (this: ReadableStream<unknown>) {
+			const reader = this.getReader();
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						return;
+					}
+					yield value;
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		},
+		configurable: true,
+		writable: true
+	});
+}
+
 async function ensurePDFjsLoaded() {
+	ensureReadableStreamAsyncIterator();
 	if (!window.pdfjsLib) {
 		const pdfjs = await import('pdfjs-dist');
 		pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;


### PR DESCRIPTION
Fixes #25151.

### Summary
- add a small `ReadableStream[Symbol.asyncIterator]` polyfill before loading pdfjs
- keep native implementations untouched and only patch browsers missing async stream iteration
- preserve the existing temporary-chat PDF extraction path while fixing Safari stable runtimes

### Tests
- Not run locally; patch created through the GitHub API.