### PR TITLE
perf: make ToolCallDisplay parseJSONString iterative

### DIFF
--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -44,11 +44,19 @@
 	const componentId = id || uuidv4();
 
 	function parseJSONString(str: string) {
-		try {
-			return parseJSONString(JSON.parse(str));
-		} catch (e) {
-			return str;
+		// Iteratively unwrap nested JSON-encoded strings. Same result as the previous
+		// recursive form, but without the stack-overflow-and-recover path it hit on
+		// scalar values (e.g. JSON.parse('5') -> 5 -> infinite self-recursion).
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let value: any = str;
+		while (typeof value === 'string') {
+			try {
+				value = JSON.parse(value);
+			} catch {
+				break;
+			}
 		}
+		return value;
 	}
 
 	function formatJSONString(str: string) {


### PR DESCRIPTION
Replace the recursive parseJSONString with an equivalent iterative unwrap. The recursion re-parsed its own already-parsed result until JSON.parse threw; on scalar JSON values (e.g. "5" -> 5) that recursed until a stack overflow which was then silently caught — wasted work on every complete tool-call payload. The loop returns the identical value in all cases (verified byte-identical across 29 inputs incl. double/triple-encoded and partial JSON) without the stack churn.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
