### PR TITLE
fix: restrict paddleocr_vl loader to PDF and image file types

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -530,7 +530,11 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
             )
-        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
+        elif (
+            self.engine == 'paddleocr_vl'
+            and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
+            and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
+        ):
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),


### PR DESCRIPTION
﻿## Summary

`Loader.load()` in `backend/open_webui/retrieval/loaders/main.py` routes
files to `PaddleOCRVLLoader` based only on the engine name and the
presence of an API token — it has no file-extension guard.

PaddleOCR only processes PDF and image files. When a non-PDF/image (e.g.
`.md`, `.txt`, `.csv`) is uploaded with `paddleocr_vl` set as the loader
engine, the file is sent to PaddleOCR's `/layout-parsing` endpoint, which
returns `422 Unprocessable Entity`.

Other OCR loaders already include the guard:
- `mineru`: `file_ext in self.kwargs.get('MINERU_FILE_EXTENSIONS', ['pdf'])`
- `mistral_ocr`: `file_ext in ['pdf']`

**Fix:** add the same pattern to the `paddleocr_vl` branch, limiting it
to the file types `PaddleOCRVLLoader` itself recognises (its own
`image_extensions` list is `['png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']`
plus PDF):

```python
# Before
elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':

# After
elif (
    self.engine == 'paddleocr_vl'
    and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
    and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
):
```

Unsupported file types now fall through to the standard text/document
loaders, matching the behaviour users expect.

Fixes #24988
