### PR TITLE
fix: discover MCP Protected Resource Metadata when server does not return 401

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -325,53 +325,57 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
                 headers={'Content-Type': 'application/json'},
                 ssl=AIOHTTP_CLIENT_SESSION_SSL,
             ) as response:
-                if response.status == 401:
-                    resource_metadata_urls = []
-                    match = re.search(
-                        r'resource_metadata=(?:"([^"]+)"|([^\s,]+))',
-                        response.headers.get('WWW-Authenticate', ''),
-                    )
-                    if match:
-                        resource_metadata_urls = [match.group(1) or match.group(2)]
-                        log.debug(f'Found resource_metadata URL: {resource_metadata_urls[0]}')
-                    else:
-                        # Fall back to well-known resource metadata URIs (RFC 9728 §4.2)
-                        parsed, base_url = get_parsed_and_base_url(server_url)
-                        if parsed.path and parsed.path != '/':
-                            path = parsed.path.rstrip('/')
-                            resource_metadata_urls.append(
-                                urllib.parse.urljoin(base_url, f'/.well-known/oauth-protected-resource{path}')
-                            )
+                # Discover Protected Resource Metadata regardless of HTTP status.
+                # A 401 carries a WWW-Authenticate header pointing at the PRM, but
+                # some MCP servers (e.g. Google's gmail/drive/calendar remote MCPs)
+                # answer 200 to an anonymous `initialize`, so we must still fall
+                # back to the RFC 9728 well-known URIs when there is no 401/header.
+                resource_metadata_urls = []
+                match = re.search(
+                    r'resource_metadata=(?:"([^"]+)"|([^\s,]+))',
+                    response.headers.get('WWW-Authenticate', ''),
+                )
+                if match:
+                    resource_metadata_urls = [match.group(1) or match.group(2)]
+                    log.debug(f'Found resource_metadata URL: {resource_metadata_urls[0]}')
+                else:
+                    # Fall back to well-known resource metadata URIs (RFC 9728 §4.2)
+                    parsed, base_url = get_parsed_and_base_url(server_url)
+                    if parsed.path and parsed.path != '/':
+                        path = parsed.path.rstrip('/')
                         resource_metadata_urls.append(
-                            urllib.parse.urljoin(base_url, '/.well-known/oauth-protected-resource')
+                            urllib.parse.urljoin(base_url, f'/.well-known/oauth-protected-resource{path}')
                         )
-                        log.debug(f'No resource_metadata in header, trying well-known URIs: {resource_metadata_urls}')
+                    resource_metadata_urls.append(
+                        urllib.parse.urljoin(base_url, '/.well-known/oauth-protected-resource')
+                    )
+                    log.debug(f'No resource_metadata in header, trying well-known URIs: {resource_metadata_urls}')
 
-                    # Fetch Protected Resource metadata from candidate URLs
-                    for resource_metadata_url in resource_metadata_urls:
-                        try:
-                            async with session.get(
-                                resource_metadata_url, ssl=AIOHTTP_CLIENT_SESSION_SSL
-                            ) as resource_response:
-                                if resource_response.status == 200:
-                                    resource_metadata = await resource_response.json()
+                # Fetch Protected Resource metadata from candidate URLs
+                for resource_metadata_url in resource_metadata_urls:
+                    try:
+                        async with session.get(
+                            resource_metadata_url, ssl=AIOHTTP_CLIENT_SESSION_SSL
+                        ) as resource_response:
+                            if resource_response.status == 200:
+                                resource_metadata = await resource_response.json()
 
-                                    resource = resource_metadata.get('resource') or None
-                                    if resource:
-                                        log.debug(f'Discovered resource indicator: {resource}')
+                                resource = resource_metadata.get('resource') or None
+                                if resource:
+                                    log.debug(f'Discovered resource indicator: {resource}')
 
-                                    servers = resource_metadata.get('authorization_servers', [])
-                                    scopes = resource_metadata.get('scopes_supported', [])
-                                    if scopes:
-                                        log.debug(f'Discovered resource scopes: {scopes}')
+                                servers = resource_metadata.get('authorization_servers', [])
+                                scopes = resource_metadata.get('scopes_supported', [])
+                                if scopes:
+                                    log.debug(f'Discovered resource scopes: {scopes}')
 
-                                    if servers:
-                                        authorization_servers = servers
-                                        log.debug(f'Discovered authorization servers: {servers}')
-                                        break
-                        except Exception as e:
-                            log.debug(f'Failed to fetch resource metadata from {resource_metadata_url}: {e}')
-                            continue
+                                if servers:
+                                    authorization_servers = servers
+                                    log.debug(f'Discovered authorization servers: {servers}')
+                                    break
+                    except Exception as e:
+                        log.debug(f'Failed to fetch resource metadata from {resource_metadata_url}: {e}')
+                        continue
     except Exception as e:
         log.debug(f'MCP Protected Resource discovery failed: {e}')
 


### PR DESCRIPTION

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25977
- [x] **Target branch:** `dev`
- [x] **Description:** provided below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** no docs change needed (no user-facing configuration is added).
- [x] **Dependencies:** none added.
- [x] **Testing:** manually verified against Google's hosted Gmail MCP (`https://gmailmcp.googleapis.com/mcp/v1`) in a production deployment: before the change, scope/authorization-server discovery silently failed (the server answers 200 to an anonymous `initialize`); after the change, the PRM document is discovered via the RFC 9728 well-known URI and the OAuth flow requests the advertised scopes. Also verified that 401-responding servers keep the exact same behavior (the `WWW-Authenticate` hint is still preferred).
- [x] **No Unchecked AI Code:** human-reviewed and manually tested.
- [x] **Self-Review:** done.
- [x] **Architecture:** no new settings; pure bugfix.
- [x] **Git Hygiene:** single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`get_protected_resource_metadata()` only attempted RFC 9728 Protected Resource Metadata discovery when the anonymous `initialize` probe returned 401 with a `WWW-Authenticate` header. Some remote MCP servers — notably Google's hosted Gmail/Drive/Calendar MCPs — answer 200 to an anonymous `initialize` and only enforce authorization on `tools/call`, so OAuth scope and authorization-server discovery silently failed and those connections could not be authorized correctly.

This PR runs the discovery regardless of the probe's HTTP status: the `resource_metadata` URL from `WWW-Authenticate` is still preferred when present, and the RFC 9728 §4.2 well-known URIs are used as fallback otherwise. The change is a de-indentation of the existing block (plus an explanatory comment); behavior for 401-responding servers is unchanged.

Trade-off: for servers that expose no PRM document, connection setup now performs a couple of extra well-known GETs (404s, logged at debug). This only happens during MCP connection setup, not on regular tool calls.

### Fixed

- Fixed OAuth scope and authorization-server discovery for MCP servers that do not answer 401 to an anonymous `initialize` (e.g. Google's hosted Gmail/Drive/Calendar MCPs), by always attempting RFC 9728 Protected Resource Metadata discovery.

---

### Additional Information

- RFC 9728 §4.2 does not condition well-known PRM discovery on a 401 challenge; the challenge is just one way to learn the metadata URL.
- Reproduced and verified against `https://gmailmcp.googleapis.com/mcp/v1`.
- Relates to #25898 (same symptom family, different root cause: there the discovered scope is lost before `handle_authorize`; here PRM discovery never runs without a 401 challenge) and #24216.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
