### PR TITLE
feat: add setting to modify terminal sidebar auto-open behavior

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -102,7 +102,7 @@
 	$: if ($selectedTerminalId && showFilesTab) {
 		activeTab = 'files';
 		if (largeScreen) {
-			showControls.set(true);
+			showControls.set($settings?.autoOpenTerminalSidebar ?? true);
 		}
 	}
 

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -62,6 +62,7 @@
 
 	let landingPageMode = '';
 	let chatBubble = true;
+	let autoOpenTerminalSidebar = true;
 	let chatDirection: 'LTR' | 'RTL' | 'auto' = 'auto';
 	let ctrlEnterToSend = false;
 	let copyFormatted = false;
@@ -241,6 +242,7 @@
 
 		landingPageMode = $settings?.landingPageMode ?? '';
 		chatBubble = $settings?.chatBubble ?? true;
+		autoOpenTerminalSidebar = $settings?.autoOpenTerminalSidebar ?? true;
 		widescreenMode = $settings?.widescreenMode ?? false;
 		splitLargeChunks = $settings?.splitLargeChunks ?? false;
 		scrollOnBranchChange = $settings?.scrollOnBranchChange ?? true;
@@ -720,6 +722,25 @@
 					</div>
 				</div>
 			{/if}
+
+			<div>
+                <div class=" py-0.5 flex w-full justify-between">
+                    <div id="auto-open-terminal-sidebar-label" class=" self-center text-xs">
+                        {$i18n.t('Auto-Open Terminal Sidebar')}
+                    </div>
+
+                    <div class="flex items-center gap-2 p-1">
+                        <Switch
+                            tooltip={true}
+                            ariaLabelledbyId="auto-open-terminal-sidebar-label"
+                            bind:state={autoOpenTerminalSidebar}
+                            on:change={() => {
+                                saveSettings({ autoOpenTerminalSidebar });
+                            }}
+                        />
+                    </div>
+                </div>
+            </div>
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -216,6 +216,7 @@ type Settings = {
 	directConnections?: null;
 	chatBubble?: boolean;
 	copyFormatted?: boolean;
+	autoOpenTerminalSidebar?: boolean;
 	models?: string[];
 	conversationMode?: boolean;
 	speechAutoSend?: boolean;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #___ / Relates to #___. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting main will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- When starting a new chat with a model that has a terminal active (Open Terminal) the right sidebar with controls and files automatically opens. It is not necessary for all users to always display the sidebar. Currently the only way to 'fix' this and get the wider, cleaner chat window is to manually close the right sidebar for every new chat or disable terminal. This PR contains changes to enable users to modify this behavior.

This PR references an existing Discussion — Relates to #24324 and #21149 

### Added

Added a toggle in the user's Settings > Interface ("Auto-Open Terminal Sidebar")
- Enabled (default), maintains current behavior
- Disabled, sidebar remains closed on new chat even with terminal active (can still be opened when needed)

### Changed

- index.ts : initialize boolean setting autoOpenTerminalSidebar
- Interface.svelte : add boolean setting to Interface Settings
- ChatControls.svelte : update reactive block for sidebar behavior to pull from new boolean setting instead of flat bool value

---

### Screenshots or Videos

<img width="1185" height="1023" alt="image" src="https://github.com/user-attachments/assets/4f1c0795-96dc-42bd-9d9f-96e519d4f170" />
<img width="561" height="238" alt="image" src="https://github.com/user-attachments/assets/be4f177f-febd-4de3-b1ad-90d12bdee9ca" />


### MANUAL VERIFICATION PERFORMED

 1. Created one model with terminal enabled, one without
 2. Confirmed user Settings >Interface > Auto-Open Terminal Sidebar enabled by default
 3. Confirmed sidebar opens when starting new chat with terminal-enabled model
 4. Confirmed sidebar does not open  when starting new chat with terminal-disabled model
 5. Changed  Auto-Open Terminal Sidebar to disabled
 6. Confirmed sidebar does not open when starting new chat with terminal-enabled model
 7. Confirmed sidebar does not open  when starting new chat with terminal-disabled model
 
### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
