### PR TITLE
feat: add compact action toolbar toggle to collapse custom action buttons

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -64,6 +64,8 @@
 	import StatusHistory from './ResponseMessage/StatusHistory.svelte';
 	import FullHeightIframe from '$lib/components/common/FullHeightIframe.svelte';
 	import OutputEditView from './OutputEditView.svelte';
+	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
+	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
 
 	interface MessageType {
 		id: string;
@@ -166,6 +168,7 @@
 	let contentContainerElement: HTMLDivElement;
 	let buttonsContainerElement: HTMLDivElement;
 	let showDeleteConfirm = false;
+	let showActions = false;
 
 	let model = null;
 	$: model = $models.find((m) => m.id === message.model);
@@ -1451,36 +1454,93 @@
 										{/if}
 									{/if}
 
-									{#each model?.actions ?? [] as action}
-										<Tooltip content={action.name} placement="bottom">
+									{#if $settings?.compactToolbar && (model?.actions ?? []).length > 0}
+										<Tooltip
+											content={showActions ? $i18n.t('Hide Actions') : $i18n.t('More Actions')}
+											placement="bottom"
+										>
 											<button
 												type="button"
-												aria-label={action.name}
+												aria-label={showActions ? $i18n.t('Hide Actions') : $i18n.t('More Actions')}
 												class="{isLastMessage || ($settings?.highContrastMode ?? false)
 													? 'visible'
 													: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
 												on:click={() => {
-													actionMessage(action.id, message);
+													showActions = !showActions;
 												}}
 											>
-												{#if action?.icon}
-													<div class="size-4">
-														<img
-															src={action.icon}
-															class="w-4 h-4 {action.icon.includes('data:image/svg')
-																? 'dark:invert-[80%]'
-																: ''}"
-															style="fill: currentColor;"
-															alt={action.name}
-															draggable="false"
-														/>
-													</div>
+												{#if showActions}
+													<ChevronLeft className="size-4" strokeWidth="2.3" />
 												{:else}
-													<Sparkles strokeWidth="2.1" className="size-4" />
+													<ChevronRight className="size-4" strokeWidth="2.3" />
 												{/if}
 											</button>
 										</Tooltip>
-									{/each}
+
+										{#if showActions}
+											{#each model?.actions ?? [] as action}
+												<Tooltip content={action.name} placement="bottom">
+													<button
+														type="button"
+														aria-label={action.name}
+														class="{isLastMessage || ($settings?.highContrastMode ?? false)
+															? 'visible'
+															: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
+														on:click={() => {
+															actionMessage(action.id, message);
+														}}
+													>
+														{#if action?.icon}
+															<div class="size-4">
+																<img
+																	src={action.icon}
+																	class="w-4 h-4 {action.icon.includes('data:image/svg')
+																		? 'dark:invert-[80%]'
+																		: ''}"
+																	style="fill: currentColor;"
+																	alt={action.name}
+																	draggable="false"
+																/>
+															</div>
+														{:else}
+															<Sparkles strokeWidth="2.1" className="size-4" />
+														{/if}
+													</button>
+												</Tooltip>
+											{/each}
+										{/if}
+									{:else}
+										{#each model?.actions ?? [] as action}
+											<Tooltip content={action.name} placement="bottom">
+												<button
+													type="button"
+													aria-label={action.name}
+													class="{isLastMessage || ($settings?.highContrastMode ?? false)
+														? 'visible'
+														: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
+													on:click={() => {
+														actionMessage(action.id, message);
+													}}
+												>
+													{#if action?.icon}
+														<div class="size-4">
+															<img
+																src={action.icon}
+																class="w-4 h-4 {action.icon.includes('data:image/svg')
+																	? 'dark:invert-[80%]'
+																	: ''}"
+																style="fill: currentColor;"
+																alt={action.name}
+																draggable="false"
+															/>
+														</div>
+													{:else}
+														<Sparkles strokeWidth="2.1" className="size-4" />
+													{/if}
+												</button>
+											</Tooltip>
+										{/each}
+									{/if}
 								{/if}
 							{/if}
 						{/if}

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -78,6 +78,8 @@
 	let showFloatingActionButtons = true;
 	let floatingActionButtons = null;
 
+	let compactToolbar = false;
+
 	let imageCompression = false;
 	let imageCompressionSize = {
 		width: '',
@@ -263,6 +265,8 @@
 
 		showFloatingActionButtons = $settings?.showFloatingActionButtons ?? true;
 		floatingActionButtons = $settings?.floatingActionButtons ?? null;
+
+		compactToolbar = $settings?.compactToolbar ?? false;
 
 		imageCompression = $settings?.imageCompression ?? false;
 		imageCompressionSize = $settings?.imageCompressionSize ?? { width: '', height: '' };
@@ -1110,6 +1114,25 @@
 							bind:state={showFloatingActionButtons}
 							on:change={() => {
 								saveSettings({ showFloatingActionButtons });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="compact-toolbar-label" class=" self-center text-xs">
+						{$i18n.t('Compact Action Toolbar')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="compact-toolbar-label"
+							tooltip={true}
+							bind:state={compactToolbar}
+							on:change={() => {
+								saveSettings({ compactToolbar });
 							}}
 						/>
 					</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (regular contributor, self-contained UI enhancement).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Adds a **Compact Action Toolbar** toggle to **Settings → Interface** that collapses custom action function buttons in the assistant response toolbar behind a chevron toggle button.

When users have many action functions enabled on a model, the toolbar becomes visually cluttered with numerous icon buttons. This setting lets users collapse those custom action buttons behind a single `›` chevron — clicking it expands the buttons inline in their original layout, and clicking `‹` collapses them again. All built-in buttons (Edit, Copy, Read Aloud, 👍/👎, Regenerate, Continue, Delete) remain visible and unaffected.

**How it works:**
- **Setting off (default):** Zero behavior change — action buttons render inline as they always have
- **Setting on, collapsed:** Built-in toolbar buttons + `›` chevron
- **Setting on, expanded:** Built-in toolbar buttons + `‹` chevron + all action buttons inline

The setting defaults to `false`, preserving the existing experience. The toggle uses local component state (`showActions`) per message instance, so expanding one message's actions doesn't affect others.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- New **Compact Action Toolbar** boolean toggle in Settings → Interface
- Chevron-based expand/collapse button (`ChevronRight` / `ChevronLeft`) for action function buttons in the response toolbar when the setting is enabled

### Changed

- The `{#each model?.actions}` rendering block in `ResponseMessage.svelte` is now conditionally wrapped: when `compactToolbar` is enabled, actions are hidden behind a toggle; otherwise they render inline as before

---

### Additional Information

- **No new dependencies** — uses existing `ChevronRight` and `ChevronLeft` icon components from `src/lib/components/icons/`
- **Files changed:** `ResponseMessage.svelte` (toolbar rendering), `Interface.svelte` (settings toggle)
- **2 files, 101 insertions, 18 deletions** — single atomic commit
- Follows the exact same Switch toggle pattern used by every other boolean setting in Interface.svelte (`showFloatingActionButtons`, `collapseCodeBlocks`, `regenerateMenu`, etc.)

### Screenshots or Videos

[Screencast from 2026-06-04 11-16-59.webm](https://github.com/user-attachments/assets/18a7fa97-fb6a-40cd-ba18-441e3682bc61)

<img width="1364" height="380" alt="image" src="https://github.com/user-attachments/assets/e55bd72d-f603-4cd0-96a4-659ea5c9be8b" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
