### PR TITLE
feat(folder): expose folder default model selection

### DIFF
--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -1,22 +1,27 @@
 <script lang="ts">
-	import { getContext, createEventDispatcher, onMount, tick } from 'svelte';
+	import { getContext, tick } from 'svelte';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
 	import { toast } from 'svelte-sonner';
-	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
 	import { user, config } from '$lib/stores';
 
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import ModelSelector from '$lib/components/chat/ModelSelector.svelte';
 	import Knowledge from '$lib/components/workspace/Models/Knowledge.svelte';
 	import { getFolderById } from '$lib/apis/folders';
+	import { normalizeFolderModelIds } from './folder-models';
 	const i18n = getContext('i18n');
 
 	export let show = false;
-	export let onSubmit: Function = (e) => {};
+	export let onSubmit: (payload: {
+		name: string;
+		meta: { background_image_url: string | null };
+		data: { system_prompt: string; files: unknown[]; model_ids?: string[] };
+		parent_id?: string | null;
+	}) => Promise<void> | void = () => {};
 
 	export let folderId = null;
 	export let parentId = null;
@@ -31,6 +36,7 @@
 		system_prompt: '',
 		files: []
 	};
+	let selectedModels = [''];
 
 	let loading = false;
 
@@ -53,10 +59,15 @@
 			return;
 		}
 
+		const normalizedModelIds = normalizeFolderModelIds(selectedModels);
+
 		await onSubmit({
 			name,
 			meta,
-			data,
+			data: {
+				...data,
+				model_ids: normalizedModelIds
+			},
 			parent_id: edit ? undefined : parentId
 		});
 		show = false;
@@ -78,6 +89,7 @@
 				system_prompt: '',
 				files: []
 			};
+			selectedModels = folder.data?.model_ids?.length ? folder.data.model_ids : [''];
 		}
 
 		focusInput();
@@ -105,6 +117,7 @@
 			system_prompt: '',
 			files: []
 		};
+		selectedModels = [''];
 	}
 </script>
 
@@ -227,6 +240,16 @@
 							</div>
 						</div>
 					{/if}
+
+					<div class="my-3">
+						<div class="mb-2 text-xs text-gray-500">{$i18n.t('Default Model')}</div>
+						<div class="w-full max-w-full">
+							<ModelSelector bind:selectedModels showSetDefault={false} />
+						</div>
+						<div class="mt-1 text-xs text-gray-500">
+							{$i18n.t('Leave model field empty to use the default model.')}
+						</div>
+					</div>
 
 					<div class="my-2">
 						<Knowledge bind:selectedItems={data.files}>

--- a/src/lib/components/layout/Sidebar/Folders/folder-models.test.ts
+++ b/src/lib/components/layout/Sidebar/Folders/folder-models.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeFolderModelIds } from './folder-models';
+
+describe('normalizeFolderModelIds', () => {
+	it('returns undefined when no concrete model is selected', () => {
+		expect(normalizeFolderModelIds([''])).toBeUndefined();
+		expect(normalizeFolderModelIds([])).toBeUndefined();
+	});
+
+	it('preserves selected model ids and strips empty placeholders', () => {
+		expect(normalizeFolderModelIds(['model-a'])).toEqual(['model-a']);
+		expect(normalizeFolderModelIds(['model-a', '', 'model-b'])).toEqual(['model-a', 'model-b']);
+	});
+});

--- a/src/lib/components/layout/Sidebar/Folders/folder-models.ts
+++ b/src/lib/components/layout/Sidebar/Folders/folder-models.ts
@@ -1,0 +1,4 @@
+export const normalizeFolderModelIds = (modelIds: string[]) => {
+	const filtered = modelIds.filter((modelId) => modelId !== '');
+	return filtered.length > 0 ? filtered : undefined;
+};


### PR DESCRIPTION
# Pull Request Checklist

- [x] Closes #25231
- [x] Targets `dev`
- [x] No dependency changes
- [x] Focused regression test included

# Changelog Entry

### Description

- Expose folder-level default model selection in the folder create/edit modal.

### Added

- A focused Vitest regression test for normalizing folder model-id persistence.

### Changed

- FolderModal now writes `folder.data.model_ids` when a folder-level default model is selected.

### Fixed

- New chats started inside a folder can now use the folder's configured default model through the existing `folder.data.model_ids` path.

### Additional Information

- Testing: `npx vitest run src/lib/components/layout/Sidebar/Folders/folder-models.test.ts`
- Testing: `npx eslint src/lib/components/layout/Sidebar/Folders/FolderModal.svelte src/lib/components/layout/Sidebar/Folders/folder-models.ts src/lib/components/layout/Sidebar/Folders/folder-models.test.ts`
- Testing: `git diff --check`

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
