### PR TITLE
fix: read Ollama Cloud web search API key env

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1624,7 +1624,7 @@ WEB_SEARCH_TRUST_ENV = ConfigVar(
 OLLAMA_CLOUD_WEB_SEARCH_API_KEY = ConfigVar(
     'OLLAMA_CLOUD_WEB_SEARCH_API_KEY',
     'rag.web.search.ollama_cloud_api_key',
-    os.getenv('OLLAMA_CLOUD_API_KEY', ''),
+    os.getenv('OLLAMA_CLOUD_WEB_SEARCH_API_KEY', os.getenv('OLLAMA_CLOUD_API_KEY', '')),
 )
 
 SEARXNG_QUERY_URL = ConfigVar(

--- a/test/backend/open_webui/test_config_env.py
+++ b/test/backend/open_webui/test_config_env.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_ollama_cloud_web_search_api_key_reads_matching_env_var():
+    config_source = Path('backend/open_webui/config.py').read_text()
+
+    setting_start = config_source.index("OLLAMA_CLOUD_WEB_SEARCH_API_KEY = ConfigVar(")
+    setting_end = config_source.index('SEARXNG_QUERY_URL = ConfigVar(', setting_start)
+    setting_source = config_source[setting_start:setting_end]
+
+    assert "os.getenv('OLLAMA_CLOUD_WEB_SEARCH_API_KEY'" in setting_source


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) — `Closes #25994`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this makes the existing env/config name work.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Focused tests and syntax compilation were run locally.
- [x] **No Unchecked AI Code:** This PR has undergone review and testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** This keeps the existing ConfigVar and adds a compatible env fallback.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses `fix`.

# Changelog Entry

### Description

- Closes #25994.
- Makes `OLLAMA_CLOUD_WEB_SEARCH_API_KEY` read from the matching environment variable.

### Added

- Added a focused regression test for the Ollama Cloud web search API key env mapping.

### Changed

- `OLLAMA_CLOUD_WEB_SEARCH_API_KEY` now defaults from `OLLAMA_CLOUD_WEB_SEARCH_API_KEY`, with `OLLAMA_CLOUD_API_KEY` retained as a fallback for compatibility.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed Docker/env setups where `OLLAMA_CLOUD_WEB_SEARCH_API_KEY` was set but ignored, causing Ollama Cloud web search requests to be sent with an empty bearer token and fail with 401.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Verification:
- `uv run --no-project --python 3.12 --with pytest pytest test/backend/open_webui/test_config_env.py -q`
- `uv run --no-project --python 3.12 python -m py_compile backend/open_webui/config.py`
- `git diff --check`

### Screenshots or Videos

- Not applicable; backend configuration fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
