### PR TITLE
fix(chat): guard chatCompletedHandler taskIds clear against concurrent sendMessage

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1556,11 +1556,20 @@
 	const chatCompletedHandler = async (_chatId, modelId, responseMessageId, messages) => {
 		// Backend handles outlet filters and persistence inline.
 		// Just refresh the sidebar chat list.
+		// Snapshot taskIds before any await so we can tell whether a concurrent
+		// sendMessage assigned new IDs while this handler was suspended.
+		const capturedTaskIds = taskIds;
 		if ($chatId == _chatId && !$temporaryChatEnabled) {
 			currentChatPage.set(1);
 			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 		}
-		taskIds = null;
+		// Only clear taskIds if sendMessage has not assigned a new set since we
+		// were dispatched. Without this guard, a fire-and-forget handler resuming
+		// after its getChatList await would overwrite IDs set by a concurrent
+		// sendMessage, making the stop-generation button non-functional.
+		if (taskIds === capturedTaskIds) {
+			taskIds = null;
+		}
 	};
 
 	const chatActionHandler = async (_chatId, actionId, modelId, responseMessageId, event = null) => {


### PR DESCRIPTION
## Summary

Fixes a race condition in `Chat.svelte` where `chatCompletedHandler` (dispatched fire-and-forget) could wipe `taskIds` that were freshly assigned by a concurrent `sendMessage`.

**Race sequence (before this fix):**
1. Response stream for message N finishes; `chatCompletedHandler` is dispatched without `await` and suspends at `getChatList(...)`.
2. User (or the queue) sends message N+1; `sendMessage` issues its HTTP request and assigns fresh task IDs to `taskIds` (`taskIds = newTaskIds`).
3. `chatCompletedHandler` resumes and executes the unconditional `taskIds = null`, erasing those IDs.
4. `stopResponse()` reads `taskIds` as null; no stop calls are issued; the stop-generation button disappears from the UI.

**Fix:**

Capture `taskIds` by reference before the first `await` and only null it out if `sendMessage` has not assigned a new value in the meantime:

```svelte
const capturedTaskIds = taskIds;
// ... await getChatList (may yield to sendMessage) ...
if (taskIds === capturedTaskIds) {
    taskIds = null;
}
```

This is the "Option A" approach suggested in the issue by the reporter.

Closes #25217

## Test plan

- [ ] Start a chat and quickly send a second message before the first fully completes
- [ ] Verify the stop-generation button remains active while message N+1 is in flight
- [ ] Verify that after both messages complete normally, `taskIds` is eventually cleared
- [ ] Verify no regression in single-message flows (stop button still works in isolation)