### PR TITLE
fix: defer missing-local-embedding error so it can't crash boot

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -927,15 +927,15 @@ def get_embedding_function(
     concurrent_requests=0,
 ) -> Awaitable:
     if embedding_engine == '':
-        if embedding_function is None:
-            raise ValueError(
-                'No embedding model is loaded. Set RAG_EMBEDDING_MODEL to a valid '
-                'SentenceTransformer model name, or configure an external '
-                'RAG_EMBEDDING_ENGINE (ollama, openai, azure_openai).'
-            )
-
         # Sentence transformers: CPU-bound sync operation
         async def async_embedding_function(query, prefix=None, user=None):
+            # Deferred so a missing local model degrades RAG instead of crashing boot.
+            if embedding_function is None:
+                raise ValueError(
+                    'No embedding model is loaded. Set RAG_EMBEDDING_MODEL to a valid '
+                    'SentenceTransformer model name, or configure an external '
+                    'RAG_EMBEDDING_ENGINE (ollama, openai, azure_openai).'
+                )
             return await asyncio.to_thread(
                 (
                     lambda query, prefix=None: embedding_function.encode(


### PR DESCRIPTION
get_embedding_function runs at import time (main.py), so the empty-engine
+ no-model guard added in 55ca719b raised ValueError during startup and bricked the instance: a blank embedding model set via the UI made the app unbootable, with no way back into settings to undo it. Move the check into the returned coroutine so construction always succeeds and the error only fires when something actually embeds, surfacing as a clear request error instead of the old cryptic 'NoneType has no attribute encode'.


Fixes #25634
Fixes #25165

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
