### PR TITLE
fix: remove duplicate onMount causing double API requests on Analytics dashboard load

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -186,8 +186,6 @@
 	$: if (typeof localStorage !== 'undefined' && selectedPeriod) {
 		localStorage.setItem('analyticsPeriod', selectedPeriod);
 	}
-
-	onMount(loadDashboard);
 </script>
 
 <!-- Header with title and period selector -->


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes duplicate API requests on the Analytics Dashboard page.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no architectural changes. Single line removal.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Every time the Analytics Dashboard loads, all 5 analytics API endpoints (`/daily`, `/models`, `/summary`, `/tokens`, `/users`) are called **twice**, doubling network traffic and backend load. This is visible in browser DevTools as 10 XHR requests instead of 5.

**Root Cause:** `Dashboard.svelte` has two independent triggers that both call `loadDashboard()` on mount:

1. **Reactive block (L143):** `$: if (selectedPeriod || selectedGroupId !== undefined) { loadDashboard(); }` — fires on mount because `selectedPeriod` is `'7d'` (truthy), and also fires when the user changes filters (its intended purpose).
2. **Explicit onMount (L190):** `onMount(loadDashboard);` — fires on mount only.

Both execute during component initialization, causing `loadDashboard()` to run twice → 5 API calls × 2 = 10 requests.

**Fix:** Remove the redundant `onMount(loadDashboard)` at L190. The reactive block at L143 already handles both the initial load (because `selectedPeriod` is truthy on mount) and subsequent filter changes.

```diff
-	onMount(loadDashboard);
 </script>
```

> **Note:** The other `onMount` at L147 (which loads user groups for the filter dropdown) is intentionally kept — it serves a different purpose and doesn't duplicate any calls.

### Fixed

- Fixed duplicate API requests (`/daily`, `/models`, `/summary`, `/tokens`, `/users`) firing on every Analytics Dashboard load — reduced from 10 requests to 5

---

### Additional Information

- **Scope:** 1 file changed, 1 deletion
- **File:** `src/lib/components/admin/Analytics/Dashboard.svelte`

### Manual Verification Performed

1. Navigate to **Admin Panel → Analytics**
2. Open DevTools → Network tab, filter by `XHR`
3. **Before fix:** 10 requests (each endpoint called twice)

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/3f5d1df4-9285-402f-ba69-feb048130287" />

4. **After fix:** 5 requests (each endpoint called once)

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/4ab0935f-9c41-42a9-a8d0-094338010cc4" />

5. Change the time period filter (e.g., "Last 7 days" → "Last 30 days") — all 5 endpoints fire once with updated parameters
6. Change the user group filter — all 5 endpoints fire once with the selected group

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
