### PR TITLE
fix: coerce string-valued tool arguments to declared scalar types

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -163,6 +163,66 @@ async def build_tool_server_headers(
     return headers, cookies
 
 
+def _unwrap_optional(annotation: Any) -> Any:
+    """Return the single concrete type of an Optional[...] / Union[..., None]
+    annotation, or the annotation unchanged when it is not such a union."""
+    if get_origin(annotation) is Union:
+        non_none = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
+
+
+def _coerce_str_to_annotation(value: str, annotation: Any) -> Any:
+    """Best-effort coercion of a string value to the scalar type it declares.
+
+    Models using native function calling sometimes emit numeric/boolean
+    parameters as strings (e.g. ``"1"`` instead of ``1``). Without coercion,
+    tools that declare ``int``/``float``/``bool`` parameters raise ``TypeError``
+    on comparisons/arithmetic. Returns the original value unchanged when
+    coercion does not apply or fails.
+    """
+    target = _unwrap_optional(annotation)
+
+    if target is bool:
+        lowered = value.strip().lower()
+        if lowered in ('true', '1', 'yes', 'on'):
+            return True
+        if lowered in ('false', '0', 'no', 'off'):
+            return False
+        return value
+    if target is int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            try:
+                # Tolerate integral floats such as "1.0"
+                return int(float(value))
+            except (TypeError, ValueError):
+                return value
+    if target is float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return value
+    return value
+
+
+def coerce_arguments_to_type_hints(kwargs: dict, type_hints: dict) -> dict:
+    """Coerce string-valued arguments to the scalar types declared in
+    ``type_hints`` (best-effort, leaving values unchanged on failure)."""
+    if not type_hints:
+        return kwargs
+    return {
+        key: (
+            _coerce_str_to_annotation(value, type_hints[key])
+            if isinstance(value, str) and key in type_hints
+            else value
+        )
+        for key, value in kwargs.items()
+    }
+
+
 # Let no function be called without need, and let what
 # it yields justify the cost of running it.
 async def get_async_tool_function_and_apply_extra_params(
@@ -170,6 +230,15 @@ async def get_async_tool_function_and_apply_extra_params(
 ) -> Callable[..., Awaitable]:
     sig = inspect.signature(function)
     extra_params = {k: v for k, v in extra_params.items() if k in sig.parameters}
+
+    # Pre-compute parameter type hints so model-supplied arguments can be
+    # coerced to their declared scalar types at call time. Native function
+    # calling can pass numeric/boolean values as strings, which would
+    # otherwise raise TypeError inside tools that expect int/float/bool.
+    try:
+        type_hints = get_type_hints(function)
+    except Exception:
+        type_hints = {}
     partial_func = partial(function, **extra_params)
 
     # Remove the 'frozen' keyword arguments from the signature
@@ -188,12 +257,12 @@ async def get_async_tool_function_and_apply_extra_params(
         # wrap the functools.partial as python-genai has trouble with it
         # https://github.com/googleapis/python-genai/issues/907
         async def new_function(*args, **kwargs):
-            return await partial_func(*args, **kwargs)
+            return await partial_func(*args, **coerce_arguments_to_type_hints(kwargs, type_hints))
 
     else:
         # Make it a coroutine function when it is not already
         async def new_function(*args, **kwargs):
-            return partial_func(*args, **kwargs)
+            return partial_func(*args, **coerce_arguments_to_type_hints(kwargs, type_hints))
 
     update_wrapper(new_function, function)
     new_function.__signature__ = new_sig


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #25641
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included below.
- [ ] **Documentation:** No documentation changes required.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual verification performed (see below).
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart default behaviour; no new settings introduced.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Models using native function calling (`function_calling: native`) sometimes emit numeric or boolean tool parameters as **strings** — e.g. `count="1"` instead of `count=1`. The builtin tools declare `int`/`Optional[int]`/`bool`/`float` type hints but never coerced the actual runtime values, so the first comparison or arithmetic on such a value raised:

```
TypeError: '<' not supported between instances of 'int' and 'str'
```

For example, `search_web` crashes on `count = max(1, min(count, max_count))` (`builtin.py`), so the model receives an error response instead of search results.

**Fix:** coerce string-valued arguments to their declared scalar type inside the shared tool wrapper `get_async_tool_function_and_apply_extra_params` (`backend/open_webui/utils/tools.py`). Because every builtin and user-defined tool is invoked through this wrapper, the fix is centralized rather than scattered across individual tools.

The coercion is **best-effort and non-intrusive**:

- Only `str` values are touched; values that already have the correct type are left untouched.
- `int` / `float` / `bool` (and their `Optional[...]` forms) are supported. `int` also tolerates integral floats like `"1.0"`.
- Booleans accept the usual `true/false/1/0/yes/no/on/off` spellings.
- Unparseable values (e.g. `count="abc"`) are passed through **unchanged**, preserving existing behaviour.
- `get_type_hints` failures fall back to no coercion.

### Fixed

- Builtin tool functions no longer crash with `TypeError` when a model passes numeric/boolean parameters as strings via native function calling (e.g. `search_web(count="1")`).

### Additional Information

- No new dependencies added.
- No behavioral change when tools receive correctly-typed arguments — purely defensive coercion for string inputs.

### Manual Verification Performed

Validated the coercion against representative tool signatures (`search_web(query: str, count: Optional[int])`, and a tool with `bool`/`float`/`int` params):

| Input | Annotation | Result |
| --- | --- | --- |
| `count="1"` | `Optional[int]` | `1` (and `min(count, max_count)` no longer raises) |
| `count="3.0"` | `Optional[int]` | `3` |
| `count=None` | `Optional[int]` | `None` (unchanged) |
| `count=2` | `Optional[int]` | `2` (unchanged) |
| `count="abc"` | `Optional[int]` | `"abc"` (unchanged) |
| `case_insensitive="false"` | `bool` | `False` |
| `ratio="0.5"` | `float` | `0.5` |
| `query="weather"` | `str` | `"weather"` (unchanged) |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
