### PR TITLE
docs: Fix Playwright version comments

### DIFF
--- a/docker-compose.playwright.yaml
+++ b/docker-compose.playwright.yaml
@@ -1,6 +1,6 @@
 services:
   playwright:
-    image: mcr.microsoft.com/playwright:v1.58.0-noble # Version must match requirements.txt
+    image: mcr.microsoft.com/playwright:v1.58.0-noble # Version must match pyproject.toml
     container_name: playwright
     command: npx -y playwright@1.58.0 run-server --port 3000 --host 0.0.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ all = [
     "docker~=7.1.0",
     "pytest~=8.3.2",
     "pytest-docker~=3.2.5",
-    "playwright==1.58.0", # Caution: version must match docker-compose.playwright.yaml - Update the docker-compose.yaml if necessary
+    "playwright==1.58.0", # Caution: version must match docker-compose.playwright.yaml
     "elasticsearch==9.3.0",
 
     "qdrant-client==1.17.0",


### PR DESCRIPTION
## Summary

- correct the Playwright version-sync comment in `pyproject.toml`
- correct the matching comment in `docker-compose.playwright.yaml`

## Why

The existing comments pointed maintainers at the wrong files when updating the Playwright version. The two version pins that need to stay in sync are `pyproject.toml` and `docker-compose.playwright.yaml`.

Fixes #25962.

## Validation

- Checked the committed diff is limited to the two comment updates.
- Verified both comments now reference the matching file.
