### PR TITLE
fix: enforce features.folders permission on all folder endpoints

### DIFF
--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -31,6 +31,25 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
+async def check_folders_permission(request, user, db=None):
+    """Verify the folders feature is enabled and the user has permission."""
+    if request.app.state.config.ENABLE_FOLDERS is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+    if user.role != 'admin' and not await has_permission(
+        user.id,
+        'features.folders',
+        request.app.state.config.USER_PERMISSIONS,
+        db=db,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+
 ############################
 # Get Folders
 ############################
@@ -42,22 +61,7 @@ async def get_folders(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    if request.app.state.config.ENABLE_FOLDERS is False:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    if user.role != 'admin' and not await has_permission(
-        user.id,
-        'features.folders',
-        request.app.state.config.USER_PERMISSIONS,
-        db=db,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
+    await check_folders_permission(request, user, db=db)
 
     folders = await Folders.get_folders_by_user_id(user.id, db=db)
 
@@ -87,10 +91,12 @@ async def get_folders(
 
 @router.post('/')
 async def create_folder(
+    request: Request,
     form_data: FolderForm,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    await check_folders_permission(request, user, db=db)
     folder = await Folders.get_folder_by_parent_id_and_user_id_and_name(
         form_data.parent_id, user.id, form_data.name, db=db
     )
@@ -119,7 +125,10 @@ async def create_folder(
 
 
 @router.get('/{id}', response_model=Optional[FolderModel])
-async def get_folder_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
+async def get_folder_by_id(
+    request: Request, id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
+):
+    await check_folders_permission(request, user, db=db)
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
     if folder:
         return folder
@@ -137,11 +146,13 @@ async def get_folder_by_id(id: str, user=Depends(get_verified_user), db: AsyncSe
 
 @router.post('/{id}/update')
 async def update_folder_name_by_id(
+    request: Request,
     id: str,
     form_data: FolderUpdateForm,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    await check_folders_permission(request, user, db=db)
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
     if folder:
         if form_data.name is not None:
@@ -193,11 +204,13 @@ class FolderParentIdForm(BaseModel):
 
 @router.post('/{id}/update/parent')
 async def update_folder_parent_id_by_id(
+    request: Request,
     id: str,
     form_data: FolderParentIdForm,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    await check_folders_permission(request, user, db=db)
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
     if folder:
         existing_folder = await Folders.get_folder_by_parent_id_and_user_id_and_name(
@@ -238,11 +251,13 @@ class FolderIsExpandedForm(BaseModel):
 
 @router.post('/{id}/update/expanded')
 async def update_folder_is_expanded_by_id(
+    request: Request,
     id: str,
     form_data: FolderIsExpandedForm,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    await check_folders_permission(request, user, db=db)
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
     if folder:
         try:
@@ -277,6 +292,7 @@ async def delete_folder_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    await check_folders_permission(request, user, db=db)
     if await Chats.count_chats_by_folder_id_and_user_id(id, user.id, db=db):
         chat_delete_permission = await has_permission(
             user.id, 'chat.delete', request.app.state.config.USER_PERMISSIONS, db=db


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #___ — Folder mutation endpoints bypass `features.folders` permission check
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

The `GET /api/v1/folders/` (list) endpoint correctly checks the `features.folders` permission before allowing access. However, all other folder endpoints — create, get-by-id, update, update-parent, update-expanded, and delete — skip this check entirely.

This means a user whose group has `features.folders = false` can bypass the restriction by calling the API directly (e.g., via `curl`), even though the UI correctly hides the folder controls.

**Problem → Root Cause → Fix:**

- **Problem**: Users without `features.folders` permission can create/modify/delete folders via direct API calls.
- **Root Cause**: Only the list endpoint (`GET /`) had the permission check; all 6 other endpoints were missing it.
- **Fix**: Extract the `ENABLE_FOLDERS` + `features.folders` check into a reusable `check_folders_permission()` helper (following the same pattern as `check_automations_permission()` in `automations.py`), and call it from every folder endpoint.

### Key Change

```diff
+async def check_folders_permission(request, user, db=None):
+    """Verify the folders feature is enabled and the user has permission."""
+    if request.app.state.config.ENABLE_FOLDERS is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+    if user.role != 'admin' and not await has_permission(
+        user.id,
+        'features.folders',
+        request.app.state.config.USER_PERMISSIONS,
+        db=db,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
```

Each endpoint now starts with:
```python
await check_folders_permission(request, user, db=db)
```

### Fixed

- Folder create (`POST /api/v1/folders/`) no longer bypasses `features.folders` permission
- Folder get-by-id (`GET /api/v1/folders/{id}`) no longer bypasses `features.folders` permission
- Folder update (`POST /api/v1/folders/{id}/update`) no longer bypasses `features.folders` permission
- Folder update-parent (`POST /api/v1/folders/{id}/update/parent`) no longer bypasses `features.folders` permission
- Folder update-expanded (`POST /api/v1/folders/{id}/update/expanded`) no longer bypasses `features.folders` permission
- Folder delete (`DELETE /api/v1/folders/{id}`) no longer bypasses `features.folders` permission

### Security

- Users without `features.folders` permission can no longer bypass the restriction via direct API calls

---

### Additional Information

**Files changed**: 1 file, +29 −13 lines
- `backend/open_webui/routers/folders.py` — extracted helper, added `Request` param + permission call to 6 endpoints

### Manual Verification Performed

Tested by running curl commands against a live local Open WebUI instance using an API key belonging to a user whose group has `features.folders = false`. The backend was run on `upstream/dev` (before) and `fix/folder-permission-bypass` (after) to compare behavior.

**Commands used:**

```bash
TOKEN="<api-key-for-user-without-folders-permission>"
BASE="http://localhost:8080/api/v1/folders"
AUTH="Authorization: Bearer $TOKEN"

# 1. List folders
curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" "$BASE/"

# 2. Create folder
curl -s -o /dev/null -w "%{http_code}" -X POST -H "$AUTH" \
  -H "Content-Type: application/json" -d '{"name":"curl-test"}' "$BASE/"

# 3. Get folder by ID
curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" \
  "$BASE/00000000-0000-0000-0000-000000000000"

# 4. Update folder
curl -s -o /dev/null -w "%{http_code}" -X POST -H "$AUTH" \
  -H "Content-Type: application/json" -d '{"name":"renamed"}' \
  "$BASE/00000000-0000-0000-0000-000000000000/update"

# 5. Update parent
curl -s -o /dev/null -w "%{http_code}" -X POST -H "$AUTH" \
  -H "Content-Type: application/json" -d '{"parent_id":null}' \
  "$BASE/00000000-0000-0000-0000-000000000000/update/parent"

# 6. Update expanded
curl -s -o /dev/null -w "%{http_code}" -X POST -H "$AUTH" \
  -H "Content-Type: application/json" -d '{"is_expanded":true}' \
  "$BASE/00000000-0000-0000-0000-000000000000/update/expanded"

# 7. Delete folder
curl -s -o /dev/null -w "%{http_code}" -X DELETE -H "$AUTH" \
  "$BASE/00000000-0000-0000-0000-000000000000"
```

**Results:**

| # | Endpoint | Before (`upstream/dev`) | After (this PR) |
|---|----------|:-----------------------:|:---------------:|
| 1 | `GET /` (list) | 403 ✅ | 403 ✅ |
| 2 | `POST /` (create) | **200 ❌ bypass** | 403 ✅ |
| 3 | `GET /{id}` (get) | **404 ❌ bypass** | 403 ✅ |
| 4 | `POST /{id}/update` | **404 ❌ bypass** | 403 ✅ |
| 5 | `POST /{id}/update/parent` | **404 ❌ bypass** | 403 ✅ |
| 6 | `POST /{id}/update/expanded` | **404 ❌ bypass** | 403 ✅ |
| 7 | `DELETE /{id}` (delete) | **404 ❌ bypass** | 403 ✅ |

> **Note:** Endpoints 3–7 returned 404 before the fix because the fake UUID doesn't match a real folder — but the request got past the permission check entirely, proving the bypass. Endpoint 2 returned 200 and **actually created a folder** in the database, confirming the vulnerability.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
