### PR TITLE
fix: strip prefix_id from model identifier during OpenAI-compatible model eject

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1596,6 +1596,11 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
         idx = model_info.get('urlIdx')
         api_config = request.app.state.config.OPENAI_API_CONFIGS.get(str(idx), {})
         provider = api_config.get('provider', '')
+
+        prefix_id = api_config.get('prefix_id', None)
+        actual_model = model_id
+        if prefix_id and actual_model.startswith(f'{prefix_id}.'):
+            actual_model = actual_model[len(f'{prefix_id}.') :]
         base_url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
         key = (
             request.app.state.config.OPENAI_API_KEYS[idx] if idx < len(request.app.state.config.OPENAI_API_KEYS) else ''
@@ -1612,7 +1617,7 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
                     }
                     async with session.post(
                         f'{root_url}/models/unload',
-                        json={'model': model_id},
+                        json={'model': actual_model},
                         headers=headers,
                     ) as r:
                         if not r.ok:


### PR DESCRIPTION
## Description

Closes #25830

When an OpenAI-compatible connection (e.g., llama.cpp) has a Prefix ID configured, the Eject/Unload action sends the full prefixed model ID to the backend instead of stripping the prefix first. The backend doesn't recognize the prefixed string and returns a 404.

The Ollama section of `unload_model()` already handles prefix stripping correctly (lines 1560-1563). This fix applies the same pattern to the OpenAI-compatible section.

### Fixed

- Strip `prefix_id` from model identifier during OpenAI-compatible model eject to fix 404 errors when Prefix ID is configured

### How to Test

1. Configure an OpenAI-compatible connection (e.g., llama.cpp) with a Prefix ID (e.g., "my-backend")
2. Load a model through this connection
3. Attempt to eject/unload the model
4. Before fix: 404 error (backend receives "my-backend.model-name")
5. After fix: model ejects successfully (backend receives "model-name")

### Additional Information

- Only 1 file changed (`backend/open_webui/main.py`), 6 insertions, 1 deletion
- The fix mirrors the existing prefix stripping logic in the Ollama section

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.