### PR TITLE
fix: default content=false for file list and search endpoints

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -380,7 +380,7 @@ PAGE_SIZE = 50
 async def list_files(
     user=Depends(get_verified_user),
     page: int = Query(1, ge=1, description='Page number (1-indexed)'),
-    content: bool = Query(True),
+    content: bool = Query(False),
     db: AsyncSession = Depends(get_async_session),
 ):
     skip = (page - 1) * PAGE_SIZE
@@ -407,7 +407,7 @@ async def search_files(
         ...,
         description="Filename pattern to search for. Supports wildcards such as '*.txt'",
     ),
-    content: bool = Query(True),
+    content: bool = Query(False),
     skip: int = Query(0, ge=0, description='Number of files to skip'),
     limit: int = Query(100, ge=1, le=1000, description='Maximum number of files to return'),
     user=Depends(get_verified_user),


### PR DESCRIPTION
﻿## Summary

`GET /api/v1/files/` and `GET /api/v1/files/search` both defaulted the
`content` query parameter to `True`, which caused the full extracted
text of every listed file to be serialized into the response.

On instances with many large documents this produces massive list
responses. The reporter measured **~64 MB** for 165 files from the
Attach-files picker, which calls `/api/v1/files/search` without any
`content` flag.

The `content` flag already existed and worked correctly when passed
explicitly (`?content=false` returned only 27 KB in the reporter's
test). The only change here is flipping the default from `True` to
`False` so clients that don't need the full extracted text get a
lightweight metadata-only response:

```python
# Before (both endpoints)
content: bool = Query(True)

# After
content: bool = Query(False)
```

Callers that need the full content can still pass `?content=true`.
The strip logic (`del file.data['content']`) is unchanged.

Fixes #25741
