### PR TITLE
fix(chat): preserve newer task ids

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -114,6 +114,7 @@
 	import Sidebar from '../icons/Sidebar.svelte';
 	import Image from '../common/Image.svelte';
 	import { getBanners } from '$lib/apis/configs';
+	import { appendTaskIds, canClearTaskIds } from './taskIds';
 
 	export let chatIdProp = '';
 
@@ -176,7 +177,8 @@
 		currentId: null
 	};
 
-	let taskIds = null;
+	let taskIds: string[] | null = null;
+	let taskIdsGeneration = 0;
 
 	// Chat Input
 	let prompt = '';
@@ -1554,13 +1556,17 @@
 	};
 
 	const chatCompletedHandler = async (_chatId, modelId, responseMessageId, messages) => {
+		const completionTaskIdsGeneration = taskIdsGeneration;
+
 		// Backend handles outlet filters and persistence inline.
 		// Just refresh the sidebar chat list.
 		if ($chatId == _chatId && !$temporaryChatEnabled) {
 			currentChatPage.set(1);
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 		}
-		taskIds = null;
+		if (canClearTaskIds(completionTaskIdsGeneration, taskIdsGeneration)) {
+			taskIds = null;
+		}
 	};
 
 	const chatActionHandler = async (_chatId, actionId, modelId, responseMessageId, event = null) => {
@@ -2529,10 +2535,9 @@
 			} else {
 				// Backend returns task_ids (multi-model) or task_id (single model)
 				const newTaskIds = res.task_ids ?? (res.task_id ? [res.task_id] : []);
-				if (taskIds) {
-					taskIds.push(...newTaskIds);
-				} else {
-					taskIds = newTaskIds;
+				if (newTaskIds.length > 0) {
+					taskIds = appendTaskIds(taskIds, newTaskIds);
+					taskIdsGeneration += 1;
 				}
 
 				// Backend returns chat_id for new chats — set store + URL.

--- a/src/lib/components/chat/taskIds.test.ts
+++ b/src/lib/components/chat/taskIds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendTaskIds, canClearTaskIds } from './taskIds';
+
+describe('chat task id tracking', () => {
+	it('preserves task ids written by a newer send while completion work is pending', () => {
+		const completionGeneration = 2;
+		const currentGeneration = completionGeneration + 1;
+
+		expect(canClearTaskIds(completionGeneration, currentGeneration)).toBe(false);
+	});
+
+	it('allows completion cleanup when no newer send has written task ids', () => {
+		const completionGeneration = 2;
+
+		expect(canClearTaskIds(completionGeneration, completionGeneration)).toBe(true);
+	});
+
+	it('appends new task ids without mutating the previous task id list', () => {
+		const previousTaskIds = ['title-task'];
+		const nextTaskIds = appendTaskIds(previousTaskIds, ['follow-up-task']);
+
+		expect(previousTaskIds).toEqual(['title-task']);
+		expect(nextTaskIds).toEqual(['title-task', 'follow-up-task']);
+	});
+
+	it('does not treat an empty task id response as a newer cancellable task', () => {
+		expect(appendTaskIds(['title-task'], [])).toEqual(['title-task']);
+	});
+});

--- a/src/lib/components/chat/taskIds.ts
+++ b/src/lib/components/chat/taskIds.ts
@@ -1,0 +1,8 @@
+export const appendTaskIds = (taskIds: string[] | null, newTaskIds: string[]) => {
+	return taskIds ? [...taskIds, ...newTaskIds] : newTaskIds;
+};
+
+export const canClearTaskIds = (
+	completionTaskIdsGeneration: number,
+	currentTaskIdsGeneration: number
+) => currentTaskIdsGeneration === completionTaskIdsGeneration;


### PR DESCRIPTION
<!--
CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE)
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - `Closes #25217`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this is a focused chat UI race-condition fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone review and local testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** The change uses local ephemeral UI state only.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses `fix`.

# Changelog Entry

### Description

- Closes #25217.
- Prevents an older fire-and-forget `chatCompletedHandler` from clearing `taskIds` that were written by a newer concurrent `sendMessage` response.

### Added

- Added focused unit coverage for chat task id generation/cleanup behavior.

### Changed

- Replaced in-place task id mutation with a small helper that returns a merged task id list.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed a race where `chatCompletedHandler` could resume after `getChatList(...)` and clear newer task ids registered by a concurrent send, making stop/cancel controls lose the active background tasks.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Personally tested locally:

- `npx.cmd vitest run src/lib/components/chat/taskIds.test.ts --passWithNoTests`
- `npx.cmd eslint src/lib/components/chat/taskIds.ts src/lib/components/chat/taskIds.test.ts`
- `npx.cmd prettier --check src/lib/components/chat/Chat.svelte src/lib/components/chat/taskIds.ts src/lib/components/chat/taskIds.test.ts`
- `git diff --check`

Notes:

- Local install was run with `npm install --engine-strict=false` because this machine currently has Node 24.13.1, while the repo requires Node `>=18.13.0 <=22.x.x`.
- `npm run check` currently fails on this checkout due to existing unrelated diagnostics in files such as `src/lib/components/common/RichTextInput/AutoCompletion.js`, `src/lib/components/common/RichTextInput/listDragHandlePlugin.js`, `src/lib/components/common/ImagePreview.svelte`, and markdown renderer components. I did not change those areas.

### Screenshots or Videos

- Not applicable; this is a task id state race fix covered by unit tests.

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
