### PR TITLE
feat: support OPENAI_API_CONFIGS and OLLAMA_API_CONFIGS environment variables

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -359,6 +359,9 @@ OLLAMA_BASE_URLS = ConfigVar('OLLAMA_BASE_URLS', 'ollama.base_urls', OLLAMA_BASE
 
 try:
     ollama_api_configs = json.loads(os.getenv('OLLAMA_API_CONFIGS', '{}'))
+    if not isinstance(ollama_api_configs, dict):
+        log.warning('OLLAMA_API_CONFIGS must be a JSON object, ignoring')
+        ollama_api_configs = {}
 except Exception as e:
     log.exception(f'Error loading OLLAMA_API_CONFIGS: {e}')
     ollama_api_configs = {}
@@ -410,6 +413,9 @@ OPENAI_API_BASE_URLS = ConfigVar('OPENAI_API_BASE_URLS', 'openai.api_base_urls',
 
 try:
     openai_api_configs = json.loads(os.getenv('OPENAI_API_CONFIGS', '{}'))
+    if not isinstance(openai_api_configs, dict):
+        log.warning('OPENAI_API_CONFIGS must be a JSON object, ignoring')
+        openai_api_configs = {}
 except Exception as e:
     log.exception(f'Error loading OPENAI_API_CONFIGS: {e}')
     openai_api_configs = {}

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -357,10 +357,16 @@ OLLAMA_BASE_URLS = OLLAMA_BASE_URLS if OLLAMA_BASE_URLS != '' else OLLAMA_BASE_U
 OLLAMA_BASE_URLS = [url.strip() for url in OLLAMA_BASE_URLS.split(';')]
 OLLAMA_BASE_URLS = ConfigVar('OLLAMA_BASE_URLS', 'ollama.base_urls', OLLAMA_BASE_URLS)
 
+try:
+    ollama_api_configs = json.loads(os.getenv('OLLAMA_API_CONFIGS', '{}'))
+except Exception as e:
+    log.exception(f'Error loading OLLAMA_API_CONFIGS: {e}')
+    ollama_api_configs = {}
+
 OLLAMA_API_CONFIGS = ConfigVar(
     'OLLAMA_API_CONFIGS',
     'ollama.api_configs',
-    {},
+    ollama_api_configs,
 )
 
 ####################################
@@ -402,10 +408,16 @@ OPENAI_API_BASE_URLS = [
 ]
 OPENAI_API_BASE_URLS = ConfigVar('OPENAI_API_BASE_URLS', 'openai.api_base_urls', OPENAI_API_BASE_URLS)
 
+try:
+    openai_api_configs = json.loads(os.getenv('OPENAI_API_CONFIGS', '{}'))
+except Exception as e:
+    log.exception(f'Error loading OPENAI_API_CONFIGS: {e}')
+    openai_api_configs = {}
+
 OPENAI_API_CONFIGS = ConfigVar(
     'OPENAI_API_CONFIGS',
     'openai.api_configs',
-    {},
+    openai_api_configs,
 )
 
 # Get the actual OpenAI API key based on the base URL

--- a/backend/open_webui/test/test_config_env.py
+++ b/backend/open_webui/test/test_config_env.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for environment variable JSON config parsing.
+
+Tests the pattern used by OPENAI_API_CONFIGS and OLLAMA_API_CONFIGS:
+    json.loads(os.getenv('VAR_NAME', '{}'))
+with fallback to {} on parse error.
+
+We define a helper that mirrors the parsing logic rather than importing
+config.py directly (it has heavy import-time side effects).
+"""
+
+import json
+import os
+
+
+def parse_config_from_env(var_name: str) -> dict:
+    """Parse a JSON dict from an env var, returning {} on any failure."""
+    raw = os.getenv(var_name, '')
+    if not raw:
+        return {}
+    try:
+        result = json.loads(raw)
+        if not isinstance(result, dict):
+            return {}
+        return result
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+class TestOpenAIApiConfigs:
+    ENV_VAR = 'OPENAI_API_CONFIGS'
+
+    def test_absent_returns_empty_dict(self, monkeypatch):
+        monkeypatch.delenv(self.ENV_VAR, raising=False)
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_empty_string_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, '')
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_single_connection(self, monkeypatch):
+        cfg = {
+            '0': {
+                'enable': True,
+                'model_ids': ['gpt-4o'],
+                'prefix_id': 'openai',
+            }
+        }
+        monkeypatch.setenv(self.ENV_VAR, json.dumps(cfg))
+        result = parse_config_from_env(self.ENV_VAR)
+        assert result == cfg
+        assert result['0']['model_ids'] == ['gpt-4o']
+
+    def test_multiple_connections(self, monkeypatch):
+        cfg = {
+            '0': {
+                'enable': True,
+                'model_ids': ['gpt-4o'],
+                'prefix_id': 'openai',
+            },
+            '1': {
+                'enable': True,
+                'model_ids': ['claude-3-opus'],
+                'prefix_id': 'anthropic',
+                'connection_type': 'external',
+            },
+        }
+        monkeypatch.setenv(self.ENV_VAR, json.dumps(cfg))
+        result = parse_config_from_env(self.ENV_VAR)
+        assert len(result) == 2
+        assert '0' in result
+        assert '1' in result
+
+    def test_invalid_json_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, '{not valid json')
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_non_dict_json_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, '["a", "b"]')
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_azure_openai_config(self, monkeypatch):
+        """Realistic Azure OpenAI connection config."""
+        cfg = {
+            '0': {
+                'enable': True,
+                'model_ids': ['gpt-4o', 'gpt-4o-mini'],
+                'prefix_id': 'azure',
+                'connection_type': 'external',
+                'auth_type': 'bearer',
+                'headers': {
+                    'api-key': 'sk-azure-abc123',
+                },
+            }
+        }
+        monkeypatch.setenv(self.ENV_VAR, json.dumps(cfg))
+        result = parse_config_from_env(self.ENV_VAR)
+        assert result['0']['auth_type'] == 'bearer'
+        assert result['0']['headers']['api-key'] == 'sk-azure-abc123'
+        assert result['0']['prefix_id'] == 'azure'
+        assert result['0']['connection_type'] == 'external'
+
+
+class TestOllamaApiConfigs:
+    ENV_VAR = 'OLLAMA_API_CONFIGS'
+
+    def test_absent_returns_empty_dict(self, monkeypatch):
+        monkeypatch.delenv(self.ENV_VAR, raising=False)
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_empty_string_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, '')
+        assert parse_config_from_env(self.ENV_VAR) == {}
+
+    def test_single_connection(self, monkeypatch):
+        cfg = {
+            '0': {
+                'enable': True,
+                'model_ids': ['llama3'],
+                'prefix_id': 'ollama',
+            }
+        }
+        monkeypatch.setenv(self.ENV_VAR, json.dumps(cfg))
+        result = parse_config_from_env(self.ENV_VAR)
+        assert result == cfg
+
+    def test_multiple_connections(self, monkeypatch):
+        cfg = {
+            '0': {
+                'enable': True,
+                'model_ids': ['llama3'],
+            },
+            '1': {
+                'enable': False,
+                'model_ids': ['mistral'],
+            },
+        }
+        monkeypatch.setenv(self.ENV_VAR, json.dumps(cfg))
+        result = parse_config_from_env(self.ENV_VAR)
+        assert len(result) == 2
+        assert result['1']['enable'] is False
+
+    def test_invalid_json_returns_empty_dict(self, monkeypatch):
+        monkeypatch.setenv(self.ENV_VAR, '{{bad')
+        assert parse_config_from_env(self.ENV_VAR) == {}


### PR DESCRIPTION
Relates to https://github.com/open-webui/open-webui/discussions/25472

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Discussion](https://github.com/open-webui/open-webui/discussions/25472).
- [x] **Target branch:** Verify that the pull request targets the `dev` branch.
- [x] **Description:** See below.
- [x] **Changelog:** See below.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** 12 unit tests added, all passing. Manually verified config loading with env vars set, including app.state wiring.
- [x] **Agentic AI Code:** This PR has gone through human review and manual testing.
- [x] **Code review:** Self-reviewed.
- [x] **Git Hygiene:** Single commit, rebased on dev.

# Changelog Entry

### Description

`OPENAI_API_CONFIGS` and `OLLAMA_API_CONFIGS` are hardcoded to `{}` in `config.py` with no environment variable override. This means per-connection settings like `model_ids`, `auth_type`, `prefix_id`, and custom headers can only be configured through the admin UI.

This adds `json.loads(os.getenv(...))` parsing for both variables, following the existing `TOOL_SERVER_CONNECTIONS` pattern in `config.py`. Falls back to empty dict on missing or invalid input.

Example:

```bash
OPENAI_API_BASE_URLS="https://myinstance.openai.azure.com/openai"
OPENAI_API_KEYS="your-azure-api-key"
OPENAI_API_CONFIGS='{"0":{"enable":true,"model_ids":["gpt-4o","gpt-4o-mini"],"prefix_id":"azure","auth_type":"bearer"}}'
```

### Added

- Environment variable support for `OPENAI_API_CONFIGS` (JSON string)
- Environment variable support for `OLLAMA_API_CONFIGS` (JSON string)
- 12 unit tests in `backend/open_webui/test/test_config_env.py`

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Pattern follows `TOOL_SERVER_CONNECTIONS` in the same file (`config.py:435-446`)
- Config keys are string indices (`"0"`, `"1"`, ...) matching position in `OPENAI_API_BASE_URLS`
- Manually verified: config parsing, ConfigVar wiring, and `app.state.config` propagation all work correctly

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.