### PR TITLE
fix: remove duplicate getChatById fetch in share chat modal

### DIFF
--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -83,30 +83,18 @@
 
 	export let show = false;
 
-	const isDifferentChat = (_chat) => {
-		if (!chat) {
-			return true;
-		}
-		if (!_chat) {
-			return false;
-		}
-		return chat.id !== _chat.id || chat.share_id !== _chat.share_id;
-	};
+	let _loadedChatId = null;
 
-	$: if (show) {
-		(async () => {
-			if (chatId) {
-				const _chat = await getChatById(localStorage.token, chatId);
-				if (isDifferentChat(_chat)) {
-					chat = _chat;
-				}
+	$: if (show && chatId) {
+		if (chatId !== _loadedChatId) {
+			_loadedChatId = chatId;
+			(async () => {
+				chat = await getChatById(localStorage.token, chatId);
 				await loadAccessGrants();
-			} else {
-				chat = null;
-				accessGrants = [];
-				console.log(chat);
-			}
-		})();
+			})();
+		}
+	} else if (!show) {
+		_loadedChatId = null;
 	}
 </script>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

When a user clicks "delete this link" in the Share Chat modal to remove a shared chat link, a duplicate `GET /api/v1/chats/{chat_id}` request is fired. The delete handler explicitly calls `getChatById` to refresh the chat state (removing `share_id`), but this assignment to `chat` triggers the modal's reactive `$: if (show)` block — which reads `chat` through the `isDifferentChat()` helper — causing Svelte to re-run the block and fire a second identical fetch.

**Root cause:** The reactive block `$: if (show)` contained an `isDifferentChat()` call that reads the `chat` variable. Svelte tracks all reactive dependencies inside the block, so any assignment to `chat` (from the delete handler, share handler, etc.) re-triggers the block while `show` is `true`, causing a redundant `getChatById` fetch.

**Fix:** Replace the reactive block with a `_loadedChatId` guard that only fetches when the modal opens or the `chatId` prop changes — not when `chat` is reassigned internally by user actions. This eliminates the `isDifferentChat` helper entirely since it was the source of the dependency leak.

**No backend changes.** One file changed, net -12 lines.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Duplicate `GET /api/v1/chats/{chat_id}` request when deleting a shared chat link from the Share Chat modal

### Changed

- `ShareChatModal.svelte`: Replaced reactive `$: if (show)` block with a `_loadedChatId` guard that only fetches on modal open or `chatId` change, removing the `isDifferentChat` helper that leaked `chat` as a reactive dependency

---

### Additional Information

- **No new dependencies**
- **No backend changes**
- **Files changed**: 1 file (`ShareChatModal.svelte`), +10 lines / -22 lines

### Duplicate request eliminated

| Endpoint | Trigger | Before | After |
|---|---|---|---|
| `GET /api/v1/chats/{id}` | Click "delete this link" in Share Chat modal | 2 requests (delete handler + reactive re-trigger) | 1 request (delete handler only) |

### Manual Verification Performed
1. **Delete shared link**: Opened the Share Chat modal for a shared chat, clicked "delete this link", and confirmed only a single `GET /api/v1/chats/{id}` request fires (no duplicate).
2. **Modal open**: Opened the Share Chat modal and confirmed the chat data loads correctly with a single fetch.
3. **Re-open modal**: Closed and re-opened the Share Chat modal for the same chat and confirmed it fetches fresh data (guard resets on close).
4. **Different chat**: Opened the Share Chat modal for a different chat and confirmed the new chat data loads correctly.
5. **Copy Link still works**: Clicked "Copy Link" / "Update and Copy Link" and confirmed sharing functionality is unaffected.
6. **Share to community**: Confirmed the "Share to Open WebUI Community" button still works correctly.
7. **Access grants**: Confirmed the access control section still loads and saves correctly for shared chats.
8. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly with no errors.

### Screenshots

#### 1. Delete shared link — `GET /api/v1/chats/{id}`

**Before** — duplicate `chats/{id}` fetch when clicking "delete this link" (delete handler + reactive re-trigger):

<img width="2552" height="1008" alt="image" src="https://github.com/user-attachments/assets/c8dedc5c-2cda-411e-8645-0d55400c87e7" />

**After** — single request (reactive block no longer re-triggers on `chat` reassignment):

<img width="2552" height="1008" alt="image" src="https://github.com/user-attachments/assets/0ad3b2f4-5f62-4373-b39f-aa90596106c4" />

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
