### PR TITLE
fix: use code block language tag to detect Vega-Lite specs for rendering

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -379,7 +379,7 @@
 			(token?.raw ?? '').slice(-4).includes('```')
 		) {
 			try {
-				renderHTML = await renderVegaVisualization(code);
+				renderHTML = await renderVegaVisualization(code, lang);
 			} catch (error) {
 				console.error('Failed to render Vega visualization:', error);
 				const errorMsg = error instanceof Error ? error.message : String(error);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1999,11 +1999,23 @@ export const renderMermaidDiagram = async (
 	}
 };
 
-export const renderVegaVisualization = async (spec: string, i18n?: any) => {
+export const renderVegaVisualization = async (spec: string, lang: string = '', i18n?: any) => {
 	const vega = await import('vega');
 	const parsedSpec = JSON.parse(spec);
+	const hasVegaLiteKeys =
+		'mark' in parsedSpec ||
+		'encoding' in parsedSpec ||
+		'layer' in parsedSpec ||
+		'hconcat' in parsedSpec ||
+		'vconcat' in parsedSpec ||
+		'repeat' in parsedSpec ||
+		'facet' in parsedSpec;
+	const isVegaLite =
+		lang === 'vega-lite' ||
+		(parsedSpec.$schema && parsedSpec.$schema.includes('vega-lite')) ||
+		hasVegaLiteKeys;
 	let vegaSpec = parsedSpec;
-	if (parsedSpec.$schema && parsedSpec.$schema.includes('vega-lite')) {
+	if (isVegaLite) {
 		const vegaLite = await import('vega-lite');
 		vegaSpec = vegaLite.compile(parsedSpec).spec;
 	}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Vega and Vega-Lite code blocks render as invisible (0×0 pixel) empty SVGs instead of displaying the chart. This affects both `` ```vega `` and `` ```vega-lite `` code blocks.

**Root cause:** `renderVegaVisualization()` only detected Vega-Lite specs by checking for `$schema` in the JSON body. Most Vega-Lite specs — especially those generated by LLMs or copied from tutorials — omit `$schema`. Without it, the function treated Vega-Lite JSON as a raw Vega spec. Vega's parser silently accepts the unknown keys but produces a degenerate 0×0 SVG (`width="0" height="0" viewBox="0 0 0 0"`), which renders as an invisible empty box.

**Fix:** Three-tiered Vega-Lite detection:

1. **Language tag** — if the code block is tagged `` ```vega-lite ``, always compile as Vega-Lite
2. **`$schema`** — if the JSON includes `$schema` containing `"vega-lite"`, compile as Vega-Lite (existing behavior, preserved)
3. **Heuristic** — if the JSON contains top-level keys unique to Vega-Lite (`mark`, `encoding`, `layer`, `hconcat`, `vconcat`, `repeat`, `facet`), compile as Vega-Lite. These keys do not exist in raw Vega specs, so this cannot misidentify a valid Vega spec.

This ensures both `` ```vega `` and `` ```vega-lite `` code blocks render correctly regardless of whether `$schema` is present.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Vega-Lite code blocks (`` ```vega-lite ``) now render correctly even when the spec omits `$schema`
- Vega code blocks (`` ```vega ``) with Vega-Lite content now render correctly via heuristic detection of Vega-Lite-specific keys

---

### Additional Information

- **Scope**: 2 files changed, +15 / −3 lines
- **No new dependencies**
- **No breaking changes** — raw Vega specs continue to render as before (they don't contain Vega-Lite-specific keys like `mark` or `encoding`)
- **Verification performed**:
  - `npm run format` — clean
  - `npm run build` — succeeds
  - `npm run test:frontend` — passes
  - Confirmed the user's exact spec (`{"data":{"values":[{"x":1,"y":2},{"x":2,"y":4}]},"mark":"line","encoding":{...}}`) now produces a proper 300×300 SVG with axes and data line, instead of a 0×0 empty SVG

### Manual Verification Performed

1. ✅ `npm run format && npm run build && npm run test:frontend` all pass
2. ✅ `` ```vega-lite `` without `$schema` — renders chart correctly (was invisible before)
3. ✅ `` ```vega `` with Vega-Lite spec — renders chart correctly (was invisible before)
4. ✅ `` ```vega-lite `` with `$schema` — still renders correctly (no regression)
5. ✅ `` ```vega `` with raw Vega spec — still renders correctly (heuristic does not trigger)
6. ✅ Mermaid diagrams unaffected (separate code path)

### Screenshots or Videos

## Before:

<img width="2011" height="557" alt="image" src="https://github.com/user-attachments/assets/3e8f592a-1ffc-4023-abfa-08e4cd2a08f5" />

<img width="1608" height="485" alt="image" src="https://github.com/user-attachments/assets/3e3b94b9-59c0-4ba2-84e7-2c97a01031e7" />

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/a73d3056-2854-4b1d-af08-fb33c6573b00" />

## After:

<img width="2344" height="1277" alt="image" src="https://github.com/user-attachments/assets/0f130758-ad04-4790-a56d-05eb1ea4ac0a" />

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/e406e263-d3a8-41c6-b38b-22c80929e834" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
