### PR TITLE
fix: guard against null timings field in streaming response

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4070,7 +4070,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                                     # Normalize usage data to standard format
                                     raw_usage = data.get('usage', {}) or {}
-                                    raw_usage.update(data.get('timings', {}))  # llama.cpp
+                                    raw_usage.update(data.get('timings', {}) or {})
                                     if raw_usage:
                                         usage = normalize_usage(raw_usage)
                                         await event_emitter(


### PR DESCRIPTION
Fixes #25753

`data.get("timings", {})` returns `None` when the key exists but value is `null` in JSON. `dict.update(None)` raises `TypeError`, which is silently caught, resulting in empty saved messages.

Added `or {}` guard, consistent with the `usage` field on the line above.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.