### PR TITLE
Require auth on ydoc:awareness:update and ydoc:document:leave handler

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -757,11 +757,13 @@ async def yjs_document_update(sid, data):
 @sio.on('ydoc:document:leave')
 async def yjs_document_leave(sid, data):
     """Handle user leaving a document"""
+    user = SESSION_POOL.get(sid)
+    if not user:  # authenticated session required (parity with sibling handlers)
+        return
     try:
         document_id = normalize_document_id(data['document_id'])
-        user_id = data.get('user_id', sid)
 
-        log.info(f'User {user_id} leaving document {document_id}')
+        log.info(f'User {user["id"]} leaving document {document_id}')
 
         # Remove user from the document
         await YDOC_MANAGER.remove_user(document_id=document_id, user_id=sid)
@@ -769,10 +771,10 @@ async def yjs_document_leave(sid, data):
         # Leave Socket.IO room
         await sio.leave_room(sid, f'doc_{document_id}')
 
-        # Notify other users
+        # Notify other users; user_id is the authenticated identity, not client-supplied
         await sio.emit(
             'ydoc:user:left',
-            {'document_id': document_id, 'user_id': user_id},
+            {'document_id': document_id, 'user_id': user['id']},
             room=f'doc_{document_id}',
         )
 
@@ -787,16 +789,21 @@ async def yjs_document_leave(sid, data):
 @sio.on('ydoc:awareness:update')
 async def yjs_awareness_update(sid, data):
     """Handle awareness updates (cursors, selections, etc.)"""
+    user = SESSION_POOL.get(sid)
+    if not user:  # authenticated session required (parity with sibling handlers)
+        return
     try:
-        document_id = data['document_id']
-        user_id = data.get('user_id', sid)
+        document_id = normalize_document_id(data['document_id'])
+        room = f'doc_{document_id}'
+        if room not in sio.rooms(sid):  # must have joined the document first
+            return
         update = data['update']
 
-        # Broadcast awareness update to all other users in the document
+        # Broadcast to the room; user_id is the authenticated identity, not client-supplied
         await sio.emit(
             'ydoc:awareness:update',
-            {'document_id': document_id, 'user_id': user_id, 'update': update},
-            room=f'doc_{document_id}',
+            {'document_id': document_id, 'user_id': user['id'], 'update': update},
+            room=room,
             skip_sid=sid,
         )
 


### PR DESCRIPTION
These were the only two ydoc Socket.IO handlers missing the SESSION_POOL guard that every sibling (join/state/update) enforces. With always_connect=True admitting unauthenticated sockets, a client that knew a note's document_id could broadcast spoofed awareness (cursors/presence) and fake ydoc:user:left events into a live editing room, attributed to any client-supplied user_id.

Both handlers now require an authenticated SESSION_POOL session; the awareness handler additionally requires prior ydoc:document:join (room membership); and the broadcast user_id is fixed to the authenticated identity instead of the client-supplied value, removing the impersonation. Document content was never reachable (ydoc:document:update already enforces write permission).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
