### PR TITLE
fix(retrieval): include web search results in sources

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1250,6 +1250,16 @@ async def get_sources_from_items(
                     'documents': [[content]],
                     'metadatas': [[{'url': item.get('url'), 'name': item.get('url')}]],
                 }
+        elif item.get('type') == 'web_search':
+            if item.get('docs'):
+                query_result = {
+                    'documents': [[doc.get('content') for doc in item.get('docs')]],
+                    'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
+                }
+            elif item.get('collection_name'):
+                collection_names.append(item['collection_name'])
+            elif item.get('collection_names'):
+                collection_names.extend(item['collection_names'])
         elif item.get('type') == 'file':
             if item.get('context') == 'full' or request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL:
                 if item.get('file', {}).get('data', {}).get('content', ''):

--- a/test/test_retrieval_utils.py
+++ b/test/test_retrieval_utils.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+from open_webui.retrieval import utils
+
+
+@pytest.mark.asyncio
+async def test_get_sources_from_items_uses_web_search_collection(monkeypatch):
+    queried = []
+
+    async def fake_query_collection(*args, **kwargs):
+        queried.extend(kwargs['collection_names'])
+        return {
+            'documents': [['search result content']],
+            'metadatas': [[{'source': 'https://example.com'}]],
+            'distances': [[0.9]],
+        }
+
+    monkeypatch.setattr(utils, 'query_collection', fake_query_collection)
+
+    request = SimpleNamespace()
+    user = SimpleNamespace(id='user-1', role='user')
+
+    sources = await utils.get_sources_from_items(
+        request,
+        items=[
+            {
+                'type': 'web_search',
+                'collection_name': 'web-search-test',
+                'name': 'weather query',
+                'queries': ['weather query'],
+            }
+        ],
+        queries=['weather query'],
+        embedding_function=lambda *args, **kwargs: None,
+        k=3,
+        reranking_function=None,
+        k_reranker=3,
+        r=0.0,
+        hybrid_bm25_weight=0.5,
+        hybrid_search=False,
+        user=user,
+    )
+
+    assert queried == ['web-search-test']
+    assert sources[0]['document'] == ['search result content']
+    assert sources[0]['source']['type'] == 'web_search'
+
+
+@pytest.mark.asyncio
+async def test_get_sources_from_items_uses_web_search_docs(monkeypatch):
+    async def fake_query_collection(*args, **kwargs):
+        raise AssertionError('web search docs should not query vector collections')
+
+    monkeypatch.setattr(utils, 'query_collection', fake_query_collection)
+
+    request = SimpleNamespace()
+    user = SimpleNamespace(id='user-1', role='user')
+
+    sources = await utils.get_sources_from_items(
+        request,
+        items=[
+            {
+                'type': 'web_search',
+                'docs': [
+                    {
+                        'content': 'direct web search content',
+                        'metadata': {'source': 'https://example.com/direct'},
+                    }
+                ],
+            }
+        ],
+        queries=['weather query'],
+        embedding_function=lambda *args, **kwargs: None,
+        k=3,
+        reranking_function=None,
+        k_reranker=3,
+        r=0.0,
+        hybrid_bm25_weight=0.5,
+        hybrid_search=False,
+        user=user,
+    )
+
+    assert sources[0]['document'] == ['direct web search content']
+    assert sources[0]['metadata'] == [{'source': 'https://example.com/direct'}]
+    assert sources[0]['source']['type'] == 'web_search'


### PR DESCRIPTION
Fixes #25585

## Summary
- handle web_search items in retrieval source collection
- support web search docs and web-search collection names
- add regression coverage for both paths

## Tests
- Not run successfully locally: `UV_CACHE_DIR=/tmp/open-webui-uv-cache uv run pytest test/test_retrieval_utils.py` triggers the editable package build, which runs the frontend Vite build and fails with Node heap out of memory before pytest executes.