### PR TITLE
fix: prevent Code Editor drawer from collapsing when content is empty

### DIFF
--- a/src/lib/components/common/CodeEditorModal.svelte
+++ b/src/lib/components/common/CodeEditorModal.svelte
@@ -20,13 +20,13 @@
 	let _content = $state(value);
 
 	$effect(() => {
-		if (_content) {
+		if (_content !== undefined && _content !== null) {
 			value = _content;
 		}
 	});
 </script>
 
-<Drawer bind:show>
+<Drawer bind:show className="h-full">
 	<div class="flex h-full flex-col">
 		<div
 			class=" sticky top-0 z-30 flex justify-between bg-white px-4.5 pt-3 pb-3 dark:bg-gray-900 dark:text-gray-100"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The `CodeEditorModal` component (used for the ComfyUI Workflow JSON editor in **Admin → Settings → Images**) collapses to a tiny bar at the bottom of the screen when the code editor content is empty. This happens for both the **Create Image** and **Edit Image** ComfyUI Workflow editors.

**Root causes:**

1. **Empty content not synced back to parent**: The `$effect` block in `CodeEditorModal.svelte` used `if (_content)` to guard the sync — but empty strings are falsy in JavaScript, so clearing the editor content never propagated back to the parent component.

2. **Drawer panel collapses without content**: The `Drawer` component's inner container uses `mt-auto` (bottom-sheet behavior) and sizes based on content height. When the CodeMirror editor has no content, it collapses to near-zero height, and `mt-auto` pushes the tiny panel to the very bottom of the viewport.

**Fixes applied:**

1. Changed the `$effect` guard from `if (_content)` to `if (_content !== undefined && _content !== null)` so empty strings are correctly synced.

2. Passed `className="h-full"` to the `Drawer` component so its inner container always fills the full viewport height, regardless of editor content.

### Fixed

- Code Editor drawer collapsing to a small bar at the bottom of the screen when content is cleared in the ComfyUI Workflow editor (Admin → Settings → Images)

### Screenshots or Videos

## Before:

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/33e825fa-81a1-4355-96e8-f60549ce3ef8" />

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/0f26985e-692e-4710-9e2c-01c2112e03ef" />

### After:

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/f2243556-1b4f-44fe-a45a-182d5078e3b2" />

<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/b6d181e4-b181-44c0-a406-eb2b2c836b5b" />


### Manual Verification Performed

1. Navigate to **Admin → Settings → Images** with Image Generation Engine set to **ComfyUI**
2. Upload or paste a ComfyUI workflow JSON into the **Create Image → ComfyUI Workflow** editor
3. Open the Code Editor, select all content, and delete it
4. Verify the Code Editor drawer still fills the full viewport (not collapsed to a bar at the bottom)
5. Repeat steps 2–4 for the **Edit Image → ComfyUI Workflow** editor
6. Verify `npm run build` passes without errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
