### PR TITLE
fix: sync pinned note state in sidebar and editor menu

### DIFF
--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -219,6 +219,10 @@
 			}).catch((e) => {
 				toast.error(`${e}`);
 			});
+
+			if (res) {
+				pinnedNotes.set(await getPinnedNoteList(localStorage.token).catch(() => []));
+			}
 		}, 200);
 	};
 
@@ -1092,7 +1096,7 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 									onDelete={() => {
 										showDeleteConfirm = true;
 									}}
-									isPinned={note.is_pinned ?? false}
+									isPinned={$pinnedNotes.some((n) => n.id === note.id)}
 									onPin={async () => {
 										await toggleNotePinnedStatusById(localStorage.token, note.id);
 										note = await getNoteById(localStorage.token, note.id);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Complimentary to #25640 which fixed a similar issue in a different code path.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Complimentary fix to #25640. Two pinned notes sync bugs in `NoteEditor.svelte`:

**Bug 1: Sidebar title not updating on rename**

When renaming a note from the note editor page, the pinned note title in the sidebar's "Notes" section does not update until a full page refresh.

**Root cause:** The `changeDebounceHandler` function calls `updateNoteById()` to save (including title changes) but never refreshes the `pinnedNotes` store afterward. The sidebar reads titles directly from `$pinnedNotes`.

**Fix:** Added `pinnedNotes.set(await getPinnedNoteList(...))` after successful save, matching the pattern used by `editChatTitle` in `ChatItem.svelte`.

---

**Bug 2: Stale pin/unpin state in editor's 3-dots menu**

After pinning a note from the editor's 3-dots menu, then unpinning it from the sidebar, the editor's menu still shows "Unpin" instead of "Pin to Sidebar".

**Root cause:** `isPinned` was derived from the local `note.is_pinned` property, which is never updated when the sidebar unpins the note externally.

**Fix:** Changed `isPinned` to derive from the reactive `$pinnedNotes` store instead:
```diff
-isPinned={note.is_pinned ?? false}
+isPinned={$pinnedNotes.some((n) => n.id === note.id)}
```

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Pinned note title in sidebar now updates immediately when renamed from the editor
- Editor's 3-dots menu now shows correct Pin/Unpin state after external changes from the sidebar

### Screenshots or Videos

## Before:
<img width="1231" height="373" alt="image" src="https://github.com/user-attachments/assets/73169bf7-1e8f-4487-a9eb-afc617c576e3" />

## After:

<img width="515" height="373" alt="image" src="https://github.com/user-attachments/assets/7c7eba3f-d729-4eef-adbc-2028c9c43192" />

### Manual Verification Performed

1. Pin a note to the sidebar → open it in the editor
2. Change the title → verify sidebar updates immediately
3. Generate a title via AI → verify sidebar updates
4. Unpin the note from the sidebar → open 3-dots menu in editor → verify it shows "Pin to Sidebar" (not "Unpin")
5. Pin from editor menu → verify sidebar shows the note
6. Unpin from editor menu → verify sidebar removes the note
7. Verify no regressions with note content saves (file uploads, content edits)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
