### PR TITLE
feat: message-scoped file context for RAG

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -899,6 +899,10 @@ ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS = os.getenv('ENABLE_RAG_HYBRID_SEARCH_EN
 
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
+RAG_FILE_CONTEXT_SCOPE_CONVERSATION = 'conversation'
+RAG_FILE_CONTEXT_SCOPE_MESSAGE = 'message'
+RAG_FILE_CONTEXT_SCOPE = os.getenv('RAG_FILE_CONTEXT_SCOPE', RAG_FILE_CONTEXT_SCOPE_CONVERSATION)
+
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
 
 RAG_FILE_MAX_SIZE = int(os.getenv('RAG_FILE_MAX_SIZE')) if os.getenv('RAG_FILE_MAX_SIZE') else None
@@ -2665,6 +2669,7 @@ DEFAULT_CONFIG = {
     'rag.enable_hybrid_search': ENABLE_RAG_HYBRID_SEARCH,
     'rag.enable_hybrid_search_enriched_texts': ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS,
     'rag.full_context': RAG_FULL_CONTEXT,
+    'rag.file_context_scope': RAG_FILE_CONTEXT_SCOPE,
     'rag.file.max_count': RAG_FILE_MAX_COUNT,
     'rag.file.max_size': RAG_FILE_MAX_SIZE,
     'file.image_compression_width': FILE_IMAGE_COMPRESSION_WIDTH,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, Iterator, Optional, Sequence, Union
+from typing import Callable, Iterator, Literal, Optional, Sequence, Union
 
 import tiktoken
 from fastapi import (
@@ -41,6 +41,8 @@ from open_webui.config import (
     RAG_EMBEDDING_MODEL_AUTO_UPDATE,
     RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
     RAG_EMBEDDING_QUERY_PREFIX,
+    RAG_FILE_CONTEXT_SCOPE_CONVERSATION,
+    RAG_FILE_CONTEXT_SCOPE_MESSAGE,
     RAG_RERANKING_MODEL_AUTO_UPDATE,
     RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
     UPLOAD_DIR,
@@ -50,6 +52,7 @@ from open_webui.env import (
     DEVICE_TYPE,
     DOCKER,
     RAG_EMBEDDING_TIMEOUT,
+    RAG_SYSTEM_CONTEXT,
     SENTENCE_TRANSFORMERS_BACKEND,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
@@ -339,6 +342,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'RAG_EXTERNAL_RERANKER_TIMEOUT': 'rag.external_reranker_timeout',
     'RAG_EXTERNAL_RERANKER_URL': 'rag.external_reranker_url',
     'RAG_FULL_CONTEXT': 'rag.full_context',
+    'RAG_FILE_CONTEXT_SCOPE': 'rag.file_context_scope',
     'RAG_OLLAMA_API_KEY': 'rag.ollama.api_key',
     'RAG_OLLAMA_BASE_URL': 'rag.ollama.base_url',
     'RAG_OPENAI_API_BASE_URL': 'rag.openai.api_base_url',
@@ -416,6 +420,20 @@ async def get_config_values(key_map: dict[str, str]) -> dict:
 
 async def get_retrieval_config() -> RetrievalConfig:
     return RetrievalConfig(await get_config_values(RETRIEVAL_CONFIG_KEYS))
+
+
+async def get_effective_rag_file_context_scope(config: RetrievalConfig | None = None) -> str:
+    if RAG_SYSTEM_CONTEXT:
+        return RAG_FILE_CONTEXT_SCOPE_CONVERSATION
+
+    if config is not None:
+        return getattr(config, 'RAG_FILE_CONTEXT_SCOPE', RAG_FILE_CONTEXT_SCOPE_CONVERSATION)
+
+    return await Config.get('rag.file_context_scope', RAG_FILE_CONTEXT_SCOPE_CONVERSATION)
+
+
+async def is_message_scoped_file_context_enabled(request: Request) -> bool:
+    return await get_effective_rag_file_context_scope() == RAG_FILE_CONTEXT_SCOPE_MESSAGE
 
 
 class CollectionNameForm(BaseModel):
@@ -609,6 +627,9 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'TOP_K': config.TOP_K,
         'BYPASS_EMBEDDING_AND_RETRIEVAL': config.BYPASS_EMBEDDING_AND_RETRIEVAL,
         'RAG_FULL_CONTEXT': config.RAG_FULL_CONTEXT,
+        'RAG_SYSTEM_CONTEXT': RAG_SYSTEM_CONTEXT,
+        'RAG_FILE_CONTEXT_SCOPE': config.RAG_FILE_CONTEXT_SCOPE,
+        'RAG_FILE_CONTEXT_SCOPE_EFFECTIVE': await get_effective_rag_file_context_scope(config),
         # Hybrid search settings
         'ENABLE_RAG_HYBRID_SEARCH': config.ENABLE_RAG_HYBRID_SEARCH,
         'ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS': config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS,
@@ -819,6 +840,7 @@ class ConfigForm(BaseModel):
     TOP_K: int | None = None
     BYPASS_EMBEDDING_AND_RETRIEVAL: bool | None = None
     RAG_FULL_CONTEXT: bool | None = None
+    RAG_FILE_CONTEXT_SCOPE: Literal['conversation', 'message'] | None = None
 
     # Hybrid search settings
     ENABLE_RAG_HYBRID_SEARCH: bool | None = None
@@ -915,6 +937,8 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         if form_data.RAG_FULL_CONTEXT is not None
         else config.RAG_FULL_CONTEXT
     )
+    if not RAG_SYSTEM_CONTEXT and form_data.RAG_FILE_CONTEXT_SCOPE is not None:
+        config.RAG_FILE_CONTEXT_SCOPE = form_data.RAG_FILE_CONTEXT_SCOPE
 
     # Hybrid search settings
     config.ENABLE_RAG_HYBRID_SEARCH = (
@@ -1308,6 +1332,8 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.LINKUP_API_KEY = form_data.web.LINKUP_API_KEY
         config.LINKUP_SEARCH_PARAMS = form_data.web.LINKUP_SEARCH_PARAMS
 
+    await config.save()
+
     return {
         'status': True,
         # RAG settings
@@ -1315,6 +1341,9 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'TOP_K': config.TOP_K,
         'BYPASS_EMBEDDING_AND_RETRIEVAL': config.BYPASS_EMBEDDING_AND_RETRIEVAL,
         'RAG_FULL_CONTEXT': config.RAG_FULL_CONTEXT,
+        'RAG_SYSTEM_CONTEXT': RAG_SYSTEM_CONTEXT,
+        'RAG_FILE_CONTEXT_SCOPE': config.RAG_FILE_CONTEXT_SCOPE,
+        'RAG_FILE_CONTEXT_SCOPE_EFFECTIVE': await get_effective_rag_file_context_scope(config),
         # Hybrid search settings
         'ENABLE_RAG_HYBRID_SEARCH': config.ENABLE_RAG_HYBRID_SEARCH,
         'TOP_K_RERANKER': config.TOP_K_RERANKER,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -60,6 +60,7 @@ from open_webui.routers.pipelines import (
 )
 from open_webui.routers.retrieval import (
     SearchForm,
+    is_message_scoped_file_context_enabled,
     process_web_search,
 )
 from open_webui.routers.tasks import (
@@ -955,12 +956,177 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
     return context_string
 
 
+FILE_CONTEXT_ITEM_TYPES = {'doc', 'text', 'note', 'chat', 'folder', 'collection'}
+
+
+def is_file_context_item(item: dict) -> bool:
+    if not isinstance(item, dict):
+        return False
+
+    item_type = item.get('type')
+    return item_type in FILE_CONTEXT_ITEM_TYPES or (
+        item_type == 'file' and not (item.get('content_type') or '').startswith('image/')
+    )
+
+
+def get_file_context_key(item: dict) -> tuple:
+    if item.get('id') is not None:
+        return (item.get('type', 'file'), item.get('id'))
+    if item.get('url') is not None:
+        return ('url', item.get('url'))
+
+    try:
+        return ('item', json.dumps(item, sort_keys=True))
+    except TypeError:
+        return ('item', str(item))
+
+
+def set_message_text_content(message: dict, content: str) -> None:
+    if isinstance(message.get('content'), list):
+        for item in message['content']:
+            if isinstance(item, dict) and item.get('type') == 'text':
+                item['text'] = content
+                return
+        message['content'].insert(0, {'type': 'text', 'text': content})
+    else:
+        message['content'] = content
+
+
+def strip_message_files(messages: list[dict]) -> None:
+    for message in messages:
+        message.pop('files', None)
+
+
+def attach_current_user_message_files(messages: list[dict], metadata: dict) -> None:
+    user_message = metadata.get('user_message') or {}
+    files = [item for item in user_message.get('files', []) if is_file_context_item(item)]
+
+    if not files:
+        return
+
+    for message in reversed(messages):
+        if message.get('role') == 'user' and not message.get('files'):
+            message['files'] = files
+            return
+
+
+async def expand_file_context_items(items: list[dict], user: UserModel) -> list[dict]:
+    expanded_items = []
+
+    for item in items:
+        if item.get('type', 'file') == 'folder':
+            folder_id = item.get('id')
+            if folder_id:
+                folder = await Folders.get_folder_by_id_and_user_id(folder_id, user.id)
+                if folder and folder.data and 'files' in folder.data:
+                    expanded_items.extend(await get_accessible_folder_files(folder.data['files'], user))
+            continue
+
+        expanded_items.append(item)
+
+    return expanded_items
+
+
+async def apply_message_file_contexts(
+    request: Request,
+    messages: list[dict],
+    files: list[dict] | None,
+    metadata: dict,
+    user: UserModel,
+    source_ids: dict | None = None,
+) -> tuple[list[dict], list[dict] | None, list[dict], list[tuple[int, str, str]]]:
+    attach_current_user_message_files(messages, metadata)
+
+    handled_file_keys = set()
+    if source_ids is None:
+        source_ids = {}
+    rag_config = await Config.get_many(
+        'rag.top_k',
+        'rag.top_k_reranker',
+        'rag.relevance_threshold',
+        'rag.hybrid_bm25_weight',
+        'rag.enable_hybrid_search',
+        'rag.full_context',
+    )
+    scoped_sources = []
+    message_contexts = []
+
+    for message_index, message in enumerate(messages):
+        if message.get('role') != 'user':
+            continue
+
+        message_files = [item for item in message.get('files', []) if is_file_context_item(item)]
+        if not message_files:
+            continue
+
+        query = get_content_from_message(message) or ''
+        expanded_items = await expand_file_context_items(message_files, user)
+
+        if not expanded_items:
+            continue
+
+        all_full_context = all(item.get('context') == 'full' for item in expanded_items)
+
+        try:
+            sources = await get_sources_from_items(
+                request=request,
+                items=expanded_items,
+                queries=[query],
+                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                    query, prefix=prefix, user=user
+                ),
+                k=rag_config.get('rag.top_k'),
+                reranking_function=(
+                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
+                ),
+                k_reranker=rag_config.get('rag.top_k_reranker'),
+                r=rag_config.get('rag.relevance_threshold'),
+                hybrid_bm25_weight=rag_config.get('rag.hybrid_bm25_weight'),
+                hybrid_search=rag_config.get('rag.enable_hybrid_search'),
+                full_context=all_full_context or rag_config.get('rag.full_context'),
+                user=user,
+            )
+        except Exception as e:
+            log.exception(e)
+            continue
+
+        context = get_source_context(sources, source_ids=source_ids).strip()
+        if context:
+            message_contexts.append((message_index, context, query))
+            scoped_sources.extend(sources)
+            handled_file_keys.update(get_file_context_key(item) for item in message_files)
+
+    if files is not None and handled_file_keys:
+        files = [item for item in files if get_file_context_key(item) not in handled_file_keys]
+
+    return messages, files, scoped_sources, message_contexts
+
+
+async def apply_message_file_context_templates(
+    request: Request,
+    messages: list[dict],
+    message_contexts: list[tuple[int, str, str]],
+) -> list[dict]:
+    template = await Config.get('rag.template')
+    for message_index, context, query in message_contexts:
+        if 0 <= message_index < len(messages):
+            set_message_text_content(
+                messages[message_index],
+                await rag_template(template, context, query),
+            )
+
+    return messages
+
+
 async def apply_source_context_to_messages(
     request: Request,
     messages: list,
     sources: list,
     user_message: str,
     include_content: bool = True,
+    source_ids: dict | None = None,
 ) -> list:
     """
     Build source context from citation sources and apply to messages.
@@ -973,7 +1139,7 @@ async def apply_source_context_to_messages(
     if not sources or not user_message:
         return messages
 
-    context = get_source_context(sources, include_content=include_content)
+    context = get_source_context(sources, source_ids=source_ids, include_content=include_content)
 
     context = context.strip()
     if not context:
@@ -2395,8 +2561,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                                 if f.get('url')
                             ],
                         ]
-                # Strip files field — it's been incorporated into content
-                message.pop('files', None)
+                # Keep non-image files only long enough for optional message-scoped RAG.
+                if await is_message_scoped_file_context_enabled(request):
+                    non_image_files = [file for file in message.get('files', []) if is_file_context_item(file)]
+                    if non_image_files:
+                        message['files'] = non_image_files
+                    else:
+                        message.pop('files', None)
+                else:
+                    message.pop('files', None)
 
     if regeneration_prompt:
         form_data['messages'].append({'role': 'user', 'content': regeneration_prompt})
@@ -2450,6 +2623,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     events = []
     sources = []
+    rag_source_ids = {}
+    message_scoped_sources = []
+    message_scoped_contexts = []
+    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
+        'file_context', True
+    )
 
     # Folder "Project" handling
     # Check if the request has chat_id and is inside of a folder
@@ -2678,6 +2857,21 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # if prompt and len(prompt or "") < 500 and (not files or len(files) == 0):
     #     urls = extract_urls(prompt)
 
+    if await is_message_scoped_file_context_enabled(request):
+        if file_context_enabled:
+            form_data['messages'], files, message_scoped_sources, message_scoped_contexts = (
+                await apply_message_file_contexts(
+                    request,
+                    form_data['messages'],
+                    files,
+                    metadata,
+                    user,
+                    source_ids=rag_source_ids,
+                )
+            )
+
+        strip_message_files(form_data['messages'])
+
     if files:
         if not files:
             files = []
@@ -2886,9 +3080,6 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 except Exception as e:
                     log.exception(e)
 
-    # Check if file context extraction is enabled for this model (default True)
-    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
-
     if file_context_enabled:
         try:
             form_data, flags = await chat_completion_files_handler(request, form_data, extra_params, user)
@@ -2896,22 +3087,36 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except Exception as e:
             log.exception(e)
 
+    if message_scoped_contexts:
+        form_data['messages'] = await apply_message_file_context_templates(
+            request,
+            form_data['messages'],
+            message_scoped_contexts,
+        )
+
     # Save the pre-RAG message state so the native tool call loop can
     # restore to the true original (before file-source injection) rather
     # than a snapshot that already has the RAG template baked in.
+    all_sources = [*message_scoped_sources, *sources]
     system_message = get_system_message(form_data['messages'])
     metadata['system_prompt'] = get_content_from_message(system_message) if system_message else None
-    metadata['user_prompt'] = get_last_user_message(form_data['messages'])
-    metadata['sources'] = sources[:] if sources else []
+    metadata['user_prompt'] = prompt
+    metadata['sources'] = all_sources[:] if all_sources else []
 
     # If context is not empty, insert it into the messages
     if sources and prompt:
-        form_data['messages'] = await apply_source_context_to_messages(request, form_data['messages'], sources, prompt)
+        form_data['messages'] = await apply_source_context_to_messages(
+            request,
+            form_data['messages'],
+            sources,
+            prompt,
+            source_ids=rag_source_ids,
+        )
 
     # If there are citations, add them to the data_items
     sources = [
         source
-        for source in sources
+        for source in all_sources
         if source.get('source', {}).get('name', '') or source.get('source', {}).get('id', '')
     ]
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1120,6 +1120,46 @@ async def apply_message_file_context_templates(
     return messages
 
 
+def merge_latest_user_source_context(
+    messages: list[dict],
+    message_contexts: list[tuple[int, str, str]],
+    sources: list,
+    source_ids: dict | None = None,
+) -> tuple[list[tuple[int, str, str]], list]:
+    if not message_contexts or not sources:
+        return message_contexts, sources
+
+    last_user_index = next(
+        (index for index in range(len(messages) - 1, -1, -1) if messages[index].get('role') == 'user'),
+        None,
+    )
+    if last_user_index is None:
+        return message_contexts, sources
+
+    message_context_index = next(
+        (
+            index
+            for index, (message_index, _message_context, _query) in enumerate(message_contexts)
+            if message_index == last_user_index
+        ),
+        None,
+    )
+    if message_context_index is None:
+        return message_contexts, sources
+
+    context = get_source_context(sources, source_ids=source_ids).strip()
+    if not context:
+        return message_contexts, sources
+
+    message_index, message_context, query = message_contexts[message_context_index]
+    message_contexts[message_context_index] = (
+        message_index,
+        f'{context}\n{message_context}' if message_context else context,
+        query,
+    )
+    return message_contexts, []
+
+
 async def apply_source_context_to_messages(
     request: Request,
     messages: list,
@@ -3087,6 +3127,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except Exception as e:
             log.exception(e)
 
+    sources_for_context = sources
+    if message_scoped_contexts and sources_for_context:
+        message_scoped_contexts, sources_for_context = merge_latest_user_source_context(
+            form_data['messages'],
+            message_scoped_contexts,
+            sources_for_context,
+            source_ids=rag_source_ids,
+        )
+
     if message_scoped_contexts:
         form_data['messages'] = await apply_message_file_context_templates(
             request,
@@ -3104,11 +3153,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     metadata['sources'] = all_sources[:] if all_sources else []
 
     # If context is not empty, insert it into the messages
-    if sources and prompt:
+    if sources_for_context and prompt:
         form_data['messages'] = await apply_source_context_to_messages(
             request,
             form_data['messages'],
-            sources,
+            sources_for_context,
             prompt,
             source_ids=rag_source_ids,
         )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -981,15 +981,15 @@ def get_file_context_key(item: dict) -> tuple:
         return ('item', str(item))
 
 
-def set_message_text_content(message: dict, content: str) -> None:
+def prepend_message_text_content(message: dict, content: str) -> None:
     if isinstance(message.get('content'), list):
         for item in message['content']:
             if isinstance(item, dict) and item.get('type') == 'text':
-                item['text'] = content
+                item['text'] = f'{content}\n{item.get("text", "")}'
                 return
         message['content'].insert(0, {'type': 'text', 'text': content})
     else:
-        message['content'] = content
+        message['content'] = f'{content}\n{message.get("content", "")}'
 
 
 def strip_message_files(messages: list[dict]) -> None:
@@ -1112,7 +1112,7 @@ async def apply_message_file_context_templates(
     template = await Config.get('rag.template')
     for message_index, context, query in message_contexts:
         if 0 <= message_index < len(messages):
-            set_message_text_content(
+            prepend_message_text_content(
                 messages[message_index],
                 await rag_template(template, context, query),
             )

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -291,6 +291,10 @@
 
 		config.MINERU_FILE_EXTENSIONS = (config?.MINERU_FILE_EXTENSIONS ?? ['pdf']).join(', ');
 
+		if (!config.RAG_FILE_CONTEXT_SCOPE) {
+			config.RAG_FILE_CONTEXT_SCOPE = 'conversation';
+		}
+
 		RAGConfig = config;
 	});
 </script>
@@ -810,6 +814,30 @@
 							</Tooltip>
 						</div>
 					</div>
+
+					{#if !RAGConfig.RAG_SYSTEM_CONTEXT}
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">
+								<Tooltip
+									content={$i18n.t(
+										'Choose whether attached files are treated as conversation-level context or scoped to the user message they were sent with.'
+									)}
+									placement="top-start"
+								>
+									{$i18n.t('File Context Scope')}
+								</Tooltip>
+							</div>
+							<div class="flex items-center relative">
+								<select
+									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									bind:value={RAGConfig.RAG_FILE_CONTEXT_SCOPE}
+								>
+									<option value="conversation">{$i18n.t('Conversation')}</option>
+									<option value="message">{$i18n.t('Message')}</option>
+								</select>
+							</div>
+						</div>
+					{/if}
 
 					{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
 						<div class="  mb-2.5 flex w-full justify-between">

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -186,6 +186,13 @@
 	let files = [];
 	let params = {};
 
+	const isImageFile = (file: any) =>
+		file?.type === 'image' || (file?.content_type ?? '').startsWith('image/');
+
+	const isFileContextItem = (file: any) =>
+		['doc', 'text', 'note', 'chat', 'folder', 'collection'].includes(file?.type) ||
+		(file?.type === 'file' && !isImageFile(file));
+
 	$: if (chatIdProp) {
 		navigateHandler();
 	}
@@ -1936,13 +1943,7 @@
 	const submitPrompt = async (inputContent, inputFiles) => {
 		const _files = structuredClone(inputFiles);
 
-		chatFiles.push(
-			..._files.filter(
-				(item) =>
-					['doc', 'text', 'note', 'chat', 'folder', 'collection'].includes(item.type) ||
-					(item.type === 'file' && !(item?.content_type ?? '').startsWith('image/'))
-			)
-		);
+		chatFiles.push(..._files.filter(isFileContextItem));
 		chatFiles = chatFiles.filter(
 			// Remove duplicates
 			(item, index, array) => array.findIndex((i) => equal(i, item)) === index
@@ -2292,13 +2293,7 @@
 		});
 
 		let files = structuredClone(chatFiles);
-		files.push(
-			...(userMessage?.files ?? []).filter(
-				(item) =>
-					['doc', 'text', 'note', 'chat', 'collection', 'folder'].includes(item.type) ||
-					(item.type === 'file' && !(item?.content_type ?? '').startsWith('image/'))
-			)
-		);
+		files.push(...(userMessage?.files ?? []).filter(isFileContextItem));
 		// Remove duplicates
 		files = files.filter((item, index, array) => array.findIndex((i) => equal(i, item)) === index);
 
@@ -2345,13 +2340,13 @@
 
 			messages = messages
 				.map((message, idx, arr) => {
-					const imageFiles = (message?.files ?? []).filter(
-						(file) => file.type === 'image' || (file?.content_type ?? '').startsWith('image/')
-					);
+					const imageFiles = (message?.files ?? []).filter(isImageFile);
+					const messageFiles = (message?.files ?? []).filter(isFileContextItem);
 
 					return {
 						role: message.role,
 						...(message.output ? { output: message.output } : {}),
+						...(message.role === 'user' && messageFiles.length > 0 ? { files: messageFiles } : {}),
 						...(message.role === 'user' && imageFiles.length > 0
 							? {
 									content: [


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR relates to https://github.com/open-webui/open-webui/discussions/26045
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** https://github.com/open-webui/docs/pull/1304
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

 - This PR adds a RAG setting to keep attached file context scoped to the user message where each file was sent.
Supported values:
  - `conversation`: existing/default behavior. File context is injected into the latest user message.
  - `message`: file context is scoped to the user message that owns the file attachment.
 - `RAG_SYSTEM_CONTEXT=true` takes priority over this new setting. When system-context mode is enabled, `RAG_FILE_CONTEXT_SCOPE` is ignored and the existing behavior is preserved: RAG context is injected into a system message. The UI also hides the file context scope selector in that mode.
- When the new setting is enabled, non-image file context is collected per user message and injected into the corresponding message instead of merging all chat files into the latest RAG context.
- Files already injected into their original message are removed from the global file list to prevent duplicate/global reinjection.
- Citations still include both message-scoped and globally retrieved sources.
- Existing behavior is unchanged when the setting is set to conversation (default value).
- This helps cases where users refer to the attachment with phrases like “this document” or “the previous document” "the first document that I gave you".
- It improves prompt-cache reuse by keeping previously attached document context in a more stable position instead of repeatedly moving older file content into the latest prompt suffix.


### Added

- Added a configurable file RAG context scope, allowing file context to be applied either at the conversation level or to the specific user message that attached the file.

## Testing

I tested the following scenarios against a local Open WebUI instance using a fake OpenAI-compatible capture server:
  - `RAG_FILE_CONTEXT_SCOPE=message`, two-turn chat with different files per user message:
    - first file context appears only in the first user message
    - second file context appears only in the latest user message
  - message-scoped full-context files
  - native function calling with message-scoped file context
  - `RAG_FILE_CONTEXT_SCOPE=conversation` default/global behavior
  - conversation-level file while message scope is enabled
  - `RAG_SYSTEM_CONTEXT=true` while stored scope is `message`
    - effective behavior falls back to conversation/system mode
    - context is injected into the system message
  - temporary chat with two turns and different files per message
  - temporary chat with a conversation-level file

## Screenshots
<img width="1760" height="386" alt="image" src="https://github.com/user-attachments/assets/ee595f6a-e96c-40fc-9dc4-05b194540882" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
