### PR TITLE
fix: disable Loguru variable diagnostics

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -178,6 +178,8 @@ def start_logger():
             _json_sink,
             level=GLOBAL_LOG_LEVEL,
             filter=audit_filter,
+            backtrace=True,
+            diagnose=False,
         )
     else:
         logger.add(
@@ -185,6 +187,8 @@ def start_logger():
             level=GLOBAL_LOG_LEVEL,
             format=stdout_format,
             filter=audit_filter,
+            backtrace=True,
+            diagnose=False,
         )
     if AUDIT_LOG_LEVEL != 'NONE' and ENABLE_AUDIT_LOGS_FILE:
         try:

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock
+
+from open_webui.utils import logger as logger_module
+
+
+def test_start_logger_disables_loguru_diagnose_for_stdout(monkeypatch):
+    add = Mock(return_value=1)
+
+    monkeypatch.setattr(logger_module, 'LOG_FORMAT', '')
+    monkeypatch.setattr(logger_module, 'AUDIT_LOG_LEVEL', 'NONE')
+    monkeypatch.setattr(logger_module.logger, 'add', add)
+    monkeypatch.setattr(logger_module.logger, 'remove', Mock())
+    monkeypatch.setattr(logger_module.logger, 'info', Mock())
+
+    logger_module.start_logger()
+
+    stdout_sink = add.call_args_list[0]
+    assert stdout_sink.kwargs['diagnose'] is False


### PR DESCRIPTION
Fixes #25767.

## Summary
- disable Loguru variable diagnostics for stdout and JSON sinks
- keep extended backtraces while avoiding local variable dumps that may contain secrets
- add a focused logger configuration regression test

## Tests
- `WEBUI_SECRET_KEY=test-secret PYTHONPATH=backend .venv/bin/python -m pytest test/test_logger.py -q`
- `.venv/bin/python -m ruff format --check backend/open_webui/utils/logger.py test/test_logger.py`
- `.venv/bin/python -m ruff check --select F backend/open_webui/utils/logger.py test/test_logger.py`
- `git diff --check HEAD^ HEAD`