### PR TITLE
fix: add null guard for config in onMount to prevent crash on API failure

### DIFF
--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -219,6 +219,10 @@
 				config = res;
 			}
 
+			if (!config) {
+				return;
+			}
+
 			if (config.ENABLE_IMAGE_GENERATION) {
 				getModels();
 			}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a crash in the Image Settings admin page when the config API request fails — `Relates to general crash prevention`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a null guard fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no architectural changes. Simple null guard.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Navigating to **Admin Panel → Settings → Images** crashes with a `TypeError` if the image config API request (`GET /api/v1/images/config`) fails for any reason (network error, backend offline, auth expiry).

**Root Cause:** In `Images.svelte`'s `onMount`, the code calls `getConfig()` with a `.catch()` that returns `null` on failure. After the catch, `config` remains `null` (its initial value), but the code immediately accesses `config.ENABLE_IMAGE_GENERATION` without a null check — causing `TypeError: can't access property "ENABLE_IMAGE_GENERATION", ... is null`.

**Fix:** Added `if (!config) return;` after the config assignment block, preventing property access on a `null` config. The template already has an `{#if config}` guard, so the page gracefully shows a blank state with an error toast instead of crashing.

```diff
 if (res) {
     config = res;
 }

+if (!config) {
+    return;
+}
+
 if (config.ENABLE_IMAGE_GENERATION) {
```

### Fixed

- Fixed `TypeError` crash on the Image Settings admin page when the config API request fails (network error, backend offline, blocked request)

---

### Additional Information

- **Scope:** 1 file changed, 4 insertions
- **File:** `src/lib/components/admin/Settings/Images.svelte`

### Screenshots or Videos

- Reproduced by blocking `GET /api/v1/images/config` via Firefox DevTools Network → Request Blocking
- **Before fix:** Page crashes with `TypeError: can't access property "ENABLE_IMAGE_GENERATION", (intermediate value)(...) is null`
- **After fix:** Page shows blank Images settings with an error toast; no console crash

### Manual Verification Performed

1. Block `GET /api/v1/images/config` in Firefox DevTools → Network → Request Blocking
2. Navigate to Admin Panel → Settings → Images
3. **Before fix:** Blank page, `TypeError` in console
4. **After fix:** Blank page (expected — `{#if config}` hides form), error toast shown, no crash in console
5. Unblock the request, reload — Images settings page loads normally with all controls

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
