### PR TITLE
perf: dont render toolcall args when hidden massive perf improvement

### DIFF
--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -51,31 +51,6 @@
 		}
 	}
 
-	function formatJSONString(str: string) {
-		try {
-			const parsed = parseJSONString(str);
-			if (typeof parsed === 'object') {
-				return JSON.stringify(parsed, null, 2);
-			} else {
-				return String(parsed);
-			}
-		} catch (e) {
-			return str;
-		}
-	}
-
-	function parseArguments(str: string): Record<string, unknown> | null {
-		try {
-			const parsed = parseJSONString(str);
-			if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-				return parsed as Record<string, unknown>;
-			}
-			return null;
-		} catch {
-			return null;
-		}
-	}
-
 	$: args = decode(attributes?.arguments ?? '');
 	export let resultContent: string = '';
 
@@ -85,7 +60,18 @@
 	$: isDone = attributes?.done === 'true';
 	$: isExecuting = attributes?.done && attributes?.done !== 'true';
 
-	$: parsedArgs = parseArguments(args);
+	// Parse args once, then derive both the structured key/value view and the raw
+	// pretty-printed fallback from that single result (previously parsed twice — once
+	// via parseArguments and again via formatJSONString in the template).
+	$: parsedArgsRaw = parseJSONString(args);
+	$: parsedArgs =
+		typeof parsedArgsRaw === 'object' && parsedArgsRaw !== null && !Array.isArray(parsedArgsRaw)
+			? (parsedArgsRaw as Record<string, unknown>)
+			: null;
+	$: argsDisplay =
+		typeof parsedArgsRaw === 'object'
+			? JSON.stringify(parsedArgsRaw, null, 2)
+			: String(parsedArgsRaw);
 	$: parsedResult = parseJSONString(result);
 </script>
 
@@ -201,9 +187,7 @@
 							{:else}
 								<div class="tool-call-body w-full max-w-none!">
 									<pre
-										class="text-xs text-gray-600 dark:text-gray-300 whitespace-pre font-mono bg-gray-50 dark:bg-gray-900 rounded-lg p-2.5 overflow-x-auto">{formatJSONString(
-											args
-										)}</pre>
+										class="text-xs text-gray-600 dark:text-gray-300 whitespace-pre font-mono bg-gray-50 dark:bg-gray-900 rounded-lg p-2.5 overflow-x-auto">{argsDisplay}</pre>
 								</div>
 							{/if}
 						</div>

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -51,7 +51,12 @@
 		}
 	}
 
-	$: args = decode(attributes?.arguments ?? '');
+	// Only decode the (potentially huge, per-frame-growing) arguments when they can
+	// actually be shown: when the panel is expanded, or when embeds need them. This
+	// avoids an O(n) decode on every streamed frame for a collapsed in-progress tool
+	// call — the args are never rendered while collapsed without embeds.
+	$: args =
+		open || (Array.isArray(embeds) && embeds.length > 0) ? decode(attributes?.arguments ?? '') : '';
 	export let resultContent: string = '';
 
 	$: result = resultContent || decode(attributes?.result ?? '');


### PR DESCRIPTION
ToolCallDisplay decoded attributes.arguments on every reactive update, even when the panel is collapsed and the args are never rendered.

For an in-progress tool call the backend re-emits a growing arguments attribute on every streamed delta, so this ran an O(n) html-entities decode each frame for content that is not shown, a major contributor to UI stutter while a large tool call (e.g.
replace_file_content) streams.

Gate the decode on visibility: only decode when the panel is expanded or when embeds reference the args. Output is unchanged in every case (the args are never rendered while collapsed without embeds).

Combined with the args-parse dedupe on the same branch because the two edits touch adjacent lines and cannot be merged into dev independently without a conflict.


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
