### PR TITLE
feat: add tag filter dropdown to admin Models settings page

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -46,6 +46,7 @@
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import AdminViewSelector from './Models/AdminViewSelector.svelte';
+	import TagSelector from '$lib/components/workspace/common/TagSelector.svelte';
 	import Pagination from '$lib/components/common/Pagination.svelte';
 
 	let shiftKey = false;
@@ -66,6 +67,9 @@
 	let showManageModal = false;
 
 	let viewOption = ''; // '' = All, 'enabled', 'disabled', 'visible', 'hidden'
+
+	let tags: string[] = [];
+	let selectedTag = '';
 
 	const perPage = 30;
 	let currentPage = 1;
@@ -88,6 +92,11 @@
 				if (viewOption === 'private') return !isPublicModel(m);
 				return true; // All
 			})
+			.filter((m) => {
+				if (!selectedTag) return true;
+				const modelTags = m?.meta?.tags ?? [];
+				return modelTags.some((t) => (typeof t === 'string' ? t : t?.name) === selectedTag);
+			})
 			.sort((a, b) => {
 				return (a?.name ?? a?.id ?? '').localeCompare(b?.name ?? b?.id ?? '');
 			});
@@ -95,7 +104,7 @@
 
 	let searchValue = '';
 
-	$: if (searchValue || viewOption !== undefined) {
+	$: if (searchValue || viewOption !== undefined || selectedTag !== undefined) {
 		currentPage = 1;
 	}
 
@@ -196,6 +205,16 @@
 				};
 			}
 		});
+
+		// Compute tags locally from the merged models list
+		const tagSet = new Set<string>();
+		for (const m of models) {
+			for (const t of m?.meta?.tags ?? []) {
+				const name = typeof t === 'string' ? t : t?.name;
+				if (name) tagSet.add(name);
+			}
+		}
+		tags = [...tagSet].sort();
 
 		_models.set(
 			await getModels(
@@ -501,6 +520,15 @@
 					class="flex gap-0.5 w-fit text-center text-sm rounded-full bg-transparent whitespace-nowrap"
 				>
 					<AdminViewSelector bind:value={viewOption} />
+
+					{#if (tags ?? []).length > 0}
+						<TagSelector
+							bind:value={selectedTag}
+							items={tags.map((tag) => {
+								return { value: tag, label: tag };
+							})}
+						/>
+					{/if}
 				</div>
 
 				<div class="flex-1"></div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to https://github.com/open-webui/open-webui/discussions/25610. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

## Description

Relates to https://github.com/open-webui/open-webui/discussions/25610

The Admin Settings → Models page supports filtering by view option (All / Enabled / Disabled / Visible / Hidden / Public / Private) but lacks the ability to filter models by tag. This is a gap because model tags — assigned via the model editor and stored in `meta.tags` — are a primary organizational tool for administrators managing large model libraries, yet the only tag filter exists on the Workspace Models page.

This PR adds the same `TagSelector` dropdown used on the Workspace Models page to the Admin Models page:

- **Fetches tags** via the existing `getModelTags()` API during page initialization
- **Renders `TagSelector`** inline next to the existing `AdminViewSelector` in the filter bar, appearing only when tags exist
- **Filters client-side** by checking each model's `meta.tags` array for the selected tag name (handles both `string` and `{name: string}` tag formats per the backend's `normalize_tags` validator)
- **Resets pagination** to page 1 when the tag selection changes

The implementation is minimal — 1 file changed, 25 lines added — because it reuses the existing `TagSelector` component and `getModelTags` API that the Workspace already uses. No new dependencies, API endpoints, or backend changes are needed.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Add tag filter dropdown to the Admin Settings → Models page, reusing the existing `TagSelector` component and `getModelTags` API from the Workspace Models page.

### Added

- Tag-based filtering on the Admin Settings → Models page via the `TagSelector` dropdown, allowing administrators to filter the model list by any existing model tag

---

### Screenshots or Videos

## Before:
<img width="2552" height="514" alt="image" src="https://github.com/user-attachments/assets/392561e7-2592-44d5-bc4c-19503f200b11" />

## After:
<img width="2552" height="514" alt="image" src="https://github.com/user-attachments/assets/b5e816ef-7706-4382-ae20-8399526527ea" />

<img width="2552" height="698" alt="image" src="https://github.com/user-attachments/assets/3c11e2a0-f1f8-409f-add0-85dab1d91ae6" />

<img width="2552" height="259" alt="image" src="https://github.com/user-attachments/assets/21aac99d-79b8-4f8f-9a20-4b4650e16061" />

<img width="2552" height="259" alt="image" src="https://github.com/user-attachments/assets/29636148-1e8f-44e6-aec6-e458b730a3b7" />

### Additional Information

- No new dependencies were added.
- No backend changes were needed — the existing `/api/v1/models/tags` endpoint is reused.
- The `TagSelector` component is imported from `src/lib/components/workspace/common/TagSelector.svelte`, which itself wraps the `Select` common component.
- Client-side filtering is consistent with the admin page's existing approach (it loads all models and filters in the browser, unlike the workspace page which uses server-side pagination).

### Manual Verification Performed

1. Navigate to Admin Settings → Models page
2. Verify the **Tag** dropdown appears in the filter bar next to the view selector (e.g. "All ▾")
3. Click the Tag dropdown — verify all model tags are listed and scrollable
4. Select a tag — verify the model list filters to show only models with that tag
5. Verify the model count updates to reflect the filtered results
6. Clear the tag filter (click the ✕ on the Tag dropdown) — verify all models are shown again
7. Combine tag filter with the view selector (e.g. "Enabled" + a tag) — verify both filters work together
8. Combine tag filter with the search input — verify all three filters work together
9. Verify pagination resets to page 1 when changing the tag filter
10. Verify the Tag dropdown does not appear when no tags exist (test with a fresh instance or remove all model tags)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
