### PR TITLE
fix: add scroll support to Select dropdown for long lists

### DIFF
--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -25,6 +25,7 @@
 
 	let triggerEl;
 	let contentEl;
+	let contentMaxHeight = '';
 
 	/** Svelte action: moves the node to document.body */
 	function portal(node) {
@@ -68,6 +69,22 @@
 		contentEl.style.position = 'fixed';
 		contentEl.style.zIndex = '9999';
 
+		// Find the trigger's nearest vertically-scrollable ancestor to use as boundary
+		let minTop = 8;
+		let scrollParent = triggerEl.parentElement;
+		while (scrollParent && scrollParent !== document.body) {
+			const style = getComputedStyle(scrollParent);
+			const oy = style.overflowY;
+			if (
+				(oy === 'auto' || oy === 'scroll') &&
+				scrollParent.scrollHeight > scrollParent.clientHeight
+			) {
+				minTop = scrollParent.getBoundingClientRect().top;
+				break;
+			}
+			scrollParent = scrollParent.parentElement;
+		}
+
 		const contentHeight = contentEl.offsetHeight || 0;
 		const spaceBelow = window.innerHeight - rect.bottom - sideOffset;
 		const spaceAbove = rect.top - sideOffset;
@@ -83,9 +100,14 @@
 		if (openAbove) {
 			contentEl.style.bottom = `${window.innerHeight - rect.top + sideOffset}px`;
 			contentEl.style.top = 'auto';
+			const maxAbove = rect.top - minTop - sideOffset;
+			contentMaxHeight = `${maxAbove}px`;
 		} else {
-			contentEl.style.top = `${rect.bottom + sideOffset}px`;
+			const dropdownTop = Math.max(minTop, rect.bottom + sideOffset);
+			contentEl.style.top = `${dropdownTop}px`;
 			contentEl.style.bottom = 'auto';
+			const availableHeight = window.innerHeight - dropdownTop - 8;
+			contentMaxHeight = `${availableHeight}px`;
 		}
 
 		if (align === 'end') {
@@ -187,6 +209,8 @@
 		bind:this={contentEl}
 		class={contentClass}
 		role="menu"
+		style:max-height={contentMaxHeight}
+		style:overflow-y="auto"
 		transition:flyAndScale
 		on:click={(e) => e.stopPropagation()}
 		on:pointerdown={(e) => e.stopPropagation()}

--- a/src/lib/components/common/Select.svelte
+++ b/src/lib/components/common/Select.svelte
@@ -38,6 +38,7 @@
 
 	let triggerEl;
 	let contentEl;
+	let contentMaxHeight = '';
 
 	$: selectedLabel = items.find((i) => i.value === value)?.label ?? placeholder;
 
@@ -59,8 +60,28 @@
 
 		contentEl.style.position = 'fixed';
 		contentEl.style.zIndex = '9999';
-		contentEl.style.top = `${rect.bottom + 4}px`;
 		contentEl.style.minWidth = `${rect.width}px`;
+
+		// Find the trigger's nearest vertically-scrollable ancestor and use its
+		// top edge as the minimum dropdown position so the dropdown never overlaps
+		// fixed headers above the scroll area (e.g. workspace nav bar)
+		let minTop = 8;
+		let parent = triggerEl.parentElement;
+		while (parent && parent !== document.body) {
+			const style = getComputedStyle(parent);
+			const oy = style.overflowY;
+			if ((oy === 'auto' || oy === 'scroll') && parent.scrollHeight > parent.clientHeight) {
+				minTop = parent.getBoundingClientRect().top;
+				break;
+			}
+			parent = parent.parentElement;
+		}
+		const dropdownTop = Math.max(minTop, rect.bottom + 4);
+		contentEl.style.top = `${dropdownTop}px`;
+
+		// Constrain dropdown height to available viewport space below the clamped top
+		const availableHeight = window.innerHeight - dropdownTop - 8;
+		contentMaxHeight = `${availableHeight}px`;
 
 		if (align === 'end') {
 			contentEl.style.right = `${window.innerWidth - rect.right}px`;
@@ -123,7 +144,14 @@
 </button>
 
 {#if open}
-	<div use:portal bind:this={contentEl} class={contentClass} transition:flyAndScale>
+	<div
+		use:portal
+		bind:this={contentEl}
+		class={contentClass}
+		style:max-height={contentMaxHeight}
+		style:overflow-y="auto"
+		transition:flyAndScale
+	>
 		<slot {open} {selectItem}>
 			{#each items as item}
 				<button class={itemClass} type="button" on:click={() => selectItem(item)}>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to https://github.com/open-webui/open-webui/discussions/25607. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

## Description

Relates to https://github.com/open-webui/open-webui/discussions/25607

The `Select` and `Dropdown` common components render their dropdown panels as portaled `position: fixed` elements with no height constraint. When a dropdown contains many items — most noticeably the **Tag filter** on the Workspace Models page (40+ tags) — the list overflows beyond the viewport edges with no way to scroll. Additionally, when the trigger element scrolls near the top of its scroll container, the dropdown can overlap fixed headers like the workspace navigation bar (Models / Knowledge / Prompts / Skills / Tools), clipping items from view.

This PR adds viewport-aware positioning and scroll support to both components:

- **Dynamic `max-height` calculation** — On each position update, the available vertical space from the dropdown's clamped position to the viewport edge is computed and applied as `max-height`, with `overflow-y: auto` enabling scrolling when the list exceeds the available space.
- **Scroll-parent boundary detection** — Walks up the DOM from the trigger to find the nearest vertically-scrollable ancestor (checking `getComputedStyle` for `overflow-y: auto|scroll` combined with `scrollHeight > clientHeight`). The ancestor's top edge is used as the minimum dropdown position, preventing overlap with any fixed headers above the scroll area.
- **Transition-safe styling** — Uses Svelte `style:` directives (`style:max-height`, `style:overflow-y`) instead of inline `element.style` assignments, ensuring the constraints persist through the `flyAndScale` CSS transition which would otherwise overwrite inline styles.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Add viewport-aware scroll support and boundary clamping to `Select` and `Dropdown` common components so dropdown panels with many items are scrollable and never overflow the viewport or overlap fixed headers.

### Fixed

- `Select` dropdown overflowing beyond viewport when containing many items (e.g. Tag filter on Workspace Models page with 40+ tags), making items inaccessible
- `Dropdown` menu overflowing beyond viewport for long option lists
- Both dropdown types overlapping fixed headers (e.g. workspace nav bar) when the trigger scrolls near the top of its scroll container

---

### Additional Information

- No new dependencies were added.
- The fix is generic and applies to all usages of `Select` and `Dropdown` across the application, not just the Models page.
- The `Dropdown` component's existing auto-flip logic (open above vs. below) integrates with the new `max-height` constraint — whichever direction is chosen gets properly bounded.

### Manual Verification Performed

1. Open Workspace → Models page with 40+ model tags
2. Click the **Tag** dropdown — verify all tags are visible via scrolling, no items clipped at top or bottom
3. Scroll the model list down so the Tag filter row approaches the workspace nav bar — verify the dropdown does not overlap "Models / Knowledge / Prompts / Skills / Tools"
4. Click a model's **3-dot menu** (More) — verify the menu respects viewport bounds and scrolls if needed
5. Click the **3-dot menu** on a model near the bottom of the viewport — verify the auto-flip (open above) still works and is height-constrained
6. Test the **"Created by you"** / **"All"** / **"Shared with you"** `Select` dropdown (ViewSelector) — verify it still functions normally with fewer items
7. Resize the browser window while a dropdown is open — verify it repositions correctly
8. Verify no regressions on other pages that use `Select` or `Dropdown` (e.g. Admin Settings, Chat Settings)

### Screenshots or Videos

## Before:
<img width="1309" height="191" alt="image" src="https://github.com/user-attachments/assets/fbf719ee-aaaa-4966-9af7-b62dcf8a616a" />

<img width="1313" height="1273" alt="image" src="https://github.com/user-attachments/assets/c44b4a10-fd02-4572-a471-8a50a485da16" />

<img width="1411" height="232" alt="image" src="https://github.com/user-attachments/assets/babf789f-ede4-46b6-9ee9-3542c0c13391" />

## After:
<img width="1309" height="191" alt="image" src="https://github.com/user-attachments/assets/fd29b513-28ab-45c6-91a7-2d4ba7c18fc4" />

<img width="1313" height="1273" alt="image" src="https://github.com/user-attachments/assets/9d80c701-e583-4f7b-b391-a58af7fcf9ac" />

<img width="1413" height="343" alt="image" src="https://github.com/user-attachments/assets/aef1191f-e787-49cf-b0d1-76223fe49526" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
