### PR TITLE
feat: add tag suggestions dropdown to model editor

### DIFF
--- a/src/lib/components/common/Tags.svelte
+++ b/src/lib/components/common/Tags.svelte
@@ -9,6 +9,9 @@
 	export let suggestionTags = [];
 	export let disabled = false;
 
+	$: tagNames = new Set(tags.map((t) => t.name));
+	$: filteredSuggestionTags = suggestionTags.filter((t) => !tagNames.has(t.name));
+
 	let inputValue = '';
 
 	const addTag = () => {
@@ -36,12 +39,25 @@
 				? 'px-0.5'
 				: ''} text-xs bg-transparent outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-500"
 			placeholder={$i18n.t('Add a tag...')}
+			list="suggestionTagOptions"
 			on:keydown={(event) => {
 				if (event.key === 'Enter' || event.key === ' ') {
 					event.preventDefault();
 					addTag();
 				}
 			}}
+			on:input={() => {
+				const value = inputValue.trim();
+				if (value !== '' && filteredSuggestionTags.some((t) => t.name === value)) {
+					addTag();
+				}
+			}}
 		/>
 	{/if}
+
+	<datalist id="suggestionTagOptions">
+		{#each filteredSuggestionTags as tag}
+			<option value={tag.name} />
+		{/each}
+	</datalist>
 </div>

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -29,6 +29,7 @@
 	import TerminalSelector from './TerminalSelector.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
+	import { getModelTags } from '$lib/apis/models';
 
 	const i18n = getContext('i18n');
 
@@ -106,6 +107,7 @@
 	let accessGrants = [];
 	let terminalId = '';
 	let tts = { voice: '' };
+	export let suggestionTags: { name: string }[] = [];
 
 	const submitHandler = async () => {
 		loading = true;
@@ -254,6 +256,26 @@
 		skillsList = (await getSkills(localStorage.token).catch(() => null)) ?? [];
 		if (!$functions) {
 			await functions.set(await getFunctions(localStorage.token));
+		}
+
+		if (suggestionTags.length === 0) {
+			if (preset) {
+				// Workspace context: use workspace-only tags API
+				const modelTags = await getModelTags(localStorage.token).catch(() => null);
+				if (modelTags) {
+					suggestionTags = modelTags.map((t) => ({ name: t }));
+				}
+			} else {
+				// Admin context: compute tags from all models in the store
+				const tagSet = new Set<string>();
+				for (const m of $models) {
+					for (const t of m?.info?.meta?.tags ?? []) {
+						const name = typeof t === 'string' ? t : t?.name;
+						if (name) tagSet.add(name);
+					}
+				}
+				suggestionTags = [...tagSet].sort().map((t) => ({ name: t }));
+			}
 		}
 
 		// Fetch admin-configured default model metadata so the editor
@@ -651,6 +673,7 @@
 								<div class="">
 									<Tags
 										tags={info?.meta?.tags ?? []}
+										{suggestionTags}
 										on:delete={(e) => {
 											const tagName = e.detail;
 											info.meta.tags = info.meta.tags.filter((tag) => tag.name !== tagName);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The model editor's "Add a tag..." input field accepted a `suggestionTags` prop but never actually used it — there was no autocomplete or dropdown to help users quickly reuse existing tags. This PR wires up a browser-native `<datalist>` dropdown on the tag input with **context-aware** tag population, and fixes a bug where workspace model tags were bleeding into the tag suggestions for base models in the admin panel.

**What changed:**

- **`Tags.svelte`** (shared component): The `suggestionTags` prop was a dead prop — accepted but never rendered. This PR connects it to a `<datalist>` element for browser-native autocomplete. It also adds two UX refinements:
  - **Auto-add on selection**: When a user clicks a suggestion from the dropdown, the tag is immediately added (no need to press Space or Enter after selecting).
  - **Filter already-applied tags**: Tags already on the current model are excluded from the suggestion list via a reactive `filteredSuggestionTags` derivation, so users only see tags they haven't added yet.

- **`ModelEditor.svelte`**: Populates tag suggestions with **context-aware** logic and exports `suggestionTags` as a prop so parent components can override the defaults:
  - **Workspace context** (`preset=true`): Fetches all existing workspace model tags via `getModelTags` (`GET /api/v1/models/tags`).
  - **Admin context** (`preset=false`): Computes tags locally from the `$models` store, which contains all models the user can access. This prevents workspace-only preset tags from bleeding into the suggestions when editing base models in the admin panel.

**No backend changes** — the `GET /api/v1/models/tags` endpoint and `getModelTags` frontend wrapper already existed and are used by the workspace model list page for tag filtering.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- Browser-native autocomplete dropdown for the "Add a tag..." input on the model editor page, populated with existing model tags
- Auto-add behavior when selecting a tag from the dropdown (no extra keypress needed)
- Reactive filtering to exclude already-applied tags from the suggestion list
- Context-aware tag population: workspace context uses the `getModelTags` API; admin context computes from the `$models` store

### Fixed

- Workspace model tags no longer bleed into the tag suggestions for base models in the admin panel model editor

### Changed

- `Tags.svelte`: Wired up the previously unused `suggestionTags` prop to render a `<datalist>` element with filtered suggestions
- `ModelEditor.svelte`: Added context-aware tag fetching on mount and exported `suggestionTags` as a prop for parent override

---

### Additional Information

- **No new dependencies** — uses the native HTML `<datalist>` element for autocomplete
- **No backend changes** — leverages the existing `GET /api/v1/models/tags` endpoint for workspace context and the `$models` store for admin context
- **Side benefit**: The `Tags.svelte` fix also benefits other consumers that pass `suggestionTags` (e.g., `chat/Tags.svelte` already passes `suggestionTags={$_tags ?? []}` but it was silently ignored until now)
- **Files changed**: 2 files, +39 lines / -1 line

### Manual Verification Performed
1. **Tag suggestions appear (workspace)**: Opened the workspace model editor, clicked the "Add a tag..." input, and confirmed the dropdown shows all existing workspace model tags fetched from the API.
2. **Tag suggestions appear (admin)**: Opened a base model in the admin Settings → Models editor and confirmed the dropdown shows tags computed from all models in the store — without workspace-only preset tags bleeding in.
3. **Auto-add on click**: Selected a tag from the dropdown and verified it was immediately added as a tag pill — no need to press Space or Enter after selection.
4. **Already-applied tags are filtered**: After adding a tag, re-focused the input and confirmed the just-added tag no longer appears in the dropdown suggestions.
5. **Last tag filtering**: Added all available suggestion tags one by one and verified the dropdown correctly shows no options when all suggestions are applied — no stale/cached options reappear.
6. **Manual tag entry still works**: Typed a brand-new tag name not in the suggestions and confirmed Space and Enter both add it as a tag.
7. **Tag deletion re-adds to suggestions**: Removed a previously added tag via the × button and confirmed it reappears in the suggestion dropdown.
8. **No regressions on empty state**: Opened the model editor for a model with no tags and confirmed the input renders correctly with suggestions available.
9. **No tag bleeding in admin**: Opened a base model (with no workspace preset entry) in the admin model editor and confirmed only tags from base model configurations appear — not workspace-only preset tags.
10. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly with no errors.

### Screenshots or Videos

#### 1. Tag suggestions dropdown — workspace model editor

Clicking the "Add a tag..." input shows a browser-native `<datalist>` dropdown populated with existing workspace model tags:

<img width="2335" height="1278" alt="Tag suggestions dropdown showing existing workspace model tags in the model editor" src="https://github.com/user-attachments/assets/80ed84b7-1650-40bf-82d5-0c33987ee64c" />

---

#### 2. Already-applied tags filtered from suggestions

After adding the "Thinking" tag, it no longer appears in the suggestion dropdown — only unapplied tags remain:

<img width="2335" height="1278" alt="Tag suggestions dropdown with already-applied tags filtered out" src="https://github.com/user-attachments/assets/b4db7316-036e-4138-be56-3709a3144467" />

---

#### 3. Auto-add on selection

Selecting a tag from the dropdown immediately adds it as a tag pill — no extra keypress (Space/Enter) required:

<img width="2335" height="1278" alt="Tag auto-added as a pill after selecting from the dropdown" src="https://github.com/user-attachments/assets/147b8611-718b-448a-8e44-ef09c6c8b495" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
