### PR TITLE
fix: resolve duplicate DOM ids breaking code blocks in channels thread view

### DIFF
--- a/src/lib/components/channel/Messages.svelte
+++ b/src/lib/components/channel/Messages.svelte
@@ -128,6 +128,7 @@
 				{message}
 				{channel}
 				{thread}
+				contextId={id}
 				replyToMessage={replyToMessage?.id === message.id}
 				disabled={!channel?.write_access || message?.temp_id}
 				pending={!!message?.temp_id}

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -47,6 +47,7 @@
 
 	export let showUserProfile = true;
 	export let thread = false;
+	export let contextId = null;
 
 	export let replyToMessage = false;
 	export let disabled = false;
@@ -177,7 +178,7 @@
 		{/if}
 
 		<div
-			id="message-{message.id}"
+			id="message-{contextId ? `${contextId}-${message.id}` : message.id}"
 			class="flex flex-col justify-between w-full max-w-full mx-auto group hover:bg-gray-300/5 dark:hover:bg-gray-700/5 relative {className
 				? className
 				: `px-5 ${
@@ -314,7 +315,7 @@
 						class="ml-12 flex items-center space-x-2 relative z-0"
 						on:click={() => {
 							const messageElement = document.getElementById(
-								`message-${message.reply_to_message.id}`
+								`message-${contextId ? `${contextId}-${message.reply_to_message.id}` : message.reply_to_message.id}`
 							);
 							if (messageElement) {
 								messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -354,7 +355,7 @@
 
 						<div class="italic text-sm text-gray-500 dark:text-gray-400 line-clamp-1 w-full flex-1">
 							<Markdown
-								id={`${message.id}-reply-to`}
+								id={`${contextId ? `${contextId}-${message.id}` : message.id}-reply-to`}
 								content={message?.reply_to_message?.content}
 								allowEmbeds={false}
 							/>
@@ -365,7 +366,7 @@
 
 			<div
 				class=" flex w-full message-{message.id} "
-				id="message-{message.id}"
+				id="message-{contextId ? `${contextId}-${message.id}` : message.id}"
 				dir={$settings.chatDirection}
 			>
 				<div class={`shrink-0 mr-1 w-9`}>
@@ -525,7 +526,7 @@
 								<Skeleton />
 							{:else}
 								<Markdown
-									id={message.id}
+									id={contextId ? `${contextId}-${message.id}` : message.id}
 									content={message.content}
 									paragraphTag="span"
 									allowEmbeds={!!message?.meta?.model_id}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (clear rendering bug).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Code blocks in channel messages render correctly in the main channel view, but appear empty (showing only the language label and Collapse/Copy buttons with no actual code content) when the same message is viewed in the thread panel sidebar.

### Root Cause

When a message appears in both the main channel and the thread panel simultaneously, both rendering contexts produce DOM elements with identical `id` attributes (e.g., `code-textarea-{messageId}-0`). CodeMirror's `CodeEditor` component uses `document.getElementById()` to find its mount target, which returns the **first** matching element — the main channel's container. The thread's CodeEditor instance mounts into the wrong container (or fails to mount), leaving the thread's code blocks empty.

The duplicate `id` issue affects:
- `code-textarea-{id}` — CodeMirror mount target (CodeEditor.svelte)
- `message-{id}` — message wrapper elements (Message.svelte, appears twice per message)
- `plt-canvas-{id}` — matplotlib canvas (CodeBlock.svelte)

### Fix

Added a `contextId` prop to the channel `Message.svelte` component, passed down from `Messages.svelte`. For the thread context, this is the `threadId`; for the main channel, it's `null`. All DOM `id` attributes and the `Markdown` component's `id` prop are namespaced using this context:

- Thread: `id="message-{threadId}-{messageId}"`, `code-textarea-{threadId}-{messageId}-0`
- Channel: `id="message-{messageId}"` (unchanged, backward compatible)

This namespacing propagates automatically through the existing `Markdown` → `MarkdownTokens` → `CodeBlock` → `CodeEditor` chain without any changes to those shared components.

**Scope:** Only channel components are modified. The chat message pipeline is unaffected.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Code blocks now render correctly in both the main channel view and the thread panel simultaneously
- Matplotlib/plot outputs also render correctly in both views

### Screenshots or Videos

## Before:

<img width="2350" height="1278" alt="image" src="https://github.com/user-attachments/assets/03918545-caaa-4cb4-8dc5-0918fc0ab9f9" />

## After:

<img width="2350" height="1278" alt="image" src="https://github.com/user-attachments/assets/a910e5f8-ca5f-4ac8-99da-c03977e509f7" />

### Manual Verification Performed

1. Open a channel containing a message with code blocks
2. Click "Reply in Thread" on that message
3. Verify code blocks render correctly in **both** the main channel AND the thread panel
4. Verify Collapse/Expand/Copy buttons work in both views
5. Test with multiple code blocks in a single message
6. Verify no regressions in channels without threads open

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
