### PR TITLE
fix(chat): preserve newer task ids

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -114,6 +114,7 @@
 	import Sidebar from '../icons/Sidebar.svelte';
 	import Image from '../common/Image.svelte';
 	import { getBanners } from '$lib/apis/configs';
+	import { appendTaskIds, canClearTaskIds } from './taskIds';
 
 	export let chatIdProp = '';
 
@@ -176,7 +177,8 @@
 		currentId: null
 	};
 
-	let taskIds = null;
+	let taskIds: string[] | null = null;
+	let taskIdsGeneration = 0;
 
 	// Chat Input
 	let prompt = '';
@@ -1554,13 +1556,17 @@
 	};
 
 	const chatCompletedHandler = async (_chatId, modelId, responseMessageId, messages) => {
+		const completionTaskIdsGeneration = taskIdsGeneration;
+
 		// Backend handles outlet filters and persistence inline.
 		// Just refresh the sidebar chat list.
 		if ($chatId == _chatId && !$temporaryChatEnabled) {
 			currentChatPage.set(1);
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 		}
-		taskIds = null;
+		if (canClearTaskIds(completionTaskIdsGeneration, taskIdsGeneration)) {
+			taskIds = null;
+		}
 	};
 
 	const chatActionHandler = async (_chatId, actionId, modelId, responseMessageId, event = null) => {
@@ -2529,10 +2535,9 @@
 			} else {
 				// Backend returns task_ids (multi-model) or task_id (single model)
 				const newTaskIds = res.task_ids ?? (res.task_id ? [res.task_id] : []);
-				if (taskIds) {
-					taskIds.push(...newTaskIds);
-				} else {
-					taskIds = newTaskIds;
+				if (newTaskIds.length > 0) {
+					taskIds = appendTaskIds(taskIds, newTaskIds);
+					taskIdsGeneration += 1;
 				}
 
 				// Backend returns chat_id for new chats — set store + URL.

--- a/src/lib/components/chat/taskIds.test.ts
+++ b/src/lib/components/chat/taskIds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendTaskIds, canClearTaskIds } from './taskIds';
+
+describe('chat task id tracking', () => {
+	it('preserves task ids written by a newer send while completion work is pending', () => {
+		const completionGeneration = 2;
+		const currentGeneration = completionGeneration + 1;
+
+		expect(canClearTaskIds(completionGeneration, currentGeneration)).toBe(false);
+	});
+
+	it('allows completion cleanup when no newer send has written task ids', () => {
+		const completionGeneration = 2;
+
+		expect(canClearTaskIds(completionGeneration, completionGeneration)).toBe(true);
+	});
+
+	it('appends new task ids without mutating the previous task id list', () => {
+		const previousTaskIds = ['title-task'];
+		const nextTaskIds = appendTaskIds(previousTaskIds, ['follow-up-task']);
+
+		expect(previousTaskIds).toEqual(['title-task']);
+		expect(nextTaskIds).toEqual(['title-task', 'follow-up-task']);
+	});
+
+	it('does not treat an empty task id response as a newer cancellable task', () => {
+		expect(appendTaskIds(['title-task'], [])).toEqual(['title-task']);
+	});
+});

--- a/src/lib/components/chat/taskIds.ts
+++ b/src/lib/components/chat/taskIds.ts
@@ -1,0 +1,8 @@
+export const appendTaskIds = (taskIds: string[] | null, newTaskIds: string[]) => {
+	return taskIds ? [...taskIds, ...newTaskIds] : newTaskIds;
+};
+
+export const canClearTaskIds = (
+	completionTaskIdsGeneration: number,
+	currentTaskIdsGeneration: number
+) => currentTaskIdsGeneration === completionTaskIdsGeneration;


### PR DESCRIPTION
## Summary

Fixes #25217.

This PR prevents an older fire-and-forget `chatCompletedHandler` from clearing `taskIds` that were written by a newer concurrent `sendMessage` response.

## Changes

- track a small `taskIdsGeneration` counter for cancellable task id writes
- only clear `taskIds` in `chatCompletedHandler` if no newer task ids were registered while it awaited the sidebar refresh
- move task id merge/clear checks into a tiny helper with unit coverage

## Testing

Personally tested locally:

- `npx.cmd vitest run src/lib/components/chat/taskIds.test.ts --passWithNoTests`
- `npx.cmd eslint src/lib/components/chat/taskIds.ts src/lib/components/chat/taskIds.test.ts`
- `npx.cmd prettier --check src/lib/components/chat/Chat.svelte src/lib/components/chat/taskIds.ts src/lib/components/chat/taskIds.test.ts`
- `git diff --check`

Notes:

- Local install was run with `npm install --engine-strict=false` because this machine currently has Node 24.13.1, while the repo requires Node `>=18.13.0 <=22.x.x`.
- `npm run check` currently fails on this checkout due to existing unrelated diagnostics in files such as `src/lib/components/common/RichTextInput/AutoCompletion.js`, `src/lib/components/common/RichTextInput/listDragHandlePlugin.js`, `src/lib/components/common/ImagePreview.svelte`, and markdown renderer components. I did not change those areas.
