### PR TITLE
fix: allow numeric MinerU API timeout updates

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -680,7 +680,7 @@ class ConfigForm(BaseModel):
     MINERU_API_MODE: str | None = None
     MINERU_API_URL: str | None = None
     MINERU_API_KEY: str | None = None
-    MINERU_API_TIMEOUT: str | None = None
+    MINERU_API_TIMEOUT: int | str | None = None
     MINERU_PARAMS: dict | None = None
     MINERU_FILE_EXTENSIONS: list[str] | None = None
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Fixes saving MinerU API timeout from the WebUI by accepting the numeric value emitted by the existing number input.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- MinerU API timeout updates no longer fail with HTTP 422 when submitted from Admin Settings > Documents.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Closes #25603.
- Relates to #20016, #18495, and implementation commit afaa404fe442435368defb0858cba213baa1725b.
- The WebUI uses `<input type="number">`, which submits `MINERU_API_TIMEOUT` as a JSON number.
- The backend schema previously accepted only `str | None`, causing Pydantic v2 request validation to reject the request before the handler ran.
- The loader already coerces the value with `int(...)`, so accepting both `int` and `str` preserves existing string/env compatibility while accepting the WebUI payload.
- Testing: verified an isolated Pydantic model accepts `MINERU_API_TIMEOUT=600`, `MINERU_API_TIMEOUT="600"`, and `MINERU_API_TIMEOUT=None` with the updated type.
- Testing: ran `ruff format --check` successfully
- Documentation: no documentation update is needed because this fixes backend validation for an existing setting.
- Dependencies: no dependencies were added or updated.

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
