### PR TITLE
fix: enforce ENABLE_IMAGE_EDIT and features.image_generation permission on /images/edit endpoint

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -826,9 +826,24 @@ async def image_edits(
     metadata: dict | None = None,
     user=Depends(get_verified_user),
 ):
+    if not request.app.state.config.ENABLE_IMAGE_EDIT:
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'features.image_generation', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     size = None
     width, height = None, None
     metadata = metadata or {}
+
 
     if (request.app.state.config.IMAGE_EDIT_SIZE and 'x' in request.app.state.config.IMAGE_EDIT_SIZE) or (
         form_data.size and 'x' in form_data.size


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (security fix discovered during access control audit — no prior issue exists).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

---

## Summary

The `POST /api/v1/images/edit` endpoint had no `ENABLE_IMAGE_EDIT` feature toggle check and no `features.image_generation` permission check. Any authenticated user could edit images via this endpoint, even when the admin had disabled image editing or revoked their image generation permission.

### Problem

The `/generations` endpoint had proper dual-layer access control:

```python
@router.post('/generations')
async def generate_images(request, form_data, user=Depends(get_verified_user)):
    if not request.app.state.config.ENABLE_IMAGE_GENERATION:  # ← feature toggle
        raise HTTPException(status_code=403, ...)

    if user.role != 'admin' and not await has_permission(    # ← user permission
        user.id, 'features.image_generation', ...
    ):
        raise HTTPException(status_code=403, ...)
```

But the `/edit` endpoint had **neither check** — it jumped straight into processing:

```python
@router.post('/edit')
async def image_edits(request, form_data, metadata=None, user=Depends(get_verified_user)):
    # No ENABLE_IMAGE_EDIT check
    # No features.image_generation permission check
    size = None  # ← proceeds immediately
    ...
```

The admin UI had an `ENABLE_IMAGE_EDIT` config toggle (persisted and exposed at lines 144, 183, 254, 292 of `images.py`), but it was never actually enforced on the endpoint itself — a classic config-without-enforcement gap.

### Fix

Added both guards to the `/edit` endpoint, matching the pattern from `/generations`:

```diff
 @router.post('/edit')
 async def image_edits(
     request: Request,
     form_data: EditImageForm,
     metadata: dict | None = None,
     user=Depends(get_verified_user),
 ):
+    if not request.app.state.config.ENABLE_IMAGE_EDIT:
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'features.image_generation', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     size = None
     width, height = None, None
```

No new imports were needed — `has_permission`, `ERROR_MESSAGES`, and `status` were already imported in `images.py`.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Enforce `ENABLE_IMAGE_EDIT` feature toggle and `features.image_generation` permission on the `POST /api/v1/images/edit` endpoint, matching the existing enforcement on `/generations`

### Fixed

- `POST /api/v1/images/edit` now returns 403 when the `ENABLE_IMAGE_EDIT` feature is disabled by the admin
- `POST /api/v1/images/edit` now returns 403 when the user lacks the `features.image_generation` permission, matching the behavior of `/generations`

### Security

- Closed a permission bypass where users with `features.image_generation` set to `False` could still edit images via the `/edit` endpoint
- Closed a feature toggle bypass where the `ENABLE_IMAGE_EDIT` admin config was never actually enforced on the endpoint

---

### Additional Information

- **Scope**: 1 file changed, 15 insertions (`backend/open_webui/routers/images.py`)
- **No new dependencies**
- **No breaking changes** — admins and users with the permission enabled are unaffected

### Manual Verification Performed

1. Set `features.image_generation = False` in default user permissions via the admin API
2. Created a test user with `role=user`
3. **Before fix**: `POST /images/edit` would proceed to process the image (or fail at the provider level) — permission was never checked
4. **After fix**: `POST /images/edit` returns 403 with `"You do not have permission to access this resource."`
5. Verified `POST /images/generations` also returns 403 (was already gated — no regression)
6. Verified admin users can still use both endpoints (admin role bypasses the check)
7. Ran `npm run format`, `npm run build`, `npm run test:frontend` — all passing

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
