### PR TITLE
fix: avoid masking ElevenLabs voice fetch errors as invalid voice id

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -429,8 +429,11 @@ async def _tts_openai(request, payload, file_path, file_body_path, user):
 
 async def _tts_elevenlabs(request, payload, file_path, file_body_path, user):
     """Generate speech via the ElevenLabs TTS API."""
-    voice_id = payload.get('voice', '')
-    if voice_id not in await get_available_voices(request):
+    voice_id = (payload.get('voice') or '').strip()
+    if not voice_id:
+        raise HTTPException(status_code=400, detail='Missing ElevenLabs voice id')
+    available_voices = await get_available_voices(request)
+    if available_voices and voice_id not in available_voices:
         raise HTTPException(status_code=400, detail='Invalid voice id')
 
     r = None
@@ -1344,7 +1347,7 @@ async def get_available_voices(request) -> dict:
                 voices_data = await resp.json()
                 return {v['voice_id']: v['name'] for v in voices_data.get('voices', [])}
         except Exception as e:
-            log.error(f'Error fetching ElevenLabs voices: {e}')
+            log.warning(f'Error fetching ElevenLabs voices: {e}')
             return {}
 
     if engine == 'azure':


### PR DESCRIPTION
Closes #26075

## Summary

This fixes an ElevenLabs TTS validation issue where failures in fetching available voices could incorrectly cause `Invalid voice id` errors before the actual TTS request is executed.

## What changed

- Voice ID is normalized and validated
- Empty voice ID is rejected early
- `available_voices` is only used for validation when successfully fetched
- Prevents failed `/v1/voices` requests from incorrectly invalidating configuration

## Testing

Tested locally using pip installation (venv) on Windows.

- Valid ElevenLabs voice ID works correctly
- TTS request is no longer blocked by voice fetch failures
- Behavior matches expected ElevenLabs API flow
<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
