### PR TITLE
fix: add max height and scroll to chat menu tags section

### DIFF
--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -496,7 +496,7 @@
 
 				<hr class="border-gray-50/30 dark:border-gray-800/30 my-1" />
 
-				<div class="flex p-1">
+				<div class="flex p-1 max-h-28 overflow-y-auto">
 					<Tags chatId={chat.id} />
 				</div>
 			{/if}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a UI overflow bug where the tags section in the chat context menu grows unbounded, pushing content off-screen.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed for this fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

When a chat has many tags, the tags section in the 3-dots context menu (Navbar `Menu.svelte`) grows unbounded vertically, causing the dropdown to overflow off-screen and become unusable. This is because the tags container `<div>` has no height constraint — tags use `flex-wrap` and simply keep wrapping to new lines indefinitely.

**Problem:** The tags container in the chat context menu has no `max-height` or `overflow` constraint. With many tags, the dropdown extends far beyond the viewport.

**Fix:** Add `max-h-28` (7rem / 112px) and `overflow-y-auto` to the tags wrapper `<div>`, capping the tags area at approximately 4 rows of tag pills and enabling vertical scrolling for the rest. This is scoped entirely to the Navbar menu — the shared `<Tags>` component and all other usages are unaffected.

```diff
- <div class="flex p-1">
+ <div class="flex p-1 max-h-28 overflow-y-auto">
     <Tags chatId={chat.id} />
 </div>
```

### Fixed

- Chat context menu tags section overflowing off-screen when a chat has many tags

---

### Additional Information

- **Scope:** 1 file changed, 1 insertion, 1 deletion
- **File:** `src/lib/components/layout/Navbar/Menu.svelte`
- The fix uses standard Tailwind utility classes (`max-h-28`, `overflow-y-auto`) consistent with existing patterns in the codebase
- No new dependencies, no i18n changes, no dark mode considerations (pure layout constraint)

### Screenshots or Videos

**Before:** Tags overflow off-screen, making the menu unusable.

<img width="330" height="1285" alt="image" src="https://github.com/user-attachments/assets/6683f6e6-3dac-4a4b-9271-bf465a365841" />

**After:** Tags are constrained to a scrollable area within the menu.

<img width="334" height="458" alt="image" src="https://github.com/user-attachments/assets/ff12ec38-d7a3-480c-8e7e-9bd6104746df" />

### Manual Verification Performed

1. Added 50+ tags to a single chat
2. Opened the 3-dots context menu from the chat navbar
3. Verified the tags area is capped at ~4 rows and scrolls vertically
4. Verified all menu items above tags (Share, Download, Copy, Move, Archive, Delete) remain accessible
5. Verified a chat with 0–3 tags renders normally with no visible scrollbar
6. Verified both light and dark modes render correctly
7. Ran `npm run format` — no formatting changes
8. Ran `npm run build` — production build succeeded
9. Ran `npm run test:frontend` — all tests passed

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
