### PR TITLE
Add TrustedRouter connection suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 
 - 🚀 **Effortless Setup**: Install seamlessly using Docker or Kubernetes (kubectl, kustomize or helm) for a hassle-free experience with support for both `:ollama` and `:cuda` tagged images.
 
-- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, and more**.
+- 🤝 **Ollama/OpenAI API Integration**: Effortlessly integrate OpenAI-compatible APIs for versatile conversations alongside Ollama models. Customize the OpenAI API URL to link with **LMStudio, GroqCloud, Mistral, OpenRouter, TrustedRouter, and more**.
 
 - 🛡️ **Granular Permissions and User Groups**: By allowing administrators to create detailed user roles and permissions, we ensure a secure user environment. This granularity not only enhances security but also allows for customized user experiences, fostering a sense of ownership and responsibility amongst users.
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -330,6 +330,7 @@
 											<option value="https://api.mistral.ai/v1" />
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
+											<option value="https://api.trustedrouter.com/v1" />
 											<option value="https://api.x.ai/v1" />
 										</datalist>
 									{/if}


### PR DESCRIPTION
## Summary
- add https://api.trustedrouter.com/v1 to the OpenAI-compatible connection URL suggestions
- mention TrustedRouter in the README OpenAI-compatible API examples

## Testing
- git diff --check