### PR TITLE
fix: resolve message_ids key collision in side-by-side chat with identical models

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1746,13 +1746,22 @@ async def chat_completion(
         parent_id = form_data.pop('parent_id', None)
         form_data.pop('new_chat', None)  # Legacy field
 
-        # Multi-model: {model_id: assistant_message_id}
+        # Multi-model: {model_key: assistant_message_id}
         # Single-model fallback: built from 'model' + 'id'
+        # Keys may carry a "::N" suffix to disambiguate when the same model
+        # is selected in multiple panes (e.g., "gemma3:270m::0", "gemma3:270m::1").
         message_ids = form_data.pop('message_ids', None)
         if not message_ids:
             message_ids = {model_id: form_data.pop('id', None)}
         else:
             form_data.pop('id', None)
+
+        def _resolve_model_id(key: str) -> str:
+            """Strip the ``::N`` pane-index suffix added by the frontend for
+            side-by-side chats that use the same model in multiple panes."""
+            idx = key.rfind('::')
+            return key[:idx] if idx != -1 else key
+
 
         user_message = form_data.pop('user_message', None) or form_data.pop('parent_message', None)
 
@@ -1855,7 +1864,7 @@ async def chat_completion(
                         user_message['childrenIds'] = all_assistant_ids
                         history_messages[user_message_id] = user_message
 
-                    for target_model_id, assistant_message_id in message_ids.items():
+                    for target_model_key, assistant_message_id in message_ids.items():
                         if assistant_message_id:
                             history_messages[assistant_message_id] = {
                                 'id': assistant_message_id,
@@ -1864,7 +1873,7 @@ async def chat_completion(
                                 'role': 'assistant',
                                 'content': '',
                                 'done': False,
-                                'model': target_model_id,
+                                'model': _resolve_model_id(target_model_key),
                                 'timestamp': int(time.time()),
                             }
 
@@ -1875,7 +1884,7 @@ async def chat_completion(
                             chat={
                                 'id': chat_id,
                                 'title': 'New Chat',
-                                'models': list(message_ids.keys()),
+                                'models': [_resolve_model_id(k) for k in message_ids.keys()],
                                 'history': {
                                     'currentId': all_assistant_ids[0] if all_assistant_ids else user_message_id,
                                     'messages': history_messages,
@@ -1986,7 +1995,7 @@ async def chat_completion(
                             )
 
                     # Save each assistant placeholder
-                    for target_model_id, assistant_message_id in message_ids.items():
+                    for target_model_key, assistant_message_id in message_ids.items():
                         if assistant_message_id:
                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                 chat_id,
@@ -1998,7 +2007,7 @@ async def chat_completion(
                                     'role': 'assistant',
                                     'content': '',
                                     'done': False,
-                                    'model': target_model_id,
+                                    'model': _resolve_model_id(target_model_key),
                                     'timestamp': int(time.time()),
                                 },
                             )
@@ -2138,9 +2147,11 @@ async def chat_completion(
         task_ids = []
         chat_id = metadata['chat_id']
 
-        for idx, (target_model_id, assistant_message_id) in enumerate(message_ids.items()):
+        for idx, (target_model_key, assistant_message_id) in enumerate(message_ids.items()):
             if not assistant_message_id:
                 continue
+
+            real_model_id = _resolve_model_id(target_model_key)
 
             # Per-model metadata: own message_id + model
             per_model_metadata = {
@@ -2151,12 +2162,12 @@ async def chat_completion(
             # Per-model form_data: own model
             model_form_data = {
                 **form_data,
-                'model': target_model_id,
+                'model': real_model_id,
                 'metadata': per_model_metadata,
             }
 
             # Resolve the model object for this specific model
-            resolved_model = request.app.state.MODELS.get(target_model_id, model)
+            resolved_model = request.app.state.MODELS.get(real_model_id, model)
 
             # Only the first model runs title/tags generation;
             # subsequent models only run follow-ups.

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2099,8 +2099,11 @@
 				: selectedModels;
 
 		// Create response messages for each selected model
-		// Build message_ids map: {model_id: assistant_message_id}
+		// Build message_ids map: {model_key: assistant_message_id}
+		// When the same model ID is selected multiple times (side-by-side with identical models),
+		// disambiguate by appending ::index (e.g., "gemma3:270m::0", "gemma3:270m::1").
 		const messageIdsMap: Record<string, string> = {};
+		const hasDuplicateModels = new Set(selectedModelIds).size !== selectedModelIds.length;
 		for (const [_modelIdx, modelId] of selectedModelIds.entries()) {
 			const model = $models.filter((m) => m.id === modelId).at(0);
 
@@ -2132,7 +2135,10 @@
 				}
 
 				responseMessageIds[`${modelId}-${modelIdx ? modelIdx : _modelIdx}`] = responseMessageId;
-				messageIdsMap[modelId] = responseMessageId;
+				const mapKey = hasDuplicateModels
+					? `${modelId}::${modelIdx ? modelIdx : _modelIdx}`
+					: modelId;
+				messageIdsMap[mapKey] = responseMessageId;
 			}
 		}
 		history = history;
@@ -2178,7 +2184,8 @@
 		// Single request — backend fans out to all models
 		const primaryModelId = selectedModelIds[0];
 		const primaryModel = $models.filter((m) => m.id === primaryModelId).at(0);
-		const primaryResponseMessageId = messageIdsMap[primaryModelId];
+		const primaryMapKey = hasDuplicateModels ? `${primaryModelId}::0` : primaryModelId;
+		const primaryResponseMessageId = messageIdsMap[primaryMapKey];
 
 		if (primaryModel && primaryResponseMessageId) {
 			const chatEventEmitter = await getChatEventEmitter(primaryModel.id, _chatId);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #25982 — Side-by-side chat with identical model IDs causes `message_ids` key collision, leaving one pane stuck waiting.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

When the same model is selected in both panes of a side-by-side chat (e.g., `gemma3:270m` vs `gemma3:270m`), the `message_ids` map in the frontend uses the raw model ID as the dictionary key. Since both panes share the same model ID, the second entry silently overwrites the first — only one assistant `message_id` survives. The backend then creates only one fan-out task, leaving the other pane stuck in a permanent "waiting for response" state with an unresponsive stop button.

**Root cause:** `messageIdsMap[modelId] = responseMessageId` at line 2135 in `Chat.svelte` — a plain object key collision when the same model ID appears twice.

**Fix:** Detect duplicate model IDs and disambiguate the map keys by appending a `::index` suffix (e.g., `"gemma3:270m::0"`, `"gemma3:270m::1"`). The backend strips this suffix via a new `_resolve_model_id()` helper before using the key as an actual model identifier for routing, storage, and fan-out. When all selected models are unique, keys remain unchanged (fully backward compatible).

Key diff (frontend — `Chat.svelte`):

```diff
+const hasDuplicateModels = new Set(selectedModelIds).size !== selectedModelIds.length;
 // ...inside the loop:
-messageIdsMap[modelId] = responseMessageId;
+const mapKey = hasDuplicateModels
+    ? `${modelId}::${modelIdx ? modelIdx : _modelIdx}`
+    : modelId;
+messageIdsMap[mapKey] = responseMessageId;
```

Key diff (backend — `main.py`):

```diff
+def _resolve_model_id(key: str) -> str:
+    """Strip the ``::N`` pane-index suffix added by the frontend."""
+    idx = key.rfind('::')
+    return key[:idx] if idx != -1 else key
```

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Side-by-side chat with the same model selected in both panes now correctly streams independent responses to each pane instead of leaving the others stuck waiting.

# Changelog Entry

### Additional Information

- **Files changed:** `src/lib/components/chat/Chat.svelte` (frontend key construction), `backend/open_webui/main.py` (backend key resolution)
- **Scope:** 2 files, ~30 insertions, ~12 deletions
- **Backward compatible:** When all selected models have unique IDs, the `::N` suffix is not appended — the payload is identical to the current behavior
- The existing `responseMessageIds` map (used internally for frontend state) already used a composite `${modelId}-${modelIdx}` key, so this pattern is consistent with the codebase

### Screenshots or Videos

## Before:

<img width="2018" height="1285" alt="image" src="https://github.com/user-attachments/assets/5d827e77-3807-429f-8222-1ec12a11f727" />

## After:
<img width="2018" height="1285" alt="image" src="https://github.com/user-attachments/assets/8f3d6307-5b78-4127-bf3d-05f308810716" />

### Manual Verification Performed

1. Started Open WebUI with a local Ollama model (`gemma3:270m`)
2. Opened a new chat and selected the same model in both side-by-side panes
3. Sent a prompt — **before fix:** one pane stuck waiting; **after fix:** both panes independently stream their responses
4. Verified that using two *different* models still works correctly (no `::N` suffix appended)
5. Verified single-model chat (no side-by-side) is unaffected
6. Reloaded the page after a side-by-side chat with identical models — both panes display their own distinct responses
7. `npm run format` → no changes, `npm run build` → success, `npm run test:frontend` → pass

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
