### PR TITLE
feat: optional inline filter toggles in the message input

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -80,6 +80,7 @@
 	import Spinner from '../common/Spinner.svelte';
 
 	import XMark from '../icons/XMark.svelte';
+	import Cog6 from '../icons/Cog6.svelte';
 	import GlobeAlt from '../icons/GlobeAlt.svelte';
 	import Photo from '../icons/Photo.svelte';
 	import Wrench from '../icons/Wrench.svelte';
@@ -511,6 +512,14 @@
 	$: toggleFilters = (atSelectedModel?.id ? [atSelectedModel.id] : selectedModels)
 		.map((id) => ($models.find((model) => model.id === id) || {})?.filters ?? [])
 		.reduce((acc, filters) => acc.filter((f1) => filters.some((f2) => f2.id === f1.id)));
+
+	// With the `inlineFilterToggles` setting on, every available toggle filter is
+	// shown as a persistent chip (greyed when off, toggled in place); otherwise the
+	// default shows only the selected filters as removable chips.
+	let filterChips = [];
+	$: filterChips = ($settings?.inlineFilterToggles ?? false)
+		? toggleFilters
+		: selectedFilterIds.map((id) => toggleFilters.find((f) => f.id === id)).filter((f) => f);
 
 	let showToolsButton = false;
 	$: showToolsButton = ($tools ?? []).length > 0 || ($toolServers ?? []).length > 0;
@@ -1791,29 +1800,37 @@
 											</Tooltip>
 										{/if}
 
-										{#each selectedFilterIds as filterId (filterId)}
-											{@const filter = toggleFilters.find((f) => f.id === filterId)}
+										{#each filterChips as filter (filter.id)}
 											{#if filter}
 												<Tooltip content={filter?.name} placement="top">
 													<button
 														on:click|preventDefault={() => {
-															if (
+															if ($settings?.inlineFilterToggles ?? false) {
+																// In-place toggle: flip selection, keep the chip visible.
+																if (selectedFilterIds.includes(filter.id)) {
+																	selectedFilterIds = selectedFilterIds.filter(
+																		(id) => id !== filter.id
+																	);
+																} else {
+																	selectedFilterIds = [...selectedFilterIds, filter.id];
+																}
+															} else if (
 																filter?.has_user_valves &&
 																($_user?.role === 'admin' ||
 																	($_user?.permissions?.chat?.valves ?? true))
 															) {
 																selectedValvesType = 'function';
-																selectedValvesItemId = filterId;
+																selectedValvesItemId = filter.id;
 																showValvesModal = true;
 															} else {
 																selectedFilterIds = selectedFilterIds.filter(
-																	(id) => id !== filterId
+																	(id) => id !== filter.id
 																);
 															}
 														}}
 														type="button"
 														class="group p-[7px] flex gap-1.5 items-center text-sm rounded-full transition-colors duration-300 focus:outline-hidden max-w-full overflow-hidden {selectedFilterIds.includes(
-															filterId
+															filter.id
 														)
 															? 'text-sky-500 dark:text-sky-300 bg-sky-50 hover:bg-sky-100 dark:bg-sky-400/10 dark:hover:bg-sky-600/10 border border-sky-200/40 dark:border-sky-500/20'
 															: 'bg-transparent text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 '} capitalize"
@@ -1834,18 +1851,36 @@
 														{/if}
 														<!-- svelte-ignore a11y-click-events-have-key-events -->
 														<!-- svelte-ignore a11y-no-static-element-interactions -->
-														<div
-															class="hidden group-hover:block"
-															on:click={(e) => {
-																e.stopPropagation();
-																e.preventDefault();
-																selectedFilterIds = selectedFilterIds.filter(
-																	(id) => id !== filterId
-																);
-															}}
-														>
-															<XMark className="size-4" strokeWidth="1.75" />
-														</div>
+														{#if $settings?.inlineFilterToggles ?? false}
+															{#if filter?.has_user_valves && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.valves ?? true))}
+																<div
+																	class="hidden group-hover:block"
+																	title={$i18n.t('Settings')}
+																	on:click={(e) => {
+																		e.stopPropagation();
+																		e.preventDefault();
+																		selectedValvesType = 'function';
+																		selectedValvesItemId = filter.id;
+																		showValvesModal = true;
+																	}}
+																>
+																	<Cog6 className="size-4" strokeWidth="1.75" />
+																</div>
+															{/if}
+														{:else}
+															<div
+																class="hidden group-hover:block"
+																on:click={(e) => {
+																	e.stopPropagation();
+																	e.preventDefault();
+																	selectedFilterIds = selectedFilterIds.filter(
+																		(id) => id !== filter.id
+																	);
+																}}
+															>
+																<XMark className="size-4" strokeWidth="1.75" />
+															</div>
+														{/if}
 													</button>
 												</Tooltip>
 											{/if}

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -30,6 +30,7 @@
 
 	let responseAutoCopy = false;
 	let widescreenMode = false;
+	let inlineFilterToggles = false;
 	let splitLargeChunks = false;
 	let scrollOnBranchChange = true;
 	let userLocation = false;
@@ -242,6 +243,7 @@
 		landingPageMode = $settings?.landingPageMode ?? '';
 		chatBubble = $settings?.chatBubble ?? true;
 		widescreenMode = $settings?.widescreenMode ?? false;
+		inlineFilterToggles = $settings?.inlineFilterToggles ?? false;
 		splitLargeChunks = $settings?.splitLargeChunks ?? false;
 		scrollOnBranchChange = $settings?.scrollOnBranchChange ?? true;
 
@@ -734,6 +736,25 @@
 							bind:state={widescreenMode}
 							on:change={() => {
 								saveSettings({ widescreenMode });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="inline-filter-toggles-label" class=" self-center text-xs">
+						{$i18n.t('Inline Filter Toggles')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="inline-filter-toggles-label"
+							tooltip={true}
+							bind:state={inlineFilterToggles}
+							on:change={() => {
+								saveSettings({ inlineFilterToggles });
 							}}
 						/>
 					</div>

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1152,6 +1152,7 @@
 	"Initials": "",
 	"Inject file content into conversation context": "",
 	"Inject the entire content as context for comprehensive processing, this is recommended for complex queries.": "",
+	"Inline Filter Toggles": "",
 	"Input": "",
 	"Input Key (e.g. text, unet_name, steps)": "",
 	"Input Variables": "",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #17574 (request to bring back the pre-"Integrations" inline filter-toggle behavior).
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** Not added — small, self-contained UI setting; happy to open a docs PR if the maintainers want this merged.
- [x] **Dependencies:** No new or changed dependencies.
- [x] **Testing:** Manually tested on a 0.9.6 instance (see below). No backend or `selectedFilterIds` semantics changed.
- [x] **No Unchecked AI Code:** AI-assisted, then human-reviewed and manually tested by the submitter before opening.
- [x] **Self-Review:** Performed.
- [ ] **Architecture:** Honest note — this adds an opt-in setting (default off), which runs against the "smart defaults over new settings" preference. It's framed as opt-in precisely so the default is unchanged; raising it here for discussion per #17574 rather than changing behavior for everyone.
- [x] **Git Hygiene:** Atomic (one logical change), rebased on `dev`, no unrelated commits.
- [x] **Title Prefix:** `feat`.

# Changelog Entry

### Description

Toggleable Filter functions currently appear in the message-input bar only while selected; clicking a chip's hover-`×` removes it from the bar, and re-enabling requires reopening the Integrations menu. There is no in-place "off" state — a deselected filter disappears. This adds an **opt-in** setting so filters can instead be shown as persistent, in-place toggles (greyed when off), which several users have asked for (e.g. #17574), **without changing the default**.

### Added

- **Settings → Interface → "Inline Filter Toggles"** (default off). When enabled, the message-input bar renders every toggleable filter in scope as a persistent chip — greyed when off, highlighted when on — and clicking a chip toggles its selection in place instead of removing it. Filters that define `UserValves` expose them via a gear shown on hover, so per-chat valves remain reachable.

### Changed

- `MessageInput.svelte`: when the setting is on, the chip row iterates all `toggleFilters` and the click handler toggles `selectedFilterIds` membership in place; the existing removable-chip behavior is preserved unchanged when the setting is off.

---

### Additional Information

- Purely a frontend rendering/interaction change; no change to `selectedFilterIds` semantics, persisted state, or the backend.
- Manually verified on a 0.9.6 deployment: with the setting off, behavior is byte-for-byte the current behavior; with it on, filters grey in place and re-toggle without reopening the Integrations menu, and `UserValves` open via the hover gear.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
