### PR TITLE
fix: surface user-readable upload errors instead of opaque stubs

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -86,6 +86,10 @@ class ERROR_MESSAGES(str, Enum):
         f"Oops! The file you're trying to upload is too large. Please upload a file that is less than {size}."
     )
 
+    FILE_NAME_TOO_LONG = lambda max_bytes='': (
+        f'File name is too long (maximum {max_bytes} bytes). Please rename the file and try again.'
+    )
+
     DUPLICATE_CONTENT = 'Duplicate content detected. Please provide unique content to proceed.'
     FILE_NOT_PROCESSED = (
         'Extracted content is not available for this file. Please ensure that the file is processed before proceeding.'

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -560,6 +560,7 @@ from open_webui.utils.chat import (
     generate_chat_completion as chat_completion_handler,
 )
 from open_webui.utils.embeddings import generate_embeddings
+from open_webui.utils.errors import UserFacingError, translate_exception
 from open_webui.utils.logger import start_logger
 from open_webui.utils.middleware import (
     build_chat_response_context,
@@ -756,6 +757,28 @@ app = FastAPI(
 
 # Used by readiness checks to gate traffic until startup work is done.
 app.state.startup_complete = False
+
+
+@app.exception_handler(UserFacingError)
+async def user_facing_error_handler(request: Request, exc: UserFacingError):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={'detail': exc.message},
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    # Full traceback stays in server logs; users get a safe message plus a
+    # reference ID an admin can grep for.
+    ref_id = uuid4().hex[:8]
+    log.exception(f'Unhandled error [ref: {ref_id}] on {request.method} {request.url.path}')
+
+    detail = translate_exception(exc) or f'Something went wrong (ref: {ref_id})'
+    return JSONResponse(
+        status_code=500,
+        content={'detail': detail},
+    )
 
 # For Open WebUI OIDC/OAuth2
 oauth_manager = OAuthManager(app)

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -42,6 +42,7 @@ from open_webui.routers.audio import transcribe
 from open_webui.routers.retrieval import ProcessFileForm, process_file
 from open_webui.storage.provider import Storage
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -279,6 +280,15 @@ async def upload_file_handler(
                     detail=ERROR_MESSAGES.DEFAULT(f'File type {file_extension} is not allowed'),
                 )
 
+        # Filesystem filename components are capped at 255 bytes; reserve room
+        # for the uuid4 prefix added below (36 chars + "_").
+        max_filename_bytes = 255 - 37
+        if len(filename.encode('utf-8')) > max_filename_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.FILE_NAME_TOO_LONG(max_filename_bytes),
+            )
+
         # replace filename with uuid
         id = str(uuid.uuid4())
         name = filename
@@ -364,7 +374,7 @@ async def upload_file_handler(
         log.exception(e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT('Error uploading file'),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error uploading file'),
         )
 
 

--- a/backend/open_webui/utils/errors.py
+++ b/backend/open_webui/utils/errors.py
@@ -1,0 +1,32 @@
+import errno
+from typing import Optional
+
+
+class UserFacingError(Exception):
+    """An anticipated error whose message is safe to show to the user verbatim."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+OS_ERRNO_MESSAGES = {
+    errno.ENAMETOOLONG: 'File name is too long.',
+    errno.ENOSPC: 'The server is out of storage space.',
+    errno.EDQUOT: 'Server storage quota exceeded.',
+    errno.EACCES: 'Server storage is not writable.',
+    errno.EPERM: 'Server storage is not writable.',
+    errno.EROFS: 'Server storage is not writable.',
+}
+
+
+def translate_exception(e: Exception) -> Optional[str]:
+    """Map a recognized internal exception to a user-safe message.
+
+    Returns None when the exception is not recognized; callers should then
+    fall back to a generic message and keep details in server logs only.
+    """
+    if isinstance(e, OSError) and e.errno in OS_ERRNO_MESSAGES:
+        return OS_ERRNO_MESSAGES[e.errno]
+    return None


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #25954 (kept open as tracking issue for the follow-up sweep)
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** No documentation changes required — this fix only changes error message contents; no configuration, API surface, or user workflow changes.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests performed (see Additional Information below).
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings introduced; errors are translated by errno with safe defaults. Approach described in the linked issue.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`, no unrelated changes.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- Uploading a file whose name exceeds the filesystem's 255-byte component limit failed with an opaque `[ERROR: Error uploading file]` toast while the real cause (`OSError: ENAMETOOLONG`) was only visible in server logs. Because the stored name is prefixed with a UUID (+37 bytes), this triggered for original names > 218 bytes — CJK filenames hit it at ~73 characters. Full background and audit in #25954.

### Added

- `backend/open_webui/utils/errors.py`: `UserFacingError` exception type for anticipated failures, and `translate_exception()` which maps recognized OS errors **by errno** (`ENAMETOOLONG`, `ENOSPC`, `EDQUOT`, `EACCES`, `EPERM`, `EROFS`) to safe, user-readable messages — exception text is never echoed, so server paths and internals cannot leak.
- Central exception handlers in `main.py`: `UserFacingError` returns its message and status code; unhandled exceptions log the full traceback with a short reference ID and return `Something went wrong (ref: a1b2c3d4)` so user reports can be correlated with server logs.

### Fixed

- File upload now validates filename byte-length up front and rejects with a clear 400 (`File name is too long (maximum 218 bytes). Please rename the file and try again.`) instead of failing with a generic error after hitting the filesystem limit.
- Recognized OS errors on the upload path (disk full, storage not writable, ...) now surface as readable messages instead of `Error uploading file`.

### Security

- Groundwork for fixing ~35 router call sites that currently pass raw exception text (which can include server-side filesystem paths) to clients via `ERROR_MESSAGES.DEFAULT(e)` — migration planned as a follow-up PR (see #25954).

---

### Additional Information

Manual testing performed against a live backend (macOS/APFS, default LocalStorageProvider):

- 254-byte ASCII filename → 400 with specific message
- 73-char CJK filename (223 bytes) → 400 with specific message
- Normal filename → 200, file record created, processing unaffected
- Read-only uploads dir → 400 "Server storage is not writable." (was "Error uploading file")
- Unhandled exception (TestClient) → 500 with ref ID, no internal details in response, traceback in server log
- `UserFacingError("...", 422)` (TestClient) → 422 with verbatim message

Frontend impact: none — the frontend renders `detail` verbatim and never branches on its content (verified across `src/`).

### Screenshots or Videos

- N/A (API-level error message change; curl outputs included above)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
