### PR TITLE
fix: strip empty assistant messages before sending to providers

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2215,6 +2215,16 @@ def process_messages_with_output(
 
         # Strip 'output' field before adding (LLM shouldn't see it)
         clean_message = {k: v for k, v in message.items() if k != 'output'}
+
+        # Skip empty assistant messages that would break strict providers
+        if message.get('role') == 'assistant':
+            content = clean_message.get('content', '')
+            has_content = content and str(content).strip()
+            has_tool_calls = bool(clean_message.get('tool_calls'))
+            has_output = bool(message.get('output'))
+            if not has_content and not has_tool_calls and not has_output:
+                continue
+
         processed.append(clean_message)
 
     return processed


### PR DESCRIPTION
## Problem

Empty assistant messages from failed streams permanently break chats for strict providers (Azure).

## Fix

Filter out assistant messages with no content, tool_calls, or output in `process_messages_with_output`.

Fixes #25083

### Description
- Filter out empty assistant messages with no content, tool_calls, or output before sending to providers to prevent Azure and other strict providers from returning errors.

### Fixed
- Fixed empty assistant messages from failed streams permanently breaking chats for strict providers like Azure

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.