### PR TITLE
fix: coerce numeric params in builtin tools for native function calling

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -134,6 +134,12 @@ async def calculate_timestamp(
 
         from dateutil.relativedelta import relativedelta
 
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        days_ago = int(days_ago)
+        weeks_ago = int(weeks_ago)
+        months_ago = int(months_ago)
+        years_ago = int(years_ago)
+
         now = datetime.datetime.now(datetime.timezone.utc)
         current_ts = int(now.timestamp())
 
@@ -171,6 +177,12 @@ async def calculate_timestamp(
     except ImportError:
         # Fallback without dateutil
         import datetime
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        days_ago = int(days_ago)
+        weeks_ago = int(weeks_ago)
+        months_ago = int(months_ago)
+        years_ago = int(years_ago)
 
         now = datetime.datetime.now(datetime.timezone.utc)
         current_ts = int(now.timestamp())
@@ -227,6 +239,9 @@ async def search_web(
     try:
         engine = __request__.app.state.config.WEB_SEARCH_ENGINE
         user = UserModel(**__user__) if __user__ else None
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count) if count is not None else None
 
         configured = __request__.app.state.config.WEB_SEARCH_RESULT_COUNT
         max_count = 5 if configured is None else configured
@@ -610,6 +625,9 @@ async def search_memories(
         return json.dumps({'error': 'Request context not available'})
 
     try:
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+
         user = UserModel(**__user__) if __user__ else None
 
         results = await query_memory(
@@ -799,6 +817,11 @@ async def search_notes(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        start_timestamp = int(start_timestamp) if start_timestamp is not None else None
+        end_timestamp = int(end_timestamp) if end_timestamp is not None else None
         user_id = __user__.get('id')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
 
@@ -1078,6 +1101,11 @@ async def search_chats(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        start_timestamp = int(start_timestamp) if start_timestamp is not None else None
+        end_timestamp = int(end_timestamp) if end_timestamp is not None else None
         user_id = __user__.get('id')
 
         chats = await Chats.get_chats_by_user_id_and_search_text(
@@ -1224,6 +1252,9 @@ async def search_channels(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
         user_id = __user__.get('id')
 
         # Get all channels the user has access to
@@ -1280,6 +1311,11 @@ async def search_channel_messages(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        start_timestamp = int(start_timestamp) if start_timestamp is not None else None
+        end_timestamp = int(end_timestamp) if end_timestamp is not None else None
         user_id = __user__.get('id')
 
         # Get all channels the user has access to
@@ -1506,6 +1542,10 @@ async def list_knowledge_bases(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        skip = int(skip)
         from open_webui.models.knowledge import Knowledges
 
         user_id = __user__.get('id')
@@ -1565,6 +1605,10 @@ async def search_knowledge_bases(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        skip = int(skip)
         from open_webui.models.knowledge import Knowledges
 
         user_id = __user__.get('id')
@@ -1628,6 +1672,10 @@ async def search_knowledge_files(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
+        skip = int(skip)
         from open_webui.models.access_grants import AccessGrants
         from open_webui.models.files import Files
         from open_webui.models.knowledge import Knowledges
@@ -1977,6 +2025,12 @@ async def view_file(
     offset = max(offset, 0)
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        offset = int(offset)
+        max_chars = int(max_chars)
+        start_line = int(start_line) if start_line is not None else None
+        end_line = int(end_line) if end_line is not None else None
         from open_webui.models.files import Files
 
         user_id = __user__.get('id')
@@ -2092,6 +2146,12 @@ async def view_knowledge_file(
     offset = max(offset, 0)
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        offset = int(offset)
+        max_chars = int(max_chars)
+        start_line = int(start_line) if start_line is not None else None
+        end_line = int(end_line) if end_line is not None else None
         from open_webui.models.access_grants import AccessGrants
         from open_webui.models.files import Files
         from open_webui.models.knowledge import Knowledges
@@ -2241,6 +2301,10 @@ async def list_knowledge(
     count = min(count, 200)
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        skip = int(skip)
+        count = int(count)
         from open_webui.models.access_grants import AccessGrants
         from open_webui.models.files import Files
         from open_webui.models.knowledge import Knowledges
@@ -2379,6 +2443,9 @@ async def query_knowledge_files(
                 knowledge_ids = [knowledge_ids]
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
         from open_webui.models.access_grants import AccessGrants
         from open_webui.models.files import Files
         from open_webui.models.knowledge import Knowledges
@@ -2538,6 +2605,9 @@ async def query_knowledge_bases(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
         import heapq
 
         from open_webui.models.knowledge import Knowledges
@@ -3019,6 +3089,9 @@ async def list_automations(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
         from open_webui.models.automations import Automations
         from open_webui.models.users import Users
         from open_webui.utils.automations import next_n_runs_ns
@@ -3242,6 +3315,9 @@ async def search_calendar_events(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        count = int(count)
         from open_webui.models.calendar import CalendarEvents
 
         user_id = __user__.get('id')
@@ -3345,6 +3421,9 @@ async def create_calendar_event(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        reminder_minutes = int(reminder_minutes) if reminder_minutes is not None else None
         from open_webui.models.calendar import CalendarEventForm, CalendarEvents, Calendars
 
         user_id = __user__.get('id')
@@ -3472,6 +3551,9 @@ async def update_calendar_event(
         return json.dumps({'error': 'User context not available'})
 
     try:
+
+        # Coerce numeric params from native tool calling (may arrive as strings)
+        reminder_minutes = int(reminder_minutes) if reminder_minutes is not None else None
         from open_webui.models.access_grants import AccessGrants
         from open_webui.models.calendar import CalendarEvents, CalendarEventUpdateForm, Calendars
         from open_webui.models.groups import Groups


### PR DESCRIPTION
When using native function calling (function_calling: native), LLMs may pass numeric parameters as strings in tool call JSON (e.g., count: "1" instead of count: 1). Builtin tool functions declared int/Optional[int] type hints but never coerced the actual runtime values, causing TypeError when used in comparisons or arithmetic.

    Add int() coercion at the start of each builtin tool function for all numeric parameters before they are used. Optional[int] params use int(param) if param is not None else None to preserve None semantics.

    Fixes TypeError: '<' not supported between instances of 'int' and 'str'

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue #25641 and closes it.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- [Describe the changes, including motivation and impact]

### Added

   - When using native function calling, LLMs may pass numeric parameters as strings. Builtin tool functions crashed with TypeError when comparing or doing arithmetic on these values.

### Changed

- [Changes, updates, refactorings, or optimizations]

### Deprecated

- [Deprecated functionality or features]

### Removed

- [Removed features, files, or functionalities]

### Fixed

- [Bug fixes or corrections]

### Security

- [Security-related changes or vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [Changes affecting compatibility or functionality]

---

### Additional Information

 - Reproduced on Open WebUI 0.9.6 with Llama 3.3 70B via vLLM (native function calling) and SearXNG search
    - Error log: open_webui.tools.builtin:search_web:245 - search_web error: '<' not supported between instances of 'int' and 'str'
    - Affected functions: calculate_timestamp, search_web, search_memories, search_notes, search_chats, search_channels, search_channel_messages, list_knowledge_bases, search_knowledge_bases, search_knowledge_files, view_file, view_knowledge_file, list_knowledge, query_knowledge_files, query_knowledge_bases, list_automations, search_calendar_events, create_calendar_event, update_calendar_event

### Screenshots or Videos

- [Attach relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
