### PR TITLE
perf: replace N+1 queries in model overview with batch operations

### DIFF
--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -367,76 +366,36 @@ async def get_model_overview(
 ):
     """Get model overview with feedback history and chat tags."""
 
-    # Get chat IDs that used this model
+    # Single-query feedback aggregation (replaces N+1 per-chat loop)
+    history_raw = await Feedbacks.get_model_evaluation_history(
+        model_id=model_id, days=days, db=db
+    )
+    history = [
+        HistoryEntry(date=entry.date, won=entry.won, lost=entry.lost)
+        for entry in history_raw
+    ]
+
+    # Batch-fetch chats for tag extraction (replaces N+1 per-chat loop)
     chat_ids = await ChatMessages.get_chat_ids_by_model_id(
         model_id=model_id,
         start_date=None,
         end_date=None,
         skip=0,
-        limit=10000,  # Get all chats
+        limit=10000,
         db=db,
     )
 
-    # Get feedback history per day
-    history_counts: dict[str, dict] = defaultdict(lambda: {'won': 0, 'lost': 0})
-
-    # Calculate start date for history
-    now = datetime.now()
-    start_dt = None
-    if days > 0:
-        start_dt = now - timedelta(days=days)
-
-    for chat_id in chat_ids:
-        feedbacks = await Feedbacks.get_feedbacks_by_chat_id(chat_id, db=db)
-        for fb in feedbacks:
-            if fb.data and 'rating' in fb.data:
-                rating = fb.data['rating']
-                fb_date = datetime.fromtimestamp(fb.created_at)
-
-                # Filter by date range
-                if start_dt and fb_date < start_dt:
-                    continue
-
-                date_str = fb_date.strftime('%Y-%m-%d')
-                if rating == 1:
-                    history_counts[date_str]['won'] += 1
-                elif rating == -1:
-                    history_counts[date_str]['lost'] += 1
-
-    # Fill in missing days
-    history = []
-    if history_counts or days > 0:
-        end_dt = now
-        if days > 0:
-            current = start_dt
-        elif history_counts:
-            # Find earliest date
-            min_date = min(history_counts.keys())
-            current = datetime.strptime(min_date, '%Y-%m-%d')
-        else:
-            current = now
-
-        while current <= end_dt:
-            date_str = current.strftime('%Y-%m-%d')
-            counts = history_counts.get(date_str, {'won': 0, 'lost': 0})
-            history.append(
-                HistoryEntry(
-                    date=date_str,
-                    won=counts['won'],
-                    lost=counts['lost'],
-                )
-            )
-            current += timedelta(days=1)
-
-    # Get chat tags
     tag_counts: dict[str, int] = defaultdict(int)
-    for chat_id in chat_ids:
-        chat = await Chats.get_chat_by_id(chat_id, db=db)
-        if chat and chat.meta:
-            for tag in chat.meta.get('tags', []):
-                tag_counts[tag] += 1
+    if chat_ids:
+        chats = await Chats.get_chat_list_by_chat_ids(chat_ids, skip=0, limit=len(chat_ids), db=db)
+        for chat in chats:
+            if chat.meta:
+                for tag in chat.meta.get('tags', []):
+                    tag_counts[tag] += 1
 
-    # Sort by count and take top 10
-    tags = [TagEntry(tag=tag, count=count) for tag, count in sorted(tag_counts.items(), key=lambda x: -x[1])[:10]]
+    tags = [
+        TagEntry(tag=tag, count=count)
+        for tag, count in sorted(tag_counts.items(), key=lambda x: -x[1])[:10]
+    ]
 
     return ModelOverviewResponse(history=history, tags=tags)


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **perf**: Performance improvements

# Changelog Entry

### Description

The `GET /api/v1/analytics/models/{model_id}/overview` endpoint in the admin Analytics panel is extremely slow (2+ seconds) when clicking a model to view its Overview tab. Switching between the 30D/1Y/All filters is equally sluggish.

**Root cause:** Two N+1 query patterns make the endpoint issue up to **2N+1 sequential database queries** (where N can reach 10,000):

1. **Feedback loop**: For each `chat_id` that used the model, `get_feedbacks_by_chat_id()` was called individually — potentially thousands of sequential queries just to aggregate win/loss ratings.
2. **Chat tags loop**: For each `chat_id`, `get_chat_by_id()` was called individually — another N sequential queries just to read `meta.tags`.

**Fix:** Replace both N+1 loops with batch operations:

- **Feedback history**: Uses the existing `Feedbacks.get_model_evaluation_history()` method that was already in the codebase but unused by this endpoint. It aggregates feedback in a **single query** by filtering on `Feedback.data['model_id']` directly, with an optional timestamp cutoff.
- **Chat tags**: Uses `Chats.get_chat_list_by_chat_ids()` to batch-fetch all chats in a **single query** instead of N individual calls.

**Result**: Total queries drop from **2N+1** to **3**, regardless of how many chats used the model.

**No frontend changes. No new dependencies.** One file changed, net -41 lines.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Pydantic type mismatch between `ModelHistoryEntry` (from `get_model_evaluation_history`) and `HistoryEntry` (expected by `ModelOverviewResponse`) that caused a 500 Internal Server Error for non-empty history results (30D/1Y filters)

### Changed

- `analytics.py`: Replaced N+1 feedback-per-chat loop with single-query `get_model_evaluation_history()` call
- `analytics.py`: Replaced N+1 chat-per-id loop with single batch `get_chat_list_by_chat_ids()` call
- `analytics.py`: Removed unused `datetime`/`timedelta` imports (date handling now delegated to `get_model_evaluation_history`)

---

### Additional Information

- **No new dependencies**
- **No frontend changes**
- **Files changed**: 1 file (`analytics.py`), +22 lines / -63 lines (net -41)
- **Key insight**: The `get_model_evaluation_history()` method already existed in `feedbacks.py` but was not being used by the overview endpoint

### Performance improvement

| Metric | Before | After |
|---|---|---|
| DB queries per request | 2N + 1 (up to 20,001) | 3 |
| Response time (observed) | 2+ seconds | < 500ms |
| Code lines | 83 | 42 |

### Manual Verification Performed
1. **30D filter**: Clicked a model in Analytics → Overview → confirmed 30D loads quickly with correct data
2. **1Y filter**: Switched to 1Y → confirmed it loads quickly with correct data.
3. **All filter**: Switched to All → confirmed it loads quickly with correct data.
4. **No activity model**: Clicked a model with no feedback data → confirmed "No activity data" still renders correctly.
5. **Tags display**: Confirmed chat tags still display correctly with accurate counts.
6. **Filter switching**: Rapidly switched between 30D/1Y/All → confirmed no errors or stale data.
7. **Backend import**: Ran `python -c "from open_webui.routers.analytics import router"` — passes.
8. **Build passes**: Ran `npm run build` — passes cleanly.

### Screenshots

#### 1. Model Overview — 30D filter

**Before** — 2+ second load time with N+1 queries visible in the Network tab:

<img width="2552" height="1280" alt="image" src="https://github.com/user-attachments/assets/e7908f48-fd8b-4af6-b859-1bda699b9735" />

**After** — sub-second response:

<img width="2552" height="1280" alt="image" src="https://github.com/user-attachments/assets/68bd5099-c242-4812-b0be-c02f2ebeaff1" />

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
