### PR TITLE
fix: await async get_content_from_url directly instead of wrapping in thread executor

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2027,7 +2027,7 @@ async def process_web(
 ):
     config = await get_retrieval_config()
     try:
-        content, docs = await run_in_threadpool(get_content_from_url, request, form_data.url)
+        content, docs = await get_content_from_url(request, form_data.url)
         log.debug(f'text_content: {content}')
 
         if process:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -262,7 +262,7 @@ async def fetch_url(
         return json.dumps({'error': 'Request context not available'})
 
     try:
-        content, _ = await asyncio.to_thread(get_content_from_url, __request__, url)
+        content, _ = await get_content_from_url(__request__, url)
 
         # Truncate if configured (WEB_FETCH_MAX_CONTENT_LENGTH)
         # Guard: content may be None if the web loader silently failed


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #26135 — `fetch_url` fails with "cannot unpack non-iterable coroutine object"
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed for this bug fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or architectural changes — this is a one-line fix at each call site.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

---

## Summary

`get_content_from_url` is an `async def` function, but two call sites incorrectly wrap it in thread executors designed for **synchronous** functions. This causes a coroutine object to be returned instead of the actual result, breaking tuple unpacking at runtime.

## Problem → Root Cause → Fix

**Problem:** The built-in `fetch_url` tool and the `process_web` endpoint (`/process/web`, `/process/youtube`) crash with:

```
cannot unpack non-iterable coroutine object
```

accompanied by `RuntimeWarning: coroutine 'get_content_from_url' was never awaited`.

**Root Cause:** Two call sites pass the async function `get_content_from_url` to thread executors that only work with synchronous callables:

1. `builtin.py:265` — `asyncio.to_thread(get_content_from_url, ...)`
2. `retrieval.py:2030` — `run_in_threadpool(get_content_from_url, ...)`

Both `asyncio.to_thread()` and Starlette's `run_in_threadpool()` call the target function in a worker thread. When the target is an `async def`, calling it simply creates a coroutine object without executing it. The `await` on the outer wrapper resolves to that coroutine object (not the `(content, docs)` tuple), so the tuple unpack fails.

**Fix:** Directly `await` the async function, since both callers are already in an async context:

```diff
# backend/open_webui/tools/builtin.py (line 265)
-        content, _ = await asyncio.to_thread(get_content_from_url, __request__, url)
+        content, _ = await get_content_from_url(__request__, url)

# backend/open_webui/routers/retrieval.py (line 2030)
-        content, docs = await run_in_threadpool(get_content_from_url, request, form_data.url)
+        content, docs = await get_content_from_url(request, form_data.url)
```

## Files Changed (2 files, 2 lines)

| File                                      | Change                                                                        |
| ----------------------------------------- | ----------------------------------------------------------------------------- |
| `backend/open_webui/tools/builtin.py`     | Line 265: `await asyncio.to_thread(...)` → `await get_content_from_url(...)`  |
| `backend/open_webui/routers/retrieval.py` | Line 2030: `await run_in_threadpool(...)` → `await get_content_from_url(...)` |

# Changelog Entry

### Description

- Fixed `fetch_url` built-in tool and `process_web` endpoint crashing with "cannot unpack non-iterable coroutine object" when fetching URL content, caused by wrapping an async function in sync-only thread executors.

### Fixed

- `fetch_url` built-in tool now correctly awaits the async `get_content_from_url` function instead of wrapping it in `asyncio.to_thread()`.
- `/process/web` and `/process/youtube` endpoints now correctly await `get_content_from_url` instead of wrapping it in `run_in_threadpool()`.

---

### Additional Information

- The other call site in `retrieval/utils.py:1277` already uses the correct pattern: `await get_content_from_url(request, ...)`.

### Screenshots or Videos

## Before:

<img width="2016" height="1275" alt="image" src="https://github.com/user-attachments/assets/70990576-a7fe-4fd4-a4e0-e09bb2ad2af5" />

<img width="2016" height="1275" alt="image" src="https://github.com/user-attachments/assets/7c64aa58-b79d-4d4b-8d73-5463879bb320" />

## After: 

<img width="2016" height="1275" alt="image" src="https://github.com/user-attachments/assets/6e8fbfa7-f3fd-45e7-ae42-c1162087814a" />

<img width="2016" height="1275" alt="image" src="https://github.com/user-attachments/assets/a10316a2-4664-49db-80fb-8c3c3e9500a8" />

### Manual Verification Performed

1. Started Open WebUI on the `dev` branch (pre-fix), confirmed the `fetch_url` tool fails with the reported error when asking a model to summarize a URL.
2. Applied the fix, restarted the backend.
3. Repeated the same prompt — the `fetch_url` tool successfully fetched and returned page content.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
