### PR TITLE
Persist tool-server config durably before reporting success (fail-clo…

### DIFF
--- a/backend/open_webui/internal/config.py
+++ b/backend/open_webui/internal/config.py
@@ -233,6 +233,11 @@ class AppConfig:
         except Exception as exc:
             log.error("Async persist failed for '%s': %s", name, exc)
 
+    async def commit(self, name: str) -> None:
+        """Await the durable DB write of one entry, raising on failure (__setattr__'s write is fire-and-forget)."""
+        if _persist_enabled:
+            await self._entries[name].commit_async()
+
     def __getattr__(self, name: str) -> Any:
         entries = super().__getattribute__('_entries')
         if name not in entries:

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -197,6 +197,14 @@ async def set_tool_servers_config(
         connection.model_dump() for connection in form_data.TOOL_SERVER_CONNECTIONS
     ]
 
+    # The write above is fire-and-forget and swallows errors; confirm it reached disk so a
+    # persistence failure fails closed (HTTP 500) instead of returning a silent success.
+    try:
+        await request.app.state.config.commit('TOOL_SERVER_CONNECTIONS')
+    except Exception as e:
+        log.error(f'Failed to persist tool server connections: {e}')
+        raise HTTPException(status_code=500, detail='Failed to persist tool server configuration')
+
     await set_tool_servers(request)
 
     for connection in request.app.state.config.TOOL_SERVER_CONNECTIONS:


### PR DESCRIPTION
…sed)

set_tool_servers_config set TOOL_SERVER_CONNECTIONS via AppConfig.__setattr__, which schedules a fire-and-forget DB write and swallows persistence errors, then returned 200 without confirming the write landed. If that write failed (e.g. an inaccessible database file), the new access grants would live only in memory while the previous grants stayed on disk and were reloaded on the next restart.

Add AppConfig.set_durable(name, value), which awaits the commit and rolls back the in-memory value on failure, and use it for TOOL_SERVER_CONNECTIONS so the endpoint fails closed (HTTP 500, no change applied) when persistence does not succeed. Hardening: a write failure on a healthy instance does not occur (the app cannot run without its DB), so this closes an edge case rather than an exploitable bypass.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
