### PR TITLE
Fix: strip <think> tags to prevent JSON extraction failures

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1535,8 +1535,9 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
 
         response = res['choices'][0]['message']['content']
 
+        response = re.sub(r'<think>.*?</think>', '', response, flags=re.DOTALL)
         try:
-            bracket_start = response.rfind('{')
+            bracket_start = response.find('{')
             bracket_end = response.rfind('}') + 1
 
             if bracket_start == -1 or bracket_end == -1:
@@ -1875,8 +1876,9 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
 
                 response = res['choices'][0]['message']['content']
 
+                response = re.sub(r'<think>.*?</think>', '', response, flags=re.DOTALL)
                 try:
-                    bracket_start = response.rfind('{')
+                    bracket_start = response.find('{')
                     bracket_end = response.rfind('}') + 1
 
                     if bracket_start == -1 or bracket_end == -1:
@@ -1979,8 +1981,9 @@ async def chat_completion_files_handler(
                 )
                 queries_response = queries_response['choices'][0]['message']['content']
 
+                queries_response = re.sub(r'<think>.*?</think>', '', queries_response, flags=re.DOTALL)
                 try:
-                    bracket_start = queries_response.rfind('{')
+                    bracket_start = queries_response.find('{')
                     bracket_end = queries_response.rfind('}') + 1
 
                     if bracket_start == -1 or bracket_end == -1:


### PR DESCRIPTION
Reasoning models output `<think>` metadata tags that often precede RAG JSON outputs, causing `json.loads()` to crash. This PR implements a regex cleaner to strip out `<think>` blocks.