### PR TITLE
fix: prevent duplicate user list API request on page load

### DIFF
--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -100,7 +100,9 @@
 		}
 	};
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			page = 1;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes duplicate API requests on the Admin Users list page.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no architectural changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Navigating to the Admin Users page fires `GET /api/v1/users/?page=1&order_by=created_at&direction=asc` **twice** on every page load, doubling network traffic and backend queries.

**Root Cause:** `UserList.svelte` has two reactive blocks that both call `getUserList()` on mount:

1. **Search reactive block (L103):** `$: if (query !== undefined) { ... getUserList() }` — fires on mount because `query = ''` (which is not `undefined`), scheduling `getUserList()` via a 300ms debounce timer.
2. **Page/sort reactive block (L111):** `$: if (page !== null && orderBy !== null && direction !== null) { getUserList() }` — fires on mount because all three values are initialized as truthy (`page = 1`, `orderBy = 'created_at'`, `direction = 'asc'`), calling `getUserList()` immediately.

The 300ms debounce doesn't prevent the duplicate because the second reactive block fires `getUserList()` synchronously — both calls execute.

**Fix:** Changed the search reactive block to track `prevQuery` so it only fires when `query` actually changes from user input, not during initialization:

```diff
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			page = 1;
```

The page/sort reactive block (L111) continues to handle the initial load and all subsequent page/sort changes as before.

### Fixed

- Fixed duplicate `GET /api/v1/users/` request firing on every Admin Users page load

---

### Additional Information

- **Scope:** 1 file changed, 4 insertions(+), 1 deletion(-)
- **File:** `src/lib/components/admin/Users/UserList.svelte`

### Manual Verification Performed

1. Navigate to **Admin Panel → Users → Overview**
2. Open DevTools → Network tab, filter by `XHR`
3. **Before fix:** 2 `GET /api/v1/users/` requests

<img width="2560" height="588" alt="image" src="https://github.com/user-attachments/assets/1b7787b8-e74d-4018-8691-3201b2963b7c" />

4. **After fix:** 1 `GET /api/v1/users/` request
<img width="2560" height="588" alt="image" src="https://github.com/user-attachments/assets/98d47d81-4a63-4768-a056-55f23b4c40d8" />

5. Type in the search box — debounced search fires 1 request after 300ms with `page=1`
6. Click column headers to sort — 1 request with updated `order_by`/`direction`
7. Navigate pagination — 1 request with updated `page`

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
