### PR TITLE
fix: skip invalid web search result URLs

### DIFF
--- a/backend/open_webui/retrieval/web/search_result.py
+++ b/backend/open_webui/retrieval/web/search_result.py
@@ -1,0 +1,17 @@
+from urllib.parse import urlparse
+
+import validators
+
+
+def is_valid_search_result_url(url: str | None) -> bool:
+    if not url:
+        return False
+
+    if isinstance(validators.url(url), validators.ValidationError):
+        return False
+
+    if any(ch in url for ch in ('\\', '\t', '\n', '\r')):
+        return False
+
+    parsed_url = urlparse(url)
+    return parsed_url.scheme in ('http', 'https')

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -96,6 +96,7 @@ from open_webui.retrieval.web.ollama import search_ollama_cloud
 from open_webui.retrieval.web.perplexity import search_perplexity
 from open_webui.retrieval.web.perplexity_search import search_perplexity_search
 from open_webui.retrieval.web.searchapi import search_searchapi
+from open_webui.retrieval.web.search_result import is_valid_search_result_url
 from open_webui.retrieval.web.searxng import search_searxng
 from open_webui.retrieval.web.serpapi import search_serpapi
 from open_webui.retrieval.web.serper import search_serper
@@ -2269,7 +2270,7 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
         for result in search_results:
             if result:
                 for item in result:
-                    if item and item.link:
+                    if item and is_valid_search_result_url(item.link):
                         result_items.append(item)
                         urls.append(item.link)
 

--- a/test/backend/open_webui/retrieval/web/test_search_result.py
+++ b/test/backend/open_webui/retrieval/web/test_search_result.py
@@ -1,0 +1,18 @@
+from open_webui.retrieval.web.search_result import is_valid_search_result_url
+
+
+def test_accepts_http_and_https_search_result_urls():
+    assert is_valid_search_result_url('https://example.com/result?q=open-webui')
+    assert is_valid_search_result_url('http://example.com/result')
+
+
+def test_rejects_missing_relative_and_non_http_search_result_urls():
+    assert not is_valid_search_result_url('')
+    assert not is_valid_search_result_url(None)
+    assert not is_valid_search_result_url('/relative/result')
+    assert not is_valid_search_result_url('ftp://example.com/result')
+
+
+def test_rejects_parser_confusing_search_result_urls():
+    assert not is_valid_search_result_url('https://example.com\\@127.0.0.1/')
+    assert not is_valid_search_result_url('https://example.com/\nnext')


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to #25710`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this is a backend bug fix with no user-facing configuration change.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Focused tests and syntax compilation were run locally.
- [x] **No Unchecked AI Code:** This PR has undergone review and testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** The fix uses the existing web search result aggregation path and does not add settings.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses `fix`.

# Changelog Entry

### Description

- Relates to #25710.
- Skips invalid web search result URLs before they enter the web loader, bypass-loader document metadata, or downstream chat payload.

### Added

- Added a small URL predicate for search result links.
- Added focused tests for valid, missing, relative, non-HTTP, and parser-confusing URLs.

### Changed

- Web search aggregation now accepts only valid `http` and `https` result links.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevents empty, relative, non-HTTP, or parser-confusing search result URLs from being forwarded downstream and later failing with errors such as `Invalid url value`.

### Security

- Rejects parser-confusing characters in search result URLs before downstream URL handling.

### Breaking Changes

- None.

---

### Additional Information

Verification:
- `PYTHONPATH=backend uv run --no-project --python 3.12 --with pytest --with validators --with typer --with uvicorn pytest test/backend/open_webui/retrieval/web/test_search_result.py -q`
- `PYTHONPATH=backend uv run --no-project --python 3.12 --with validators --with typer --with uvicorn python -m py_compile backend/open_webui/retrieval/web/search_result.py backend/open_webui/routers/retrieval.py`
- `git diff --check HEAD~1..HEAD`

I used `uv run --no-project` for the focused backend verification to avoid triggering the full editable package build/frontend Cypress download.

### Screenshots or Videos

- Not applicable; backend-only fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
