### PR TITLE
fix: prevent Mermaid diagram labels from being clipped in chat preview

### DIFF
--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -440,7 +440,7 @@
 		{#if ['mermaid', 'vega', 'vega-lite'].includes(lang)}
 			{#if renderHTML}
 				<SvgPanZoom
-					className=" rounded-2xl max-h-fit overflow-hidden"
+					className=" rounded-2xl max-h-fit "
 					svg={renderHTML}
 					content={_token.text}
 				/>

--- a/src/lib/components/common/SVGPanZoom.svelte
+++ b/src/lib/components/common/SVGPanZoom.svelte
@@ -32,10 +32,10 @@
 	};
 </script>
 
-<div class="relative {className}">
+<div class="svg-pan-zoom relative {className}">
 	<PanzoomContainer
 		bind:this={panzoomRef}
-		className="flex h-full max-h-full justify-center items-center"
+		className="flex justify-center items-center overflow-visible"
 	>
 		{@html DOMPurify.sanitize(svg, {
 			USE_PROFILES: { svg: true, svgFilters: true }, // allow <svg>, <defs>, <filter>, etc.
@@ -118,3 +118,26 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	.svg-pan-zoom :global(svg) {
+		display: block;
+		max-width: 100%;
+		height: auto;
+		overflow: visible;
+	}
+
+	.svg-pan-zoom :global(foreignObject) {
+		overflow: visible;
+	}
+
+	.svg-pan-zoom :global(foreignObject div),
+	.svg-pan-zoom :global(foreignObject span),
+	.svg-pan-zoom :global(foreignObject p) {
+		margin: 0 !important;
+		padding: 0 !important;
+		line-height: 1.2 !important;
+		white-space: normal !important;
+		overflow: visible !important;
+	}
+</style>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26061
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the Open WebUI Docs Repository.
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Fixes Mermaid diagram labels being clipped in the chat preview when node labels are long.
- The exported/downloaded SVG rendered correctly, so the issue was isolated to the in-app preview layer rather than Mermaid diagram generation itself.

### Changed

- Removed restrictive overflow behavior from the Mermaid preview wrapper in `CodeBlock.svelte`.
- Updated `SVGPanZoom.svelte` to avoid constraining the preview container height and to allow visible overflow.
- Added scoped styling for rendered Mermaid SVG and `foreignObject` label content to reduce clipping caused by inherited layout styles.

### Fixed

- Prevented long Mermaid node labels from being visually clipped in the chat preview.

---

### Additional Information

- No dependency changes were introduced.
- This change is scoped to Mermaid preview rendering in the chat UI.

### Screenshots or Videos

<img width="1529" height="2866" alt="before" src="https://github.com/user-attachments/assets/f3b100c4-aae3-4320-bd8a-97e9ed72d268" />
<img width="1448" height="2866" alt="after" src="https://github.com/user-attachments/assets/6a488a88-36d9-45f0-95b3-41808bde1daf" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.