### PR TITLE
fix: strip reasoning tags from RAG document responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,4 +310,3 @@ dist
 cypress/videos
 cypress/screenshots
 .vscode/settings.json
-.cptr

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1790,9 +1790,12 @@ async def chat_completion(
                 'stream_delta_chunk_size': stream_delta_chunk_size,
                 'reasoning_tags': reasoning_tags,
                 'function_calling': (
-                    form_data.get('params', {}).get('function_calling')
-                    or model_info_params.get('function_calling')
-                    or 'native'
+                    'native'
+                    if (
+                        form_data.get('params', {}).get('function_calling') == 'native'
+                        or model_info_params.get('function_calling') == 'native'
+                    )
+                    else 'default'
                 ),
             },
         }

--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -64,18 +64,9 @@ def get_custom_headers(custom_headers: dict, user=None, metadata: dict = None) -
         return {}
 
     metadata = metadata or {}
-
-    # Extract user_message info for tree mapping
-    user_message = metadata.get('user_message') or {}
-    user_message_id = metadata.get('user_message_id', '') or (user_message.get('id', '') if user_message else '')
-    user_message_parent_id = user_message.get('parentId', '') if user_message else ''
-
     template_vars = {
         '{{CHAT_ID}}': metadata.get('chat_id', '') or '',
         '{{MESSAGE_ID}}': metadata.get('message_id', '') or '',
-        '{{USER_MESSAGE_ID}}': user_message_id or '',
-        '{{USER_MESSAGE_PARENT_ID}}': user_message_parent_id or '',
-        '{{TASK}}': metadata.get('task', '') or '',
         '{{USER_ID}}': (user.id if user else '') or '',
         '{{USER_NAME}}': (user.name if user else '') or '',
         '{{USER_EMAIL}}': (user.email if user else '') or '',

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1535,8 +1535,9 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
 
         response = res['choices'][0]['message']['content']
 
+        response = re.sub(r'<think>.*?</think>', '', response, flags=re.DOTALL)
         try:
-            bracket_start = response.rfind('{')
+            bracket_start = response.find('{')
             bracket_end = response.rfind('}') + 1
 
             if bracket_start == -1 or bracket_end == -1:
@@ -1875,8 +1876,9 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
 
                 response = res['choices'][0]['message']['content']
 
+                response = re.sub(r'<think>.*?</think>', '', response, flags=re.DOTALL)
                 try:
-                    bracket_start = response.rfind('{')
+                    bracket_start = response.find('{')
                     bracket_end = response.rfind('}') + 1
 
                     if bracket_start == -1 or bracket_end == -1:
@@ -1979,8 +1981,9 @@ async def chat_completion_files_handler(
                 )
                 queries_response = queries_response['choices'][0]['message']['content']
 
+                queries_response = re.sub(r'<think>.*?</think>', '', queries_response, flags=re.DOTALL)
                 try:
-                    bracket_start = queries_response.rfind('{')
+                    bracket_start = queries_response.find('{')
                     bracket_end = queries_response.rfind('}') + 1
 
                     if bracket_start == -1 or bracket_end == -1:
@@ -2471,7 +2474,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             if 'files' in folder.data:
                 # Defensive: filter to entries the caller can still read.
                 allowed_files = await get_accessible_folder_files(folder.data['files'], user)
-                if metadata.get('params', {}).get('function_calling') == 'legacy':
+                if metadata.get('params', {}).get('function_calling') != 'native':
                     form_data['files'] = [
                         *allowed_files,
                         *form_data.get('files', []),
@@ -2485,7 +2488,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     user_message = get_last_user_message(form_data['messages'])
     model_knowledge = model.get('info', {}).get('meta', {}).get('knowledge', False)
 
-    if model_knowledge and metadata.get('params', {}).get('function_calling') == 'legacy':
+    if model_knowledge and metadata.get('params', {}).get('function_calling') != 'native':
         await event_emitter(
             {
                 'type': 'status',
@@ -2563,17 +2566,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
         if 'memory' in features and features['memory']:
             # Skip forced memory injection when native FC is enabled - model can use memory tools
-            if metadata.get('params', {}).get('function_calling') == 'legacy':
+            if metadata.get('params', {}).get('function_calling') != 'native':
                 form_data = await chat_memory_handler(request, form_data, extra_params, user)
 
         if 'web_search' in features and features['web_search']:
             # Skip forced RAG web search when native FC is enabled - model can use web_search tool
-            if metadata.get('params', {}).get('function_calling') == 'legacy':
+            if metadata.get('params', {}).get('function_calling') != 'native':
                 form_data = await chat_web_search_handler(request, form_data, extra_params, user)
 
         if 'image_generation' in features and features['image_generation']:
             # Skip forced image generation when native FC is enabled - model can use generate_image tool
-            if metadata.get('params', {}).get('function_calling') == 'legacy':
+            if metadata.get('params', {}).get('function_calling') != 'native':
                 form_data = await chat_image_generation_handler(request, form_data, extra_params, user)
 
         if 'code_interpreter' in features and features['code_interpreter']:
@@ -2581,7 +2584,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
             # Skip XML-tag prompt injection when native FC is enabled —
             # execute_code will be injected as a builtin tool instead
-            if metadata.get('params', {}).get('function_calling') == 'legacy':
+            if metadata.get('params', {}).get('function_calling') != 'native':
                 prompt = (
                     request.app.state.config.CODE_INTERPRETER_PROMPT_TEMPLATE
                     if request.app.state.config.CODE_INTERPRETER_PROMPT_TEMPLATE != ''
@@ -2843,7 +2846,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         builtin_tools_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
             'builtin_tools', True
         )
-        if metadata.get('params', {}).get('function_calling') != 'legacy' and builtin_tools_enabled:
+        if metadata.get('params', {}).get('function_calling') == 'native' and builtin_tools_enabled:
             # Add file context to user messages
             chat_id = metadata.get('chat_id')
             form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
@@ -2866,7 +2869,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             # (e.g. pipe functions) can access all tools including MCP and builtins.
             metadata['tools'] = tools_dict
 
-            if metadata.get('params', {}).get('function_calling') != 'legacy':
+            if metadata.get('params', {}).get('function_calling') == 'native':
                 # If the function calling is native, then call the tools function calling handler
                 form_data['tools'] = [
                     {'type': 'function', 'function': tool.get('spec', {})} for tool in tools_dict.values()

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -150,7 +150,7 @@
 	<div>
 		<Tooltip
 			content={$i18n.t(
-				"Native mode (default) leverages the model's built-in tool-calling capabilities. Legacy mode works with a wider range of models by calling tools once before execution via prompt injection."
+				"Default mode works with a wider range of models by calling tools once before execution. Native mode leverages the model's built-in tool-calling capabilities, but requires the model to inherently support this feature."
 			)}
 			placement="top-start"
 			className="inline-tooltip"
@@ -162,20 +162,12 @@
 				<button
 					class="p-1 px-3 text-xs flex rounded-sm transition"
 					on:click={() => {
-						if ((params?.function_calling ?? null) === null) {
-							params.function_calling = 'native';
-						} else if (params.function_calling === 'native') {
-							params.function_calling = 'legacy';
-						} else {
-							params.function_calling = null;
-						}
+						params.function_calling = (params?.function_calling ?? null) === null ? 'native' : null;
 					}}
 					type="button"
 				>
 					{#if params.function_calling === 'native'}
 						<span class="ml-2 self-center">{$i18n.t('Native')}</span>
-					{:else if params.function_calling === 'legacy'}
-						<span class="ml-2 self-center">{$i18n.t('Legacy')}</span>
 					{:else}
 						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
 					{/if}


### PR DESCRIPTION
### Description

- Strips <think>...</think> reasoning tags from RAG document retrieval to prevent AI thought process from polluting the context window.

### Fixed

- RAG retrieval now properly sanitizes deepseek thought tags.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.