### PR TITLE
Authorize POST /api/v1/images/edit (enforce ENABLE_IMAGE_EDIT + image-gen permission)

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -820,6 +820,28 @@ class EditImageForm(BaseModel):
 
 
 @router.post('/edit')
+async def edit_images(request: Request, form_data: EditImageForm, user=Depends(get_verified_user)):
+    # Authorize the direct route like /generations and the edit_image tool: enforce the
+    # global image-edit switch and the per-user image-generation permission. The internal
+    # callers (edit_image tool, chat middleware) gate themselves and call image_edits()
+    # directly, so they are unaffected by this wrapper.
+    if not request.app.state.config.ENABLE_IMAGE_EDIT:
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'features.image_generation', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    return await image_edits(request, form_data, user=user)
+
+
 async def image_edits(
     request: Request,
     form_data: EditImageForm,


### PR DESCRIPTION
The direct image-edit route was the only image-edit surface with no authorization: it ran on get_verified_user alone, while POST /generations enforces ENABLE_IMAGE_GENERATION + features.image_generation and the built-in edit_image tool enforces ENABLE_IMAGE_EDIT + features.image_generation. A verified non-admin user could therefore reach the configured image-edit provider (spending IMAGES_EDIT_OPENAI_API_KEY) even when the administrator had globally disabled image editing (ENABLE_IMAGE_EDIT=False) or denied the user image generation.

Split the route from the shared impl (mirroring generate_images/image_generations): the new /edit wrapper enforces ENABLE_IMAGE_EDIT and the per-user image-generation permission, then delegates to image_edits(). The internal callers (the edit_image tool and the chat middleware) already gate themselves and call image_edits() directly, so they are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
