### PR TITLE
fix: set diagnose=False on Loguru stdout handler to prevent secrets leaking in tracebacks

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -185,6 +185,7 @@ def start_logger():
             level=GLOBAL_LOG_LEVEL,
             format=stdout_format,
             filter=audit_filter,
+            diagnose=False,
         )
     if AUDIT_LOG_LEVEL != 'NONE' and ENABLE_AUDIT_LOGS_FILE:
         try:


### PR DESCRIPTION
Fixes #25767

Loguru defaults to `diagnose=True`, which causes local variable values to be printed alongside each frame in a traceback. When an exception occurs inside third-party libraries (e.g. an API client), this exposes any secrets stored in local variables — such as API keys passed as HTTP headers.

Adding `diagnose=False` to the stdout `logger.add()` call suppresses variable inspection in tracebacks while keeping the full call stack (`backtrace=True` is already the default). Stack frames and error messages are still shown; only the variable values at each frame are omitted.

## Changes

- `backend/open_webui/utils/logger.py`: add `diagnose=False` to the stdout Loguru sink