### PR TITLE
perf: serve knowledge file lists as metadata-only, drop the content blob

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -31,6 +31,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import defer
 
 log = logging.getLogger(__name__)
 
@@ -177,6 +178,24 @@ class KnowledgeFileListResponse(BaseModel):
     directories: list[KnowledgeDirectoryModel] = Field(default_factory=list)
     breadcrumbs: list[KnowledgeDirectoryModel] = Field(default_factory=list)
     total: int
+
+
+def _to_file_user_response(file: File, user: Optional[User], **extra) -> FileUserResponse:
+    """Metadata-only file row; omits the extracted-text blob (#26144).
+
+    The originating query defers File.data, so do not access file.data here.
+    """
+    return FileUserResponse(
+        id=file.id,
+        user_id=file.user_id,
+        hash=file.hash,
+        filename=file.filename,
+        meta=file.meta,
+        created_at=file.created_at,
+        updated_at=file.updated_at,
+        user=(UserResponse(**UserModel.model_validate(user).model_dump()) if user else None),
+        **extra,
+    )
 
 
 class KnowledgeTable:
@@ -405,15 +424,17 @@ class KnowledgeTable:
                 if limit:
                     stmt = stmt.limit(limit)
 
+                stmt = stmt.options(defer(File.data))  # metadata-only (#26144)
+
                 result = await db.execute(stmt)
                 rows = result.all()
 
                 items = []
                 for file, user, knowledge in rows:
                     items.append(
-                        FileUserResponse(
-                            **FileModel.model_validate(file).model_dump(),
-                            user=(UserResponse(**UserModel.model_validate(user).model_dump()) if user else None),
+                        _to_file_user_response(
+                            file,
+                            user,
                             collection=(await self._to_knowledge_model(knowledge, db=db)).model_dump(),
                         )
                     )
@@ -592,17 +613,12 @@ class KnowledgeTable:
                 if limit:
                     stmt = stmt.limit(limit)
 
+                stmt = stmt.options(defer(File.data))  # metadata-only (#26144)
+
                 result = await db.execute(stmt)
                 items = result.all()
 
-                files = []
-                for file, user in items:
-                    files.append(
-                        FileUserResponse(
-                            **FileModel.model_validate(file).model_dump(),
-                            user=(UserResponse(**UserModel.model_validate(user).model_dump()) if user else None),
-                        )
-                    )
+                files = [_to_file_user_response(file, user) for file, user in items]
 
                 return KnowledgeFileListResponse(
                     items=files,

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -107,6 +107,7 @@
 	let selectedFileId = null;
 	let selectedFile = null;
 	let selectedFileContent = '';
+	let selectedFileContentLoading = false;
 
 	let inputFiles = null;
 
@@ -235,11 +236,20 @@
 	};
 
 	const fileSelectHandler = async (file) => {
+		selectedFile = file;
+		selectedFileContent = '';
+
+		if (!file?.id) return;
+
+		// list rows are metadata-only; fetch content on demand
+		selectedFileContentLoading = true;
 		try {
-			selectedFile = file;
-			selectedFileContent = selectedFile?.data?.content || '';
+			const fullFile = await getFileById(localStorage.token, file.id);
+			selectedFileContent = fullFile?.data?.content || '';
 		} catch (e) {
 			toast.error($i18n.t('Failed to load file content.'));
+		} finally {
+			selectedFileContentLoading = false;
 		}
 	};
 
@@ -1543,7 +1553,7 @@
 											<div>
 												<button
 													class="flex self-center w-fit text-sm py-1 px-2.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-													disabled={isSaving}
+													disabled={isSaving || selectedFileContentLoading}
 													on:click={() => {
 														updateFileContentHandler();
 													}}
@@ -1560,13 +1570,19 @@
 									</div>
 
 									{#key selectedFile.id}
-										<textarea
-											class="w-full h-full text-sm outline-none resize-none px-3 py-2"
-											bind:value={selectedFileContent}
-											disabled={!knowledge?.write_access}
-											aria-label={$i18n.t('File content')}
-											placeholder={$i18n.t('Add content here')}
-										/>
+										{#if selectedFileContentLoading}
+											<div class="flex justify-center items-center h-full">
+												<Spinner className="size-4" />
+											</div>
+										{:else}
+											<textarea
+												class="w-full h-full text-sm outline-none resize-none px-3 py-2"
+												bind:value={selectedFileContent}
+												disabled={!knowledge?.write_access}
+												aria-label={$i18n.t('File content')}
+												placeholder={$i18n.t('Add content here')}
+											/>
+										{/if}
 									{/key}
 								</div>
 							</div>


### PR DESCRIPTION
Opening a Knowledge Base (`GET /knowledge/{id}/files`) and the global file search (`GET /knowledge/search/files`) serialized `data.content` (the full extracted text) for every file on the page. A handful of large spreadsheets/PDFs balloons the response to tens of MB, producing a ~60s spinner before the list renders. The list view never displays that text — only filename/size/timestamps — so it is pure dead weight.

Defer `File.data` in both list queries so the TOAST-stored blob is never read, deserialized, or transferred, and build the rows through a shared metadata-only helper. This avoids the Postgres detoast, the Pydantic validate/dump of the blob, the network transfer, and the browser parse in one shot — no new request flag (the list is metadata-only by contract). Search-within-content still works because the `include_content` toggle is a WHERE clause, unaffected by the defer.

A single file's content is now fetched on demand via the existing `GET /files/{id}` when it is opened for preview in KnowledgeBase.svelte; the editor shows a spinner and the Save button is disabled until the content has loaded, so an in-flight fetch can't overwrite the file with an empty body. Access is unchanged: `has_access_to_file(..., 'read')` grants read to any file reachable through a knowledge base the user can read, so shared-KB viewers can still preview.


Fixes #26144

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
