### PR TITLE
fix: skip invalid web search result URLs

### DIFF
--- a/backend/open_webui/retrieval/web/search_result.py
+++ b/backend/open_webui/retrieval/web/search_result.py
@@ -1,0 +1,17 @@
+from urllib.parse import urlparse
+
+import validators
+
+
+def is_valid_search_result_url(url: str | None) -> bool:
+    if not url:
+        return False
+
+    if isinstance(validators.url(url), validators.ValidationError):
+        return False
+
+    if any(ch in url for ch in ('\\', '\t', '\n', '\r')):
+        return False
+
+    parsed_url = urlparse(url)
+    return parsed_url.scheme in ('http', 'https')

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -96,6 +96,7 @@ from open_webui.retrieval.web.ollama import search_ollama_cloud
 from open_webui.retrieval.web.perplexity import search_perplexity
 from open_webui.retrieval.web.perplexity_search import search_perplexity_search
 from open_webui.retrieval.web.searchapi import search_searchapi
+from open_webui.retrieval.web.search_result import is_valid_search_result_url
 from open_webui.retrieval.web.searxng import search_searxng
 from open_webui.retrieval.web.serpapi import search_serpapi
 from open_webui.retrieval.web.serper import search_serper
@@ -2269,7 +2270,7 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
         for result in search_results:
             if result:
                 for item in result:
-                    if item and item.link:
+                    if item and is_valid_search_result_url(item.link):
                         result_items.append(item)
                         urls.append(item.link)
 

--- a/test/backend/open_webui/retrieval/web/test_search_result.py
+++ b/test/backend/open_webui/retrieval/web/test_search_result.py
@@ -1,0 +1,18 @@
+from open_webui.retrieval.web.search_result import is_valid_search_result_url
+
+
+def test_accepts_http_and_https_search_result_urls():
+    assert is_valid_search_result_url('https://example.com/result?q=open-webui')
+    assert is_valid_search_result_url('http://example.com/result')
+
+
+def test_rejects_missing_relative_and_non_http_search_result_urls():
+    assert not is_valid_search_result_url('')
+    assert not is_valid_search_result_url(None)
+    assert not is_valid_search_result_url('/relative/result')
+    assert not is_valid_search_result_url('ftp://example.com/result')
+
+
+def test_rejects_parser_confusing_search_result_urls():
+    assert not is_valid_search_result_url('https://example.com\\@127.0.0.1/')
+    assert not is_valid_search_result_url('https://example.com/\nnext')


### PR DESCRIPTION
Addresses the invalid URL failure path reported in #25710.

Some search providers can return empty, relative, non-HTTP, or otherwise parser-confusing URLs. `process_web_search` previously accepted any non-empty `SearchResult.link`, so an invalid result URL could be added to the downstream loader/vector/chat payload and later fail with errors such as `Invalid url value`.

This adds a small shared URL predicate for web search results and uses it when collecting search results. Invalid result links are skipped before they enter the web loader or bypass-loader document metadata, while valid `http` and `https` result URLs continue through unchanged.

Verification:
- `PYTHONPATH=backend uv run --no-project --python 3.12 --with pytest --with validators --with typer --with uvicorn pytest test/backend/open_webui/retrieval/web/test_search_result.py -q`
- `PYTHONPATH=backend uv run --no-project --python 3.12 --with validators --with typer --with uvicorn python -m py_compile backend/open_webui/retrieval/web/search_result.py backend/open_webui/routers/retrieval.py`
- `git diff --check`

Note: I used `uv run --no-project` for the focused backend test to avoid triggering the full editable package build/frontend Cypress download.
