### PR TITLE
fix: handle orphaned shared_chat rows when unsharing

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1388,11 +1388,11 @@ async def delete_shared_chat_by_id(
     if not chat:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
 
-    if not chat.share_id:
-        return False
-
     await SharedChats.delete_by_chat_id(id, db=db)
-    await Chats.update_chat_share_id_by_id(id, None, db=db)
+
+    if chat.share_id:
+        await Chats.update_chat_share_id_by_id(id, None, db=db)
+
     await AccessGrants.set_access_grants('shared_chat', id, [], db=db)
 
     return True


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to https://github.com/open-webui/open-webui/discussions/25633. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Fix "Failed to unshare chat." error when unsharing chats from the Shared Chats modal (Settings → Data Controls → Shared Chats → Manage).

**Root cause:** The `delete_shared_chat_by_id` route in `chats.py` had an early `return False` when `chat.share_id` was falsy. If a `shared_chat` table row existed but `chat.share_id` on the original chat was already `None` (data inconsistency), the route would exit without cleaning up the orphaned row — leaving the entry permanently stuck in the modal.

**Fix:** Remove the early return and always perform cleanup. The route now unconditionally deletes `shared_chat` rows, conditionally clears `chat.share_id` (only if set), and always clears access grants. This makes the operation idempotent and self-healing.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Shared chats that were stuck in the "Shared Chats" modal with a "Failed to unshare chat." error can now be unshared successfully
- The `delete_shared_chat_by_id` route now handles orphaned `shared_chat` rows gracefully instead of returning `false`

---

### Additional Information

- 1 file changed, 4 insertions, 4 deletions — minimal surface area
- No frontend changes needed
- No new dependencies
- The fix makes the unshare operation idempotent: calling it multiple times on the same chat is harmless

### Screenshots or Videos

## Before:
<img width="2109" height="1076" alt="image" src="https://github.com/user-attachments/assets/8bd6c313-e060-46e2-8501-283de982ee1b" />

## After:
<img width="2133" height="1048" alt="image" src="https://github.com/user-attachments/assets/7f2194c2-3670-4498-a847-85231190081b" />

### Manual Verification Performed

1. Identified a shared chat stuck in the Shared Chats modal with the "Failed to unshare chat." error
2. Applied the fix to `chats.py`
3. Clicked the unshare button on the previously stuck chat — confirmed it now unshares successfully with "Chat unshared successfully." toast
4. Verified the chat no longer appears in the Shared Chats modal
5. Verified that normally shared chats (with valid `share_id`) still unshare correctly (no regression)
6. Ran `npm run format` — no formatting changes needed
7. Ran `npm run build` — production build succeeded

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
