### PR TITLE
fix: dispatch all queued TTS content parts

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -67,7 +67,7 @@
 		isYoutubeUrl,
 		displayFileHandler
 	} from '$lib/utils';
-	import { AudioQueue } from '$lib/utils/audio';
+	import { AudioQueue, getUndispatchedAudioContentParts } from '$lib/utils/audio';
 
 	import {
 		archiveChatById,
@@ -1754,6 +1754,31 @@
 		}
 	};
 
+	const dispatchChatTTSContentParts = (message, includeLastPart = false) => {
+		const messageContentParts = getMessageContentParts(
+			removeAllDetails(message.content),
+			$config?.audio?.tts?.split_on ?? 'punctuation'
+		);
+
+		for (const { index, content } of getUndispatchedAudioContentParts(
+			messageContentParts,
+			message.lastDispatchedContentPartIndex,
+			includeLastPart
+		)) {
+			message.lastDispatchedContentPartIndex = index;
+			message.lastSentence = content;
+
+			eventTarget.dispatchEvent(
+				new CustomEvent('chat', {
+					detail: {
+						id: message.id,
+						content
+					}
+				})
+			);
+		}
+	};
+
 	const chatCompletionEventHandler = async (data, message, chatId) => {
 		const { id, done, choices, content, output, sources, selected_model_id, error, usage } = data;
 
@@ -1788,27 +1813,7 @@
 
 					// Emit chat event for TTS (only when call overlay is active)
 					if ($showCallOverlay) {
-						const messageContentParts = getMessageContentParts(
-							removeAllDetails(message.content),
-							$config?.audio?.tts?.split_on ?? 'punctuation'
-						);
-						messageContentParts.pop();
-
-						// dispatch only last sentence and make sure it hasn't been dispatched before
-						if (
-							messageContentParts.length > 0 &&
-							messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-						) {
-							message.lastSentence = messageContentParts[messageContentParts.length - 1];
-							eventTarget.dispatchEvent(
-								new CustomEvent('chat', {
-									detail: {
-										id: message.id,
-										content: messageContentParts[messageContentParts.length - 1]
-									}
-								})
-							);
-						}
+						dispatchChatTTSContentParts(message);
 					}
 				}
 			}
@@ -1824,27 +1829,7 @@
 
 			// Emit chat event for TTS (only when call overlay is active)
 			if ($showCallOverlay) {
-				const messageContentParts = getMessageContentParts(
-					removeAllDetails(message.content),
-					$config?.audio?.tts?.split_on ?? 'punctuation'
-				);
-				messageContentParts.pop();
-
-				// dispatch only last sentence and make sure it hasn't been dispatched before
-				if (
-					messageContentParts.length > 0 &&
-					messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-				) {
-					message.lastSentence = messageContentParts[messageContentParts.length - 1];
-					eventTarget.dispatchEvent(
-						new CustomEvent('chat', {
-							detail: {
-								id: message.id,
-								content: messageContentParts[messageContentParts.length - 1]
-							}
-						})
-					);
-				}
+				dispatchChatTTSContentParts(message);
 			}
 		}
 
@@ -1873,18 +1858,7 @@
 
 			// Emit chat event for TTS (only when call overlay is active)
 			if ($showCallOverlay) {
-				let lastMessageContentPart =
-					getMessageContentParts(
-						removeAllDetails(message.content),
-						$config?.audio?.tts?.split_on ?? 'punctuation'
-					)?.at(-1) ?? '';
-				if (lastMessageContentPart) {
-					eventTarget.dispatchEvent(
-						new CustomEvent('chat', {
-							detail: { id: message.id, content: lastMessageContentPart }
-						})
-					);
-				}
+				dispatchChatTTSContentParts(message, true);
 			}
 			eventTarget.dispatchEvent(
 				new CustomEvent('chat:finish', {

--- a/src/lib/utils/audio.test.ts
+++ b/src/lib/utils/audio.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUndispatchedAudioContentParts } from './audio';
+
+describe('getUndispatchedAudioContentParts', () => {
+	it('returns every completed content part that has not been dispatched yet', () => {
+		expect(
+			getUndispatchedAudioContentParts(
+				['Sentence one.', 'Sentence two.', 'Sentence three.', 'partial'],
+				0
+			)
+		).toEqual([
+			{ index: 1, content: 'Sentence two.' },
+			{ index: 2, content: 'Sentence three.' }
+		]);
+	});
+
+	it('tracks by index so repeated sentences are still dispatched once each', () => {
+		expect(
+			getUndispatchedAudioContentParts(['Hello.', 'Goodbye.', 'Hello.', 'partial'], -1)
+		).toEqual([
+			{ index: 0, content: 'Hello.' },
+			{ index: 1, content: 'Goodbye.' },
+			{ index: 2, content: 'Hello.' }
+		]);
+	});
+
+	it('includes the final content part when the stream is complete', () => {
+		expect(
+			getUndispatchedAudioContentParts(
+				['Sentence one.', 'Sentence two.', 'Final sentence.'],
+				1,
+				true
+			)
+		).toEqual([{ index: 2, content: 'Final sentence.' }]);
+	});
+});

--- a/src/lib/utils/audio.ts
+++ b/src/lib/utils/audio.ts
@@ -1,5 +1,30 @@
 type AudioQueueEvent = 'stop' | 'empty-queue' | 'id-change';
 
+export interface UndispatchedAudioContentPart {
+	index: number;
+	content: string;
+}
+
+/**
+ * Returns the TTS content parts that have not been emitted yet.
+ * While streaming, the trailing part is left pending because it may still be incomplete.
+ */
+export const getUndispatchedAudioContentParts = (
+	contentParts: string[],
+	lastDispatchedIndex = -1,
+	includeLastPart = false
+): UndispatchedAudioContentPart[] => {
+	const normalizedLastDispatchedIndex = Number.isInteger(lastDispatchedIndex)
+		? lastDispatchedIndex
+		: -1;
+	const dispatchableContentParts = includeLastPart ? contentParts : contentParts.slice(0, -1);
+
+	return dispatchableContentParts
+		.map((content, index) => ({ index, content }))
+		.slice(Math.max(0, normalizedLastDispatchedIndex + 1))
+		.filter(({ content }) => content);
+};
+
 interface AudioQueueStopDetail {
 	event: AudioQueueEvent;
 	id: string | null;


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #19861.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this is a focused frontend TTS bug fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Automated checks are listed below.
- [x] **No Unchecked AI Code:** This change has been reviewed and tested with targeted automated coverage.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Uses local per-message dispatch state; no new settings or UX changes.
- [x] **Git Hygiene:** The PR is atomic and based on `dev`.
- [x] **Title Prefix:** The PR title uses `fix:`.

# Changelog Entry

### Description

Fixes voice-mode TTS sentence skipping when multiple completed response chunks arrive between streaming updates.

### Fixed

- Track dispatched TTS content parts by index and emit every newly completed part instead of only the latest completed sentence.
- Dispatch the final pending TTS content part when streaming completes.
- Preserve repeated sentences such as `Hello. Goodbye. Hello.` by using the part index instead of deduplicating by text.

---

### Additional Information

Testing performed:

- `npm run test:frontend -- --run src/lib/utils/audio.test.ts`
- `npx eslint src/lib/utils/audio.ts src/lib/utils/audio.test.ts`
- `npx prettier --check src/lib/components/chat/Chat.svelte src/lib/utils/audio.ts src/lib/utils/audio.test.ts`

Note: a full `npm run check` was attempted with an increased Node heap, but the current `dev` branch reports existing unrelated project-wide `svelte-check` diagnostics; none referenced the files changed in this PR.

### Screenshots or Videos

- Not applicable; this changes TTS dispatch logic and is covered by unit tests.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
