### PR TITLE
fix: deduplicate store fetches with null-guards and mutex

### DIFF
--- a/src/lib/components/admin/Analytics/AnalyticsModelModal.svelte
+++ b/src/lib/components/admin/Analytics/AnalyticsModelModal.svelte
@@ -150,7 +150,8 @@
 		selectedTab = 'overview';
 		chatList = [];
 		allChatsLoaded = false;
-		selectRange(selectedRange);
+		selectedRange = '30d';
+		loadOverview(30);
 	}
 </script>
 

--- a/src/lib/components/admin/Evaluations/LeaderboardModal.svelte
+++ b/src/lib/components/admin/Evaluations/LeaderboardModal.svelte
@@ -51,7 +51,8 @@
 
 	// Load history when model changes and modal is shown
 	$: if (show && model?.id) {
-		selectRange(selectedRange);
+		selectedRange = '30d';
+		loadHistory(30);
 	}
 
 	// Use top_tags from backend response (already computed)

--- a/src/lib/components/channel/MessageInput/MentionList.svelte
+++ b/src/lib/components/channel/MessageInput/MentionList.svelte
@@ -117,10 +117,6 @@
 					.map((c) => ({ type: 'channel', id: c.id, label: c.name, data: c }))
 			];
 		} else {
-			if (userSuggestions) {
-				getUserList();
-			}
-
 			if (modelSuggestions) {
 				_models = [
 					...$models

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -113,7 +113,6 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import Sidebar from '../icons/Sidebar.svelte';
 	import Image from '../common/Image.svelte';
-	import { getBanners } from '$lib/apis/configs';
 
 	export let chatIdProp = '';
 
@@ -327,107 +326,117 @@
 		);
 	};
 
+	let settingDefaults = false;
 	const setDefaults = async () => {
-		if (!$tools) {
-			tools.set(await getTools(localStorage.token));
-		}
-		if (!$functions) {
-			functions.set(await getFunctions(localStorage.token));
-		}
-		if (!$skills) {
-			skills.set(await getSkills(localStorage.token));
-		}
-		if (selectedModels.length !== 1 && !atSelectedModel) {
-			return;
-		}
+		if (settingDefaults) return;
+		settingDefaults = true;
 
-		const model = atSelectedModel ?? $models.find((m) => m.id === selectedModels[0]);
-		if (model) {
-			// Set Default Tools
-			if (model?.info?.meta?.toolIds) {
-				const defaultIds = [
-					...new Set(
-						[...(model?.info?.meta?.toolIds ?? [])].filter((id) => $tools.find((t) => t.id === id))
-					)
-				];
+		try {
+			if (!$tools) {
+				tools.set(await getTools(localStorage.token));
+			}
+			if (!$functions) {
+				functions.set(await getFunctions(localStorage.token));
+			}
+			if (!$skills) {
+				skills.set(await getSkills(localStorage.token));
+			}
+			if (selectedModels.length !== 1 && !atSelectedModel) {
+				return;
+			}
 
-				// Separate unauthenticated OAuth tools
-				const unauthed = [];
-				const authed = [];
-				for (const id of defaultIds) {
-					const tool = $tools.find((t) => t.id === id);
-					if (tool && tool.authenticated === false) {
-						const parts = id.split(':');
-						const serverId = parts.at(-1) ?? id;
-						const authType =
-							parts.length > 1 ? (parts[0] === 'server' ? parts[1] : parts[0]) : null;
-						unauthed.push({ id, name: tool.name ?? id, serverId, authType });
-					} else {
-						authed.push(id);
+			const model = atSelectedModel ?? $models.find((m) => m.id === selectedModels[0]);
+			if (model) {
+				// Set Default Tools
+				if (model?.info?.meta?.toolIds) {
+					const defaultIds = [
+						...new Set(
+							[...(model?.info?.meta?.toolIds ?? [])].filter((id) =>
+								$tools.find((t) => t.id === id)
+							)
+						)
+					];
+
+					// Separate unauthenticated OAuth tools
+					const unauthed = [];
+					const authed = [];
+					for (const id of defaultIds) {
+						const tool = $tools.find((t) => t.id === id);
+						if (tool && tool.authenticated === false) {
+							const parts = id.split(':');
+							const serverId = parts.at(-1) ?? id;
+							const authType =
+								parts.length > 1 ? (parts[0] === 'server' ? parts[1] : parts[0]) : null;
+							unauthed.push({ id, name: tool.name ?? id, serverId, authType });
+						} else {
+							authed.push(id);
+						}
+					}
+					selectedToolIds = authed;
+					pendingOAuthTools = unauthed;
+				} else if ($settings?.tools) {
+					selectedToolIds = $settings.tools;
+				} else {
+					selectedToolIds = selectedToolIds.filter((id) => !id.startsWith('direct_server:'));
+				}
+
+				// Set Default Skills
+				if (model?.info?.meta?.skillIds) {
+					selectedSkillIds = [
+						...new Set(
+							[...(model?.info?.meta?.skillIds ?? [])].filter((id) =>
+								($skills ?? []).find((s) => s.id === id && s.is_active)
+							)
+						)
+					];
+				} else {
+					selectedSkillIds = [];
+				}
+
+				// Set Default Filters (Toggleable only)
+				if (model?.info?.meta?.defaultFilterIds) {
+					selectedFilterIds = model.info.meta.defaultFilterIds.filter((id) =>
+						model?.filters?.find((f) => f.id === id)
+					);
+				}
+
+				// Set Default Features
+				if (model?.info?.meta?.defaultFeatureIds) {
+					if (
+						model.info?.meta?.capabilities?.['image_generation'] &&
+						$config?.features?.enable_image_generation &&
+						($user?.role === 'admin' || $user?.permissions?.features?.image_generation)
+					) {
+						imageGenerationEnabled = model.info.meta.defaultFeatureIds.includes('image_generation');
+					}
+
+					if (
+						model.info?.meta?.capabilities?.['web_search'] &&
+						$config?.features?.enable_web_search &&
+						($user?.role === 'admin' || $user?.permissions?.features?.web_search)
+					) {
+						webSearchEnabled = model.info.meta.defaultFeatureIds.includes('web_search');
+					}
+
+					if (
+						model.info?.meta?.capabilities?.['code_interpreter'] &&
+						$config?.features?.enable_code_interpreter &&
+						($user?.role === 'admin' || $user?.permissions?.features?.code_interpreter)
+					) {
+						codeInterpreterEnabled = model.info.meta.defaultFeatureIds.includes('code_interpreter');
 					}
 				}
-				selectedToolIds = authed;
-				pendingOAuthTools = unauthed;
-			} else if ($settings?.tools) {
-				selectedToolIds = $settings.tools;
-			} else {
-				selectedToolIds = selectedToolIds.filter((id) => !id.startsWith('direct_server:'));
-			}
 
-			// Set Default Skills
-			if (model?.info?.meta?.skillIds) {
-				selectedSkillIds = [
-					...new Set(
-						[...(model?.info?.meta?.skillIds ?? [])].filter((id) =>
-							($skills ?? []).find((s) => s.id === id && s.is_active)
-						)
-					)
-				];
-			} else {
-				selectedSkillIds = [];
-			}
-
-			// Set Default Filters (Toggleable only)
-			if (model?.info?.meta?.defaultFilterIds) {
-				selectedFilterIds = model.info.meta.defaultFilterIds.filter((id) =>
-					model?.filters?.find((f) => f.id === id)
-				);
-			}
-
-			// Set Default Features
-			if (model?.info?.meta?.defaultFeatureIds) {
-				if (
-					model.info?.meta?.capabilities?.['image_generation'] &&
-					$config?.features?.enable_image_generation &&
-					($user?.role === 'admin' || $user?.permissions?.features?.image_generation)
-				) {
-					imageGenerationEnabled = model.info.meta.defaultFeatureIds.includes('image_generation');
-				}
-
-				if (
-					model.info?.meta?.capabilities?.['web_search'] &&
-					$config?.features?.enable_web_search &&
-					($user?.role === 'admin' || $user?.permissions?.features?.web_search)
-				) {
-					webSearchEnabled = model.info.meta.defaultFeatureIds.includes('web_search');
-				}
-
-				if (
-					model.info?.meta?.capabilities?.['code_interpreter'] &&
-					$config?.features?.enable_code_interpreter &&
-					($user?.role === 'admin' || $user?.permissions?.features?.code_interpreter)
-				) {
-					codeInterpreterEnabled = model.info.meta.defaultFeatureIds.includes('code_interpreter');
+				// Set Default Terminal — only if the referenced terminal actually exists
+				if (model?.info?.meta?.terminalId) {
+					const tid = model.info.meta.terminalId;
+					if (isTerminalAvailable(tid)) {
+						selectedTerminalId.set(tid);
+					}
 				}
 			}
-
-			// Set Default Terminal — only if the referenced terminal actually exists
-			if (model?.info?.meta?.terminalId) {
-				const tid = model.info.meta.terminalId;
-				if (isTerminalAvailable(tid)) {
-					selectedTerminalId.set(tid);
-				}
-			}
+		} finally {
+			settingDefaults = false;
 		}
 	};
 
@@ -793,13 +802,6 @@
 			if (p.url.pathname === '/') {
 				await tick();
 				initNewChat();
-
-				// Re-fetch banners on navigation to homepage so newly configured banners appear
-				try {
-					banners.set(await getBanners(localStorage.token).catch(() => []));
-				} catch (e) {
-					console.error('Failed to refresh banners:', e);
-				}
 			}
 
 			stopAudio();

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -58,8 +58,6 @@
 	import { deleteFileById } from '$lib/apis/files';
 	import { getChatById } from '$lib/apis/chats';
 	import { getSessionUser } from '$lib/apis/auths';
-	import { getTools } from '$lib/apis/tools';
-	import { getSkills } from '$lib/apis/skills';
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
 	import { getOAuthClientAuthorizationUrl } from '$lib/apis/configs';
@@ -1106,9 +1104,6 @@
 				dropzoneElement.addEventListener('drop', onDrop, true);
 				dropzoneElement.addEventListener('dragleave', onDragLeave);
 			}
-
-			tools.set(await getTools(localStorage.token));
-			skills.set(await getSkills(localStorage.token));
 		};
 		initialize();
 

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -249,9 +249,13 @@
 	};
 
 	onMount(async () => {
-		await tools.set(await getTools(localStorage.token));
+		if (!$tools) {
+			await tools.set(await getTools(localStorage.token));
+		}
 		skillsList = (await getSkills(localStorage.token).catch(() => null)) ?? [];
-		await functions.set(await getFunctions(localStorage.token));
+		if (!$functions) {
+			await functions.set(await getFunctions(localStorage.token));
+		}
 
 		// Fetch admin-configured default model metadata so the editor
 		// reflects the actual defaults rather than hardcoded values


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes duplicate store-level and reactive-chain API requests in chat, message input, workspace, and analytics components.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Multiple components independently fetch the same store data (`tools`, `skills`, `functions`) on mount or re-trigger API calls due to reactive dependency chains, causing duplicate API requests on every page load. This PR eliminates the duplicates using four targeted patterns:

**1. Store null-guards (ModelEditor):** `getTools()` and `getFunctions()` are called unconditionally in `onMount`, even when the stores are already populated by the app layout. Added `if (!$tools)` / `if (!$functions)` guards to skip redundant fetches.

```diff
  onMount(async () => {
+     if (!$tools) {
          await tools.set(await getTools(localStorage.token));
+     }
      skillsList = (await getSkills(localStorage.token).catch(() => null)) ?? [];
+     if (!$functions) {
          await functions.set(await getFunctions(localStorage.token));
+     }
  });
```

**2. Remove redundant fetches (MessageInput, MentionList):** `MessageInput.svelte` called `getTools()` and `getSkills()` in its own `initialize()` function, racing with `Chat.svelte`'s `setDefaults()` which already handles the same stores. `MentionList.svelte` had a redundant `getUserList()` call in `onMount` that duplicated the reactive block's initial fire. Both removed.

**3. Mutex flag (Chat.svelte `setDefaults`):** During `initNewChat()`, `selectedModels` is reassigned in multiple steps (initial set → filter unavailable → fallback). Each reassignment triggers the reactive chain `selectedModels → selectedModelIds → resetInput → setDefaults()`. Added a `settingDefaults` boolean flag with `try/finally` to ensure only the first call executes while the reactive chain settles.

```diff
+ let settingDefaults = false;
  const setDefaults = async () => {
+     if (settingDefaults) return;
+     settingDefaults = true;
+     try {
          // ... fetch tools/skills/functions, set model defaults ...
+     } finally {
+         settingDefaults = false;
+     }
  };
```

Also removed a redundant `getBanners()` re-fetch in `Chat.svelte`'s `page.subscribe` callback — the banners store is already populated by the app layout and updated via admin settings.

**4. Break reactive dependency cycle (AnalyticsModelModal, LeaderboardModal):** Both modals had reactive blocks `$: if (show && model?.id)` that called `selectRange(selectedRange)`, making `selectedRange` a tracked dependency. When the user clicks a time range button (30D/1Y/All), `selectRange()` updates `selectedRange`, re-triggering the reactive block and producing a duplicate API request. Fixed by replacing the call with direct assignment and `loadOverview(30)` / `loadHistory(30)`, removing `selectedRange` from the dependency chain.

```diff
  $: if (show && model?.id) {
-     selectRange(selectedRange);
+     selectedRange = '30d';
+     loadOverview(30); // or loadHistory(30) for LeaderboardModal
  }
```

**Endpoints fixed:**
- `GET /api/v1/tools/`
- `GET /api/v1/skills/`
- `GET /api/v1/functions/`
- `GET /api/v1/configs/banners`
- `GET /api/v1/analytics/models/{id}/overview`
- `GET /api/v1/evaluations/models/{id}/history`

### Fixed

- Eliminated duplicate `tools/`, `skills/`, and `functions/` API requests on new chat page load
- Eliminated duplicate `users/search` request in channel MentionList on mount
- Eliminated redundant `configs/banners` re-fetch on homepage navigation
- Prevented concurrent `setDefaults()` calls from reactive chain firing during model selection initialization
- Eliminated duplicate `analytics/models/{id}/overview` request when clicking time range filters in the Analytics model modal
- Eliminated duplicate `evaluations/models/{id}/history` request when clicking time range filters in the Leaderboard model modal

---

### Screenshots

#### 1. Homepage refresh — `GET /api/v1/tools/`, `GET /api/v1/skills/`, `GET /api/v1/functions/`

<details>
<summary><b>Before</b> — duplicate <code>tools/</code>, <code>skills/</code>, and <code>functions/</code> requests on homepage load</summary>

**`tools/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/7260f2e4-de0d-4761-a479-71d06d48ef71" />

**`skills/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/da896b0a-8d8e-4d86-bc75-f05ccb3a3a05" />

**`functions/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/c1bcd3d3-1264-41f8-9000-c9a9e836f331" />

</details>

<details>
<summary><b>After</b> — each called exactly once</summary>

**`tools/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/36af2156-ecfb-4953-b4d9-30fa3ea90527" />

**`skills/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/782adb6e-4181-466f-a2af-e41a86df1b1f" />

**`functions/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/a659b1a4-b2de-4909-9b83-8308662a67ac" />

</details>

---

#### 2. Model Editor — `GET /api/v1/tools/`, `GET /api/v1/functions/`

<details>
<summary><b>Before</b> — duplicate <code>tools/</code> and <code>functions/</code> requests when opening Model Editor (stores already populated)</summary>

**`tools/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/ac7def31-08db-438f-8f31-4e899daade03" />

**`functions/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/fbec20d0-6237-4aa8-a68d-9fa98af5229d" />

</details>

<details>
<summary><b>After</b> — no re-fetch (null-guard skips, stores already populated)</summary>

**`tools/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/75da393e-8405-40f4-8982-e1a9fc560220" />

**`functions/`**
<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/c705c84e-0fe1-467b-94a3-19e9b8cd2b56" />

</details>

---

#### 3. Channel MentionList — `GET /api/v1/users/search`

**Before** — duplicate `users/search` request when typing `@` in a channel:

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/a75ebb0b-d07b-41d5-8d78-ec7ded773385" />

**After** — single request:

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/569da354-6d7d-4b73-a403-7c34123dc338" />

---

#### 4. Homepage navigation — `GET /api/v1/configs/banners`

**Before** — redundant `configs/banners` re-fetch on every homepage navigation:

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/2acfc805-743f-4118-91a1-b573d4a3c930" />

**After** — no re-fetch (uses existing store value):

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/8ebbe516-e016-4508-afc0-5ba3ed2a83fb" />

---

#### 5. Analytics model modal — `GET /api/v1/analytics/models/{id}/overview`

**Before** — duplicate `overview` request when clicking 30D/1Y/All time range filter:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/f9979b3e-4c09-456d-a02d-444d16c452c4" />

**After** — single request per filter click:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/897cd863-0e6d-48bf-a932-150259ca7ba6" />

---

#### 6. Leaderboard model modal — `GET /api/v1/evaluations/models/{id}/history`

**Before** — duplicate `history` request when clicking 30D/1Y/All time range filter:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/2a2beadb-e8ac-458b-9f9c-be03c06a3991" />

**After** — single request per filter click:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/ff5bd5c4-67a0-448e-8724-a2b515fa689a" />

---

### Manual Verification Performed

1. Hard-refresh the homepage (`/`) → verify `tools/`, `skills/`, `functions/` are each called exactly once in the Network tab
2. Navigate to an existing chat → verify no duplicate store fetches
3. Open the Model Editor → verify `tools/` and `functions/` are not re-fetched (already in store)
4. Switch models in the chat → verify `setDefaults()` runs correctly (tools/skills/filters populate based on model config)
5. Open a channel → type `@` → verify `users/search` is called once
6. Navigate away from homepage, then back → verify `configs/banners` is not re-fetched
7. Configure a banner in Admin → Settings → verify it displays correctly on the homepage (store value is used, not a fresh fetch)
8. Open Analytics → click a model → verify `analytics/models/{id}/overview` is called once
9. Click 30D/1Y/All filter buttons → verify each click fires exactly one `overview` request
10. Open Evaluations → Leaderboard → click a model → verify `evaluations/models/{id}/history` is called once
11. Click 30D/1Y/All filter buttons → verify each click fires exactly one `history` request
12. Sidebar chat list loads normally
13. `npm run build` passes with no errors

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
