### PR TITLE
fix: restore request-scoped web search source retrieval

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1374,6 +1374,23 @@ async def get_sources_from_items(
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
+        elif item.get('type') == 'web_search':
+            web_search_collection_names = []
+            if item.get('collection_name'):
+                web_search_collection_names.append(item['collection_name'])
+            if item.get('collection_names'):
+                web_search_collection_names.extend(item['collection_names'])
+
+            allowed_web_search_collection_names = getattr(
+                getattr(request, 'state', None),
+                'web_search_collection_names',
+                set(),
+            )
+            collection_names.extend(
+                name
+                for name in web_search_collection_names
+                if isinstance(name, str) and name in allowed_web_search_collection_names
+            )
         elif item.get('collection_name'):
             if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                 collection_names.append(item['collection_name'])

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1595,7 +1595,11 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
             files = form_data.get('files', [])
 
             if results.get('collection_names'):
+                web_search_collection_names = set(
+                    getattr(request.state, 'web_search_collection_names', set())
+                )
                 for col_idx, collection_name in enumerate(results.get('collection_names')):
+                    web_search_collection_names.add(collection_name)
                     files.append(
                         {
                             'collection_name': collection_name,
@@ -1605,6 +1609,7 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
                             'queries': queries,
                         }
                     )
+                request.state.web_search_collection_names = web_search_collection_names
             elif results.get('docs'):
                 # Invoked when bypass embedding and retrieval is set to True
                 docs = results['docs']


### PR DESCRIPTION
## Summary

This restores the non-bypass Web Search RAG path for temporary `web-search-*` collections.

In v0.9.6, web search can successfully:

- return search result items,
- load web pages,
- generate embeddings,
- save documents into a temporary `web-search-*` vector collection,

but still produce `sources_retrieved` with `count: 0` and no assistant citations when `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=false`.

The missing piece is that `chat_web_search_handler()` attaches the temporary collection as a `type: "web_search"` item, but `get_sources_from_items()` does not have a dedicated `web_search` branch. The item can then fall through to the untrusted direct `collection_name` path and be ignored after retrieval access-control hardening.

## Fix

- Record web-search collection names created by `chat_web_search_handler()` on `request.state`.
- Teach `get_sources_from_items()` to resolve `type: "web_search"` items only when their collection name was created by the same server-side request.
- Keep the existing `item.get("docs")` bypass path ahead of the new branch, so `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true` behavior is unchanged.
- Keep normal `filter_accessible_collections()` validation in the downstream retrieval flow.

This follows the safer request-scoped approach discussed in #25654 while addressing the open confirmed regression in #25585. It is intentionally narrower than allowing arbitrary client-supplied `web-search-*` collection names.

## Testing

- `python3 -m py_compile backend/open_webui/retrieval/utils.py backend/open_webui/utils/middleware.py`
- `git diff --check`

## Related

- Fixes #25585
- Related to #25600
- Related to #25654

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
