### PR TITLE
fix: handle null tool server info

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -184,7 +184,7 @@ async def set_tool_servers_config(
 
         if auth_type in ('oauth_2.1', 'oauth_2.1_static'):
             # Remove existing OAuth clients for tool servers
-            server_id = connection.get('info', {}).get('id')
+            server_id = (connection.get('info') or {}).get('id')
             client_key = f'{server_type}:{server_id}'
 
             try:
@@ -202,7 +202,7 @@ async def set_tool_servers_config(
     for connection in request.app.state.config.TOOL_SERVER_CONNECTIONS:
         server_type = connection.get('type', 'openapi')
         if server_type == 'mcp':
-            server_id = connection.get('info', {}).get('id')
+            server_id = (connection.get('info') or {}).get('id')
             auth_type = connection.get('auth_type', 'none')
 
             if auth_type in ('oauth_2.1', 'oauth_2.1_static') and server_id:


### PR DESCRIPTION
## Summary

Fix POST /api/v1/configs/tool_servers crashing when an MCP tool-server connection has info: null.

## Root Cause

ToolServerConnection.info is declared as nullable, and model_dump() can preserve that value as None. The tool-server config update path used connection.get('info', {}).get('id'), but dict.get(key, default) returns the stored value when the key exists, even if that value is None. That made the subsequent .get('id') call raise AttributeError.

## Changes

- Coalesce nullable info values with (connection.get('info') or {}) before reading id in both cleanup and registration loops.

## Verification

- python -m py_compile backend/open_webui/routers/configs.py

Fixes #25991.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
