### PR TITLE
feat: Add Personal Knowledge Management (PKM) Markdown Exporter

### DIFF
--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -7,6 +7,7 @@
 
 	import { downloadChatAsPDF } from '$lib/apis/utils';
 	import { copyToClipboard, createMessagesList } from '$lib/utils';
+	import { exportChatToMarkdown } from '$lib/utils/exportMarkdown';
 
 	import {
 		showControls,
@@ -35,6 +36,7 @@
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Download from '$lib/components/icons/Download.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -53,6 +55,7 @@
 	export let scrollToTop: (() => void) | null = null;
 
 	let showFullMessages = false;
+	let markdownExportLoading = false;
 
 	const getChatAsText = async () => {
 		const history = chat.chat.history;
@@ -251,6 +254,40 @@
 			saveAs(blob, `chat-export-${Date.now()}.json`);
 		}
 	};
+
+	const downloadMarkdown = async () => {
+		if (markdownExportLoading) {
+			return;
+		}
+
+		markdownExportLoading = true;
+
+		try {
+			const history = chat?.chat?.history;
+
+			if (!history?.messages || !history?.currentId) {
+				toast.error($i18n.t('No message history available to export.'));
+				return;
+			}
+
+			exportChatToMarkdown(
+				{
+					...chat,
+					title: chat?.title ?? chat?.chat?.title,
+					models: chat?.models ?? chat?.chat?.models,
+					created_at: chat?.created_at ?? chat?.chat?.created_at
+				},
+				history.messages,
+				history.currentId
+			);
+			toast.success($i18n.t('Chat exported as Markdown.'));
+		} catch (error) {
+			console.error('Error exporting Markdown', error);
+			toast.error(error instanceof Error ? error.message : `${error}`);
+		} finally {
+			markdownExportLoading = false;
+		}
+	};
 </script>
 
 {#if showFullMessages}
@@ -388,6 +425,7 @@
 
 					<div class="flex items-center">{$i18n.t('Download')}</div>
 				</button>
+
 				{#if $user?.role === 'admin' || ($user.permissions?.chat?.export ?? true)}
 					<button
 						draggable="false"
@@ -399,6 +437,23 @@
 						<div class="flex items-center line-clamp-1">{$i18n.t('Export chat (.json)')}</div>
 					</button>
 				{/if}
+
+				<button
+					draggable="false"
+					class="flex gap-2 items-center justify-between px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full disabled:cursor-not-allowed disabled:opacity-50"
+					disabled={markdownExportLoading}
+					on:click={() => {
+						downloadMarkdown();
+					}}
+				>
+					<div class="flex items-center line-clamp-1">
+						{$i18n.t(markdownExportLoading ? 'Exporting Markdown...' : 'Markdown (pkm)')}
+					</div>
+					{#if markdownExportLoading}
+						<Spinner className="size-4" />
+					{/if}
+				</button>
+
 				<button
 					draggable="false"
 					class="flex gap-2 items-center px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl select-none w-full"

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { toast } from 'svelte-sonner';
 	import { getContext, tick } from 'svelte';
 
 	import fileSaver from 'file-saver';
@@ -22,10 +23,12 @@
 	} from '$lib/apis/chats';
 	import { chats, folders, settings, theme, user } from '$lib/stores';
 	import { createMessagesList } from '$lib/utils';
+	import { exportChatToMarkdown } from '$lib/utils/exportMarkdown';
 	import { downloadChatAsPDF } from '$lib/apis/utils';
 	import Download from '$lib/components/icons/Download.svelte';
 	import Folder from '$lib/components/icons/Folder.svelte';
 	import Messages from '$lib/components/chat/Messages.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -45,6 +48,7 @@
 
 	let chat = null;
 	let showFullMessages = false;
+	let markdownExportLoading = false;
 
 	export let onPinChange: () => void = () => {};
 
@@ -258,6 +262,41 @@
 		}
 	};
 
+	const downloadMarkdown = async () => {
+		if (markdownExportLoading) {
+			return;
+		}
+
+		markdownExportLoading = true;
+
+		try {
+			const chat = await getChatById(localStorage.token, chatId);
+			const history = chat?.chat?.history;
+
+			if (!history?.messages || !history?.currentId) {
+				toast.error($i18n.t('No message history available to export.'));
+				return;
+			}
+
+			exportChatToMarkdown(
+				{
+					...chat,
+					title: chat?.title ?? chat?.chat?.title,
+					models: chat?.models ?? chat?.chat?.models,
+					created_at: chat?.created_at ?? chat?.chat?.created_at
+				},
+				history.messages,
+				history.currentId
+			);
+			toast.success($i18n.t('Chat exported as Markdown.'));
+		} catch (error) {
+			console.error('Error exporting Markdown', error);
+			toast.error(error instanceof Error ? error.message : `${error}`);
+		} finally {
+			markdownExportLoading = false;
+		}
+	};
+
 	$: if (show) {
 		checkPinned();
 	}
@@ -336,6 +375,22 @@
 						<div class="flex items-center line-clamp-1">{$i18n.t('Export chat (.json)')}</div>
 					</button>
 				{/if}
+
+				<button
+					draggable="false"
+					class="flex gap-2 items-center justify-between px-3 py-1.5 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-xl w-full disabled:cursor-not-allowed disabled:opacity-50"
+					disabled={markdownExportLoading}
+					on:click={() => {
+						downloadMarkdown();
+					}}
+				>
+					<div class="flex items-center line-clamp-1">
+						{$i18n.t(markdownExportLoading ? 'Exporting Markdown...' : 'Markdown (pkm)')}
+					</div>
+					{#if markdownExportLoading}
+						<Spinner className="size-4" />
+					{/if}
+				</button>
 
 				<button
 					draggable="false"

--- a/src/lib/utils/exportMarkdown.ts
+++ b/src/lib/utils/exportMarkdown.ts
@@ -1,0 +1,134 @@
+type ChatMessage = {
+	parentId?: string | null;
+	role?: string | null;
+	content?: unknown;
+};
+
+type ChatMessages = Record<string, ChatMessage | undefined>;
+
+type ChatMetadata = {
+	title?: unknown;
+	created_at?: unknown;
+	models?: unknown;
+};
+
+const yamlQuote = (value: string) =>
+	JSON.stringify(value.replace(/\r\n/g, '\n').replace(/\r/g, '\n'));
+
+const getDate = (createdAt: unknown) => {
+	const timestamp =
+		typeof createdAt === 'number' && Number.isFinite(createdAt)
+			? createdAt * 1000
+			: typeof createdAt === 'string' && Number.isFinite(Number(createdAt))
+				? Number(createdAt) * 1000
+				: Date.now();
+
+	return new Date(timestamp).toISOString().split('T')[0];
+};
+
+const getTitle = (title: unknown) => {
+	return typeof title === 'string' && title.trim() ? title.trim() : 'Open WebUI Conversation';
+};
+
+const getModel = (models: unknown) => {
+	if (Array.isArray(models)) {
+		const model = models.find((item) => typeof item === 'string' && item.trim());
+		return model ?? 'Unknown Model';
+	}
+
+	return typeof models === 'string' && models.trim() ? models.trim() : 'Unknown Model';
+};
+
+const formatContent = (content: unknown) => {
+	if (typeof content === 'string') {
+		return content.trim() ? content : '_No content_';
+	}
+
+	if (content === null || content === undefined) {
+		return '_No content_';
+	}
+
+	return String(content);
+};
+
+/**
+ * Traverses the chat history tree, formats it as Markdown with YAML frontmatter,
+ * and triggers a browser download.
+ */
+export const exportChatToMarkdown = (
+	chat: ChatMetadata | null | undefined,
+	messages: ChatMessages | null | undefined,
+	currentId: string | null | undefined
+) => {
+	if (!messages || !currentId) {
+		console.error('No message history available to export.');
+		return false;
+	}
+
+	// 1. Traverse the tree from leaf to root
+	const thread: ChatMessage[] = [];
+	const visited = new Set<string>();
+	let currId: string | null | undefined = currentId;
+
+	while (currId && messages[currId]) {
+		if (visited.has(currId)) {
+			break;
+		}
+
+		visited.add(currId);
+		const message: ChatMessage | undefined = messages[currId];
+		if (!message) {
+			break;
+		}
+
+		thread.push(message);
+		// Move up to the parent message
+		currId = message.parentId;
+	}
+
+	// 2. Reverse the array so the conversation is chronological
+	thread.reverse();
+
+	// 3. Generate YAML Frontmatter
+	const date = getDate(chat?.created_at);
+	const title = getTitle(chat?.title);
+	const model = getModel(chat?.models);
+
+	let markdown = `---\n`;
+	markdown += `title: ${yamlQuote(title)}\n`;
+	markdown += `date: ${date}\n`;
+	markdown += `model: ${yamlQuote(model)}\n`;
+	markdown += `tags: [open-webui, pkm-export]\n`;
+	markdown += `---\n\n`;
+	markdown += `# ${title}\n\n`;
+
+	// 4. Format the conversation thread
+	thread.forEach((msg) => {
+		// Skip system prompts if desired, or include them based on preference
+		if (msg.role === 'system') return;
+
+		const roleHeader = msg.role === 'user' ? '### User' : '### Assistant';
+		markdown += `${roleHeader}\n\n${formatContent(msg.content)}\n\n---\n\n`;
+	});
+
+	// 5. Create the Blob and trigger the download
+	const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8;' });
+	const url = URL.createObjectURL(blob);
+
+	// Sanitize the filename
+	const safeTitle = title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+
+	const link = document.createElement('a');
+	link.href = url;
+	link.download = `${safeTitle}_${date}.md`;
+	link.style.display = 'none';
+
+	document.body.appendChild(link);
+	link.click();
+
+	// Cleanup
+	document.body.removeChild(link);
+	URL.revokeObjectURL(url);
+
+	return true;
+};


### PR DESCRIPTION
# Changelog Entry

### Description

- Adds a Personal Knowledge Management Markdown export option for chat threads.
- The new `Markdown (pkm)` option appears in the existing chat Download menu.
- Exported files include YAML frontmatter and a clean Markdown transcript suitable for Obsidian, Logseq, Notion, or other Markdown-based workflows.

### Added

- Added `src/lib/utils/exportMarkdown.ts` to generate Markdown exports client-side.
- Added `Markdown (pkm)` to the top chat action Download submenu.
- Added `Markdown (pkm)` to the sidebar chat Download submenu.
- Added export loading/disabled state and toast feedback.

### Changed

- Chat export behavior now supports a PKM-friendly Markdown format in addition to existing JSON, TXT, and PDF options.
- The Markdown exporter reconstructs the active visible chat branch by walking from `currentId` through `parentId`, avoiding inactive regenerated or edited branches.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Relates to #25885.
- This implementation is intentionally client-side. The frontend already has the active chat history needed to render the visible conversation, so no backend export route is required.
- The exporter writes YAML frontmatter with `title`, `date`, `model`, and `tags`, then formats user and assistant messages with Markdown headings.
- No new dependencies were added.

### Testing

Manual testing performed locally:

1. Started the backend and frontend locally.
2. Created/opened a test chat.
3. Opened the chat action menu.
4. Selected `Download > Markdown (pkm)`.
5. Verified that a `.md` file was downloaded.
6. Verified that the exported file includes YAML frontmatter.
7. Verified that user and assistant messages are exported in chronological order.
8. Verified that the menu item aligns visually with the existing JSON, TXT, and PDF download options.

Targeted validation:

```bash
npx tsc --noEmit --skipLibCheck src/lib/utils/exportMarkdown.ts
```

### Screenshot
<img width="1196" height="289" alt="Screenshot 2026-06-09 at 15 20 53" src="https://github.com/user-attachments/assets/e049ac94-464e-4fff-bdd7-02d10d564ad7" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
