### PR TITLE
Don't let SCIM's active flag demote an admin (defense-in-depth)

### DIFF
--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -672,7 +672,10 @@ async def update_user(
     if user_data.emails and len(user_data.emails) > 0:
         update_data['email'] = user_data.emails[0].value
 
-    if user_data.active is not None:
+    # Do not let SCIM's active flag demote an existing admin: a routine IdP sync or misconfiguration
+    # must not silently strip a locally-provisioned admin's role and lock the instance out. Admin
+    # role changes go through the dedicated admin endpoints, not SCIM provisioning.
+    if user_data.active is not None and user.role != 'admin':
         update_data['role'] = 'user' if user_data.active else 'pending'
 
     if user_data.photos and len(user_data.photos) > 0:
@@ -719,7 +722,9 @@ async def patch_user(
 
         if op == 'replace':
             if path == 'active':
-                update_data['role'] = 'user' if value else 'pending'
+                # Same guard as update_user: never demote an existing admin via SCIM.
+                if user.role != 'admin':
+                    update_data['role'] = 'user' if value else 'pending'
             elif path == 'userName':
                 update_data['email'] = value
             elif path == 'displayName':


### PR DESCRIPTION
The SCIM update_user (PUT) and patch_user (PATCH) handlers mapped the SCIM active field unconditionally onto the role column (role = 'user' if active else 'pending'), so a routine IdP sync or a misconfigured IdP that marked a locally-provisioned admin inactive would silently strip that admin's role and could lock an instance out of its own administration.

Gate both active->role assignments on user.role != 'admin' so SCIM provisioning can activate/deactivate ordinary users but never demotes an existing admin; admin role changes continue to go through the dedicated admin endpoints. SCIM already cannot promote to admin (active only maps to user/pending), so this is symmetric.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
