### PR TITLE
fix: use correct field name for prompt clone title suffix

### DIFF
--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -130,7 +130,7 @@
 	const cloneHandler = async (prompt) => {
 		const clonedPrompt = { ...prompt };
 
-		clonedPrompt.title = `${clonedPrompt.title} (Clone)`;
+		clonedPrompt.name = `${clonedPrompt.name} (Clone)`;
 		const baseCommand = clonedPrompt.command.startsWith('/')
 			? clonedPrompt.command.substring(1)
 			: clonedPrompt.command;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #DISCUSSION_NUMBER`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The clone handler for prompts in the Workspace Prompts page was setting `clonedPrompt.title` to append "(Clone)", but the prompt data model uses `name` as the display field — `title` does not exist on the prompt object. When the create page reads the cloned data via `_prompt.name || _prompt.title`, it picks up the unchanged `name` first, so the "(Clone)" suffix never appeared.

This one-line fix changes `clonedPrompt.title` to `clonedPrompt.name`, bringing prompt cloning in line with all other cloneable workspace items (Models, Tools, Skills) which already correctly append "(Clone)" to their display name.

### Fixed

- Prompt clone from Workspace Prompts page now correctly appends "(Clone)" to the prompt name

---

### Additional Information

- Only 1 file changed, 1 line modified — minimal and atomic fix
- All other workspace clone handlers (Models, Tools, Skills) already use the correct `name` field
- Production build passes with no errors or warnings

### Screenshots or Videos

## Before:

<img width="2344" height="391" alt="image" src="https://github.com/user-attachments/assets/425dc8b6-0368-4d61-b491-bebcf70b4f11" />

## After:

<img width="2344" height="391" alt="image" src="https://github.com/user-attachments/assets/c601c7b3-f8ef-42e2-91ca-926bff3f75fe" />

### Manual Verification Performed

1. Navigate to Workspace → Prompts
2. Click the ⋯ menu on any prompt → Clone
3. Verify the create form now shows the prompt name with "(Clone)" appended
4. Verify the command slug also includes "-clone"
5. Save the cloned prompt and verify it appears correctly in the list

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
