### PR TITLE
fix: close DNS-rebinding SSRF in get_content_from_url URL probe

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -171,7 +171,7 @@ def _is_text_content_type(content_type: str) -> bool:
 
 
 def get_content_from_url(request, url: str) -> str:
-    from open_webui.retrieval.web.utils import validate_url
+    from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 
     # Validate URL before making any request (blocks private IPs, non-HTTP, filter list)
     validate_url(url)
@@ -189,12 +189,12 @@ def get_content_from_url(request, url: str) -> str:
         return content, docs
 
     # Streamed GET to check Content-Type without downloading the body.
-    # allow_redirects=False prevents redirect-based SSRF: validate_url() above is
-    # called on the originally-submitted URL only; following 3xx redirects without
-    # re-validation would let an attacker reach private IPs (RFC1918, loopback,
-    # cloud-metadata 169.254.169.254) via a public host that redirects internally.
+    # SSRF-safe session (not bare requests.get): re-validates the resolved IP at
+    # connect time, closing the DNS-rebinding window left open by validate_url()'s
+    # up-front resolve. allow_redirects defaults to False (no redirect SSRF).
+    session = get_ssrf_safe_session()
     try:
-        response = requests.get(url, stream=True, timeout=30, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS)
+        response = session.get(url, stream=True, timeout=30, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS)
         response.raise_for_status()
         content_type = response.headers.get('Content-Type', '')
     except Exception:
@@ -205,6 +205,7 @@ def get_content_from_url(request, url: str) -> str:
     if response is None or _is_text_content_type(content_type):
         if response is not None:
             response.close()
+        session.close()
         loader = get_loader(request, url)
         docs = loader.load()
         content = ' '.join([doc.page_content for doc in docs])
@@ -215,6 +216,7 @@ def get_content_from_url(request, url: str) -> str:
         return _extract_text_from_binary_response(request, response, url)
     finally:
         response.close()
+        session.close()
 
 
 CHUNK_HASH_KEY = '_chunk_hash'

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -197,6 +197,19 @@ class _SSRFSafeResolver(aiohttp.resolver.DefaultResolver):
         return results
 
 
+def get_ssrf_safe_session() -> requests.Session:
+    """requests.Session that re-validates resolved IPs at connect time.
+
+    Unlike the stock default adapter, _SSRFSafeAdapter pins the global-IP check
+    to the address actually connected to, closing the DNS-rebinding window left
+    open by validate_url()'s up-front resolve. Mirrors SafeWebBaseLoader.
+    """
+    session = requests.Session()
+    session.mount('http://', _SSRFSafeAdapter())
+    session.mount('https://', _SSRFSafeAdapter())
+    return session
+
+
 def extract_metadata(soup, url):
     metadata = {'source': url}
     if title := soup.find('title'):


### PR DESCRIPTION
The Content-Type probe in get_content_from_url() used a bare requests.get(), whose default adapter resolves DNS again at connect time with no re-validation. validate_url() resolves and checks the host once, up front, leaving a DNS-rebinding / TOCTOU window: a host can pass validation as a public IP, then rebind to an internal address (RFC1918, loopback, cloud-metadata 169.254.169.254) before the socket connects. Reachable via POST /process/web (any authenticated user); the binary branch returns the internal response body to the caller.

Route the probe through a new get_ssrf_safe_session() that mounts the existing _SSRFSafeAdapter -- the same connection-layer protection SafeWebBaseLoader already uses -- so the resolved IP is re-validated at connect time and pinned to the address actually connected to. Close the session on all paths.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
