### PR TITLE
feat: show chat count in ChatsModal title

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -829,6 +829,17 @@ class ChatTable:
                 for chat in all_chats
             ]
 
+    async def count_archived_chats_by_user_id(
+        self,
+        user_id: str,
+        db: AsyncSession | None = None,
+    ) -> int:
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                select(func.count(Chat.id)).filter_by(user_id=user_id, archived=True)
+            )
+            return result.scalar() or 0
+
     async def get_shared_chat_list_by_user_id(
         self,
         user_id: str,

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -801,6 +801,19 @@ async def get_archived_session_user_chat_list(
 
 
 ############################
+# GetArchivedChatsCount
+############################
+
+
+@router.get('/archived/count', response_model=int)
+async def get_archived_session_user_chat_count(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    return await Chats.count_archived_chats_by_user_id(user.id, db=db)
+
+
+############################
 # ArchiveAllChats
 ############################
 

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -255,6 +255,34 @@ export const getArchivedChatList = async (
 	}));
 };
 
+export const getArchivedChatCount = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/archived/count`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getSharedChatList = async (token: string = '', page: number = 1, filter?: object) => {
 	let error = null;
 

--- a/src/lib/components/layout/ArchivedChatsModal.svelte
+++ b/src/lib/components/layout/ArchivedChatsModal.svelte
@@ -9,6 +9,7 @@
 	import {
 		archiveChatById,
 		getAllArchivedChats,
+		getArchivedChatCount,
 		getArchivedChatList,
 		unarchiveAllChats
 	} from '$lib/apis/chats';
@@ -25,6 +26,7 @@
 
 	let loading = false;
 	let chatList: any[] | null = null;
+	let chatCount: number | null = null;
 	let page = 1;
 
 	let query = '';
@@ -110,8 +112,9 @@
 			toast.error(`${error}`);
 		});
 
+		chatList = chatList?.filter((c) => c.id !== chatId) ?? null;
+		if (chatCount !== null) chatCount--;
 		onUpdate();
-		init();
 	};
 
 	const unarchiveAllHandler = async () => {
@@ -130,6 +133,7 @@
 
 	const init = async () => {
 		chatList = await getArchivedChatList(localStorage.token);
+		chatCount = await getArchivedChatCount(localStorage.token);
 	};
 
 	$: if (show) {
@@ -153,13 +157,15 @@
 	bind:direction
 	title={$i18n.t('Archived Chats')}
 	emptyPlaceholder={$i18n.t('You have no archived conversations.')}
+	count={chatCount}
 	{chatList}
 	{allChatsLoaded}
 	{chatListLoading}
 	onUpdate={() => {
-		init();
+		onUpdate();
 	}}
 	onDelete={(id) => {
+		if (chatCount !== null) chatCount--;
 		onDelete(id);
 	}}
 	loadHandler={loadMoreChats}

--- a/src/lib/components/layout/ChatsModal.svelte
+++ b/src/lib/components/layout/ChatsModal.svelte
@@ -36,6 +36,8 @@
 	export let showSearch = true;
 	export let readOnly = false;
 
+	export let count: number | null = null;
+
 	export let query = '';
 
 	export let orderBy = 'updated_at';
@@ -71,6 +73,7 @@
 		});
 
 		if (res) {
+			chatList = chatList?.filter((c) => c.id !== chatId) ?? null;
 			onDelete(chatId);
 		}
 		onUpdate();
@@ -90,7 +93,18 @@
 <Modal size="lg" bind:show>
 	<div>
 		<div class=" flex justify-between dark:text-gray-300 px-5 pt-4 pb-1">
-			<div class=" text-lg font-medium self-center">{title}</div>
+			<div class="flex items-center gap-2 text-lg font-medium self-center">
+				<div>{title}</div>
+				{#if count !== null}
+					<div class="text-lg font-medium text-gray-500 dark:text-gray-500">
+						{count}
+					</div>
+				{:else if chatList}
+					<div class="text-lg font-medium text-gray-500 dark:text-gray-500">
+						{chatList.length}
+					</div>
+				{/if}
+			</div>
 			<button
 				class="self-center"
 				on:click={() => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Adds a **total chat count** next to the title in the Archived Chats modal, matching the existing count pattern used in other areas of the UI (e.g., **Tools 38**, **Prompts 12**).

#### Problem

The Archived Chats modal uses pagination (pages of 60 items), so a naive `chatList.length` count would only reflect the number of *loaded* items — not the true total. Deleting or unarchiving a chat would also cause the count to bounce (optimistic removal immediately overwritten by a server refetch repopulating the page).

#### Solution

This PR adds a lightweight `SELECT COUNT(id)` backend endpoint and wires it into the frontend:

**Backend:**
- `Chats.count_archived_chats_by_user_id()` — new model method using `func.count(Chat.id)` with `archived=True` filter
- `GET /api/v1/chats/archived/count` — new router endpoint returning the total count as an integer

**Frontend:**
- `getArchivedChatCount()` — new API function in `src/lib/apis/chats/index.ts`
- `ArchivedChatsModal.svelte` — fetches the total count on modal open, decrements optimistically on unarchive/delete (no refetch bounce)
- `ChatsModal.svelte` — new optional `count` prop; when provided, displays the server-backed total instead of `chatList.length`

The `ChatsModal` component falls back to `chatList.length` when no `count` prop is passed, so other consumers (Shared Chats, User Chats) continue to work as before.

No new dependencies.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- `GET /api/v1/chats/archived/count` backend endpoint returning the total number of archived chats
- Total archived chat count displayed next to the title in the Archived Chats modal
- Optional `count` prop on `ChatsModal` for server-backed counts (falls back to `chatList.length`)
- Optimistic count decrement on unarchive and delete actions

### Screenshots or Videos

## Before:

<img width="911" height="254" alt="image" src="https://github.com/user-attachments/assets/4a7cf39d-fd11-43e9-b88c-e81ba7d767f1" />

<img width="907" height="548" alt="image" src="https://github.com/user-attachments/assets/a2fa761a-25fc-414c-8d9a-8998164c75c7" />

<img width="910" height="472" alt="image" src="https://github.com/user-attachments/assets/a3add6e6-2e7e-43d1-b0f5-52c6279872eb" />

## After:

<img width="911" height="254" alt="image" src="https://github.com/user-attachments/assets/28ec157e-1328-47ac-8113-3b488fff27bd" />

<img width="911" height="563" alt="image" src="https://github.com/user-attachments/assets/fd8632aa-be0f-4a85-9f2d-447fdfda75a2" />

<img width="910" height="472" alt="image" src="https://github.com/user-attachments/assets/1b412158-c964-4439-8c6d-28fcd85fc0f2" />

### Manual Verification Performed

1. Open **Settings → Data Controls → Archived Chats** → verify total count appears next to "Archived Chats"
2. Verify count matches the actual total (not just loaded page count) by cross-referencing with the database
3. Unarchive a chat → verify the count decrements by 1 immediately (no bounce)
4. Delete an archived chat → verify the count decrements by 1 immediately (no bounce)
5. Close and reopen the modal → verify the count refreshes from the server
6. Unarchive All → verify the count resets to 0
7. Verify Shared Chats and User Chats modals still display `chatList.length` (no regression)
8. `npm run build` passes without errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
