### PR TITLE
Fix: Handle web_search without requiring BYPASS_RETRIEVAL_ACCESS_CONTROL

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1369,13 +1369,14 @@ async def get_sources_from_items(
                         collection_names.append(item['id'])
 
         elif item.get('docs'):
-            # BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
+            # BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL (and we need to accept type=='web_search')
             query_result = {
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
         elif item.get('collection_name'):
-            if BYPASS_RETRIEVAL_ACCESS_CONTROL:
+            # Fix: Accept type=='web_search'
+            if BYPASS_RETRIEVAL_ACCESS_CONTROL or item.get('type') == 'web_search':
                 collection_names.append(item['collection_name'])
             else:
                 log.debug(


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #25618 ` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [NA] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [NA] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [NA] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Handle web_search without requiring BYPASS_RETRIEVAL_ACCESS_CONTROL

### Fixed

- Handle web_search without requiring BYPASS_RETRIEVAL_ACCESS_CONTROL

Commit ee47c9c introduced `BYPASS_RETRIEVAL_ACCESS_CONTROL` and added guards to the untyped `collection_name`/`collection_names` fallback paths in `get_sources_from_items()`, correctly blocking untrusted direct collection access. However, `web_search` items — produced by `chat_web_search_handler()` in `middleware.py` — were never added as an explicit trusted type in the dispatch chain above those fallbacks.

This fixes it for 'collection_name' and adds a relevant commit for 'docs' to guard it from being overlooked.

Closes #25618 

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.