### PR TITLE
fix: add missing skills permission to workspace menu visibility check

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -301,7 +301,7 @@
 
 			<hr class=" border-gray-50/30 dark:border-gray-800/30 my-1 p-0" />
 
-			{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools}
+			{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools || $user?.permissions?.workspace?.skills}
 				<div class="flex items-center w-full">
 					<a
 						href="/workspace"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Bug found during a permissions audit — the user menu dropdown was inconsistent with the sidebar for users with only `workspace.skills` permission.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Add missing `workspace.skills` permission check to the user menu "Workspace" link visibility condition.

**Bug:** The user menu dropdown's "Workspace" link checks `models`, `knowledge`, `prompts`, and `tools` permissions — but not `skills`. A non-admin user with **only** `workspace.skills` permission won't see the "Workspace" link in the dropdown menu, even though:
- The sidebar correctly shows the Workspace link (it includes `skills` in its check)
- The user can navigate to `/workspace/skills` directly via URL

**Fix:** Add `|| $user?.permissions?.workspace?.skills` to the visibility condition, matching the sidebar's check.

```diff
-{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools}
+{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools || $user?.permissions?.workspace?.skills}
```

**Scope:** 1 file, 1 line.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

<img width="923" height="579" alt="image" src="https://github.com/user-attachments/assets/db8b6012-38b9-41b6-86ae-9082bd39d5f2" />

## Before:

> Non-admin user with only workspace.skills permission — user menu dropdown missing the Workspace link

<img width="220" height="260" alt="image" src="https://github.com/user-attachments/assets/fb64d2cf-11ef-4796-873e-b1583bd9a297" />

<img width="276" height="355" alt="image" src="https://github.com/user-attachments/assets/d9873f3c-6aa0-43a0-b005-6b1732faf419" />

## After:

> Non-admin user with only workspace.skills permission — user menu dropdown now shows the Workspace link

<img width="223" height="295" alt="image" src="https://github.com/user-attachments/assets/0087f2b6-4bde-40a4-99da-da2cc83daca9" />

<img width="276" height="355" alt="image" src="https://github.com/user-attachments/assets/7f6c34cd-3344-41c5-9d08-0be15ec00392" />

### Fixed

- Non-admin users with only `workspace.skills` permission now see the "Workspace" link in the user menu dropdown, consistent with the sidebar behavior

### Manual Verification Performed

1. Create a non-admin user with only `workspace.skills` permission (no models/knowledge/prompts/tools)
2. Before fix: open user menu → "Workspace" link missing
3. After fix: open user menu → "Workspace" link visible
4. Click "Workspace" → navigates to `/workspace` correctly
5. Verify users with other workspace permissions (models, tools, etc.) still see the link
6. Verify admin always sees the link

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
