### PR TITLE
fix: ensure Playwright pages and browser are closed on failure

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -561,60 +561,78 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
         from playwright.sync_api import sync_playwright
 
         with sync_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    self._safe_process_url_sync(url)
-                    page = browser.new_page()
-                    page.route('**/*', self._intercept_navigation_sync)
-                    response = page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        self._safe_process_url_sync(url)
+                        page = browser.new_page()
+                        page.route('**/*', self._intercept_navigation_sync)
+                        response = page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = self.evaluator.evaluate(page, browser, response)
+                        text = self.evaluator.evaluate(page, browser, response)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page:
+                            page.close()
+
                     metadata = {'source': url}
                     yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            browser.close()
+            finally:
+                if browser:
+                    browser.close()
 
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Safely load URLs asynchronously with support for remote browser."""
         from playwright.async_api import async_playwright
 
         async with async_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = await p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = await p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    await self._safe_process_url(url)
-                    page = await browser.new_page()
-                    await page.route('**/*', self._intercept_navigation)
-                    response = await page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        await self._safe_process_url(url)
+                        page = await browser.new_page()
+                        await page.route('**/*', self._intercept_navigation)
+                        response = await page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = await self.evaluator.evaluate_async(page, browser, response)
+                        text = await self.evaluator.evaluate_async(page, browser, response)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page:
+                            await page.close()
+
                     metadata = {'source': url}
                     yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            await browser.close()
+            finally:
+                if browser:
+                    await browser.close()
 
 
 class SafeWebBaseLoader(WebBaseLoader):


### PR DESCRIPTION
Closes #25880

SafePlaywrightURLLoader (sync and async) previously left Playwright 
pages open indefinitely and skipped browser.close() when an 
unhandled exception occurred mid-loop.

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25880
- [x] **Target branch:** This PR targets `dev`
- [x] **Description:** Provided above
- [x] **Changelog:** See below
- [ ] **Documentation:** N/A — internal bug fix, no user-facing doc changes
- [ ] **Dependencies:** None added/changed
- [ ] **Testing:** Code-reviewed and logic-traced manually for all paths
      (success, continue_on_failure, raised exception). Could not run
      a live integration test in this environment because the full
      open-webui backend dependency set (e.g. typer) is not installed
      alongside Playwright — happy to add automated tests if a
      maintainer points me to the right test setup/fixtures.
- [x] **No Unchecked AI Code:** This PR was AI-assisted but every line
      has been manually reviewed by me for correctness
- [x] **Self-Review:** Completed
- [x] **Architecture:** No new settings added — pure resource cleanup fix
- [x] **Git Hygiene:** Single atomic commit, rebased on dev
- [x] **Title Prefix:** fix

# Changelog Entry

### Description
Fixes a resource leak in SafePlaywrightURLLoader where Playwright 
pages and browser instances were not properly closed on failure.

### Fixed
- page.close() now always runs after each URL load, success or failure
- browser.close() now always runs, even when an exception is raised 
  and continue_on_failure is False
- continue_on_failure behavior preserved exactly as before

### Additional Information
No existing unit tests cover this class. Changes are purely additive 
(try/finally wrapping around existing logic) — no existing logic 
paths altered, only resource cleanup added.

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read 
      and fully agree to the Contributor License Agreement (CLA), 
      and I am providing my contributions under its terms.