### PR TITLE
Gate scheduled automations and fail closed on per-model access for no…

### DIFF
--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -321,7 +321,8 @@ async def check_model_access(
         return
 
     if model_info:
-        if user.role == 'user':
+        # Enforce for every non-admin role (including pending); never fail open.
+        if user.role != 'admin':
             from open_webui.models.access_grants import AccessGrants
 
             user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id)}

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -359,6 +359,16 @@ async def execute_automation(app, automation: AutomationModel) -> None:
             await _record_run(automation.id, 'error', error='User not found')
             return
 
+        # Re-gate the rehydrated owner: a demoted/deactivated or de-permissioned owner must not run.
+        from open_webui.utils.access_control import has_permission
+
+        if user.role not in ('user', 'admin') or (
+            user.role != 'admin'
+            and not await has_permission(user.id, 'features.automations', app.state.config.USER_PERMISSIONS)
+        ):
+            await _record_run(automation.id, 'error', error='Owner no longer permitted to run automations')
+            return
+
         prompt = await prompt_template(automation.data['prompt'], user)
         model_id = automation.data['model_id']
         terminal_config = automation.data.get('terminal')


### PR DESCRIPTION
…n-user roles

Two lifecycle/authorization gaps let a deactivated (pending) account keep acting:

1. The background automation scheduler (execute_automation) rehydrated the owner by ID and dispatched the chat pipeline without re-checking the owner. A user later set to pending, or one whose features.automations permission was revoked, kept running scheduled automations on the operator's provider credentials, even though the HTTP create/update/run routes already gate on get_verified_user + features.automations. Re-gate the rehydrated owner before dispatch: require role user/admin and, for non-admins, the features.automations permission; otherwise record an error and skip the run.

2. check_model_access enforced per-model ACLs only for exactly role == 'user', so any other non-admin role (a pending principal) fell through and was granted access. Enforce for every non-admin role (admins still bypass), so the check fails closed (CWE-862, CWE-863).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
