### PR TITLE
fix: request file list/search without extracted content by default

### DIFF
--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -145,10 +145,13 @@ export const uploadDir = async (token: string) => {
 	return res;
 };
 
-export const getFiles = async (token: string = '') => {
+export const getFiles = async (token: string = '', content: boolean = false) => {
 	let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/files/`, {
+	const searchParams = new URLSearchParams();
+	searchParams.append('content', String(content));
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/files/?${searchParams.toString()}`, {
 		method: 'GET',
 		headers: {
 			Accept: 'application/json',
@@ -180,7 +183,8 @@ export const searchFiles = async (
 	token: string,
 	filename: string = '*',
 	skip: number = 0,
-	limit: number = 50
+	limit: number = 50,
+	content: boolean = false
 ) => {
 	let error = null;
 
@@ -188,6 +192,7 @@ export const searchFiles = async (
 	searchParams.append('filename', filename);
 	searchParams.append('skip', String(skip));
 	searchParams.append('limit', String(limit));
+	searchParams.append('content', String(content));
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/files/search?${searchParams.toString()}`, {
 		method: 'GET',


### PR DESCRIPTION
The file picker and Files modal only render filenames and metadata, but searchFiles()/getFiles() never passed content=false, so the backend serialized data.content (full extracted text) of every file into each response. On instances with many large documents this turns a metadata list into tens of MB per request, re-issued on every picker keystroke.

The backend already supports content=false on GET /files/ and GET /files/search; this just makes the list/search callers opt out of the payload by default. The param stays overridable for callers that need it.


Fixes #25741

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
