### PR TITLE
fix: enforce features.api_keys permission on GET and DELETE /api_key endpoints

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1237,19 +1237,25 @@ async def update_ldap_config(request: Request, form_data: LdapConfigForm, user=D
 ############################
 
 
-# create api key
-@router.post('/api_key', response_model=ApiKey)
-async def generate_api_key(
-    request: Request, user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)
-):
+async def _check_api_key_permission(request: Request, user, db: AsyncSession):
     if not request.app.state.config.ENABLE_API_KEYS or (
         user.role != 'admin'
-        and not await has_permission(user.id, 'features.api_keys', request.app.state.config.USER_PERMISSIONS)
+        and not await has_permission(
+            user.id, 'features.api_keys', request.app.state.config.USER_PERMISSIONS, db=db
+        )
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=ERROR_MESSAGES.API_KEY_CREATION_NOT_ALLOWED,
         )
+
+
+# create api key
+@router.post('/api_key', response_model=ApiKey)
+async def generate_api_key(
+    request: Request, user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)
+):
+    await _check_api_key_permission(request, user, db)
 
     api_key = create_api_key()
     success = await Users.update_user_api_key_by_id(user.id, api_key, db=db)
@@ -1264,13 +1270,19 @@ async def generate_api_key(
 
 # delete api key
 @router.delete('/api_key', response_model=bool)
-async def delete_api_key(user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)):
+async def delete_api_key(
+    request: Request, user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)
+):
+    await _check_api_key_permission(request, user, db)
     return await Users.delete_user_api_key_by_id(user.id, db=db)
 
 
 # get api key
 @router.get('/api_key', response_model=ApiKey)
-async def get_api_key(user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)):
+async def get_api_key(
+    request: Request, user=Depends(get_current_user), db: AsyncSession = Depends(get_async_session)
+):
+    await _check_api_key_permission(request, user, db)
     api_key = await Users.get_user_api_key_by_id(user.id, db=db)
     if api_key:
         return {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (security fix discovered during access control audit — no prior issue exists).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

---

## Summary

The `GET /api/v1/auths/api_key` and `DELETE /api/v1/auths/api_key` endpoints did not enforce the `features.api_keys` permission or the `ENABLE_API_KEYS` feature flag. A user with `features.api_keys` set to `False` could still **retrieve** and **delete** their API key via direct API calls, even though the frontend correctly hid the UI and the `POST /api_key` (creation) endpoint correctly rejected them.

### Problem

The `POST /api_key` endpoint had the correct permission guard:

```python
if not request.app.state.config.ENABLE_API_KEYS or (
    user.role != 'admin'
    and not await has_permission(user.id, 'features.api_keys', ...)
):
    raise HTTPException(403, ...)
```

But `GET /api_key` and `DELETE /api_key` had **no permission check at all** — they only required basic authentication (`get_current_user`):

```python
# No permission check — any authenticated user could hit these
@router.delete('/api_key', response_model=bool)
async def delete_api_key(user=Depends(get_current_user), ...):
    return await Users.delete_user_api_key_by_id(user.id, db=db)

@router.get('/api_key', response_model=ApiKey)
async def get_api_key(user=Depends(get_current_user), ...):
    api_key = await Users.get_user_api_key_by_id(user.id, db=db)
    ...
```

### Root Cause

The permission check was added only to the creation endpoint. The retrieval and deletion endpoints were never updated to enforce the same `features.api_keys` permission, meaning the backend relied entirely on the frontend UI hiding the API key management interface — which is trivially bypassed with a direct HTTP request.

### Fix

Extracted the existing permission guard into a shared `_check_api_key_permission()` helper and applied it to all three `/api_key` endpoints:

```diff
+async def _check_api_key_permission(request: Request, user, db: AsyncSession):
+    if not request.app.state.config.ENABLE_API_KEYS or (
+        user.role != 'admin'
+        and not await has_permission(
+            user.id, 'features.api_keys', request.app.state.config.USER_PERMISSIONS, db=db
+        )
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.API_KEY_CREATION_NOT_ALLOWED,
+        )

 @router.post('/api_key', response_model=ApiKey)
 async def generate_api_key(
     request: Request, user=Depends(get_current_user), ...
 ):
-    if not request.app.state.config.ENABLE_API_KEYS or (...):
-        raise HTTPException(...)
+    await _check_api_key_permission(request, user, db)
     ...

 @router.delete('/api_key', response_model=bool)
-async def delete_api_key(user=Depends(get_current_user), ...):
+async def delete_api_key(
+    request: Request, user=Depends(get_current_user), ...
+):
+    await _check_api_key_permission(request, user, db)
     ...

 @router.get('/api_key', response_model=ApiKey)
-async def get_api_key(user=Depends(get_current_user), ...):
+async def get_api_key(
+    request: Request, user=Depends(get_current_user), ...
+):
+    await _check_api_key_permission(request, user, db)
     ...
```

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Enforce `features.api_keys` permission and `ENABLE_API_KEYS` feature flag on the `GET` and `DELETE` `/api/v1/auths/api_key` endpoints, matching the existing enforcement on `POST`

### Fixed

- `GET /api/v1/auths/api_key` no longer returns the API key when the user lacks the `features.api_keys` permission
- `DELETE /api/v1/auths/api_key` no longer allows key deletion when the user lacks the `features.api_keys` permission
- Extracted shared `_check_api_key_permission()` helper to eliminate duplicated permission logic and ensure consistency across all three API key endpoints

### Security

- Closed a permission bypass where users with `features.api_keys` set to `False` could retrieve or delete API keys via direct API calls, bypassing the frontend-only UI gate

---

### Additional Information

- **Scope**: 1 file changed, 20 insertions, 8 deletions (`backend/open_webui/routers/auths.py`)
- **No new dependencies**
- **No breaking changes** — admins and users with `features.api_keys = True` are unaffected

### Manual Verification Performed

1. Set `features.api_keys = False` in default user permissions (Admin → Settings → Users)
2. Created a test user with `role=user`
3. Confirmed the user's effective `features.api_keys` permission is `False` via session endpoint
4. **Before fix**: `GET /api_key` returned 200 with the key value; `DELETE /api_key` returned 200. Both bypassed the permission.
5. **After fix**: All three endpoints (`POST`, `GET`, `DELETE`) return 403 with `"API key creation is not allowed in the environment."`
6. Verified admin users can still create/retrieve/delete API keys (admin bypasses permission check)
7. Ran `npm run format`, `npm run build`, `npm run test:frontend` — all passing

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
