### PR TITLE
refac(telemetry): drop deprecated semconv SpanAttributes subclass

### DIFF
--- a/backend/open_webui/utils/telemetry/constants.py
+++ b/backend/open_webui/utils/telemetry/constants.py
@@ -1,4 +1,9 @@
-from opentelemetry.semconv.trace import SpanAttributes as _SpanAttributes
+from opentelemetry.semconv._incubating.attributes import (
+    db_attributes as _db,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    http_attributes as _http,
+)
 
 # Span Tags
 SPAN_DB_TYPE = 'mysql'
@@ -9,11 +14,29 @@ SPAN_SQL_EXPLAIN = 'explain'
 SPAN_ERROR_TYPE = 'error'
 
 
-class SpanAttributes(_SpanAttributes):
-    """
-    Span Attributes
+class SpanAttributes:
+    """Span attribute keys used by the telemetry instrumentors.
+
+    Legacy semconv keys (http.* and db.*) are sourced from the `_incubating`
+    attribute modules, which still define these exact string values.
+    `opentelemetry.semconv.trace.SpanAttributes` (previously subclassed here)
+    is deprecated since semconv 1.25.0, and the *stable* http module renamed
+    the keys (e.g. `http.request.method`), so only the incubating module keeps
+    the original `http.method` / `http.url` / `http.status_code` / `db.*` values.
+    Sourcing from it keeps emitted span attribute keys unchanged.
     """
 
+    # HTTP — legacy keys retained in the incubating module
+    HTTP_URL = _http.HTTP_URL  # 'http.url'
+    HTTP_METHOD = _http.HTTP_METHOD  # 'http.method'
+    HTTP_STATUS_CODE = _http.HTTP_STATUS_CODE  # 'http.status_code'
+
+    # DB — incubating semconv keys
+    DB_NAME = _db.DB_NAME  # 'db.name'
+    DB_STATEMENT = _db.DB_STATEMENT  # 'db.statement'
+    DB_OPERATION = _db.DB_OPERATION  # 'db.operation'
+
+    # Open WebUI custom keys (not part of semconv)
     DB_INSTANCE = 'db.instance'
     DB_TYPE = 'db.type'
     DB_IP = 'db.ip'


### PR DESCRIPTION
constants.py subclassed opentelemetry.semconv.trace.SpanAttributes, which is deprecated since semconv 1.25.0 (emits a DeprecationWarning; the pinned 0.63b1 has it live). Source the legacy span-attribute keys from the non-deprecated _incubating attribute modules instead:
  http.url / http.method / http.status_code  <- _incubating http_attributes
  db.name / db.statement / db.operation      <- _incubating db_attributes
The stable http module renamed these (http.request.method, ...), so only
the incubating module preserves the original values. Custom keys
(db.instance/type/ip/port, error.*, result.*) stay literals.

Verified: emitted attribute keys are byte-identical before/after for every key instrumentors.py reads, and importing constants no longer emits a DeprecationWarning.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
