### PR TITLE
fix: scope Socket.IO event-caller to the requesting user's own session

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1015,9 +1015,10 @@ async def get_event_call(request_info):
     async def __event_caller__(event_data):
         session_id = request_info['session_id']
 
-        # Fast-fail if the client has disconnected.
-        if session_id not in SESSION_POOL:
-            log.warning(f'Event caller: session {session_id} no longer connected')
+        # session_id is client-supplied; only the requesting user's own live session may be targeted.
+        session = SESSION_POOL.get(session_id)
+        if session is None or session.get('id') != request_info.get('user_id'):
+            log.warning(f'Event caller: session {session_id} not owned by requesting user or disconnected')
             return {'error': 'Client session disconnected.'}
 
         try:


### PR DESCRIPTION
get_event_call() routed execute:python / execute:tool events to a client-supplied session_id after only checking the session was connected, not that it belonged to the requester. Verify the target session is owned by the requesting user (metadata user_id) before delivering, so a client cannot route code/tool execution into another user's session.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
