### PR TITLE
feat: pre-select last model when adding a new model slot

### DIFF
--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -79,7 +79,10 @@
 								class=" "
 								{disabled}
 								on:click={() => {
-									selectedModels = [...selectedModels, ''];
+									selectedModels = [
+										...selectedModels,
+										selectedModels[selectedModels.length - 1] || ''
+									];
 								}}
 								aria-label="Add Model"
 							>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features

# Changelog Entry

### Description

When clicking the `+` button to add a new model in the chat model selector, the newly added slot shows "Select a model" as an empty placeholder, requiring the user to manually pick a model every time. This is an unnecessary extra step — in most cases, the user wants the same model or at least a reasonable starting point.

**Fix:** The new model slot now pre-selects the last model in the list (i.e., the model you most recently selected or added). If no model is selected yet, it falls back to the empty placeholder as before.

**No backend changes. No new dependencies.** 1 file changed, +4/-1 lines.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Changed

- `ModelSelector.svelte`: New model slots are pre-populated with the last selected model instead of an empty placeholder

---

### Additional Information

- **No new dependencies**
- **No backend changes**
- **Files changed**: 1 file (`ModelSelector.svelte`), +4/-1 lines
- **Backward compatible** — falls back to empty placeholder if no model is selected

### Manual Verification Performed
1. **Single model selected**: Selected "Granite 4.1 3B", clicked `+` → new slot pre-selected "Granite 4.1 3B".
2. **Changed second model**: Changed the second model to a different model, clicked `+` again → new slot pre-selected the last model in the list (the one just changed).
3. **Removed model**: Removed the second model via `−` → confirmed remaining models unaffected.
4. **Set as default**: Selected multiple models, clicked "Set as default" → confirmed save works correctly with pre-selected models.
5. **Fresh chat**: Started a new chat with default model → clicked `+` → confirmed the default model is pre-selected.
6. **Build passes**: Ran `npm run format`, `npm run build` — both pass cleanly.

### Screenshots

#### 1. Before — empty placeholder on add

Clicking `+` shows an empty "Select a model" placeholder:

<img width="492" height="262" alt="image" src="https://github.com/user-attachments/assets/36b4094e-c675-45f5-967b-1749173b8080" />

---

#### 2. After — model pre-selected on add

Clicking `+` now pre-selects the last model from the list:

<img width="492" height="262" alt="image" src="https://github.com/user-attachments/assets/5ef4189f-a7e0-48d1-9e3b-b2a95f3b32ca" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
