### PR TITLE
fix: enforce chat.tts permission on OpenAI /audio/speech proxy endpoint

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -37,7 +37,7 @@ from open_webui.models.access_grants import AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.models import Models
 from open_webui.models.users import UserModel
-from open_webui.utils.access_control import check_model_access, has_connection_access
+from open_webui.utils.access_control import check_model_access, has_connection_access, has_permission
 from open_webui.utils.anthropic import get_anthropic_models, is_anthropic_url
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
@@ -289,6 +289,14 @@ async def update_config(request: Request, form_data: OpenAIConfigForm, user=Depe
 
 @router.post('/audio/speech')
 async def speech(request: Request, user=Depends(get_verified_user)):
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'chat.tts', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     idx = None
     try:
         idx = request.app.state.config.OPENAI_API_BASE_URLS.index('https://api.openai.com/v1')


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (security fix discovered during access control audit — no prior issue exists).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

---

## Summary

The OpenAI proxy `POST /openai/audio/speech` endpoint did not enforce the `chat.tts` permission. Any authenticated user could generate speech through this route, bypassing the permission check that the dedicated `POST /api/v1/audio/speech` endpoint in `audio.py` correctly enforced.

### Problem

Open WebUI has two TTS speech endpoints:

1. **`POST /api/v1/audio/speech`** (in `audio.py`) — properly checks `chat.tts`:
   ```python
   if user.role != 'admin' and not await has_permission(
       user.id, 'chat.tts', request.app.state.config.USER_PERMISSIONS
   ):
       raise HTTPException(status_code=403, ...)
   ```

2. **`POST /openai/audio/speech`** (in `openai.py`) — acts as a passthrough proxy to the OpenAI TTS API, but had **no permission check**:
   ```python
   @router.post('/audio/speech')
   async def speech(request: Request, user=Depends(get_verified_user)):
       # No chat.tts check — proceeds directly to proxy the request
       idx = request.app.state.config.OPENAI_API_BASE_URLS.index(...)
       ...
   ```

This meant that even when an admin disabled TTS for users via `chat.tts = False`, users could still generate speech by hitting the OpenAI proxy endpoint directly.

### Fix

Added the same `has_permission('chat.tts')` guard to the OpenAI proxy endpoint, matching the existing pattern in `audio.py`:

```diff
 @router.post('/audio/speech')
 async def speech(request: Request, user=Depends(get_verified_user)):
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'chat.tts', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     idx = None
     try:
```

Also added `has_permission` to the existing import from `open_webui.utils.access_control`.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Enforce `chat.tts` permission on the OpenAI proxy `/audio/speech` endpoint, closing a bypass where users could generate speech through the proxy even when TTS was disabled for their role

### Fixed

- `POST /openai/audio/speech` now returns 403 when the user lacks the `chat.tts` permission, matching the behavior of the dedicated `POST /api/v1/audio/speech` endpoint in `audio.py`

### Security

- Closed a permission bypass where users with `chat.tts` set to `False` could generate speech via the OpenAI passthrough proxy, incurring API costs and bypassing the admin's intent to restrict TTS access

---

### Additional Information

- **Scope**: 1 file changed, 9 insertions, 1 deletion (`backend/open_webui/routers/openai.py`)
- **No new dependencies**
- **No breaking changes** — admins and users with `chat.tts = True` are unaffected

### Manual Verification Performed

1. Set `chat.tts = False` in default user permissions via the admin API
2. Created a test user with `role=user`
3. Confirmed `has_permission('chat.tts')` returns `False` for the test user
4. **Before fix**: `POST /openai/audio/speech` would proxy the request to OpenAI (status 200 or upstream error) — the permission was never checked
5. **After fix**: `POST /openai/audio/speech` returns 403 with `"You do not have permission to access this resource."`
6. Verified `POST /api/v1/audio/speech` also returns 403 (was already gated — no regression)
7. Verified admin users can still use both endpoints (admin role bypasses the check)
8. Ran `npm run format`, `npm run build`, `npm run test:frontend` — all passing

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
