### PR TITLE
fix: enforce settings.interface permission on /user/settings/update endpoint

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -294,6 +294,14 @@ async def update_user_settings_by_session_user(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'settings.interface', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     updated_user_settings = form_data.model_dump()
     ui_settings = updated_user_settings.get('ui')
     if (


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — N/A (security fix discovered during access control audit — no prior issue exists).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

---

## Summary

The `POST /api/v1/users/user/settings/update` endpoint did not check the `settings.interface` permission. Any authenticated user could modify their interface settings via the API even when an admin had set `settings.interface = False` to disable this capability.

### Problem

The `settings.interface` permission was defined in `SettingsPermissions` (line 241-242 of `users.py`), exposed via the admin default-permissions API, and visible in the admin UI — but was **never actually enforced** on the settings update endpoint.

The endpoint already had a targeted check for `features.direct_tool_servers` (stripping the `toolServers` key from the `ui` dict when that permission is disabled), but the broader `settings.interface` permission was completely ignored:

```python
@router.post('/user/settings/update', response_model=UserSettings)
async def update_user_settings_by_session_user(request, form_data, user=...):
    # No settings.interface check ← the gap
    updated_user_settings = form_data.model_dump()
    # Only checks features.direct_tool_servers for toolServers specifically
    ...
```

### Fix

Added a `has_permission('settings.interface')` guard at the top of the endpoint, matching the pattern used across all other permission-gated endpoints:

```diff
 @router.post('/user/settings/update', response_model=UserSettings)
 async def update_user_settings_by_session_user(
     request: Request,
     form_data: UserSettings,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'settings.interface', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     updated_user_settings = form_data.model_dump()
```

No new imports were needed — `has_permission`, `status`, and `ERROR_MESSAGES` were already imported in `users.py`.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Enforce `settings.interface` permission on the `POST /api/v1/users/user/settings/update` endpoint

### Fixed

- `POST /api/v1/users/user/settings/update` now returns 403 when the user lacks the `settings.interface` permission, matching the admin's intent when disabling interface customization for users

### Security

- Closed a permission bypass where users with `settings.interface` set to `False` could still modify their interface settings (theme, chat bubble, widescreen mode, etc.) via direct API calls

---

### Additional Information

- **Scope**: 1 file changed, 8 insertions (`backend/open_webui/routers/users.py`)
- **No new dependencies**
- **No breaking changes** — admins and users with `settings.interface = True` (the default) are unaffected

### Manual Verification Performed

**BEFORE fix (bypass confirmed):**
1. Set `settings.interface = False` in default user permissions via the admin API
2. Created a test user with `role=user`
3. `POST /users/user/settings/update` with `{"ui": {"theme": "dark"}}` → **200 OK** (bypass!)
4. `GET /users/user/settings` → confirmed `theme: dark` was persisted

**AFTER fix (bypass closed):**
1. Same setup with `settings.interface = False`
2. `POST /users/user/settings/update` → **403** `"You do not have permission to access this resource."`
3. `GET /users/user/settings` → confirmed settings were NOT modified
4. Admin `POST /users/user/settings/update` → **200 OK** (admin bypasses correctly)
5. Ran `npm run format`, `npm run build` — all passing

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
