### PR TITLE
fix: normalize terminal bearer token whitespace

### DIFF
--- a/src/lib/apis/terminal/index.test.ts
+++ b/src/lib/apis/terminal/index.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getTerminalConfig, normalizeTerminalToken } from './index';
+
+describe('terminal API token normalization', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('trims leading and trailing token whitespace', () => {
+		expect(normalizeTerminalToken('  token-value \n')).toBe('token-value');
+	});
+
+	it('keeps an empty token empty', () => {
+		expect(normalizeTerminalToken('')).toBe('');
+		expect(normalizeTerminalToken('   ')).toBe('');
+	});
+
+	it('uses the normalized token in Authorization headers', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({ features: { terminal: true } })
+		});
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getTerminalConfig('https://terminal.example/', '  secret-token  ');
+
+		expect(fetchMock).toHaveBeenCalledWith('https://terminal.example/api/config', {
+			headers: {
+				Authorization: 'Bearer secret-token'
+			}
+		});
+	});
+});

--- a/src/lib/apis/terminal/index.test.ts
+++ b/src/lib/apis/terminal/index.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getTerminalConfig, normalizeTerminalToken } from './index';
+import {
+	createDirectory,
+	getCwd,
+	getTerminalConfig,
+	getTerminalServers,
+	normalizeTerminalToken
+} from './index';
 
 describe('terminal API token normalization', () => {
 	afterEach(() => {
@@ -30,6 +36,67 @@ describe('terminal API token normalization', () => {
 			headers: {
 				Authorization: 'Bearer secret-token'
 			}
+		});
+	});
+
+	it('normalizes Open WebUI terminal server requests', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue([])
+		});
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getTerminalServers('\n webui-token ');
+
+		expect(fetchMock).toHaveBeenCalledWith('/api/v1/terminals/', {
+			headers: {
+				Authorization: 'Bearer webui-token'
+			}
+		});
+	});
+
+	it('preserves session headers while normalizing terminal file requests', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({ cwd: '/workspace' })
+		});
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getCwd('https://terminal.example/', '\tterminal-token\n', 'session-1');
+
+		expect(fetchMock).toHaveBeenCalledWith('https://terminal.example/files/cwd', {
+			headers: {
+				Authorization: 'Bearer terminal-token',
+				'X-Session-Id': 'session-1'
+			}
+		});
+	});
+
+	it('preserves JSON headers while normalizing terminal mutations', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({ path: '/workspace' })
+		});
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await createDirectory(
+			'https://terminal.example/',
+			' terminal-token ',
+			'/workspace',
+			'session-2'
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith('https://terminal.example/files/mkdir', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer terminal-token',
+				'Content-Type': 'application/json',
+				'X-Session-Id': 'session-2'
+			},
+			body: JSON.stringify({ path: '/workspace' })
 		});
 	});
 });

--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -23,11 +23,15 @@ export type TerminalServer = {
 	name: string;
 };
 
+export const normalizeTerminalToken = (token: string): string => token.trim();
+
+const terminalAuthHeaders = (token: string): Record<string, string> => ({
+	Authorization: `Bearer ${normalizeTerminalToken(token)}`
+});
+
 export const getTerminalServers = async (token: string): Promise<TerminalServer[]> => {
 	const res = await fetch(`${WEBUI_API_BASE_URL}/terminals/`, {
-		headers: {
-			Authorization: `Bearer ${token}`
-		}
+		headers: terminalAuthHeaders(token)
 	}).catch(() => null);
 	if (!res || !res.ok) return [];
 	return res.json().catch(() => []);
@@ -39,7 +43,7 @@ export const getTerminalConfig = async (
 ): Promise<{ features: TerminalFeatures } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/api/config`;
 	const res = await fetch(url, {
-		headers: { Authorization: `Bearer ${apiKey}` }
+		headers: terminalAuthHeaders(apiKey)
 	}).catch(() => null);
 	if (!res || !res.ok) return null;
 	return res.json().catch(() => null);
@@ -51,7 +55,7 @@ export const getCwd = async (
 	sessionId?: string
 ): Promise<string | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/cwd`;
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, { headers }).catch(() => null);
 	if (!res || !res.ok) return null;
@@ -67,7 +71,7 @@ export const listFiles = async (
 ): Promise<FileEntry[] | null> => {
 	// The endpoint uses `directory` as the query param name
 	const url = `${baseUrl.replace(/\/$/, '')}/files/list?directory=${encodeURIComponent(path)}`;
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, { headers })
 		.then(async (res) => {
@@ -88,7 +92,7 @@ export const readFile = async (
 	sessionId?: string
 ): Promise<string | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/read?path=${encodeURIComponent(path)}`;
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, { headers }).catch((err) => {
 		console.error('open-terminal readFile error:', err);
@@ -116,7 +120,7 @@ export const downloadFileBlob = async (
 	sessionId?: string
 ): Promise<{ blob: Blob; filename: string } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/view?path=${encodeURIComponent(path)}`;
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, { headers }).catch(() => null);
 
@@ -135,7 +139,7 @@ export const archiveFromTerminal = async (
 ): Promise<{ blob: Blob; filename: string } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/archive`;
 	const headers: Record<string, string> = {
-		Authorization: `Bearer ${apiKey}`,
+		...terminalAuthHeaders(apiKey),
 		'Content-Type': 'application/json'
 	};
 	if (sessionId) headers['X-Session-Id'] = sessionId;
@@ -164,7 +168,7 @@ export const uploadToTerminal = async (
 	const url = `${baseUrl.replace(/\/$/, '')}/files/upload?directory=${encodeURIComponent(directory)}`;
 	const body = new FormData();
 	body.append('file', file);
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, {
 		method: 'POST',
@@ -190,7 +194,7 @@ export const createDirectory = async (
 ): Promise<{ path: string } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/mkdir`;
 	const headers: Record<string, string> = {
-		Authorization: `Bearer ${apiKey}`,
+		...terminalAuthHeaders(apiKey),
 		'Content-Type': 'application/json'
 	};
 	if (sessionId) headers['X-Session-Id'] = sessionId;
@@ -217,7 +221,7 @@ export const deleteEntry = async (
 	sessionId?: string
 ): Promise<{ path: string; type: string } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/delete?path=${encodeURIComponent(path)}`;
-	const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+	const headers = terminalAuthHeaders(apiKey);
 	if (sessionId) headers['X-Session-Id'] = sessionId;
 	const res = await fetch(url, {
 		method: 'DELETE',
@@ -242,7 +246,7 @@ export const setCwd = async (
 ): Promise<{ cwd: string } | null> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/cwd`;
 	const headers: Record<string, string> = {
-		Authorization: `Bearer ${apiKey}`,
+		...terminalAuthHeaders(apiKey),
 		'Content-Type': 'application/json'
 	};
 	if (sessionId) headers['X-Session-Id'] = sessionId;
@@ -271,7 +275,7 @@ export const moveEntry = async (
 ): Promise<{ source: string; destination: string } | { error: string }> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/files/move`;
 	const headers: Record<string, string> = {
-		Authorization: `Bearer ${apiKey}`,
+		...terminalAuthHeaders(apiKey),
 		'Content-Type': 'application/json'
 	};
 	if (sessionId) headers['X-Session-Id'] = sessionId;
@@ -297,7 +301,7 @@ export const getListeningPorts = async (
 ): Promise<ListeningPort[]> => {
 	const url = `${baseUrl.replace(/\/$/, '')}/ports`;
 	const res = await fetch(url, {
-		headers: { Authorization: `Bearer ${apiKey}` }
+		headers: terminalAuthHeaders(apiKey)
 	}).catch(() => null);
 	if (!res || !res.ok) return [];
 	const json = await res.json().catch(() => null);
@@ -321,7 +325,7 @@ export const createNotebookSession = async (
 	const res = await fetch(url, {
 		method: 'POST',
 		headers: {
-			Authorization: `Bearer ${apiKey}`,
+			...terminalAuthHeaders(apiKey),
 			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify({ path })
@@ -354,7 +358,7 @@ export const executeNotebookCell = async (
 	const res = await fetch(url, {
 		method: 'POST',
 		headers: {
-			Authorization: `Bearer ${apiKey}`,
+			...terminalAuthHeaders(apiKey),
 			'Content-Type': 'application/json'
 		},
 		body: JSON.stringify(body)
@@ -381,7 +385,7 @@ export const stopNotebookSession = async (
 	const url = `${baseUrl.replace(/\/$/, '')}/notebooks/${sessionId}`;
 	const res = await fetch(url, {
 		method: 'DELETE',
-		headers: { Authorization: `Bearer ${apiKey}` }
+		headers: terminalAuthHeaders(apiKey)
 	}).catch(() => null);
 	return res?.ok ?? false;
 };

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -17,7 +17,7 @@
 		verifyTerminalServerConnection,
 		putOrchestratorPolicy
 	} from '$lib/apis/configs';
-	import { getTerminalConfig } from '$lib/apis/terminal';
+	import { getTerminalConfig, normalizeTerminalToken } from '$lib/apis/terminal';
 
 	export let show = false;
 	export let edit = false;
@@ -107,6 +107,7 @@
 
 	const verifyHandler = async () => {
 		const _url = url.replace(/\/$/, '');
+		const normalizedKey = normalizeTerminalToken(key);
 		if (!_url) {
 			toast.error($i18n.t('Please enter a valid URL'));
 			return;
@@ -118,7 +119,7 @@
 				// System connection: proxy through backend to avoid CORS / key exposure
 				const result = await verifyTerminalServerConnection(localStorage.token, {
 					url: _url,
-					key,
+					key: normalizedKey,
 					auth_type
 				});
 				const type = result?.type ?? null;
@@ -147,7 +148,7 @@
 				}
 			} else {
 				// Direct connection: verify from browser
-				const res = await getTerminalConfig(_url, key);
+				const res = await getTerminalConfig(_url, normalizedKey);
 				if (res) {
 					toast.success($i18n.t('Server connection verified'));
 				} else {
@@ -199,11 +200,18 @@
 
 		// Remove trailing slash
 		url = url.replace(/\/$/, '');
+		const normalizedKey = normalizeTerminalToken(key);
 
 		// Save policy to orchestrator if applicable
 		if (serverType === 'orchestrator' && !direct && policyId) {
 			try {
-				await putOrchestratorPolicy(localStorage.token, url, key, policyId, buildPolicyData());
+				await putOrchestratorPolicy(
+					localStorage.token,
+					url,
+					normalizedKey,
+					policyId,
+					buildPolicyData()
+				);
 			} catch (err) {
 				toast.error($i18n.t('Failed to save policy: {{error}}', { error: err }));
 				return;
@@ -213,7 +221,7 @@
 		const result = {
 			...(!direct && id.trim() ? { id: id.trim() } : {}),
 			url,
-			key,
+			key: normalizedKey,
 			name,
 			path,
 			auth_type,

--- a/src/lib/components/chat/XTerminal.svelte
+++ b/src/lib/components/chat/XTerminal.svelte
@@ -7,6 +7,7 @@
 
 	import { terminalServers, settings, selectedTerminalId, user } from '$lib/stores';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import { normalizeTerminalToken } from '$lib/apis/terminal';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
 	const i18n = getContext('i18n');
@@ -52,7 +53,7 @@
 
 		connecting = true;
 
-		const token = localStorage.getItem('token') ?? '';
+		const token = normalizeTerminalToken(localStorage.getItem('token') ?? '');
 
 		try {
 			let sessionId: string;
@@ -64,7 +65,7 @@
 				const base = info.baseUrl.replace(/\/$/, '');
 				const directTerminals = ($settings?.terminalServers ?? []).filter((s: any) => s.url);
 				const directMatch = directTerminals.find((s: any) => s.url === $selectedTerminalId);
-				const apiKey = directMatch?.key ?? '';
+				const apiKey = normalizeTerminalToken(directMatch?.key ?? '');
 				authToken = apiKey;
 
 				// Create session
@@ -106,7 +107,7 @@
 			ws.onopen = () => {
 				// First-message auth (no token in URL)
 				if (ws) {
-					ws.send(JSON.stringify({ type: 'auth', token: authToken }));
+					ws.send(JSON.stringify({ type: 'auth', token: normalizeTerminalToken(authToken) }));
 				}
 				connected = true;
 				connecting = false;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - `Fixes #25613`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation changes are needed for this small bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Targeted frontend tests were added and run.
- [x] **No Unchecked AI Code:** This PR was Codex-assisted and has undergone review and targeted testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses `fix`.

# Changelog Entry

### Description

Fixes Open Terminal interactive sessions failing when a saved Bearer token contains accidental leading or trailing whitespace.

### Added

- Added targeted Vitest coverage for terminal token normalization across Open WebUI terminal server requests, direct terminal file requests, and JSON mutation requests.

### Changed

- Normalized terminal Bearer tokens before saving, verifying, sending terminal HTTP requests, and sending the WebSocket auth message.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed inconsistent Open Terminal behavior where connection testing and file APIs could work while the interactive WebSocket terminal immediately closed because the auth token contained trailing whitespace.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Fixes #25613.

Tested with:

```bash
npm run test:frontend -- --run src/lib/apis/terminal/index.test.ts
npx prettier --check src/lib/apis/terminal/index.test.ts
git diff --check
```

`npm run check` was also attempted, but the current workspace reports existing diagnostics outside this PR's files.

### Screenshots or Videos

- Not applicable; this is an auth normalization fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
