### PR TITLE
Fix web search collection source retrieval

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1374,6 +1374,23 @@ async def get_sources_from_items(
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
+        elif item.get('type') == 'web_search':
+            web_search_collection_names = []
+            if item.get('collection_name'):
+                web_search_collection_names.append(item['collection_name'])
+            if item.get('collection_names'):
+                web_search_collection_names.extend(item['collection_names'])
+
+            allowed_web_search_collection_names = getattr(
+                getattr(request, 'state', None),
+                'web_search_collection_names',
+                set(),
+            )
+            collection_names.extend(
+                name
+                for name in web_search_collection_names
+                if isinstance(name, str) and name in allowed_web_search_collection_names
+            )
         elif item.get('collection_name'):
             if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                 collection_names.append(item['collection_name'])

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1595,7 +1595,11 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
             files = form_data.get('files', [])
 
             if results.get('collection_names'):
+                web_search_collection_names = set(
+                    getattr(request.state, 'web_search_collection_names', set())
+                )
                 for col_idx, collection_name in enumerate(results.get('collection_names')):
+                    web_search_collection_names.add(collection_name)
                     files.append(
                         {
                             'collection_name': collection_name,
@@ -1605,6 +1609,7 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
                             'queries': queries,
                         }
                     )
+                request.state.web_search_collection_names = web_search_collection_names
             elif results.get('docs'):
                 # Invoked when bypass embedding and retrieval is set to True
                 docs = results['docs']


### PR DESCRIPTION
# fix: restore web search collection source retrieval

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is a small bug fix for an existing web search RAG path. It does not add a new feature or dependency.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** Relates to #___
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable; this restores existing web search citation behavior and does not add user-facing configuration.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This change has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** The fix reuses the existing web-search collection access-control path and does not add new settings.
- [x] **Git Hygiene:** The PR is atomic and based on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

This PR fixes source retrieval for the web search RAG path when web search results are saved to a temporary `web-search-*` vector collection.

When `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL` is disabled, `process_web_search()` stores fetched web pages in a temporary collection and `chat_web_search_handler()` attaches that collection to the chat payload as a `type: "web_search"` file item. Later, `get_sources_from_items()` is responsible for resolving attached items into source documents and metadata for citation display.

Before this change, `get_sources_from_items()` did not have a branch for `type: "web_search"`. As a result, the web-search item could fall through without querying the temporary `web-search-*` collection, and the chat could report `sources_retrieved` with `count: 0` even though the search, web loading, embedding generation, and vector insert had succeeded.

This change records the `web-search-*` collection names created by `chat_web_search_handler()` on the server-side request state, then teaches `get_sources_from_items()` to recognize `type: "web_search"` items and pass only those request-created collection names through the existing collection retrieval flow. The normal `filter_accessible_collections()` check still runs afterwards.

The existing `item.get("docs")` path remains ahead of the new `type: "web_search"` collection path, so `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true` continues to use direct docs injection as before.

### Added

- Handling for `type: "web_search"` items with `collection_name` or `collection_names` in `get_sources_from_items()`.
- Request-scoped tracking for web-search collections created during `chat_web_search_handler()`.

### Changed

- Web search source retrieval now resolves temporary `web-search-*` collections through the existing RAG source extraction flow instead of requiring bypass mode to preserve citations.
- The existing direct-docs bypass path is preserved and still takes precedence when `docs` are present on the item.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed a case where web search results could be fetched, embedded, and stored successfully but produce no assistant message sources/citations because the temporary web-search collection was not resolved by `get_sources_from_items()`.

### Security

- The fix does not enable global retrieval access bypass.
- The new `type: "web_search"` branch only accepts collection names recorded on `request.state` by the same server-side web search request.
- The existing `filter_accessible_collections()` validation still runs before querying collections.
- Client-supplied `type: "web_search"` collection names that were not produced by the current request's server-side web search handler are not trusted.

### Breaking Changes

- None.

---

### Additional Information

Observed behavior before the fix:

- Web search returned result items.
- Web loader fetched pages.
- Embeddings were generated and inserted into a temporary `web-search-*` collection.
- The assistant message stored `sources: null` and status history showed `sources_retrieved` with `count: 0`.

Observed behavior with the workaround `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true` confirmed that sources/citations returned when `get_sources_from_items()` used the existing `item.get("docs")` branch. This PR fixes the non-bypass collection path instead of relying on that workaround.

Validation performed:

- `python -m py_compile backend/open_webui/retrieval/utils.py`
- `git diff --check upstream/dev...HEAD`
- Manual verification on a Docker deployment using SearXNG web search:
  - Before workaround/fix: `sources_retrieved count=0`, assistant message `sources=null`.
  - With web loader enabled and embedding/retrieval bypass disabled path isolated: web search temporary collections were created but not returned as sources.
  - With the docs bypass path: sources were populated, confirming the failure was in the collection source retrieval path rather than SearXNG or embedding generation.

### Screenshots or Videos

Not included. The behavior is backend source/citation metadata; database/log evidence was used for validation.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
