### PR TITLE
docs: add multi-user auth setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ export HF_HUB_OFFLINE=1
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).
 
+## Community Guides
+
+Practical guides written by the community:
+
+- [Open WebUI Multi-User Auth Setup (2026)](https://runaihome.com/blog/open-webui-multi-user-auth-family-setup-2026/) — Covers role-based access control, creating user accounts with different permission levels, and securing a shared Open WebUI instance for home or small-team use
+
 ## License 📜
 
 This project contains code under multiple licenses. The current codebase includes components licensed under the Open WebUI License with an additional requirement to preserve the "Open WebUI" branding, as well as prior contributions under their respective original licenses. For a detailed record of license changes and the applicable terms for each section of the code, please refer to [LICENSE_HISTORY](./LICENSE_HISTORY). For complete and updated licensing details, please see the [LICENSE](./LICENSE) and [LICENSE_HISTORY](./LICENSE_HISTORY) files.


### PR DESCRIPTION
## What this adds

A new **Community Guides** section in `README.md` (placed before the License section) with one external guide:

> [Open WebUI Multi-User Auth Setup (2026)](https://runaihome.com/blog/open-webui-multi-user-auth-family-setup-2026/)

## Why it's useful

Open WebUI has solid RBAC built in, but the official docs don't walk through the practical day-one questions that come up when deploying for a household or small team:
- How do you create accounts with different permission levels?
- What's the difference between `admin`, `user`, and pending states?
- How do you lock down model access so one user can't burn your API budget?

This community article covers the full flow end-to-end, including the specific admin panel settings that aren't obvious on first run. It directly addresses one of the most common questions in the Open WebUI Discord.

## Change scope

- One file edited: `README.md`
- 6 lines added, 0 deleted
- No code or dependency changes