### PR TITLE
fix: pass correct request object to _resolve_api_config in get_ollama_loaded_models

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -434,7 +434,7 @@ async def get_ollama_loaded_models(
     for idx, response in enumerate(responses):
         if not response:
             continue
-        api_config = _resolve_api_config(request.app.state.config, idx, request.app.state.config.OLLAMA_BASE_URLS[idx])
+        api_config = _resolve_api_config(request, idx, request.app.state.config.OLLAMA_BASE_URLS[idx])
         prefix_id = api_config.get('prefix_id')
         if prefix_id:
             for m in response.get('models', []):


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (regression fix from recent refactor).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Fixes the model unload (eject) button not appearing for loaded Ollama models in the model selector dropdown.

**Root Cause:** In `get_ollama_loaded_models()`, `_resolve_api_config()` was being called with `request.app.state.config` (the config object) instead of `request` (the FastAPI Request object). Since `_resolve_api_config()` internally accesses `request.app.state.config.OLLAMA_API_CONFIGS`, passing the config object directly caused an `AttributeError` (`config.app.state.config.OLLAMA_API_CONFIGS`).

This error was silently caught by the `try/except` block in `get_all_models()` (line 362, logged at `debug` level), which prevented `expires_at` from being annotated onto models. Without `expires_at`, `loaded` was always `False` (per `utils/models.py:41` — `'loaded': 'expires_at' in model`), so the eject button's condition `$user?.role === 'admin' && item.model.loaded` was never satisfied.

**The fix:** One-line change — pass `request` instead of `request.app.state.config` to `_resolve_api_config()`.

```diff
- api_config = _resolve_api_config(request.app.state.config, idx, request.app.state.config.OLLAMA_BASE_URLS[idx])
+ api_config = _resolve_api_config(request, idx, request.app.state.config.OLLAMA_BASE_URLS[idx])
```

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Ollama model unload (eject) button not appearing for admin users in the model selector when models are loaded in memory
- Green "loaded" indicator dot and "Unloads in X minutes" tooltip also affected by the same bug — now restored

---

### Additional Information

- **1 file changed, 1 insertion, 1 deletion** — minimal, surgical fix
- The bug was confirmed by calling `curl http://localhost:11434/api/ps` directly, which correctly returns `expires_at` — proving Ollama is responding correctly but Open WebUI was failing to process the response
- The silent `log.debug` error message would have been: `Failed to get loaded models: 'OLLAMA_API_CONFIGS'` (or similar AttributeError)

### Screenshots or Videos

## Before:

<img width="559" height="405" alt="image" src="https://github.com/user-attachments/assets/7a66bd41-2558-494e-b6a4-55e690ab97b5" />

## After:

<img width="559" height="405" alt="image" src="https://github.com/user-attachments/assets/7753ab02-7b91-4af4-b9c5-dc13d5d81368" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
