### PR TITLE
fix: close Playwright pages per-URL and browser in finally block

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -588,9 +588,15 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
                         raise e
                     finally:
                         if page:
-                            page.close()
+                            try:
+                                page.close()
+                            except Exception as e:
+                                log.debug(f"Error closing Playwright page for {url}: {e}", exc_info=True)
             finally:
-                browser.close()
+                try:
+                    browser.close()
+                except Exception as e:
+                    log.debug(f"Error closing Playwright browser: {e}", exc_info=True)
 
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Safely load URLs asynchronously with support for remote browser."""
@@ -624,9 +630,15 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
                         raise e
                     finally:
                         if page:
-                            await page.close()
+                            try:
+                                await page.close()
+                            except Exception as e:
+                                log.debug(f"Error closing Playwright page for {url}: {e}", exc_info=True)
             finally:
-                await browser.close()
+                try:
+                    await browser.close()
+                except Exception as e:
+                    log.debug(f"Error closing Playwright browser: {e}", exc_info=True)
 
 
 class SafeWebBaseLoader(WebBaseLoader):

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -567,24 +567,30 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
             else:
                 browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    self._safe_process_url_sync(url)
-                    page = browser.new_page()
-                    page.route('**/*', self._intercept_navigation_sync)
-                    response = page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+            try:
+                for url in self.urls:
+                    page = None
+                    try:
+                        self._safe_process_url_sync(url)
+                        page = browser.new_page()
+                        page.route('**/*', self._intercept_navigation_sync)
+                        response = page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = self.evaluator.evaluate(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            browser.close()
+                        text = self.evaluator.evaluate(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page:
+                            page.close()
+            finally:
+                browser.close()
 
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Safely load URLs asynchronously with support for remote browser."""
@@ -597,24 +603,30 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
             else:
                 browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    await self._safe_process_url(url)
-                    page = await browser.new_page()
-                    await page.route('**/*', self._intercept_navigation)
-                    response = await page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+            try:
+                for url in self.urls:
+                    page = None
+                    try:
+                        await self._safe_process_url(url)
+                        page = await browser.new_page()
+                        await page.route('**/*', self._intercept_navigation)
+                        response = await page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = await self.evaluator.evaluate_async(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            await browser.close()
+                        text = await self.evaluator.evaluate_async(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page:
+                            await page.close()
+            finally:
+                await browser.close()
 
 
 class SafeWebBaseLoader(WebBaseLoader):


### PR DESCRIPTION
### Description

SafePlaywrightURLLoader creates a Playwright page per URL but never closes it in a finally block. If page.goto(), route handling, or evaluation throws, the page stays open. The browser is also only closed after the normal loop exit, so early exceptions (with continue_on_failure=False) skip cleanup entirely.

This adds per-URL finally blocks to close each page and wraps the URL loop in try/finally to ensure browser.close() always runs.

### Fixed

- Pages are now closed in a per-URL finally block after each URL is processed
- Browser is now closed in an outer finally block, even when exceptions propagate

### How to Test

1. Run the web loader with a URL that times out or returns an error
2. Verify that Playwright pages are not left open (check browser context count)
3. Verify that the browser is properly closed even when continue_on_failure=False raises

### Additional Information

- Closes #25880
- 1 file changed (backend/open_webui/retrieval/web/utils.py), 48 insertions, 36 deletions
- No new dependencies

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
