### PR TITLE
fix: wrap executeToolServer call in try-catch to prevent hang on errors

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -419,29 +419,36 @@
 		console.log('executeTool', data, toolServer);
 
 		if (toolServer) {
-			const res = await executeToolServer(
-				token,
-				toolServer.url,
-				data?.name,
-				data?.params,
-				toolServerData,
-				chatId
-			);
+			try {
+				const res = await executeToolServer(
+					token,
+					toolServer.url,
+					data?.name,
+					data?.params,
+					toolServerData,
+					chatId
+				);
 
-			console.log('executeToolServer', res);
+				console.log('executeToolServer', res);
 
-			if (data?.name === 'display_file' && data?.params?.path) {
-				if (res?.exists !== false) {
-					displayFileHandler(data.params.path, { showControls, showFileNavPath });
+				if (data?.name === 'display_file' && data?.params?.path) {
+					if (res?.exists !== false) {
+						displayFileHandler(data.params.path, { showControls, showFileNavPath });
+					}
 				}
-			}
 
-			if (['write_file'].includes(data?.name) && data?.params?.path) {
-				showFileNavDir.set(res?.path ?? data.params.path);
-			}
+				if (['write_file'].includes(data?.name) && data?.params?.path) {
+					showFileNavDir.set(res?.path ?? data.params.path);
+				}
 
-			if (cb) {
-				cb(structuredClone(res));
+				if (cb) {
+					cb(structuredClone(res));
+				}
+			} catch (err) {
+				console.error('executeTool error:', err);
+				if (cb) {
+					cb({ error: err?.message || 'Tool execution failed' });
+				}
 			}
 		} else {
 			if (cb) {


### PR DESCRIPTION
"## Description\n\nWhen `executeToolServer()` throws (e.g. tool server unreachable, malformed response, network timeout), the error is unhandled and the chat hangs indefinitely with no feedback to the user. The `cb` callback is never called, so the UI waits forever.\n\nThis wraps the `executeToolServer` call and all subsequent processing in a try-catch block. On error, the callback receives `{ error: message }` so the UI can display the error and the user can retry or continue.\n\nCloses #25850\n\n## Changes\n\n- Wrapped `executeToolServer()` call in try-catch in `src/routes/+layout.svelte`\n- On catch, logs the error and calls `cb({ error: message })` so the UI gets a response\n\n## Testing\n\n1. Configure a per-user tool server that throws errors (e.g. point to a non-existent URL)\n2. Send a chat message that triggers tool execution\n3. Before fix: chat hangs indefinitely\n4. After fix: error message appears in chat, user can continue\n\n## Checklist\n\n- [x] Linked Issue: Closes #25850\n- [x] Target branch: dev\n- [x] Description provided\n- [x] Manual testing performed\n- [x] Self-review performed\n\n### Contributor License Agreement\n\n<!--\n🚨 DO NOT DELETE THE TEXT BELOW 🚨\nKeep the \"Contributor License Agreement\" confirmation text intact.\nDeleting it will trigger the CLA-Bot to INVALIDATE your PR.\n\nYour PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.\n-->\n\n- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.\n\n> [!NOTE]\n> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.\n"