### PR TITLE
fix(loader): restrict paddleocr_vl to PDF and image files only

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -530,7 +530,11 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
             )
-        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
+        elif (
+            self.engine == 'paddleocr_vl'
+            and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
+            and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
+        ):
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),


### PR DESCRIPTION
## Summary

`PaddleOCR-VL` only processes PDF and image files, but the loader condition had no file extension check. Text-based files (`.md`, `.txt`, `.csv`, etc.) were sent to the PaddleOCR API and returned `422 Unprocessable Entity` errors.

This matches how `mistral_ocr` and `mineru` already handle unsupported file types — by checking `file_ext` before routing to the specialised loader, so unsupported files fall through to the standard text/PDF loaders.

Fixes #24988

## Changes

- `backend/open_webui/retrieval/loaders/main.py`: added `file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']` guard to the `paddleocr_vl` condition, consistent with the extension list already used inside `PaddleOCRVLLoader` itself