### PR TITLE
fix: add redirect_uri to OAuth preflight keyword detection for stale …

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -765,7 +765,7 @@ class OAuthClientManager:
 
                     error_message = f'{error or ""} {error_description or ""}'.lower()
 
-                    if any(keyword in error_message for keyword in ('invalid_client', 'invalid client', 'client id')):
+                    if any(keyword in error_message for keyword in ('invalid_client', 'invalid client', 'client id', 'redirect_uri')):
                         log.warning(
                             f'OAuth client preflight detected invalid registration for {client_info.client_id}: {error} {error_description}'
                         )


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to #18309. Related PR: #18415.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Reproduced against a live MCP server using callback proxy mode — a stale/unknown client_id returns `400 {"error":"invalid_request","error_description":"Unregistered redirect_uri"}`, while a freshly DCR-registered client_id returns `302` to the upstream IdP. Confirmed the existing `_preflight_authorization_url` keyword list does not match this error, so re-registration is never triggered; adding `redirect_uri` makes the match fire and routes into the existing re-registration path (which already clears the authlib client cache via `remove_client`).
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or architectural changes.
- [x] **Git Hygiene:** Single atomic commit rebased on `dev`.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

MCP servers using callback proxy mode (where a single fixed `/callback` URL is registered with the identity provider) return `{"error":"invalid_request","error_description":"Unregistered redirect_uri"}` when a client_id is unknown — e.g. after a server restart that loses in-memory DCR state.

The `_preflight_authorization_url` check (introduced in #18415) only detects `invalid_client`, `invalid client`, and `client id` keywords, missing this error case. As a result, automatic re-registration doesn't trigger and users see the raw OAuth error.

This adds `redirect_uri` to the keyword list so these stale registrations are correctly detected and re-registered automatically.

### Added

- None

### Changed

- Added `redirect_uri` to the error keyword detection list in `_preflight_authorization_url` (`backend/open_webui/utils/oauth.py`)

### Deprecated

- None

### Removed

- None

### Fixed

- OAuth preflight check now detects "Unregistered redirect_uri" errors from MCP servers, triggering automatic client re-registration instead of showing a raw error to users

### Security

- No change

### Breaking Changes

- None

---

### Additional Information

- Relates to discussion #18309 ("When re-registering for an MCP tool with OAuth 2.1, a restart is required")
- Extends the fix from PR #18415 which introduced the preflight mechanism but with an incomplete keyword list
- Reproducible with any MCP server that uses a callback proxy pattern (fixed redirect_uri registered with IdP, dynamic client registration for MCP clients)

### Screenshots or Videos

- N/A (one-line keyword addition to existing detection logic)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
