### PR TITLE
Encode terminal ws session_id to block upstream user_id query injection

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -282,10 +282,14 @@ async def ws_terminal(
 
     import urllib.parse
 
+    # Encode session_id as an opaque path segment so it cannot smuggle '?'/'#'/'&' (at any
+    # decode depth) and inject an attacker-chosen user_id ahead of the one appended below.
+    safe_session_id = urllib.parse.quote(session_id, safe='')
+
     if policy_id:
-        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{session_id}'
+        upstream_url = f'{ws_base}/p/{policy_id}/api/terminals/{safe_session_id}'
     else:
-        upstream_url = f'{ws_base}/api/terminals/{session_id}'
+        upstream_url = f'{ws_base}/api/terminals/{safe_session_id}'
     if upstream_params:
         upstream_url += f'?{urllib.parse.urlencode(upstream_params)}'
 


### PR DESCRIPTION
ws_terminal() interpolated the path parameter session_id directly into the upstream terminal WebSocket URL and then appended ?user_id=<caller>, with no encoding or validation (the HTTP sibling proxy_terminal runs _sanitize_proxy_path; this path ran nothing). An encoded '?'/'&' smuggled through session_id survives Open WebUI's single decode and is re-decoded by the upstream, injecting an attacker-chosen user_id ahead of the appended one. Query parsing binds the first occurrence, so the orchestrator resolves the spoofed user's terminal scope, letting a normal authenticated user present another user's identity to the upstream (CWE-116/863).

Encode session_id as an opaque path segment with urllib.parse.quote(session_id, safe=''). This neutralises '?'/'#'/'&' at any decode depth (the upstream's single decode reverses only the quote, leaving the original delimiters inert as path content), while legitimate UUID session ids pass through unchanged. The appended user_id is then the only query parameter the upstream binds.

This closes the ws_terminal injection vector consolidated into GHSA-j657-m4c4-24jq. The broader concern in that advisory, that the forwarded identity is a bearer claim with no integrity binding, is a separate change spanning Open WebUI and the upstream terminal server and is not addressed here.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
