### PR TITLE
feat: add reset to defaults button in permissions modals

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -269,6 +269,20 @@ async def update_default_user_permissions(request: Request, form_data: UserPermi
     return request.app.state.config.USER_PERMISSIONS
 
 
+@router.get('/default/permissions/defaults', response_model=UserPermissions)
+async def get_default_user_permissions_defaults(user=Depends(get_admin_user)):
+    from open_webui.config import DEFAULT_USER_PERMISSIONS
+
+    return {
+        'workspace': WorkspacePermissions(**DEFAULT_USER_PERMISSIONS.get('workspace', {})),
+        'sharing': SharingPermissions(**DEFAULT_USER_PERMISSIONS.get('sharing', {})),
+        'access_grants': AccessGrantsPermissions(**DEFAULT_USER_PERMISSIONS.get('access_grants', {})),
+        'chat': ChatPermissions(**DEFAULT_USER_PERMISSIONS.get('chat', {})),
+        'features': FeaturesPermissions(**DEFAULT_USER_PERMISSIONS.get('features', {})),
+        'settings': SettingsPermissions(**DEFAULT_USER_PERMISSIONS.get('settings', {})),
+    }
+
+
 ############################
 # GetUserSettingsBySessionUser
 ############################

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -85,6 +85,33 @@ export const updateUserDefaultPermissions = async (token: string, permissions: o
 	return res;
 };
 
+export const getUserDefaultPermissionsDefaults = async (token: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/users/default/permissions/defaults`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const updateUserRole = async (token: string, id: string, role: string) => {
 	let error = null;
 

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -10,9 +10,11 @@
 	import Users from './Users.svelte';
 	import GroupPreviewPanel from './GroupPreviewPanel.svelte';
 	import { DEFAULT_PERMISSIONS } from '$lib/constants/permissions';
+	import { getUserDefaultPermissions, getUserDefaultPermissionsDefaults } from '$lib/apis/users';
 	import UserPlusSolid from '$lib/components/icons/UserPlusSolid.svelte';
 	import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
 	export let onSubmit: Function = () => {};
@@ -31,6 +33,7 @@
 	let selectedTab = 'general';
 	let loading = false;
 	let showDeleteConfirmDialog = false;
+	let showResetConfirmDialog = false;
 
 	let userCount = 0;
 
@@ -54,6 +57,29 @@
 
 		loading = false;
 		show = false;
+	};
+
+	const resetToDefaultsHandler = async () => {
+		try {
+			// For user groups: reset to current global default permissions
+			// For default permissions modal: reset to stock/env-var configuration
+			const defaults = custom
+				? await getUserDefaultPermissions(localStorage.token)
+				: await getUserDefaultPermissionsDefaults(localStorage.token);
+			if (defaults) {
+				permissions = {
+					workspace: { ...DEFAULT_PERMISSIONS.workspace, ...defaults.workspace },
+					sharing: { ...DEFAULT_PERMISSIONS.sharing, ...defaults.sharing },
+					access_grants: { ...DEFAULT_PERMISSIONS.access_grants, ...defaults.access_grants },
+					chat: { ...DEFAULT_PERMISSIONS.chat, ...defaults.chat },
+					features: { ...DEFAULT_PERMISSIONS.features, ...defaults.features },
+					settings: { ...DEFAULT_PERMISSIONS.settings, ...defaults.settings }
+				};
+				toast.success($i18n.t('Permissions reset to defaults'));
+			}
+		} catch (error) {
+			toast.error(`${error}`);
+		}
 	};
 
 	const init = () => {
@@ -91,6 +117,17 @@
 	on:confirm={() => {
 		onDelete();
 		show = false;
+	}}
+/>
+
+<ConfirmDialog
+	bind:show={showResetConfirmDialog}
+	title={$i18n.t('Reset to Defaults')}
+	message={$i18n.t(
+		'Are you sure you want to reset all permissions to their default values? You will still need to save to apply the changes.'
+	)}
+	on:confirm={() => {
+		resetToDefaultsHandler();
 	}}
 />
 
@@ -250,7 +287,29 @@
 							</div>
 
 							{#if ['general', 'permissions'].includes(selectedTab)}
-								<div class="flex justify-end pt-3 text-sm font-medium gap-1.5">
+								<div class="flex justify-between items-center pt-3 text-sm font-medium gap-1.5">
+									<div>
+										{#if selectedTab === 'permissions'}
+											<Tooltip
+												content={custom
+													? $i18n.t(
+															'Reset group permissions to match the current default user permissions'
+														)
+													: $i18n.t('Reset all permissions to their initial configuration values')}
+											>
+												<button
+													class="text-sm font-normal text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300 transition hover:underline"
+													type="button"
+													on:click={() => {
+														showResetConfirmDialog = true;
+													}}
+												>
+													{$i18n.t('Reset to Defaults')}
+												</button>
+											</Tooltip>
+										{/if}
+									</div>
+
 									<button
 										class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full flex items-center gap-2 whitespace-nowrap {loading
 											? ' cursor-not-allowed'


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Feature request — no existing issue. Addresses the lack of a way to revert permissions back to stock configuration after modifying them.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **feat**

# Changelog Entry

### Description

Add a **Reset to Defaults** button to the permissions tab in both the Edit Default Permissions modal and the Edit User Group modal.

**Problem:**

Once an admin modifies default permissions or group-level permissions, there is no way to revert them back to their original values without manually toggling each switch. This is especially painful when many permissions have been changed, or when an admin wants to start fresh after experimenting with different configurations.

**Solution:**

A new "Reset to Defaults" button appears on the permissions tab, left of the existing Save button. Clicking it shows a confirmation dialog, then resets all toggles to the appropriate defaults:

| Modal | "Reset to Defaults" resets to... |
|---|---|
| **Edit Default Permissions** | Stock Open WebUI configuration (respects env var overrides like `USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS`) |
| **Edit User Group** | The current global default permissions (what the admin has configured for all users) |

The reset only updates the local toggle state — the admin must still click **Save** to persist the changes. This is called out in the confirmation dialog message.

**Changes:**

| File | What changed |
|---|---|
| `backend/open_webui/routers/users.py` | New `GET /api/v1/users/default/permissions/defaults` endpoint that returns `DEFAULT_USER_PERMISSIONS` (the env-var-based initial defaults, not the runtime-saved ConfigVar) |
| `src/lib/apis/users/index.ts` | New `getUserDefaultPermissionsDefaults()` API function |
| `src/lib/components/admin/Users/Groups/EditGroupModal.svelte` | "Reset to Defaults" button with `ConfirmDialog`, `resetToDefaultsHandler()` that fetches the correct defaults based on modal mode |

**UX flow:**
1. Open the Edit Default Permissions (or Edit User Group) modal
2. Navigate to the Permissions tab
3. Click "Reset to Defaults" (ghost-styled button to the left of Save)
4. Confirmation dialog: *"Are you sure you want to reset all permissions to their default values? You will still need to save to apply the changes."*
5. Confirm → all toggles update → toast: *"Permissions reset to defaults"*
6. Click Save to persist (or close to discard)

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

## Before:

<img width="921" height="583" alt="image" src="https://github.com/user-attachments/assets/7b16841e-0972-485c-9546-c1c5744e7a7a" />

<img width="921" height="583" alt="image" src="https://github.com/user-attachments/assets/1f1955fa-3164-469a-ace9-b5553527d50e" />

## After:

<img width="921" height="593" alt="image" src="https://github.com/user-attachments/assets/0e24c7c1-72c1-45f9-9d33-15ec44271992" />

<img width="921" height="593" alt="image" src="https://github.com/user-attachments/assets/87ee8b8a-a050-422e-a396-138aa67a089f" />

### Added

- "Reset to Defaults" button on the permissions tab of the `Edit Default Permissions` and `Edit User Group` modals
- `GET /api/v1/users/default/permissions/defaults` API endpoint for retrieving stock/env-var-based permission defaults

### Manual Verification Performed

1. Open Edit Default Permissions → Permissions tab → verify "Reset to Defaults" button appears left of Save
2. Toggle several permissions → click Reset to Defaults → confirm → verify all toggles revert to stock values
3. Close modal without saving → reopen → verify original (pre-reset) values are still active (reset didn't auto-save)
4. Reset → Save → reopen → verify reset values persisted
5. Open Edit User Group → Permissions tab → verify "Reset to Defaults" button appears
6. Toggle group permissions → Reset to Defaults → verify toggles match the current global default permissions (not stock)
7. Verify env var override: set `USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS=true` → restart → Reset to Defaults → verify Models Access is ON
8. Verify General tab does NOT show the reset button (only appears on Permissions tab)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
