### PR TITLE
fix: reset Default Permissions modal state on close without save

### DIFF
--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -224,7 +224,7 @@
 	<EditGroupModal
 		bind:show={showDefaultPermissionsModal}
 		tabs={['permissions']}
-		bind:permissions={defaultPermissions}
+		permissions={defaultPermissions}
 		custom={false}
 		onSubmit={updateDefaultPermissionsHandler}
 	/>

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -52,9 +52,16 @@
 
 		await onSubmit(group);
 
+		// Update saved snapshot so next open reflects the just-saved state
+		_savedPermissions = JSON.parse(JSON.stringify(permissions));
+
 		loading = false;
 		show = false;
 	};
+
+	// Deep-clone the parent's permissions at creation time so we can
+	// reset on close-without-save without mutating the parent's object.
+	let _savedPermissions = JSON.parse(JSON.stringify(permissions));
 
 	const init = () => {
 		if (group) {
@@ -73,6 +80,9 @@
 			data = group?.data ?? {};
 
 			userCount = group?.member_count ?? 0;
+		} else {
+			// Reset to last-saved permissions (e.g. Default Permissions modal)
+			permissions = JSON.parse(JSON.stringify(_savedPermissions));
 		}
 	};
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

The "Edit Default Permissions" modal (Admin → Users → Groups tab) does not reset toggle state when closed without saving. If a user opens the modal, toggles off some permissions, then closes without pressing Save, re-opening the modal shows the unsaved toggle changes instead of the actual saved permissions.

This behavior is inconsistent with the "Edit User Group" modal on the same page, which correctly resets on close.

**Root cause:** Two issues combined:

1. **`bind:permissions`**: The `EditGroupModal` for default permissions used `bind:permissions={defaultPermissions}`, creating a two-way binding. Since JavaScript objects are passed by reference, toggle changes inside the modal mutated the parent's `defaultPermissions` object directly — even without saving.

2. **`init()` skipped reset**: The `init()` function in `EditGroupModal` only reset permissions when `group` was set. For the Default Permissions modal, `group` is `null`, so `init()` was a no-op and permissions were never reset on re-open.

**Fix:**

- **`Groups.svelte`**: Changed `bind:permissions={defaultPermissions}` to `permissions={defaultPermissions}` (one-way prop).
- **`EditGroupModal.svelte`**: Added `_savedPermissions` — a deep clone of the permissions prop captured at creation time. On modal open, `init()` resets `permissions` from this snapshot (deep copy). On successful save, `_savedPermissions` is updated to reflect the new saved state.

**No backend changes. No new dependencies.** 2 files changed, +11/-1 lines.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Default Permissions modal now resets toggle state on close without save, matching the Edit User Group modal behavior

### Changed

- `Groups.svelte`: Changed `bind:permissions` to one-way `permissions` prop for Default Permissions modal
- `EditGroupModal.svelte`: Added `_savedPermissions` deep-clone snapshot with reset-on-open and update-on-save logic

---

### Additional Information

- **No new dependencies**
- **No backend changes**
- **Files changed**: 2 files (`Groups.svelte`, `EditGroupModal.svelte`), +11/-1 lines
- **No impact on Edit User Group modal** — the group-based `init()` path is unchanged

### Manual Verification Performed
1. **Toggle and close**: Opened Default Permissions modal, toggled off several permissions, closed without saving → re-opened and confirmed all toggles reset to their saved state.
2. **Toggle and save**: Opened the modal, toggled off a permission, clicked Save → re-opened and confirmed the saved change persists.
3. **Save then close-without-save**: Saved a change, re-opened, toggled another permission, closed without saving → re-opened and confirmed only the previously saved change persists.
4. **Edit User Group modal**: Opened an existing group's edit modal, toggled permissions, closed without saving → re-opened and confirmed toggles reset correctly (no regression).
5. **Add Group modal**: Created a new group → confirmed default permissions are still correctly applied.
6. **No infinite loops**: Toggled permissions rapidly in the Default Permissions modal → confirmed no `effect_update_depth_exceeded` errors in the console.
7. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly.

**Before** — toggling off permissions and closing without save persists the unsaved changes on re-open

**After** — toggles correctly reset to the saved state on re-open

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
