### PR TITLE
fix: route Account Pending sign out through backend signout flow

### DIFF
--- a/src/lib/components/layout/Overlay/AccountPending.svelte
+++ b/src/lib/components/layout/Overlay/AccountPending.svelte
@@ -2,7 +2,7 @@
 	import DOMPurify from 'dompurify';
 	import { marked } from 'marked';
 
-	import { getAdminDetails } from '$lib/apis/auths';
+	import { getAdminDetails, userSignOut } from '$lib/apis/auths';
 	import { onMount, tick, getContext } from 'svelte';
 	import { config } from '$lib/stores';
 
@@ -70,8 +70,12 @@
 					<button
 						class="text-xs text-center w-full mt-2 text-gray-400 underline"
 						on:click={async () => {
+							const res = await userSignOut().catch((err) => {
+								console.error(err);
+								return null;
+							});
 							localStorage.removeItem('token');
-							location.href = '/auth';
+							location.href = res?.redirect_url ?? '/auth';
 						}}>{$i18n.t('Sign Out')}</button
 					>
 				</div>


### PR DESCRIPTION
The Sign Out button on the Account Pending overlay only cleared the local token and redirected to /auth, skipping the backend signout. This left the OAuth/OIDC session alive at the IdP, so re-login bounced the user straight back into pending and never re-fetched updated role/group claims. Call userSignOut() and honor the returned redirect_url, matching the sidebar logout flow.


Fixes #25644

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
