### PR TITLE
feat: cap profile image data URI size to bound model/avatar bloat

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -780,6 +780,10 @@ PROFILE_IMAGE_ALLOWED_MIME_TYPES = frozenset(
     if t.strip()
 )
 
+# Max stored length (bytes) of a data:image profile URI; bounds Postgres/Redis
+# bloat from inline avatars and model icons. 0 disables the cap.
+PROFILE_IMAGE_MAX_DATA_URI_SIZE = int(os.getenv('PROFILE_IMAGE_MAX_DATA_URI_SIZE', str(256 * 1024)))
+
 ####################################
 # Forward Headers
 ####################################

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -781,8 +781,11 @@ PROFILE_IMAGE_ALLOWED_MIME_TYPES = frozenset(
 )
 
 # Max stored length (bytes) of a data:image profile URI; bounds Postgres/Redis
-# bloat from inline avatars and model icons. 0 disables the cap.
-PROFILE_IMAGE_MAX_DATA_URI_SIZE = int(os.getenv('PROFILE_IMAGE_MAX_DATA_URI_SIZE', str(256 * 1024)))
+# bloat from inline avatars and model icons. Unset (default) disables the cap.
+_profile_image_max_data_uri_size = os.getenv('PROFILE_IMAGE_MAX_DATA_URI_SIZE', '').strip()
+PROFILE_IMAGE_MAX_DATA_URI_SIZE = (
+    int(_profile_image_max_data_uri_size) if _profile_image_max_data_uri_size else None
+)
 
 ####################################
 # Forward Headers

--- a/backend/open_webui/utils/validate.py
+++ b/backend/open_webui/utils/validate.py
@@ -3,7 +3,10 @@
 import re
 from urllib.parse import urlparse
 
-from open_webui.env import PROFILE_IMAGE_ALLOWED_MIME_TYPES
+from open_webui.env import (
+    PROFILE_IMAGE_ALLOWED_MIME_TYPES,
+    PROFILE_IMAGE_MAX_DATA_URI_SIZE,
+)
 
 _USER_PROFILE_IMAGE_RE = re.compile(r'^/api/v1/users/[^/?#]+/profile/image$')
 
@@ -40,6 +43,7 @@ def validate_profile_image_url(url: str) -> str:
     - SVG data URIs (can contain embedded scripts)
     - Arbitrary relative paths (prevents authenticated GET triggers)
     - Scheme-relative URLs (``//host/path``)
+    - data URIs larger than PROFILE_IMAGE_MAX_DATA_URI_SIZE bytes
     """
     if not url:
         return url
@@ -70,6 +74,11 @@ def validate_profile_image_url(url: str) -> str:
     # The regex enforces the ;base64, boundary and is case-insensitive
     # per the data-URI / MIME-type specs.
     if _SAFE_DATA_URI_RE.match(url):
+        if PROFILE_IMAGE_MAX_DATA_URI_SIZE and len(url) > PROFILE_IMAGE_MAX_DATA_URI_SIZE:
+            raise ValueError(
+                f'Invalid profile image URL: data URI exceeds the '
+                f'{PROFILE_IMAGE_MAX_DATA_URI_SIZE}-byte limit.'
+            )
         return url
 
     raise ValueError(


### PR DESCRIPTION
validate_profile_image_url() validated data-URI format (MIME allowlist, SVG rejection, scheme checks) but never its length, so a valid data:image/...;base64,<huge> passed for both custom-model icons and user avatars. Large inline images bloat Postgres and the Redis MODELS hash and degrade model-list latency.

Add PROFILE_IMAGE_MAX_DATA_URI_SIZE (default 256 KiB, 0 disables) and reject oversized data URIs in the shared validator, so both model meta (ModelMeta.profile_image_url) and user avatars (UpdateProfileForm) are bounded at one chokepoint. ModelMeta already clears invalid values to None on read, so existing oversized icons stop propagating into the MODELS hash on the next refresh.

Fixes #25468

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
