### PR TITLE
feat: add chat context menu to search modal

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -5,7 +5,18 @@
 
 	import Modal from '$lib/components/common/Modal.svelte';
 	import SearchInput from './Sidebar/SearchInput.svelte';
-	import { getChatById, getChatList, getChatListBySearchText } from '$lib/apis/chats';
+	import {
+		getChatById,
+		getChatList,
+		getChatListBySearchText,
+		cloneChatById,
+		deleteChatById,
+		archiveChatById,
+		updateChatById,
+		updateChatFolderIdById,
+		getPinnedChatList,
+		getAllTags
+	} from '$lib/apis/chats';
 	import Spinner from '../common/Spinner.svelte';
 
 	import dayjs from '$lib/dayjs';
@@ -13,16 +24,233 @@
 	import calendar from 'dayjs/plugin/calendar';
 	import Loader from '../common/Loader.svelte';
 	import { createMessagesList } from '$lib/utils';
-	import { config, user } from '$lib/stores';
+	import {
+		config,
+		user,
+		chats,
+		chatId as currentChatId,
+		pinnedChats,
+		currentChatPage,
+		tags
+	} from '$lib/stores';
 	import Messages from '../chat/Messages.svelte';
 	import { goto } from '$app/navigation';
 	import PencilSquare from '../icons/PencilSquare.svelte';
 	import PageEdit from '../icons/PageEdit.svelte';
+
+	import ChatMenu from './Sidebar/ChatMenu.svelte';
+	import ShareChatModal from '../chat/ShareChatModal.svelte';
+	import DeleteConfirmDialog from '../common/ConfirmDialog.svelte';
+	import Tooltip from '../common/Tooltip.svelte';
+	import Sparkles from '../icons/Sparkles.svelte';
+	import ArchiveBox from '../icons/ArchiveBox.svelte';
+	import GarbageBin from '../icons/GarbageBin.svelte';
+	import { generateTitle } from '$lib/apis';
 	dayjs.extend(calendar);
 	dayjs.extend(localizedFormat);
 
 	export let show = false;
 	export let onClose = () => {};
+
+	let showShareChatModal = false;
+	let showDeleteConfirm = false;
+	let menuChatId = '';
+	let menuChatTitle = '';
+
+	let editingChatId = null;
+	let editingChatTitle = '';
+
+	let shiftKey = false;
+
+	const onShiftKeyDown = (e) => {
+		if (e.key === 'Shift') shiftKey = true;
+	};
+
+	const onShiftKeyUp = (e) => {
+		if (e.key === 'Shift') shiftKey = false;
+	};
+	let generating = false;
+
+	const refreshSidebar = async () => {
+		currentChatPage.set(1);
+		await chats.set(await getChatList(localStorage.token, $currentChatPage));
+		await pinnedChats.set(await getPinnedChatList(localStorage.token));
+	};
+
+	const cloneChatHandler = async (id) => {
+		const chat = chatList?.find((c) => c.id === id);
+		const res = await cloneChatById(
+			localStorage.token,
+			id,
+			$i18n.t('Clone of {{TITLE}}', {
+				TITLE: chat?.title ?? 'Chat'
+			})
+		).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			await refreshSidebar();
+			await searchHandler();
+		}
+	};
+
+	const archiveChatHandler = async (id) => {
+		try {
+			await archiveChatById(localStorage.token, id);
+
+			chatList = chatList?.filter((c) => c.id !== id) ?? null;
+
+			if ($currentChatId === id) {
+				await goto('/');
+				currentChatId.set('');
+			}
+
+			await refreshSidebar();
+			toast.success($i18n.t('Chat archived.'));
+		} catch (error) {
+			toast.error($i18n.t('Failed to archive chat.'));
+		}
+	};
+
+	const deleteChatHandler = async (id) => {
+		const res = await deleteChatById(localStorage.token, id).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			chatList = chatList?.filter((c) => c.id !== id) ?? null;
+			tags.set(await getAllTags(localStorage.token));
+
+			if ($currentChatId === id) {
+				await goto('/');
+				currentChatId.set('');
+			}
+
+			await refreshSidebar();
+		}
+	};
+
+	const moveChatHandler = async (chatId, folderId) => {
+		if (chatId && folderId) {
+			const res = await updateChatFolderIdById(localStorage.token, chatId, folderId).catch(
+				(error) => {
+					toast.error(`${error}`);
+					return null;
+				}
+			);
+
+			if (res) {
+				chatList = chatList?.filter((c) => c.id !== chatId) ?? null;
+				await refreshSidebar();
+				toast.success($i18n.t('Chat moved successfully'));
+			}
+		}
+	};
+
+	const renameHandler = async (id) => {
+		editingChatId = id;
+		editingChatTitle = chatList?.find((c) => c.id === id)?.title ?? '';
+
+		await tick();
+		const input = document.getElementById(`search-chat-title-input-${id}`);
+		if (input) {
+			input.focus();
+			input.select();
+		}
+	};
+
+	const confirmRename = async () => {
+		if (!editingChatId) return;
+
+		const trimmed = editingChatTitle.trim();
+		if (trimmed === '') {
+			toast.error($i18n.t('Title cannot be an empty string.'));
+			return;
+		}
+
+		await updateChatById(localStorage.token, editingChatId, { title: trimmed });
+
+		if (chatList) {
+			chatList = chatList.map((c) => (c.id === editingChatId ? { ...c, title: trimmed } : c));
+		}
+
+		editingChatId = null;
+		editingChatTitle = '';
+		await refreshSidebar();
+	};
+
+	const cancelRename = () => {
+		editingChatId = null;
+		editingChatTitle = '';
+	};
+
+	const generateTitleHandler = async () => {
+		if (!editingChatId || generating) return;
+
+		generating = true;
+		const chat = await getChatById(localStorage.token, editingChatId).catch(() => null);
+
+		if (!chat) {
+			toast.error($i18n.t('Failed to load chat'));
+			generating = false;
+			return;
+		}
+
+		const chatContent = chat.chat;
+		const history = chatContent?.history;
+		let msgList = [];
+
+		if (history?.messages && history?.currentId) {
+			msgList = createMessagesList(history, history.currentId).map((m) => ({
+				role: m.role,
+				content: m.content
+			}));
+		} else {
+			msgList = (chatContent?.messages ?? []).map((m) => ({
+				role: m.role,
+				content: m.content
+			}));
+		}
+
+		let model = '';
+		if (history?.messages && history?.currentId) {
+			let currentId = history.currentId;
+			while (currentId) {
+				const msg = history.messages[currentId];
+				if (!msg) break;
+				if (msg.role === 'assistant' && msg.model) {
+					model = msg.model;
+					break;
+				}
+				currentId = msg.parentId;
+			}
+		}
+		if (!model) {
+			model = chatContent?.models?.at(0) ?? '';
+		}
+
+		editingChatTitle = '';
+
+		const generatedTitle = await generateTitle(localStorage.token, model, msgList).catch(
+			(error) => {
+				toast.error(`${error}`);
+				return null;
+			}
+		);
+
+		if (generatedTitle) {
+			editingChatTitle = generatedTitle;
+		}
+
+		generating = false;
+
+		if (generatedTitle) {
+			await confirmRename();
+		}
+	};
 
 	let actions = [
 		{
@@ -173,11 +401,20 @@
 
 	$: if (show) {
 		searchHandler();
+	} else {
+		editingChatId = null;
+		editingChatTitle = '';
+		generating = false;
 	}
 
 	const onKeyDown = (e) => {
 		const searchOptions = document.getElementById('search-options-container');
 		if (searchOptions || !show) {
+			return;
+		}
+
+		// Don't handle navigation/activation keys while editing a chat title
+		if (editingChatId) {
 			return;
 		}
 
@@ -246,6 +483,8 @@
 		];
 
 		document.addEventListener('keydown', onKeyDown);
+		document.addEventListener('keydown', onShiftKeyDown);
+		document.addEventListener('keyup', onShiftKeyUp);
 	});
 
 	onDestroy(() => {
@@ -253,8 +492,24 @@
 			clearTimeout(searchDebounceTimeout);
 		}
 		document.removeEventListener('keydown', onKeyDown);
+		document.removeEventListener('keydown', onShiftKeyDown);
+		document.removeEventListener('keyup', onShiftKeyUp);
 	});
 </script>
+
+<ShareChatModal bind:show={showShareChatModal} chatId={menuChatId} />
+
+<DeleteConfirmDialog
+	bind:show={showDeleteConfirm}
+	title={$i18n.t('Delete chat?')}
+	on:confirm={() => {
+		deleteChatHandler(menuChatId);
+	}}
+>
+	<div class="text-sm text-gray-500 flex-1 line-clamp-3">
+		{$i18n.t('This will delete')} <span class="font-semibold">{menuChatTitle}</span>.
+	</div>
+</DeleteConfirmDialog>
 
 <Modal size="xl" bind:show>
 	<div class="py-3 dark:text-gray-300 text-gray-700">
@@ -367,42 +622,169 @@
 							</div>
 						{/if}
 
-						<a
-							class=" w-full flex justify-between items-center rounded-xl text-sm py-2 px-3 hover:bg-gray-50 dark:hover:bg-gray-850 {selectedIdx ===
+						<!-- svelte-ignore a11y-no-static-element-interactions -->
+						<div
+							class="w-full flex justify-between items-center rounded-xl text-sm py-2 px-3 hover:bg-gray-50 dark:hover:bg-gray-850 group/item relative {selectedIdx ===
 							idx + actions.length
 								? 'bg-gray-50 dark:bg-gray-850'
 								: ''}"
-							href="/c/{chat.id}"
-							draggable="false"
 							data-arrow-selected={selectedIdx === idx + actions.length ? 'true' : undefined}
 							on:mouseenter={() => {
 								selectedIdx = idx + actions.length;
 							}}
-							on:click={async () => {
-								await goto(`/c/${chat.id}`);
-								show = false;
-								onClose();
-							}}
 						>
-							<div class=" flex-1">
-								<div class="text-ellipsis line-clamp-1 w-full">
-									{chat?.title}
+							{#if editingChatId === chat.id}
+								<div class="flex-1 min-w-0">
+									<input
+										id="search-chat-title-input-{chat.id}"
+										bind:value={editingChatTitle}
+										class="bg-transparent w-full outline-none"
+										placeholder={generating ? $i18n.t('Generating...') : ''}
+										disabled={generating}
+										on:keydown={(e) => {
+											e.stopPropagation();
+											if (e.key === 'Enter') {
+												e.preventDefault();
+												confirmRename();
+											} else if (e.key === 'Escape') {
+												e.preventDefault();
+												cancelRename();
+											}
+										}}
+										on:blur={() => {
+											if (!generating) {
+												confirmRename();
+											}
+										}}
+									/>
+								</div>
+
+								<div class="flex items-center shrink-0 pl-1">
+									<Tooltip content={$i18n.t('Generate')}>
+										<button
+											class="self-center dark:hover:text-white transition disabled:cursor-not-allowed"
+											disabled={generating}
+											on:mousedown|preventDefault={() => {}}
+											on:click|preventDefault|stopPropagation={() => {
+												generateTitleHandler();
+											}}
+										>
+											{#if generating}
+												<Spinner className="size-4" />
+											{:else}
+												<Sparkles strokeWidth="2" />
+											{/if}
+										</button>
+									</Tooltip>
+								</div>
+							{:else}
+								<a
+									class="flex-1 min-w-0"
+									href="/c/{chat.id}"
+									draggable="false"
+									on:click={async () => {
+										await goto(`/c/${chat.id}`);
+										show = false;
+										onClose();
+									}}
+								>
+									<div class="text-ellipsis line-clamp-1 w-full">
+										{chat?.title}
+									</div>
+								</a>
+							{/if}
+
+							<div class="flex items-center gap-1 pl-2 shrink-0">
+								{#if editingChatId !== chat.id}
+									{#if shiftKey}
+										<div class="invisible group-hover/item:visible flex items-center space-x-1.5">
+											<Tooltip content={$i18n.t('Archive')} className="flex items-center">
+												<button
+													class="self-center dark:hover:text-white transition"
+													on:click|stopPropagation={() => {
+														archiveChatHandler(chat.id);
+													}}
+													type="button"
+												>
+													<ArchiveBox className="size-4 translate-y-[0.5px]" strokeWidth="2" />
+												</button>
+											</Tooltip>
+
+											<Tooltip content={$i18n.t('Delete')}>
+												<button
+													class="self-center dark:hover:text-white transition"
+													on:click|stopPropagation={() => {
+														deleteChatHandler(chat.id);
+													}}
+													type="button"
+												>
+													<GarbageBin strokeWidth="2" />
+												</button>
+											</Tooltip>
+										</div>
+									{:else}
+										<div class="invisible group-hover/item:visible">
+											<ChatMenu
+												chatId={chat.id}
+												shareHandler={() => {
+													menuChatId = chat.id;
+													showShareChatModal = true;
+												}}
+												{moveChatHandler}
+												cloneChatHandler={() => {
+													cloneChatHandler(chat.id);
+												}}
+												archiveChatHandler={() => {
+													archiveChatHandler(chat.id);
+												}}
+												renameHandler={() => {
+													renameHandler(chat.id);
+												}}
+												deleteHandler={() => {
+													menuChatId = chat.id;
+													menuChatTitle = chat.title;
+													showDeleteConfirm = true;
+												}}
+												onClose={() => {}}
+												onPinChange={async () => {
+													await refreshSidebar();
+													await searchHandler();
+												}}
+											>
+												<button
+													aria-label="Chat Menu"
+													class="self-center dark:hover:text-white transition"
+												>
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														viewBox="0 0 16 16"
+														fill="currentColor"
+														class="w-4 h-4"
+													>
+														<path
+															d="M2 8a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM6.5 8a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM12.5 6.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"
+														/>
+													</svg>
+												</button>
+											</ChatMenu>
+										</div>
+									{/if}
+								{/if}
+
+								<div class="text-gray-500 dark:text-gray-400 text-xs">
+									{$i18n.t(
+										dayjs(chat?.updated_at * 1000).calendar(null, {
+											sameDay: '[Today]',
+											nextDay: '[Tomorrow]',
+											nextWeek: 'dddd',
+											lastDay: '[Yesterday]',
+											lastWeek: '[Last] dddd',
+											sameElse: 'L'
+										})
+									)}
 								</div>
 							</div>
-
-							<div class=" pl-3 shrink-0 text-gray-500 dark:text-gray-400 text-xs">
-								{$i18n.t(
-									dayjs(chat?.updated_at * 1000).calendar(null, {
-										sameDay: '[Today]',
-										nextDay: '[Tomorrow]',
-										nextWeek: 'dddd',
-										lastDay: '[Yesterday]',
-										lastWeek: '[Last] dddd',
-										sameElse: 'L' // use localized format, otherwise dayjs.calendar() defaults to DD/MM/YYYY
-									})
-								)}
-							</div>
-						</a>
+						</div>
 					{/each}
 
 					{#if !allChatsLoaded}

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -362,6 +362,7 @@
 				draggable="false"
 				class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
 				on:click={() => {
+					show = false;
 					renameHandler();
 				}}
 			>
@@ -375,6 +376,7 @@
 				draggable="false"
 				class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
 				on:click={() => {
+					show = false;
 					pinHandler();
 				}}
 			>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to https://github.com/open-webui/open-webui/discussions/25489. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The Search modal (`Ctrl+K` / `Cmd+K`) currently lets users find chats, but the **only available action is clicking to navigate** to a chat. If a user wants to rename, pin, archive, move, or delete a chat they found via search, they must close the modal, scroll through the sidebar to locate the same chat, and then use the 3-dot menu there.

This PR adds the same 3-dot context menu already available in the sidebar to every chat result in the Search modal, enabling users to act on chats directly from search results.

**What was added:**

- **3-dot ChatMenu** on each search result row (hover-visible, matching sidebar behavior)
- **All menu actions**: Share, Download (JSON/TXT/PDF), Rename, Pin/Unpin, Clone, Move to folder, Archive, Delete
- **Inline rename** with keyboard support (Enter to save, Escape to cancel, blur to auto-save)
- **Generate title** button (sparkles icon) next to the rename input — auto-generates a title using the chat's model, then auto-saves and exits edit mode
- **Shift+hover quick actions**: Archive and Delete buttons replace the 3-dot menu when Shift is held (matching sidebar behavior); Delete bypasses the confirmation dialog
- **Post-action list refresh**: Clone refreshes search results; Archive/Delete/Move remove the chat from the list and refresh the sidebar

**Implementation approach:**

- Reuses the existing `ChatMenu` component from `src/lib/components/layout/Sidebar/ChatMenu.svelte` — zero new components created
- Reuses existing `ShareChatModal` and `ConfirmDialog` for Share and Delete actions
- All handler logic adapted from `ChatItem.svelte` patterns to work within the SearchModal context
- No new dependencies added

**ChatMenu.svelte fix (2 lines):**

The Pin/Unpin and Rename buttons in `ChatMenu` did not close the dropdown on click (unlike Clone, Archive, Delete which all set `show = false`). This caused the dropdown to stay open after pinning or renaming. Added `show = false` to both handlers — this fix benefits both the sidebar and the Search modal.

> *This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

### Added

- 3-dot context menu (`ChatMenu`) to each chat result in the Search modal with all sidebar actions: Share, Download, Rename, Pin/Unpin, Clone, Move, Archive, Delete
- Inline rename editing with keyboard support (Enter/Escape) directly in search results
- AI title generation (sparkles button) during inline rename — auto-generates, saves, and exits edit mode
- Shift+hover quick actions (Archive and Delete buttons) in the Search modal, matching sidebar behavior

### Fixed

- `ChatMenu` dropdown not closing when Pin/Unpin or Rename is clicked (added `show = false` before calling handlers)

---

### Additional Information

- No new dependencies were added
- The existing `ChatMenu` component is reused as-is (only the 2-line `show = false` fix was needed)
- Keyboard navigation (arrow keys, Enter) continues to work as before — disabled during inline rename to prevent conflicts
- Editing state (inline rename, generating) is fully reset when the Search modal closes

### Screenshots or Videos

<img width="1153" height="732" alt="image" src="https://github.com/user-attachments/assets/98afaae9-d3fd-4e0c-b345-9795e2d22859" />

<img width="1153" height="732" alt="image" src="https://github.com/user-attachments/assets/53b1f671-ddf5-4bf3-9608-07dd23f96334" />

<img width="1153" height="732" alt="image" src="https://github.com/user-attachments/assets/4ec6f1a3-5600-44ab-9eb3-4a17afdbe754" />

<img width="1153" height="732" alt="image" src="https://github.com/user-attachments/assets/2ec4e710-63bf-4f48-a363-5dced8f67ae9" />

### Manual Verification Performed

1. **Open the Search modal** (`Ctrl+K`) → verify chat list loads normally
2. **Hover over a chat result** → verify 3-dot menu button appears on the right
3. **Click the 3-dot menu** → verify all actions are present (Share, Download, Rename, Pin, Clone, Move, Archive, Delete)
4. **Click Rename** → verify dropdown closes and inline edit mode activates with title text selected
5. **Type a new title and press Enter** → verify title updates in the list and sidebar, edit mode exits
6. **Click Rename again, press Escape** → verify rename is cancelled
7. **Click the sparkles icon during rename** → verify spinner appears, title generates, auto-saves, and edit mode exits
8. **Click Pin** → verify dropdown closes; reopen menu → verify it shows "Unpin"
9. **Click Archive** → verify chat is removed from search results and sidebar
10. **Click Delete** → verify confirmation dialog appears, chat is removed on confirm
11. **Shift+hover over a chat** → verify Archive and Delete buttons appear instead of 3-dot menu
12. **Shift+click Delete** → verify chat is deleted immediately (no confirmation dialog)
13. **Shift+click Archive** → verify chat is archived immediately
14. **Click Clone** → verify sidebar refreshes and cloned chat appears in search results
15. **Close and reopen the modal** → verify editing state is fully reset
16. **Verify keyboard navigation** → arrow keys still work to select chats, Enter opens selected chat (disabled during rename)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
