### PR TITLE
Add group model access management

### DIFF
--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -17,15 +17,135 @@ from open_webui.models.groups import (
     UserIdsForm,
 )
 from open_webui.models.knowledge import Knowledges
-from open_webui.models.models import Models
+from open_webui.models.models import ModelForm, ModelMeta, ModelParams, Models
 from open_webui.models.tools import Tools
 from open_webui.models.users import UserInfoResponse, Users
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.models import get_all_models
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class GroupModelIdsForm(BaseModel):
+    model_ids: list[str] = Field(default_factory=list, max_length=100)
+
+
+class GroupModelResponse(BaseModel):
+    id: str
+    name: str
+    base_model_id: str | None = None
+    description: str | None = None
+    selected: bool = False
+
+
+def _model_label(model: dict) -> str:
+    return str(model.get('name') or model.get('id') or '')
+
+
+def _model_info(model: dict) -> dict:
+    info = model.get('info') or {}
+    return info if isinstance(info, dict) else {}
+
+
+def _grant_data(grant) -> dict:
+    return grant.model_dump() if hasattr(grant, 'model_dump') else dict(grant)
+
+
+def _model_meta(model) -> dict:
+    data = model.model_dump() if hasattr(model, 'model_dump') else dict(model)
+    meta = data.get('meta') or {}
+    return meta if isinstance(meta, dict) else {}
+
+
+def _model_hidden(model) -> bool:
+    return bool(_model_meta(model).get('hidden'))
+
+
+def _is_assignable_model(model: dict) -> bool:
+    if model.get('arena'):
+        return False
+    if 'pipeline' in model and model['pipeline'].get('type', None) == 'filter':
+        return False
+    if _model_meta(model).get('hidden'):
+        return False
+    return True
+
+
+def _model_summary(model, selected: bool = False) -> dict:
+    data = model.model_dump() if hasattr(model, 'model_dump') else dict(model)
+    meta = _model_meta(model)
+    return {
+        'id': data.get('id'),
+        'name': data.get('name') or data.get('id'),
+        'base_model_id': data.get('base_model_id'),
+        'description': meta.get('description') if isinstance(meta, dict) else None,
+        'selected': selected,
+    }
+
+
+def _with_group_read_grant(access_grants: list, group_id: str) -> list[dict]:
+    grants = [_grant_data(grant) for grant in (access_grants or [])]
+    if not any(
+        grant.get('principal_type') == 'group'
+        and grant.get('principal_id') == group_id
+        and grant.get('permission') == 'read'
+        for grant in grants
+    ):
+        grants.append(
+            {
+                'principal_type': 'group',
+                'principal_id': group_id,
+                'permission': 'read',
+            }
+        )
+    return grants
+
+
+def _without_group_grants(access_grants: list, group_id: str) -> list[dict]:
+    grants = []
+    for grant in access_grants or []:
+        grant_data = _grant_data(grant)
+        if (
+            grant_data.get('principal_type') == 'group'
+            and grant_data.get('principal_id') == group_id
+            and grant_data.get('permission') == 'read'
+        ):
+            continue
+        grants.append(grant_data)
+    return grants
+
+
+async def _ensure_model_access_record(model_id: str, visible_model: dict, user, db: AsyncSession):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if model:
+        if not model.is_active or _model_hidden(model):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+        return model
+
+    model_info = _model_info(visible_model)
+    model_meta = model_info.get('meta') or {}
+
+    return await Models.insert_new_model(
+        ModelForm(
+            id=model_id,
+            base_model_id=None,
+            name=_model_label(visible_model),
+            meta=ModelMeta(
+                description=visible_model.get('description')
+                or (model_meta.get('description') if isinstance(model_meta, dict) else None),
+                capabilities=visible_model.get('capabilities'),
+            ),
+            params=ModelParams(),
+            access_grants=[],
+            is_active=True,
+        ),
+        user.id,
+        db=db,
+    )
 
 ############################
 # GetFunctions
@@ -253,6 +373,146 @@ async def remove_users_from_group(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT(e),
         )
+
+
+############################
+# ManageGroupModels
+############################
+
+
+@router.get('/id/{id}/models', response_model=list[GroupModelResponse])
+async def get_group_models(id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    models = await Models.get_all_models(db=db)
+    return [
+        _model_summary(model, selected=True)
+        for model in models
+        if model.is_active
+        and not _model_hidden(model)
+        and any(
+            grant.principal_type == 'group'
+            and grant.principal_id == id
+            and grant.permission == 'read'
+            for grant in (model.access_grants or [])
+        )
+    ]
+
+
+@router.get('/id/{id}/models/available', response_model=list[GroupModelResponse])
+async def get_available_group_models(
+    id: str,
+    request: Request,
+    query: Optional[str] = None,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    configured = {model.id: model for model in await Models.get_all_models(db=db)}
+    q = (query or '').strip().lower()
+    items = []
+
+    for model in await get_all_models(request, user=user):
+        if not _is_assignable_model(model):
+            continue
+
+        model_id = str(model.get('id') or '')
+        if not model_id:
+            continue
+
+        model_info = _model_info(model)
+        model_meta = model_info.get('meta') or {}
+        configured_model = configured.get(model_id)
+        if configured_model and (not configured_model.is_active or _model_hidden(configured_model)):
+            continue
+
+        access_grants = configured_model.access_grants if configured_model else model_info.get('access_grants', [])
+        grants = [_grant_data(grant) for grant in (access_grants or [])]
+        selected = any(
+            grant.get('principal_type') == 'group'
+            and grant.get('principal_id') == id
+            and grant.get('permission') == 'read'
+            for grant in grants
+        )
+        item = {
+            'id': model_id,
+            'name': _model_label(model),
+            'base_model_id': model_info.get('base_model_id'),
+            'description': model.get('description')
+            or (model_meta.get('description') if isinstance(model_meta, dict) else None),
+            'selected': selected,
+        }
+        if q and q not in item['id'].lower() and q not in item['name'].lower():
+            continue
+        items.append(item)
+
+    return sorted(items, key=lambda item: item['name'].lower())
+
+
+@router.post('/id/{id}/models/add', response_model=list[GroupModelResponse])
+async def add_models_to_group(
+    id: str,
+    form_data: GroupModelIdsForm,
+    request: Request,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    visible_models = {
+        model.get('id'): model
+        for model in await get_all_models(request, user=user)
+        if model.get('id') and _is_assignable_model(model)
+    }
+
+    for model_id in form_data.model_ids:
+        visible_model = visible_models.get(model_id)
+        if not visible_model:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+        model = await _ensure_model_access_record(model_id, visible_model, user, db)
+        if not model:
+            continue
+        await AccessGrants.set_access_grants(
+            'model',
+            model.id,
+            _with_group_read_grant(model.access_grants or [], id),
+            db=db,
+        )
+
+    return await get_group_models(id, user=user, db=db)
+
+
+@router.post('/id/{id}/models/remove', response_model=list[GroupModelResponse])
+async def remove_models_from_group(
+    id: str,
+    form_data: GroupModelIdsForm,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    for model_id in form_data.model_ids:
+        model = await Models.get_model_by_id(model_id, db=db)
+        if not model:
+            continue
+        await AccessGrants.set_access_grants(
+            'model',
+            model.id,
+            _without_group_grants(model.access_grants or [], id),
+            db=db,
+        )
+
+    return await get_group_models(id, user=user, db=db)
 
 
 ############################

--- a/src/lib/apis/groups/index.ts
+++ b/src/lib/apis/groups/index.ts
@@ -295,3 +295,124 @@ export const getGroupPreview = async (token: string, id: string) => {
 
 	return res;
 };
+
+export const getGroupModels = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/groups/id/${id}/models`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getAvailableGroupModels = async (token: string, id: string, query = '') => {
+	let error = null;
+	const searchParams = new URLSearchParams();
+	if (query) {
+		searchParams.append('query', query);
+	}
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/groups/id/${id}/models/available?${searchParams.toString()}`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const addModelsToGroup = async (token: string, id: string, modelIds: string[]) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/groups/id/${id}/models/add`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ model_ids: modelIds })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const removeModelsFromGroup = async (token: string, id: string, modelIds: string[]) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/groups/id/${id}/models/remove`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ model_ids: modelIds })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 	import { getContext, onMount } from 'svelte';
-	const i18n = getContext('i18n');
+	const i18n: any = getContext('i18n');
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import General from './General.svelte';
 	import Permissions from './Permissions.svelte';
 	import Users from './Users.svelte';
+	import GroupModels from './GroupModels.svelte';
 	import GroupPreviewPanel from './GroupPreviewPanel.svelte';
 	import { DEFAULT_PERMISSIONS } from '$lib/constants/permissions';
 	import UserPlusSolid from '$lib/components/icons/UserPlusSolid.svelte';
 	import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
+	import Cube from '$lib/components/icons/Cube.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
@@ -21,7 +23,7 @@
 	export let show = false;
 	export let edit = false;
 
-	export let group = null;
+	export let group: any = null;
 	export let defaultPermissions = {};
 
 	export let custom = true;
@@ -33,6 +35,7 @@
 	let showDeleteConfirmDialog = false;
 
 	let userCount = 0;
+	let groupId = '';
 
 	export let name = '';
 	export let description = '';
@@ -79,6 +82,8 @@
 	$: if (show) {
 		init();
 	}
+
+	$: groupId = group?.id ?? '';
 
 	onMount(() => {
 		selectedTab = tabs[0];
@@ -197,6 +202,24 @@
 								</button>
 							{/if}
 
+							{#if tabs.includes('models') && groupId}
+								<button
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									'models'
+										? ''
+										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									on:click={() => {
+										selectedTab = 'models';
+									}}
+									type="button"
+								>
+									<div class="self-center mr-2">
+										<Cube className="size-4" />
+									</div>
+									<div class="self-center">{$i18n.t('Models')}</div>
+								</button>
+							{/if}
+
 							{#if tabs.includes('preview')}
 								<button
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
@@ -244,6 +267,10 @@
 									<Permissions bind:permissions {defaultPermissions} />
 								{:else if selectedTab == 'users'}
 									<Users bind:userCount groupId={group?.id} />
+								{:else if selectedTab == 'models'}
+									{#if groupId}
+										<GroupModels {groupId} />
+									{/if}
 								{:else if selectedTab == 'preview'}
 									<GroupPreviewPanel groupId={group?.id} />
 								{/if}

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -57,7 +57,7 @@
 	edit
 	{group}
 	{defaultPermissions}
-	tabs={['general', 'permissions', 'users', 'preview']}
+	tabs={['general', 'permissions', 'users', 'models', 'preview']}
 	onSubmit={updateHandler}
 	onDelete={deleteHandler}
 />

--- a/src/lib/components/admin/Users/Groups/GroupModels.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupModels.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+	import { getContext, onDestroy, onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
+
+	import Search from '$lib/components/icons/Search.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import Checkbox from '$lib/components/common/Checkbox.svelte';
+	import {
+		addModelsToGroup,
+		getAvailableGroupModels,
+		getGroupModels,
+		removeModelsFromGroup
+	} from '$lib/apis/groups';
+
+	type GroupModel = {
+		id: string;
+		name?: string;
+		base_model_id?: string | null;
+		description?: string | null;
+		selected?: boolean;
+	};
+
+	const i18n: any = getContext('i18n');
+
+	export let groupId: string;
+
+	let loading = true;
+	let saving = false;
+	let models: GroupModel[] = [];
+	let availableModels: GroupModel[] = [];
+	let query = '';
+	let addQuery = '';
+	let showAddModal = false;
+	let selectedModelIds = new Set<string>();
+	let searchDebounceTimer: ReturnType<typeof setTimeout>;
+	let availableRequestId = 0;
+
+	$: filteredModels = models.filter((model) => {
+		if (!query) {
+			return true;
+		}
+		const q = query.toLowerCase();
+		return model.id.toLowerCase().includes(q) || (model.name ?? '').toLowerCase().includes(q);
+	});
+
+	const loadModels = async () => {
+		loading = true;
+		models = await getGroupModels(localStorage.token, groupId).catch((error) => {
+			toast.error(`${error}`);
+			return [];
+		});
+		loading = false;
+	};
+
+	const loadAvailableModels = async () => {
+		const requestId = ++availableRequestId;
+		const models = await getAvailableGroupModels(localStorage.token, groupId, addQuery).catch(
+			(error) => {
+				toast.error(`${error}`);
+				return [];
+			}
+		);
+		if (requestId === availableRequestId) {
+			availableModels = models;
+		}
+	};
+
+	const searchAvailableModels = () => {
+		clearTimeout(searchDebounceTimer);
+		searchDebounceTimer = setTimeout(loadAvailableModels, 300);
+	};
+
+	const openAddModal = async () => {
+		selectedModelIds = new Set();
+		addQuery = '';
+		showAddModal = true;
+		await loadAvailableModels();
+	};
+
+	const toggleSelected = (modelId: string) => {
+		const next = new Set(selectedModelIds);
+		if (next.has(modelId)) {
+			next.delete(modelId);
+		} else {
+			next.add(modelId);
+		}
+		selectedModelIds = next;
+	};
+
+	const addSelectedModels = async () => {
+		const modelIds = Array.from(selectedModelIds);
+		if (modelIds.length === 0) {
+			return;
+		}
+		saving = true;
+		const updatedModels = await addModelsToGroup(localStorage.token, groupId, modelIds).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+		saving = false;
+		if (!updatedModels) {
+			return;
+		}
+		models = updatedModels;
+		showAddModal = false;
+		toast.success($i18n.t('Models added successfully'));
+	};
+
+	const removeModel = async (modelId: string) => {
+		saving = true;
+		const updatedModels = await removeModelsFromGroup(localStorage.token, groupId, [modelId]).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+		saving = false;
+		if (!updatedModels) {
+			return;
+		}
+		models = updatedModels;
+		toast.success($i18n.t('Model removed successfully'));
+	};
+
+	onMount(loadModels);
+
+	onDestroy(() => {
+		clearTimeout(searchDebounceTimer);
+	});
+</script>
+
+<Modal size="lg" bind:show={showAddModal}>
+	<div class="px-5 pt-4 pb-5 dark:text-gray-100">
+		<div class="flex items-center justify-between mb-3">
+			<div class="text-lg font-medium">{$i18n.t('Add Models')}</div>
+			<button on:click={() => (showAddModal = false)}><XMark className="size-5" /></button>
+		</div>
+
+		<div class="flex items-center w-full rounded-xl bg-gray-50 dark:bg-gray-850 px-3 py-2 mb-3">
+			<Search className="size-3.5" />
+			<input
+				class="w-full text-sm ml-2 bg-transparent outline-hidden"
+				bind:value={addQuery}
+				placeholder={$i18n.t('Search models')}
+				on:input={searchAvailableModels}
+			/>
+		</div>
+
+		<div class="max-h-96 overflow-y-auto space-y-1 pr-1">
+			{#each availableModels as model}
+				<div
+					class="w-full text-left px-3 py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition flex items-center gap-3 {model.selected
+						? 'opacity-50'
+						: ''}"
+				>
+					<Checkbox
+						state={selectedModelIds.has(model.id) || model.selected ? 'checked' : 'unchecked'}
+						disabled={model.selected}
+						on:change={() => toggleSelected(model.id)}
+					/>
+					<div class="min-w-0">
+						<div class="text-sm font-medium truncate">{model.name}</div>
+						<div class="text-xs text-gray-500 truncate">{model.id}</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<div class="flex justify-end pt-4">
+			<button
+				class="px-3.5 py-1.5 rounded-full bg-black text-white dark:bg-white dark:text-black text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+				type="button"
+				disabled={saving || selectedModelIds.size === 0}
+				on:click={addSelectedModels}
+			>
+				{$i18n.t('Add')}
+				{#if saving}<Spinner />{/if}
+			</button>
+		</div>
+	</div>
+</Modal>
+
+<div class="flex flex-col h-full">
+	<div class="flex items-center gap-2 mb-3">
+		<div class="flex items-center flex-1 rounded-xl bg-gray-50 dark:bg-gray-850 px-3 py-2">
+			<Search className="size-3.5" />
+			<input
+				class="w-full text-sm ml-2 bg-transparent outline-hidden"
+				bind:value={query}
+				placeholder={$i18n.t('Search models')}
+			/>
+		</div>
+		<button
+			class="px-3 py-2 rounded-xl bg-black text-white dark:bg-white dark:text-black text-sm font-medium flex items-center gap-1"
+			type="button"
+			on:click={openAddModal}
+		>
+			<Plus className="size-3" />
+			{$i18n.t('Add')}
+		</button>
+	</div>
+
+	{#if loading}
+		<div class="flex justify-center py-12"><Spinner /></div>
+	{:else if filteredModels.length === 0}
+		<div class="text-center text-sm text-gray-500 py-12">{$i18n.t('No models assigned')}</div>
+	{:else}
+		<div class="space-y-1 overflow-y-auto pr-1">
+			{#each filteredModels as model}
+				<div class="flex items-center justify-between gap-3 px-3 py-2 rounded-xl bg-gray-50/60 dark:bg-gray-850/60">
+					<div class="min-w-0">
+						<div class="text-sm font-medium truncate">{model.name}</div>
+						<div class="text-xs text-gray-500 truncate">{model.id}</div>
+					</div>
+					<button
+						class="text-xs text-red-600 dark:text-red-400 hover:underline disabled:opacity-50"
+						type="button"
+						disabled={saving}
+						on:click={() => removeModel(model.id)}
+					>
+						{$i18n.t('Remove')}
+					</button>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary
- Adds a Models tab to the admin group edit modal
- Allows admins to grant/revoke group read access for assignable models
- Reuses existing model access_grants without adding migrations

## Notes
- Hidden, inactive, arena, and filter-pipeline models are excluded from assignment
- Removing a model only removes the managed group read grant
- Existing model access behavior remains unchanged outside group management
- This change proposal was created with AI assistance and reviewed before submission

## Testing
- `python -m py_compile backend/open_webui/routers/groups.py`
- `git diff --check`
- `npm run build`