### PR TITLE
fix: truncate_content returns whole string when max_chars is 0

### DIFF
--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -147,10 +147,13 @@ def truncate_content(content: str, max_chars: int, mode: str = 'middletruncate')
     if mode == 'start':
         return content[:max_chars]
     elif mode == 'end':
-        return content[-max_chars:]
+        # ``content[-max_chars:]`` returns the whole string when max_chars is 0
+        # because ``-0 == 0``; guard against that so 0 truncates to empty.
+        return content[-max_chars:] if max_chars else ''
     else:  # middletruncate
         half = max_chars // 2
-        return f'{content[:half]}...{content[-(max_chars - half) :]}'
+        tail = max_chars - half
+        return f'{content[:half]}...{content[-tail:] if tail else ""}'
 
 
 def apply_content_filter(messages: list[dict], filter_str: str) -> list[dict]:


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** No existing issue/discussion — this is a small, self-contained correctness fix found while reading `utils/task.py`. Happy to open a discussion if preferred.
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** See below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** No docs change needed (internal helper behavior).
- [ ] **Dependencies:** None.
- [x] **Testing:** Verified with a focused pytest (command + output below).
- [x] **No Unchecked AI Code:** See disclosure note below — reviewed and manually verified by a human.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings; pure bug fix.
- [x] **Git Hygiene:** Single atomic commit on `dev`.
- [x] **Title Prefix:** `fix:`

### Description

`truncate_content()` in `backend/open_webui/utils/task.py` is documented to "Truncate a string to max_chars", but for `max_chars == 0` it returns the **entire** string in the `end` and `middletruncate` modes.

The cause is Python's negative-index slicing: `content[-max_chars:]` with `max_chars == 0` becomes `content[-0:]`, and since `-0 == 0` this is `content[0:]` — the whole string. The same applies to the middletruncate tail slice `content[-(max_chars - half):]` when the tail length is 0.

`max_chars` reaches this helper from the `{{MESSAGES:...|end:N}}` / `{{MESSAGES:...|middletruncate:N}}` content filters parsed in `apply_content_filter()`, so an `N` of `0` silently leaves the content untruncated instead of dropping it.

The fix guards the zero-length tail slices so `max_chars == 0` truncates to empty (`end`) or to just the `...` marker (`middletruncate`). Positive lengths are unaffected.

```python
# before
truncate_content("Hello, World!", 0, "end")            # -> "Hello, World!"  (whole string)
truncate_content("Hello, World!", 0, "middletruncate") # -> "...Hello, World!"
# after
truncate_content("Hello, World!", 0, "end")            # -> ""
truncate_content("Hello, World!", 0, "middletruncate") # -> "..."
```

### Verification

A focused regression test against the helper:

```
$ python -m pytest test_truncate_content.py -v
test_end_mode_zero_returns_empty PASSED
test_middletruncate_zero_returns_marker_only PASSED
test_end_mode_positive_unaffected PASSED
test_start_mode_zero PASSED
test_no_truncation_when_short PASSED
5 passed
```

`ruff format --check backend/open_webui/utils/task.py` → `1 file already formatted`.

> Note: this patch was drafted with AI assistance and then reviewed and manually verified by a human (behavior reproduced before/after and confirmed with the test above).

# Changelog Entry

### Fixed

- Fixed `truncate_content` returning the full string instead of truncating when `max_chars` is `0` in the `end` and `middletruncate` modes (negative-index `-0` slice bug).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
