### PR TITLE
fix: collapse Code Execution settings when toggle is disabled

### DIFF
--- a/src/lib/components/admin/Settings/CodeExecution.svelte
+++ b/src/lib/components/admin/Settings/CodeExecution.svelte
@@ -41,7 +41,7 @@
 		{#if config}
 			<div>
 				<div class="mb-3.5">
-					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('General')}</div>
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Code Execution')}</div>
 
 					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
@@ -55,112 +55,117 @@
 						</div>
 					</div>
 
-					<div class="mb-2.5">
-						<div class="flex w-full justify-between">
-							<div class=" self-center text-xs font-medium">{$i18n.t('Code Execution Engine')}</div>
-							<div class="flex items-center relative">
-								<select
-									class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
-									bind:value={config.CODE_EXECUTION_ENGINE}
-									placeholder={$i18n.t('Select a engine')}
-									required
-								>
-									<option disabled selected value="">{$i18n.t('Select a engine')}</option>
-									{#each engines as engine}
-										<option value={engine}>{engine}{engine === 'jupyter' ? ' (Legacy)' : ''}</option
-										>
-									{/each}
-								</select>
-							</div>
-						</div>
-
-						{#if config.CODE_EXECUTION_ENGINE === 'jupyter'}
-							<div class="text-gray-500 text-xs">
-								{$i18n.t(
-									'Warning: Jupyter execution enables arbitrary code execution, posing severe security risks—proceed with extreme caution.'
-								)}
-							</div>
-						{/if}
-					</div>
-
-					{#if config.CODE_EXECUTION_ENGINE === 'jupyter'}
-						<div class="mb-2.5 flex flex-col gap-1.5 w-full">
-							<div class="text-xs font-medium">
-								{$i18n.t('Jupyter URL')}
-							</div>
-
-							<div class="flex w-full">
-								<div class="flex-1">
-									<input
-										class="w-full text-sm py-0.5 placeholder:text-gray-300 dark:placeholder:text-gray-700 bg-transparent outline-hidden"
-										type="text"
-										placeholder={$i18n.t('Enter Jupyter URL')}
-										bind:value={config.CODE_EXECUTION_JUPYTER_URL}
-										autocomplete="off"
-									/>
+					{#if config.ENABLE_CODE_EXECUTION}
+						<div class="mb-2.5">
+							<div class="flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">
+									{$i18n.t('Code Execution Engine')}
 								</div>
-							</div>
-						</div>
-
-						<div class="mb-2.5 flex flex-col gap-1.5 w-full">
-							<div class=" flex gap-2 w-full items-center justify-between">
-								<div class="text-xs font-medium">
-									{$i18n.t('Jupyter Auth')}
-								</div>
-
-								<div>
+								<div class="flex items-center relative">
 									<select
-										class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-left"
-										bind:value={config.CODE_EXECUTION_JUPYTER_AUTH}
-										placeholder={$i18n.t('Select an auth method')}
+										class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+										bind:value={config.CODE_EXECUTION_ENGINE}
+										placeholder={$i18n.t('Select a engine')}
+										required
 									>
-										<option selected value="">{$i18n.t('None')}</option>
-										<option value="token">{$i18n.t('Token')}</option>
-										<option value="password">{$i18n.t('Password')}</option>
+										<option disabled selected value="">{$i18n.t('Select a engine')}</option>
+										{#each engines as engine}
+											<option value={engine}
+												>{engine}{engine === 'jupyter' ? ' (Legacy)' : ''}</option
+											>
+										{/each}
 									</select>
 								</div>
 							</div>
 
-							{#if config.CODE_EXECUTION_JUPYTER_AUTH}
-								<div class="flex w-full gap-2">
-									<div class="flex-1">
-										{#if config.CODE_EXECUTION_JUPYTER_AUTH === 'password'}
-											<SensitiveInput
-												type="text"
-												placeholder={$i18n.t('Enter Jupyter Password')}
-												bind:value={config.CODE_EXECUTION_JUPYTER_AUTH_PASSWORD}
-												autocomplete="off"
-											/>
-										{:else}
-											<SensitiveInput
-												type="text"
-												placeholder={$i18n.t('Enter Jupyter Token')}
-												bind:value={config.CODE_EXECUTION_JUPYTER_AUTH_TOKEN}
-												autocomplete="off"
-											/>
-										{/if}
-									</div>
+							{#if config.CODE_EXECUTION_ENGINE === 'jupyter'}
+								<div class="text-gray-500 text-xs">
+									{$i18n.t(
+										'Warning: Jupyter execution enables arbitrary code execution, posing severe security risks—proceed with extreme caution.'
+									)}
 								</div>
 							{/if}
 						</div>
 
-						<div class="flex gap-2 w-full items-center justify-between">
-							<div class="text-xs font-medium">
-								{$i18n.t('Code Execution Timeout')}
+						{#if config.CODE_EXECUTION_ENGINE === 'jupyter'}
+							<div class="mb-2.5 flex flex-col gap-1.5 w-full">
+								<div class="text-xs font-medium">
+									{$i18n.t('Jupyter URL')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<input
+											class="w-full text-sm py-0.5 placeholder:text-gray-300 dark:placeholder:text-gray-700 bg-transparent outline-hidden"
+											type="text"
+											placeholder={$i18n.t('Enter Jupyter URL')}
+											bind:value={config.CODE_EXECUTION_JUPYTER_URL}
+											autocomplete="off"
+										/>
+									</div>
+								</div>
 							</div>
 
-							<div class="">
-								<Tooltip content={$i18n.t('Enter timeout in seconds')}>
-									<input
-										class="w-fit rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
-										type="number"
-										bind:value={config.CODE_EXECUTION_JUPYTER_TIMEOUT}
-										placeholder={$i18n.t('e.g. 60')}
-										autocomplete="off"
-									/>
-								</Tooltip>
+							<div class="mb-2.5 flex flex-col gap-1.5 w-full">
+								<div class=" flex gap-2 w-full items-center justify-between">
+									<div class="text-xs font-medium">
+										{$i18n.t('Jupyter Auth')}
+									</div>
+
+									<div>
+										<select
+											class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-left"
+											bind:value={config.CODE_EXECUTION_JUPYTER_AUTH}
+											placeholder={$i18n.t('Select an auth method')}
+										>
+											<option selected value="">{$i18n.t('None')}</option>
+											<option value="token">{$i18n.t('Token')}</option>
+											<option value="password">{$i18n.t('Password')}</option>
+										</select>
+									</div>
+								</div>
+
+								{#if config.CODE_EXECUTION_JUPYTER_AUTH}
+									<div class="flex w-full gap-2">
+										<div class="flex-1">
+											{#if config.CODE_EXECUTION_JUPYTER_AUTH === 'password'}
+												<SensitiveInput
+													type="text"
+													placeholder={$i18n.t('Enter Jupyter Password')}
+													bind:value={config.CODE_EXECUTION_JUPYTER_AUTH_PASSWORD}
+													autocomplete="off"
+												/>
+											{:else}
+												<SensitiveInput
+													type="text"
+													placeholder={$i18n.t('Enter Jupyter Token')}
+													bind:value={config.CODE_EXECUTION_JUPYTER_AUTH_TOKEN}
+													autocomplete="off"
+												/>
+											{/if}
+										</div>
+									</div>
+								{/if}
 							</div>
-						</div>
+
+							<div class="flex gap-2 w-full items-center justify-between">
+								<div class="text-xs font-medium">
+									{$i18n.t('Code Execution Timeout')}
+								</div>
+
+								<div class="">
+									<Tooltip content={$i18n.t('Enter timeout in seconds')}>
+										<input
+											class="w-fit rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+											type="number"
+											bind:value={config.CODE_EXECUTION_JUPYTER_TIMEOUT}
+											placeholder={$i18n.t('e.g. 60')}
+											autocomplete="off"
+										/>
+									</Tooltip>
+								</div>
+							</div>
+						{/if}
 					{/if}
 				</div>
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

On the admin Settings → Code Execution tab, the "Enable Code Interpreter" toggle correctly collapses its section when toggled off, but the "Enable Code Execution" toggle does not — leaving the engine selector, Jupyter URL, auth, and timeout fields visible even when code execution is disabled.

Additionally, the section header was labeled "General" which is vague and inconsistent with the "Code Interpreter" section header below it.

**Fix:**
1. Wrapped the Code Execution settings (engine, Jupyter URL/auth/timeout) inside `{#if config.ENABLE_CODE_EXECUTION}` so they collapse when toggled off — matching the Code Interpreter toggle behavior.
2. Renamed the "General" section header to "Code Execution" for clarity and consistency.

**No backend changes. No new dependencies.** One file changed.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Code Execution settings (engine, Jupyter URL, auth, timeout) no longer remain visible when the "Enable Code Execution" toggle is off
- Renamed vague "General" section header to "Code Execution" for consistency with the "Code Interpreter" header

### Changed

- `CodeExecution.svelte`: Added `{#if config.ENABLE_CODE_EXECUTION}` guard around the Code Execution settings section
- `CodeExecution.svelte`: Renamed section header from "General" to "Code Execution"

---

### Additional Information

- **No new dependencies**
- **No backend changes**
- **Files changed**: 1 file (`CodeExecution.svelte`)

### Manual Verification Performed
1. **Toggle off Code Execution**: Toggled "Enable Code Execution" off → confirmed engine, Jupyter URL, auth, and timeout fields collapse.
2. **Toggle on Code Execution**: Toggled back on → confirmed all settings reappear correctly.
3. **Toggle off Code Interpreter**: Confirmed the Code Interpreter section still collapses independently.
4. **Both off**: Toggled both off → confirmed only the toggle rows and section headers remain visible.
5. **Section headers**: Confirmed the header now reads "Code Execution" instead of "General".
6. **Save behavior**: Toggled settings on/off and saved → confirmed config persists correctly.
7. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly.

### Screenshots

#### 1. Both toggles disabled — sections collapsed

Both "Enable Code Execution" and "Enable Code Interpreter" toggled off — all settings are hidden, showing only the toggles and section headers:

<img width="2559" height="1275" alt="image" src="https://github.com/user-attachments/assets/e9e5e96f-adb8-4344-a6d9-54f6b10e7c4e" />

---

#### 2. Code Execution enabled — settings visible

"Enable Code Execution" toggled on — engine selector and related settings are now visible:

<img width="2559" height="1275" alt="image" src="https://github.com/user-attachments/assets/75e0382b-8f7d-40d0-980c-14254b96846b" />

---

#### 3. Both toggles enabled — full settings visible

Both sections expanded, showing all configuration options:

<img width="2559" height="1275" alt="image" src="https://github.com/user-attachments/assets/9599836a-9f6e-4f71-b579-97f96aaf06d5" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
