### PR TITLE
fix: check descendant subfolders for chat.delete permission on folder delete

### DIFF
--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -277,11 +277,22 @@ async def delete_folder_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    if await Chats.count_chats_by_folder_id_and_user_id(id, user.id, db=db):
-        chat_delete_permission = await has_permission(
+    # Check for chats in this folder AND all descendant subfolders
+    folder_ids_to_check = [id]
+    children = await Folders.get_children_folders_by_id_and_user_id(id, user.id, db=db)
+    if children:
+        folder_ids_to_check.extend([child.id for child in children])
+
+    has_chats = False
+    for folder_id in folder_ids_to_check:
+        if await Chats.count_chats_by_folder_id_and_user_id(folder_id, user.id, db=db):
+            has_chats = True
+            break
+
+    if has_chats:
+        if user.role != 'admin' and not await has_permission(
             user.id, 'chat.delete', request.app.state.config.USER_PERMISSIONS, db=db
-        )
-        if user.role != 'admin' and not chat_delete_permission:
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #25920 — `delete_folder_by_id` bypasses `chat.delete` permission when deleting a parent folder with chats inside subfolders
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Fix `chat.delete` permission bypass when deleting a parent folder that contains chats in subfolders.

**Problem (Closes #25920):**

When an admin disables `chat.delete` for a user group, the restriction is enforced correctly when:
- A user deletes an individual chat ✅
- A user deletes a folder that **directly** contains chats ✅

But the restriction is **NOT** enforced when a user deletes a **parent folder** whose subfolders contain chats. The permission check only examined the folder being deleted — not its descendants. Since the parent folder itself has zero direct chats, the check passes, and the cascade delete wipes all chats in subfolders.

**Root cause:** [`delete_folder_by_id`](https://github.com/open-webui/open-webui/blob/dev/backend/open_webui/routers/folders.py#L280) calls `count_chats_by_folder_id_and_user_id(id, ...)` with only the top-level folder ID. When the parent has no direct chats, this returns 0 and the permission block is skipped entirely.

**Fix:** Before checking the permission, collect all descendant folder IDs using the existing `get_children_folders_by_id_and_user_id()` helper, then check if **any** folder in the subtree contains chats. If so, enforce the `chat.delete` permission.

```diff
-    if await Chats.count_chats_by_folder_id_and_user_id(id, user.id, db=db):
-        chat_delete_permission = await has_permission(...)
-        if user.role != 'admin' and not chat_delete_permission:
-            raise HTTPException(...)
+    # Check for chats in this folder AND all descendant subfolders
+    folder_ids_to_check = [id]
+    children = await Folders.get_children_folders_by_id_and_user_id(id, user.id, db=db)
+    if children:
+        folder_ids_to_check.extend([child.id for child in children])
+
+    has_chats = False
+    for folder_id in folder_ids_to_check:
+        if await Chats.count_chats_by_folder_id_and_user_id(folder_id, user.id, db=db):
+            has_chats = True
+            break
+
+    if has_chats:
+        if user.role != 'admin' and not await has_permission(...):
+            raise HTTPException(...)
```

**Scope:** 1 file, 1 endpoint. No new dependencies. Uses existing `get_children_folders_by_id_and_user_id()` helper.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

### Fixed

- `chat.delete` permission is now enforced when deleting parent folders that contain chats in descendant subfolders

### Manual Verification Performed

1. As admin, disable `chat.delete` for a user group
2. As restricted user, create Master Folder → Subfolder → start a chat in Subfolder
3. Attempt to delete Subfolder → ✅ Correctly blocked (403)
4. Attempt to delete Master Folder → ✅ **Now correctly blocked** (was bypassed before)
5. As admin, delete the same folder structure → ✅ Works (admin bypass intact)
6. Re-enable `chat.delete` → user can delete folders with chats again

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
