### PR TITLE
fix: prevent secrets in Loguru tracebacks

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -185,6 +185,7 @@ def start_logger():
             level=GLOBAL_LOG_LEVEL,
             format=stdout_format,
             filter=audit_filter,
+            diagnose=False,  # Prevent local variable values from leaking through tracebacks.
         )
     if AUDIT_LOG_LEVEL != 'NONE' and ENABLE_AUDIT_LOGS_FILE:
         try:

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_logger_module(monkeypatch):
+    env = types.ModuleType('open_webui.env')
+    env._LEVEL_MAP = {}
+    env.AUDIT_LOG_FILE_ROTATION_SIZE = '10 MB'
+    env.AUDIT_LOG_LEVEL = 'NONE'
+    env.AUDIT_LOGS_FILE_PATH = 'audit.log'
+    env.AUDIT_UVICORN_LOGGER_NAMES = []
+    env.ENABLE_AUDIT_LOGS_FILE = False
+    env.ENABLE_AUDIT_STDOUT = False
+    env.ENABLE_OTEL = False
+    env.ENABLE_OTEL_LOGS = False
+    env.GLOBAL_LOG_LEVEL = 'INFO'
+    env.LOG_FORMAT = ''
+
+    package = types.ModuleType('open_webui')
+    package.__path__ = []
+    monkeypatch.setitem(sys.modules, 'open_webui', package)
+    monkeypatch.setitem(sys.modules, 'open_webui.env', env)
+
+    logger_path = Path(__file__).parents[1] / 'backend/open_webui/utils/logger.py'
+    spec = importlib.util.spec_from_file_location('test_logger_module', logger_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_text_logs_do_not_include_exception_frame_values(monkeypatch, capsys):
+    logger_module = _load_logger_module(monkeypatch)
+    secret = 'test-api-key-that-must-not-be-logged'
+
+    def raise_request_error(_request):
+        raise RuntimeError('request failed')
+
+    def send_request():
+        http_request = {'headers': {'x-api-key': secret}}
+        raise_request_error(http_request)
+
+    logger_module.start_logger()
+    try:
+        try:
+            send_request()
+        except RuntimeError:
+            logger_module.logger.exception('Upstream request failed')
+
+        output = capsys.readouterr().out
+        assert 'send_request' in output
+        assert 'RuntimeError: request failed' in output
+        assert secret not in output
+    finally:
+        logger_module.logger.remove()


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #25767
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this logging security fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** An automated regression test verifies traceback context remains while frame values are hidden.
- [ ] **No Unchecked AI Code:** Please complete after human review and manual testing.
- [x] **Self-Review:** The diff was reviewed for scope and repository style.
- [x] **Architecture:** This uses Loguru's supported sink configuration without adding settings.
- [x] **Git Hygiene:** The PR is atomic and based on `dev`.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Loguru text sinks default to `diagnose=True`, which renders values from exception frames. Request objects can contain sensitive headers such as API keys, causing secrets to appear in stack traces regardless of the configured log level.

This change disables diagnostic variable rendering for the human-readable stdout sink while retaining traceback function and exception context. It also adds a regression test using a simulated API key.

## Validation

- `python3 -m pytest -q test/test_logger.py`
- `python3 -m py_compile backend/open_webui/utils/logger.py test/test_logger.py`
- `python3 -m ruff format --check backend/open_webui/utils/logger.py test/test_logger.py`
- Targeted Ruff checks pass; the existing logger file has unrelated pre-existing `E501` and `E731` findings.

# Changelog Entry

### Security

- Prevent exception tracebacks from exposing local variable values, including secrets in request headers.

### Fixed

- Preserve useful traceback context without Loguru diagnostic value rendering.

---

### Additional Information

Fixes #25767

### Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.