### PR TITLE
fix: add admin bypass to memories permission checks

### DIFF
--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -39,7 +39,7 @@ async def get_memories(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -79,7 +79,7 @@ async def add_memory(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -130,7 +130,7 @@ async def query_memory(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -205,7 +205,7 @@ async def reset_memory_from_vector_db(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -256,7 +256,7 @@ async def delete_memory_by_user_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -296,7 +296,7 @@ async def update_memory_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -345,7 +345,7 @@ async def delete_memory_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    if not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', request.app.state.config.USER_PERMISSIONS):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Bug found during a permissions audit — every other router guards `has_permission()` with `user.role != 'admin'`, but `memories.py` does not.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Add missing `user.role != 'admin'` guard to all 7 memory endpoints, ensuring admin users always bypass per-group permission checks.

**Bug:** Every other router in the codebase guards `has_permission()` calls with `user.role != 'admin'`, ensuring admins always pass. `memories.py` was the only router missing this guard — all 7 of its endpoints called `has_permission()` directly without checking admin role first.

**Impact:** If `features.memories` is set to `false` in default permissions or a group's permissions, admin users are blocked from all memory operations (list, add, query, reset, update, delete). This is inconsistent with the rest of the codebase where admins always have full access.

**Fix:** Add `user.role != 'admin' and` before each `has_permission()` check, matching the pattern used by every other router:

```diff
-    if not await has_permission(user.id, 'features.memories', ...):
+    if user.role != 'admin' and not await has_permission(user.id, 'features.memories', ...):
```

**Scope:** 1 file, 7 identical one-line changes.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

## Before:

<img width="2551" height="1278" alt="image" src="https://github.com/user-attachments/assets/010b79fa-355f-4601-b82e-38d00f235c6b" />

## After:

<img width="2551" height="1278" alt="image" src="https://github.com/user-attachments/assets/2bb52db6-43d9-4c7c-8f96-e26fc8a8b2d4" />

### Fixed

- Admin users are no longer subject to `features.memories` permission checks — they now bypass permission checks like they do in every other router

### Manual Verification Performed

1. Set `features.memories` default to `false` → verify admin can still access memories (was blocked before fix)
2. Set `features.memories` default to `true` → verify non-admin users can still access memories
3. Remove non-admin user from all groups → verify they are blocked from memories
4. Add non-admin user to a group with `features.memories` enabled → verify access is restored
5. Verify no regressions with memory add, query, update, delete, and reset operations

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
