### PR TITLE
fix: add partial index for pending knowledge files query

### DIFF
--- a/backend/open_webui/migrations/versions/b9f3c1d7a2e4_add_file_pending_knowledge_index.py
+++ b/backend/open_webui/migrations/versions/b9f3c1d7a2e4_add_file_pending_knowledge_index.py
@@ -34,22 +34,37 @@ def upgrade():
         return
 
     if dialect == 'postgresql':
-        op.execute(
-            f'CREATE INDEX {INDEX_NAME} ON file '
-            "((meta -> 'data' ->> 'knowledge_id')) "
-            "WHERE (data ->> 'status') IN ('pending', 'processing')"
-        )
+        # CONCURRENTLY avoids an ACCESS EXCLUSIVE lock while the index builds,
+        # which matters on large `file` tables (file.data holds full extracted
+        # document content). It cannot run inside a transaction, so use an
+        # autocommit block.
+        with op.get_context().autocommit_block():
+            op.execute(
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} ON file '
+                "((meta -> 'data' ->> 'knowledge_id')) "
+                "WHERE (data ->> 'status') IN ('pending', 'processing')"
+            )
     elif dialect == 'sqlite':
+        # Expression/path must match exactly what SQLAlchemy emits for the
+        # SQLite dialect (nested JSON_EXTRACT/JSON_QUOTE, double-quoted path
+        # keys), otherwise SQLite will not use this index for the ORM query.
         op.execute(
             f'CREATE INDEX {INDEX_NAME} ON file '
-            "(json_extract(meta, '$.data.knowledge_id')) "
-            "WHERE json_extract(data, '$.status') IN ('pending', 'processing')"
+            '(JSON_EXTRACT(JSON_QUOTE(JSON_EXTRACT(meta, \'$."data"\')), \'$."knowledge_id"\')) '
+            'WHERE JSON_EXTRACT(data, \'$."status"\') IN (\'pending\', \'processing\')'
         )
 
 
 def downgrade():
     conn = op.get_bind()
+    dialect = conn.dialect.name
     existing_indexes = {idx['name'] for idx in sa.inspect(conn).get_indexes('file')}
 
-    if INDEX_NAME in existing_indexes:
+    if INDEX_NAME not in existing_indexes:
+        return
+
+    if dialect == 'postgresql':
+        with op.get_context().autocommit_block():
+            op.execute(f'DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}')
+    else:
         op.drop_index(INDEX_NAME, table_name='file')

--- a/backend/open_webui/migrations/versions/b9f3c1d7a2e4_add_file_pending_knowledge_index.py
+++ b/backend/open_webui/migrations/versions/b9f3c1d7a2e4_add_file_pending_knowledge_index.py
@@ -1,0 +1,55 @@
+"""Add partial index for pending knowledge files
+
+Adds a partial expression index supporting
+Files.get_pending_files_for_knowledge, whose query filters on
+file.meta->data->knowledge_id and file.data->status. Without it, every
+call (driven by the knowledge-base pending-files polling) performs a full
+sequential scan of the file table, which is expensive because file.data
+stores full extracted document content. The index keeps the lookup cost
+proportional to the number of pending files rather than total content size.
+
+Revision ID: b9f3c1d7a2e4
+Revises: 461111b60977
+Create Date: 2026-06-04 12:35:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = 'b9f3c1d7a2e4'
+down_revision = '461111b60977'
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = 'idx_file_pending_knowledge'
+
+
+def upgrade():
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+    existing_indexes = {idx['name'] for idx in sa.inspect(conn).get_indexes('file')}
+
+    if INDEX_NAME in existing_indexes:
+        return
+
+    if dialect == 'postgresql':
+        op.execute(
+            f'CREATE INDEX {INDEX_NAME} ON file '
+            "((meta -> 'data' ->> 'knowledge_id')) "
+            "WHERE (data ->> 'status') IN ('pending', 'processing')"
+        )
+    elif dialect == 'sqlite':
+        op.execute(
+            f'CREATE INDEX {INDEX_NAME} ON file '
+            "(json_extract(meta, '$.data.knowledge_id')) "
+            "WHERE json_extract(data, '$.status') IN ('pending', 'processing')"
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    existing_indexes = {idx['name'] for idx in sa.inspect(conn).get_indexes('file')}
+
+    if INDEX_NAME in existing_indexes:
+        op.drop_index(INDEX_NAME, table_name='file')


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Adds a partial expression index supporting `Files.get_pending_files_for_knowledge` (`backend/open_webui/models/files.py`). That query filters on the JSON fields `file.meta->'data'->>'knowledge_id'` and `file.data->>'status'`, neither of which is indexed, so every call performs a full sequential scan of the `file` table. Because `file.data` stores the full extracted document content, the scan is multi-GB on large deployments. The knowledge-base pending-files polling added in 0.9.6 calls this on every KB page load and then every 5s, so the scans stack into many concurrent parallel seq-scans and can saturate the database. **Motivation/impact:** on a production deployment (5k users, hundreds of thousands of files) this pinned Aurora Serverless v2 at 100% of 120 ACU and forced a rollback to 0.9.5. The index makes the lookup cost scale with the number of *pending* files instead of total content size.

### Added

- New Alembic migration `b9f3c1d7a2e4_add_file_pending_knowledge_index.py` creating partial index `idx_file_pending_knowledge` on the `file` table (PostgreSQL and SQLite variants, idempotent, dialect-aware).

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed full table scans / database saturation caused by the unindexed pending-knowledge-files query introduced in 0.9.6 (#25717). The query now uses an index scan instead of a sequential scan over the entire `file` table.

### Security

- N/A

### Breaking Changes

- **BREAKING CHANGE**: [Changes affecting compatibility or functionality]

- None.

### Additional Information

- Related issue: #25717. Same underlying pathology (unindexed JSON seq-scan over `file`) as #25082, on a different endpoint.

### Screenshots or Videos

**Before:**

Concurrency at peak: count of in-flight calls to the pending-files query => 

```
SELECT count(*) AS concurrent_calls,
state,
max(now() - query_start) AS oldest_running
FROM pg_stat_activity
WHERE query LIKE 'SELECT public.file.id, public.file.user_id%'
GROUP BY state;
```

concurrent_calls | state | oldest_running
------------------+---------------------+----------------
34 | active | 00:03:14
6 | idle in transaction | 00:00:21
(2 rows)

-- pg_stat_activity (filtered), peak of the storm. Single knowledge base,
-- one query shape, dozens of concurrent full/parallel seq-scans of public.file.
-- (file.data holds full extracted document content, so each scan is multi-GB.)

pid | state | wait_event_type | wait_event | runtime | query
-------+----------+-----------------+-------------------+----------+----------------------------------------------
51445 | active | | | 00:03:14 | SELECT public.file.id, public.file.user_id, ... FROM public.file WHERE CAST(((meta -> $1) ->> $2) AS VARCHAR) = $3 AND CAST((data ->> $4) AS VARCHAR) IN ($5,$6) AND id NOT IN (SELECT file_id FROM knowledge_file WHERE knowledge_id = $7)
53152 | active | IPC | MessageQueueReceive | 00:01:07 | SELECT public.file.id, public.file.user_id, ... (parallel worker coordination)
53328 | active | | | 00:01:07 | SELECT public.file.id, public.file.user_id, ...
53017 | active | | | 00:01:06 | SELECT public.file.id, public.file.user_id, ...
53038 | active | | | 00:01:06 | SELECT public.file.id, public.file.user_id, ...
53440 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53442 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53443 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53446 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53448 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53450 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53451 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53456 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53457 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53467 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53469 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53471 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53473 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53475 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53477 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53479 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
53481 | active | | | 00:00:28 | SELECT public.file.id, public.file.user_id, ...
... (~13 more identical active scans elided) ...
(34 concurrent executions of the same query against a single knowledge base)
=> 
```
SELECT count(*) FROM public.file
WHERE data->>'status' IN ('pending','processing');
```
count

1770
(1 row)

Time: 103184.512 ms (01:43.185)


**After**

```
EXPLAIN SELECT public.file.id FROM public.file
WHERE CAST(((meta -> 'data') ->> 'knowledge_id') AS VARCHAR) = 'some-kb-id'
AND CAST((data ->> 'status') AS VARCHAR) IN ('pending','processing');
```

Bitmap Heap Scan on file (cost=4.14..59.50 rows=14 width=37)
Recheck Cond: (...)
-> Bitmap Index Scan on idx_file_pending_knowledge (cost=0.00..4.13 rows=14 width=0)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
