### PR TITLE
Enforce per-model access on arena fallback before bypass_filter dispatch

### DIFF
--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -237,6 +237,12 @@ async def generate_chat_completion(
 
             form_data['model'] = selected_model_id
 
+            # bypass_filter recursion below skips the line-200 check; gate the resolved model here.
+            if not bypass_filter and user.role == 'user':
+                selected_model = request.app.state.MODELS.get(selected_model_id)
+                if selected_model:
+                    await check_model_access(user, selected_model)
+
         if selected_model_id:
             if form_data.get('stream') == True:
 


### PR DESCRIPTION
generate_chat_completion() checks model access on line 200 only when bypass_filter is False. When an arena model reaches this function without a pre-resolved selected_model_id, which is the task and background path (the /api/v1/tasks/* endpoints call generate_chat_completion directly rather than through process_chat_payload), the fallback resolves the arena to an underlying model and recurses with bypass_filter=True, so the resolved model's access check is skipped. An authenticated user with access to an arena could therefore reach a model they are denied directly, and for the default or exclude arena, whose candidate pool is every non-arena model, any model on the instance (CWE-862). The normal chat path resolves the arena in process_chat_payload before this function, so its resolved model is checked on line 200; the task path was not, which is the inconsistency.

Enforce check_model_access() on the resolved model in the fallback, before the bypass_filter=True recursion, mirroring the normal-path check. Admins and already-bypassed recursive calls are unaffected, and legitimate arena use of accessible models is unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
