### PR TITLE
feat: admin-only Extension plugin primitive (lifecycle + asset injection)

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -732,10 +732,25 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             log.warning(f'Failed to initialize terminal servers at startup: {e}')
 
+    # Start admin-only Extension functions (lifecycle + global asset injection).
+    try:
+        from open_webui.utils.extensions import startup_extensions
+
+        await startup_extensions(app)
+    except Exception as e:
+        log.warning(f'Failed to start extensions: {e}')
+
     # Mark application as ready to accept traffic from a startup perspective.
     app.state.startup_complete = True
 
     yield
+
+    try:
+        from open_webui.utils.extensions import shutdown_extensions
+
+        await shutdown_extensions(app)
+    except Exception as e:
+        log.warning(f'Failed to shut down extensions: {e}')
 
     # Shutdown: clean up shared resources
     from open_webui.utils.session_pool import close_session

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -519,17 +519,18 @@ async def ldap_auth(
                         db=db,
                     )
 
-                    if request.app.state.config.WEBHOOK_URL:
-                        await post_webhook(
-                            request.app.state.WEBUI_NAME,
-                            request.app.state.config.WEBHOOK_URL,
-                            WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-                            {
-                                'action': 'signup',
-                                'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-                                'user': user.model_dump_json(exclude_none=True),
-                            },
-                        )
+                    # Unconditional: post_webhook posts to the URL only if set,
+                    # but always dispatches to extensions (on_webhook).
+                    await post_webhook(
+                        request.app.state.WEBUI_NAME,
+                        request.app.state.config.WEBHOOK_URL,
+                        WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+                        {
+                            'action': 'signup',
+                            'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+                            'user': user.model_dump_json(exclude_none=True),
+                        },
+                    )
 
                 except HTTPException:
                     raise
@@ -716,17 +717,18 @@ async def signup_handler(
         user = await Users.get_user_by_id(user.id, db=db)
         request.app.state.config.ENABLE_SIGNUP = False
 
-    if request.app.state.config.WEBHOOK_URL:
-        await post_webhook(
-            request.app.state.WEBUI_NAME,
-            request.app.state.config.WEBHOOK_URL,
-            WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-            {
-                'action': 'signup',
-                'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-                'user': user.model_dump_json(exclude_none=True),
-            },
-        )
+    # Unconditional: post_webhook posts to the URL only if set, but always
+    # dispatches to extensions (on_webhook).
+    await post_webhook(
+        request.app.state.WEBUI_NAME,
+        request.app.state.config.WEBHOOK_URL,
+        WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+        {
+            'action': 'signup',
+            'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+            'user': user.model_dump_json(exclude_none=True),
+        },
+    )
 
     await apply_default_group_assignment(
         request.app.state.config.DEFAULT_GROUP_ID,

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -260,12 +260,22 @@ async def get_function_by_id(id: str, user=Depends(get_admin_user), db: AsyncSes
 
 
 @router.post('/id/{id}/toggle', response_model=FunctionModel | None)
-async def toggle_function_by_id(id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
+async def toggle_function_by_id(
+    request: Request, id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)
+):
     function = await Functions.get_function_by_id(id, db=db)
     if function:
         function = await Functions.update_function_by_id(id, {'is_active': not function.is_active}, db=db)
 
         if function:
+            if function.type == 'extension':
+                # Apply enable/disable at runtime so it takes effect without a restart.
+                try:
+                    from open_webui.utils.extensions import set_extension_active
+
+                    await set_extension_active(request.app, function, function.is_active)
+                except Exception as e:
+                    log.exception(f'Failed to toggle extension {id}: {e}')
             return function
         else:
             raise HTTPException(

--- a/backend/open_webui/utils/extensions.py
+++ b/backend/open_webui/utils/extensions.py
@@ -35,6 +35,10 @@ log = logging.getLogger(__name__)
 EXTENSIONS_SUBDIR = 'extensions'
 STARTUP_TIMEOUT = 30  # seconds; a hung hook must not stall boot/shutdown
 
+# Active extension modules keyed by function id. Mirrors app.state.EXTENSIONS but
+# lives at module level so post_webhook can dispatch without an app handle.
+_ACTIVE: dict = {}
+
 
 def _assets_dir() -> Path:
     d = Path(STATIC_DIR) / EXTENSIONS_SUBDIR
@@ -97,6 +101,7 @@ async def _activate(app, function) -> bool:
             'priority': int((frontmatter or {}).get('priority', 0) or 0),
             'assets': await _collect_assets(module),
         }
+        _ACTIVE[function.id] = module
         log.info(f'Extension started: {function.id}')
         return True
     except Exception:
@@ -105,6 +110,7 @@ async def _activate(app, function) -> bool:
 
 
 async def _deactivate(app, function_id) -> None:
+    _ACTIVE.pop(function_id, None)
     entry = app.state.EXTENSIONS.pop(function_id, None)
     if not entry:
         return
@@ -162,6 +168,7 @@ def regenerate_assets(app) -> None:
 async def startup_extensions(app) -> None:
     """Called once from the lifespan, after dependency install."""
     app.state.EXTENSIONS = {}
+    _ACTIVE.clear()
     if SAFE_MODE:
         log.info('SAFE_MODE: skipping extension startup')
         regenerate_assets(app)
@@ -195,3 +202,17 @@ async def set_extension_active(app, function, is_active: bool) -> None:
     else:
         await _deactivate(app, function.id)
     regenerate_assets(app)
+
+
+async def dispatch_webhook(name, message, event_data) -> None:
+    """Fan a webhook event out to every active extension exposing on_webhook.
+    Called from post_webhook regardless of whether an outbound URL is set.
+    Best-effort: a failing handler must not break webhook delivery."""
+    for function_id, module in list(_ACTIVE.items()):
+        hook = getattr(module, 'on_webhook', None)
+        if hook is None:
+            continue
+        try:
+            await _maybe_await(hook(name, message, event_data))
+        except Exception:
+            log.exception(f'Extension on_webhook failed: {function_id}')

--- a/backend/open_webui/utils/extensions.py
+++ b/backend/open_webui/utils/extensions.py
@@ -1,0 +1,197 @@
+"""
+Extension functions: an admin-only, non-user-facing plugin type.
+
+Unlike tools/actions/filters/pipes, an Extension has no per-user or per-model
+surface. It is enabled/disabled from the admin Functions page and exists to run
+backend lifecycle work (on_startup / on_shutdown) and to inject global frontend
+assets (custom JS/CSS) via the static seams the app already serves
+(/static/loader.js and /static/custom.css).
+
+Lifecycle hooks (all optional, sync or async):
+    async def on_startup(self, __app__=None)   # at server boot, and on enable
+    async def on_shutdown(self)                 # at server shutdown, and on disable
+    def assets(self) -> dict                    # {"js": "...", "css": "..."} injected globally
+
+Asset injection model: there is exactly one loader.js and one custom.css, so
+core aggregates every enabled extension. CSS is concatenated (the CSS parser
+tolerates a bad rule). JS is written to one file per extension under
+/static/extensions/<id>.js and pulled in by a generated loader.js that injects a
+separate <script> per extension, so a syntax error in one cannot break the rest
+(a parse error in a concatenated blob would, and try/catch can't catch it).
+"""
+
+import asyncio
+import inspect
+import json
+import logging
+import re
+from pathlib import Path
+
+from open_webui.env import SAFE_MODE, STATIC_DIR
+from open_webui.models.functions import Functions
+
+log = logging.getLogger(__name__)
+
+EXTENSIONS_SUBDIR = 'extensions'
+STARTUP_TIMEOUT = 30  # seconds; a hung hook must not stall boot/shutdown
+
+
+def _assets_dir() -> Path:
+    d = Path(STATIC_DIR) / EXTENSIONS_SUBDIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _safe_id(function_id: str) -> str:
+    # Filenames are served at a public URL, so keep them to a known-safe set.
+    return re.sub(r'[^a-zA-Z0-9_-]', '_', str(function_id))
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def _call_hook(module, name, app=None):
+    hook = getattr(module, name, None)
+    if hook is None:
+        return
+    kwargs = {}
+    try:
+        if '__app__' in inspect.signature(hook).parameters:
+            kwargs['__app__'] = app
+    except (TypeError, ValueError):
+        pass
+    await asyncio.wait_for(_maybe_await(hook(**kwargs)), timeout=STARTUP_TIMEOUT)
+
+
+async def _collect_assets(module) -> dict:
+    fn = getattr(module, 'assets', None)
+    if fn is None:
+        return {}
+    try:
+        result = await _maybe_await(fn())
+        return result if isinstance(result, dict) else {}
+    except Exception:
+        log.exception('extension assets() failed')
+        return {}
+
+
+async def _activate(app, function) -> bool:
+    """Load one extension, set its valves, run on_startup, cache its assets."""
+    from open_webui.utils.plugin import load_function_module_by_id
+
+    try:
+        module, _type, frontmatter = await load_function_module_by_id(function.id)
+
+        if hasattr(module, 'valves') and hasattr(module, 'Valves'):
+            valves = await Functions.get_function_valves_by_id(function.id)
+            module.valves = module.Valves(**(valves or {}))
+
+        await _call_hook(module, 'on_startup', app=app)
+
+        app.state.EXTENSIONS[function.id] = {
+            'module': module,
+            'name': function.name,
+            'priority': int((frontmatter or {}).get('priority', 0) or 0),
+            'assets': await _collect_assets(module),
+        }
+        log.info(f'Extension started: {function.id}')
+        return True
+    except Exception:
+        log.exception(f'Extension failed to start: {function.id}')
+        return False
+
+
+async def _deactivate(app, function_id) -> None:
+    entry = app.state.EXTENSIONS.pop(function_id, None)
+    if not entry:
+        return
+    try:
+        await _call_hook(entry['module'], 'on_shutdown')
+    except Exception:
+        log.exception(f'Extension on_shutdown failed: {function_id}')
+
+
+def regenerate_assets(app) -> None:
+    """Rewrite custom.css + loader.js + per-extension JS from currently active
+    extensions. Deterministic order: priority, then id."""
+    extensions = getattr(app.state, 'EXTENSIONS', {})
+    items = sorted(extensions.items(), key=lambda kv: (kv[1]['priority'], kv[0]))
+
+    assets_dir = _assets_dir()
+    for stale in assets_dir.glob('*.js'):
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+
+    css_parts = []
+    js_urls = []
+    for function_id, entry in items:
+        assets = entry.get('assets') or {}
+        css = assets.get('css')
+        js = assets.get('js')
+        if css:
+            css_parts.append(f'/* === extension: {function_id} === */\n{css}')
+        if js:
+            safe = _safe_id(function_id)
+            # IIFE + try/catch isolates scope and runtime errors per extension.
+            wrapped = (
+                f'// extension: {function_id}\n'
+                f"(function () {{\ntry {{\n{js}\n}} catch (e) {{ console.error('[ext {function_id}]', e); }}\n}})();\n"
+            )
+            (assets_dir / f'{safe}.js').write_text(wrapped, encoding='utf-8')
+            js_urls.append(f'/static/{EXTENSIONS_SUBDIR}/{safe}.js')
+
+    Path(STATIC_DIR, 'custom.css').write_text('\n\n'.join(css_parts), encoding='utf-8')
+
+    loader = '// Generated by Open WebUI extension loader. Do not edit.\n'
+    if js_urls:
+        loader += (
+            f'{json.dumps(js_urls)}.forEach(function (src) {{'
+            "var s = document.createElement('script');"
+            's.src = src; s.defer = true;'
+            'document.head.appendChild(s);'
+            '});\n'
+        )
+    Path(STATIC_DIR, 'loader.js').write_text(loader, encoding='utf-8')
+
+
+async def startup_extensions(app) -> None:
+    """Called once from the lifespan, after dependency install."""
+    app.state.EXTENSIONS = {}
+    if SAFE_MODE:
+        log.info('SAFE_MODE: skipping extension startup')
+        regenerate_assets(app)
+        return
+    try:
+        functions = await Functions.get_functions_by_type('extension', active_only=True)
+    except Exception:
+        log.exception('Failed to list extensions at startup')
+        return
+
+    for function in functions:
+        await _activate(app, function)
+    regenerate_assets(app)
+    log.info(f'Started {len(app.state.EXTENSIONS)} extension(s)')
+
+
+async def shutdown_extensions(app) -> None:
+    """Called from the lifespan after yield."""
+    for function_id in list(getattr(app.state, 'EXTENSIONS', {}).keys()):
+        await _deactivate(app, function_id)
+
+
+async def set_extension_active(app, function, is_active: bool) -> None:
+    """Enable/disable an extension at runtime (from the toggle route) so it
+    takes effect without a restart."""
+    if not hasattr(app.state, 'EXTENSIONS'):
+        app.state.EXTENSIONS = {}
+    if is_active:
+        if not SAFE_MODE:
+            await _activate(app, function)
+    else:
+        await _deactivate(app, function.id)
+    regenerate_assets(app)

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1742,17 +1742,18 @@ class OAuthManager:
                         await Users.update_user_role_by_id(user.id, 'admin', db=db)
                         user = await Users.get_user_by_id(user.id, db=db)
 
-                    if auth_manager_config.WEBHOOK_URL:
-                        await post_webhook(
-                            WEBUI_NAME,
-                            auth_manager_config.WEBHOOK_URL,
-                            WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-                            {
-                                'action': 'signup',
-                                'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
-                                'user': user.model_dump_json(exclude_none=True),
-                            },
-                        )
+                    # Unconditional: post_webhook posts to the URL only if set,
+                    # but always dispatches to extensions (on_webhook).
+                    await post_webhook(
+                        WEBUI_NAME,
+                        auth_manager_config.WEBHOOK_URL,
+                        WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+                        {
+                            'action': 'signup',
+                            'message': WEBHOOK_MESSAGES.USER_SIGNUP(user.name),
+                            'user': user.model_dump_json(exclude_none=True),
+                        },
+                    )
 
                     await apply_default_group_assignment(request.app.state.config.DEFAULT_GROUP_ID, user.id, db=db)
 

--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -285,6 +285,8 @@ async def load_function_module_by_id(function_id: str, content: str | None = Non
             return module.Filter(), 'filter', frontmatter
         elif hasattr(module, 'Action'):
             return module.Action(), 'action', frontmatter
+        elif hasattr(module, 'Extension'):
+            return module.Extension(), 'extension', frontmatter
         else:
             raise Exception('No Function class found in the module')
     except Exception as e:

--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -17,6 +17,18 @@ log = logging.getLogger(__name__)
 # Let this message reach those for whom it was written, and
 # may no network partition deny the word its destination.
 async def post_webhook(name: str, url: str, message: str, event_data: dict) -> bool:
+    # Always notify in-process extensions (on_webhook), regardless of whether an
+    # outbound webhook URL is configured.
+    try:
+        from open_webui.utils.extensions import dispatch_webhook
+
+        await dispatch_webhook(name, message, event_data)
+    except Exception:
+        log.exception('extension webhook dispatch failed')
+
+    if not url:
+        return True
+
     try:
         log.debug(f'post_webhook: {url}, {message}, {event_data}')
         # Block private-IP / loopback / cloud-metadata targets — the URL is


### PR DESCRIPTION
# Tested

Verified end to end on a live 0.9.6 dev instance (real uvicorn boot, isolated DB):

- Lifespan loads and starts active extensions at boot, runs `on_startup`, tears down on `on_shutdown`.
- `on_startup` registers an API route via `__app__` and it resolves correctly (inserted ahead of the SPA catch-all, so it isn't shadowed).
- Asset injection works: `loader.js` bootstrap + per-extension `/static/extensions/<id>.js` (IIFE-isolated) + concatenated `custom.css`, all served on boot.
- `on_webhook` fires on a real user signup with no `WEBHOOK_URL` configured, confirming the dispatch is decoupled from outbound webhook delivery.

## Summary

Adds a new function type, **Extension**, alongside pipe / filter / action / tool. Unlike those, an Extension has no per-user or per-model surface: an admin enables or disables it on the Functions page, and it exists to run backend lifecycle work and inject global frontend assets. It is the first function type whose code reliably runs at server startup.

## Motivation

Today there is no point at which an enabled function's code is guaranteed to run. Function modules load lazily on first use (a filter on the first chat, an action on the first click), and the startup path only reads frontmatter for dependency install, it never imports the modules. So anything cross-cutting (registering a route, installing a hook, injecting CSS/JS, reacting to an event) either waits for first use or gets hacked in by monkey-patching at import time, with no clean teardown. Extension gives that work a defined home with a real lifecycle.

## What's new

A module exposing `class Extension` resolves to type `extension`. All hooks are optional and may be sync or async:

```python
"""
title: My Extension
type: extension
"""

class Extension:
    class Valves(BaseModel):
        ...

    async def on_startup(self, __app__=None):
        # at server boot and on enable: register routes, install setup, start tasks
        ...

    async def on_shutdown(self):
        # at shutdown and on disable: tear down cleanly
        ...

    async def on_webhook(self, name, message, event_data):
        # whenever post_webhook fires (e.g. a user signs up)
        ...

    def assets(self) -> dict:
        return {"js": "...", "css": "..."}
```

Properties:
- Loaded and started at server boot (after dependency install), torn down after the lifespan yield.
- Admin-only, enabled/disabled from the Functions page. No per-model assignment, never exposed to users or the model.
- Hooks run with a timeout and per-extension error isolation, and honour `SAFE_MODE`.
- `on_startup` may receive `__app__` by signature to register routes or touch `app.state`.
- Enable/disable takes effect at runtime, no restart, via the existing toggle endpoint.

## Asset injection

Extensions inject global JS/CSS through the static seams the app already serves (`/static/loader.js`, `/static/custom.css`). Because there is one of each file, core aggregates every enabled extension:
- **CSS** is concatenated (the CSS parser tolerates a bad rule), in deterministic order, with per-extension markers.
- **JS** is written one file per extension under `/static/extensions/<id>.js` and pulled in by a generated `loader.js` that injects a separate `<script>` per extension. A syntax error in one extension therefore cannot break the others (a parse error in a single concatenated blob would, and `try/catch` cannot catch it).

Output is regenerated on enable/disable so toggling takes effect without a restart.

## Webhook event hook

`post_webhook` now also dispatches to every active extension exposing `on_webhook`, decoupled from whether an outbound `WEBHOOK_URL` is configured: extensions are notified first, then the HTTP POST happens only if a URL is set. The user-signup call sites are ungated so signup events reach extensions even with no webhook URL configured. Dispatch is best-effort and per-handler isolated, so a slow or failing extension cannot break webhook delivery. This gives extensions a lightweight, curated event hook that reuses the existing webhook chokepoint instead of monkey-patching core.

## Changes (backend only)

- `utils/extensions.py` (new): lifecycle, asset aggregation, webhook dispatch.
- `utils/plugin.py`: resolve `class Extension` to type `extension`.
- `main.py`: start extensions in the lifespan (after dependency install), stop them after the yield.
- `routers/functions.py`: apply enable/disable at runtime for extensions.
- `utils/webhook.py`: dispatch to extensions; POST only when a URL is set.
- `routers/auths.py`, `utils/oauth.py`: ungate the signup webhook so the event always fires.

No frontend changes: extensions already list on the Functions page with an enable/disable toggle, and the per-model/user surfaces explicitly select `filter`/`action`, so extensions are excluded automatically.

## Notes

- `on_schedule` / cron is intentionally not included: it is already achievable from `on_startup` (spawn an `asyncio` task, cancel it in `on_shutdown`).
- The webhook hook covers the user-facing signup paths (email / LDAP / OAuth). SCIM auto-provisioning does not emit the signup event yet; wiring that in is a separate follow-up PR, out of scope here.

# Benefit

any new webhook that will ever be added to open webui can be easily programmatically be talked to via an extension addon

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
