### PR TITLE
perf: drop cluster-wide SCAN from ydoc disconnect cleanup

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -217,6 +217,8 @@ class YdocManager:
         if self._redis:
             redis_key = f'{self._redis_key_prefix}:{document_id}:users'
             await self._redis.sadd(redis_key, user_id)
+            # Reverse index so disconnect can target this user's docs without a SCAN.
+            await self._redis.sadd(f'{self._redis_key_prefix}:user:{user_id}:documents', document_id)
         else:
             if document_id not in self._users:
                 self._users[document_id] = set()
@@ -228,22 +230,24 @@ class YdocManager:
         if self._redis:
             redis_key = f'{self._redis_key_prefix}:{document_id}:users'
             await self._redis.srem(redis_key, user_id)
+            await self._redis.srem(f'{self._redis_key_prefix}:user:{user_id}:documents', document_id)
         else:
             if document_id in self._users and user_id in self._users[document_id]:
                 self._users[document_id].remove(user_id)
 
     async def remove_user_from_all_documents(self, user_id: str):
         if self._redis:
-            keys = []
-            async for key in self._redis.scan_iter(match=f'{self._redis_key_prefix}:*', count=100):
-                keys.append(key)
-            for key in keys:
-                if key.endswith(':users'):
-                    await self._redis.srem(key, user_id)
-
-                    document_id = key.split(':')[-2]
-                    if len(await self.get_users(document_id)) == 0:
-                        await self.clear_document(document_id)
+            # Use the per-user reverse index instead of SCANning every key.
+            # On Redis Cluster a SCAN fans out to all masters; this touches only
+            # the documents the user actually joined (none for most disconnects).
+            index_key = f'{self._redis_key_prefix}:user:{user_id}:documents'
+            document_ids = await self._redis.smembers(index_key)
+            for document_id in document_ids:
+                await self._redis.srem(f'{self._redis_key_prefix}:{document_id}:users', user_id)
+                if len(await self.get_users(document_id)) == 0:
+                    await self.clear_document(document_id)
+            if document_ids:
+                await self._redis.delete(index_key)
 
         else:
             for document_id in list(self._users.keys()):


### PR DESCRIPTION
remove_user_from_all_documents() ran scan_iter('{prefix}:*') over every ydoc key on every websocket disconnect, then filtered for ':users' keys client-side. Cost scaled with the total number of documents rather than what the user touched, fired even for users who never opened a note, and on Redis Cluster fanned out to all masters — producing SCAN storms when many users disconnect at the end of a peak period.

Maintain a per-session reverse index ({prefix}:user:{sid}:documents) in add_user/remove_user, and on disconnect SMEMBERS it to clean up only the documents that session actually joined, then delete the index key. The SCAN is gone; a disconnect now costs one SMEMBERS on a single shard plus work proportional to the user's own documents (zero if they opened none).

The in-memory path is unchanged. Stale index entries are self-healing: a later SREM on a missing key is a no-op and clear_document is idempotent.

Fixes #25466

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
