### PR TITLE
fix: don't revert replace/outlet content on chat save

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -968,12 +968,15 @@ async def update_chat_by_id(
     if chat:
         updated_chat = {**chat.chat, **form_data.chat}
 
-        # Re-derive content from output for assistant messages so that
-        # frontend edits to output items are always reflected in content.
-        # serialize_output() is the single source of truth for this conversion.
-        for msg in updated_chat.get('history', {}).get('messages', {}).values():
+        # Re-derive content from output for assistant messages so that frontend
+        # edits to output items are reflected in content. Only when output
+        # actually changed — otherwise content set independently of output
+        # (e.g. a `replace` event or an outlet filter footer) would be reverted.
+        existing_messages = (chat.chat.get('history') or {}).get('messages') or {}
+        for msg_id, msg in updated_chat.get('history', {}).get('messages', {}).items():
             if msg.get('role') == 'assistant' and msg.get('output'):
-                msg['content'] = serialize_output(msg['output'])
+                if msg.get('output') != existing_messages.get(msg_id, {}).get('output'):
+                    msg['content'] = serialize_output(msg['output'])
 
         chat = await Chats.update_chat_by_id(id, updated_chat, db=db)
 


### PR DESCRIPTION
update_chat_by_id re-derived assistant content from `output` on every save (serialize_output) so frontend edits to output items reflect in content. But it ran unconditionally, so content set independently of output — an __event_emitter__ {"type":"replace"} from an Action, or an outlet filter footer — was reverted to the original output-derived text on the next save. The reload reads chat.chat directly, so the change vanished after navigating away (regression vs 0.9.2, which predates the output mechanism).

Re-derive only when the message's `output` actually changed versus what's stored, which still reflects genuine output edits but leaves independently-set content intact.

Fixes #24585

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
