### PR TITLE
fix: prevent all-day event date drift on calendar event save

### DIFF
--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -39,7 +39,11 @@
 	const NS = 1_000_000;
 
 	function nsToDateStr(ns: number): string {
-		return new Date(ns / NS).toISOString().slice(0, 10);
+		const d = new Date(ns / NS);
+		const year = d.getFullYear();
+		const month = String(d.getMonth() + 1).padStart(2, '0');
+		const day = String(d.getDate()).padStart(2, '0');
+		return `${year}-${month}-${day}`;
 	}
 
 	function nsToTimeStr(ns: number): string {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Fixes a bug where **all-day calendar events drift forward by one day** each time they are opened for editing and saved — even without making any changes.

**Root cause:** The `nsToDateStr()` helper in `CalendarEventModal.svelte` used `.toISOString()` to extract the date portion, which returns the date in **UTC**. However, `dateTimeToNs()` — the inverse function used when saving — parses date strings in **local time** via `new Date('YYYY-MM-DDThh:mm')`. This UTC/local mismatch caused the end date of all-day events to silently shift forward for users in negative UTC offsets (e.g., EDT, UTC-4):

1. An all-day event ending at `23:59 local (EDT)` = `03:59 next day (UTC)`
2. On edit load, `nsToDateStr()` extracts the UTC date → gets the **next day**
3. On save, `dateTimeToNs()` interprets that date as local time → end shifts forward by 1 day
4. Each edit→save cycle repeats the drift

Meanwhile, `nsToTimeStr()` already correctly used `.toTimeString()` (local time), making the inconsistency non-obvious.

**Fix:** Replaced `.toISOString().slice(0, 10)` with local date getters (`getFullYear()`, `getMonth()`, `getDate()`), making `nsToDateStr()` consistent with the rest of the local-time date handling in the component.

No new dependencies. No backend changes.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- All-day calendar events drifting forward by one day on each edit→save cycle due to UTC/local timezone mismatch in date conversion

### Screenshots or Videos

## Before:
[Screencast from 2026-06-09 10-00-14.webm](https://github.com/user-attachments/assets/6324bfad-84cc-46ec-9fe1-cfa1f71702fa)

## After:

<img width="2348" height="915" alt="image" src="https://github.com/user-attachments/assets/5cbb40eb-9a0b-427e-93f6-f443e73469b0" />

<img width="2348" height="915" alt="image" src="https://github.com/user-attachments/assets/e60154af-a621-4d3a-8fba-58a026e00397" />

### Manual Verification Performed

1. Create an all-day event on a specific date (e.g., June 9)
2. Click the event to edit → click **Save** without making any changes
3. Verify the event remains on the same date (previously it would shift to June 10)
4. Repeat step 2 multiple times → verify the event stays put (previously it drifted forward each time)
5. Create a non-all-day event → edit and save → verify no date drift
6. Test in a positive UTC offset timezone (e.g., UTC+8) if possible — the same mismatch affected those users in the opposite direction
7. `npm run build` passes without errors

---

### Additional Information

- Only `nsToDateStr()` was affected — `nsToTimeStr()` already used local time correctly via `.toTimeString()`
- The fix is a 5-line change in a single file: `src/lib/components/calendar/CalendarEventModal.svelte`

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
