### PR TITLE
fix: add file extension filter for paddleocr_vl loader

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -530,7 +530,11 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
             )
-        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
+        elif (
+            self.engine == 'paddleocr_vl'
+            and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
+            and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
+        ):
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),


### PR DESCRIPTION
## Problem

The `paddleocr_vl` loader condition has no file extension filter, so all file types (including `.md`, `.txt`, `.csv`) are sent to the PaddleOCR API, which only handles PDF and images — causing HTTP 422 errors.

## Fix

Added file extension filtering matching the pattern used by `mistral_ocr` and `mineru`:

```python
# Before
elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':

# After
elif (
    self.engine == 'paddleocr_vl'
    and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
    and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
):
```

The allowed extensions match the `image_extensions` list in `paddleocr_vl.py`, plus `pdf`.

**File:** `backend/open_webui/retrieval/loaders/main.py`

Fixes #24988