### PR TITLE
feat(auth): add argon2 password hashing to remove 72-byte password limit

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -26,7 +26,8 @@ class ERROR_MESSAGES(str, Enum):
     EMAIL_TAKEN = 'Uh-oh! This email is already registered. Sign in with your existing account or choose another email to start anew.'
     USERNAME_TAKEN = 'Uh-oh! This username is already registered. Please choose another username.'
     PASSWORD_TOO_LONG = (
-        'Uh-oh! The password you entered is too long. Please make sure your password is less than 72 bytes long.'
+        'Uh-oh! The password you entered is too long. When using bcrypt, passwords must be 72 bytes or fewer. '
+        'Set PASSWORD_HASH_ALGORITHM=argon2 to remove this limit.'
     )
     COMMAND_TAKEN = 'Uh-oh! This command is already registered. Please choose another command string.'
     FILE_EXISTS = 'Uh-oh! This file is already registered. Please choose another file.'

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -662,6 +662,7 @@ WEBUI_AUTH_TRUSTED_ROLE_HEADER = os.getenv('WEBUI_AUTH_TRUSTED_ROLE_HEADER', Non
 CUSTOM_API_KEY_HEADER = os.getenv('CUSTOM_API_KEY_HEADER', 'x-api-key')
 
 ENABLE_PASSWORD_VALIDATION = os.getenv('ENABLE_PASSWORD_VALIDATION', 'False').lower() == 'true'
+PASSWORD_HASH_ALGORITHM = os.getenv('PASSWORD_HASH_ALGORITHM', 'bcrypt').lower()
 PASSWORD_VALIDATION_REGEX_PATTERN = os.getenv(
     'PASSWORD_VALIDATION_REGEX_PATTERN',
     r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$',

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -651,15 +651,6 @@ async def signin(
                 detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
             )
 
-        password_bytes = form_data.password.encode('utf-8')
-        if len(password_bytes) > 72:
-            # TODO: Implement other hashing algorithms that support longer passwords
-            log.info('Password too long, truncating to 72 bytes for bcrypt')
-            password_bytes = password_bytes[:72]
-
-            # decode safely — ignore incomplete UTF-8 sequences
-            form_data.password = password_bytes.decode('utf-8', errors='ignore')
-
         user = await Auths.authenticate_user(
             form_data.email.lower(),
             lambda pw: verify_password(form_data.password, pw),

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from typing import Optional, Union
 
 import bcrypt
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, VerificationError, InvalidHashError
 import jwt
 import pytz
 import requests
@@ -25,6 +27,7 @@ from open_webui.env import (
     ENABLE_PASSWORD_VALIDATION,
     LICENSE_BLOB,
     OFFLINE_MODE,
+    PASSWORD_HASH_ALGORITHM,
     PASSWORD_VALIDATION_HINT,
     PASSWORD_VALIDATION_REGEX_PATTERN,
     REDIS_KEY_PREFIX,
@@ -157,17 +160,21 @@ def get_license_data(app, key):
 bearer_security = HTTPBearer(auto_error=False)
 
 
+_argon2_hasher = PasswordHasher()
+
+
 def get_password_hash(password: str) -> str:
-    """Hash a password using bcrypt"""
+    """Hash a password using the configured algorithm (bcrypt or argon2)."""
+    if PASSWORD_HASH_ALGORITHM == 'argon2':
+        return _argon2_hasher.hash(password)
+    # bcrypt default
     return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
 
 def validate_password(password: str) -> bool:
-    # The password passed to bcrypt must be 72 bytes or fewer. If it is longer, it will be truncated before hashing.
-    if len(password.encode('utf-8')) > 72:
-        raise Exception(
-            ERROR_MESSAGES.PASSWORD_TOO_LONG,
-        )
+    # bcrypt silently truncates passwords longer than 72 bytes; reject them explicitly.
+    if PASSWORD_HASH_ALGORITHM == 'bcrypt' and len(password.encode('utf-8')) > 72:
+        raise Exception(ERROR_MESSAGES.PASSWORD_TOO_LONG)
 
     if ENABLE_PASSWORD_VALIDATION:
         if not PASSWORD_VALIDATION_REGEX_PATTERN.match(password):
@@ -177,14 +184,18 @@ def validate_password(password: str) -> bool:
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify a password against its hash"""
-    return (
-        bcrypt.checkpw(
-            plain_password.encode('utf-8'),
-            hashed_password.encode('utf-8'),
-        )
-        if hashed_password
-        else None
+    """Verify a password against its hash, auto-detecting bcrypt or argon2."""
+    if not hashed_password:
+        return False
+    if hashed_password.startswith('$argon2'):
+        try:
+            return _argon2_hasher.verify(hashed_password, plain_password)
+        except (VerifyMismatchError, VerificationError, InvalidHashError):
+            return False
+    # Fall back to bcrypt for existing hashes
+    return bcrypt.checkpw(
+        plain_password.encode('utf-8'),
+        hashed_password.encode('utf-8'),
     )
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to the known bcrypt 72-byte truncation limitation documented in the codebase (`TODO: Implement other hashing algorithms that support longer passwords`)
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Provided below
- [x] **Dependencies:** `argon2-cffi` was already a declared dependency in `requirements.txt`
- [x] **Testing:** Manual verification performed — existing bcrypt hashes still authenticate correctly; argon2 hashes work for passwords >72 bytes
- [x] **Self-Review:** Completed
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

bcrypt silently truncates passwords longer than 72 bytes before hashing. This means two passwords that share the same first 72 bytes are treated as identical — a security issue. The previous workaround in `auths.py` silently truncated the password at signin, preserving the broken behavior. This PR resolves it by adding opt-in argon2 support which has no byte-length limit.

### Added

- `PASSWORD_HASH_ALGORITHM` env var (`bcrypt` | `argon2`, default: `bcrypt`) to select the hashing algorithm for new passwords

### Changed

- `get_password_hash()` routes to argon2 or bcrypt based on `PASSWORD_HASH_ALGORITHM`
- `verify_password()` auto-detects algorithm from hash prefix (`$argon2` vs `$2b$`) — existing bcrypt hashes continue to work after switching algorithms with no migration needed
- `validate_password()` only enforces the 72-byte limit when `bcrypt` is the active algorithm
- Updated `PASSWORD_TOO_LONG` error message to mention the `argon2` escape hatch

### Removed

- Silent 72-byte password truncation at signin in `routers/auths.py`

### Security

- Eliminates the bcrypt 72-byte truncation issue where two distinct passwords could hash identically

---

### Additional Information

`argon2-cffi` is already listed in `requirements.txt` and `requirements-min.txt` — no new dependency is introduced.

**Backward compatibility:** Fully preserved. Existing users with bcrypt hashes (`$2b$...`) authenticate normally regardless of the `PASSWORD_HASH_ALGORITHM` setting. Only new signups use the configured algorithm.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.