### PR TITLE
fix: merge chat history to prevent message loss

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -134,6 +134,7 @@ class ChatFileModel(BaseModel):
 class ChatForm(BaseModel):
     chat: dict
     folder_id: str | None = None
+    deleted_message_ids: list[str] | None = None
 
 
 class ChatImportForm(ChatForm):
@@ -497,6 +498,69 @@ class ChatTable:
             if msg.get('parentId') and msg['parentId'] not in messages_map
         }
 
+    @staticmethod
+    def _expand_deleted_ids(messages_map: dict, deleted_ids, protected_ids=()) -> set[str]:
+        """Expand a deletion set to include its orphaned descendants, keeping any
+        node that reappears in ``protected_ids`` (reparented children survive).
+        """
+        dead = set(deleted_ids)
+        if not dead:
+            return dead
+        changed = True
+        while changed:
+            changed = False
+            for message_id, message in messages_map.items():
+                if message_id in dead or message_id in protected_ids:
+                    continue
+                if message.get('parentId') in dead:
+                    dead.add(message_id)
+                    changed = True
+        # Intersect so unknown/already-gone ids in deleted_ids don't leak out.
+        return dead & set(messages_map)
+
+    @staticmethod
+    def merge_history(existing_history: dict, incoming_history: dict, deleted_message_ids=None) -> dict:
+        """Merge an incoming history onto the stored one without inferring deletions.
+
+        Messages absent from the push are kept — only ``deleted_message_ids`` and
+        their orphaned descendants are removed — so a stale client can't drop a
+        message it never saw. Blob counterpart to ``reconcile_messages_by_chat_id``.
+        """
+        existing = (existing_history or {}).get('messages') or {}
+        incoming = (incoming_history or {}).get('messages') or {}
+        merged = {**existing, **incoming}
+        # Drop non-dict nodes so a corrupt stored entry can't crash the rebuild below.
+        merged = {mid: msg for mid, msg in merged.items() if isinstance(msg, dict)}
+
+        for message_id in ChatTable._expand_deleted_ids(
+            merged, deleted_message_ids or [], protected_ids=incoming
+        ):
+            merged.pop(message_id, None)
+
+        # Rebuild childrenIds from parentId so concurrent branches stay reachable
+        # (display only; the model context walks parentId, not childrenIds).
+        for message in merged.values():
+            message['childrenIds'] = [
+                child_id for child_id in (message.get('childrenIds') or []) if child_id in merged
+            ]
+        for message_id, message in merged.items():
+            parent_id = message.get('parentId')
+            if parent_id in merged and message_id not in merged[parent_id]['childrenIds']:
+                merged[parent_id]['childrenIds'].append(message_id)
+
+        # Keep the push's currentId; fall back only if it was pruned.
+        current_id = (incoming_history or {}).get('currentId')
+        if current_id not in merged:
+            fallback = (existing_history or {}).get('currentId')
+            current_id = fallback if fallback in merged else None
+
+        # Preserve any other history keys from the push (fall back to existing).
+        return {
+            **(incoming_history or existing_history or {}),
+            'messages': merged,
+            'currentId': current_id,
+        }
+
     async def backfill_messages_by_chat_id(self, chat_id: str, user_id: str, messages: dict[str, dict]) -> None:
         """Write messages to the ``chat_message`` table so future lookups
         use the fast path.  Errors are logged but never raised.
@@ -514,21 +578,29 @@ class ChatTable:
             except Exception as e:
                 log.warning('Backfill failed for message %s in chat %s: %s', message_id, chat_id, e)
 
-    async def reconcile_messages_by_chat_id(self, chat_id: str, user_id: str, messages: dict[str, dict]) -> None:
+    async def reconcile_messages_by_chat_id(
+        self, chat_id: str, user_id: str, messages: dict[str, dict], deleted_message_ids=None
+    ) -> None:
         """Sync ``chat_message`` rows with the committed JSON blob.
 
-        Upserts current messages via ``backfill_messages_by_chat_id``
-        and deletes orphaned rows whose message_id no longer appears
-        in the blob.  Best-effort: errors are logged but never raised.
+        Upserts the pushed messages via ``backfill_messages_by_chat_id``, then
+        prunes only the IDs the client explicitly reported in ``deleted_message_ids``
+        plus their orphaned descendants. Rows merely missing from the push are never
+        inferred as deletions — otherwise a stale/lost-update save would silently drop
+        a still-valid message from the model context. Best-effort: errors are logged
+        but never raised.
         """
         try:
             await self.backfill_messages_by_chat_id(chat_id, user_id, messages)
 
-            existing_map = await ChatMessages.get_messages_map_by_chat_id(chat_id)
-            if existing_map is not None:
-                orphaned_ids = set(existing_map.keys()) - set(messages.keys())
-                if orphaned_ids:
-                    await ChatMessages.delete_message_ids_by_chat_id(chat_id, orphaned_ids)
+            if deleted_message_ids:
+                existing_map = await ChatMessages.get_messages_map_by_chat_id(chat_id)
+                if existing_map is not None:
+                    dead_ids = self._expand_deleted_ids(
+                        existing_map, deleted_message_ids, protected_ids=messages
+                    )
+                    if dead_ids:
+                        await ChatMessages.delete_message_ids_by_chat_id(chat_id, dead_ids)
         except Exception as e:
             log.warning('Failed to reconcile chat_message rows for chat %s: %s', chat_id, e)
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -973,13 +973,22 @@ async def update_chat_by_id(
     if chat:
         updated_chat = {**chat.chat, **form_data.chat}
 
+        # Merge (don't replace) history so a stale save can't clobber unseen
+        # messages; see Chats.merge_history for the full rationale.
+        if 'history' in form_data.chat:
+            updated_chat['history'] = Chats.merge_history(
+                chat.chat.get('history'),
+                form_data.chat.get('history'),
+                deleted_message_ids=form_data.deleted_message_ids,
+            )
+
         # Re-derive content from output for assistant messages so that frontend
         # edits to output items are reflected in content. Only when output
         # actually changed — otherwise content set independently of output
         # (e.g. a `replace` event or an outlet filter footer) would be reverted.
         existing_messages = (chat.chat.get('history') or {}).get('messages') or {}
         for msg_id, msg in updated_chat.get('history', {}).get('messages', {}).items():
-            if msg.get('role') == 'assistant' and msg.get('output'):
+            if isinstance(msg, dict) and msg.get('role') == 'assistant' and msg.get('output'):
                 if msg.get('output') != existing_messages.get(msg_id, {}).get('output'):
                     msg['content'] = serialize_output(msg['output'])
 
@@ -990,7 +999,9 @@ async def update_chat_by_id(
         # history with potential edits, deletions, or new branches.
         messages = (updated_chat.get('history') or {}).get('messages') or {}
         if messages:
-            await Chats.reconcile_messages_by_chat_id(id, user.id, messages)
+            await Chats.reconcile_messages_by_chat_id(
+                id, user.id, messages, deleted_message_ids=form_data.deleted_message_ids
+            )
 
         return ChatResponse(**chat.model_dump())
     else:

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -1039,7 +1039,12 @@ export const getChatAccessGrants = async (token: string, id: string) => {
 	return res;
 };
 
-export const updateChatById = async (token: string, id: string, chat: object) => {
+export const updateChatById = async (
+	token: string,
+	id: string,
+	chat: object,
+	deletedMessageIds: string[] = []
+) => {
 	let error = null;
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}`, {
@@ -1050,7 +1055,9 @@ export const updateChatById = async (token: string, id: string, chat: object) =>
 			...(token && { authorization: `Bearer ${token}` })
 		},
 		body: JSON.stringify({
-			chat: chat
+			chat: chat,
+			// Only sent when the client explicitly deleted messages; absent => upsert-only (no pruning).
+			...(deletedMessageIds.length > 0 && { deleted_message_ids: deletedMessageIds })
 		})
 	})
 		.then(async (res) => {

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -431,7 +431,7 @@
 		}
 	};
 
-	const showMessage = async (message, scroll = true) => {
+	const showMessage = async (message, scroll = true, save = true) => {
 		const _chatId = JSON.parse(JSON.stringify($chatId));
 		let _messageId = JSON.parse(JSON.stringify(message.id));
 
@@ -464,7 +464,10 @@
 		await tick();
 		await tick();
 
-		saveChatHandler(_chatId, history);
+		// Callers that persist separately (e.g. deleteMessage's save that carries the deleted IDs) pass save=false.
+		if (save) {
+			saveChatHandler(_chatId, history);
+		}
 	};
 
 	const updateLastReadAt = (id) => {

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -164,14 +164,26 @@
 		}
 	};
 
+	// IDs explicitly deleted by the user, sent with the next save so the backend prunes
+	// the matching chat_message rows. Cleared only on a successful save (survives retry).
+	let deletedMessageIds = new Set();
+
 	const updateChat = async () => {
 		if (!$temporaryChatEnabled) {
 			history = history;
 			await tick();
-			const res = await updateChatById(localStorage.token, chatId, {
-				history: history,
-				messages: messages
-			});
+			const res = await updateChatById(
+				localStorage.token,
+				chatId,
+				{
+					history: history,
+					messages: messages
+				},
+				Array.from(deletedMessageIds)
+			);
+
+			// Reached only when the save succeeded (updateChatById throws on failure).
+			deletedMessageIds.clear();
 
 			// Refresh local message content from backend (e.g. re-derived via serialize_output)
 			if (res?.chat?.history?.messages) {
@@ -458,12 +470,18 @@
 			}
 		});
 
-		// Delete the message and its children
+		// Delete the message and its children, buffering the IDs so the next save
+		// tells the backend to prune the matching chat_message rows. Grandchildren
+		// were reparented above and are intentionally not added to the deleted-IDs buffer.
 		[messageId, ...childMessageIds].forEach((id) => {
 			delete history.messages[id];
+			deletedMessageIds.add(id);
 		});
 
-		showMessage({ id: parentMessageId }, false);
+		// Move currentId to the parent without saving, then persist once via
+		// updateChat() so the deletion travels with its deleted_message_ids.
+		showMessage({ id: parentMessageId }, false, false);
+		await updateChat();
 	};
 
 	const triggerScroll = () => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

A chat lives in two places that have to agree: the chat JSON (the conversation you see) and the per-message rows in `chat_message` that the model's prompt is built from. Saving the history is a read-modify-write with no lock. The frontend sends its in-memory copy, but the server's copy moves on in the meantime, as streamed completions and socket updates add messages to both places and other tabs or devices save their own.

If a save sends an out-of-date history, messages vanish. `update_chat_by_id` overwrote the stored history with whatever was sent, and reconcile deleted any `chat_message` row not in it, treating "missing" as "deleted". A message the sender never had was erased from the conversation and the prompt, with no way back.

The fix stops guessing and makes the client say what it deleted:

- The backend merges the sent history into the stored one instead of overwriting it.
- Reconcile deletes a row only if its ID is in the new optional `deleted_message_ids`, plus any children orphaned by that delete. A child moved back into the sent history stays.
- The frontend gathers deleted IDs, sends them on the next save, and clears them only after the save succeeds, so a failed save and retry still works.
- Clients that omit the field behave as before and delete nothing.

### Added

- [New features, functionalities, or additions]

### Changed

- [Changes, updates, refactorings, or optimizations]

### Deprecated

- [Deprecated functionality or features]

### Removed

- [Removed features, files, or functionalities]

### Fixed

- Concurrent or out-of-date saves no longer drop messages from the conversation or the prompt.
- A non-dict message node left in stored history no longer crashes the save.

### Security

- [Security-related changes or vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [Changes affecting compatibility or functionality]

---

### Additional Information

Repro (one easy way to trigger it): open a chat in two tabs, send a turn in one, then save from the other. The new turn vanishes from the chat and the model's context: the second tab's save omits a message it never saw, and reconcile treats that omission as a deletion. The same loss can happen in a single session, since a streamed completion and the background title, tag, and follow-up tasks all save the chat concurrently. Verified against the reconcile code: saving only the first turn of a two-turn chat drops the second turn before the fix and keeps it after.

Note: table rows are pruned only when `deleted_message_ids` is sent. A client that deletes by posting a trimmed history without it leaves the row in place, where it can resurface in the prompt. That is deliberate: a leftover row is recoverable, a silently deleted message is not.

### Screenshots or Videos

- [Attach relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
