### PR TITLE
fix: prevent duplicate data requests caused by search reactive blocks firing on mount

### DIFF
--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -71,7 +71,9 @@
 	let functions = null;
 	let filteredItems = [];
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			setFilteredItems();

--- a/src/lib/components/admin/Users/Groups/Users.svelte
+++ b/src/lib/components/admin/Users/Groups/Users.svelte
@@ -84,7 +84,9 @@
 		getUserList();
 	}
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			page = 1;

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -100,7 +100,9 @@
 		}
 	};
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			page = 1;

--- a/src/lib/components/channel/ChannelInfoModal/UserList.svelte
+++ b/src/lib/components/channel/ChannelInfoModal/UserList.svelte
@@ -38,6 +38,7 @@
 	let total = null;
 
 	let query = '';
+	let prevQuery = query;
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	let orderBy = 'name'; // default sort key
@@ -80,7 +81,8 @@
 	};
 
 	// Debounce only query changes
-	$: if (query !== undefined && channel !== null) {
+	$: if (query !== prevQuery && channel !== null) {
+		prevQuery = query;
 		clearTimeout(debounceTimer);
 		debounceTimer = setTimeout(() => {
 			getUserList();

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -180,7 +180,9 @@
 		await getItemsPage();
 	};
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			if (loaded) {

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -45,7 +45,9 @@
 	let allItemsLoaded = false;
 	let itemsLoading = false;
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			init();
@@ -146,6 +148,7 @@
 	onMount(async () => {
 		viewOption = localStorage?.workspaceViewOption || '';
 		loaded = true;
+		init();
 	});
 </script>
 

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -111,6 +111,7 @@
 	let inputFiles = null;
 
 	let query = '';
+	let prevQuery = query;
 	let includeContent = false;
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
@@ -143,7 +144,8 @@
 	};
 
 	// Debounce only query changes
-	$: if (query !== undefined) {
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 
 		searchDebounceTimer = setTimeout(() => {

--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -24,6 +24,7 @@
 	let show = false;
 
 	let query = '';
+	let prevQuery = query;
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
 	let noteItems = [];
@@ -34,7 +35,8 @@
 
 	$: items = [...noteItems, ...knowledgeItems, ...fileItems];
 
-	$: if (query !== undefined) {
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			getItems();

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -59,8 +59,9 @@
 
 	let page = 1;
 
-	// Debounce only query changes
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		loading = true;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
@@ -176,6 +177,7 @@
 	onMount(async () => {
 		viewOption = localStorage?.workspaceViewOption || '';
 		loaded = true;
+		getPromptList();
 
 		const onKeyDown = (event) => {
 			if (event.key === 'Shift') {

--- a/src/lib/components/workspace/Skills.svelte
+++ b/src/lib/components/workspace/Skills.svelte
@@ -78,8 +78,9 @@
 		}
 	};
 
-	// Debounce only query changes
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		loading = true;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
@@ -141,6 +142,7 @@
 	onMount(async () => {
 		viewOption = localStorage?.workspaceViewOption || '';
 		loaded = true;
+		loadSkillItems();
 
 		const onKeyDown = (event) => {
 			if (event.key === 'Shift') {

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -63,7 +63,9 @@
 
 	let showImportModal = false;
 
-	$: if (query !== undefined) {
+	let prevQuery = query;
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			setFilteredItems();

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -41,6 +41,7 @@
 	let total = null;
 
 	let query = '';
+	let prevQuery = query;
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let orderBy = 'name'; // default sort key
 	let direction = 'asc'; // default sort order
@@ -63,7 +64,8 @@
 		}
 	};
 
-	$: if (query !== undefined) {
+	$: if (query !== prevQuery) {
+		prevQuery = query;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
 			getUserList();

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -45,13 +45,15 @@
 	let deleteTarget: AutomationResponse | null = null;
 
 	let query = '';
+	let prevQuery = query;
 	let statusFilter = 'all';
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
 	let page = 1;
 
 	// Debounce only query changes (gate behind loaded to prevent double-fetch on mount)
-	$: if (loaded && query !== undefined) {
+	$: if (loaded && query !== prevQuery) {
+		prevQuery = query;
 		loading = true;
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
@@ -195,8 +197,6 @@
 		}
 
 		loaded = true;
-		// Explicit initial fetch — reactive blocks will handle subsequent changes
-		await getAutomationList();
 
 		return () => {
 			clearTimeout(searchDebounceTimer);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes duplicate data fetch requests across 13 components when pages load or modals open.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no architectural changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Multiple pages and modals across the admin panel, workspace, channels, and editor views fire duplicate data requests on every load. For example, navigating to the Users page sends `GET /api/v1/users/` twice, clicking a knowledgebase sends `GET /api/v1/knowledge/{id}/files` twice, opening the Automations tab sends `GET /api/v1/automations/list` three times, and opening the Add Access modal sends `GET /api/v1/users/search` twice. This doubles (or triples) network traffic and backend query load across the entire application.

**Root Cause:** A systemic anti-pattern where search debounce reactive blocks use `$: if (query !== undefined)` as their guard condition. Since `query` is always initialized as `''` (empty string), the condition `'' !== undefined` evaluates to `true` on mount, causing the reactive block to fire immediately alongside whatever other trigger (another `$:` block or `onMount`) is responsible for the initial data load.

```js
// BEFORE: Both fire on mount → duplicate request
let query = '';
$: if (query !== undefined) { ... getUserList() }  // '' !== undefined → true ✓
$: if (page && orderBy) { getUserList() }           // all truthy → true ✓
```

**Fix (two parts):**

**1. Replace `query !== undefined` with `prevQuery` tracking** so the search reactive block only fires when `query` actually changes from user input:

```diff
+  let prevQuery = query;
-  $: if (query !== undefined) {
+  $: if (query !== prevQuery) {
+    prevQuery = query;
     clearTimeout(searchDebounceTimer);
     searchDebounceTimer = setTimeout(() => { ... }, 300);
   }
```

On mount, `query === prevQuery` (both `''`), so the block is skipped. When the user types, `query` changes but `prevQuery` still holds the old value, so the block fires and updates `prevQuery` — working exactly as intended.

**2. Add explicit `init()` calls in `onMount`** for 3 components (Knowledge, Prompts, Skills) where the old search block's 300ms delay had been inadvertently serving as the initial data loader. These components have a `loaded` guard (`if (!loaded) return`) that prevents their other reactive blocks from loading data before `onMount` runs. The old search block's 300ms debounce happened to fire *after* `onMount` set `loaded = true`, making it the de-facto initial loader. With the search block no longer firing on mount, an explicit call is needed:

```diff
  onMount(async () => {
    viewOption = localStorage?.workspaceViewOption || '';
    loaded = true;
+   init(); // Explicit initial data load
  });
```

### Fixed

- Fixed duplicate data requests firing on mount across 13 components throughout the admin panel, workspace, channels, and editor views

### Files Changed (13 files)

| File | Area | Change |
|------|------|--------|
| `src/lib/components/admin/Users/UserList.svelte` | Admin → Users → Overview | `prevQuery` guard |
| `src/lib/components/admin/Users/Groups/Users.svelte` | Admin → Users → Edit Group → Users tab | `prevQuery` guard |
| `src/lib/components/admin/Functions.svelte` | Admin → Functions | `prevQuery` guard |
| `src/lib/components/notes/Notes.svelte` | Notes | `prevQuery` guard |
| `src/lib/components/workspace/Knowledge.svelte` | Workspace → Knowledge | `prevQuery` guard + `init()` in `onMount` |
| `src/lib/components/workspace/Knowledge/KnowledgeBase.svelte` | Workspace → Knowledge → Detail page | `prevQuery` guard |
| `src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte` | Model Editor → Knowledge selector | `prevQuery` guard |
| `src/lib/components/workspace/common/MemberSelector.svelte` | Add Access modal (shared) | `prevQuery` guard |
| `src/lib/components/workspace/Prompts.svelte` | Workspace → Prompts | `prevQuery` guard + `getPromptList()` in `onMount` |
| `src/lib/components/workspace/Skills.svelte` | Workspace → Skills | `prevQuery` guard + `loadSkillItems()` in `onMount` |
| `src/lib/components/workspace/Tools.svelte` | Workspace → Tools | `prevQuery` guard |
| `src/lib/components/channel/ChannelInfoModal/UserList.svelte` | Channel → Users modal | `prevQuery` guard |
| `src/routes/(app)/automations/+page.svelte` | Automations tab | `prevQuery` guard + removed redundant `onMount` fetch |

---

### Screenshots

#### 1. Admin → Users → Overview (`GET /api/v1/users/`)

**Before** — duplicate request on load:

<img width="2560" height="509" alt="image" src="https://github.com/user-attachments/assets/ea68c0f2-ea94-46a2-8630-7342f1ab3dc2" />

**After** — single request:

<img width="2560" height="509" alt="image" src="https://github.com/user-attachments/assets/ba606256-291e-4a65-8e37-8917a231daa2" />

---

#### 2. Admin → Users → Edit Group → Users tab (`GET /api/v1/users/?order_by=group_id`)

**Before** — duplicate request on load:

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/406fe7b1-2074-400f-b037-a9f9076ac36f" />

**After** — single request:

<img width="2560" height="1281" alt="image" src="https://github.com/user-attachments/assets/92e74c9b-343e-4c60-b038-a35a168f62da" />

---

#### 3. Admin → Functions (`setFilteredItems()`)

**Before** — duplicate client-side filter on load:
<!-- screenshot -->

**After** — single filter pass:
<!-- screenshot -->

---

#### 4. Channel → Users list modal (`GET /api/v1/channels/{id}/members`)

**Before** — duplicate request when clicking the Users button in a channel:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/5da1a7f5-2a7d-44b6-ba5f-3110de4f0866" />

**After** — single request:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/49553e13-54ac-44fb-b013-71ab58dc6768" />

---

#### 5. Notes (`searchNotes()`)

**Before** — duplicate request on load:

<img width="2560" height="478" alt="image" src="https://github.com/user-attachments/assets/727eaa7d-1353-46ef-a175-9438ca53e7c7" />

**After** — single request:

<img width="2560" height="478" alt="image" src="https://github.com/user-attachments/assets/e92ba1c2-c507-4ff8-b524-e5fe42a0b360" />

---

#### 6. Workspace → Knowledge (Knowledge list API)

**Before** — duplicate request on load:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 7. Workspace → Knowledge → Detail page (`GET /api/v1/knowledge/{id}/files` + `/files/pending`)

**Before** — duplicate request when clicking a knowledgebase:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 8. Model Editor → Knowledge selector (`GET /api/v1/knowledge/search/files`, `/search`, `/notes/search`)

**Before** — duplicate request when opening model editor:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 9. Add Access modal (`GET /api/v1/users/search`)

**Before** — duplicate request when opening Add Access modal:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 10. Workspace → Prompts (`GET /api/v1/prompts/list`)

**Before** — duplicate request on load:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 11. Workspace → Skills (Skills list API)

**Before** — duplicate request on load:
<!-- screenshot -->

**After** — single request:
<!-- screenshot -->

---

#### 12. Workspace → Tools (`setFilteredItems()`)

**Before** — duplicate client-side filter on load:
<!-- screenshot -->

**After** — single filter pass:
<!-- screenshot -->

#### 13. Automations tab (`GET /api/v1/automations/list`)

**Before** — triple request on load (debounced search + page/filter reactive + explicit `onMount`):

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/1756fc19-a672-4698-b48a-a53f5585f9e2" />

**After** — single request:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/70d4d192-7234-4aa0-bcf5-d66c49360e29" />

### Manual Verification Performed

For each affected page/modal:
1. Open DevTools → Network tab, filter by `XHR`
2. Navigate to the page or open the modal
3. **Before fix:** 2 or more matching requests on load
4. **After fix:** 1 request on load
5. Type in the search box → debounced search fires correctly after 300ms
6. Clear search → results reset correctly
7. Page loads data on initial visit (no stuck spinners)

Tested pages:
- Admin → Users → Overview
- Admin → Users → Groups → Edit Group → Users tab
- Admin → Functions
- Notes
- Workspace → Knowledge (list page)
- Workspace → Knowledge → click a knowledgebase (detail page)
- Model Editor → Knowledge selector panel
- Add Access modal (from any sharing dialog)
- Workspace → Prompts
- Workspace → Skills
- Workspace → Tools
- Channel → click Users button (members modal)
- Automations tab

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
