### PR TITLE
fix: repair Mistral OCR async upload (aiohttp.streams.FilePayload removed)

### DIFF
--- a/backend/open_webui/retrieval/loaders/mistral.py
+++ b/backend/open_webui/retrieval/loaders/mistral.py
@@ -261,33 +261,32 @@ class MistralLoader:
         url = f'{self.base_url}/files'
 
         async def upload_request():
-            # Create multipart writer for streaming upload
-            writer = aiohttp.MultipartWriter('form-data')
+            # Open inside the request so the handle stays valid for the whole
+            # streamed POST and is closed right after.
+            with open(self.file_path, 'rb') as f:
+                writer = aiohttp.MultipartWriter('form-data')
 
-            # Add purpose field
-            purpose_part = writer.append('ocr')
-            purpose_part.set_content_disposition('form-data', name='purpose')
+                # Add purpose field
+                purpose_part = writer.append('ocr')
+                purpose_part.set_content_disposition('form-data', name='purpose')
 
-            # Add file part with streaming
-            file_part = writer.append_payload(
-                aiohttp.streams.FilePayload(
-                    self.file_path,
-                    filename=self.file_name,
-                    content_type='application/pdf',
-                )
-            )
-            file_part.set_content_disposition('form-data', name='file', filename=self.file_name)
+                # Stream the file. aiohttp builds a payload from the file object;
+                # the previous aiohttp.streams.FilePayload was removed upstream
+                # (payloads live in aiohttp.payload and there is no FilePayload),
+                # so this path raised AttributeError on every async OCR upload.
+                file_part = writer.append(f, {'Content-Type': 'application/pdf'})
+                file_part.set_content_disposition('form-data', name='file', filename=self.file_name)
 
-            self._debug_log(f'Uploading file: {self.file_name} ({self.file_size:,} bytes)')
+                self._debug_log(f'Uploading file: {self.file_name} ({self.file_size:,} bytes)')
 
-            async with session.post(
-                url,
-                data=writer,
-                headers=self.headers,
-                timeout=aiohttp.ClientTimeout(total=self.upload_timeout),
-                ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            ) as response:
-                return await self._handle_response_async(response)
+                async with session.post(
+                    url,
+                    data=writer,
+                    headers=self.headers,
+                    timeout=aiohttp.ClientTimeout(total=self.upload_timeout),
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                ) as response:
+                    return await self._handle_response_async(response)
 
         response_data = await self._retry_request_async(upload_request)
 


### PR DESCRIPTION
_upload_file_async built its multipart body with
`aiohttp.streams.FilePayload(...)`, which no longer exists in aiohttp (payload classes live in aiohttp.payload, and there is no FilePayload). The reference sits inside a lazy closure, so import succeeds and only the async Mistral OCR file-upload path blows up at runtime with AttributeError on every call.

Mirror the working sync path: open the file in a context manager and let MultipartWriter.append(file_obj, {...}) build a streaming BufferedReaderPayload, with the POST issued inside the open() block so the handle stays valid for the whole upload. Preserves the streaming / memory-efficiency intent.

Found via the dependency-contract test suite (unit/deps/test_aiohttp.py), which pins aiohttp.streams.FilePayload as absent.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
