### PR TITLE
fix: remove premature drag-and-drop upload toast

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -1000,9 +1000,7 @@
 						}
 					);
 				} else {
-					toast.info($i18n.t('Uploading file...'));
 					uploadFileHandler(item.getAsFile());
-					toast.success($i18n.t('File uploaded!'));
 				}
 			}
 		};


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to https://github.com/open-webui/open-webui/discussions/25483`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The Knowledge Base drag-and-drop handler shows a premature `"File uploaded!"` success toast **before the upload actually completes** — and even when the upload **fails**.

When a user drags and drops a file onto a Knowledge Base, three toasts appear:

1. `"Uploading file..."` (info) — fires immediately
2. `"File uploaded!"` (success) — fires immediately, **before the upload completes**
3. `"File added successfully."` (success from `uploadFileHandler`) — fires when the upload actually finishes

The root cause is that `uploadFileHandler()` is an `async` function but is not `await`ed in the drag-and-drop handler. The `toast.info` and `toast.success` calls surrounding it execute synchronously on the next line, before the upload promise resolves.

Additionally, `uploadFileHandler` already manages its own success/error toasts internally (line 369: `"File added successfully."` on success, line 373: `"Failed to upload file."` on failure), making the two toasts in the drop handler both **premature** and **redundant**.

**Fix:** Remove the two premature/redundant toast calls from the drag-and-drop `else` branch. `uploadFileHandler` already provides the correct feedback once the upload completes or fails.

This makes the drag-and-drop path consistent with the file input `on:change` handler (line 1143), which correctly `await`s `uploadFileHandler` and does not add its own toasts.

> *This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

### Fixed

- Knowledge Base drag-and-drop no longer shows premature `"File uploaded!"` success toast before upload completes
- Knowledge Base drag-and-drop no longer shows contradictory success + error toasts when upload fails
- Removed redundant `"Uploading file..."` info toast (duplicate of `uploadFileHandler`'s own status handling)

---

### Additional Information

- No new dependencies added
- No behavioral change to the upload itself — only the toast notifications are affected
- The file input (`on:change`) handler already follows the correct pattern; this fix makes drag-and-drop consistent with it

**No user feedback is lost.** `uploadFileHandler` already covers every outcome with its own toasts:

| Scenario | Line | Toast |
|---|---|---|
| Upload succeeds | 369 | ✅ `toast.success("File added successfully.")` |
| Upload API call fails (network/server error) | 351 | ❌ `toast.error(e)` (e.g., "Error calling DocRag API...") |
| Upload returns null | 373 | ❌ `toast.error("Failed to upload file.")` |
| File uploaded but has processing error | 366 | ⚠️ `toast.warning(uploadedFile.error)` |
| Any other exception | 376 | ❌ `toast.error(e)` |
| Empty file (0 bytes) | 317 | ❌ `toast.error("You cannot upload an empty file.")` |
| File exceeds size limit | 329 | ❌ `toast.error("File size should not exceed X MB.")` |

### Screenshots or Videos

**Before fix** — three toasts shown simultaneously on drag-and-drop, including `"File uploaded!"` even when the upload fails:

<!-- Paste your screenshot here -->

**After fix** — only the appropriate toast from `uploadFileHandler` is shown after the upload completes or fails.

### Manual Verification Performed

1. Drag and drop a file onto a Knowledge Base → confirmed only `"File added successfully."` toast appears after upload completes (no premature toasts)
2. Drag and drop a file that fails to process → confirmed only the error toast appears (no contradictory `"File uploaded!"` toast)
3. Upload a file via the file input button → confirmed behavior is unchanged (was already correct)
4. Verified production build succeeds with no errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.