### PR TITLE
fix(loaders): restrict paddleocr_vl to PDF and image files

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -530,7 +530,11 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
             )
-        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
+        elif (
+            self.engine == 'paddleocr_vl'
+            and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
+            and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
+        ):
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),


### PR DESCRIPTION
## Summary

- PaddleOCR only processes PDF and image files, but the `paddleocr_vl` engine condition in `loaders/main.py` had no file extension guard. Every file type (`.md`, `.txt`, `.csv`, etc.) was routed to `PaddleOCRVLLoader`, which sent them to the `/layout-parsing` endpoint with `fileType=0` (PDF). The API responded with `422 Unprocessable Entity` because the payload was not a valid PDF.
- This PR adds a `file_ext in [...]` check, matching the pattern already used by `mistral_ocr` and `mineru`. Non-PDF/image files now fall through to the generic loaders as intended.

Fixes #24988

## Changes

- `backend/open_webui/retrieval/loaders/main.py`: expand `paddleocr_vl` condition to include `and file_ext in ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']`