### PR TITLE
feat(knowledge): per-file full-context injection in knowledge bases

### DIFF
--- a/backend/open_webui/migrations/versions/1a2b3c4d5e6f_add_context_to_knowledge_file.py
+++ b/backend/open_webui/migrations/versions/1a2b3c4d5e6f_add_context_to_knowledge_file.py
@@ -1,0 +1,27 @@
+"""Add context column to knowledge_file table
+
+Revision ID: 1a2b3c4d5e6f
+Revises: f1e2d3c4b5a6
+Create Date: 2026-06-18 00:00:00.000000
+
+Adds an optional `context` column to the `knowledge_file` join table.
+When set to 'full', the file is injected directly into the LLM context
+(bypassing chunked RAG retrieval) while the rest of the knowledge base
+still uses vector search.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '1a2b3c4d5e6f'
+down_revision = 'f1e2d3c4b5a6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('knowledge_file', sa.Column('context', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('knowledge_file', 'context')

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -105,6 +105,8 @@ class KnowledgeFile(Base):
     created_at = Column(BigInteger, nullable=False)
     updated_at = Column(BigInteger, nullable=False)
 
+    context = Column(Text, nullable=True)
+
     __table_args__ = (
         UniqueConstraint('knowledge_id', 'file_id', name='uq_knowledge_file_knowledge_file'),
         Index('ix_knowledge_file_directory_id', 'directory_id'),
@@ -120,6 +122,8 @@ class KnowledgeFileModel(BaseModel):
 
     created_at: int  # timestamp in epoch
     updated_at: int  # timestamp in epoch
+
+    context: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -633,6 +637,40 @@ class KnowledgeTable:
                 return [FileModel.model_validate(file) for file in files]
         except Exception:
             return []
+
+    async def get_files_with_context_by_id(
+        self, knowledge_id: str, db: Optional[AsyncSession] = None
+    ) -> list[tuple[FileModel, Optional[str]]]:
+        """Return (FileModel, context) pairs for all files in a KB."""
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(
+                    select(File, KnowledgeFile.context)
+                    .join(KnowledgeFile, File.id == KnowledgeFile.file_id)
+                    .filter(KnowledgeFile.knowledge_id == knowledge_id)
+                )
+                return [(FileModel.model_validate(file), ctx) for file, ctx in result.all()]
+        except Exception:
+            return []
+
+    async def update_file_context_by_id(
+        self,
+        knowledge_id: str,
+        file_id: str,
+        context: Optional[str],
+        db: Optional[AsyncSession] = None,
+    ) -> bool:
+        try:
+            async with get_async_db_context(db) as db:
+                await db.execute(
+                    update(KnowledgeFile)
+                    .filter_by(knowledge_id=knowledge_id, file_id=file_id)
+                    .values(context=context, updated_at=int(time.time()))
+                )
+                await db.commit()
+                return True
+        except Exception:
+            return False
 
     async def get_file_metadatas_by_id(
         self, knowledge_id: str, db: Optional[AsyncSession] = None

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1353,6 +1353,28 @@ async def get_sources_from_items(
                             'metadatas': [metadatas],
                         }
                 else:
+                    # Per-file full context: inject files marked with context='full'
+                    # directly into the result, bypassing vector retrieval for those files.
+                    # The rest of the collection still goes through normal RAG.
+                    for file, file_ctx in await Knowledges.get_files_with_context_by_id(knowledge_base.id):
+                        if file_ctx == 'full':
+                            content = (file.data or {}).get('content', '')
+                            if content.strip():
+                                query_results.append({
+                                    'documents': [[content]],
+                                    'metadatas': [[{
+                                        'file_id': file.id,
+                                        'name': file.filename,
+                                        'source': file.filename,
+                                    }]],
+                                    'file': {
+                                        'type': 'file',
+                                        'context': 'full',
+                                        'id': file.id,
+                                        'name': file.filename,
+                                    },
+                                })
+
                     if item.get('legacy'):
                         if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                             collection_names = item.get('collection_names', [])

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -19,6 +19,7 @@ from open_webui.models.knowledge import (
     KnowledgeDirectoryForm,
     KnowledgeDirectoryModel,
     KnowledgeFileListResponse,
+    KnowledgeFileModel,
     KnowledgeForm,
     KnowledgeResponse,
     Knowledges,
@@ -696,6 +697,11 @@ class KnowledgeFileIdForm(BaseModel):
     directory_id: Optional[str] = None
 
 
+class KnowledgeFileContextForm(BaseModel):
+    file_id: str
+    context: Optional[str] = None  # 'full' to inject verbatim; None to restore RAG
+
+
 @router.post('/{id}/file/add', response_model=KnowledgeFilesResponse | None)
 async def add_file_to_knowledge_by_id(
     request: Request,
@@ -781,6 +787,57 @@ async def add_file_to_knowledge_by_id(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
+
+
+@router.post('/{id}/file/context', response_model=KnowledgeFileModel | None)
+async def update_file_context_in_knowledge_by_id(
+    id: str,
+    form_data: KnowledgeFileContextForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)
+    if not knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    if (
+        knowledge.user_id != user.id
+        and not await AccessGrants.has_access(
+            user_id=user.id,
+            resource_type='knowledge',
+            resource_id=knowledge.id,
+            permission='write',
+            db=db,
+        )
+        and user.role != 'admin'
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    if not await Knowledges.has_file(id, form_data.file_id, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    ok = await Knowledges.update_file_context_by_id(
+        knowledge_id=id,
+        file_id=form_data.file_id,
+        context=form_data.context,
+        db=db,
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(),
+        )
+
+    return None
 
 
 @router.post('/{id}/file/update', response_model=KnowledgeFilesResponse | None)


### PR DESCRIPTION
## Problem

Knowledge bases currently support two retrieval modes for a collection:
1. **RAG** (default) — relevant chunks are retrieved by vector similarity
2. **Full context** (`context: 'full'` on the item) — *all* files in the KB are injected verbatim

There is no middle ground: you cannot mark a **single file** for verbatim injection while keeping the rest of the KB on RAG.

### Why this matters

A common pattern when building document-based knowledge bases is to include a **structured index or README file** — a human- or machine-generated map that describes what the KB contains, how it is organized, and how to navigate it. This file is small (a few KB) but must be present in the LLM context on *every* query so the model can reason about the structure of the knowledge base before (and after) retrieving specific chunks.

With the current implementation, the only way to achieve this is to put the entire KB in full-context mode, which defeats the purpose of RAG for large collections. Alternatively, a Filter pipe can inject the file manually, but this requires custom code per deployment.

The natural solution is a **per-file context flag**: mark a single file (e.g. the README / index) as `context='full'` so it is always injected verbatim, while all other files in the same KB continue to use vector search.

---

## Changes

### Database
- New Alembic migration (`1a2b3c4d5e6f`) — adds `context TEXT NULL` to `knowledge_file`

### `models/knowledge.py`
- `KnowledgeFile` ORM model: `context` column
- `KnowledgeFileModel` Pydantic model: `context: Optional[str] = None`
- `KnowledgeTable.get_files_with_context_by_id()` — returns `(FileModel, context)` tuples for a KB
- `KnowledgeTable.update_file_context_by_id()` — sets/clears the context flag for one file in a KB

### `retrieval/utils.py`
- `get_sources_from_items()`: when a collection item is **not** in whole-KB full-context mode, iterate its files; any file with `context='full'` is appended directly to `query_results` (bypassing chunked retrieval), then the remaining files go through normal vector search as before

### `routers/knowledge.py`
- New form: `KnowledgeFileContextForm(file_id, context)`
- New endpoint: `POST /{id}/file/context` — requires KB `write` access; sets or clears `context` on a single `knowledge_file` row

---

## Behaviour

```
KB (RAG mode)
├── README.md    [context='full']  → always injected verbatim on every query
├── section-01.md                 → vector RAG
├── section-02.md                 → vector RAG
└── ...
```

A query on this KB returns:
1. The full text of `README.md` (directly, no chunking, no similarity threshold)
2. The top-K relevant chunks from the remaining sections (vector search)

The model always has the map of the knowledge base, and always retrieves the relevant detail.

---

## Test plan

- [ ] Apply migration, verify `knowledge_file` gains the `context` column
- [ ] `POST /{id}/file/context` with `{"file_id": "...", "context": "full"}` sets the flag
- [ ] `POST /{id}/file/context` with `{"file_id": "...", "context": null}` clears the flag
- [ ] Returns 403 for a user without KB write access
- [ ] Returns 400 when `file_id` is not a member of the KB
- [ ] Query on a KB with a full-context file: the file content appears in sources regardless of query text
- [ ] Other files in the same KB are still retrieved by vector similarity
- [ ] Existing KB-level `context='full'` behaviour is unchanged (all files injected verbatim)
- [ ] `downgrade` migration cleanly drops the column

Generated with [Claude Code](https://claude.com/claude-code)
