### PR TITLE
fix: guard against null timings field in streaming response

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4070,7 +4070,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                                     # Normalize usage data to standard format
                                     raw_usage = data.get('usage', {}) or {}
-                                    raw_usage.update(data.get('timings', {}))  # llama.cpp
+                                    raw_usage.update(data.get('timings', {}) or {})
                                     if raw_usage:
                                         usage = normalize_usage(raw_usage)
                                         await event_emitter(


### PR DESCRIPTION
Fixes #25753

`data.get("timings", {})` returns `None` when the key exists but value is `null` in JSON. `dict.update(None)` raises `TypeError`, which is silently caught, resulting in empty saved messages.

Added `or {}` guard, consistent with the `usage` field on the line above.

# Contributor License Agreement

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**