### PR TITLE
fix(auth): reuse shared signout flow for pending accounts

### DIFF
--- a/src/lib/components/layout/Overlay/AccountPending.svelte
+++ b/src/lib/components/layout/Overlay/AccountPending.svelte
@@ -3,7 +3,8 @@
 	import { marked } from 'marked';
 
 	import { getAdminDetails } from '$lib/apis/auths';
-	import { onMount, tick, getContext } from 'svelte';
+	import { performSignOut } from '$lib/utils/signout';
+	import { onMount, getContext } from 'svelte';
 	import { config } from '$lib/stores';
 
 	const i18n = getContext('i18n');
@@ -69,10 +70,8 @@
 
 					<button
 						class="text-xs text-center w-full mt-2 text-gray-400 underline"
-						on:click={async () => {
-							localStorage.removeItem('token');
-							location.href = '/auth';
-						}}>{$i18n.t('Sign Out')}</button
+						type="button"
+						on:click={performSignOut}>{$i18n.t('Sign Out')}</button
 					>
 				</div>
 			</div>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -5,7 +5,7 @@
 	import { fade, slide } from 'svelte/transition';
 
 	import { getUsage } from '$lib/apis';
-	import { getSessionUser, userSignOut } from '$lib/apis/auths';
+	import { getSessionUser } from '$lib/apis/auths';
 
 	import {
 		showSettings,
@@ -18,6 +18,7 @@
 	} from '$lib/stores';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import { performSignOut } from '$lib/utils/signout';
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -623,12 +624,8 @@
 				class="flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer select-none"
 				type="button"
 				on:click={async () => {
-					const res = await userSignOut();
-					user.set(null);
-					localStorage.removeItem('token');
-
-					location.href = res?.redirect_url ?? '/auth';
 					show = false;
+					await performSignOut();
 				}}
 			>
 				<div class=" self-center mr-3">

--- a/src/lib/utils/signout.test.ts
+++ b/src/lib/utils/signout.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { removeItem, setUser, userSignOut } = vi.hoisted(() => ({
+	removeItem: vi.fn(),
+	setUser: vi.fn(),
+	userSignOut: vi.fn()
+}));
+
+vi.mock('$lib/apis/auths', () => ({
+	userSignOut
+}));
+
+vi.mock('$lib/stores', () => ({
+	user: {
+		set: setUser
+	}
+}));
+
+import { performSignOut, resolveSignOutRedirect } from './signout';
+
+describe('signout helper', () => {
+	beforeEach(() => {
+		removeItem.mockReset();
+		setUser.mockReset();
+		userSignOut.mockReset();
+
+		Object.defineProperty(globalThis, 'localStorage', {
+			value: {
+				removeItem
+			},
+			configurable: true
+		});
+
+		Object.defineProperty(globalThis, 'location', {
+			value: {
+				href: 'http://localhost/app'
+			},
+			configurable: true,
+			writable: true
+		});
+	});
+
+	it('uses the backend redirect when signout returns one', async () => {
+		userSignOut.mockResolvedValue({ redirect_url: 'https://idp.example/logout' });
+
+		await performSignOut();
+
+		expect(userSignOut).toHaveBeenCalledTimes(1);
+		expect(setUser).toHaveBeenCalledWith(null);
+		expect(removeItem).toHaveBeenCalledWith('token');
+		expect(globalThis.location.href).toBe('https://idp.example/logout');
+	});
+
+	it('falls back to /auth when signout has no redirect url', async () => {
+		userSignOut.mockResolvedValue(null);
+
+		await performSignOut();
+
+		expect(globalThis.location.href).toBe('/auth');
+	});
+
+	it('resolves the default auth path without a response payload', () => {
+		expect(resolveSignOutRedirect(null)).toBe('/auth');
+	});
+});

--- a/src/lib/utils/signout.ts
+++ b/src/lib/utils/signout.ts
@@ -1,0 +1,18 @@
+import { userSignOut } from '$lib/apis/auths';
+import { user } from '$lib/stores';
+
+type SignOutResponse = {
+	redirect_url?: string;
+} | null;
+
+export const resolveSignOutRedirect = (res: SignOutResponse) => {
+	return res?.redirect_url ?? '/auth';
+};
+
+export const performSignOut = async () => {
+	const res = await userSignOut();
+	user.set(null);
+	localStorage.removeItem('token');
+	location.href = resolveSignOutRedirect(res);
+	return res;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -52,7 +52,7 @@
 	import 'tippy.js/dist/tippy.css';
 
 	import { executeToolServer, getBackendConfig, getModels, getVersion } from '$lib/apis';
-	import { getSessionUser, updateUserTimezone, userSignOut } from '$lib/apis/auths';
+	import { getSessionUser, updateUserTimezone } from '$lib/apis/auths';
 	import { getAllTags, getChatList } from '$lib/apis/chats';
 	import { chatCompletion } from '$lib/apis/openai';
 	import {
@@ -65,6 +65,7 @@
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
 	import { bestMatchingLanguage, displayFileHandler, getUserTimezone } from '$lib/utils';
 	import { setTextScale } from '$lib/utils/text-scale';
+	import { performSignOut } from '$lib/utils/signout';
 
 	import NotificationToast from '$lib/components/NotificationToast.svelte';
 	import AppSidebar from '$lib/components/app/AppSidebar.svelte';
@@ -770,11 +771,7 @@
 		}
 
 		if (now >= exp - TOKEN_EXPIRY_BUFFER) {
-			const res = await userSignOut();
-			user.set(null);
-			localStorage.removeItem('token');
-
-			location.href = res?.redirect_url ?? '/auth';
+			await performSignOut();
 		}
 	};
 


### PR DESCRIPTION
## Summary

- reuse the shared frontend signout helper for the Account Pending overlay instead of deleting the local token and redirecting straight to `/auth`
- keep Sidebar logout and token-expiry logout on the same helper path so backend `redirect_url` handling stays consistent across OAuth/OIDC flows
- add a focused Vitest regression test for backend redirect and `/auth` fallback behavior

## Testing

- `npx vitest run src/lib/utils/signout.test.ts`
- `git diff --check`

Fixes #25644
