### PR TITLE
feat: add sortable column headers to analytics chat list

### DIFF
--- a/src/lib/components/common/ChatList.svelte
+++ b/src/lib/components/common/ChatList.svelte
@@ -5,6 +5,8 @@
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Loader from '$lib/components/common/Loader.svelte';
+	import ChevronUp from '$lib/components/icons/ChevronUp.svelte';
+	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 
 	dayjs.extend(calendar);
 
@@ -25,36 +27,105 @@
 	export let emptyMessage = 'No chats found';
 	export let onLoadMore: (() => void) | null = null;
 	export let onChatClick: ((chatId: string) => void) | null = null;
+
+	let orderBy = 'updated_at';
+	let direction: 'asc' | 'desc' = 'desc';
+
+	const toggleSort = (key: string) => {
+		if (orderBy === key) {
+			direction = direction === 'asc' ? 'desc' : 'asc';
+		} else {
+			orderBy = key;
+			direction = key === 'updated_at' ? 'desc' : 'asc';
+		}
+	};
+
+	$: sortedChatList = chatList
+		? [...chatList].sort((a, b) => {
+				if (orderBy === 'user_name') {
+					const aName = (a.user_name || '').toLowerCase();
+					const bName = (b.user_name || '').toLowerCase();
+					return direction === 'asc' ? aName.localeCompare(bName) : bName.localeCompare(aName);
+				}
+				if (orderBy === 'title') {
+					const aTitle = (a.title || '').toLowerCase();
+					const bTitle = (b.title || '').toLowerCase();
+					return direction === 'asc' ? aTitle.localeCompare(bTitle) : bTitle.localeCompare(aTitle);
+				}
+				// updated_at (numeric)
+				return direction === 'asc' ? a.updated_at - b.updated_at : b.updated_at - a.updated_at;
+			})
+		: null;
 </script>
 
 <div>
-	{#if chatList && chatList.length > 0}
+	{#if sortedChatList && sortedChatList.length > 0}
 		<div class="flex text-xs font-medium mb-1.5">
 			{#if showUserInfo}
-				<div class="px-1.5 py-1 w-32">
-					{$i18n.t('User')}
-				</div>
+				<button
+					class="px-1.5 py-1 w-32 cursor-pointer select-none"
+					on:click={() => toggleSort('user_name')}
+				>
+					<div class="flex gap-1 items-center">
+						{$i18n.t('User')}
+						{#if orderBy === 'user_name'}
+							{#if direction === 'asc'}<ChevronUp className="size-2" />{:else}<ChevronDown
+									className="size-2"
+								/>{/if}
+						{:else}
+							<span class="invisible"><ChevronUp className="size-2" /></span>
+						{/if}
+					</div>
+				</button>
 			{/if}
-			<div class="px-1.5 py-1 {showUserInfo ? 'flex-1' : 'basis-3/5'}">
-				{$i18n.t('Title')}
-			</div>
-			<div class="px-1.5 py-1 hidden sm:flex {showUserInfo ? 'w-28' : 'basis-2/5'} justify-end">
-				{$i18n.t('Updated at')}
-			</div>
+			<button
+				class="px-1.5 py-1 {showUserInfo
+					? 'flex-1'
+					: 'basis-3/5'} cursor-pointer select-none text-left"
+				on:click={() => toggleSort('title')}
+			>
+				<div class="flex gap-1 items-center">
+					{$i18n.t('Title')}
+					{#if orderBy === 'title'}
+						{#if direction === 'asc'}<ChevronUp className="size-2" />{:else}<ChevronDown
+								className="size-2"
+							/>{/if}
+					{:else}
+						<span class="invisible"><ChevronUp className="size-2" /></span>
+					{/if}
+				</div>
+			</button>
+			<button
+				class="px-1.5 py-1 hidden sm:flex {showUserInfo
+					? 'w-28'
+					: 'basis-2/5'} justify-end cursor-pointer select-none"
+				on:click={() => toggleSort('updated_at')}
+			>
+				<div class="flex gap-1 items-center">
+					{$i18n.t('Updated at')}
+					{#if orderBy === 'updated_at'}
+						{#if direction === 'asc'}<ChevronUp className="size-2" />{:else}<ChevronDown
+								className="size-2"
+							/>{/if}
+					{:else}
+						<span class="invisible"><ChevronUp className="size-2" /></span>
+					{/if}
+				</div>
+			</button>
 		</div>
 	{/if}
 	<div class="max-h-[22rem] overflow-y-scroll">
-		{#if loading && (!chatList || chatList.length === 0)}
+		{#if loading && (!sortedChatList || sortedChatList.length === 0)}
 			<div class="flex justify-center py-8">
 				<Spinner />
 			</div>
-		{:else if !chatList || chatList.length === 0}
+		{:else if !sortedChatList || sortedChatList.length === 0}
 			<div class="text-center text-gray-500 text-sm py-8">
 				{$i18n.t(emptyMessage)}
 			</div>
 		{:else}
-			{#each chatList as chat, idx (chat.id)}
-				{#if chat.time_range && (idx === 0 || chat.time_range !== chatList[idx - 1]?.time_range)}
+			{#each sortedChatList as chat, idx (chat.id)}
+				{#if chat.time_range && (idx === 0 || chat.time_range !== sortedChatList[idx - 1]?.time_range)}
 					<div
 						class="w-full text-xs text-gray-500 dark:text-gray-500 font-medium {idx === 0
 							? ''


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #___ — Add sortable column headers to Analytics model chats list
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The Chats tab in the Analytics model usage modal displays a list of chats with User, Title, and Updated at columns. Currently, these column headers are static text with no interactivity. This PR adds click-to-sort functionality with chevron arrows, matching the existing sorting pattern used in `ModelUsage.svelte` and other table-like UI throughout the admin panel.

**Key changes to `ChatList.svelte`:**

- Added `orderBy` and `direction` state variables with a `toggleSort(key)` function
- Added a reactive `sortedChatList` that sorts the input data client-side
- Converted column headers from `<div>` to `<button>` elements with `ChevronUp`/`ChevronDown` icons
- Default sort: Updated at (descending — most recent first)
- Text columns (User, Title) default to ascending on first click; Updated at defaults to descending

```diff
-<div class="px-1.5 py-1 w-32">
-    {$i18n.t('User')}
-</div>
+<button class="px-1.5 py-1 w-32 cursor-pointer select-none"
+    on:click={() => toggleSort('user_name')}>
+    <div class="flex gap-1 items-center">
+        {$i18n.t('User')}
+        {#if orderBy === 'user_name'}
+            {#if direction === 'asc'}<ChevronUp />{:else}<ChevronDown />{/if}
+        {:else}
+            <span class="invisible"><ChevronUp /></span>
+        {/if}
+    </div>
+</button>
```

The `ChatList` component is only consumed by `AnalyticsModelModal.svelte`, so this change has no side effects on other parts of the UI. No API changes are needed — sorting is purely client-side on already-loaded data.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- Sortable column headers (User, Title, Updated at) with chevron arrow indicators in the Analytics model usage Chats tab

### Screenshots or Videos

## Before:

<img width="704" height="576" alt="image" src="https://github.com/user-attachments/assets/f43cd11b-1bd4-4c51-8d2e-ed7cbc8ac50f" />

## After:

<img width="704" height="576" alt="image" src="https://github.com/user-attachments/assets/a1153910-1b25-49ec-b7e2-7b194ed1bd30" />

<img width="704" height="576" alt="image" src="https://github.com/user-attachments/assets/69569cc9-33c8-4cf2-afd2-29638b2005ce" />

<img width="704" height="576" alt="image" src="https://github.com/user-attachments/assets/be7b5bac-3055-4c1f-9ee9-c091492980a3" />

### Manual Verification Performed

1. Navigate to **Admin → Analytics** tab
2. Click any model in the **Model Usage** list to open the modal
3. Click the **Chats** tab
4. Verify **Updated at** column shows a down chevron (default sort: newest first)
5. Click **Updated at** header → verify chevron flips to up and list reverses to oldest first
6. Click **User** header → verify list sorts alphabetically A→Z with up chevron
7. Click **User** again → verify it reverses to Z→A with down chevron
8. Click **Title** header → verify same toggle behavior
9. Verify the Overview tab and Close button still function correctly

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
