### PR TITLE
chore: Escape voice-derived attributes in Azure TTS SSML

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -467,8 +467,8 @@ async def _tts_azure(request, payload, file_path, file_body_path, user):
     output_format = request.app.state.config.TTS_AZURE_SPEECH_OUTPUT_FORMAT
 
     ssml = (
-        f'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="{locale}">'
-        f'<voice name="{language}">{html.escape(payload["input"])}</voice>'
+        f'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="{html.escape(locale)}">'
+        f'<voice name="{html.escape(language)}">{html.escape(payload["input"])}</voice>'
         f'</speak>'
     )
 


### PR DESCRIPTION
The Azure TTS handler (_tts_azure) interpolated the user-supplied voice, and the locale derived from it, into the SSML xml:lang and <voice name> attributes without XML-escaping, while the text body was already escaped (2e75c6dbd). Escape both attributes too, so every user-derived value in the SSML document is consistently encoded.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
