### PR TITLE
chore: fix InsecureKeyLengthWarning

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -38,7 +38,7 @@ def serve(
         typer.echo('Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.')
         if not KEY_FILE.exists():
             typer.echo(f'Generating a new secret key and saving it to {KEY_FILE}')
-            KEY_FILE.write_bytes(base64.b64encode(random.randbytes(12)))
+            KEY_FILE.write_bytes(base64.b64encode(random.randbytes(24)))
         typer.echo(f'Loading WEBUI_SECRET_KEY from {KEY_FILE}')
         os.environ['WEBUI_SECRET_KEY'] = KEY_FILE.read_text()
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -38,7 +38,7 @@ if [[ -z "${WEBUI_SECRET_KEY:-}" && -z "${WEBUI_JWT_SECRET_KEY:-}" ]]; then
 
   if [[ ! -f "$KEY_FILE" ]]; then
     echo "Generating new WEBUI_SECRET_KEY..."
-    head -c 12 /dev/random | base64 > "$KEY_FILE"
+    head -c 24 /dev/random | base64 > "$KEY_FILE"
   fi
 
   echo "Loading WEBUI_SECRET_KEY from ${KEY_FILE}"


### PR DESCRIPTION
Fixing the InsecureKeyLengthWarning by increasing the generated key length from 12 to 24 which increases the base64 value from 16 to 32 chars

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [ ] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Increase the generates secret key size from 16 to 32 to satisfy the minimum recommended length.

### Changed

- Generated secret key is now 32 bytes long
- 
---

### Screenshots or Videos

Log output (including the warning) with 16 bytes:

```
user@my:/workspaces/open-webui/backend# ./start.sh 
No WEBUI_SECRET_KEY environment variable set, loading from file.
Generating new WEBUI_SECRET_KEY...
Loading WEBUI_SECRET_KEY from .webui_secret_key
...
 ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
██║   ██║██████╔╝█████╗  ██╔██╗ ██║    ██║ █╗ ██║█████╗  ██████╔╝██║   ██║██║
██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║    ██║███╗██║██╔══╝  ██╔══██╗██║   ██║██║
╚██████╔╝██║     ███████╗██║ ╚████║    ╚███╔███╔╝███████╗██████╔╝╚██████╔╝██║
 ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝     ╚══╝╚══╝ ╚══════╝╚═════╝  ╚═════╝ ╚═╝


v0.9.6 - building the best AI user interface.
...
2026-06-10 11:28:27.958 | INFO     | open_webui.utils.logger:start_logger:214 - GLOBAL_LOG_LEVEL: INFO
2026-06-10 11:28:27.959 | INFO     | open_webui.main:lifespan:661 - Installing external dependencies of functions and tools...
2026-06-10 11:28:27.997 | INFO     | open_webui.utils.plugin:install_frontmatter_requirements:419 - No requirements found in frontmatter.
2026-06-10 11:28:27.997 | INFO     | open_webui.utils.automations:scheduler_worker_loop:171 - Scheduler worker started (poll interval: 10s)
/usr/local/lib/python3.11/site-packages/jwt/api_jwt.py:371: InsecureKeyLengthWarning: The HMAC key is 16 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
  decoded = self.decode_complete(
2026-06-10 11:28:31.754 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:52626 - "GET /api/config HTTP/1.1" 200
2026-06-10 11:28:31.882 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:52626 - "GET /static/favicon.png HTTP/1.1" 200
```

Log output with 32 bytes (warning gone):

```
user@my:/workspaces/open-webui/backend# ./start.sh 
No WEBUI_SECRET_KEY environment variable set, loading from file.
Generating new WEBUI_SECRET_KEY...
Loading WEBUI_SECRET_KEY from .webui_secret_key
...
 ██████╗ ██████╗ ███████╗███╗   ██╗    ██╗    ██╗███████╗██████╗ ██╗   ██╗██╗
██╔═══██╗██╔══██╗██╔════╝████╗  ██║    ██║    ██║██╔════╝██╔══██╗██║   ██║██║
██║   ██║██████╔╝█████╗  ██╔██╗ ██║    ██║ █╗ ██║█████╗  ██████╔╝██║   ██║██║
██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║    ██║███╗██║██╔══╝  ██╔══██╗██║   ██║██║
╚██████╔╝██║     ███████╗██║ ╚████║    ╚███╔███╔╝███████╗██████╔╝╚██████╔╝██║
 ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝     ╚══╝╚══╝ ╚══════╝╚═════╝  ╚═════╝ ╚═╝


v0.9.6 - building the best AI user interface.
...
2026-06-10 11:29:28.981 | INFO     | open_webui.utils.logger:start_logger:214 - GLOBAL_LOG_LEVEL: INFO
2026-06-10 11:29:28.981 | INFO     | open_webui.main:lifespan:661 - Installing external dependencies of functions and tools...
2026-06-10 11:29:29.034 | INFO     | open_webui.utils.plugin:install_frontmatter_requirements:419 - No requirements found in frontmatter.
2026-06-10 11:29:29.035 | INFO     | open_webui.utils.automations:scheduler_worker_loop:171 - Scheduler worker started (poll interval: 10s)
2026-06-10 11:29:33.323 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:43636 - "GET /static/favicon.png HTTP/1.1" 200
2026-06-10 11:29:33.326 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:43622 - "GET /api/config HTTP/1.1" 200
2026-06-10 11:29:33.353 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:43654 - "GET /api/version HTTP/1.1" 200
2026-06-10 11:29:33.386 | INFO     | uvicorn.protocols.http.httptools_impl:send:483 - 127.0.0.1:43622 - "GET /static/favicon-dark.png HTTP/1.1" 200
```

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
