### PR TITLE
fix(chat): auto-open artifacts after outlet html transforms

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -64,6 +64,7 @@
 		processDetails,
 		removeAllDetails,
 		getCodeBlockContents,
+		hasRenderableArtifactContent,
 		isYoutubeUrl,
 		displayFileHandler
 	} from '$lib/utils';
@@ -546,19 +547,30 @@
 				} else if (type === 'chat:outlet') {
 					// Outlet filter ran on backend — sync in-memory state
 					const outletMessages = data.messages ?? [];
+					let shouldOpenArtifacts = false;
 					for (const msg of outletMessages) {
 						if (msg?.id && history.messages[msg.id]) {
 							const existing = history.messages[msg.id];
 							if (existing.content !== msg.content) {
+								const hadArtifacts = hasRenderableArtifactContent(existing.content ?? '');
+								const hasArtifacts = hasRenderableArtifactContent(msg.content ?? '');
 								history.messages[msg.id] = {
 									...existing,
 									originalContent: existing.content,
 									...msg
 								};
+								if (($settings?.detectArtifacts ?? true) && !$mobile && $chatId && !hadArtifacts && hasArtifacts) {
+									shouldOpenArtifacts = true;
+								}
 							}
 						}
 					}
 					history = history;
+					if (shouldOpenArtifacts) {
+						await tick();
+						showArtifacts.set(true);
+						showControls.set(true);
+					}
 					return; // Patches history.messages directly; skip the trailing write-back.
 				} else if (type === 'chat:message:favorite') {
 					// Update message favorite status
@@ -1096,50 +1108,54 @@
 
 	$: onHistoryChange(history);
 
-	const getContents = () => {
-		const messages = history ? createMessagesList(history, history.currentId) : [];
-		let contents = [];
-		messages.forEach((message) => {
-			if (message?.role !== 'user' && message?.content) {
-				const { codeBlocks: codeBlocks, htmlGroups: htmlGroups } = getCodeBlockContents(
-					message.content
-				);
+	const buildArtifactContentsFromMessage = (content) => {
+		const { codeBlocks, htmlGroups } = getCodeBlockContents(content);
+		const contents = [];
 
-				if (htmlGroups && htmlGroups.length > 0) {
-					htmlGroups.forEach((group) => {
-						const renderedContent = `
+		if (htmlGroups && htmlGroups.length > 0) {
+			htmlGroups.forEach((group) => {
+				const renderedContent = `
                         <!DOCTYPE html>
                         <html lang="en">
                         <head>
                             <meta charset="UTF-8">
                             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-							<${''}style>
-								body {
-									background-color: white; /* Ensure the iframe has a white background */
-								}
+					<${''}style>
+						body {
+							background-color: white; /* Ensure the iframe has a white background */
+						}
 
-								${group.css}
-							</${''}style>
+						${group.css}
+					</${''}style>
                         </head>
                         <body>
                             ${group.html}
 
-							<${''}script>
+					<${''}script>
                             	${group.js}
-							</${''}script>
+					</${''}script>
                         </body>
                         </html>
                     `;
-						contents = [...contents, { type: 'iframe', content: renderedContent }];
-					});
-				} else {
-					// Check for SVG content
-					for (const block of codeBlocks) {
-						if (block.lang === 'svg' || (block.lang === 'xml' && block.code.includes('<svg'))) {
-							contents = [...contents, { type: 'svg', content: block.code }];
-						}
-					}
+				contents.push({ type: 'iframe', content: renderedContent });
+			});
+		} else {
+			for (const block of codeBlocks) {
+				if (block.lang === 'svg' || (block.lang === 'xml' && block.code.includes('<svg'))) {
+					contents.push({ type: 'svg', content: block.code });
 				}
+			}
+		}
+
+		return contents;
+	};
+
+	const getContents = () => {
+		const messages = history ? createMessagesList(history, history.currentId) : [];
+		let contents = [];
+		messages.forEach((message) => {
+			if (message?.role !== 'user' && message?.content) {
+				contents = [...contents, ...buildArtifactContentsFromMessage(message.content)];
 			}
 		});
 

--- a/src/lib/utils/artifact-content.test.ts
+++ b/src/lib/utils/artifact-content.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCodeBlockContents, hasRenderableArtifactContent } from './index';
+
+describe('artifact content detection', () => {
+	it('detects html artifacts from fenced code blocks', () => {
+		expect(hasRenderableArtifactContent('```html\n<div>Hello</div>\n```')).toBe(true);
+	});
+
+	it('detects svg artifacts from xml code blocks', () => {
+		expect(hasRenderableArtifactContent('```xml\n<svg></svg>\n```')).toBe(true);
+	});
+
+	it('ignores non-artifact code blocks', () => {
+		expect(hasRenderableArtifactContent('```markdown\n# title\n```')).toBe(false);
+	});
+
+	it('builds grouped html artifacts from outlet-transformed content', () => {
+		const result = getCodeBlockContents('```html\n<div>Hello</div>\n```') as {
+			htmlGroups: Array<{ html: string; css: string; js: string }>;
+		};
+
+		expect(result.htmlGroups).toHaveLength(1);
+		expect(result.htmlGroups[0]).toMatchObject({ html: '<div>Hello</div>', css: '', js: '' });
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2105,6 +2105,22 @@ export const getCodeBlockContents = (content: string): object => {
 			}))
 	};
 };
+
+export const hasRenderableArtifactContent = (content: string): boolean => {
+	const { codeBlocks, htmlGroups } = getCodeBlockContents(content) as {
+		codeBlocks: Array<{ lang: string; code: string }>;
+		htmlGroups: Array<{ html: string; css: string; js: string }>;
+	};
+
+	if (htmlGroups?.length > 0) {
+		return true;
+	}
+
+	return codeBlocks.some(
+		(block) => block.lang === 'svg' || (block.lang === 'xml' && block.code.includes('<svg'))
+	);
+};
+
 export const parseFrontmatter = (content) => {
 	const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
 	if (match) {


### PR DESCRIPTION
# Pull Request Checklist

- [x] fixes #25752
- [x] Targets `dev`
- [x] Focused tests included
- [x] Atomic change

# Changelog Entry

### Description

- Auto-open the artifacts panel when an outlet filter rewrites assistant content into renderable HTML after streaming has already finished.

### Added

- Focused regression coverage for artifact detection.

### Changed

- Reused the existing artifact parsing path during `chat:outlet` updates.

### Fixed

- The UI now re-checks artifact presence after outlet rewrites and opens the panel only when content changes from non-artifact to artifact.

---

### Additional Information

- Direct HTML/SVG blocks already auto-opened artifacts before this patch.
- The missing path was backend `chat:outlet` content replacement.

### Testing

- `npx vitest run src/lib/utils/artifact-content.test.ts src/lib/components/layout/Sidebar/Folders/folder-models.test.ts`

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
