### PR TITLE
fix: scope every channel chat-completion message_id to the channel, n…

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1834,8 +1834,10 @@ async def chat_completion(
                                 status_code=status.HTTP_403_FORBIDDEN,
                                 detail=ERROR_MESSAGES.DEFAULT(),
                             )
-                target_message_id = list(message_ids.values())[0] if message_ids else None
-                if target_message_id:
+                # Every message_ids value must match the channel; first-only let a multimodel id slip past.
+                for target_message_id in (message_ids or {}).values():
+                    if not target_message_id:
+                        continue
                     target_message = await Messages.get_message_by_id(target_message_id)
                     if target_message and target_message.channel_id != channel.id:
                         raise HTTPException(

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -841,11 +841,15 @@ async def _make_channel_emitter(request_info):
     async def _emit_channel_update(content: str, done: bool = False):
         from open_webui.models.messages import MessageForm, Messages
 
+        # Fail closed: only update a message that actually belongs to this channel.
+        msg = await Messages.get_message_by_id(message_id)
+        if not msg or msg.channel_id != channel_id:
+            return
+
         update_form = MessageForm(content=content)
         if done:
             # Merge done flag into existing meta (preserve model_id etc.)
-            msg = await Messages.get_message_by_id(message_id)
-            existing_meta = (msg.meta or {}) if msg else {}
+            existing_meta = msg.meta or {}
             update_form = MessageForm(
                 content=content,
                 meta={**existing_meta, 'done': True},


### PR DESCRIPTION
…ot just the first

#24725 added a channel-access + message-scoping gate to the chat_completion `channel:` branch, but it validated only list(message_ids.values())[0]. A multimodel request (message_ids with more than one entry) could pass a permitted-channel id as the first value and a victim-channel message id as a later value; the fan-out then drove _make_channel_emitter to overwrite the victim message in a channel the caller cannot access.

Validate every message_ids value against the channel, and make _make_channel_emitter fail closed so it only updates a message whose channel_id matches the channel in chat_id.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
