### PR TITLE
fix(markdown): keep code blocks with nested ``` fences intact

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -25,6 +25,9 @@ import markedKatexExtension from '$lib/utils/marked/katex-extension';
 import hljs from 'highlight.js';
 import { decode } from 'html-entities';
 
+import { normalizeNestedFences } from './markdown-fences';
+export { normalizeNestedFences } from './markdown-fences';
+
 //////////////////////////
 // Helper functions
 // No one thanks the foundation, but without it the
@@ -95,6 +98,7 @@ export const sanitizeResponseContent = (content: string) => {
 };
 
 export const processResponseContent = (content: string) => {
+	content = normalizeNestedFences(content);
 	content = processChineseContent(content);
 	return content.trim();
 };

--- a/src/lib/utils/markdown-fences.test.ts
+++ b/src/lib/utils/markdown-fences.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { Marked } from 'marked';
+import { normalizeNestedFences } from './markdown-fences';
+
+// Triple backtick, kept in a constant so the source itself stays readable.
+const F = '```';
+
+const lex = (s: string) => new Marked().lexer(s);
+const codeTokens = (tokens: any[]) => tokens.filter((t) => t.type === 'code');
+const hasType = (tokens: any[], type: string) => tokens.some((t) => t.type === type);
+
+// The shape that broke in the "Automated ModSecurity Log Analyzer" chat: a language-tagged
+// block whose body (a prompt string) embeds ``` fences. The visible break happened right
+// after the colon-terminated lines, because those are the last code lines before a nested ```.
+const pythonExample = [
+	F + 'python',
+	'    prompt = f"""You are a security expert.',
+	'',
+	'Provide ModSec rules in proper syntax:',
+	'   ' + F,
+	'   SecRule VARIABLES "OPERATOR" \\',
+	'       "id:900000,phase:2,deny"',
+	'   ' + F,
+	'',
+	'LOG CONTENT:',
+	F,
+	'{log_content}',
+	F,
+	'"""',
+	'    return prompt',
+	F
+].join('\n');
+
+describe('normalizeNestedFences', () => {
+	it('keeps a python block with nested ``` fences as a single code token', () => {
+		const tokens = lex(normalizeNestedFences(pythonExample));
+		const codes = codeTokens(tokens);
+
+		expect(codes).toHaveLength(1);
+		expect(codes[0].lang).toBe('python');
+		expect(codes[0].text).toContain('SecRule');
+		expect(codes[0].text).toContain('{log_content}');
+		expect(codes[0].text).toContain(F); // inner fences preserved as content
+		expect(hasType(tokens, 'paragraph')).toBe(false); // nothing spilled out
+	});
+
+	it('(control) reproduces the bug on un-normalized input', () => {
+		const tokens = lex(pythonExample);
+		// The block splits at the first inner ```; prose (e.g. "SecRule ...") spills out.
+		expect(codeTokens(tokens).length).toBeGreaterThan(1);
+		expect(hasType(tokens, 'paragraph')).toBe(true);
+	});
+
+	it('preserves the language tag for a csharp block', () => {
+		const csharp = [
+			F + 'csharp',
+			'var msg = $@"prompt with a fenced example:',
+			F,
+			'SecRule ...',
+			F,
+			'";'
+		].join('\n');
+		const codes = codeTokens(lex(normalizeNestedFences(csharp)));
+		expect(codes).toHaveLength(1);
+		expect(codes[0].lang).toBe('csharp');
+	});
+
+	it('promotes a nested block without swallowing a following tagged block', () => {
+		const s = [
+			F + 'python',
+			'p = """',
+			'in proper syntax:',
+			F,
+			'SecRule',
+			F,
+			'end',
+			'"""',
+			F, // true close of the python block
+			'',
+			'More text.',
+			'',
+			F + 'bash',
+			'echo hi',
+			F
+		].join('\n');
+		const tokens = lex(normalizeNestedFences(s));
+		const codes = codeTokens(tokens);
+
+		expect(codes).toHaveLength(2);
+		expect(codes[0].lang).toBe('python');
+		expect(codes[0].text).toContain('SecRule');
+		expect(codes[0].text).toContain(F);
+		expect(codes[1].lang).toBe('bash');
+		expect(hasType(tokens, 'paragraph')).toBe(true); // "More text." between the blocks
+	});
+
+	it('is a no-op for content without code fences', () => {
+		const s = 'Just some **markdown** text, with a $cost of 5 and no code.';
+		expect(normalizeNestedFences(s)).toBe(s);
+	});
+
+	it('leaves a well-formed single code block unchanged', () => {
+		const s = [F + 'js', 'const x = 1;', F].join('\n');
+		expect(normalizeNestedFences(s)).toBe(s);
+		const codes = codeTokens(lex(s));
+		expect(codes).toHaveLength(1);
+		expect(codes[0].lang).toBe('js');
+	});
+
+	it('is idempotent and skips already-wide outer fences', () => {
+		// Outer already 4 backticks, inner 3 -> already safe, must not change.
+		const safe = ['````python', 'x = """', F, 'inner', F, '"""', '````'].join('\n');
+		expect(normalizeNestedFences(safe)).toBe(safe);
+
+		// Re-running on already-normalized content is stable.
+		const once = normalizeNestedFences(pythonExample);
+		expect(normalizeNestedFences(once)).toBe(once);
+	});
+
+	it('is stable on a streaming prefix (block not yet closed)', () => {
+		const prefix = [
+			F + 'python',
+			'p = """',
+			'in proper syntax:',
+			F,
+			'SecRule',
+			F,
+			'still streaming...'
+		].join('\n');
+		const once = normalizeNestedFences(prefix);
+		expect(normalizeNestedFences(once)).toBe(once);
+		expect(() => lex(once)).not.toThrow();
+	});
+});

--- a/src/lib/utils/markdown-fences.ts
+++ b/src/lib/utils/markdown-fences.ts
@@ -1,0 +1,136 @@
+/**
+ * Normalize nested triple-backtick fences inside a language-tagged code block.
+ *
+ * LLMs frequently emit a language-tagged block (e.g. ```python) opened with only
+ * three backticks whose body itself contains ``` fences — a prompt string, a
+ * markdown example, etc. Per CommonMark (which `marked` implements) the 3-backtick
+ * outer fence is closed by the FIRST inner ```, so the block breaks apart and the
+ * remainder spills into alternating prose/code tokens. The model should have used
+ * 4+ backticks on the outer fence; this rewrites the outer fence pair to use one
+ * more backtick than the longest nested fence so the inner fences become content.
+ *
+ * Heuristic: a language-tagged opener owns everything up to the LAST fence before
+ * the next language-tagged opener, EOF, or a markdown section heading — whichever
+ * comes first. We trust the *last* close (not the first), but never extend across a
+ * prose boundary. This matches LLM conventions: outer blocks are language-tagged,
+ * nested example fences are bare and embedded in code, and distinct top-level blocks
+ * are separated by prose (headings).
+ *
+ * The "prose boundary" is an ATX heading of level >= 2 (`## ` … `###### `). Level is
+ * capped at 2+ on purpose so a single-`#` code comment (`# Configuration`) is NOT
+ * mistaken for a heading. Stopping at a heading prevents a tagged block from swallowing
+ * a later, unrelated bare code block (and the prose between them) into itself.
+ *
+ * Streaming-safe: a no-op until 2+ fences are present and a nested fence would
+ * actually close the block. Idempotent: already-wide outer fences are skipped.
+ *
+ * Known limitations: tilde (~~~) fences are not handled (a ~ fence cannot close a
+ * backtick fence in marked, so there is nothing to corrupt); two code blocks separated
+ * only by a plain sentence (no heading) where the second is bare can still over-merge.
+ * The bias is toward UNDER-merging (leaving a block unfixed, i.e. no worse than today)
+ * rather than over-merging (hiding prose inside a code block).
+ *
+ * NOTE: `replaceOutsideCode` in ./index.ts shares the same naive ```...``` pairing
+ * blind spot, but it only drives token substitution (low blast radius) and is left
+ * untouched here.
+ */
+export const normalizeNestedFences = (content: string): string => {
+	if (!content || !content.includes('```')) return content;
+
+	const lines = content.split('\n');
+	// Whole-line fence: ≤3 leading spaces, 3+ backticks, optional info string (no backticks).
+	const fenceRe = /^( {0,3})(`{3,})[ \t]*([^`]*?)[ \t]*$/;
+
+	type Fence = { lineIdx: number; indent: number; ticks: number; info: string; tagged: boolean };
+	const fences: Fence[] = [];
+	for (let i = 0; i < lines.length; i++) {
+		const m = fenceRe.exec(lines[i]);
+		if (m) {
+			fences.push({
+				lineIdx: i,
+				indent: m[1].length,
+				ticks: m[2].length,
+				info: m[3],
+				tagged: m[3] !== ''
+			});
+		}
+	}
+	if (fences.length < 2) return content;
+
+	// ATX heading, level >= 2 — a prose boundary a tagged block must not extend across.
+	const headingRe = /^ {0,3}#{2,6}\s/;
+
+	const edits: { openIdx: number; closeIdx: number; ticks: number; indent: number; info: string }[] =
+		[];
+	let k = 0;
+	while (k < fences.length) {
+		const open = fences[k];
+		if (!open.tagged) {
+			// Leave orphan bare top-level fences alone — we can't tell open from close.
+			k++;
+			continue;
+		}
+
+		// The next language-tagged opener begins a sibling block; the current opener
+		// cannot extend past it.
+		let nextTagged = k + 1;
+		while (nextTagged < fences.length && !fences[nextTagged].tagged) {
+			nextTagged++;
+		}
+
+		// A markdown heading after the opener also bounds the block: nested example
+		// fences live in code (no headings between them), so the first heading marks
+		// where this code block must already have ended.
+		const regionEnd = nextTagged < fences.length ? fences[nextTagged].lineIdx : lines.length;
+		let proseLine = regionEnd;
+		for (let li = open.lineIdx + 1; li < regionEnd; li++) {
+			if (headingRe.test(lines[li])) {
+				proseLine = li;
+				break;
+			}
+		}
+
+		// True close = last fence before the next tagged opener AND before any heading.
+		let closePos = -1;
+		for (let j = k + 1; j < nextTagged; j++) {
+			if (fences[j].lineIdx < proseLine) closePos = j;
+			else break;
+		}
+
+		if (closePos <= k) {
+			// No nested fence before the boundary → ordinary, well-formed block.
+			k = nextTagged;
+			continue;
+		}
+
+		// Widest nested fence strictly between the opener and its true close.
+		let maxInner = 0;
+		for (let j = k + 1; j < closePos; j++) {
+			if (fences[j].ticks > maxInner) maxInner = fences[j].ticks;
+		}
+
+		// Only rewrite when a nested fence would actually close the block
+		// (maxInner >= open.ticks). This guard also makes the transform idempotent.
+		if (closePos - k - 1 >= 1 && maxInner >= open.ticks) {
+			edits.push({
+				openIdx: open.lineIdx,
+				closeIdx: fences[closePos].lineIdx,
+				ticks: maxInner + 1,
+				indent: open.indent,
+				info: open.info
+			});
+		}
+
+		k = nextTagged;
+	}
+
+	if (edits.length === 0) return content;
+
+	for (const e of edits) {
+		const fence = '`'.repeat(e.ticks);
+		const pad = ' '.repeat(e.indent);
+		lines[e.openIdx] = `${pad}${fence}${e.info}`;
+		lines[e.closeIdx] = `${pad}${fence}`;
+	}
+	return lines.join('\n');
+};

--- a/src/lib/utils/marked/katex-extension.test.ts
+++ b/src/lib/utils/marked/katex-extension.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { Marked } from 'marked';
+import markedKatexExtension from './katex-extension';
+
+const buildMarked = () => {
+	const m = new Marked();
+	m.use(markedKatexExtension({}));
+	return m;
+};
+
+// Recursively collect every token type in the tree (inline tokens live under .tokens / .items).
+const collectTypes = (tokens: any[], acc: Set<string> = new Set<string>()): Set<string> => {
+	for (const t of tokens ?? []) {
+		acc.add(t.type);
+		if (t.tokens) collectTypes(t.tokens, acc);
+		if (t.items) for (const item of t.items) collectTypes(item.tokens ?? [], acc);
+	}
+	return acc;
+};
+
+const countType = (tokens: any[], type: string): number => {
+	let n = 0;
+	for (const t of tokens ?? []) {
+		if (t.type === type) n++;
+		if (t.tokens) n += countType(t.tokens, type);
+		if (t.items) for (const item of t.items) n += countType(item.tokens ?? [], type);
+	}
+	return n;
+};
+
+describe('katex-extension: $ adjacent to / inside code is not math', () => {
+	it('does not turn $ inside inline code spans into math', () => {
+		const tokens = buildMarked().lexer('Use `$PATH` and `$HOME` in your shell.');
+		const types = collectTypes(tokens);
+
+		expect(types.has('inlineKatex')).toBe(false);
+		expect(types.has('blockKatex')).toBe(false);
+		expect(countType(tokens, 'codespan')).toBe(2);
+	});
+
+	it('rejects a $...$ match whose body contains a backtick', () => {
+		const tokens = buildMarked().lexer('value $x = `a`$ end');
+		expect(collectTypes(tokens).has('inlineKatex')).toBe(false);
+	});
+});
+
+describe('katex-extension: real math still renders (no over-correction)', () => {
+	it('renders real inline math', () => {
+		const tokens = buildMarked().lexer('Pythagoras: $x^2 + y^2 = z^2$ is classic.');
+		expect(countType(tokens, 'inlineKatex')).toBe(1);
+	});
+
+	it('renders real display math', () => {
+		const tokens = buildMarked().lexer('$$\\int_0^1 x\\,dx$$');
+		const types = collectTypes(tokens);
+		expect(types.has('blockKatex') || types.has('inlineKatex')).toBe(true);
+	});
+
+	it('renders math that legitimately follows a closed code span', () => {
+		const tokens = buildMarked().lexer('Run `cmd` then compute $a+b$.');
+		expect(countType(tokens, 'codespan')).toBe(1);
+		expect(countType(tokens, 'inlineKatex')).toBe(1);
+	});
+});

--- a/src/lib/utils/marked/katex-extension.ts
+++ b/src/lib/utils/marked/katex-extension.ts
@@ -9,8 +9,11 @@ const DELIMITER_LIST = [
 ];
 
 // Defines characters that are allowed to immediately precede or follow a math delimiter.
+// NOTE: the backtick (`) is deliberately EXCLUDED (range ends at `_`, not `` ` ``) so that a
+// `$` sitting directly against an inline code span — e.g. C# `$"..."` or shell `` `$PATH` `` —
+// is not treated as the start/end of math. Real LaTeX is never delimited right against a backtick.
 const ALLOWED_SURROUNDING_CHARS =
-	'\\s。，、､;；„“‘’“”（）「」『』［］《》【】‹›«»…⋯:：？！～⇒?!-\\/:-@\\[-`{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
+	'\\s。，、､;；„“‘’“”（）「」『』［］《》【】‹›«»…⋯:：？！～⇒?!-\\/:-@\\[-_{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
 // Modified to fit more formats in different languages. Originally: '\\s?。，、；!-\\/:-@\\[-`{-~\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}';
 
 // Pre-compile the surrounding character regex once at module load time.
@@ -161,6 +164,13 @@ function katexTokenizer(src, tokens, displayMode: boolean) {
 			.slice(2)
 			.filter((item) => item)
 			.find((item) => item.trim());
+
+		// A math body containing a raw backtick is almost never valid LaTeX — it means the
+		// `$...$` span swallowed an inline code span (e.g. `` `$PATH` and `$HOME` ``). Bail so
+		// marked falls back to normal inline parsing (codespans + text).
+		if (!text || text.includes('`')) {
+			return;
+		}
 
 		return {
 			type,


### PR DESCRIPTION
LLM replies that show code containing triple-backtick fences (e.g. a prompt string with embedded ``` examples) open the outer block with 3 backticks, so marked closes it at the first inner fence and the rest spills out as alternating prose/code.

- normalizeNestedFences(): promote a language-tagged outer fence to one more backtick than its widest nested fence, bounded by the next tagged opener, EOF, or a markdown heading so it never absorbs following prose.
- katex: drop backtick from allowed math neighbours and reject $...$ whose body contains a backtick, so $ next to/inside inline code (C# $"...", shell `$PATH`) is not parsed as math.

Adds vitest coverage for both.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
