### PR TITLE
feat: improve chat overview with persistent viewport and pinning

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -454,10 +454,12 @@
 		await tick();
 
 		if (($settings?.scrollOnBranchChange ?? true) && scroll) {
-			const messageElement = document.getElementById(`message-${message.id}`);
-			if (messageElement) {
-				messageElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-			}
+			setTimeout(() => {
+				const messageElement = document.getElementById(`message-${message.id}`);
+				if (messageElement) {
+					messageElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				}
+			}, 0);
 		}
 
 		await tick();

--- a/src/lib/components/chat/Overview/Flow.svelte
+++ b/src/lib/components/chat/Overview/Flow.svelte
@@ -1,7 +1,7 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
+	import { getContext } from 'svelte';
 
-	const dispatch = createEventDispatcher();
+	const i18n = getContext('i18n');
 
 	import { theme } from '$lib/stores';
 	import {
@@ -11,22 +11,23 @@
 		BackgroundVariant,
 		ControlButton
 	} from '@xyflow/svelte';
-	import BarsArrowUp from '$lib/components/icons/BarsArrowUp.svelte';
-	import Bars3BottomLeft from '$lib/components/icons/Bars3BottomLeft.svelte';
 	import AlignVertical from '$lib/components/icons/AlignVertical.svelte';
 	import AlignHorizontal from '$lib/components/icons/AlignHorizontal.svelte';
+	import Pin from '$lib/components/icons/Pin.svelte';
+	import PinSlash from '$lib/components/icons/PinSlash.svelte';
 
 	export let nodes;
 	export let nodeTypes;
 	export let edges;
 	export let setLayoutDirection;
+	export let viewportPinned = false;
+	export let onNodeClick;
 </script>
 
 <SvelteFlow
 	{nodes}
 	{nodeTypes}
 	{edges}
-	fitView
 	minZoom={0.001}
 	colorMode={$theme.includes('dark')
 		? 'dark'
@@ -37,12 +38,20 @@
 			: 'light'}
 	nodesConnectable={false}
 	nodesDraggable={false}
-	on:nodeclick={(e) => dispatch('nodeclick', e.detail)}
-	oninit={() => {
-		console.log('Flow initialized');
-	}}
+	on:nodeclick={(e) => onNodeClick?.(e.detail)}
+	oninit={() => {}}
 >
 	<Controls showLock={false}>
+		<ControlButton
+			on:click={() => (viewportPinned = !viewportPinned)}
+			title={viewportPinned ? $i18n.t('Viewport Pinned') : $i18n.t('Viewport Unpinned')}
+		>
+			{#if viewportPinned}
+				<Pin />
+			{:else}
+				<PinSlash />
+			{/if}
+		</ControlButton>
 		<ControlButton on:click={() => setLayoutDirection('vertical')} title="Vertical Layout">
 			<AlignVertical className="size-4" />
 		</ControlButton>

--- a/src/lib/components/chat/Overview/View.svelte
+++ b/src/lib/components/chat/Overview/View.svelte
@@ -1,25 +1,20 @@
 <script lang="ts">
-	import { getContext, createEventDispatcher, onDestroy } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import { useSvelteFlow, useNodesInitialized, useStore } from '@xyflow/svelte';
-
-	const dispatch = createEventDispatcher();
-	const i18n = getContext('i18n');
 
 	import { onMount, tick } from 'svelte';
 
 	import { writable } from 'svelte/store';
-	import { models, theme, user } from '$lib/stores';
+	import { models, user, chatId } from '$lib/stores';
 
 	import '@xyflow/svelte/dist/style.css';
 
 	import CustomNode from './Node.svelte';
 	import Flow from './Flow.svelte';
-	import XMark from '../../icons/XMark.svelte';
-	import ArrowLeft from '../../icons/ArrowLeft.svelte';
 
-	const { width, height } = useStore();
+	const { width, height, viewport } = useStore();
 
-	const { fitView, getViewport } = useSvelteFlow();
+	const { fitView, setViewport } = useSvelteFlow();
 	const nodesInitialized = useNodesInitialized();
 
 	export let history;
@@ -27,6 +22,10 @@
 	export let onNodeClick;
 
 	let selectedMessageId = null;
+	let viewportPinned = false;
+	let isInitialized = false;
+	let viewportSaveTimeout;
+	let unsubs = [];
 
 	const nodes = writable([]);
 	const edges = writable([]);
@@ -45,11 +44,48 @@
 		focusNode();
 	}
 
+	$: if (isInitialized) {
+		try {
+			localStorage.setItem('overviewPinned', String(viewportPinned));
+		} catch (e) {
+			console.warn('Failed to save pinned state to local storage', e);
+		}
+	}
+
+	$: if (isInitialized && $viewport && $chatId) {
+		clearTimeout(viewportSaveTimeout);
+		const vp = $viewport;
+		const id = $chatId;
+		viewportSaveTimeout = setTimeout(() => {
+			try {
+				let viewports = JSON.parse(localStorage.getItem('overviewViewports') || '{}');
+
+				// Delete and re-insert to maintain insertion order for LRU eviction
+				if (id in viewports) {
+					delete viewports[id];
+				}
+
+				viewports[id] = vp;
+
+				const keys = Object.keys(viewports);
+				if (keys.length > 50) {
+					delete viewports[keys[0]];
+				}
+
+				localStorage.setItem('overviewViewports', JSON.stringify(viewports));
+			} catch (e) {
+				console.warn('Failed to save viewport to local storage', e);
+			}
+		}, 300);
+	}
+
 	const focusNode = async () => {
-		if (selectedMessageId === null) {
-			await fitView({ nodes: [{ id: history.currentId }] });
-		} else {
-			await fitView({ nodes: [{ id: selectedMessageId }] });
+		if (isInitialized && !viewportPinned) {
+			if (selectedMessageId === null) {
+				await fitView({ nodes: [{ id: history.currentId }] });
+			} else {
+				await fitView({ nodes: [{ id: selectedMessageId }] });
+			}
 		}
 
 		selectedMessageId = null;
@@ -135,37 +171,73 @@
 
 	const setLayoutDirection = (direction) => {
 		layoutDirection = direction;
+		try {
+			localStorage.setItem('overviewLayoutDirection', direction);
+		} catch (e) {
+			console.warn('Failed to save layout direction to local storage', e);
+		}
 		drawFlow(layoutDirection);
 	};
 
 	onMount(() => {
+		try {
+			viewportPinned = localStorage.getItem('overviewPinned') === 'true';
+			layoutDirection = localStorage.getItem('overviewLayoutDirection') || 'vertical';
+		} catch (e) {
+			viewportPinned = false;
+			layoutDirection = 'vertical';
+		}
 		drawFlow(layoutDirection);
 
-		nodesInitialized.subscribe(async (initialized) => {
-			if (initialized) {
-				await tick();
-				const res = await fitView({ nodes: [{ id: history.currentId }] });
-			}
-		});
+		unsubs.push(
+			nodesInitialized.subscribe(async (initialized) => {
+				if (initialized) {
+					await tick();
+					
+					let restored = false;
+					if ($chatId) {
+						try {
+							const viewports = JSON.parse(localStorage.getItem('overviewViewports') || '{}');
+							const saved = viewports[$chatId];
 
-		width.subscribe((value) => {
-			if (value) {
-				// fitView();
-				fitView({ nodes: [{ id: history.currentId }] });
-			}
-		});
+							if (saved) {
+								const { x, y, zoom } = saved;
+								await setViewport({ x, y, zoom });
+								restored = true;
+							}
+						} catch (e) {
+							// Ignored
+						}
+					}
 
-		height.subscribe((value) => {
-			if (value) {
-				// fitView();
-				fitView({ nodes: [{ id: history.currentId }] });
-			}
-		});
+					if (!restored) {
+						await fitView({ nodes: [{ id: history.currentId }] });
+					}
+					isInitialized = true;
+				}
+			})
+		);
+
+		unsubs.push(
+			width.subscribe((value) => {
+				if (isInitialized && value && !viewportPinned) {
+					fitView({ nodes: [{ id: history.currentId }] });
+				}
+			})
+		);
+
+		unsubs.push(
+			height.subscribe((value) => {
+				if (isInitialized && value && !viewportPinned) {
+					fitView({ nodes: [{ id: history.currentId }] });
+				}
+			})
+		);
 	});
 
 	onDestroy(() => {
-		console.log('Overview destroyed');
-
+		unsubs.forEach((unsub) => unsub());
+		clearTimeout(viewportSaveTimeout);
 		nodes.set([]);
 		edges.set([]);
 	});
@@ -178,10 +250,13 @@
 			{nodeTypes}
 			{edges}
 			{setLayoutDirection}
-			on:nodeclick={(e) => {
-				onNodeClick(e.detail);
-				selectedMessageId = e.detail.node.data.message.id;
-				fitView({ nodes: [{ id: selectedMessageId }] });
+			bind:viewportPinned
+			onNodeClick={(detail) => {
+				onNodeClick?.(detail);
+				selectedMessageId = detail.node.data.message.id;
+				if (!viewportPinned) {
+					fitView({ nodes: [{ id: selectedMessageId }] });
+				}
 			}}
 		/>
 	{/if}


### PR DESCRIPTION
Introduces viewport state persistence and a pin toggle for the chat overview (tree view), along with minor fix and cleanup.

- Added a "Viewport Pinned" toggle to disable auto-focus on active node.
- Persists viewport coordinates (x, y, zoom), layout direction, and pin state to localStorage.
  - Debounced the localStorage viewport save (300ms) to prevent blocking during smooth pan/zoom gestures.
  - Structured overviewViewports cache as a self-pruning 50-item LRU to prevent unbounded storage bloat.
- Resolved an existing memory leak by properly cleaning up nodesInitialized, width, and height store subscriptions on component destroy.
- Fixed a scroll alignment bug when navigating from the Overview tree. Defers scrollIntoView to the next event loop tick (0ms) so dynamic elements can layout properly before calculating the target scroll coordinate.
- Removed unused imports.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing [Discussion](https://github.com/open-webui/open-webui/discussions/21149) — `Relates to #21149`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** N/A — no new user-facing settings or API changes.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Uses local state (`localStorage`) for ephemeral UI state (viewport position, pin preference). No new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Description

The linked [Discussion](https://github.com/open-webui/open-webui/discussions/21149) requests persistent Overview in right sidebar. While the side bar currently seems to keep open when switching between chats, the overview (tree/flow view) resets the viewport on every render. It doesn't remember pan/zoom position or layout direction. This makes it inconvenient to use on large conversation trees where you've scrolled to a specific region.

This PR introduces viewport state persistence, a pin toggle to suppress auto-focus, and fixes a subscription leak and a scroll-timing bug.

### Added

- **Viewport Pin toggle** — a pin button in the flow controls to disable auto-focus on the active node, allowing free exploration of the conversation tree.
- **Viewport persistence** — pan/zoom coordinates are saved to `localStorage` per chat, with a debounced (300ms) write and a self-pruning 50-entry LRU cache.
- **Layout direction persistence** — the chosen layout direction (vertical/horizontal) is remembered across sessions.

### Changed

- `Flow.svelte` now uses a callback prop (`onNodeClick`) instead of Svelte event dispatching (`createEventDispatcher` / `on:nodeclick`).
- The `fitView` attribute was removed from `<SvelteFlow>` — the parent now controls view initialization to support viewport restore.

### Fixed

- **Memory leak** — `nodesInitialized`, `width`, and `height` store subscriptions are now properly unsubscribed in `onDestroy`.
- **Scroll alignment bug** — `scrollIntoView` after navigating from the overview tree is now deferred to the next event-loop tick (`setTimeout(…, 0)`) so dynamically rendered elements can complete layout before the scroll offset is calculated.

### Removed

- Unused imports
- `console.log('Overview destroyed')` and `console.log('Flow initialized')`.

### Security

- N/A

### Breaking Changes

- None

---

### Additional Information

- None

### Screenshots or Videos

[Screencast_20260604_233305.webm](https://github.com/user-attachments/assets/6f2b95ef-6974-484e-8dbc-e66210dd5bf2)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
