### PR TITLE
fix: remove orphaned image nodes when files deleted from controls

### DIFF
--- a/src/lib/components/common/RichTextInput/Image/image.ts
+++ b/src/lib/components/common/RichTextInput/Image/image.ts
@@ -149,10 +149,10 @@ export const Image = Node.create<ImageOptions>({
 			img.setAttribute('alt', node.attrs.alt || '');
 			img.setAttribute('title', node.attrs.title || '');
 
-			img.addEventListener('data', (e) => {
-				const files = e?.files || [];
-				if (files && node.attrs.src.startsWith('data://')) {
-					const file = editorFiles.find((f) => f.id === fileId);
+			img.addEventListener('data', () => {
+				const currentFiles = editor.storage?.files || [];
+				if (node.attrs.src.startsWith('data://')) {
+					const file = currentFiles.find((f) => f.id === fileId);
 					if (file) {
 						img.setAttribute('src', safeImageUrl(file.url || ''));
 					} else {

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -1438,7 +1438,45 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 				bind:show={showPanel}
 				bind:selectedModelId
 				bind:files
-				onUpdate={() => {
+				onUpdate={(updatedFiles) => {
+					if (editor) {
+						editor.storage.files = updatedFiles;
+
+						// Remove orphaned image nodes whose files were deleted
+						const fileIds = new Set(updatedFiles.map((f) => f.id));
+						const { state } = editor;
+						const nodesToRemove = [];
+
+						state.doc.descendants((node, pos) => {
+							if (node.type.name === 'image' && node.attrs.src?.startsWith('data://')) {
+								const refId = node.attrs.src.replace('data://', '');
+								if (!fileIds.has(refId)) {
+									nodesToRemove.push({ from: pos, to: pos + node.nodeSize });
+								}
+							}
+						});
+
+						if (nodesToRemove.length > 0) {
+							// Delete in reverse order to preserve positions
+							let tr = state.tr;
+							for (let i = nodesToRemove.length - 1; i >= 0; i--) {
+								tr = tr.delete(nodesToRemove[i].from, nodesToRemove[i].to);
+							}
+							editor.view.dispatch(tr);
+						}
+
+						// Refresh remaining image nodes
+						for (const file of updatedFiles) {
+							if (file.type === 'image' || (file?.content_type ?? '').startsWith('image/')) {
+								const img = document.getElementById(`image:${file.id}`);
+								if (img) {
+									img.dispatchEvent(new CustomEvent('data'));
+								}
+							}
+						}
+					}
+
+					note.data.files = updatedFiles.length > 0 ? updatedFiles : null;
 					changeDebounceHandler();
 				}}
 			/>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

When an image is pasted into a note and then removed from the Controls panel, the image node in the TipTap editor was not being cleaned up. The orphaned node would display a broken placeholder icon (`/image-placeholder.png`) instead of the actual image or being removed entirely. This happened because:

1. **`editor.storage.files` was not synced** when files were removed via the Controls panel — it was only synced during upload (`inputFileHandler`) and socket events (`noteEventHandler`), but not on removal.
2. **The image node view's `data` event listener used a stale closure** — it captured `editorFiles` at node creation time and never read the updated `editor.storage.files`, so even if storage was updated, already-rendered images wouldn't reflect the change.
3. **Orphaned image nodes were never removed from the editor document** — only the file entry was removed from the `files[]` array, leaving behind `<img src="data://[deleted-id]">` nodes in the ProseMirror document.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Fix orphaned image placeholder appearing in note editor after removing an image from the Controls panel
- Sync `editor.storage.files` in the Controls `onUpdate` callback so the editor's file list stays current
- Remove orphaned image nodes from the TipTap document when their corresponding file is deleted from Controls
- Fix stale closure in the image node view's `data` event listener to read from `editor.storage.files` at dispatch time instead of a captured reference from node creation

### Files Changed

- `src/lib/components/common/RichTextInput/Image/image.ts` — Fixed stale closure in `data` event listener; now reads live `editor.storage.files` instead of captured `editorFiles`
- `src/lib/components/notes/NoteEditor.svelte` — Enhanced `onUpdate` callback on the Controls component to sync `editor.storage.files`, walk the ProseMirror document to remove orphaned image nodes, refresh remaining image nodes via `data` events, and update `note.data.files`

---

### Additional Information

- No new dependencies introduced
- Build passes cleanly (`npm run build`)
- Formatting verified (`npm run format`)
- The fix follows the existing pattern used in `noteEventHandler` (L804–816) for syncing `editor.storage.files` and dispatching `data` events to image nodes

### Screenshots or Videos

## Before:

<img width="2340" height="1281" alt="image" src="https://github.com/user-attachments/assets/b28e7c9e-1622-41bc-ad3c-8c1ce0a30409" />

## After:

<img width="2340" height="1281" alt="image" src="https://github.com/user-attachments/assets/326cb96a-5e2a-465f-ae55-d9e8eb175c54" />

### Manual Verification Performed

1. Create a new note
2. Paste an image into the note editor — confirm it renders correctly
3. Open the Controls panel — confirm the image appears in the file list
4. Click dismiss/remove on the image in the Controls panel
5. **Expected (after fix):** The image node is removed from the editor content; no placeholder icon appears
6. **Before fix:** The image node remained with a broken placeholder icon (when you leave the note and revisit it again)
7. Paste another image — confirm it renders correctly (regression check)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
