### PR TITLE
feat: add Legacy Message Skeleton toggle in user settings

### DIFF
--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -414,7 +414,7 @@
 
 								<div class="mt-1 markdown-prose w-full min-w-full">
 									{#if (message?.content ?? '') === ''}
-										<Skeleton />
+										<Skeleton legacy={$settings?.legacyMessageSkeleton ?? false} />
 									{:else}
 										<Markdown id={`merged`} content={message.content ?? ''} />
 									{/if}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -827,7 +827,7 @@
 							id="response-content-container"
 						>
 							{#if message.content === '' && !message.done && !message.error && !hasVisibleStatus}
-								<Skeleton />
+								<Skeleton legacy={$settings?.legacyMessageSkeleton ?? false} />
 							{:else if message.content && message.error !== true}
 								<!-- always show message contents even if there's an error -->
 								<!-- unless message.error === true which is legacy error handling, where the error message is stored in message.content -->

--- a/src/lib/components/chat/Messages/Skeleton.svelte
+++ b/src/lib/components/chat/Messages/Skeleton.svelte
@@ -1,25 +1,70 @@
 <script lang="ts">
 	export let size = 'md';
+	export let legacy = false;
 </script>
 
-<span
-	class="relative flex {size === 'md'
-		? 'size-3 my-2'
-		: size === 'xs'
-			? 'size-1.5 my-1'
-			: 'size-2 my-1'} mx-1"
->
+{#if legacy}
+	<div class="w-full mt-2 mb-2">
+		<div class="animate-pulse flex w-full">
+			<div class="{size === 'md' ? 'space-y-2' : 'space-y-1.5'} w-full">
+				<div
+					class="{size === 'md' ? 'h-2' : 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm mr-14"
+				/>
+
+				<div class="grid grid-cols-3 gap-4">
+					<div
+						class="{size === 'md'
+							? 'h-2'
+							: 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm col-span-2"
+					/>
+					<div
+						class="{size === 'md'
+							? 'h-2'
+							: 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm col-span-1"
+					/>
+				</div>
+				<div class="grid grid-cols-4 gap-4">
+					<div
+						class="{size === 'md'
+							? 'h-2'
+							: 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm col-span-1"
+					/>
+					<div
+						class="{size === 'md'
+							? 'h-2'
+							: 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm col-span-2"
+					/>
+					<div
+						class="{size === 'md'
+							? 'h-2'
+							: 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm col-span-1 mr-4"
+					/>
+				</div>
+
+				<div class="{size === 'md' ? 'h-2' : 'h-1.5'} bg-gray-200 dark:bg-gray-600 rounded-sm" />
+			</div>
+		</div>
+	</div>
+{:else}
 	<span
-		class="absolute inline-flex h-full w-full animate-pulse rounded-full bg-gray-700 dark:bg-gray-200 opacity-75"
-	></span>
-	<span
-		class="relative inline-flex {size === 'md'
-			? 'size-3'
+		class="relative flex {size === 'md'
+			? 'size-3 my-2'
 			: size === 'xs'
-				? 'size-1.5'
-				: 'size-2'} rounded-full bg-black dark:bg-white animate-size"
-	></span>
-</span>
+				? 'size-1.5 my-1'
+				: 'size-2 my-1'} mx-1"
+	>
+		<span
+			class="absolute inline-flex h-full w-full animate-pulse rounded-full bg-gray-700 dark:bg-gray-200 opacity-75"
+		></span>
+		<span
+			class="relative inline-flex {size === 'md'
+				? 'size-3'
+				: size === 'xs'
+					? 'size-1.5'
+					: 'size-2'} rounded-full bg-black dark:bg-white animate-size"
+		></span>
+	</span>
+{/if}
 
 <style>
 	@keyframes size {

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -68,6 +68,7 @@
 
 	let temporaryChatByDefault = false;
 	let chatFadeStreamingText = true;
+	let legacyMessageSkeleton = false;
 	let collapseCodeBlocks = false;
 	let renderMarkdownInUserMessages = true;
 	let renderMarkdownInAssistantMessages = true;
@@ -217,6 +218,7 @@
 
 		displayMultiModelResponsesInTabs = $settings?.displayMultiModelResponsesInTabs ?? false;
 		chatFadeStreamingText = $settings?.chatFadeStreamingText ?? true;
+		legacyMessageSkeleton = $settings?.legacyMessageSkeleton ?? false;
 
 		richTextInput = $settings?.richTextInput ?? true;
 		showFormattingToolbar = $settings?.showFormattingToolbar ?? false;
@@ -774,6 +776,25 @@
 							bind:state={chatFadeStreamingText}
 							on:change={() => {
 								saveSettings({ chatFadeStreamingText });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="legacy-message-skeleton-label" class=" self-center text-xs">
+						{$i18n.t('Legacy Message Skeleton')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="legacy-message-skeleton-label"
+							tooltip={true}
+							bind:state={legacyMessageSkeleton}
+							on:change={() => {
+								saveSettings({ legacyMessageSkeleton });
 							}}
 						/>
 					</div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -215,6 +215,7 @@ type Settings = {
 	scrollOnBranchChange?: boolean;
 	directConnections?: null;
 	chatBubble?: boolean;
+	legacyMessageSkeleton?: boolean;
 	copyFormatted?: boolean;
 	models?: string[];
 	conversationMode?: boolean;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features

# Changelog Entry

### Description

The legacy message skeleton (multi-line animated bars that simulate text content loading) was removed in [`8d49288`](https://github.com/open-webui/open-webui/commit/8d49288499b4e1a85e8023a4b7cf8dc5eafab646) (part of [#15390](https://github.com/open-webui/open-webui/pull/15390)) in favor of a minimal pulsing dot indicator. Some users preferred the original skeleton style as it provided a clearer visual cue that content was loading.

This PR brings back the legacy skeleton as an opt-in user setting, preserving the current pulsing dot as the default.

**Changes:**
- Added a `legacy` prop to `Skeleton.svelte` — when `true`, renders the original multi-line skeleton bars; when `false` (default), renders the current pulsing dot
- Added a "Legacy Message Skeleton" toggle in **Settings → Interface → Chat** (default: off)
- Wired the setting through `ResponseMessage.svelte` and `MultiResponseMessages.svelte`
- Added `legacyMessageSkeleton` to the `Settings` type

**No backend changes. No new dependencies.** 5 files changed, +85/-18 lines.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- "Legacy Message Skeleton" toggle in Settings → Interface → Chat section
- Multi-line skeleton bar animation (the original loading indicator) available via opt-in setting

### Changed

- `Skeleton.svelte`: Added `legacy` prop to conditionally render legacy multi-line bars or default pulsing dot
- `ResponseMessage.svelte`: Passes `legacy` setting to `Skeleton` component
- `MultiResponseMessages.svelte`: Passes `legacy` setting to `Skeleton` component in merged response view
- `Interface.svelte`: Added Switch toggle for the new setting
- `stores/index.ts`: Added `legacyMessageSkeleton` to `Settings` type

---

### Additional Information

- **No new dependencies**
- **No backend changes**
- **Files changed**: 5 files
- **Default behavior unchanged** — the pulsing dot remains the default; legacy skeleton is opt-in

### Manual Verification Performed
1. **Default (off)**: Sent a message → confirmed the pulsing dot skeleton appears as before.
2. **Legacy (on)**: Enabled the toggle → sent a message → confirmed the multi-line skeleton bars appear with pulse animation.
3. **Toggle persistence**: Toggled on, refreshed the page → confirmed the setting persists.
4. **Multi-model responses**: Tested with multiple models → confirmed the legacy skeleton works in the merged response view.
5. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly.

### Screenshots

#### 1. Default skeleton (pulsing dot — current behavior, unchanged)

Pulsing dot indicator shown while waiting for model response:

<img width="2560" height="1282" alt="image" src="https://github.com/user-attachments/assets/808c0368-12ad-4803-8b7f-b732de50e402" />

<img width="2557" height="1276" alt="image" src="https://github.com/user-attachments/assets/57c44ce1-29a0-423a-9a3a-e6a879b5543a" />

---

#### 2. Legacy skeleton (multi-line bars — opt-in)

Multi-line skeleton bars shown while waiting for model response after enabling the toggle:

<img width="2557" height="1276" alt="image" src="https://github.com/user-attachments/assets/3d7990c7-4413-4a04-93ad-55f8a9bccd84" />

<img width="2557" height="1276" alt="image" src="https://github.com/user-attachments/assets/7c5af422-c950-49f0-a209-af978f9fff0d" />

---

#### 3. Settings toggle location

"Legacy Message Skeleton" toggle in Settings → Interface → Chat section:

<img width="1362" height="768" alt="image" src="https://github.com/user-attachments/assets/65f0557f-0c3f-4df6-9b63-59e0d118ff85" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
