### PR TITLE
fix(notes): sync external note content updates into open editors

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -20,7 +20,6 @@ from open_webui.models.notes import (
     NoteUserResponse,
 )
 from open_webui.models.users import UserResponse, Users
-from open_webui.socket.main import sio
 from open_webui.utils.access_control import (
     filter_allowed_access_grants,
     has_permission,
@@ -28,6 +27,7 @@ from open_webui.utils.access_control import (
     has_public_write_access_grant,
 )
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.notes import sync_note_update
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -345,10 +345,9 @@ async def update_note_by_id(
         pinned_note_ids = await Notes.get_pinned_note_ids(user.id, db=db)
         note.is_pinned = note.id in pinned_note_ids
 
-        await sio.emit(
-            'note-events',
-            note.model_dump(),
-            to=f'note:{note.id}',
+        await sync_note_update(
+            note,
+            clear_document=bool(form_data.data and 'content' in form_data.data),
         )
 
         return note

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -24,6 +24,7 @@ from open_webui.models.messages import Message, Messages
 from open_webui.models.notes import Notes
 from open_webui.models.users import UserModel
 from open_webui.retrieval.utils import get_content_from_url
+from open_webui.utils.notes import sync_note_update
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.routers.images import (
     CreateImageForm,
@@ -1033,6 +1034,8 @@ async def replace_note_content(
 
         if not updated_note:
             return json.dumps({'error': 'Failed to update note'})
+
+        await sync_note_update(updated_note, clear_document=True)
 
         return json.dumps(
             {

--- a/backend/open_webui/utils/notes.py
+++ b/backend/open_webui/utils/notes.py
@@ -1,0 +1,12 @@
+from open_webui.models.notes import NoteModel
+from open_webui.socket.main import YDOC_MANAGER, sio
+
+
+async def sync_note_update(note: NoteModel, *, clear_document: bool = False):
+    if clear_document:
+        await YDOC_MANAGER.clear_document(f'note:{note.id}')
+    await sio.emit(
+        'note-events',
+        note.model_dump(),
+        to=f'note:{note.id}',
+    )

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -44,6 +44,7 @@
 
 	import Controls from './NoteEditor/Controls.svelte';
 	import Chat from './NoteEditor/Chat.svelte';
+	import { resolveIncomingNoteContent } from './NoteEditor/noteEventContent';
 
 	import NotePanel from '$lib/components/notes/NotePanel.svelte';
 	import AccessControlModal from '$lib/components/workspace/common/AccessControlModal.svelte';
@@ -794,6 +795,19 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		if (_note.data && _note.data.files) {
 			files = _note.data.files;
 			note.data.files = files;
+		}
+
+		if (_note.data?.content) {
+			const nextContent = resolveIncomingNoteContent(note.data.content, _note.data.content);
+			const contentChanged = !areContentsEqual(nextContent, note.data.content);
+
+			if (contentChanged) {
+				note.data.content = nextContent;
+
+				if (editor && !editor.isDestroyed) {
+					editor.commands.setContent(note.data.content.html || marked.parse(note.data.content.md || ''));
+				}
+			}
 		}
 
 		if (_note.title && _note.title) {

--- a/src/lib/components/notes/NoteEditor/noteEventContent.test.ts
+++ b/src/lib/components/notes/NoteEditor/noteEventContent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveIncomingNoteContent } from './noteEventContent';
+
+describe('resolveIncomingNoteContent', () => {
+	it('rebuilds html and clears json when an incoming note event only provides markdown', () => {
+		const next = resolveIncomingNoteContent(
+			{
+				json: { type: 'doc', stale: true },
+				html: '<p>Old content</p>',
+				md: 'Old content'
+			},
+			{
+				md: '# LLM Edit\nLLM wrote this.'
+			}
+		);
+
+		expect(next.md).toBe('# LLM Edit\nLLM wrote this.');
+		expect(next.html).toContain('<h1>LLM Edit</h1>');
+		expect(next.html).toContain('<p>LLM wrote this.</p>');
+		expect(next.json).toBeNull();
+	});
+
+	it('preserves explicit html and json from the incoming content payload', () => {
+		const next = resolveIncomingNoteContent(
+			{
+				json: null,
+				html: '<p>Old content</p>',
+				md: 'Old content'
+			},
+			{
+				json: { type: 'doc', content: [] },
+				html: '<p>New content</p>',
+				md: 'New content'
+			}
+		);
+
+		expect(next).toEqual({
+			json: { type: 'doc', content: [] },
+			html: '<p>New content</p>',
+			md: 'New content'
+		});
+	});
+});

--- a/src/lib/components/notes/NoteEditor/noteEventContent.ts
+++ b/src/lib/components/notes/NoteEditor/noteEventContent.ts
@@ -1,0 +1,32 @@
+import { marked } from 'marked';
+
+export type NoteContent = {
+	json?: unknown | null;
+	html?: string | null;
+	md?: string | null;
+};
+
+const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
+
+export const resolveIncomingNoteContent = (
+	currentContent: NoteContent | null | undefined,
+	incomingContent: NoteContent
+): Required<NoteContent> => {
+	const hasMd = hasOwn(incomingContent, 'md');
+	const hasHtml = hasOwn(incomingContent, 'html');
+	const hasJson = hasOwn(incomingContent, 'json');
+
+	const md = hasMd ? (incomingContent.md ?? '') : (currentContent?.md ?? '');
+	const html = hasHtml
+		? (incomingContent.html ?? '')
+		: hasMd
+			? String(marked.parse(md))
+			: (currentContent?.html ?? '');
+	const json = hasJson ? (incomingContent.json ?? null) : hasMd ? null : (currentContent?.json ?? null);
+
+	return {
+		json,
+		html,
+		md
+	};
+};


### PR DESCRIPTION
## Summary
- clear stale note Yjs state when note content is updated outside the open editor so the next keystroke cannot write the pre-edit document back into the database
- reuse a shared backend `sync_note_update` helper for both the REST note update route and the `replace_note_content` built-in tool
- apply incoming note content updates inside `NoteEditor` so open editors refresh from socket events instead of keeping stale local content
- add a focused regression helper test for markdown-only note event payloads rebuilding fresh html/json state

Fixes #25916.

## Testing
- `python3 -m py_compile backend/open_webui/routers/notes.py backend/open_webui/tools/builtin.py backend/open_webui/utils/notes.py`
- `npx eslint src/lib/components/notes/NoteEditor/noteEventContent.ts src/lib/components/notes/NoteEditor/noteEventContent.test.ts`
- `node --experimental-strip-types --input-type=module` assertions for `resolveIncomingNoteContent`

## Notes
- `npm run check` is currently noisy on this checkout due to many pre-existing TypeScript errors in unrelated files, so I did not use it as a regression gate for this focused fix.
- `npx vitest run src/lib/components/notes/NoteEditor/noteEventContent.test.ts` hit the local watcher limit (`ENOSPC`) in this environment; the helper assertions above cover the same logic path without relying on the watcher setup.
