### PR TITLE
fix: stop marking collection_names entries as legacy in ModelEditor

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -312,7 +312,7 @@
 						name: item.name,
 						type: 'collection',
 						collection_names: item.collection_names,
-						legacy: true
+						legacy: false
 					};
 				} else {
 					return item;


### PR DESCRIPTION
## Description

Closes #26035

The knowledge mapping logic in `ModelEditor.svelte` (lines 303-320) unconditionally sets `legacy: true` for entries using the `collection_names` format. But `collection_names` is the current format - it replaced the old singular `collection_name` string in the knowledge table migration. Only the old `collection_name` format should be marked legacy.

This causes all knowledge collections to display as "Legacy Collection" in the Model Editor UI, even when they are using the current data format.

### Fix

One-line change: `legacy: true` to `legacy: false` on line 315 for the `collection_names` branch. The `collection_name` (singular) branch on line 308 correctly stays `legacy: true`.

## Changelog Entry

### Fixed

- Fixed ModelEditor incorrectly marking collection_names knowledge entries as legacy, causing all collections to display "Legacy Collection" label

## Testing

1. Create a knowledge collection via the Knowledge interface
2. Create or edit a model and associate it with that knowledge collection
3. Save the model
4. Re-open the model in the Model Editor
5. The knowledge section should now display "collection" instead of "Legacy Collection"

---

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.