### PR TITLE
feat: add Edit option to prompts 3-dots menu

### DIFF
--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -468,6 +468,9 @@
 									</button>
 								</Tooltip>
 								<PromptMenu
+									editHandler={() => {
+										goto(`/workspace/prompts/${prompt.id}`);
+									}}
 									shareHandler={() => {
 										shareHandler(prompt);
 									}}

--- a/src/lib/components/workspace/Prompts/PromptMenu.svelte
+++ b/src/lib/components/workspace/Prompts/PromptMenu.svelte
@@ -11,6 +11,7 @@
 
 	const i18n = getContext('i18n');
 
+	export let editHandler: Function;
 	export let shareHandler: Function;
 	export let cloneHandler: Function;
 	export let exportHandler: Function;
@@ -34,11 +35,37 @@
 
 	<div slot="content">
 		<div
-			class="min-w-[170px] rounded-2xl p-1 border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg"
+			class="min-w-[170px] rounded-2xl px-1 py-1 border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg"
 		>
+			<button
+				class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+				draggable="false"
+				on:click={() => {
+					editHandler();
+				}}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="w-4 h-4"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125"
+					/>
+				</svg>
+
+				<div class="flex items-center">{$i18n.t('Edit')}</div>
+			</button>
+
 			{#if $config.features.enable_community_sharing}
 				<button
 					class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+					draggable="false"
 					on:click={() => {
 						shareHandler();
 					}}
@@ -50,6 +77,7 @@
 
 			<button
 				class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+				draggable="false"
 				on:click={() => {
 					cloneHandler();
 				}}
@@ -61,6 +89,7 @@
 			{#if $user?.role === 'admin' || $user?.permissions?.workspace?.prompts_export}
 				<button
 					class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+					draggable="false"
 					on:click={() => {
 						exportHandler();
 					}}
@@ -74,6 +103,7 @@
 
 			<button
 				class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+				draggable="false"
 				on:click={() => {
 					deleteHandler();
 				}}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** N/A — this is a minor UI consistency fix submitted by a regular contributor.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a frontend-only UI fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or architectural changes — this mirrors the existing `ToolMenu` pattern.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

The Prompts page 3-dots (overflow) menu is missing an "Edit" option that exists in the equivalent Tools page menu. This creates an inconsistency in the Workspace UI. While clicking the prompt row itself navigates to the edit page, users who rely on the dropdown menu to access actions have no explicit "Edit" entry.

This PR adds an "Edit" menu item to `PromptMenu`, positioned as the first item — matching the order and styling of `ToolMenu`. It navigates to the existing `/workspace/prompts/{id}` edit route.

### Fixed

- Added missing "Edit" option to the Prompts page 3-dots dropdown menu, matching the Tools page menu for UI consistency
- Added `draggable="false"` to all `PromptMenu` dropdown buttons for consistency with `ToolMenu`

# Changelog Entry

### Additional Information

**Files changed (2):**
- `src/lib/components/workspace/Prompts/PromptMenu.svelte` — Added `editHandler` prop and Edit button with pencil icon (identical SVG to `ToolMenu`)
- `src/lib/components/workspace/Prompts.svelte` — Wired up `editHandler` to navigate to `/workspace/prompts/${prompt.id}`

### Screenshots or Videos

## Before: Prompts menu shows Share, Clone, Export, Delete (no Edit)

<img width="1256" height="243" alt="image" src="https://github.com/user-attachments/assets/5c5e1b6f-dbfb-4ae7-b094-bb7d1216eeeb" />

## After: Prompts menu shows Edit, Share, Clone, Export, Delete (matches Tools)

<img width="1256" height="262" alt="image" src="https://github.com/user-attachments/assets/00edf85c-fa3d-4ec4-ab79-b1f3d1ad1bcb" />

### 3-dots menu options for `Tools`, for reference

<img width="1303" height="427" alt="image" src="https://github.com/user-attachments/assets/1d5b39e1-2513-46a1-b91a-788b46a5a5f0" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
