### PR TITLE
fix(notes): sync external note content updates into open editors

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -20,7 +20,6 @@ from open_webui.models.notes import (
     NoteUserResponse,
 )
 from open_webui.models.users import UserResponse, Users
-from open_webui.socket.main import sio
 from open_webui.utils.access_control import (
     filter_allowed_access_grants,
     has_permission,
@@ -28,6 +27,7 @@ from open_webui.utils.access_control import (
     has_public_write_access_grant,
 )
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.notes import sync_note_update
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -345,10 +345,9 @@ async def update_note_by_id(
         pinned_note_ids = await Notes.get_pinned_note_ids(user.id, db=db)
         note.is_pinned = note.id in pinned_note_ids
 
-        await sio.emit(
-            'note-events',
-            note.model_dump(),
-            to=f'note:{note.id}',
+        await sync_note_update(
+            note,
+            clear_document=bool(form_data.data and 'content' in form_data.data),
         )
 
         return note

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -24,6 +24,7 @@ from open_webui.models.messages import Message, Messages
 from open_webui.models.notes import Notes
 from open_webui.models.users import UserModel
 from open_webui.retrieval.utils import get_content_from_url
+from open_webui.utils.notes import sync_note_update
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.routers.images import (
     CreateImageForm,
@@ -1033,6 +1034,8 @@ async def replace_note_content(
 
         if not updated_note:
             return json.dumps({'error': 'Failed to update note'})
+
+        await sync_note_update(updated_note, clear_document=True)
 
         return json.dumps(
             {

--- a/backend/open_webui/utils/notes.py
+++ b/backend/open_webui/utils/notes.py
@@ -1,0 +1,12 @@
+from open_webui.models.notes import NoteModel
+from open_webui.socket.main import YDOC_MANAGER, sio
+
+
+async def sync_note_update(note: NoteModel, *, clear_document: bool = False):
+    if clear_document:
+        await YDOC_MANAGER.clear_document(f'note:{note.id}')
+    await sio.emit(
+        'note-events',
+        note.model_dump(),
+        to=f'note:{note.id}',
+    )

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -44,6 +44,7 @@
 
 	import Controls from './NoteEditor/Controls.svelte';
 	import Chat from './NoteEditor/Chat.svelte';
+	import { resolveIncomingNoteContent } from './NoteEditor/noteEventContent';
 
 	import NotePanel from '$lib/components/notes/NotePanel.svelte';
 	import AccessControlModal from '$lib/components/workspace/common/AccessControlModal.svelte';
@@ -794,6 +795,19 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		if (_note.data && _note.data.files) {
 			files = _note.data.files;
 			note.data.files = files;
+		}
+
+		if (_note.data?.content) {
+			const nextContent = resolveIncomingNoteContent(note.data.content, _note.data.content);
+			const contentChanged = !areContentsEqual(nextContent, note.data.content);
+
+			if (contentChanged) {
+				note.data.content = nextContent;
+
+				if (editor && !editor.isDestroyed) {
+					editor.commands.setContent(note.data.content.html || marked.parse(note.data.content.md || ''));
+				}
+			}
 		}
 
 		if (_note.title && _note.title) {

--- a/src/lib/components/notes/NoteEditor/noteEventContent.test.ts
+++ b/src/lib/components/notes/NoteEditor/noteEventContent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveIncomingNoteContent } from './noteEventContent';
+
+describe('resolveIncomingNoteContent', () => {
+	it('rebuilds html and clears json when an incoming note event only provides markdown', () => {
+		const next = resolveIncomingNoteContent(
+			{
+				json: { type: 'doc', stale: true },
+				html: '<p>Old content</p>',
+				md: 'Old content'
+			},
+			{
+				md: '# LLM Edit\nLLM wrote this.'
+			}
+		);
+
+		expect(next.md).toBe('# LLM Edit\nLLM wrote this.');
+		expect(next.html).toContain('<h1>LLM Edit</h1>');
+		expect(next.html).toContain('<p>LLM wrote this.</p>');
+		expect(next.json).toBeNull();
+	});
+
+	it('preserves explicit html and json from the incoming content payload', () => {
+		const next = resolveIncomingNoteContent(
+			{
+				json: null,
+				html: '<p>Old content</p>',
+				md: 'Old content'
+			},
+			{
+				json: { type: 'doc', content: [] },
+				html: '<p>New content</p>',
+				md: 'New content'
+			}
+		);
+
+		expect(next).toEqual({
+			json: { type: 'doc', content: [] },
+			html: '<p>New content</p>',
+			md: 'New content'
+		});
+	});
+});

--- a/src/lib/components/notes/NoteEditor/noteEventContent.ts
+++ b/src/lib/components/notes/NoteEditor/noteEventContent.ts
@@ -1,0 +1,32 @@
+import { marked } from 'marked';
+
+export type NoteContent = {
+	json?: unknown | null;
+	html?: string | null;
+	md?: string | null;
+};
+
+const hasOwn = (value: object, key: string) => Object.prototype.hasOwnProperty.call(value, key);
+
+export const resolveIncomingNoteContent = (
+	currentContent: NoteContent | null | undefined,
+	incomingContent: NoteContent
+): Required<NoteContent> => {
+	const hasMd = hasOwn(incomingContent, 'md');
+	const hasHtml = hasOwn(incomingContent, 'html');
+	const hasJson = hasOwn(incomingContent, 'json');
+
+	const md = hasMd ? (incomingContent.md ?? '') : (currentContent?.md ?? '');
+	const html = hasHtml
+		? (incomingContent.html ?? '')
+		: hasMd
+			? String(marked.parse(md))
+			: (currentContent?.html ?? '');
+	const json = hasJson ? (incomingContent.json ?? null) : hasMd ? null : (currentContent?.json ?? null);
+
+	return {
+		json,
+		html,
+		md
+	};
+};


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Fixes #25916`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes.

# Changelog Entry

### Description

- Keep external note content updates from being overwritten by stale open-editor state.

### Added

- A shared backend note sync helper for broadcasting fresh note state after external content updates.
- A focused frontend helper plus regression coverage for rebuilding editor content from note socket events.

### Changed

- The note update route and `replace_note_content` tool now clear stale note Yjs state before notifying open editors.
- `NoteEditor` now applies incoming content updates from `note-events` instead of keeping stale local content.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed a bug where `replace_note_content` updates appeared successful in the database but were reverted as soon as the user typed in an already-open note editor.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Fixes #25916.
- Root cause: note content lived in both the database and the Yjs collaboration document, but external updates only changed the database. The next editor keystroke flushed the stale Yjs state back into storage.
- Verification used focused gates because this checkout has unrelated baseline issues: `python3 -m py_compile backend/open_webui/routers/notes.py backend/open_webui/tools/builtin.py backend/open_webui/utils/notes.py`, `npx eslint src/lib/components/notes/NoteEditor/noteEventContent.ts src/lib/components/notes/NoteEditor/noteEventContent.test.ts`, and direct Node assertions for `resolveIncomingNoteContent`.

### Screenshots or Videos

- Not included. This fix targets note state synchronization and was verified through focused code-path assertions and backend/frontend compilation checks.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.