### PR TITLE
fix: use await asyncio.sleep() instead of time.sleep() in async generator for Redis

### DIFF
--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -185,7 +185,7 @@ class SentinelRedisProxy:
                         if proxy._should_retry(attempt):
                             proxy._log_retry(exc, attempt)
                             if REDIS_RECONNECT_DELAY:
-                                time.sleep(REDIS_RECONNECT_DELAY / 1000)
+                                await asyncio.sleep(REDIS_RECONNECT_DELAY / 1000)
                             continue
                         proxy._log_exhausted(exc)
                         raise


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #DISCUSSION_NUMBER`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

`time.sleep()` is used inside an async generator in `SentinelRedisProxy._wrap_async_gen()`, which **blocks the entire event loop** during Redis Sentinel failover retries. This is a bug — the sibling method `_wrap_async_call()` (line 212) already correctly uses `await asyncio.sleep()`.

**The problem:**

```python
# _wrap_async_gen() — BEFORE (line 188, inside async generator _inner())
time.sleep(REDIS_RECONNECT_DELAY / 1000)  # ❌ Blocks event loop

# _wrap_async_call() — already correct (line 212)
await asyncio.sleep(REDIS_RECONNECT_DELAY / 1000)  # ✅ Yields to event loop
```

When a Sentinel failover occurs, the retry loop in `_wrap_async_gen()` calls `time.sleep()` inside an async generator (`_inner()`). Because `_inner()` runs on the event loop (it uses `yield` and `async for`), `time.sleep()` blocks all other coroutines for the full reconnect delay — potentially multiple seconds across multiple retry attempts.

**The fix:** Replace `time.sleep()` with `await asyncio.sleep()` to yield control back to the event loop during the retry delay, matching the pattern already used in `_wrap_async_call()`.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Event loop blocking during Redis Sentinel failover retries in async generator wrapper (`time.sleep()` → `await asyncio.sleep()`)

---

### Additional Information

- **1 file changed, 1 line modified** — minimal, surgical fix
- No new dependencies — `asyncio` was already imported
- The sync wrapper `_wrap_sync()` (line 233) correctly continues to use `time.sleep()` since it runs outside the event loop
- No benchmark needed — this is a correctness fix, not a performance optimization. `time.sleep()` inside an async generator is always wrong.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
