### PR TITLE
fix: avoid 502 on admin feedback list by using a lightweight count query

### DIFF
--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -217,11 +217,20 @@ class FeedbackTable:
         async with get_async_db_context(db) as db:
             stmt = select(Feedback, User).join(User, Feedback.user_id == User.id)
 
+            # Lightweight count: JOIN + WHERE only, no ORDER BY and without
+            # selecting the JSON ``data`` column. Wrapping the full
+            # select(Feedback, User) + JSON-ORDER BY statement in a subquery
+            # just to count rows forces PostgreSQL to materialize the JSON
+            # column and evaluate the JSON-cast ORDER BY, which surfaces as a
+            # 502 on the admin feedback list endpoint. (#25953)
+            count_stmt = select(func.count(Feedback.id)).select_from(Feedback).join(User, Feedback.user_id == User.id)
+
             if filter:
                 # Apply model_id filter (exact match)
                 model_id = filter.get('model_id')
                 if model_id:
                     stmt = stmt.filter(Feedback.data['model_id'].as_string() == model_id)
+                    count_stmt = count_stmt.filter(Feedback.data['model_id'].as_string() == model_id)
 
                 order_by = filter.get('order_by')
                 direction = filter.get('direction')
@@ -251,7 +260,7 @@ class FeedbackTable:
                 stmt = stmt.order_by(Feedback.created_at.desc())
 
             # Count BEFORE pagination
-            count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+            count_result = await db.execute(count_stmt)
             total = count_result.scalar()
 
             if skip:
@@ -395,7 +404,15 @@ class FeedbackTable:
                 .order_by(Feedback.updated_at.desc())
             )
 
-            count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+            # Lightweight count: JOIN + WHERE only, no ORDER BY and without
+            # selecting the JSON ``data`` column (see get_feedback_items). (#25953)
+            count_stmt = (
+                select(func.count(Feedback.id))
+                .select_from(Feedback)
+                .join(User, Feedback.user_id == User.id)
+                .filter(Feedback.user_id == user_id)
+            )
+            count_result = await db.execute(count_stmt)
             total = count_result.scalar()
 
             if skip:


### PR DESCRIPTION
### Description

The admin feedback list endpoint `GET /api/v1/evaluations/feedbacks/list` returns HTTP 502 on PostgreSQL.

In `backend/open_webui/models/feedbacks.py`, `get_feedback_items()` builds the row count as:

```python
count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
```

where `stmt` is a `select(Feedback, User).join(...)` carrying an `ORDER BY` on a JSON-extracted field (e.g. `Feedback.data['model_id'].as_string()`). Wrapping that statement in a subquery just to count rows forces PostgreSQL to build a derived table that selects the full JSON `data` column and to evaluate the JSON-cast `ORDER BY` even though only `count(*)` is needed. On real data this surfaces as a 502 (the same failure class as #24670, "invalid memory alloc request size" / cast errors on JSON columns).

The user-scoped path `get_feedbacks_by_user_id()` (`/feedbacks/user`) used the identical fragile subquery pattern; it happened to work because it orders by a plain column, but it still needlessly materialized both entities (including the JSON `data` column) just to count.

### Changed

- `get_feedback_items()`: build a separate lightweight count statement — `select(func.count(Feedback.id)).select_from(Feedback).join(User, ...)` — that re-applies only the WHERE filters (`model_id`) and never the `ORDER BY` or entity/JSON columns.
- `get_feedbacks_by_user_id()`: apply the same lightweight count pattern.

This mirrors the pattern already used in `backend/open_webui/models/knowledge.py` ("Lightweight count: avoid selecting File.data and ORDER BY"), introduced during the same async-DB migration.

### Fixed

- Fixed admin feedback list endpoint returning 502 on PostgreSQL due to a JSON-column + JSON-cast-ORDER-BY subquery being wrapped in a `COUNT(*)`.

### Testing

Verified the regression at the SQL-compilation level (PostgreSQL dialect) and functionally on SQLite, mirroring the exact ORM shapes:

- Before: the count compiles to `SELECT count(*) FROM (SELECT feedback.id, ..., feedback.data, ... FROM feedback JOIN "user" ... ORDER BY CAST(feedback.data ->> ... AS VARCHAR)) AS anon_1` — selects the JSON `data` column and carries `ORDER BY`.
- After: the count compiles to `SELECT count(feedback.id) FROM feedback JOIN "user" ON ... WHERE ...` — no JSON `data` column, no `ORDER BY`, WHERE filter preserved.
- Functional totals verified correct: unfiltered, `model_id`-filtered, and per-user counts all return the expected values.

`ruff format --check` passes on the changed file.

Closes #25953

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
