### PR TITLE
fix: strip prefix_id from model identifier during OpenAI-compatible model eject

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1596,6 +1596,11 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
         idx = model_info.get('urlIdx')
         api_config = request.app.state.config.OPENAI_API_CONFIGS.get(str(idx), {})
         provider = api_config.get('provider', '')
+
+        prefix_id = api_config.get('prefix_id', None)
+        actual_model = model_id
+        if prefix_id and actual_model.startswith(f'{prefix_id}.'):
+            actual_model = actual_model[len(f'{prefix_id}.') :]
         base_url = request.app.state.config.OPENAI_API_BASE_URLS[idx]
         key = (
             request.app.state.config.OPENAI_API_KEYS[idx] if idx < len(request.app.state.config.OPENAI_API_KEYS) else ''
@@ -1612,7 +1617,7 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
                     }
                     async with session.post(
                         f'{root_url}/models/unload',
-                        json={'model': model_id},
+                        json={'model': actual_model},
                         headers=headers,
                     ) as r:
                         if not r.ok:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #25830`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is human-written and has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

When an OpenAI-compatible connection (e.g., llama.cpp) has a Prefix ID configured, the Eject/Unload action sends the full prefixed model ID (e.g., "my-backend.model-name") to the backend instead of the clean model name ("model-name"). The backend doesn't recognize the prefixed string and returns a 404.

The Ollama section of `unload_model()` already handles prefix stripping correctly. This fix applies the same pattern to the OpenAI-compatible section.

### Fixed

- Strip `prefix_id` from model identifier during OpenAI-compatible model eject to fix 404 errors when Prefix ID is configured

### How to Test

1. Configure an OpenAI-compatible connection (e.g., llama.cpp) with a Prefix ID (e.g., "my-backend")
2. Load a model through this connection
3. Attempt to eject/unload the model
4. Before fix: 404 error (backend receives "my-backend.model-name")
5. After fix: model ejects successfully (backend receives "model-name")

### Additional Information

- Only 1 file changed (`backend/open_webui/main.py`), 6 insertions, 1 deletion
- The fix mirrors the existing prefix stripping logic in the Ollama section (lines 1560-1563)

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
