### PR TITLE
fix(oauth): use Protected Resource Metadata scopes in MCP DCR flow

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -435,6 +435,17 @@ async def get_oauth_client_info_with_dynamic_client_registration(
         # Attempt to fetch OAuth server metadata to get registration endpoint & scopes
         resource_metadata = await get_protected_resource_metadata(oauth_server_url)
         resource = resource_metadata.resource
+
+        # Prefer the resource-specific scopes from the Protected Resource Metadata
+        # (RFC 9728 Section 2) over the Authorization Server's scopes_supported
+        # (RFC 8414 Section 2). The AS scopes_supported is a full catalog of every
+        # scope the server can grant across all resources, whereas the PRM
+        # scopes_supported represents what this specific resource requires - making
+        # it the correct, least-privilege source. This mirrors the static-credentials
+        # flow (see #24690).
+        if resource_metadata.scopes_supported:
+            oauth_client_metadata.scope = ' '.join(resource_metadata.scopes_supported)
+
         discovery_urls = resource_metadata.get_discovery_urls(oauth_server_url)
         for url in discovery_urls:
             async with aiohttp.ClientSession(trust_env=True) as session:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #23668 and #24690 (the static-credentials counterpart of this fix). This PR extends that same correction to the **Dynamic Client Registration** path #25950 . A dedicated issue can be filed if maintainers prefer.
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No docs change required.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually verified against a live AS/RS pair — the PRM `scopes_supported` is honored in the DCR registration request. See "Additional Information".
- [x] **No Unchecked AI Code:** This change was AI-assisted and has undergone human review and manual testing.
- [x] **Self-Review:** The diff has been reviewed for correctness and consistency with the existing code style.
- [x] **Architecture:** No new settings; uses existing data already fetched in the function. Smart-default behavior.
- [x] **Git Hygiene:** Atomic single-file change, rebased on `dev`.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

In the MCP / OAuth 2.1 **Dynamic Client Registration (DCR)** flow,
`get_oauth_client_info_with_dynamic_client_registration()` populated the registration
request's `scope` from the **Authorization Server Metadata** `scopes_supported`
(RFC 8414 §2) — the full catalog of every scope the AS can grant across **all** of its
resources. Per RFC 9728 §2 and the MCP
[Scope Selection Strategy](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy),
the resource-specific **Protected Resource Metadata** `scopes_supported` is the correct,
least-privilege source for what to request to access a given resource.

The Protected Resource Metadata is already fetched in this function. This change prefers
its `scopes_supported`, and keeps the AS `scopes_supported` only as a fallback for when
the PRM advertises none. This mirrors the static-credentials flow already corrected in
**#24690** (merged in v0.9.6), applying the same fix to the DCR path which that PR did not
touch.

### Changed

- The DCR registration request now derives its `scope` from the Protected Resource Metadata
  `scopes_supported` (RFC 9728) when available, falling back to the Authorization Server's
  `scopes_supported` (RFC 8414) only when the PRM advertises no scopes.

### Fixed

- DCR clients no longer request the Authorization Server's entire scope catalog (which may
  span unrelated resources) when registering for a single MCP resource, restoring
  least-privilege behavior consistent with the static-credentials flow.

---

### Additional Information

**Before (current `dev`)** — `backend/open_webui/utils/oauth.py`, inside the discovery loop:

```python
if (
    oauth_client_metadata.scope is None
    and oauth_server_metadata.scopes_supported is not None  # AS catalog
):
    oauth_client_metadata.scope = ' '.join(oauth_server_metadata.scopes_supported)
```

**After** — prefer the resource-specific PRM scopes before the loop; the existing AS block
(guarded by `scope is None`) becomes a natural fallback:

```python
resource_metadata = await get_protected_resource_metadata(oauth_server_url)
resource = resource_metadata.resource

# Prefer the resource-specific scopes from the Protected Resource Metadata
# (RFC 9728 Section 2) over the Authorization Server's scopes_supported ...
if resource_metadata.scopes_supported:
    oauth_client_metadata.scope = ' '.join(resource_metadata.scopes_supported)
```

**Spec references**
- RFC 8414 §2 — AS `scopes_supported` is a non-exhaustive catalog of everything the AS
  supports; not a per-resource request list.
- RFC 9728 §2 + Security Considerations — PRM `scopes_supported` is the scopes "used in
  authorization requests to request access to **this** protected resource"; clients SHOULD
  "request tokens with as limited a scope as possible."
- MCP Authorization spec — Scope Selection Strategy (WWW-Authenticate `scope` → PRM
  `scopes_supported`; least privilege).

**Testing status:** Manually verified end-to-end against a live AS/RS pair — with an MCP
server whose PRM advertises a `scopes_supported`, the DCR registration request now carries
those resource-specific scopes (rather than the AS's full catalog). The change is also a
minimal, behavior-preserving fallback: when the PRM advertises no scopes, behavior is
unchanged (it falls back to the AS `scopes_supported`).

### Screenshots or Videos

- N/A (server-side OAuth flow).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.