### PR TITLE
feat: add MCP_OAUTH_ALLOWED_SCOPES to restrict OAuth scopes requested from MCP servers

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -554,6 +554,15 @@ try:
 except (ValueError, TypeError):
     MCP_INITIALIZE_TIMEOUT = 10
 
+# Optional allowlist restricting which OAuth scopes are requested when
+# connecting to an MCP server. Space- or comma-separated list of scope
+# strings; scopes advertised by a server that are not in the list are not
+# requested. Empty/unset keeps the default behavior (request everything
+# the server advertises). Useful for servers that advertise broad or
+# mutually-exclusive scopes, e.g. Google's Gmail MCP advertises both
+# gmail.metadata and the full-access mail.google.com scope.
+MCP_OAUTH_ALLOWED_SCOPES = os.getenv('MCP_OAUTH_ALLOWED_SCOPES', '').replace(',', ' ').split()
+
 
 ####################################
 # AIOHTTP Connection Pool

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -70,6 +70,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     ENABLE_OAUTH_EMAIL_FALLBACK,
     ENABLE_OAUTH_ID_TOKEN_COOKIE,
+    MCP_OAUTH_ALLOWED_SCOPES,
     OAUTH_CLIENT_INFO_ENCRYPTION_KEY,
     OAUTH_MAX_SESSIONS_PER_USER,
     REDIS_KEY_PREFIX,
@@ -287,6 +288,28 @@ def get_parsed_and_base_url(server_url) -> tuple[urllib.parse.ParseResult, str]:
     return parsed, base_url
 
 
+def _filter_scopes(scopes: list[str]) -> list[str]:
+    """
+    Optionally restrict discovered OAuth scopes to an admin-defined allowlist.
+
+    Set MCP_OAUTH_ALLOWED_SCOPES (space- or comma-separated) to limit which of
+    a server's advertised scopes are actually requested. Some servers advertise
+    broad or mutually-exclusive scopes — e.g. Google's Gmail MCP advertises
+    both gmail.metadata and the full-access mail.google.com scope — and
+    requesting all of them can break operations or over-grant access.
+
+    Scopes are matched exactly; any advertised scope not in the allowlist is
+    dropped. If the env var is unset/empty, all discovered scopes are kept
+    (default behavior).
+    """
+    if not MCP_OAUTH_ALLOWED_SCOPES:
+        return scopes
+    allowed = set(MCP_OAUTH_ALLOWED_SCOPES)
+    filtered = [s for s in scopes if s in allowed]
+    log.debug(f'Scope allowlist active: advertised {scopes} -> requesting {filtered}')
+    return filtered
+
+
 @dataclass
 class ProtectedResourceMetadata:
     """RFC 9728 Protected Resource Metadata fields relevant to OAuth flows."""
@@ -449,7 +472,9 @@ async def get_oauth_client_info_with_dynamic_client_registration(
                                 oauth_client_metadata.scope is None
                                 and oauth_server_metadata.scopes_supported is not None
                             ):
-                                oauth_client_metadata.scope = ' '.join(oauth_server_metadata.scopes_supported)
+                                _scopes = _filter_scopes(oauth_server_metadata.scopes_supported)
+                                if _scopes:
+                                    oauth_client_metadata.scope = ' '.join(_scopes)
 
                             if (
                                 oauth_server_metadata.token_endpoint_auth_methods_supported
@@ -565,7 +590,8 @@ async def get_oauth_client_info_with_static_credentials(
         # Unlike the Authorization Server's scopes_supported (which is a full catalog
         # of every scope the server can grant), the PRM scopes_supported represents
         # what this specific resource requires — making it safe to request them all.
-        scope = ' '.join(resource_metadata.scopes_supported) if resource_metadata.scopes_supported else None
+        _scopes = _filter_scopes(resource_metadata.scopes_supported)
+        scope = ' '.join(_scopes) if _scopes else None
 
         # Determine token_endpoint_auth_method
         token_endpoint_auth_method = 'client_secret_post'


### PR DESCRIPTION

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25978
- [x] **Target branch:** `dev`
- [x] **Description:** provided below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** will submit an env-var documentation entry to the docs repo if this is accepted.
- [x] **Dependencies:** none added.
- [x] **Testing:** manually verified against Google's hosted Gmail MCP in a production deployment. With `MCP_OAUTH_ALLOWED_SCOPES="https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose"`, the Google consent screen and the issued token contain exactly those two scopes (confirmed via the tokeninfo endpoint), and full-content reads work — whereas requesting the full advertised catalog (including `gmail.metadata`) breaks them. With the variable unset, behavior is byte-identical to current `dev`.
- [x] **No Unchecked AI Code:** human-reviewed and manually tested.
- [x] **Self-Review:** done.
- [x] **Architecture:** opt-in env var, no behavior change by default; declared in `env.py` following the existing `MCP_INITIALIZE_TIMEOUT` pattern.
- [x] **Git Hygiene:** single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

Open WebUI currently requests every OAuth scope an MCP server advertises (AS metadata `scopes_supported` during dynamic client registration, or RFC 9728 PRM `scopes_supported` with static credentials). Some servers advertise catalogs that are broader than needed or mutually exclusive — Google's Gmail MCP advertises `gmail.metadata` alongside the full-access `https://mail.google.com/` scope; requesting both over-grants access and breaks full-content reads.

This PR adds an optional `MCP_OAUTH_ALLOWED_SCOPES` environment variable (space- or comma-separated allowlist) applied at both scope-construction sites via a small `_filter_scopes()` helper. When unset (default), behavior is unchanged. If filtering leaves no scopes, the flow falls back to requesting no explicit scope (`scope=None`) rather than sending an empty string.

### Added

- Added `MCP_OAUTH_ALLOWED_SCOPES` environment variable: an optional space- or comma-separated allowlist restricting which OAuth scopes are requested when connecting to MCP servers. Unset by default (no behavior change).

---

### Additional Information

- This is a deployment-level least-privilege knob. A per-connection scope selector in the Tool Server connection UI would be a natural follow-up, but the env var covers the multi-connection case today because scope strings are globally unique per service.
- Scope strings are matched exactly (no globbing) to keep semantics predictable.
- Relates to #25950 (DCR seeding scopes from the AS catalog instead of the PRM — the over-broad-scope scenario this allowlist mitigates) and #23668.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
