### PR TITLE
perf: skip no-op MODELS Redis writes in get_all_models()

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import uuid
 
@@ -50,6 +51,7 @@ class RedisLock:
 class RedisDict:
     def __init__(self, name, redis_url, redis_sentinels=[], redis_cluster=False):
         self.name = name
+        self._last_signature = None
         self.redis = get_redis_connection(
             redis_url,
             redis_sentinels,
@@ -90,6 +92,18 @@ class RedisDict:
     def set(self, mapping: dict):
         if not mapping:
             self.redis.delete(self.name)
+            self._last_signature = None
+            return
+
+        serialized = {k: json.dumps(v) for k, v in mapping.items()}
+
+        # Skip the write when the prepared mapping is identical to the last one
+        # this instance wrote — model lists rarely change between calls, and the
+        # full HSET is the dominant Redis write source on busy multi-pod setups.
+        signature = hashlib.sha256(
+            json.dumps(serialized, sort_keys=True).encode()
+        ).hexdigest()
+        if signature == self._last_signature:
             return
 
         # Fetch existing keys before writing so we know which ones to remove.
@@ -101,9 +115,10 @@ class RedisDict:
         # HSET first (add/update all new values), then HDEL (remove stale keys).
         # We never DELETE the whole hash — this eliminates the race window
         # where concurrent readers would see an empty models dict.
-        self.redis.hset(self.name, mapping={k: json.dumps(v) for k, v in mapping.items()})
+        self.redis.hset(self.name, mapping=serialized)
         if keys_to_remove:
             self.redis.hdel(self.name, *keys_to_remove)
+        self._last_signature = signature
 
     def get(self, key, default=None):
         try:

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -28,6 +28,9 @@ from open_webui.utils.plugin import (
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 
+# Frozen at import so synthetic models (ollama/arena) keep a stable `created`, letting RedisDict.set() skip no-op writes.
+MODEL_CREATED = int(time.time())
+
 
 async def fetch_ollama_models(request: Request, user: UserModel = None):
     raw_ollama_models = await ollama.get_all_models(request, user=user)
@@ -36,7 +39,7 @@ async def fetch_ollama_models(request: Request, user: UserModel = None):
             'id': model['model'],
             'name': model['name'],
             'object': 'model',
-            'created': int(time.time()),
+            'created': MODEL_CREATED,
             'owned_by': 'ollama',
             'ollama': model,
             'loaded': 'expires_at' in model,
@@ -100,7 +103,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                         'meta': model['meta'],
                     },
                     'object': 'model',
-                    'created': int(time.time()),
+                    'created': MODEL_CREATED,
                     'owned_by': 'arena',
                     'arena': True,
                 }
@@ -116,7 +119,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                         'meta': DEFAULT_ARENA_MODEL['meta'],
                     },
                     'object': 'model',
-                    'created': int(time.time()),
+                    'created': MODEL_CREATED,
                     'owned_by': 'arena',
                     'arena': True,
                 }


### PR DESCRIPTION
RedisDict.set() unconditionally HSET the full model mapping on every get_all_models() call. With many call sites and a high pod count this became the dominant Redis HSET source even when the model list had not changed.

- Freeze the synthetic `created` timestamp for ollama/arena models (MODEL_CREATED, set at import) so the prepared dict is byte-stable across calls. Each call previously stamped int(time.time()), which alone defeated any content comparison.
- RedisDict.set() now hashes the serialized mapping and skips the write when it matches the last value this instance wrote. The serialized dict is reused for the HSET, so it is built only once.

The signature is per-instance and in memory; the empty-mapping path still deletes unconditionally to clear stale state on a fresh process.

Fixes #25469

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
