### PR TITLE
fix: preserve STT transcription response_format output

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -12,7 +12,7 @@ import os
 import uuid
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import aiofiles
 import aiohttp
@@ -26,7 +26,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, PlainTextResponse
 from pydantic import BaseModel
 from pydub import AudioSegment
 from pydub.silence import split_on_silence
@@ -70,6 +70,51 @@ AZURE_MAX_FILE_SIZE: int = AZURE_MAX_FILE_SIZE_MB * 1024 * 1024
 
 SPEECH_CACHE_DIR = CACHE_DIR / 'audio' / 'speech'
 SPEECH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+TRANSCRIPTION_RESPONSE_FORMATS = {'json', 'text', 'srt', 'verbose_json', 'vtt'}
+PLAIN_TEXT_TRANSCRIPTION_RESPONSE_FORMATS = {'text', 'srt', 'vtt'}
+TRANSCRIPTION_RESPONSE_MEDIA_TYPES = {
+    'text': 'text/plain',
+    'srt': 'application/x-subrip',
+    'vtt': 'text/vtt',
+}
+
+
+def normalize_transcription_response_format(response_format: Optional[str]) -> str:
+    if response_format is None:
+        return 'json'
+
+    normalized = response_format.strip().lower()
+    if not normalized:
+        return 'json'
+
+    if normalized not in TRANSCRIPTION_RESPONSE_FORMATS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Invalid response_format. Must be one of: {", ".join(sorted(TRANSCRIPTION_RESPONSE_FORMATS))}',
+        )
+
+    return normalized
+
+
+def extract_transcript_text(result: Any) -> str:
+    if isinstance(result, str):
+        return result.strip()
+
+    if isinstance(result, dict):
+        return str(result.get('text', '')).strip()
+
+    return ''
+
+
+def merge_transcription_results(results: list[Any], response_format: str) -> Any:
+    if len(results) == 1:
+        return results[0]
+
+    separator = '\n\n' if response_format in {'srt', 'vtt'} else ' '
+    return {
+        'text': separator.join([text for text in (extract_transcript_text(result) for result in results) if text]),
+    }
 
 
 def is_audio_conversion_required(file_path):
@@ -645,7 +690,7 @@ async def _transcribe_whisper(request, file_path, languages, file_dir, id):
     return data
 
 
-async def _transcribe_openai(request, file_path, filename, languages, file_dir, id, user=None):
+async def _transcribe_openai(request, file_path, filename, languages, file_dir, id, response_format=None, user=None):
     """Transcribe audio via an OpenAI-compatible STT endpoint."""
     r = None
     try:
@@ -654,6 +699,8 @@ async def _transcribe_openai(request, file_path, filename, languages, file_dir, 
             payload = {'model': request.app.state.config.STT_MODEL}
             if language:
                 payload['language'] = language
+            if response_format:
+                payload['response_format'] = response_format
 
             headers = {'Authorization': f'Bearer {request.app.state.config.STT_OPENAI_API_KEY}'}
             if user and ENABLE_FORWARD_USER_INFO_HEADERS:
@@ -674,10 +721,14 @@ async def _transcribe_openai(request, file_path, filename, languages, file_dir, 
                 break
 
         r.raise_for_status()
-        data = await r.json()
+        if response_format in PLAIN_TEXT_TRANSCRIPTION_RESPONSE_FORMATS:
+            data = await r.text()
+        else:
+            data = await r.json()
 
-        async with aiofiles.open(os.path.join(file_dir, f'{id}.json'), 'w') as f:
-            await f.write(json.dumps(data))
+        cache_path = os.path.join(file_dir, f'{id}.{response_format}' if isinstance(data, str) else f'{id}.json')
+        async with aiofiles.open(cache_path, 'w') as f:
+            await f.write(data if isinstance(data, str) else json.dumps(data))
         return data
     except Exception as e:
         log.exception(e)
@@ -875,6 +926,7 @@ async def transcription_handler(request, file_path, metadata, user=None):
     id = filename.split('.')[0]
 
     metadata = metadata or {}
+    response_format = metadata.get('response_format')
 
     languages = [
         metadata.get('language', None) if not WHISPER_LANGUAGE else WHISPER_LANGUAGE,
@@ -884,7 +936,7 @@ async def transcription_handler(request, file_path, metadata, user=None):
     if request.app.state.config.STT_ENGINE == '':
         return await _transcribe_whisper(request, file_path, languages, file_dir, id)
     elif request.app.state.config.STT_ENGINE == 'openai':
-        return await _transcribe_openai(request, file_path, filename, languages, file_dir, id, user)
+        return await _transcribe_openai(request, file_path, filename, languages, file_dir, id, response_format, user)
     elif request.app.state.config.STT_ENGINE == 'deepgram':
         return await _transcribe_deepgram(request, file_path, languages, file_dir, id)
     elif request.app.state.config.STT_ENGINE == 'azure':
@@ -1030,6 +1082,7 @@ async def _transcribe_mistral(request, file_path, filename, metadata, file_dir, 
 
 async def transcribe(request: Request, file_path: str, metadata: Optional[dict] = None, user=None):
     log.info(f'transcribe: {file_path} {metadata}')
+    response_format = normalize_transcription_response_format((metadata or {}).get('response_format'))
 
     if BYPASS_PYDUB_PREPROCESSING:
         log.info('Bypassing pydub preprocessing (BYPASS_PYDUB_PREPROCESSING=true)')
@@ -1059,19 +1112,16 @@ async def transcribe(request: Request, file_path: str, metadata: Optional[dict] 
                 detail=ERROR_MESSAGES.DEFAULT(e),
             )
 
-    results = []
     try:
         tasks = [transcription_handler(request, chunk_path, metadata, user) for chunk_path in chunk_paths]
-        for coro in asyncio.as_completed(tasks):
-            try:
-                results.append(await coro)
-            except HTTPException:
-                raise
-            except Exception as transcribe_exc:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f'Error transcribing chunk: {transcribe_exc}',
-                )
+        results = await asyncio.gather(*tasks)
+    except HTTPException:
+        raise
+    except Exception as transcribe_exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f'Error transcribing chunk: {transcribe_exc}',
+        )
     finally:
         # Clean up only the temporary chunks, never the original file
         for chunk_path in chunk_paths:
@@ -1081,9 +1131,7 @@ async def transcribe(request: Request, file_path: str, metadata: Optional[dict] 
                 except Exception:
                     pass
 
-    return {
-        'text': ' '.join([result['text'] for result in results]),
-    }
+    return merge_transcription_results(results, response_format)
 
 
 def compress_audio(file_path):
@@ -1151,6 +1199,7 @@ async def transcription(
     request: Request,
     file: UploadFile = File(...),
     language: Optional[str] = Form(None),
+    response_format: Optional[str] = Form(None),
     user=Depends(get_verified_user),
 ):
     if user.role != 'admin' and not await has_permission(
@@ -1197,12 +1246,24 @@ async def transcription(
             f.write(contents)
 
         try:
-            metadata = None
+            metadata = {}
+            normalized_response_format = normalize_transcription_response_format(response_format)
+            response_format_provided = bool(response_format and response_format.strip())
 
             if language:
-                metadata = {'language': language}
+                metadata['language'] = language
+            if response_format_provided:
+                metadata['response_format'] = normalized_response_format
 
-            result = await transcribe(request, file_path, metadata, user)
+            result = await transcribe(request, file_path, metadata or None, user)
+
+            if response_format_provided and normalized_response_format in PLAIN_TEXT_TRANSCRIPTION_RESPONSE_FORMATS:
+                return PlainTextResponse(
+                    content=result if isinstance(result, str) else extract_transcript_text(result),
+                    media_type=TRANSCRIPTION_RESPONSE_MEDIA_TYPES[normalized_response_format],
+                )
+            if response_format_provided:
+                return result
 
             return {
                 **result,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [ ] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [ ] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [ ] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [ ] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [ ] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

## Description

Fixes #25622.

- Accept and validate `response_format` on the audio transcription endpoint.
- Forward `response_format` to OpenAI-compatible STT providers.
- Return plain-text formats (`text`, `srt`, `vtt`) without forcing JSON parsing.
- Preserve explicit JSON responses such as `verbose_json` instead of reducing them to `{ text }`.
- Keep the existing default response behavior, including `filename`, when no `response_format` is provided.
- Preserve chunk result ordering when merging split audio transcription output.

## Testing

- `python3 -m compileall -q backend/open_webui/routers/audio.py`

---

### Additional Information

- [Any additional context, notes, or references to related issues/commits]

### Screenshots or Videos

- [Attach relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
