### PR TITLE
Add native macOS launcher

### DIFF
--- a/macos/OpenWebUIMac/.gitignore
+++ b/macos/OpenWebUIMac/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/macos/OpenWebUIMac/Package.swift
+++ b/macos/OpenWebUIMac/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenWebUIMac",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "OpenWebUIMac", targets: ["OpenWebUIMac"])
+    ],
+    targets: [
+        .target(name: "OpenWebUIMacCore"),
+        .executableTarget(
+            name: "OpenWebUIMac",
+            dependencies: ["OpenWebUIMacCore"],
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("WebKit")
+            ]
+        ),
+        .testTarget(
+            name: "OpenWebUIMacCoreTests",
+            dependencies: ["OpenWebUIMacCore"]
+        )
+    ]
+)

--- a/macos/OpenWebUIMac/Scripts/package-app.sh
+++ b/macos/OpenWebUIMac/Scripts/package-app.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+APP_DIR="${PACKAGE_DIR}/.build/Open WebUI.app"
+CONTENTS_DIR="${APP_DIR}/Contents"
+MACOS_DIR="${CONTENTS_DIR}/MacOS"
+
+cd "${PACKAGE_DIR}"
+swift build -c release --arch "$(uname -m)"
+BUILD_DIR="$(swift build -c release --arch "$(uname -m)" --show-bin-path)"
+
+rm -rf "${APP_DIR}"
+mkdir -p "${MACOS_DIR}" "${CONTENTS_DIR}/Resources"
+cp "${BUILD_DIR}/OpenWebUIMac" "${MACOS_DIR}/Open WebUI"
+
+cat > "${CONTENTS_DIR}/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>Open WebUI</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.openwebui.mac</string>
+  <key>CFBundleName</key>
+  <string>Open WebUI</string>
+  <key>CFBundleDisplayName</key>
+  <string>Open WebUI</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+printf 'APPL????' > "${CONTENTS_DIR}/PkgInfo"
+
+echo "Created ${APP_DIR}"

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/AppState.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/AppState.swift
@@ -1,0 +1,36 @@
+import Foundation
+import OpenWebUIMacCore
+
+@MainActor
+final class AppState: ObservableObject {
+    let settingsStore: SettingsStore
+    let service: OpenWebUIService
+
+    init(settingsStore: SettingsStore = SettingsStore()) {
+        self.settingsStore = settingsStore
+        self.service = OpenWebUIService()
+    }
+
+    func startIfNeeded() {
+        guard settingsStore.settings.autoStartService else {
+            Task {
+                await service.refreshHealth(settings: settingsStore.settings)
+            }
+            return
+        }
+
+        service.start(settings: settingsStore.settings)
+    }
+
+    func restart() {
+        service.restart(settings: settingsStore.settings)
+    }
+
+    func stopForQuitIfNeeded() {
+        guard settingsStore.settings.stopServiceOnQuit else {
+            return
+        }
+
+        service.stop()
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/ContentView.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/ContentView.swift
@@ -1,0 +1,147 @@
+import OpenWebUIMacCore
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var showingSettings = false
+    @State private var showingLogs = false
+    @State private var reloadToken = 0
+
+    var body: some View {
+        Group {
+            switch appState.service.status {
+            case .running(let url, _):
+                WebView(url: url, reloadToken: reloadToken)
+            case .failed(let message):
+                LaunchStatusView(
+                    status: appState.service.status,
+                    detail: message,
+                    primaryAction: appState.restart,
+                    secondaryAction: { showingLogs = true }
+                )
+            default:
+                LaunchStatusView(
+                    status: appState.service.status,
+                    detail: "Open WebUI will appear here when the local service is ready.",
+                    primaryAction: appState.restart,
+                    secondaryAction: { showingLogs = true }
+                )
+            }
+        }
+        .frame(minWidth: 1024, minHeight: 720)
+        .toolbar {
+            ToolbarItemGroup {
+                Button {
+                    reloadToken += 1
+                } label: {
+                    Label("Reload", systemImage: "arrow.clockwise")
+                }
+
+                Button {
+                    NSWorkspace.shared.open(appState.settingsStore.settings.rootURL)
+                } label: {
+                    Label("Open in Browser", systemImage: "safari")
+                }
+
+                Button {
+                    showingLogs = true
+                } label: {
+                    Label("Logs", systemImage: "doc.text.magnifyingglass")
+                }
+
+                Button {
+                    showingSettings = true
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+            }
+        }
+        .sheet(isPresented: $showingSettings) {
+            SettingsView()
+                .environmentObject(appState)
+        }
+        .sheet(isPresented: $showingLogs) {
+            LogsView()
+                .environmentObject(appState)
+        }
+        .task {
+            appState.startIfNeeded()
+        }
+    }
+}
+
+private struct LaunchStatusView: View {
+    let status: OpenWebUIServiceStatus
+    let detail: String
+    let primaryAction: () -> Void
+    let secondaryAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: iconName)
+                .font(.system(size: 52, weight: .semibold))
+                .foregroundStyle(iconColor)
+
+            VStack(spacing: 8) {
+                Text("Open WebUI")
+                    .font(.largeTitle.bold())
+
+                Text(status.title)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+
+                Text(detail)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: 520)
+            }
+
+            if status == .starting {
+                ProgressView()
+                    .controlSize(.large)
+            }
+
+            HStack(spacing: 12) {
+                Button {
+                    primaryAction()
+                } label: {
+                    Label("Restart Service", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    secondaryAction()
+                } label: {
+                    Label("View Logs", systemImage: "doc.text")
+                }
+            }
+        }
+        .padding(32)
+    }
+
+    private var iconName: String {
+        switch status {
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        case .running:
+            return "checkmark.circle.fill"
+        case .starting:
+            return "hourglass"
+        case .stopped:
+            return "power.circle"
+        }
+    }
+
+    private var iconColor: Color {
+        switch status {
+        case .failed:
+            return .orange
+        case .running:
+            return .green
+        case .starting:
+            return .accentColor
+        case .stopped:
+            return .secondary
+        }
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/LogsView.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/LogsView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct LogsView: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Service Logs")
+                    .font(.title2.bold())
+
+                Spacer()
+
+                Button {
+                    dismiss()
+                } label: {
+                    Label("Close", systemImage: "xmark")
+                }
+            }
+
+            ScrollView {
+                Text(appState.service.logLines.joined(separator: "\n"))
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .padding(24)
+        .frame(width: 760, height: 460)
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/OpenWebUIMacApp.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/OpenWebUIMacApp.swift
@@ -1,0 +1,151 @@
+import AppKit
+import SwiftUI
+
+@main
+enum OpenWebUIMacMain {
+    @MainActor
+    static func main() {
+        let application = NSApplication.shared
+        let delegate = AppDelegate()
+        AppDelegateRetainer.shared = delegate
+
+        application.delegate = delegate
+        application.setActivationPolicy(.regular)
+        application.finishLaunching()
+        delegate.configureMainMenu()
+        delegate.showMainWindow()
+        application.activate(ignoringOtherApps: true)
+        application.run()
+    }
+}
+
+@MainActor
+private enum AppDelegateRetainer {
+    static var shared: AppDelegate?
+}
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private let appState = AppState()
+    private var window: NSWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        appState.stopForQuitIfNeeded()
+        return .terminateNow
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showMainWindow()
+        }
+        return true
+    }
+
+    func showMainWindow() {
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let rootView = ContentView()
+            .environmentObject(appState)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1200, height: 820),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Open WebUI"
+        window.contentViewController = NSHostingController(rootView: rootView)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        self.window = window
+    }
+
+    func configureMainMenu() {
+        let mainMenu = NSMenu()
+        mainMenu.addItem(appMenuItem())
+        mainMenu.addItem(editMenuItem())
+        mainMenu.addItem(serviceMenuItem())
+        NSApplication.shared.mainMenu = mainMenu
+    }
+
+    private func appMenuItem() -> NSMenuItem {
+        let menuItem = NSMenuItem()
+        let menu = NSMenu(title: "Open WebUI")
+        menu.addItem(
+            withTitle: "Quit Open WebUI",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
+        menuItem.submenu = menu
+        return menuItem
+    }
+
+    private func editMenuItem() -> NSMenuItem {
+        let menuItem = NSMenuItem()
+        let menu = NSMenu(title: "Edit")
+        menu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        menu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        menu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        menu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        menuItem.submenu = menu
+        return menuItem
+    }
+
+    private func serviceMenuItem() -> NSMenuItem {
+        let menuItem = NSMenuItem()
+        let menu = NSMenu(title: "Service")
+
+        let restart = NSMenuItem(
+            title: "Restart Service",
+            action: #selector(restartService),
+            keyEquivalent: "R"
+        )
+        restart.keyEquivalentModifierMask = [.command, .shift]
+        restart.target = self
+        menu.addItem(restart)
+
+        let stop = NSMenuItem(
+            title: "Stop Managed Service",
+            action: #selector(stopManagedService),
+            keyEquivalent: "S"
+        )
+        stop.keyEquivalentModifierMask = [.command, .shift]
+        stop.target = self
+        menu.addItem(stop)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let browser = NSMenuItem(
+            title: "Open in Browser",
+            action: #selector(openInBrowser),
+            keyEquivalent: "B"
+        )
+        browser.keyEquivalentModifierMask = [.command, .shift]
+        browser.target = self
+        menu.addItem(browser)
+
+        menuItem.submenu = menu
+        return menuItem
+    }
+
+    @objc private func restartService() {
+        appState.restart()
+    }
+
+    @objc private func stopManagedService() {
+        appState.service.stop()
+    }
+
+    @objc private func openInBrowser() {
+        NSWorkspace.shared.open(appState.settingsStore.settings.rootURL)
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/OpenWebUIService.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/OpenWebUIService.swift
@@ -1,0 +1,217 @@
+import Foundation
+import OpenWebUIMacCore
+
+enum OpenWebUIServiceStatus: Equatable {
+    case stopped
+    case starting
+    case running(URL, managed: Bool)
+    case failed(String)
+
+    var title: String {
+        switch self {
+        case .stopped:
+            return "Stopped"
+        case .starting:
+            return "Starting"
+        case .running(_, let managed):
+            return managed ? "Running" : "Running externally"
+        case .failed:
+            return "Failed"
+        }
+    }
+
+    var isRunning: Bool {
+        if case .running = self {
+            return true
+        }
+        return false
+    }
+}
+
+@MainActor
+final class OpenWebUIService: ObservableObject {
+    @Published private(set) var status: OpenWebUIServiceStatus = .stopped
+    @Published private(set) var logLines: [String] = []
+
+    private var process: Process?
+    private var outputPipe: Pipe?
+    private var startupTask: Task<Void, Never>?
+
+    func start(settings: OpenWebUISettings) {
+        let settings = settings.sanitized
+        startupTask?.cancel()
+        appendLog("Preparing Open WebUI on \(settings.rootURL.absoluteString)")
+        status = .starting
+
+        startupTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            if await self.isHealthy(settings: settings) {
+                self.status = .running(settings.rootURL, managed: false)
+                self.appendLog("Detected an existing Open WebUI service.")
+                return
+            }
+
+            do {
+                try self.launch(settings: settings)
+                try await self.waitUntilReady(settings: settings)
+                self.status = .running(settings.rootURL, managed: true)
+                self.appendLog("Open WebUI is ready.")
+            } catch is CancellationError {
+                self.appendLog("Startup was cancelled.")
+            } catch {
+                self.status = .failed(error.localizedDescription)
+                self.appendLog("Startup failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func restart(settings: OpenWebUISettings) {
+        stop()
+        start(settings: settings)
+    }
+
+    func stop() {
+        startupTask?.cancel()
+        startupTask = nil
+
+        guard let process else {
+            status = .stopped
+            appendLog("No managed service process to stop.")
+            return
+        }
+
+        appendLog("Stopping managed Open WebUI service.")
+        process.terminate()
+        self.process = nil
+        outputPipe?.fileHandleForReading.readabilityHandler = nil
+        outputPipe = nil
+        status = .stopped
+    }
+
+    func refreshHealth(settings: OpenWebUISettings) async {
+        let settings = settings.sanitized
+        status = await isHealthy(settings: settings) ? .running(settings.rootURL, managed: process != nil) : .stopped
+    }
+
+    private func launch(settings: OpenWebUISettings) throws {
+        if let process, process.isRunning {
+            appendLog("Managed service is already running.")
+            return
+        }
+
+        let plan = ServiceCommandBuilder.launchPlan(for: settings)
+        appendLog("Launching: \(plan.displayCommand)")
+
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = plan.executableURL
+        process.arguments = plan.arguments
+        process.environment = plan.environment
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let output = String(data: data, encoding: .utf8) else {
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                self?.appendLog(output)
+            }
+        }
+
+        process.terminationHandler = { [weak self] terminatedProcess in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+
+                let exitCode = terminatedProcess.terminationStatus
+                self.appendLog("Service process exited with status \(exitCode).")
+                self.process = nil
+                self.outputPipe?.fileHandleForReading.readabilityHandler = nil
+                self.outputPipe = nil
+
+                if self.status.isRunning || self.status == .starting {
+                    self.status = exitCode == 0 ? .stopped : .failed("Service exited with status \(exitCode).")
+                }
+            }
+        }
+
+        try process.run()
+        self.process = process
+        self.outputPipe = pipe
+    }
+
+    private func waitUntilReady(settings: OpenWebUISettings) async throws {
+        let deadline = Date().addingTimeInterval(90)
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+
+            let ready = await isReady(settings: settings)
+            let healthy = ready ? true : await isHealthy(settings: settings)
+            if healthy {
+                return
+            }
+
+            try await Task.sleep(for: .milliseconds(750))
+        }
+
+        throw ServiceError.timedOut(settings.rootURL)
+    }
+
+    private func isReady(settings: OpenWebUISettings) async -> Bool {
+        await requestReturnsSuccess(settings.readyURL)
+    }
+
+    private func isHealthy(settings: OpenWebUISettings) async -> Bool {
+        await requestReturnsSuccess(settings.healthURL)
+    }
+
+    private nonisolated func requestReturnsSuccess(_ url: URL) async -> Bool {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return false
+            }
+
+            return (200..<300).contains(httpResponse.statusCode)
+        } catch {
+            return false
+        }
+    }
+
+    private func appendLog(_ text: String) {
+        let lines = text
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+
+        if lines.isEmpty {
+            return
+        }
+
+        logLines.append(contentsOf: lines)
+        if logLines.count > 400 {
+            logLines.removeFirst(logLines.count - 400)
+        }
+    }
+}
+
+private enum ServiceError: LocalizedError {
+    case timedOut(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut(let url):
+            return "Timed out waiting for Open WebUI at \(url.absoluteString)."
+        }
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/SettingsView.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/SettingsView.swift
@@ -1,0 +1,66 @@
+import OpenWebUIMacCore
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: OpenWebUISettings = OpenWebUISettings()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Settings")
+                .font(.title2.bold())
+
+            Form {
+                TextField("Host", text: $draft.host)
+
+                Stepper(value: $draft.port, in: 1...65_535) {
+                    TextField("Port", value: $draft.port, format: .number)
+                }
+
+                TextField("Service command", text: $draft.serviceCommand)
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("Ollama URL", text: $draft.ollamaBaseURL)
+                    .textFieldStyle(.roundedBorder)
+
+                TextField("Data directory", text: $draft.dataDirectory)
+                    .textFieldStyle(.roundedBorder)
+
+                Toggle("Start service when app opens", isOn: $draft.autoStartService)
+                Toggle("Stop managed service on quit", isOn: $draft.stopServiceOnQuit)
+            }
+
+            Divider()
+
+            HStack {
+                Button {
+                    draft = OpenWebUISettings()
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+
+                Spacer()
+
+                Button("Cancel") {
+                    dismiss()
+                }
+
+                Button {
+                    appState.settingsStore.save(draft)
+                    appState.restart()
+                    dismiss()
+                } label: {
+                    Label("Apply and Restart", systemImage: "checkmark")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 560)
+        .onAppear {
+            draft = appState.settingsStore.settings
+        }
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMac/WebView.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMac/WebView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import WebKit
+
+struct WebView: NSViewRepresentable {
+    let url: URL
+    let reloadToken: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = true
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        if webView.url?.absoluteString != url.absoluteString {
+            webView.load(URLRequest(url: url))
+        } else if context.coordinator.reloadToken != reloadToken {
+            context.coordinator.reloadToken = reloadToken
+            webView.reload()
+        }
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var reloadToken = 0
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard navigationAction.navigationType == .linkActivated,
+                  let url = navigationAction.request.url,
+                  let currentHost = webView.url?.host,
+                  url.host != currentHost
+            else {
+                decisionHandler(.allow)
+                return
+            }
+
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+        }
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/OpenWebUISettings.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/OpenWebUISettings.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public struct OpenWebUISettings: Codable, Equatable, Sendable {
+    public static let defaultHost = "127.0.0.1"
+    public static let defaultPort = 8080
+    public static let defaultServiceCommand = "open-webui serve"
+    public static let defaultOllamaBaseURL = "http://127.0.0.1:11434"
+
+    public var host: String
+    public var port: Int
+    public var serviceCommand: String
+    public var ollamaBaseURL: String
+    public var dataDirectory: String
+    public var autoStartService: Bool
+    public var stopServiceOnQuit: Bool
+
+    public init(
+        host: String = Self.defaultHost,
+        port: Int = Self.defaultPort,
+        serviceCommand: String = Self.defaultServiceCommand,
+        ollamaBaseURL: String = Self.defaultOllamaBaseURL,
+        dataDirectory: String = Self.defaultDataDirectory,
+        autoStartService: Bool = true,
+        stopServiceOnQuit: Bool = true
+    ) {
+        self.host = host
+        self.port = port
+        self.serviceCommand = serviceCommand
+        self.ollamaBaseURL = ollamaBaseURL
+        self.dataDirectory = dataDirectory
+        self.autoStartService = autoStartService
+        self.stopServiceOnQuit = stopServiceOnQuit
+    }
+
+    public static var defaultDataDirectory: String {
+        let baseURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+
+        return baseURL
+            .appendingPathComponent("Open WebUI Mac", isDirectory: true)
+            .path
+    }
+
+    public var sanitized: OpenWebUISettings {
+        var copy = self
+        copy.host = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        if copy.host.isEmpty {
+            copy.host = Self.defaultHost
+        }
+
+        copy.port = min(max(port, 1), 65_535)
+
+        copy.serviceCommand = serviceCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        if copy.serviceCommand.isEmpty {
+            copy.serviceCommand = Self.defaultServiceCommand
+        }
+
+        copy.ollamaBaseURL = ollamaBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        if copy.ollamaBaseURL.isEmpty {
+            copy.ollamaBaseURL = Self.defaultOllamaBaseURL
+        }
+
+        copy.dataDirectory = NSString(string: dataDirectory.trimmingCharacters(in: .whitespacesAndNewlines))
+            .expandingTildeInPath
+        if copy.dataDirectory.isEmpty {
+            copy.dataDirectory = Self.defaultDataDirectory
+        }
+
+        return copy
+    }
+
+    public var rootURL: URL {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+
+        return components.url ?? URL(string: "http://\(Self.defaultHost):\(Self.defaultPort)")!
+    }
+
+    public var healthURL: URL {
+        rootURL.appendingPathComponent("health")
+    }
+
+    public var readyURL: URL {
+        rootURL.appendingPathComponent("ready")
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/ServiceCommandBuilder.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/ServiceCommandBuilder.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public struct CommandLaunchPlan: Equatable, Sendable {
+    public var executableURL: URL
+    public var arguments: [String]
+    public var environment: [String: String]
+    public var displayCommand: String
+
+    public init(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        displayCommand: String
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
+        self.environment = environment
+        self.displayCommand = displayCommand
+    }
+}
+
+public enum ServiceCommandBuilder {
+    public static func launchPlan(for settings: OpenWebUISettings) -> CommandLaunchPlan {
+        let settings = settings.sanitized
+        var environment = ProcessInfo.processInfo.environment
+        environment["DATA_DIR"] = settings.dataDirectory
+        environment["OLLAMA_BASE_URL"] = settings.ollamaBaseURL
+        environment["ENV"] = "prod"
+
+        let shellScript = [
+            "mkdir -p \(shellQuote(settings.dataDirectory))",
+            "export DATA_DIR=\(shellQuote(settings.dataDirectory))",
+            "export OLLAMA_BASE_URL=\(shellQuote(settings.ollamaBaseURL))",
+            "export ENV=prod",
+            "exec \(settings.serviceCommand) --host \(shellQuote(settings.host)) --port \(settings.port)"
+        ].joined(separator: "\n")
+
+        return CommandLaunchPlan(
+            executableURL: URL(fileURLWithPath: "/bin/zsh"),
+            arguments: ["-lc", shellScript],
+            environment: environment,
+            displayCommand: "\(settings.serviceCommand) --host \(settings.host) --port \(settings.port)"
+        )
+    }
+
+    public static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/SettingsStore.swift
+++ b/macos/OpenWebUIMac/Sources/OpenWebUIMacCore/SettingsStore.swift
@@ -1,0 +1,41 @@
+import Combine
+import Foundation
+
+public final class SettingsStore: ObservableObject {
+    private static let storageKey = "OpenWebUIMac.settings.v1"
+
+    @Published public private(set) var settings: OpenWebUISettings
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.settings = Self.load(from: defaults, decoder: JSONDecoder())
+    }
+
+    public func save(_ newSettings: OpenWebUISettings) {
+        let sanitizedSettings = newSettings.sanitized
+        settings = sanitizedSettings
+
+        if let data = try? encoder.encode(sanitizedSettings) {
+            defaults.set(data, forKey: Self.storageKey)
+        }
+    }
+
+    public func reset() {
+        defaults.removeObject(forKey: Self.storageKey)
+        settings = OpenWebUISettings()
+    }
+
+    private static func load(from defaults: UserDefaults, decoder: JSONDecoder) -> OpenWebUISettings {
+        guard let data = defaults.data(forKey: storageKey),
+              let decoded = try? decoder.decode(OpenWebUISettings.self, from: data)
+        else {
+            return OpenWebUISettings()
+        }
+
+        return decoded.sanitized
+    }
+}

--- a/macos/OpenWebUIMac/Tests/OpenWebUIMacCoreTests/OpenWebUISettingsTests.swift
+++ b/macos/OpenWebUIMac/Tests/OpenWebUIMacCoreTests/OpenWebUISettingsTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import OpenWebUIMacCore
+
+final class OpenWebUISettingsTests: XCTestCase {
+    func testSanitizedSettingsClampPortAndRestoreDefaults() {
+        let settings = OpenWebUISettings(
+            host: "   ",
+            port: 99_999,
+            serviceCommand: "",
+            ollamaBaseURL: "",
+            dataDirectory: "~/Open WebUI Test"
+        ).sanitized
+
+        XCTAssertEqual(settings.host, OpenWebUISettings.defaultHost)
+        XCTAssertEqual(settings.port, 65_535)
+        XCTAssertEqual(settings.serviceCommand, OpenWebUISettings.defaultServiceCommand)
+        XCTAssertEqual(settings.ollamaBaseURL, OpenWebUISettings.defaultOllamaBaseURL)
+        XCTAssertFalse(settings.dataDirectory.contains("~"))
+    }
+
+    func testURLsUseConfiguredHostAndPort() {
+        let settings = OpenWebUISettings(host: "localhost", port: 5050)
+
+        XCTAssertEqual(settings.rootURL.absoluteString, "http://localhost:5050")
+        XCTAssertEqual(settings.healthURL.absoluteString, "http://localhost:5050/health")
+        XCTAssertEqual(settings.readyURL.absoluteString, "http://localhost:5050/ready")
+    }
+
+    func testInvalidURLFallsBackToDefaultAddress() {
+        let settings = OpenWebUISettings(host: "not a host", port: 5050)
+
+        XCTAssertEqual(settings.rootURL.absoluteString, "http://127.0.0.1:8080")
+    }
+
+    func testShellQuoteHandlesSingleQuotes() {
+        XCTAssertEqual(ServiceCommandBuilder.shellQuote("John's Mac"), "'John'\\''s Mac'")
+    }
+
+    func testLaunchPlanExportsDesktopDefaults() {
+        let settings = OpenWebUISettings(
+            host: "127.0.0.1",
+            port: 9090,
+            serviceCommand: "python -m open_webui serve",
+            ollamaBaseURL: "http://127.0.0.1:11434",
+            dataDirectory: "/tmp/open webui"
+        )
+
+        let plan = ServiceCommandBuilder.launchPlan(for: settings)
+
+        XCTAssertEqual(plan.executableURL.path, "/bin/zsh")
+        XCTAssertEqual(plan.environment["DATA_DIR"], "/tmp/open webui")
+        XCTAssertEqual(plan.environment["OLLAMA_BASE_URL"], "http://127.0.0.1:11434")
+        XCTAssertEqual(plan.environment["ENV"], "prod")
+        XCTAssertTrue(plan.arguments.last?.contains("--host '127.0.0.1' --port 9090") ?? false)
+    }
+}

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,64 @@
+# Open WebUI for macOS
+
+This directory contains the first native macOS desktop shell for Open WebUI.
+It keeps the existing SvelteKit/FastAPI application intact and adds a SwiftUI
+launcher that supervises a local Open WebUI service and renders it in a
+`WKWebView`.
+
+## Current scope
+
+- SwiftUI desktop window with a WebKit view.
+- Automatic local service startup using `open-webui serve`.
+- Health/readiness polling via `/health` and `/ready`.
+- Settings for host, port, service command, Ollama URL, data directory, startup,
+  and quit behavior.
+- Managed service restart/stop commands and an in-app log viewer.
+- Swift unit tests for settings normalization and launch command generation.
+
+## Prerequisites
+
+- macOS 13 or newer.
+- Xcode Command Line Tools.
+- Python 3.11 or 3.12 with Open WebUI installed:
+
+  ```bash
+  pip install open-webui
+  ```
+
+## Run from source
+
+```bash
+cd macos/OpenWebUIMac
+swift run OpenWebUIMac
+```
+
+The default service command is:
+
+```bash
+open-webui serve --host 127.0.0.1 --port 8080
+```
+
+The default data directory is:
+
+```text
+~/Library/Application Support/Open WebUI Mac
+```
+
+## Build a local app bundle
+
+```bash
+cd macos/OpenWebUIMac
+Scripts/package-app.sh
+open ".build/Open WebUI.app"
+```
+
+The generated app bundle is unsigned and intended for local development. A
+release-ready distribution still needs an embedded Python runtime, app signing,
+notarization, and a DMG/pkg installer.
+
+## Next release steps
+
+- Bundle the built Open WebUI wheel and a standalone Python runtime.
+- Add first-run dependency validation and migration/backup tooling.
+- Add signed and notarized `.app`/DMG release automation.
+- Add UI automation for onboarding, settings, logs, and service lifecycle.

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,6 +1,7 @@
-@import 'tailwindcss';
+@import 'tailwindcss' source(none);
 
 @config '../tailwind.config.js';
+@source not '../static/pyodide';
 
 @theme {
 	--color-gray-50: oklch(0.98 0 0);


### PR DESCRIPTION
## Summary
- Add a SwiftUI/AppKit macOS launcher that supervises a local Open WebUI service and renders it in a WKWebView.
- Add settings, service lifecycle controls, log viewing, and local app bundle packaging script.
- Constrain Tailwind v4 source scanning so generated Pyodide assets are not scanned during production builds.

## Verification
- npm ci using Node 22.22.3
- npm run build
- swift test in macos/OpenWebUIMac
- macos/OpenWebUIMac/Scripts/package-app.sh
- git diff --check

## Notes
- npm run check currently reports existing upstream Svelte/TypeScript diagnostics outside the new macOS package.
- Computer Use UI click testing was blocked by the host being at the macOS lock screen; automated build/package verification passed.