### PR TITLE
fix: clear usage interval in finally so it cannot leak on send failure

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2159,22 +2159,24 @@
 		if (primaryModel && primaryResponseMessageId) {
 			const chatEventEmitter = await getChatEventEmitter(primaryModel.id, _chatId);
 
-			scrollToBottom();
-			await sendMessageSocket(
-				primaryModel,
-				messages && messages.length > 0
-					? messages
-					: createMessagesList(_history, primaryResponseMessageId),
-				_history,
-				primaryResponseMessageId,
-				_chatId,
-				{
-					messageIdsMap: selectedModelIds.length > 1 ? messageIdsMap : undefined,
-					regenerationPrompt
-				}
-			);
-
-			if (chatEventEmitter) clearInterval(chatEventEmitter);
+			try {
+				scrollToBottom();
+				await sendMessageSocket(
+					primaryModel,
+					messages && messages.length > 0
+						? messages
+						: createMessagesList(_history, primaryResponseMessageId),
+					_history,
+					primaryResponseMessageId,
+					_chatId,
+					{
+						messageIdsMap: selectedModelIds.length > 1 ? messageIdsMap : undefined,
+						regenerationPrompt
+					}
+				);
+			} finally {
+				if (chatEventEmitter) clearInterval(chatEventEmitter);
+			}
 		}
 	};
 


### PR DESCRIPTION
getChatEventEmitter starts a setInterval emitting a `usage` socket event every second; clearInterval ran only after sendMessageSocket resolved, so any throw/reject left the interval firing for the page lifetime. Each failed send added another orphaned interval, inflating server-side usage accounting and growing CPU/memory over a session.

Wrap the send in try/finally so the interval is always cleared, on both the happy path and any thrown/rejected path. The exception still propagates unchanged.

Fixes #25465

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
