### PR TITLE
perf: lazy-load user info in channel profile previews on hover

### DIFF
--- a/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
+++ b/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
@@ -28,5 +28,5 @@
 		</button>
 	</LinkPreview.Trigger>
 
-	<UserStatusLinkPreview id={user?.id} {side} {align} {sideOffset} />
+	<UserStatusLinkPreview id={user?.id} open={openPreview} {side} {align} {sideOffset} />
 </LinkPreview.Root>

--- a/src/lib/components/channel/Messages/Message/UserStatusLinkPreview.svelte
+++ b/src/lib/components/channel/Messages/Message/UserStatusLinkPreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	import { LinkPreview } from 'bits-ui';
 
 	const i18n = getContext('i18n');
@@ -8,20 +8,25 @@
 	import UserStatus from './UserStatus.svelte';
 
 	export let id = null;
+	export let open = false;
 
 	export let side = 'top';
 	export let align = 'start';
 	export let sideOffset = 6;
 
 	let user = null;
-	onMount(async () => {
-		if (id) {
-			user = await getUserInfoById(localStorage.token, id).catch((error) => {
+	let fetched = false;
+
+	$: if (open && id && !fetched) {
+		fetched = true;
+		getUserInfoById(localStorage.token, id)
+			.then((res) => {
+				user = res;
+			})
+			.catch((error) => {
 				console.error('Error fetching user by ID:', error);
-				return null;
 			});
-		}
-	});
+	}
 </script>
 
 {#if user}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes excessive `GET /api/v1/users/{id}/info` requests in channel views caused by eager fetching on mount.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `perf`

# Changelog Entry

### Description

**Problem:** Every message rendered in a Channel view triggers a `GET /api/v1/users/{id}/info` API call on mount — even though the user info is only displayed in a hover preview tooltip. A channel with 20 messages from 5 users fires **20 requests** (one per message component), not 5. Opening a thread sidebar fires additional requests for each thread message. This creates significant unnecessary network traffic.

**Root cause:** `UserStatusLinkPreview.svelte` fetches user info eagerly in `onMount`, but it's rendered inside a `LinkPreview` component that only shows content on hover/click. The fetch should be deferred until the user actually interacts with the profile avatar.

**Fix:** Replace the eager `onMount` fetch with a lazy reactive block that fires only when the `LinkPreview` opens. The parent `ProfilePreview.svelte` already tracks `openPreview` via `bind:open` — this PR passes it down as an `open` prop and gates the fetch on it.

```diff
  // ProfilePreview.svelte
- <UserStatusLinkPreview id={user?.id} {side} {align} {sideOffset} />
+ <UserStatusLinkPreview id={user?.id} open={openPreview} {side} {align} {sideOffset} />

  // UserStatusLinkPreview.svelte
- onMount(async () => {
-     if (id) {
-         user = await getUserInfoById(localStorage.token, id).catch(...);
-     }
- });
+ let fetched = false;
+ $: if (open && id && !fetched) {
+     fetched = true;
+     getUserInfoById(localStorage.token, id)
+         .then((res) => { user = res; })
+         .catch((error) => { console.error(...); });
+ }
```

The `fetched` boolean guard ensures the API call only fires **once** per component instance — on first hover — and never again for subsequent hovers of the same avatar.

**Impact:**
- **Before:** N messages in a channel = N `users/{id}/info` API calls on page load
- **After:** 0 API calls on page load; 1 call per unique avatar hovered

### Fixed

- Eliminated eager `GET /api/v1/users/{id}/info` requests fired on mount for every message in channel views
- Eliminated additional duplicate requests when opening a thread sidebar

---

### Screenshots

#### Channel page load — `GET /api/v1/users/{id}/info`

**Before** — multiple `users/{id}/info` requests fire immediately on channel page load (one per message):

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/bbf465ea-1f60-4e9e-8e8e-b05c120176d0" />

**After** — zero requests on page load; fetches only on first hover of a profile avatar:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/9749001a-fd92-4b7e-a4de-4b5945e01467" />

---

#### Thread sidebar — `GET /api/v1/users/{id}/info`

**Before** — opening a thread fires additional `users/{id}/info` requests for each thread message:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/fb923129-dae0-4f12-9c0c-50787df61e1c" />

**After** — zero requests when opening a thread; fetches only on hover:

<img width="2558" height="1275" alt="image" src="https://github.com/user-attachments/assets/aedac7c7-8373-477d-9b17-a6e823a481c7" />
---

### Manual Verification Performed

1. Navigate to a channel with multiple messages → verify **zero** `users/{id}/info` requests fire on page load
2. Hover over a user's profile avatar → verify a single `users/{id}/info` request fires and the preview tooltip shows user status correctly
3. Hover over the same avatar again → verify **no** additional request fires (cached by `fetched` flag)
4. Hover over a different user's avatar → verify a new request fires for that user
5. Click on a message to open the thread sidebar → verify **zero** `users/{id}/info` requests fire on thread load
6. Hover over a profile avatar in the thread → verify the preview tooltip loads correctly
7. `npm run build` passes with no errors

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.