### PR TITLE
fix: avoid masking ElevenLabs voice fetch errors as invalid voice id

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -429,8 +429,11 @@ async def _tts_openai(request, payload, file_path, file_body_path, user):
 
 async def _tts_elevenlabs(request, payload, file_path, file_body_path, user):
     """Generate speech via the ElevenLabs TTS API."""
-    voice_id = payload.get('voice', '')
-    if voice_id not in await get_available_voices(request):
+    voice_id = (payload.get('voice') or '').strip()
+    if not voice_id:
+         raise HTTPException(status_code=400, detail='Missing ElevenLabs voice id')
+    available_voices = await get_available_voices(request)
+    if available_voices and voice_id not in available_voices:
         raise HTTPException(status_code=400, detail='Invalid voice id')
 
     r = None
@@ -1344,7 +1347,7 @@ async def get_available_voices(request) -> dict:
                 voices_data = await resp.json()
                 return {v['voice_id']: v['name'] for v in voices_data.get('voices', [])}
         except Exception as e:
-            log.error(f'Error fetching ElevenLabs voices: {e}')
+            log.warning(f'Error fetching ElevenLabs voices: {e}')
             return {}
 
     if engine == 'azure':


### PR DESCRIPTION
Closes #26075

## Summary

This fixes an ElevenLabs TTS validation issue where a failed available voices fetch could cause Open WebUI to report `Invalid voice id` before the actual TTS request is attempted.

The updated logic:
- normalizes and validates that `voice_id` is not empty
- fetches `available_voices`
- only rejects the configured voice ID when `available_voices` is non-empty and the configured voice ID is absent
- avoids treating a failed or empty voice fetch result as proof that the configured voice ID is invalid

## Testing

Tested manually with a local pip/venv installation of Open WebUI v0.9.6 on Windows.

Before:
- Open WebUI returned `Invalid voice id`
- ElevenLabs logs showed failures while fetching voices
- the actual `/v1/text-to-speech/{voice_id}` request was not reached

After:
- Open WebUI no longer masks failed voice fetching as an invalid voice ID
- the actual ElevenLabs TTS request is allowed to proceed
- TTS works with the configured ElevenLabs voice ID