### PR TITLE
feat: add typical_p sampling parameter to Advanced Params

### DIFF
--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -161,6 +161,7 @@ def apply_model_params_to_body_ollama(params: dict, form_data: dict) -> dict:
         'repeat_last_n': int,
         'top_k': int,
         'min_p': float,
+        'typical_p': float,
         'repeat_penalty': float,
         'presence_penalty': float,
         'frequency_penalty': float,

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -34,6 +34,7 @@
 		mirostat_tau: null,
 		repeat_last_n: null,
 		tfs_z: null,
+		typical_p: null,
 		repeat_penalty: null,
 		use_mmap: null,
 		use_mlock: null,
@@ -1073,6 +1074,62 @@
 						class=" bg-transparent text-center w-14"
 						min="0"
 						max="2"
+						step="any"
+					/>
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<div class=" py-0.5 w-full justify-between">
+		<Tooltip
+			content={$i18n.t(
+				'Locally typical sampling selects tokens based on how "typical" they are relative to the expected information content of the text. A value of 1.0 disables this setting.'
+			)}
+			placement="top-start"
+			className="inline-tooltip"
+		>
+			<div class="flex w-full justify-between">
+				<div class=" self-center text-xs">
+					{'typical_p'}
+				</div>
+
+				<button
+					class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
+					type="button"
+					on:click={() => {
+						params.typical_p = (params?.typical_p ?? null) === null ? 1 : null;
+					}}
+				>
+					{#if (params?.typical_p ?? null) === null}
+						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
+					{:else}
+						<span class="ml-2 self-center">{$i18n.t('Custom')}</span>
+					{/if}
+				</button>
+			</div>
+		</Tooltip>
+
+		{#if (params?.typical_p ?? null) !== null}
+			<div class="flex mt-0.5 space-x-2">
+				<div class=" flex-1">
+					<input
+						id="steps-range"
+						type="range"
+						min="0"
+						max="1"
+						step="0.05"
+						bind:value={params.typical_p}
+						class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+					/>
+				</div>
+				<div>
+					<input
+						bind:value={params.typical_p}
+						type="number"
+						class=" bg-transparent text-center w-14"
+						min="0"
+						max="1"
 						step="any"
 					/>
 				</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to https://github.com/open-webui/open-webui/discussions/25630. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Add first-class UI support for Ollama's `typical_p` (locally typical sampling) parameter in the Advanced Params panel, completing the sampling strategy set alongside `top_p`, `min_p`, and `tfs_z`.

**Context:** I previously removed `typical_p` from Open WebUI's backend mappings in #17850 as part of a dead-code cleanup — the parameter had a backend mapping but no corresponding UI, making it an unreachable code path. However, `typical_p` itself was never deprecated by Ollama. It remains actively supported in Ollama's [`api/types.go` Options struct](https://github.com/ollama/ollama/blob/main/api/types.go), is listed in their [API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md), and is actively used in their sampling logic. This PR re-introduces `typical_p` properly — with both a UI control and a backend mapping.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- `typical_p` slider in Advanced Params panel (between `tfs_z` and `repeat_penalty`)
  - Default/Custom toggle (default value: `1.0` — disabled)
  - Range slider: `0` to `1`, step `0.05`
  - Companion number input for precise value entry
  - Tooltip describing the parameter's behavior
- `typical_p` float cast in `apply_model_params_to_body_ollama()` backend mapping

---

### Additional Information

- No new dependencies added
- No i18n changes needed — parameter labels use raw strings (consistent with `tfs_z`, `min_p`, `top_p`, etc.)
- The UI follows the exact same pattern as the existing `tfs_z` parameter block
- Verified locally: the parameter appears correctly in Ollama's server logs when set via the UI
- Related prior PR: #17850 (removed `typical_p` backend mapping as dead code — this PR re-introduces it with proper UI support)

### Screenshots or Videos

<img width="2343" height="1277" alt="image" src="https://github.com/user-attachments/assets/e5fc3755-66c0-4123-8a30-80316acfb8e5" />

<img width="375" height="131" alt="image" src="https://github.com/user-attachments/assets/d22f5c4f-45ba-4e81-a05c-7def683c6282" />

### Manual Verification Performed

1. Opened Settings → Advanced Params and verified `typical_p` appears between `tfs_z` and `repeat_penalty`
2. Toggled Default ↔ Custom — confirmed slider appears/disappears correctly
3. Confirmed slider range is `0` to `1` with `0.05` step increments
4. Set a custom value, verified it works as expected
5. Sent a chat message to an Ollama model with `typical_p` set — confirmed the parameter appears in Ollama's server logs (via `OLLAMA_DEBUG=1`) inside the `options` object
6. Ran `npm run format` — no formatting changes needed
7. Ran `npm run build` — production build succeeded
8. Ran `npm run test:frontend` — all tests pass

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
