### PR TITLE
fix: trim terminal bearer token so whitespace can't break the WebSocket

### DIFF
--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -199,6 +199,8 @@
 
 		// Remove trailing slash
 		url = url.replace(/\/$/, '');
+		// Bearer key whitespace breaks the terminal WebSocket auth (HTTP headers strip it, JSON doesn't)
+		key = key.trim();
 
 		// Save policy to orchestrator if applicable
 		if (serverType === 'orchestrator' && !direct && policyId) {

--- a/src/lib/components/chat/XTerminal.svelte
+++ b/src/lib/components/chat/XTerminal.svelte
@@ -106,7 +106,7 @@
 			ws.onopen = () => {
 				// First-message auth (no token in URL)
 				if (ws) {
-					ws.send(JSON.stringify({ type: 'auth', token: authToken }));
+					ws.send(JSON.stringify({ type: 'auth', token: authToken.trim() }));
 				}
 				connected = true;
 				connecting = false;


### PR DESCRIPTION
A trailing space in the Open Terminal bearer token broke only the interactive terminal: HTTP calls put the token in the Authorization header, where the spec strips trailing whitespace, so the connection test, file listing and tool calls all worked. The terminal WebSocket can't set headers from the browser, so it sends the token inside a JSON auth message that preserves the space verbatim, failing auth with [Connection closed]. Normalize the key on save so whitespace never enters storage, and trim it in the WebSocket auth message so existing saved configs work without re-saving.


Fixes #25613

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
