### PR TITLE
feat: default user memory toggle to admin's global ENABLE_MEMORIES config

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2238,7 +2238,7 @@
 			}
 		}
 
-		if ($settings?.memory ?? false) {
+		if ($settings?.memory ?? $config?.features?.enable_memories ?? false) {
 			features = { ...features, memory: true };
 		}
 

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -17,7 +17,7 @@
 	let enableMemory = false;
 
 	onMount(async () => {
-		enableMemory = $settings?.memory ?? false;
+		enableMemory = $settings?.memory ?? $config?.features?.enable_memories ?? false;
 	});
 </script>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #17018`. Community members confirmed that while [PR #20462](https://github.com/open-webui/open-webui/pull/20462) added admin-level feature toggle and permissions, the original request for memory to be **enabled by default** for users was not addressed.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

When an admin enables the Memories feature globally (`ENABLE_MEMORIES=true` in Admin → Settings → General), new users still had to manually enable the Memory toggle in their personal Settings → Personalization before it would take effect. This meant every user had to discover and opt into a feature the admin had already enabled for the entire deployment.

This PR changes the per-user memory toggle's default to inherit from the admin's global `ENABLE_MEMORIES` configuration. Users who have never touched the toggle will now automatically have memory enabled when the admin has it turned on. Users who have explicitly toggled the setting on or off retain their personal preference.

### Changed

- **Per-user memory default**: The Memory toggle in Settings → Personalization now defaults to the admin's global `enable_memories` config instead of hardcoded `false`. This applies to both the UI toggle state and the memory feature flag sent during chat completions.

---

### Additional Information

- Relates to [Discussion #17018](https://github.com/open-webui/open-webui/discussions/17018) — OP requested an environment variable to automatically enable memory for all users by default. [PR #20462](https://github.com/open-webui/open-webui/pull/20462) added the admin-level toggle and permissions, but the per-user default remained `false`. Community member [@zuberek confirmed this gap](https://github.com/open-webui/open-webui/discussions/17018#discussioncomment-17248462) on June 10, 2026.
- **No new env vars or backend changes** — this is a frontend-only change (2 lines) that uses the existing `$config.features.enable_memories` value already exposed by the backend.
- **Behavior matrix:**

| `$settings.memory` | `$config.features.enable_memories` | Result |
|---|---|---|
| `true` (user opted in) | any | ✅ Memory ON |
| `false` (user opted out) | any | ❌ Memory OFF |
| `undefined` (never set) | `true` | ✅ Memory ON ← **new behavior** |
| `undefined` (never set) | `false` | ❌ Memory OFF (unchanged) |

### Files Changed

| File | Change |
|---|---|
| `src/lib/components/chat/Chat.svelte` | Changed fallback in `getFeatures()` from `false` to `$config?.features?.enable_memories ?? false` |
| `src/lib/components/chat/Settings/Personalization.svelte` | Changed `onMount` fallback from `false` to `$config?.features?.enable_memories ?? false` |

### Manual Verification Performed

1. **New user (never toggled):** With `ENABLE_MEMORIES=true` in admin settings, confirm the Memory toggle shows as ON in Settings → Personalization and the memory feature is sent in chat requests.
2. **New user (admin disabled):** With `ENABLE_MEMORIES=false`, confirm the Personalization tab is hidden entirely (existing behavior from PR #20462).
3. **Existing user (explicitly set):** Toggle memory on/off in Personalization, refresh — confirm the user's explicit preference is preserved regardless of admin config.
4. **Build verification:** `npm run build` completes without errors.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
