### PR TITLE
Fix: knowledge file upload

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from open_webui.utils.misc import sanitize_text_for_db
 
 KEYS_TO_EXCLUDE = ['content', 'pages', 'tables', 'paragraphs', 'sections', 'figures']
@@ -14,16 +12,20 @@ def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
 def process_metadata(
     metadata: dict[str, any],
 ) -> dict[str, any]:
-    # Removes large fields, converts non-serializable types (datetime, list, dict) to strings,
-    # and sanitizes strings for database storage (strips null bytes and invalid surrogates).
+    # Returns a dict whose values are only str/int/float/bool, which all supported
+    # vector DBs accept (notably ChromaDB's Rust bindings, which reject None and
+    # non-primitive types). Drops KEYS_TO_EXCLUDE and None values; coerces any
+    # other non-primitive (datetime, list, dict, tuple, bytes, numpy, ...) via str().
     result = {}
     for key, value in metadata.items():
-        # Skip large fields
         if key in KEYS_TO_EXCLUDE:
             continue
-        # Convert non-serializable fields to strings
-        if isinstance(value, (datetime, list, dict)):
-            result[key] = sanitize_text_for_db(str(value))
-        else:
+        if value is None:
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            result[key] = value
+        elif isinstance(value, str):
             result[key] = sanitize_text_for_db(value)
+        else:
+            result[key] = sanitize_text_for_db(str(value))
     return result


### PR DESCRIPTION
# Changelog Entry

### Description

Guarantee that only str/int/float/bool are returned by the process_metadata function. This fixes an error when uploading MD files via the API to knowledge. I validated this fix on our server.

### Added

- Nothing

### Changed

- backend/open_webui/retrieval/vector/utils.py -> `process_metadata()`

### Deprecated

- Nothing

### Removed

- Nothing

### Fixed

- https://github.com/open-webui/open-webui/discussions/25009
- https://github.com/open-webui/open-webui/issues/24974

### Security

- No

### Breaking Changes

- Not sure / hopefully not
---

### Additional Information

- None

### Screenshots or Videos

- None

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
