### PR TITLE
feat: show total file count in FilesModal title

### DIFF
--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -201,6 +201,18 @@ class FilesTable:
             result = await db.execute(select(File))
             return [FileModel.model_validate(file) for file in result.scalars().all()]
 
+    async def count_files_by_user_id(
+        self,
+        user_id: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> int:
+        async with get_async_db_context(db) as db:
+            stmt = select(func.count(File.id))
+            if user_id:
+                stmt = stmt.filter_by(user_id=user_id)
+            result = await db.execute(stmt)
+            return result.scalar() or 0
+
     async def check_access_by_user_id(self, id, user_id, permission='write', db: AsyncSession | None = None) -> bool:
         file = await self.get_file_by_id(id, db=db)
         if not file:

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -444,6 +444,20 @@ async def search_files(
 
 
 ############################
+# Count Files
+############################
+
+
+@router.get('/count', response_model=int)
+async def count_files(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    user_id = None if (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL) else user.id
+    return await Files.count_files_by_user_id(user_id=user_id, db=db)
+
+
+############################
 # Delete All Files
 ############################
 

--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -214,6 +214,34 @@ export const searchFiles = async (
 	return res;
 };
 
+export const getFileCount = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/files/count`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getFileById = async (token: string, id: string) => {
 	let error = null;
 

--- a/src/lib/components/layout/FilesModal.svelte
+++ b/src/lib/components/layout/FilesModal.svelte
@@ -4,7 +4,7 @@
 	import type { Writable } from 'svelte/store';
 	import dayjs from 'dayjs';
 
-	import { searchFiles, deleteFileById } from '$lib/apis/files';
+	import { searchFiles, deleteFileById, getFileCount } from '$lib/apis/files';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -21,6 +21,7 @@
 	export let show = false;
 
 	let files: any[] | null = null;
+	let fileCount: number | null = null;
 	let query = '';
 	let orderBy = 'created_at';
 	let direction = 'desc';
@@ -70,6 +71,10 @@
 			const newFiles = await searchFiles(localStorage.token, pattern, 0, PAGE_SIZE);
 			files = sortFiles(newFiles);
 			allFilesLoaded = newFiles.length < PAGE_SIZE;
+
+			if (!query) {
+				fileCount = await getFileCount(localStorage.token);
+			}
 		} catch (error) {
 			// Handle 404 or other errors - show empty state instead of spinner
 			files = [];
@@ -124,6 +129,7 @@
 			toast.success($i18n.t('File deleted successfully.'));
 			// Remove from local array instead of re-fetching to allow rapid deletion
 			files = files?.filter((f) => f.id !== fileId) ?? null;
+			if (fileCount !== null) fileCount--;
 		} catch (error) {
 			toast.error(`${error}`);
 		}
@@ -197,7 +203,18 @@
 <Modal size="xl" bind:show>
 	<div>
 		<div class="flex justify-between dark:text-gray-300 px-5 pt-4 pb-1">
-			<div class="text-lg font-medium self-center">{$i18n.t('Files')}</div>
+			<div class="flex items-center gap-2 text-lg font-medium self-center">
+				<div>{$i18n.t('Files')}</div>
+				{#if query && files}
+					<div class="text-lg font-medium text-gray-500 dark:text-gray-500">
+						{files.length}
+					</div>
+				{:else if fileCount !== null}
+					<div class="text-lg font-medium text-gray-500 dark:text-gray-500">
+						{fileCount}
+					</div>
+				{/if}
+			</div>
 			<button
 				class="self-center"
 				on:click={() => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Adds a **total file count** next to the title in the Files modal (Settings → Data Controls → Files → Manage), matching the existing count pattern used in other areas of the UI (e.g., **Tools 38**, **Prompts 12**).

#### Problem

The Files modal uses pagination (pages of 50 items), so a naive `files.length` count would only reflect the number of *loaded* items on the current page — not the true total. The count also shouldn't change when the user is searching, since the total files haven't changed — but filtered results should show their own count.

#### Solution

This PR adds a lightweight `SELECT COUNT(id)` backend endpoint and wires it into the frontend:

**Backend:**
- `FilesTable.count_files_by_user_id()` — new model method using `func.count(File.id)` with optional `user_id` filter (respects admin bypass)
- `GET /api/v1/files/count` — new router endpoint returning the total count as an integer

**Frontend:**
- `getFileCount()` — new API function in `src/lib/apis/files/index.ts`
- `FilesModal.svelte`:
  - Fetches the total count alongside the initial file list (no extra reactive block)
  - When a search query is active, displays `files.length` (filtered count) instead of the total
  - Decrements the total count optimistically on file deletion (no refetch bounce)

The count is **search-aware**:
- **No query** → shows total from server (e.g., "Files 99")
- **Active search** → shows loaded matches (e.g., "Files 1")
- **Clear search** → re-fetches total from server

No new dependencies.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- `GET /api/v1/files/count` backend endpoint returning the total number of files
- Total file count displayed next to the title in the Files modal
- Search-aware count: shows filtered result count during search, total count otherwise
- Optimistic count decrement on file deletion

### Screenshots or Videos

## Before:

<img width="1144" height="676" alt="image" src="https://github.com/user-attachments/assets/8470b67c-1858-420d-ac48-c273e1ced20a" />

<img width="1144" height="676" alt="image" src="https://github.com/user-attachments/assets/2a3eb363-cc86-4de5-90ca-ad60748abc8e" />


## After:

<img width="1144" height="676" alt="image" src="https://github.com/user-attachments/assets/f1b93a3a-6c29-4ff7-b081-355720daa274" />

<img width="1144" height="676" alt="image" src="https://github.com/user-attachments/assets/74e38f65-0a68-404e-a4fb-08ace526e6ce" />


### Manual Verification Performed

1. Open **Settings → Data Controls → Files → Manage** → verify total count appears next to "Files"
2. Search for a filename → verify count changes to reflect filtered results
3. Clear the search → verify count returns to the total
4. Delete a file → verify the count decrements by 1 immediately (no bounce)
5. Shift+click delete → verify instant deletion with count decrement
6. Close and reopen the modal → verify the count refreshes from the server
7. `npm run build` passes without errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
