### PR TITLE
fix: prevent space key from opening file/directory during rename in knowledge base

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/DirectoryRow.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/DirectoryRow.svelte
@@ -116,7 +116,10 @@
 	<button
 		class="relative flex items-center gap-1 rounded-xl p-2 text-left flex-1 justify-between"
 		type="button"
-		on:click={() => onNavigate(directory.id)}
+		on:click={() => {
+			if (editing) return;
+			onNavigate(directory.id);
+		}}
 	>
 		<div>
 			<div class="flex gap-2 items-center line-clamp-1">
@@ -129,6 +132,10 @@
 						on:keydown={(e) => {
 							if (e.key === 'Enter') submitRename();
 							if (e.key === 'Escape') cancelRename();
+							if (e.key === ' ') e.stopPropagation();
+						}}
+						on:keyup={(e) => {
+							if (e.key === ' ') e.stopPropagation();
 						}}
 						on:blur={submitRename}
 						on:click={(e) => e.stopPropagation()}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -108,6 +108,7 @@
 				class="relative flex items-center gap-1 rounded-xl p-2 text-left flex-1 justify-between"
 				type="button"
 				on:click={() => {
+					if (editingFileId) return;
 					onClick(file?.id ?? file?.tempId);
 				}}
 				on:dblclick={() => {
@@ -125,6 +126,10 @@
 								on:keydown={(e) => {
 									if (e.key === 'Enter') submitRename();
 									if (e.key === 'Escape') cancelRename();
+									if (e.key === ' ') e.stopPropagation();
+								}}
+								on:keyup={(e) => {
+									if (e.key === ' ') e.stopPropagation();
 								}}
 								on:blur={submitRename}
 								on:click={(e) => e.stopPropagation()}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #25596`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

In Chrome, pressing the Space key while renaming a file or directory within a knowledge base triggers the parent `<button>` element's native click activation, which opens the file or navigates into the directory — interrupting the rename. Firefox does not exhibit this behavior because it does not propagate Space-triggered activation from a child `<input>` to a parent `<button>`.

This fix applies two defensive measures:
1. **Guard on the parent button's `on:click`**: When the component is in rename/editing mode, the click handler returns early, preventing navigation regardless of how the click was triggered.
2. **`stopPropagation` on Space key events**: The rename `<input>` now stops `keydown` and `keyup` propagation for the Space key, preventing Chrome's native button activation from firing on the parent element.

Both layers are needed because Chrome's `<button>` activation fires on Space `keyup` and operates at the browser's native event dispatch level.

Relates to #25596

> *This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

### Fixed

- Fixed Space key opening a file or navigating into a directory when renaming items inside a knowledge base (Chrome-specific, [#25596](https://github.com/open-webui/open-webui/issues/25596))

# Manual Verification Performed

1. Navigate to a knowledge base containing files and directories
2. Click the 3-dot menu on a file → click **Rename**
3. Type a space character in the rename input field
4. **Expected**: Space is inserted into the file name; the file does NOT open
5. Repeat for directory rename via 3-dot menu → **Rename**
6. **Expected**: Space is inserted into the directory name; the directory does NOT navigate
7. Verify normal click-to-open and click-to-navigate behavior still works when NOT in rename mode
8. Test in both Chrome and Firefox

---

### Additional Information

- Affected components: `Files.svelte`, `DirectoryRow.svelte` (in `src/lib/components/workspace/Knowledge/KnowledgeBase/`)
- Root cause: Rename `<input>` is nested inside a `<button>` with an `on:click` handler. Chrome's native `<button>` activation via Space key fires internally, bypassing `stopPropagation` on the input alone — hence the guard at the button level is also needed.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
