### PR TITLE
fix: prevent duplicate leaderboard API requests on navigation

### DIFF
--- a/src/routes/(app)/admin/evaluations/+page.svelte
+++ b/src/routes/(app)/admin/evaluations/+page.svelte
@@ -2,11 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
-	import Evaluations from '$lib/components/admin/Evaluations.svelte';
-
 	onMount(() => {
 		goto('/admin/evaluations/leaderboard');
 	});
 </script>
-
-<Evaluations />


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes duplicate API requests on the Evaluations Leaderboard page.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no architectural changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Navigating to the Evaluations Leaderboard page fires duplicate API requests to `GET /api/v1/evaluations/leaderboard` — visible as two identical network requests in the browser DevTools every time the page loads.

**Root Cause:** The base route file `src/routes/(app)/admin/evaluations/+page.svelte` both renders the `<Evaluations />` component AND redirects to `/admin/evaluations/leaderboard` via `goto()` in `onMount`:

```svelte
<!-- BEFORE -->
<script>
    import Evaluations from '$lib/components/admin/Evaluations.svelte';
    onMount(() => {
        goto('/admin/evaluations/leaderboard');
    });
</script>

<Evaluations />  <!-- ← renders Leaderboard, fires request #1 -->
<!-- then goto() navigates away, [tab]/+page.svelte mounts a NEW Evaluations → request #2 -->
```

This causes a mount-unmount-remount cycle:
1. Base route mounts `<Evaluations />` → `<Leaderboard />` mounts → **request 1.**
2. `goto()` navigates to `[tab]/+page.svelte` → old instance unmounts, new `<Evaluations />` mounts → `<Leaderboard />` mounts again → **request 2.**

**Fix:** Remove the `<Evaluations />` component render from the base redirect route. It's a pure redirect page — it should not render anything.

```diff
 <script>
     import { goto } from '$app/navigation';
     import { onMount } from 'svelte';
-    import Evaluations from '$lib/components/admin/Evaluations.svelte';

     onMount(() => {
         goto('/admin/evaluations/leaderboard');
     });
 </script>
-
-<Evaluations />
```

### Fixed

- Fixed duplicate `GET /api/v1/evaluations/leaderboard` requests firing every time the Evaluations Leaderboard page is loaded

---

### Additional Information

- **Scope:** 1 file changed, 2 deletions (component import + render tag)
- **File:** `src/routes/(app)/admin/evaluations/+page.svelte`
- Verified no other route files in the codebase have this same "render + redirect" anti-pattern

### Screenshots or Videos

**Before fix:** 2 GET requests to `/leaderboard` on every navigation

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/845378b2-988d-4ac8-9f93-2380108eac7d" />

**After fix:** 1 GET request to `/leaderboard` — clean single load

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/578e823f-839a-4e67-878a-e629bf1ebd12" />

### Manual Verification Performed

1. Navigate to **Admin Panel → Evaluations → Leaderboard**
2. Open DevTools → Network tab, filter by `XHR`
3. **Before fix:** 2 `GET /api/v1/evaluations/leaderboard` requests visible
4. **After fix:** 1 `GET /api/v1/evaluations/leaderboard` request
5. Switch between Leaderboard and Feedback tabs — each fires only 1 request
6. Search box in Leaderboard works correctly with debounced requests
7. Direct navigation to `/admin/evaluations` correctly redirects to `/admin/evaluations/leaderboard`

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
