### PR TITLE
fix: prevent long default group name from overflowing admin settings layout

### DIFF
--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -322,9 +322,9 @@
 
 					<div class="  mb-2.5 flex w-full justify-between">
 						<div class=" self-center text-xs font-medium">{$i18n.t('Default Group')}</div>
-						<div class="flex items-center relative">
+						<div class="flex items-center relative max-w-48">
 							<select
-								class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+								class="w-full pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right truncate"
 								bind:value={adminConfig.DEFAULT_GROUP_ID}
 								placeholder={$i18n.t('Select a group')}
 							>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a layout overflow bug when a long group name is assigned as the Default Group in admin settings.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

Fixes a layout overflow bug in the admin Settings → General page where a long Default Group name causes the `<select>` dropdown to extend beyond the settings panel, breaking the page layout.

The Default Group dropdown used `w-fit` which allowed it to grow unbounded. This changes the container to `max-w-48` and the select to `w-full truncate`, capping the dropdown width and clipping long names with an ellipsis.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Default Group dropdown in admin settings overflowing layout when assigned a long group name

---

### Additional Information

- **1 file changed, +2/-2 lines** — minimal CSS-only fix
- No structural or behavioral changes — only width constraint and text truncation added
- The adjacent Default User Role dropdown is unaffected (its options are short fixed strings like "pending", "user", "admin")

### Manual Verification Performed

1. Create a group with a very long name (e.g., repeating text)
2. Set it as the Default Group in admin Settings → General
3. **Before fix:** Dropdown overflows the settings panel, breaking layout
4. **After fix:** Dropdown is constrained to `max-w-48`, long name is truncated with ellipsis
5. Short group names still display normally without truncation

## Before:

<img width="2334" height="548" alt="image" src="https://github.com/user-attachments/assets/5bb12d0f-730e-4ffd-b66c-3d4f7d6ed8c2" />

<img width="2334" height="1270" alt="image" src="https://github.com/user-attachments/assets/9b3418d5-73da-42e6-83ec-d682b4e92187" />

## After:

<img width="2334" height="1270" alt="image" src="https://github.com/user-attachments/assets/e092f2f4-3a1e-4ed4-af6a-f581b19c835d" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
