### PR TITLE
Fail closed when the proxy/redirect path decode cap is exceeded

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -60,6 +60,9 @@ def _safe_static_redirect_path(url: str) -> str | None:
         if decoded == path:
             break
         path = decoded
+    # Fail closed: a value still encoded after the cap would be decoded further downstream.
+    if unquote(path) != path:
+        return None
     if '\x00' in path or '\\' in path:
         return None
     if not path.startswith('/'):

--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -43,6 +43,9 @@ def _sanitize_proxy_path(path: str) -> str | None:
         if once == decoded:
             break
         decoded = once
+    # Fail closed: still encoded after the cap means the upstream would decode further into traversal.
+    if unquote(decoded) != decoded:
+        return None
     had_trailing_slash = decoded.endswith('/')
     normalized = posixpath.normpath(decoded)
     # Remove any leading slashes that would reset the base


### PR DESCRIPTION
The decode-until-stable loops in _sanitize_proxy_path (terminals.py, cap 8) and _safe_static_redirect_path (models.py, cap 2) proceed with whatever remains after the cap instead of rejecting it. A path encoded more times than the cap therefore exits the loop still percent-encoded, passes the literal '..' / prefix checks (the dots are still %2E, not '..'), and is forwarded to the upstream terminal server, or emitted as a redirect Location, which then decodes it once more and resolves the traversal. This is the residual of the decode-until-stable hardening added for CVE-2026-54017: the cap is a fixed depth, not a true stability guarantee.

Reject when the value is still not stable after the cap (unquote(x) != x), so anything encoded more deeply than the cap fails closed rather than being forwarded. Legitimate paths stabilize within a pass or two and are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
