### PR TITLE
fix: polyfill ReadableStream async iteration for Safari PDFs

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1764,7 +1764,42 @@ export const parseJsonValue = (value: string): any => {
 	return value;
 };
 
+type ReadableStreamWithAsyncIterator<T> = ReadableStream<T> & {
+	[Symbol.asyncIterator]?: () => AsyncIterableIterator<T>;
+};
+
+function ensureReadableStreamAsyncIterator() {
+	if (typeof ReadableStream === 'undefined') {
+		return;
+	}
+
+	const prototype = ReadableStream.prototype as ReadableStreamWithAsyncIterator<unknown>;
+	if (prototype[Symbol.asyncIterator]) {
+		return;
+	}
+
+	Object.defineProperty(prototype, Symbol.asyncIterator, {
+		value: async function* (this: ReadableStream<unknown>) {
+			const reader = this.getReader();
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						return;
+					}
+					yield value;
+				}
+			} finally {
+				reader.releaseLock();
+			}
+		},
+		configurable: true,
+		writable: true
+	});
+}
+
 async function ensurePDFjsLoaded() {
+	ensureReadableStreamAsyncIterator();
 	if (!window.pdfjsLib) {
 		const pdfjs = await import('pdfjs-dist');
 		pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;


### PR DESCRIPTION
<!--
1. Target branch: this PR targets `dev`.
2. CLA section is kept at the bottom.
-->

Fixes #25151.

### Summary
- add a small `ReadableStream[Symbol.asyncIterator]` polyfill before loading pdfjs
- keep native implementations untouched and only patch browsers missing async stream iteration
- preserve the existing temporary-chat PDF extraction path while fixing Safari stable runtimes

### Testing
- Not run locally; this is a browser compatibility patch created through the GitHub API.
- The code path is limited to browsers missing native `ReadableStream` async iteration and is a no-op in Chrome/Firefox/current runtimes that already support it.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.