### PR TITLE
feat: add Clone option to automations 3-dots menu

### DIFF
--- a/src/lib/components/AutomationModal.svelte
+++ b/src/lib/components/AutomationModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, tick } from 'svelte';
 	import { toast } from 'svelte-sonner';
 
 	import Modal from '$lib/components/common/Modal.svelte';
@@ -21,6 +21,7 @@
 
 	export let show = false;
 	export let automation: AutomationResponse | null = null;
+	export let cloneFrom: AutomationResponse | null = null;
 
 	let name = '';
 	let prompt = '';
@@ -75,6 +76,8 @@
 	};
 
 	const init = async () => {
+		await tick();
+
 		if (automation) {
 			name = automation.name;
 			prompt = automation.data.prompt;
@@ -82,6 +85,14 @@
 			is_active = automation.is_active;
 			if (scheduleDropdown) {
 				scheduleDropdown.parseRrule(automation.data.rrule);
+			}
+		} else if (cloneFrom) {
+			name = cloneFrom.name;
+			prompt = cloneFrom.data.prompt;
+			model_id = cloneFrom.data.model_id;
+			is_active = true;
+			if (scheduleDropdown) {
+				scheduleDropdown.parseRrule(cloneFrom.data.rrule);
 			}
 		} else {
 			name = '';

--- a/src/lib/components/automations/AutomationMenu.svelte
+++ b/src/lib/components/automations/AutomationMenu.svelte
@@ -3,11 +3,13 @@
 
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
+	import DocumentDuplicate from '$lib/components/icons/DocumentDuplicate.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
 	const i18n = getContext('i18n');
 
 	export let editHandler: Function;
+	export let cloneHandler: Function;
 	export let runHandler: Function = () => {};
 	export let deleteHandler: Function;
 	export let onClose: Function = () => {};
@@ -55,6 +57,18 @@
 				</svg>
 
 				<div class="flex items-center">{$i18n.t('Edit')}</div>
+			</button>
+
+			<button
+				class="select-none flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full"
+				draggable="false"
+				on:click={() => {
+					cloneHandler();
+					show = false;
+				}}
+			>
+				<DocumentDuplicate />
+				<div class="flex items-center">{$i18n.t('Clone')}</div>
 			</button>
 
 			<button

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -40,6 +40,7 @@
 	let loading = false;
 
 	let showCreateModal = false;
+	let cloneFrom: AutomationResponse | null = null;
 
 	let showDeleteConfirm = false;
 	let deleteTarget: AutomationResponse | null = null;
@@ -63,6 +64,10 @@
 	// Immediate response to page/filter changes (gate behind loaded)
 	$: if (loaded && page && statusFilter !== undefined) {
 		getAutomationList();
+	}
+
+	$: if (!showCreateModal) {
+		cloneFrom = null;
 	}
 
 	const getAutomationList = async () => {
@@ -137,6 +142,14 @@
 
 		page = 1;
 		getAutomationList();
+	};
+
+	const cloneHandler = (automation: AutomationResponse) => {
+		cloneFrom = {
+			...automation,
+			name: `${automation.name} (Clone)`
+		};
+		showCreateModal = true;
 	};
 
 	const formatRRule = (rrule: string): string => {
@@ -227,6 +240,7 @@
 <AutomationModal
 	bind:show={showCreateModal}
 	automation={null}
+	{cloneFrom}
 	on:save={(e) => {
 		getAutomationList();
 		if (e.detail?.id) {
@@ -273,6 +287,7 @@
 							<button
 								class="px-2 py-1.5 rounded-xl bg-black text-white dark:bg-white dark:text-black transition font-medium text-sm flex items-center"
 								on:click={() => {
+									cloneFrom = null;
 									showCreateModal = true;
 								}}
 							>
@@ -429,6 +444,9 @@
 										<AutomationMenu
 											editHandler={() => {
 												goto(`/automations/${automation.id}`);
+											}}
+											cloneHandler={() => {
+												cloneHandler(automation);
 											}}
 											runHandler={() => {
 												runNowHandler(automation);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** N/A — this is a commonly requested enhancement submitted by a regular contributor.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a frontend-only UI enhancement.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new backend endpoints or settings. Adds a `cloneFrom` prop to `AutomationModal` and follows the same clone UX pattern used by Prompts, Tools, Models, and Skills.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `feat` prefix.

# Changelog Entry

### Description

Automations are currently missing a "Clone" option in their 3-dots dropdown menu, unlike Prompts, Tools, Models, and Skills which all support cloning. This makes it tedious for users who want to create variations of existing automations — they have to manually recreate the entire configuration from scratch.

This PR adds a "Clone" option to the Automations 3-dots menu. When clicked, it opens the "New Automation" modal pre-filled with the source automation's data (name, prompt, model, and schedule), with "(Clone)" appended to the name. This follows the same pre-fill-then-save pattern used by other clone actions across the UI, giving users the opportunity to review and modify the cloned configuration before saving.

### Added

- Clone option in the Automations 3-dots dropdown menu (between Edit and Run Now), using the `DocumentDuplicate` icon consistent with other clone actions across the UI
- `cloneFrom` prop on `AutomationModal` to support pre-filling form fields from an existing automation when creating a new one

# Changelog Entry

### Additional Information

**Files changed (3):**
- `src/lib/components/automations/AutomationMenu.svelte` — Added `cloneHandler` prop, `DocumentDuplicate` icon import, and Clone button between Edit and Run Now
- `src/lib/components/AutomationModal.svelte` — Added `cloneFrom` prop; `init()` populates form fields from `cloneFrom` when creating (not editing)
- `src/routes/(app)/automations/+page.svelte` — Added `cloneFrom` state, `cloneHandler` function, wired to `AutomationMenu` and `AutomationModal`; `cloneFrom` is cleared automatically when the modal closes

### Screenshots or Videos

## Before

<img width="2331" height="485" alt="image" src="https://github.com/user-attachments/assets/7d9e23ba-2459-4ecd-ad7a-36341cb98072" />

## After

<img width="2331" height="485" alt="image" src="https://github.com/user-attachments/assets/03f4803c-1ba1-47db-8ce5-a245ed9cdc75" />

<img width="2331" height="827" alt="image" src="https://github.com/user-attachments/assets/ab20dd2b-dbd0-41e4-a7e1-07e968a91fd6" />

<img width="2331" height="827" alt="image" src="https://github.com/user-attachments/assets/911dae1c-a7b8-43de-8985-18310ceea3ec" />

<img width="2331" height="827" alt="image" src="https://github.com/user-attachments/assets/15dfe7dc-3c32-4db7-aa68-a62137441801" />

### Manual Verification Performed

1. Open the Automations page
2. Click the 3-dots menu on any automation — verify "Clone" appears between "Edit" and "Run Now"
3. Click "Clone" — verify the New Automation modal opens with the source automation's name (with "(Clone)" suffix), prompt, model, and schedule pre-filled
4. Modify the name/prompt if desired and click "Create" — verify a new automation is created
5. Click "New Automation" button — verify the modal opens blank (no stale clone data)
6. Verify the original automation is unaffected

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
