### PR TITLE
 fix: handle null tool_calls in Anthropic response conversion

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -382,7 +382,7 @@ def convert_openai_to_anthropic_response(openai_response: dict, model: str = '')
         content.append({'type': 'text', 'text': msg_content})
 
     # Tool calls → tool_use blocks
-    tool_calls = message.get('tool_calls', [])
+    tool_calls = message.get('tool_calls') or []
     for tc in tool_calls:
         func = tc.get('function', {})
         try:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #https://github.com/open-webui/open-webui/discussions/25964
- [x] **Target branch:** dev
- [x] **Description:** Provided below
- [x] **Changelog:** Included below
- [x] **Documentation:** Not required — internal conversion bug fix with no user-facing config changes
- [x] **Dependencies:** None
- [x] **Testing:** Manual test described below
- [x] **No Unchecked AI Code:** Human-reviewed one-line defensive fix
- [x] **Self-Review:** Completed
- [x] **Architecture:** No architectural changes
- [x] **Git Hygiene:** Single atomic change in convert_openai_to_anthropic_response
- [x] **Title Prefix:** fix

---

# Changelog Entry

### Description

Fixes a TypeError in convert_openai_to_anthropic_response when upstream providers return "tool_calls": null on the assistant message. dict.get('tool_calls', []) only applies its default when the key is missing, not when the value is explicitly None, so iterating over tool_calls crashed the /api/v1/messages non-streaming path with a 500 error.

### Fixed

- Handle explicit null tool_calls in OpenAI chat completion responses when converting to Anthropic Messages API format, by using message.get('tool_calls') or [] instead of message.get('tool_calls', []).

---

### Additional Information

**File changed:** backend/open_webui/utils/anthropic.py — convert_openai_to_anthropic_response

**Before:**

    tool_calls = message.get('tool_calls', [])

**After:**

    tool_calls = message.get('tool_calls') or []

Some providers (e.g. OpenAI-compatible gateways) include "tool_calls": null on text-only assistant replies. The previous code raised TypeError: 'NoneType' object is not iterable at the for tc in tool_calls loop, causing /api/v1/messages to return HTTP 500 even when the response was otherwise valid.

### Testing

Manual verification with a mocked response where tool_calls is explicitly None:

    resp = {
        'choices': [{
            'message': {'role': 'assistant', 'content': 'Hello', 'tool_calls': None},
            'finish_reason': 'stop',
        }],
        'usage': {'prompt_tokens': 10, 'completion_tokens': 5},
    }
    result = convert_openai_to_anthropic_response(resp, model='test-model')

- [x] tool_calls: None converts successfully to a text-only Anthropic message
- [x] tool_calls absent — unchanged behavior (empty list)
- [x] tool_calls present — unchanged behavior (tool_use blocks still emitted)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA) (https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.