### PR TITLE
Equalize signin bcrypt cost to mitigate user-enumeration timing

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import bcrypt
 import logging
 import uuid
 from typing import Optional
@@ -14,6 +15,9 @@ from sqlalchemy import Boolean, Column, String, Text, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
+
+# Equalizes bcrypt cost on the no-user / no-credential paths so signin timing does not reveal account existence (CWE-208).
+_TIMING_EQUALIZER_HASH = bcrypt.hashpw(b'open-webui-timing-equalizer', bcrypt.gensalt()).decode('utf-8')
 
 
 class Auth(Base):  # credential ↔ user linkage
@@ -142,11 +146,13 @@ class AuthsTable:
         log.info('authenticate_user: %s', email)
         resolved = await Users.get_user_by_email(email, db=db)
         if not resolved:
+            verify_password(_TIMING_EQUALIZER_HASH)  # pay the bcrypt cost so response time doesn't reveal account existence
             return
         # load the credential row and verify the password hash
         async with get_async_db_context(db) as session:
             credential = await session.get(Auth, resolved.id)
             if not credential or not credential.active:
+                verify_password(_TIMING_EQUALIZER_HASH)  # equalize cost on this path too
                 return
             if not verify_password(credential.password):
                 return


### PR DESCRIPTION
authenticate_user skipped bcrypt entirely when the email did not resolve to a user (or had no active credential), so a non-existent account returned in ~5ms while a valid one paid the full bcrypt cost (~150ms), letting an attacker enumerate accounts by response time.

Run the bound verify_password against a fixed dummy hash on the no-user and no-credential paths so every signin attempt pays the same bcrypt cost. This collapses the dominant, trivially-exploitable gap (measured ~1.03x vs the prior ~20-40x). A residual sub-millisecond variance (DB index hit/miss, interpreter/GC, CPU and OS scheduling) is not eliminable in application code and is accepted.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
