### PR TITLE
fix(chat): preserve selected models across MCP OAuth

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -68,6 +68,7 @@
 		displayFileHandler
 	} from '$lib/utils';
 	import { AudioQueue } from '$lib/utils/audio';
+	import { applyPendingOAuthState, consumePendingOAuthState } from '$lib/utils/oauth-pending-state';
 
 	import {
 		archiveChatById,
@@ -1313,14 +1314,15 @@
 				.filter((id) => id);
 		}
 
-		// Restore tool selection after OAuth redirect
-		const pendingToolId = sessionStorage.getItem('pendingOAuthToolId');
-		if (pendingToolId) {
-			sessionStorage.removeItem('pendingOAuthToolId');
-			if (!selectedToolIds.includes(pendingToolId)) {
-				selectedToolIds = [...selectedToolIds, pendingToolId];
-			}
-		}
+		// Restore model + tool selection after OAuth redirect.
+		const restoredPendingOAuthState = applyPendingOAuthState({
+			availableModels,
+			selectedModels,
+			selectedToolIds,
+			pendingState: consumePendingOAuthState()
+		});
+		selectedModels = restoredPendingOAuthState.selectedModels;
+		selectedToolIds = restoredPendingOAuthState.selectedToolIds;
 
 		if ($page.url.searchParams.get('call') === 'true') {
 			showCallOverlay.set(true);

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -63,6 +63,7 @@
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
 	import { getOAuthClientAuthorizationUrl } from '$lib/apis/configs';
+	import { savePendingOAuthState } from '$lib/utils/oauth-pending-state';
 
 	import { createNoteHandler } from '../notes/utils';
 	import { getSuggestionRenderer } from '../common/RichTextInput/suggestions';
@@ -1917,7 +1918,10 @@
 											<Tooltip content={$i18n.t('Click to connect')} placement="top">
 												<button
 													on:click|preventDefault={() => {
-														sessionStorage.setItem('pendingOAuthToolId', pendingTool.id);
+														savePendingOAuthState({
+															toolId: pendingTool.id,
+															selectedModels
+														});
 														const authUrl = getOAuthClientAuthorizationUrl(
 															pendingTool.serverId,
 															pendingTool.authType ?? 'mcp'

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -14,6 +14,7 @@
 	} from '$lib/stores';
 
 	import { getOAuthClientAuthorizationUrl } from '$lib/apis/configs';
+	import { savePendingOAuthState } from '$lib/utils/oauth-pending-state';
 	import { deleteOAuthSession } from '$lib/apis/auths';
 	import { getTools } from '$lib/apis/tools';
 	import { getSkills } from '$lib/apis/skills';
@@ -390,8 +391,12 @@
 									let parts = toolId.split(':');
 									let serverId = parts?.at(-1) ?? toolId;
 
-									// Persist the tool ID so we can re-enable it after OAuth redirect
-									sessionStorage.setItem('pendingOAuthToolId', toolId);
+									// Persist the tool and model selection so OAuth can return the user
+									// to the same chat/tool context after redirect.
+									savePendingOAuthState({
+										toolId,
+										selectedModels
+									});
 
 									const authUrl = getOAuthClientAuthorizationUrl(serverId, 'mcp');
 									window.open(authUrl, '_self', 'noopener');

--- a/src/lib/utils/oauth-pending-state.test.ts
+++ b/src/lib/utils/oauth-pending-state.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+	applyPendingOAuthState,
+	consumePendingOAuthState,
+	savePendingOAuthState
+} from './oauth-pending-state';
+
+class SessionStorageStub {
+	private store = new Map<string, string>();
+
+	getItem(key: string) {
+		return this.store.has(key) ? this.store.get(key)! : null;
+	}
+
+	setItem(key: string, value: string) {
+		this.store.set(key, value);
+	}
+
+	removeItem(key: string) {
+		this.store.delete(key);
+	}
+}
+
+const originalSessionStorage = globalThis.sessionStorage;
+let sessionStorageStub: SessionStorageStub;
+
+beforeEach(() => {
+	sessionStorageStub = new SessionStorageStub();
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		value: sessionStorageStub,
+		configurable: true
+	});
+});
+
+afterEach(() => {
+	if (originalSessionStorage === undefined) {
+		Reflect.deleteProperty(globalThis, 'sessionStorage');
+		return;
+	}
+
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		value: originalSessionStorage,
+		configurable: true
+	});
+});
+
+describe('oauth pending state helpers', () => {
+	it('stores and restores tool + selected models for oauth redirects', () => {
+		savePendingOAuthState({
+			toolId: 'server:mcp:demo',
+			selectedModels: ['model-a', 'model-b']
+		});
+
+		expect(sessionStorage.getItem('pendingOAuthToolId')).toBe('server:mcp:demo');
+		expect(sessionStorage.getItem('pendingOAuthSelectedModels')).toBe(
+			JSON.stringify(['model-a', 'model-b'])
+		);
+
+		expect(consumePendingOAuthState()).toEqual({
+			toolId: 'server:mcp:demo',
+			selectedModels: ['model-a', 'model-b']
+		});
+
+		expect(sessionStorage.getItem('pendingOAuthToolId')).toBeNull();
+		expect(sessionStorage.getItem('pendingOAuthSelectedModels')).toBeNull();
+	});
+
+	it('ignores malformed selected-model snapshots', () => {
+		sessionStorage.setItem('pendingOAuthToolId', 'server:mcp:demo');
+		sessionStorage.setItem('pendingOAuthSelectedModels', '{bad json');
+
+		expect(consumePendingOAuthState()).toEqual({
+			toolId: 'server:mcp:demo',
+			selectedModels: null
+		});
+	});
+
+	it('restores the pending tool and filters restored models against available models', () => {
+		expect(
+			applyPendingOAuthState({
+				availableModels: ['model-a', 'model-c'],
+				selectedModels: ['model-z'],
+				selectedToolIds: ['existing-tool'],
+				pendingState: {
+					toolId: 'server:mcp:demo',
+					selectedModels: ['model-a', 'model-b']
+				}
+			})
+		).toEqual({
+			selectedModels: ['model-a'],
+			selectedToolIds: ['existing-tool', 'server:mcp:demo']
+		});
+	});
+
+	it('preserves the current selection when no pending oauth state exists', () => {
+		expect(
+			applyPendingOAuthState({
+				availableModels: ['model-a'],
+				selectedModels: ['model-a'],
+				selectedToolIds: ['existing-tool'],
+				pendingState: {
+					toolId: 'existing-tool',
+					selectedModels: null
+				}
+			})
+		).toEqual({
+			selectedModels: ['model-a'],
+			selectedToolIds: ['existing-tool']
+		});
+	});
+});

--- a/src/lib/utils/oauth-pending-state.ts
+++ b/src/lib/utils/oauth-pending-state.ts
@@ -1,0 +1,84 @@
+const PENDING_OAUTH_TOOL_ID_KEY = 'pendingOAuthToolId';
+const PENDING_OAUTH_SELECTED_MODELS_KEY = 'pendingOAuthSelectedModels';
+
+export type PendingOAuthState = {
+	toolId: string | null;
+	selectedModels: string[] | null;
+};
+
+const canUseSessionStorage = () => typeof sessionStorage !== 'undefined';
+
+export const savePendingOAuthState = ({
+	toolId,
+	selectedModels
+}: {
+	toolId: string;
+	selectedModels: string[];
+}) => {
+	if (!canUseSessionStorage()) {
+		return;
+	}
+
+	sessionStorage.setItem(PENDING_OAUTH_TOOL_ID_KEY, toolId);
+	sessionStorage.setItem(
+		PENDING_OAUTH_SELECTED_MODELS_KEY,
+		JSON.stringify(selectedModels.filter((id) => id))
+	);
+};
+
+export const consumePendingOAuthState = (): PendingOAuthState => {
+	if (!canUseSessionStorage()) {
+		return { toolId: null, selectedModels: null };
+	}
+
+	const toolId = sessionStorage.getItem(PENDING_OAUTH_TOOL_ID_KEY);
+	const selectedModelsString = sessionStorage.getItem(PENDING_OAUTH_SELECTED_MODELS_KEY);
+
+	if (toolId) {
+		sessionStorage.removeItem(PENDING_OAUTH_TOOL_ID_KEY);
+	}
+	if (selectedModelsString) {
+		sessionStorage.removeItem(PENDING_OAUTH_SELECTED_MODELS_KEY);
+	}
+
+	let selectedModels: string[] | null = null;
+	if (selectedModelsString) {
+		try {
+			const parsed = JSON.parse(selectedModelsString);
+			if (Array.isArray(parsed)) {
+				selectedModels = parsed.filter((id) => typeof id === 'string' && id);
+			}
+		} catch {
+			selectedModels = null;
+		}
+	}
+
+	return { toolId, selectedModels };
+};
+
+export const applyPendingOAuthState = ({
+	availableModels,
+	selectedModels,
+	selectedToolIds,
+	pendingState
+}: {
+	availableModels: string[];
+	selectedModels: string[];
+	selectedToolIds: string[];
+	pendingState: PendingOAuthState;
+}) => {
+	const nextSelectedModels =
+		pendingState.selectedModels && pendingState.selectedModels.length > 0
+			? pendingState.selectedModels.filter((modelId) => availableModels.includes(modelId))
+			: selectedModels;
+
+	const nextSelectedToolIds =
+		pendingState.toolId && !selectedToolIds.includes(pendingState.toolId)
+			? [...selectedToolIds, pendingState.toolId]
+			: selectedToolIds;
+
+	return {
+		selectedModels: nextSelectedModels,
+		selectedToolIds: nextSelectedToolIds
+	};
+};


### PR DESCRIPTION
# Pull Request Checklist

- [x] fixes #25735
- [x] Targets `dev`
- [x] Focused tests included
- [x] Atomic change

# Changelog Entry

### Description

- Preserve the initiating chat model selection when MCP OAuth redirects the user away from and back to Open WebUI.

### Added

- Focused regression coverage for pending OAuth state save/consume/restore behavior.

### Changed

- Reused a small helper from both MCP OAuth entry points so the chat can snapshot the selected models before redirect.
- Restored both the pending tool and the previously selected models after the OAuth round-trip.

### Fixed

- OAuth flows triggered from a non-default model no longer return the user to the chat with the default model selected.

---

### Additional Information

- Current `dev` already restores `pendingOAuthToolId`; this patch extends the same round-trip to the initiating model selection.
- Restored models are filtered against the currently available model IDs before they are applied.

### Testing

- `npx vitest run --config .tmp-vitest-oauth.config.ts`
- `npx eslint src/lib/utils/oauth-pending-state.ts src/lib/utils/oauth-pending-state.test.ts`
- `npx tsc --noEmit --lib es2020,dom --module esnext --moduleResolution bundler --target es2020 --types vitest/globals src/lib/utils/oauth-pending-state.ts src/lib/utils/oauth-pending-state.test.ts`
- `git diff --check`

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
