### PR TITLE
feat: add search to tools, filters, and actions selectors in model editor

### DIFF
--- a/src/lib/components/workspace/Models/ActionsSelector.svelte
+++ b/src/lib/components/workspace/Models/ActionsSelector.svelte
@@ -9,6 +9,7 @@
 	export let selectedActionIds = [];
 
 	let _actions = {};
+	let searchQuery = '';
 
 	onMount(() => {
 		_actions = actions.reduce((acc, action) => {
@@ -20,6 +21,14 @@
 			return acc;
 		}, {});
 	});
+
+	$: filteredActionKeys = Object.keys(_actions).filter((id) => {
+		if (!searchQuery.trim()) return true;
+		const q = searchQuery.toLowerCase();
+		return (
+			_actions[id].name?.toLowerCase().includes(q) || _actions[id].id?.toLowerCase().includes(q)
+		);
+	});
 </script>
 
 {#if actions.length > 0}
@@ -28,9 +37,20 @@
 			<div class=" self-center text-xs font-medium text-gray-500">{$i18n.t('Actions')}</div>
 		</div>
 
+		{#if Object.keys(_actions).length > 10}
+			<div class="mb-2">
+				<input
+					class="w-full text-sm bg-transparent outline-none border border-gray-100 dark:border-gray-800 rounded-lg px-3 py-1.5 placeholder-gray-400"
+					type="text"
+					placeholder={$i18n.t('Search actions...')}
+					bind:value={searchQuery}
+				/>
+			</div>
+		{/if}
+
 		<div class="flex flex-col">
 			<div class=" flex items-center flex-wrap">
-				{#each Object.keys(_actions) as action, actionIdx}
+				{#each filteredActionKeys as action, actionIdx}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">
 							<Checkbox

--- a/src/lib/components/workspace/Models/DefaultFiltersSelector.svelte
+++ b/src/lib/components/workspace/Models/DefaultFiltersSelector.svelte
@@ -7,6 +7,14 @@
 
 	export let filters = [];
 	export let selectedFilterIds = [];
+
+	let searchQuery = '';
+
+	$: filteredFilters = filters.filter((filter) => {
+		if (!searchQuery.trim()) return true;
+		const q = searchQuery.toLowerCase();
+		return filter.name?.toLowerCase().includes(q) || filter.id?.toLowerCase().includes(q);
+	});
 </script>
 
 <div>
@@ -14,10 +22,21 @@
 		<div class=" self-center text-xs text-gray-500 font-medium">{$i18n.t('Default Filters')}</div>
 	</div>
 
+	{#if filters.length > 10}
+		<div class="mb-2">
+			<input
+				class="w-full text-sm bg-transparent outline-none border border-gray-100 dark:border-gray-800 rounded-lg px-3 py-1.5 placeholder-gray-400"
+				type="text"
+				placeholder={$i18n.t('Search filters...')}
+				bind:value={searchQuery}
+			/>
+		</div>
+	{/if}
+
 	<div class="flex flex-col">
 		{#if filters.length > 0}
 			<div class=" flex items-center flex-wrap">
-				{#each filters as filter}
+				{#each filteredFilters as filter}
 					{@const isSelected = selectedFilterIds.includes(filter.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">

--- a/src/lib/components/workspace/Models/FiltersSelector.svelte
+++ b/src/lib/components/workspace/Models/FiltersSelector.svelte
@@ -7,6 +7,14 @@
 
 	export let filters = [];
 	export let selectedFilterIds = [];
+
+	let searchQuery = '';
+
+	$: filteredFilters = filters.filter((filter) => {
+		if (!searchQuery.trim()) return true;
+		const q = searchQuery.toLowerCase();
+		return filter.name?.toLowerCase().includes(q) || filter.id?.toLowerCase().includes(q);
+	});
 </script>
 
 {#if filters.length > 0}
@@ -15,10 +23,21 @@
 			<div class=" self-center text-xs font-medium text-gray-500">{$i18n.t('Filters')}</div>
 		</div>
 
+		{#if filters.length > 10}
+			<div class="mb-2">
+				<input
+					class="w-full text-sm bg-transparent outline-none border border-gray-100 dark:border-gray-800 rounded-lg px-3 py-1.5 placeholder-gray-400"
+					type="text"
+					placeholder={$i18n.t('Search filters...')}
+					bind:value={searchQuery}
+				/>
+			</div>
+		{/if}
+
 		<!-- TODO: Filter order matters -->
 		<div class="flex flex-col">
 			<div class=" flex items-center flex-wrap">
-				{#each filters as filter}
+				{#each filteredFilters as filter}
 					{@const isSelected = filter.is_global || selectedFilterIds.includes(filter.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">

--- a/src/lib/components/workspace/Models/ToolsSelector.svelte
+++ b/src/lib/components/workspace/Models/ToolsSelector.svelte
@@ -6,6 +6,7 @@
 	export let tools = [];
 
 	let _tools = {};
+	let searchQuery = '';
 
 	export let selectedToolIds = [];
 
@@ -21,6 +22,12 @@
 			return acc;
 		}, {});
 	});
+
+	$: filteredToolKeys = Object.keys(_tools).filter((id) => {
+		if (!searchQuery.trim()) return true;
+		const q = searchQuery.toLowerCase();
+		return _tools[id].name?.toLowerCase().includes(q) || _tools[id].id?.toLowerCase().includes(q);
+	});
 </script>
 
 <div>
@@ -28,10 +35,21 @@
 		<div class=" self-center text-xs font-medium text-gray-500">{$i18n.t('Tools')}</div>
 	</div>
 
+	{#if Object.keys(_tools).length > 10}
+		<div class="mb-2">
+			<input
+				class="w-full text-sm bg-transparent outline-none border border-gray-100 dark:border-gray-800 rounded-lg px-3 py-1.5 placeholder-gray-400"
+				type="text"
+				placeholder={$i18n.t('Search tools...')}
+				bind:value={searchQuery}
+			/>
+		</div>
+	{/if}
+
 	<div class="flex flex-col mb-1">
 		{#if tools.length > 0}
 			<div class=" flex items-center flex-wrap">
-				{#each Object.keys(_tools) as tool, toolIdx}
+				{#each filteredToolKeys as tool, toolIdx}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">
 							<Checkbox


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The model editor's SkillsSelector already has a search bar that appears when there are more than 10 items, making it easy to find specific skills. This PR brings that same search functionality to the remaining selector components — Tools, Filters, Actions, and Default Filters — for a consistent experience across all sections.

**What changed:**

Each selector now has:
- A `searchQuery` state variable
- A reactive filtered list (case-insensitive match on item `name` and `id`)
- A conditional search `<input>` that only renders when there are more than 10 items (matching the SkillsSelector threshold)

The implementation follows the exact same pattern established by `SkillsSelector.svelte`, adapting for the two architectural patterns used across these components:

| Pattern | Components | How search integrates |
|---|---|---|
| Internal `_object = {}` keyed by ID | **ToolsSelector**, **ActionsSelector** | `filteredKeys = Object.keys(_object).filter(...)` |
| Raw array prop iteration | **FiltersSelector**, **DefaultFiltersSelector** | `filteredItems = items.filter(...)` |

All search inputs use the same CSS classes and placeholder format (`Search tools...`, `Search filters...`, `Search actions...`) for visual consistency.

**No backend changes** — this is purely a frontend UX improvement using existing data.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- Search bar in ToolsSelector (appears when >10 tools)
- Search bar in FiltersSelector (appears when >10 filters)
- Search bar in ActionsSelector (appears when >10 actions)
- Search bar in DefaultFiltersSelector (appears when >10 filters)

### Manual Verification Performed

1. **Search appears at threshold**: Verified search bars only render when the respective section has more than 10 items.
2. **Name filtering works**: Typed partial tool/filter/action names and confirmed the list narrows correctly.
3. **ID filtering works**: Typed partial IDs and confirmed matching items appear.
4. **Case insensitive**: Confirmed searches work regardless of capitalization.
5. **Clear restores all**: Cleared search text and verified all items reappear.
6. **Global items preserved**: Confirmed `is_global` filters and actions still show correctly (checkbox disabled) during and after search.
7. **Selection state preserved**: Checked/unchecked items while search was active and confirmed selections persist after clearing search.
8. **Empty search shows all**: Verified that whitespace-only queries show all items (matching SkillsSelector behavior).
9. **Build passes**: Ran `npm run format` and `npm run build` — both pass cleanly with no errors.

---

### Additional Information

- **No new dependencies** — uses a plain HTML `<input>` element
- **No backend changes** — filters existing client-side data
- **Pattern consistency** — all 4 components now match the existing SkillsSelector search pattern exactly
- **Files changed**: 4 files, +80 lines / -4 lines

### Screenshots or Videos

## Before:

<img width="2549" height="1278" alt="image" src="https://github.com/user-attachments/assets/4261a190-331f-4435-9473-d42a707dd1b9" />

## After:

<img width="2549" height="1278" alt="image" src="https://github.com/user-attachments/assets/93bbeaa3-2cb7-4a4d-be73-7d30bd6787ef" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
