### PR TITLE
fix: inject code interpreter images directly into chat content

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -570,6 +570,18 @@ def serialize_output(output: list) -> str:
                 parts.append(
                     f'<details type="code_interpreter" done="true" duration="{duration or 0}"{output_attr}>\n<summary>Analyzed</summary>\n{display}\n</details>'
                 )
+                # Inject images from code interpreter output directly into chat content
+                if ci_output and isinstance(ci_output, dict):
+                    image_lines = []
+                    for field in ['result', 'stdout']:
+                        field_content = ci_output.get(field, '')
+                        if isinstance(field_content, str):
+                            for line in field_content.splitlines():
+                                stripped = line.strip()
+                                if re.match(r'!\[.*?\]\(/api/v1/', stripped) and stripped not in image_lines:
+                                    image_lines.append(stripped)
+                    if image_lines:
+                        parts.append('\n'.join(image_lines))
             else:
                 parts.append(
                     f'<details type="code_interpreter" done="false"{output_attr}>\n<summary>Analyzing…</summary>\n{display}\n</details>'


### PR DESCRIPTION
## Problem

Closes #23847

When the code interpreter generates images (e.g. matplotlib plots via Jupyter), the resulting ![Output Image](url) markdown is only stored in the JSON output attribute of the <details> block and never reaches the visible chat content. The model is prompted to repeat the URL itself, but local models (Gemma, Qwen, etc.) do this unreliably, resulting in images never appearing in the chat.

## Fix

Extended serialize_output() in middleware.py to automatically extract image markdown lines from ci_output['result'] and ci_output['stdout'] and append them directly to the chat content parts after the <details> block.

This makes images visible regardless of model behavior — no model cooperation required.

## Testing

Tested on v0.9.6 with:
- Jupyter backend (scipy-notebook Docker container)
- Gemma3 and Qwen2.5 models via Ollama
- matplotlib plt.show() plots now appear correctly in chat