### PR TITLE
fix: chroma has_collection always returns False (name vs Collection)

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -57,7 +57,11 @@ class ChromaClient(VectorDBBase):
 
     def has_collection(self, collection_name: str) -> bool:
         # Check if the collection exists based on the collection name.
-        collection_names = self.client.list_collections()
+        # chromadb's list_collections() returns Collection objects (1.x), so a
+        # bare `name in collections` membership test is always False — compare
+        # against the names. (hasattr guard tolerates versions that yield names.)
+        collections = self.client.list_collections()
+        collection_names = [c.name if hasattr(c, 'name') else c for c in collections]
         return collection_name in collection_names
 
     def delete_collection(self, collection_name: str):


### PR DESCRIPTION
has_collection did `collection_name in self.client.list_collections()`, but chromadb's list_collections() returns Collection objects (1.x), not name strings — so the membership test is always False, even when the collection exists. Compare against the collection names instead (with a hasattr guard tolerating versions that yield plain names).

Found via the dependency-contract test suite (unit/deps/test_chromadb.py).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
