### PR TITLE
fix: add timeout to getUserPosition to prevent chat hang on HTTPS

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -760,28 +760,7 @@ export const getImportOrigin = (_chats) => {
 	return 'webui';
 };
 
-export const getUserPosition = async (raw = false) => {
-	// Get the user's location using the Geolocation API
-	const position = await new Promise((resolve, reject) => {
-		navigator.geolocation.getCurrentPosition(resolve, reject);
-	}).catch((error) => {
-		console.error('Error getting user location:', error);
-		throw error;
-	});
-
-	if (!position) {
-		return 'Location not available';
-	}
-
-	// Extract the latitude and longitude from the position
-	const { latitude, longitude } = position.coords;
-
-	if (raw) {
-		return { latitude, longitude };
-	} else {
-		return `${latitude.toFixed(3)}, ${longitude.toFixed(3)} (lat, long)`;
-	}
-};
+export { getUserPosition } from './location';
 
 const extractOpenAIMessageContent = (message): string => {
 	// Extract text content from a ChatGPT message, handling various content formats

--- a/src/lib/utils/location.test.ts
+++ b/src/lib/utils/location.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getUserPosition } from './location';
+
+const mockGetCurrentPosition = vi.fn();
+
+beforeEach(() => {
+	vi.stubGlobal('navigator', {
+		geolocation: { getCurrentPosition: mockGetCurrentPosition }
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
+
+describe('getUserPosition', () => {
+	it('passes timeout options to getCurrentPosition', async () => {
+		mockGetCurrentPosition.mockImplementation((success: PositionCallback) => {
+			success({ coords: { latitude: 48.123, longitude: 37.456 } } as GeolocationPosition);
+		});
+
+		await getUserPosition();
+
+		expect(mockGetCurrentPosition).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.any(Function),
+			{ timeout: 5000, maximumAge: 60_000, enableHighAccuracy: false }
+		);
+	});
+
+	it('returns formatted coordinates by default', async () => {
+		mockGetCurrentPosition.mockImplementation((success: PositionCallback) => {
+			success({ coords: { latitude: 48.1234, longitude: 37.4567 } } as GeolocationPosition);
+		});
+
+		const result = await getUserPosition();
+		expect(result).toBe('48.123, 37.457 (lat, long)');
+	});
+
+	it('returns raw coordinates when raw=true', async () => {
+		mockGetCurrentPosition.mockImplementation((success: PositionCallback) => {
+			success({ coords: { latitude: 48.123, longitude: 37.456 } } as GeolocationPosition);
+		});
+
+		const result = await getUserPosition(true);
+		expect(result).toEqual({ latitude: 48.123, longitude: 37.456 });
+	});
+
+	it('throws when geolocation permission is denied', async () => {
+		const error = { code: 1, message: 'User denied geolocation' } as GeolocationPositionError;
+		mockGetCurrentPosition.mockImplementation((_: PositionCallback, reject: PositionErrorCallback) => {
+			reject(error);
+		});
+
+		await expect(getUserPosition()).rejects.toMatchObject({ message: 'User denied geolocation' });
+	});
+
+	it('throws when geolocation times out', async () => {
+		const error = { code: 3, message: 'Timeout expired' } as GeolocationPositionError;
+		mockGetCurrentPosition.mockImplementation((_: PositionCallback, reject: PositionErrorCallback) => {
+			reject(error);
+		});
+
+		await expect(getUserPosition()).rejects.toMatchObject({ message: 'Timeout expired' });
+	});
+
+	it('throws when geolocation API is unavailable', async () => {
+		vi.stubGlobal('navigator', {});
+
+		await expect(getUserPosition()).rejects.toThrow(
+			'Geolocation is not supported by this browser'
+		);
+	});
+});

--- a/src/lib/utils/location.ts
+++ b/src/lib/utils/location.ts
@@ -1,0 +1,28 @@
+export const getUserPosition = async (raw = false) => {
+	const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+		if (!('geolocation' in navigator)) {
+			reject(new Error('Geolocation is not supported by this browser'));
+			return;
+		}
+		navigator.geolocation.getCurrentPosition(resolve, reject, {
+			timeout: 5000,
+			maximumAge: 60_000,
+			enableHighAccuracy: false
+		});
+	}).catch((error) => {
+		console.error('Error getting user location:', error);
+		throw error;
+	});
+
+	if (!position) {
+		return 'Location not available';
+	}
+
+	const { latitude, longitude } = position.coords;
+
+	if (raw) {
+		return { latitude, longitude };
+	} else {
+		return `${latitude.toFixed(3)}, ${longitude.toFixed(3)} (lat, long)`;
+	}
+};


### PR DESCRIPTION
## Problem

When **User Location** is enabled in Settings → Interface, `getUserPosition()` is awaited in `Chat.svelte` before the LLM request is dispatched. The function calls `navigator.geolocation.getCurrentPosition()` **without a timeout option** — the [Web specification](https://w3c.github.io/geolocation/#dom-positionoptions-timeout) defaults this to `Infinity`.

On **HTTP** origins the browser rejects geolocation immediately (insecure context), so the Promise settles fast and chat works fine. On **HTTPS** origins, one of the following can cause the Promise to hang indefinitely:

- The browser shows a permission prompt and the user does not interact with it.
- The user clicks **Allow** but the underlying OS location service is slow or unreachable (e.g. Windows Location Service contacts `inference.location.live.net`, which may be blocked by a Pi-hole, corporate firewall, or network policy).

In both cases the `await` in `Chat.svelte` never returns, the spinner shows, and `POST /api/chat/completions` is never sent. No error is surfaced to the user.

**Affected surface:** `Chat.svelte` (blocks message send), `Settings/Interface.svelte` (blocks toggle, less critical — already shows a toast on error).

## Fix

Pass explicit `PositionOptions` to `getCurrentPosition`:

```ts
navigator.geolocation.getCurrentPosition(resolve, reject, {
    timeout: 5000,
    maximumAge: 60_000,
    enableHighAccuracy: false
});
```

- **`timeout: 5000`** — reject after 5 s; the error is caught and the chat request continues normally.  
- **`maximumAge: 60_000`** — accept a cached fix up to 1 min old; avoids triggering a new OS lookup on every message.  
- **`enableHighAccuracy: false`** — use the fastest/cheapest fix (Wi-Fi/IP); high accuracy (GPS) is not needed for the location string injected into the prompt.

An explicit `'geolocation' in navigator` guard is also added so the error message is clear when the API is blocked by a `Permissions-Policy` header.

## Refactor for testability

`getUserPosition` is extracted to `src/lib/utils/location.ts`. This lets tests import the function in isolation, without mocking the many heavy browser dependencies (`dompurify`, `pdfjs-dist ?url` import, `$lib/constants`, etc.) that the `utils/index.ts` barrel pulls in. `index.ts` re-exports the function unchanged, so no call sites need updating.

## Tests

`src/lib/utils/location.test.ts` (Vitest, node environment + `vi.stubGlobal`):

| Test | What it verifies |
|------|-----------------|
| passes timeout options | `getCurrentPosition` is called with the exact `{ timeout, maximumAge, enableHighAccuracy }` object — directly tests the fix |
| formatted string | default `raw=false` returns `"lat, long (lat, long)"` format |
| raw coordinates | `raw=true` returns `{ latitude, longitude }` object |
| permission denied | rejection propagates with the original error |
| timeout rejection | `TIMEOUT` error (code 3) propagates correctly |
| API unavailable | throws `"Geolocation is not supported by this browser"` when `navigator.geolocation` is absent |

## Reproduction (controlled)

Build locally with `npm run build` and serve over HTTPS (e.g. via `caddy file-server --browse --listen :443`). Enable User Location, then block `inference.location.live.net` in your hosts file or firewall and click Allow on the location prompt. Without this fix the chat hangs; with it, it fails gracefully after 5 s.

## Checklist

- [x] Bug fix (non-breaking — error is caught and chat continues)
- [x] Unit tests added
- [x] No new dependencies
- [x] All existing call sites (`Chat.svelte`, `Settings/Interface.svelte`, `apis/users`) unchanged — re-export is transparent