### PR TITLE
fix: pass web search results to model when embedding & retrieval enabled

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1374,6 +1374,10 @@ async def get_sources_from_items(
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
+        elif item.get('type') == 'web_search' and item.get('collection_name'):
+            # Trusted server-generated collection; authorized by
+            # filter_accessible_collections below (allowlists web-search-*).
+            collection_names.append(item['collection_name'])
         elif item.get('collection_name'):
             if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                 collection_names.append(item['collection_name'])


### PR DESCRIPTION
Web search results stored as a vector collection were silently dropped before retrieval when BYPASS_RETRIEVAL_ACCESS_CONTROL is False (the default). The server-generated web_search file item carries a 'collection_name' but its 'web_search' type is not matched by any explicit dispatch branch in get_sources_from_items, so it fell through to the untrusted client-supplied collection_name branch and was ignored.

Add an explicit branch for type == 'web_search' items so the collection is queried again. Access control is preserved: the collection still passes through filter_accessible_collections, which already allowlists web-search-* and bypasses only for admins.

Regression introduced when the retrieval access-control hardening gated the bare collection_name fallback behind BYPASS_RETRIEVAL_ACCESS_CONTROL.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
