### PR TITLE
fix: per-user model cache used static key= (cross-user model exposure)

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -301,7 +301,9 @@ def _resolve_api_config(request: Request, idx: int, url: str) -> dict:
 
 @cached(
     ttl=MODELS_CACHE_TTL,
-    key=lambda _, user: f'ollama_all_models_{user.id}' if user else 'ollama_all_models',
+    # key_builder (not key) is the per-call hook in aiocache 0.12; `key=` is a
+    # static key, so a `key=lambda` collapsed every caller to one shared entry.
+    key_builder=lambda _func, request, user=None: f'ollama_all_models_{user.id}' if user else 'ollama_all_models',
 )
 async def get_all_models(request: Request, user: UserModel | None = None):
     """Aggregate model tags from every enabled Ollama backend."""

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -487,7 +487,9 @@ async def get_filtered_models(models, user, db=None):
 
 @cached(
     ttl=MODELS_CACHE_TTL,
-    key=lambda _, user: f'openai_all_models_{user.id}' if user else 'openai_all_models',
+    # key_builder (not key) is the per-call hook in aiocache 0.12; `key=` is a
+    # static key, so a `key=lambda` collapsed every caller to one shared entry.
+    key_builder=lambda _func, request, user=None: f'openai_all_models_{user.id}' if user else 'openai_all_models',
 )
 async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
     log.info('get_all_models()')


### PR DESCRIPTION
routers/openai.py and routers/ollama.py decorated get_all_models with `@cached(key=lambda _, user: ...)`. In aiocache 0.12, `key=` is a STATIC cache key: get_cache_key returns `self.key` verbatim (the lambda object) without calling it, so every caller collides to ONE shared entry within the TTL. The intended per-user namespacing never happened — one user's permission-filtered model list could be served to another user (or an anonymous caller) during the cache window.

The per-call hook is `key_builder=` (called as key_builder(func, *args, **kwargs)). Switch both sites to key_builder with a (func, request, user=None) signature so the key is built per call. user=None mirrors ollama's optional-user signature and stays correct whether user is passed positionally, as a kwarg, or omitted.

Verified offline: old form returns the same key object for distinct users (collision); new form yields distinct openai_all_models_<id> / ollama_all_models_<id> keys, and the unauthenticated base key when no user. These two were the only @cached(key=lambda ...) sites in the backend.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
