### PR TITLE
fix: handle urllib3 2.x 4-element socket options in _ssrf_safe_new_conn

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -148,7 +148,7 @@ def _ssrf_safe_new_conn(self):
             if getattr(self, 'source_address', None):
                 sock.bind(self.source_address)
             for opt in getattr(self, 'socket_options', None) or ():
-                sock.setsockopt(*opt)
+                sock.setsockopt(*opt[:3])
             sock.connect(sa)
             return sock
         except OSError as exc:


### PR DESCRIPTION
## Description

When Open WebUI is deployed with urllib3 >= 2.0 (as installed by default in recent versions), the `_ssrf_safe_new_conn` function in `retrieval/web/utils.py` crashes on **every** URL fetch with:

```
TypeError: setsockopt() takes exactly 3 arguments (4 given)
sock.setsockopt(*opt)  # opt = (6, 1, 1, 'tcp')
```

### Root Cause

urllib3 >= 2.0 introduced support for **4-element socket option tuples** in the format `(level, optname, value, protocol)` where `protocol` is `"tcp"` or `"udp"` [urllib3#3301](https://github.com/urllib3/urllib3/issues/3301). This allows per-protocol socket options.

The `_ssrf_safe_new_conn` function overrides urllib3's `_new_conn` for SSRF protection, but naively passes the full tuple to `socket.setsockopt()`, which only accepts 3 positional arguments: `(level, optname, value)`.

### Fix

Truncate the tuple to its first 3 elements (`opt[:3]`), matching exactly how urllib3 handles this in its own `_set_socket_options()` (see `urllib3/util/connection.py` lines 75-81).

### Impact

This bug makes `fetch_url` and web search **completely non-functional** — every URL fetch fails with a silent `TypeError` caught in the exception handler, returning empty content to the user.

### Related Issues

- Similar TypeError pattern in web search: https://github.com/open-webui/open-webui/issues/24875
- Generic web search failure with empty content: https://github.com/open-webui/open-webui/discussions/12833
- HTTP/2 connection error affecting web fetching: https://github.com/open-webui/open-webui/issues/19734

### Checklist

- [x] The fix is minimal (1 line change)
- [x] Backward compatible: `*opt[:3]` with 3-element tuples returns the same tuple unchanged
- [x] Matches upstream urllib3 handling pattern