### PR TITLE
Fix: anthropic cache control propagation

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2251,6 +2251,10 @@ async def generate_messages(
     # Convert Anthropic payload to OpenAI format
     requested_model = form_data.get('model', '')
 
+    # Plugin clients manage their own tools/prompts; skip OWUI middleware mutation.
+    request.state.client_managed_tools = True
+    request.state.bypass_system_prompt = True
+
     openai_payload = convert_anthropic_to_openai_payload(form_data)
 
     # Route through the existing chat_completion handler

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -38,7 +38,11 @@ from open_webui.models.groups import Groups
 from open_webui.models.models import Models
 from open_webui.models.users import UserModel
 from open_webui.utils.access_control import check_model_access, has_connection_access
-from open_webui.utils.anthropic import get_anthropic_models, is_anthropic_url
+from open_webui.utils.anthropic import (
+    get_anthropic_forward_headers,
+    get_anthropic_models,
+    is_anthropic_url,
+)
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
 from open_webui.utils.misc import (
@@ -209,6 +213,9 @@ async def get_headers_and_cookies(
     if config.get('headers') and isinstance(config.get('headers'), dict):
         custom_headers = get_custom_headers(config.get('headers'), user, metadata)
         headers.update(custom_headers)
+
+    if getattr(request.state, 'client_managed_tools', False):
+        headers.update(get_anthropic_forward_headers(request.headers))
 
     return headers, cookies
 
@@ -1139,7 +1146,7 @@ async def generate_chat_completion(
     key = request.app.state.config.OPENAI_API_KEYS[idx]
 
     # Check if model is a reasoning model that needs special handling
-    if is_openai_new_model(payload['model']):
+    if is_openai_new_model(payload['model']) and not getattr(request.state, 'client_managed_tools', False):
         payload = openai_reasoning_model_handler(payload)
     elif 'api.openai.com' not in url:
         # Remove "max_completion_tokens" from the payload for backward compatibility

--- a/backend/open_webui/static/custom.css
+++ b/backend/open_webui/static/custom.css
@@ -1,0 +1,158 @@
+/* Expedient AI Hub Custom Branding */
+
+/* ── Brand tokens: edit here to retheme ── */
+:root {
+	/* Light mode variables */
+	--sidebar-main-lightmode: #262626;
+	--sidebar-hover-lightmode: #d10404;
+	--sidebar-text-lightmode: #ffffff;
+	--sidebar-subheader-lightmode: #f20505;
+	--logo-url-lightmode: url('https://expedient.com/uploads/logo-light.png');
+	--logo-opacity-lightmode: 0.7;
+
+	/* Dark mode variables */
+	--sidebar-main-darkmode: #262626;
+	--sidebar-hover-darkmode: #d10404;
+	--sidebar-text-darkmode: #ffffff;
+	--sidebar-subheader-darkmode: #f20505;
+	--logo-url-darkmode: url('https://expedient.com/uploads/logo-dark.png');
+	--logo-opacity-darkmode: 0.7;
+}
+
+/* ── Solid sidebar background + no red right border on collapsed state ── */
+#sidebar {
+	background-color: var(--sidebar-bg) !important;
+	border-color: transparent !important;
+}
+
+/* ── Less rounded buttons (rounded-xl/2xl → rounded-lg) ── */
+#sidebar .rounded-xl,
+#sidebar .rounded-2xl {
+	border-radius: 0.5rem !important;
+}
+
+/* ── Light mode sidebar ──
+   Resolve mode-specific tokens into generic aliases used by all rules below. */
+html.light #sidebar {
+	--sidebar-bg: var(--sidebar-main-lightmode);
+	--sidebar-hover: var(--sidebar-hover-lightmode);
+	--sidebar-text: var(--sidebar-text-lightmode);
+	--sidebar-accent: var(--sidebar-subheader-lightmode);
+
+	color: var(--sidebar-text) !important;
+	--color-gray-50: var(--sidebar-bg);
+	--color-gray-100: var(--sidebar-hover);
+	--color-gray-200: #3d3d3d;
+	--color-gray-300: #555555;
+	--color-gray-400: var(--sidebar-accent);
+	--color-gray-500: var(--sidebar-accent);
+	--color-gray-600: var(--sidebar-accent);
+	--color-gray-700: var(--sidebar-accent);
+	--color-gray-800: var(--sidebar-text);
+	--color-gray-850: var(--sidebar-bg);
+	--color-gray-900: var(--sidebar-text);
+	--color-gray-950: var(--sidebar-bg);
+}
+
+/* ── Dark mode sidebar ──
+   OWUI JS sets gray-800–950 as inline styles on <html>;
+   our #sidebar declaration wins for all descendants. */
+html.dark #sidebar {
+	--sidebar-bg: var(--sidebar-main-darkmode);
+	--sidebar-hover: var(--sidebar-hover-darkmode);
+	--sidebar-text: var(--sidebar-text-darkmode);
+	--sidebar-accent: var(--sidebar-subheader-darkmode);
+
+	--color-gray-50: var(--sidebar-bg);
+	--color-gray-100: var(--sidebar-hover);
+	--color-gray-200: var(--sidebar-text);
+	--color-gray-300: var(--sidebar-text);
+	--color-gray-400: var(--sidebar-accent);
+	--color-gray-500: var(--sidebar-accent);
+	--color-gray-600: var(--sidebar-accent);
+	--color-gray-700: #555555;
+	--color-gray-800: #3d3d3d;
+	--color-gray-850: var(--sidebar-hover);
+	--color-gray-900: var(--sidebar-hover);
+	--color-gray-950: var(--sidebar-bg);
+}
+
+/* ── Selected state: text on colored background ── */
+#sidebar .selected,
+#sidebar .selected * {
+	color: var(--sidebar-text) !important;
+}
+
+/* ── Hover: solid background + text color ── */
+#sidebar [class*='hover:bg-gray']:hover {
+	background-color: var(--sidebar-hover) !important;
+	color: var(--sidebar-text) !important;
+}
+
+#sidebar [class*='hover:bg-gray']:hover * {
+	color: var(--sidebar-text) !important;
+}
+
+/* ── Chat item hover ── */
+#sidebar-chat-group:hover #sidebar-chat-item {
+	background-color: var(--sidebar-hover) !important;
+}
+
+#sidebar-chat-group:hover #sidebar-chat-item * {
+	color: var(--sidebar-text) !important;
+}
+
+/* Ellipsis gradient: match hover color in dark mode */
+html.dark #sidebar-chat-group:hover #sidebar-chat-item-menu {
+	--color-gray-950: var(--sidebar-hover-darkmode);
+}
+
+/* ── Status indicator border: match sidebar bg so no bleed ── */
+html.light #sidebar .border-white,
+html.dark #sidebar .dark\:border-gray-900 {
+	border-color: var(--sidebar-bg) !important;
+}
+
+/* ── Sidebar header: brand name + close button ── */
+#sidebar #sidebar-webui-name {
+	color: var(--sidebar-accent) !important;
+}
+
+#sidebar button[aria-label='Close Sidebar'] {
+	color: var(--sidebar-text) !important;
+}
+
+/* ===== CHAT BAR LOGO ===== */
+#message-input-container::after {
+	content: '';
+	position: absolute;
+	bottom: 12px;
+	right: 130px;
+	width: 120px;
+	height: 30px;
+	background-repeat: no-repeat !important;
+	background-position: center right !important;
+	background-size: contain !important;
+	pointer-events: none !important;
+	z-index: 0;
+}
+
+/* Light/Dark specific logo and opacity */
+html.light #message-input-container::after {
+	background-image: var(--logo-url-lightmode);
+	opacity: var(--logo-opacity-lightmode);
+}
+
+html.dark #message-input-container::after {
+	background-image: var(--logo-url-darkmode);
+	opacity: var(--logo-opacity-darkmode);
+}
+
+/* Mobile: shrink chat bar logo */
+@media (max-width: 640px) {
+	#message-input-container::after {
+		width: 72px !important;
+		height: 20px !important;
+		right: 130px !important;
+	}
+}

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -88,6 +88,70 @@ async def get_anthropic_models(url: str, key: str, user: UserModel = None) -> di
 #
 ##############################
 
+# Client headers forwarded to upstream gateways that proxy Anthropic APIs.
+ANTHROPIC_FORWARD_HEADER_NAMES = (
+    'anthropic-beta',
+    'anthropic-version',
+)
+
+# Top-level Anthropic request fields passed through to OpenAI-shaped gateways.
+# Note: `thinking` is intentionally excluded — plugin clients may send adaptive
+# thinking on every request, but OpenAI-shaped gateways reject it for models
+# that do not support it (e.g. Haiku sidecar calls).
+ANTHROPIC_PASSTHROUGH_PARAMS = (
+    'metadata',
+    'top_k',
+    'service_tier',
+)
+
+
+def get_anthropic_forward_headers(request_headers) -> dict[str, str]:
+    """Return Anthropic client headers that should reach the upstream gateway."""
+    return {
+        name: request_headers[name]
+        for name in ANTHROPIC_FORWARD_HEADER_NAMES
+        if request_headers.get(name)
+    }
+
+
+def _copy_cache_control(source: dict, target: dict) -> None:
+    cache_control = source.get('cache_control')
+    if cache_control:
+        target['cache_control'] = cache_control
+
+
+def _finalize_openai_content(openai_content: list) -> str | list:
+    """Flatten single plain text blocks; keep arrays when cache_control is present."""
+    if (
+        len(openai_content) == 1
+        and openai_content[0].get('type') == 'text'
+        and not openai_content[0].get('cache_control')
+    ):
+        return openai_content[0]['text']
+    return openai_content
+
+
+def _anthropic_usage_from_openai(openai_usage: dict) -> dict:
+    usage = {
+        'input_tokens': openai_usage.get('prompt_tokens', 0),
+        'output_tokens': openai_usage.get('completion_tokens', 0),
+    }
+    for key in (
+        'cache_creation_input_tokens',
+        'cache_read_input_tokens',
+        'cache_creation',
+    ):
+        if key in openai_usage:
+            usage[key] = openai_usage[key]
+
+    prompt_details = openai_usage.get('prompt_tokens_details') or {}
+    if isinstance(prompt_details, dict):
+        cached_tokens = prompt_details.get('cached_tokens')
+        if cached_tokens is not None and 'cache_read_input_tokens' not in usage:
+            usage['cache_read_input_tokens'] = cached_tokens
+
+    return usage
+
 
 def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
     """
@@ -112,14 +176,27 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
         if isinstance(system, str):
             messages.append({'role': 'system', 'content': system})
         elif isinstance(system, list):
-            # Anthropic supports system as list of content blocks
-            text_parts = []
+            # Preserve block structure (and cache_control) when present.
+            system_blocks = []
             for block in system:
                 if isinstance(block, dict) and block.get('type') == 'text':
-                    text_parts.append(block.get('text', ''))
+                    system_block = {
+                        'type': 'text',
+                        'text': block.get('text', ''),
+                    }
+                    _copy_cache_control(block, system_block)
+                    system_blocks.append(system_block)
                 elif isinstance(block, str):
-                    text_parts.append(block)
-            messages.append({'role': 'system', 'content': '\n'.join(text_parts)})
+                    system_blocks.append({'type': 'text', 'text': block})
+
+            if (
+                len(system_blocks) == 1
+                and system_blocks[0].get('type') == 'text'
+                and not system_blocks[0].get('cache_control')
+            ):
+                messages.append({'role': 'system', 'content': system_blocks[0]['text']})
+            elif system_blocks:
+                messages.append({'role': 'system', 'content': system_blocks})
 
     # Convert messages
     for msg in anthropic_payload.get('messages', []):
@@ -137,12 +214,12 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                 block_type = block.get('type', 'text')
 
                 if block_type == 'text':
-                    openai_content.append(
-                        {
-                            'type': 'text',
-                            'text': block.get('text', ''),
-                        }
-                    )
+                    text_block = {
+                        'type': 'text',
+                        'text': block.get('text', ''),
+                    }
+                    _copy_cache_control(block, text_block)
+                    openai_content.append(text_block)
                 elif block_type == 'image':
                     source = block.get('source', {})
                     if source.get('type') == 'base64':
@@ -195,12 +272,12 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                             content_type = content_block.get('type', 'text')
 
                             if content_type == 'text':
-                                converted_parts.append(
-                                    {
-                                        'type': 'text',
-                                        'text': content_block.get('text', ''),
-                                    }
-                                )
+                                text_part = {
+                                    'type': 'text',
+                                    'text': content_block.get('text', ''),
+                                }
+                                _copy_cache_control(content_block, text_part)
+                                converted_parts.append(text_part)
                             elif content_type == 'image':
                                 source = content_block.get('source', {})
                                 if source.get('type') == 'base64':
@@ -287,21 +364,13 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                 # Assistant message with tool calls
                 msg_dict = {'role': role}
                 if openai_content:
-                    # If there's only text, flatten it
-                    if len(openai_content) == 1 and openai_content[0]['type'] == 'text':
-                        msg_dict['content'] = openai_content[0]['text']
-                    else:
-                        msg_dict['content'] = openai_content
+                    msg_dict['content'] = _finalize_openai_content(openai_content)
                 else:
                     msg_dict['content'] = ''
                 msg_dict['tool_calls'] = tool_calls
                 messages.append(msg_dict)
             elif openai_content:
-                # If there's only a single text block, flatten it to a string
-                if len(openai_content) == 1 and openai_content[0]['type'] == 'text':
-                    messages.append({'role': role, 'content': openai_content[0]['text']})
-                else:
-                    messages.append({'role': role, 'content': openai_content})
+                messages.append({'role': role, 'content': _finalize_openai_content(openai_content)})
         else:
             messages.append({'role': role, 'content': str(content) if content else ''})
 
@@ -323,16 +392,16 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
     if 'tools' in anthropic_payload:
         openai_tools = []
         for tool in anthropic_payload['tools']:
-            openai_tools.append(
-                {
-                    'type': 'function',
-                    'function': {
-                        'name': tool.get('name', ''),
-                        'description': tool.get('description', ''),
-                        'parameters': tool.get('input_schema', {}),
-                    },
-                }
-            )
+            openai_tool = {
+                'type': 'function',
+                'function': {
+                    'name': tool.get('name', ''),
+                    'description': tool.get('description', ''),
+                    'parameters': tool.get('input_schema', {}),
+                },
+            }
+            _copy_cache_control(tool, openai_tool)
+            openai_tools.append(openai_tool)
         openai_payload['tools'] = openai_tools
 
     # tool_choice
@@ -349,6 +418,14 @@ def convert_anthropic_to_openai_payload(anthropic_payload: dict) -> dict:
                     'type': 'function',
                     'function': {'name': tc.get('name', '')},
                 }
+
+    for param in ANTHROPIC_PASSTHROUGH_PARAMS:
+        if param in anthropic_payload:
+            openai_payload[param] = anthropic_payload[param]
+
+    system_raw = anthropic_payload.get('system')
+    if isinstance(system_raw, list):
+        openai_payload['system'] = system_raw
 
     return openai_payload
 
@@ -382,7 +459,7 @@ def convert_openai_to_anthropic_response(openai_response: dict, model: str = '')
         content.append({'type': 'text', 'text': msg_content})
 
     # Tool calls → tool_use blocks
-    tool_calls = message.get('tool_calls', [])
+    tool_calls = message.get('tool_calls') or []
     for tc in tool_calls:
         func = tc.get('function', {})
         try:
@@ -398,12 +475,9 @@ def convert_openai_to_anthropic_response(openai_response: dict, model: str = '')
             }
         )
 
-    # Usage
-    openai_usage = openai_response.get('usage', {})
-    usage = {
-        'input_tokens': openai_usage.get('prompt_tokens', 0),
-        'output_tokens': openai_usage.get('completion_tokens', 0),
-    }
+    # Usage (include prompt-cache token counts when upstream provides them)
+    openai_usage = openai_response.get('usage', {}) or {}
+    usage = _anthropic_usage_from_openai(openai_usage)
 
     return {
         'id': openai_response.get('id', f'msg_{_uuid.uuid4().hex[:24]}'),
@@ -430,8 +504,7 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
     import uuid as _uuid
 
     msg_id = f'msg_{_uuid.uuid4().hex[:24]}'
-    input_tokens = 0
-    output_tokens = 0
+    final_usage: dict = {}
     stop_reason = 'end_turn'
 
     # Track content blocks with a running index.
@@ -486,8 +559,7 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
                 if not choices:
                     # Check for usage in the final chunk
                     if data.get('usage'):
-                        input_tokens = data['usage'].get('prompt_tokens', input_tokens)
-                        output_tokens = data['usage'].get('completion_tokens', output_tokens)
+                        final_usage = data['usage']
                     continue
 
                 delta = choices[0].get('delta', {})
@@ -495,8 +567,7 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
 
                 # Update usage if present
                 if data.get('usage'):
-                    input_tokens = data['usage'].get('prompt_tokens', input_tokens)
-                    output_tokens = data['usage'].get('completion_tokens', output_tokens)
+                    final_usage = data['usage']
 
                 # --- Handle text content ---
                 content = delta.get('content')
@@ -593,13 +664,19 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
         yield f'event: content_block_stop\ndata: {json.dumps(block_stop)}\n\n'.encode()
 
     # Emit message_delta with stop reason
+    anthropic_usage = _anthropic_usage_from_openai(final_usage) if final_usage else {'output_tokens': 0}
+    if 'input_tokens' not in anthropic_usage:
+        anthropic_usage.setdefault('input_tokens', 0)
+    if 'output_tokens' not in anthropic_usage:
+        anthropic_usage['output_tokens'] = 0
+
     message_delta = {
         'type': 'message_delta',
         'delta': {
             'stop_reason': stop_reason,
             'stop_sequence': None,
         },
-        'usage': {'output_tokens': output_tokens},
+        'usage': anthropic_usage,
     }
     yield f'event: message_delta\ndata: {json.dumps(message_delta)}\n\n'.encode()
 

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -160,11 +160,11 @@ async def generate_chat_completion(
     if BYPASS_MODEL_ACCESS_CONTROL:
         bypass_filter = True
 
-    # Propagate bypass_filter and bypass_system_prompt via request.state so that
-    # downstream route handlers (openai/ollama) can read them without exposing
-    # them as query parameters.
     request.state.bypass_filter = bypass_filter
-    request.state.bypass_system_prompt = bypass_system_prompt
+    if getattr(request.state, 'client_managed_tools', False):
+        request.state.bypass_system_prompt = True
+    else:
+        request.state.bypass_system_prompt = bypass_system_prompt
 
     if hasattr(request.state, 'metadata'):
         if 'metadata' not in form_data:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2313,6 +2313,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if not isinstance(metadata.get('chat_id'), str):
         metadata['chat_id'] = ''
 
+    # Anthropic /api/v1/messages plugin clients manage their own payload.
+    client_managed_tools = getattr(request.state, 'client_managed_tools', False)
+
     # Pipeline Inlet -> Filter Inlet -> Chat Memory -> Chat Web Search -> Chat Image Generation
     # -> Chat Code Interpreter (Form Data Update) -> (Default) Chat Tools Function Calling
     # -> Chat Files
@@ -2407,7 +2410,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     )
 
     system_message = get_system_message(form_data.get('messages', []))
-    if system_message:  # Chat Controls/User Settings
+    if system_message and not client_managed_tools:  # Chat Controls/User Settings
         try:
             form_data = await apply_system_prompt_to_body(
                 system_message.get('content'), form_data, metadata, user, replace=True
@@ -2462,7 +2465,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if not folder_id:
         folder_id = metadata.get('folder_id', None)
 
-    if folder_id and user:
+    if folder_id and user and not client_managed_tools:
         folder = await Folders.get_folder_by_id_and_user_id(folder_id, user.id)
 
         if folder and folder.data:
@@ -2485,7 +2488,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     user_message = get_last_user_message(form_data['messages'])
     model_knowledge = model.get('info', {}).get('meta', {}).get('knowledge', False)
 
-    if model_knowledge and metadata.get('params', {}).get('function_calling') != 'native':
+    if (
+        model_knowledge
+        and not client_managed_tools
+        and metadata.get('params', {}).get('function_calling') != 'native'
+    ):
         await event_emitter(
             {
                 'type': 'status',
@@ -2526,25 +2533,26 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     variables = form_data.pop('variables', None)
     payload_tools = form_data.get('tools', None)  # snapshot before filters
 
-    # Process the form_data through the pipeline
-    try:
-        form_data = await process_pipeline_inlet_filter(request, form_data, user, models)
-    except Exception as e:
-        raise e
+    # Process the form_data through the pipeline (skip for plugin-managed payloads)
+    if not client_managed_tools:
+        try:
+            form_data = await process_pipeline_inlet_filter(request, form_data, user, models)
+        except Exception as e:
+            raise e
 
-    try:
-        filter_ids = await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
-        filter_functions = await Functions.get_functions_by_ids(filter_ids)
+        try:
+            filter_ids = await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
+            filter_functions = await Functions.get_functions_by_ids(filter_ids)
 
-        form_data, flags = await process_filter_functions(
-            request=request,
-            filter_functions=filter_functions,
-            filter_type='inlet',
-            form_data=form_data,
-            extra_params=extra_params,
-        )
-    except Exception as e:
-        raise Exception(f'{e}')
+            form_data, flags = await process_filter_functions(
+                request=request,
+                filter_functions=filter_functions,
+                filter_type='inlet',
+                form_data=form_data,
+                extra_params=extra_params,
+            )
+        except Exception as e:
+            raise Exception(f'{e}')
 
     features = form_data.pop('features', None) or {}
     extra_params['__features__'] = features
@@ -2706,8 +2714,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     # When the caller provides an explicit OpenAI-style `tools` array in the
     # request body, skip all server-side tool resolution and pass the caller's
-    # tools through to the model unchanged.
-    if not payload_tools:
+    # tools through to the model unchanged. Client-managed clients (e.g.
+    # /api/v1/messages) must not get OWUI tools on turns that omit tools.
+    if client_managed_tools and not payload_tools:
+        form_data.pop('tools', None)
+    elif not payload_tools:
         # Server side tools
         tool_ids = metadata.get('tool_ids', None)
         # Client side tools
@@ -2932,9 +2943,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # to prevent errors from providers like Gemini and Claude
     form_data['messages'] = strip_empty_content_blocks(form_data.get('messages', []))
 
-    # Merge any duplicate system messages into a single message at position 0
-    # to prevent template parsing errors with strict chat templates (e.g. Qwen)
-    form_data['messages'] = merge_system_messages(form_data.get('messages', []))
+    if not client_managed_tools:
+        form_data['messages'] = merge_system_messages(form_data.get('messages', []))
 
     return form_data, metadata, events
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: `fix`

Relates to #___ <!-- replace with issue/discussion URL after opening one -->

# Changelog Entry

### Description

Anthropic API clients using `/api/v1/messages` (e.g. IDE plugins) can send `cache_control: {type: "ephemeral"}` on system, content, and tool blocks for [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching). Open WebUI was stripping those markers before the request reached the upstream provider:

1. **Conversion** — `convert_anthropic_to_openai_payload` flattened block arrays to plain strings and joined multi-block system prompts into one string, dropping `cache_control`.
2. **Middleware** — `merge_system_messages` consolidated system messages into a single plain-text message, destroying per-block cache breakpoints.
3. **Middleware / model config** — chat controls, pipeline filters, knowledge injection, and OWUI tool resolution could rewrite the client payload.

This PR preserves `cache_control` through Anthropic→OpenAI conversion and skips payload mutation for `/api/v1/messages` clients that manage their own tools and prompts (`client_managed_tools` + `bypass_system_prompt`).

### Added

- `_copy_cache_control()` and `_finalize_openai_content()` helpers in `anthropic.py` to preserve block structure when `cache_control` is present.
- `get_anthropic_forward_headers()` to forward `anthropic-beta` and `anthropic-version` from the client to the upstream connection on client-managed requests.
- Passthrough of top-level Anthropic `system` block arrays on the OpenAI-shaped gateway payload.
- Passthrough of `metadata`, `top_k`, and `service_tier` where present (excluding `thinking`, which breaks some models on OpenAI-shaped gateways).
- Mapping of `cache_creation_input_tokens` / `cache_read_input_tokens` from OpenAI-shaped usage back to Anthropic usage in responses.

### Changed

- `/api/v1/messages` sets `client_managed_tools` and `bypass_system_prompt` so plugin clients are not modified by OWUI middleware or model system prompts.
- `process_chat_payload` skips pipeline filters, chat-control system replacement, folder/knowledge injection, `merge_system_messages`, and OWUI tool attachment when `client_managed_tools` is set.
- Client-managed turns that omit `tools` no longer receive OWUI/MCP tools (`form_data.pop('tools')`).
- `chat_completion` preserves `bypass_system_prompt` when `client_managed_tools` is already set.
- OpenAI reasoning-model handler is skipped for client-managed requests.

### Fixed

- Anthropic `cache_control` markers are no longer stripped during `/api/v1/messages` → `/chat/completions` conversion.
- System prompt blocks with `cache_control` are no longer merged into a single plain string.
- Plugin clients no longer have OWUI system prompts, tools, or filters injected into cached request prefixes.

---

### Additional Information

**Scope:** Backend only (`main.py`, `anthropic.py`, `middleware.py`, `chat.py`, `openai.py`). No new env vars or UI settings.

**Why `client_managed_tools`:** Reuses the existing pattern for API clients that supply their own tools. `/api/v1/messages` plugin clients need the same passthrough for prompts and middleware, not only tools.

**Upstream provider note:** Prompt caching also requires the upstream provider/gateway to honor `cache_control` and the `prompt-caching` beta header. That is outside this PR; this change ensures OWUI does not destroy markers before the request leaves Open WebUI.

**Manual testing:**
1. POST to `/api/v1/messages` with a Claude model, `stream: true`, and `system` blocks containing `cache_control: {type: "ephemeral"}` on blocks ≥ provider minimum token threshold.
2. Confirm the outbound `/chat/completions` body still contains `cache_control` on system/content/tool blocks (proxy log or upstream telemetry).
3. Repeat within the cache TTL; upstream should report `cache_read_input_tokens > 0` on the second request with an identical cached prefix.
4. Confirm normal OWUI UI chat is unchanged (no `client_managed_tools` on standard chat requests).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.