### PR TITLE
fix: accept numeric MinerU API timeout from WebUI

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -680,7 +680,7 @@ class ConfigForm(BaseModel):
     MINERU_API_MODE: str | None = None
     MINERU_API_URL: str | None = None
     MINERU_API_KEY: str | None = None
-    MINERU_API_TIMEOUT: str | None = None
+    MINERU_API_TIMEOUT: int | str | None = None
     MINERU_PARAMS: dict | None = None
     MINERU_FILE_EXTENSIONS: list[str] | None = None
 


### PR DESCRIPTION
## Problem

The MinerU API Timeout field in Documents settings cannot be saved — the WebUI sends a JSON number (from `<input type="number">`), but the backend config model declares it as `str | None`, causing Pydantic v2 to reject with HTTP 422.

## Fix

Changed the type annotation in the config form to accept both `int` and `str`:

```python
# Before
MINERU_API_TIMEOUT: str | None = None

# After
MINERU_API_TIMEOUT: int | str | None = None
```

Using `int | str | None` because:
- Frontend sends `int` (from `<input type="number">`)
- Config/env default is `str` (`os.getenv('MINERU_API_TIMEOUT', '300')`)
- Downstream loader already calls `int(mineru_timeout)` to handle both types

**File:** `backend/open_webui/routers/retrieval.py`

Fixes #25603