### PR TITLE
fix: make chat scrollbar visible

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3089,7 +3089,7 @@
 					<div id="chat-pane" class="flex flex-col flex-auto z-10 w-full @container overflow-auto">
 						{#if ($settings?.landingPageMode === 'chat' && !$selectedFolder) || createMessagesList(history, history.currentId).length > 0}
 							<div
-								class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10 scrollbar-hidden"
+								class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10"
 								id="messages-container"
 								bind:this={messagesContainerElement}
 								on:scroll={(e) => {


### PR DESCRIPTION

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] This is a small UI-only change
- [x] No dependencies were added
- [x] The change is limited to the chat messages container
- [x] Manual testing was considered for long chat conversations

Fixes #25833

This changes the main chat messages container so the vertical scrollbar is not hidden.

Previously, the chat messages container used the scrollbar-hidden class. This made long AI responses and long conversations harder to navigate because the scrollbar could be hidden or difficult to access.

With this change, the messages container still uses overflow-auto, but the scrollbar is allowed to stay visible. This should make it easier to scroll through long AI responses and copy text from earlier parts of the conversation.

Release Notes:

- Fixed long chat conversations being hard to scroll because the chat scrollbar was hidden.
- No backend logic was changed.
- No new settings or dependencies were added.

This is my first contribution to Open WebUI. I tried to keep the change small and focused. Feedback is welcome.

Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement, and I am providing my contributions under its terms."