### PR TITLE
fix: enforce allow_users permission in share chat modal

### DIFF
--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -159,6 +159,8 @@
 							bind:accessGrants
 							accessRoles={['read']}
 							sharePublic={$user?.permissions?.sharing?.public_chats || $user?.role === 'admin'}
+							shareUsers={($user?.permissions?.access_grants?.allow_users ?? true) ||
+								$user?.role === 'admin'}
 							onChange={saveAccessGrants}
 						/>
 					</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (minor bug fix — no discussion needed per contributor).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

The Share Chat modal's `AccessControl` component was missing the `shareUsers` prop, causing it to always show the user picker for sharing with specific users — even when the admin has disabled `access_grants.allow_users` for a user's group.

**Current behavior:** When `access_grants.allow_users` is set to `false` for a user group:
1. User opens the Share Chat modal → the "Add Access" button and individual user picker are fully visible
2. User adds specific users to the access list and saves
3. The backend silently strips these user grants via `filter_allowed_access_grants` — confusing UX

**Expected behavior:** The user picker for individual users should be hidden, matching the behavior of all workspace resource editors (Models, Knowledge, Prompts, Tools, Skills, Notes) which already correctly gate the `shareUsers` prop.

### Root Cause

The `AccessControl` component's `shareUsers` prop defaults to `true`. All workspace resource editors explicitly pass this prop gated by `$user?.permissions?.access_grants?.allow_users`, but `ShareChatModal` did not.

### Fix

Added the `shareUsers` prop to the `AccessControl` instance in `ShareChatModal.svelte`, using the same pattern as all workspace editors:

```svelte
shareUsers={($user?.permissions?.access_grants?.allow_users ?? true) || $user?.role === 'admin'}
```

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Share Chat modal now respects the `access_grants.allow_users` group permission — when disabled, the individual user picker is hidden and only group-based sharing is available

## Screenshots

### From Admin Account

> `Shadow Realm (Permissionless)` Usergroup
<img width="916" height="583" alt="image" src="https://github.com/user-attachments/assets/3e1a556b-eb9a-4c2e-9230-0a1c47b1fab1" />

> `Shadow Realm (Permissionless)` Usergroup Permissions
<img width="916" height="583" alt="image" src="https://github.com/user-attachments/assets/492ccab9-b0bb-4230-a4f7-cb2d924503e9" />

<img width="916" height="583" alt="image" src="https://github.com/user-attachments/assets/4981add6-563b-4a0f-9e0e-c9895df34c1d" />

> `Shadow Realm (Permissionless)` User
<img width="916" height="583" alt="image" src="https://github.com/user-attachments/assets/85048344-fe73-4e37-9fa4-03a8998c6e04" />

### From user Account

> Before:

<img width="697" height="497" alt="image" src="https://github.com/user-attachments/assets/ef99584d-8870-4f18-9fbe-5a2fad859cd9" />

> After:

<img width="700" height="335" alt="image" src="https://github.com/user-attachments/assets/19fedfee-5308-4675-acac-f933a3eca4ce" />


### Manual Verification Performed

1. Create a test user group with `access_grants.allow_users` set to **disabled**
2. Assign a non-admin user to this group
3. Log in as the non-admin user
4. Share a chat → open the Share Chat modal → verify the individual user picker is **hidden** (only group sharing available)
5. Log in as admin → verify the user picker is still visible (admins bypass all permission checks)
6. Re-enable `access_grants.allow_users` → verify non-admin user can now see the user picker again
7. Compare behavior with workspace editors (e.g., Knowledge Base sharing) to confirm consistency

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
