### PR TITLE
Stop /channels/{id}/members from leaking members' private fields

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -440,6 +440,11 @@ async def get_channel_by_id(
 PAGE_ITEM_COUNT = 30
 
 
+# UserModel fields that must not leak to other channel members: credentials / integration config
+# (settings holds tool-server bearer keys + webhook URLs), identity-provider data, and PII.
+_CHANNEL_MEMBER_PRIVATE_FIELDS = {'settings', 'oauth', 'scim', 'info', 'date_of_birth', 'gender', 'bio'}
+
+
 @router.get('/{id}/members', response_model=UserListResponse)
 async def get_channel_members_by_id(
     request: Request,
@@ -475,7 +480,7 @@ async def get_channel_members_by_id(
         total = len(fetched_users)
 
         return {
-            'users': [UserModelResponse(**u.model_dump(), is_active=Users.is_active(u)) for u in fetched_users],
+            'users': [UserModelResponse(**u.model_dump(exclude=_CHANNEL_MEMBER_PRIVATE_FIELDS), is_active=Users.is_active(u)) for u in fetched_users],
             'total': total,
         }
     else:
@@ -503,7 +508,7 @@ async def get_channel_members_by_id(
         total = result['total']
 
         return {
-            'users': [UserModelResponse(**u.model_dump(), is_active=Users.is_active(u)) for u in fetched_users],
+            'users': [UserModelResponse(**u.model_dump(exclude=_CHANNEL_MEMBER_PRIVATE_FIELDS), is_active=Users.is_active(u)) for u in fetched_users],
             'total': total,
         }
 


### PR DESCRIPTION
get_channel_members_by_id returned the full UserModel for every channel member via UserModelResponse(**u.model_dump(), ...), including settings (which holds per-user tool-server bearer keys and webhook URLs), oauth, scim, info and PII (date_of_birth/gender/bio). Channel membership is self-grantable (any user can open a DM with any other user), so a low-privilege user could DM an admin and read the admin's tool-server API keys from the members list.

Exclude those fields from both members response paths (DM and group/non-DM) via a shared _CHANNEL_MEMBER_PRIVATE_FIELDS set. The response shape is unchanged; the sensitive fields are simply omitted. Sibling endpoints that embed users already use the minimal UserIdNameStatusResponse and are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
