### PR TITLE
fix: web search source retrieval

### DIFF
--- a/backend/open_webui/retrieval/tests/test_utils.py
+++ b/backend/open_webui/retrieval/tests/test_utils.py
@@ -1,0 +1,60 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'test-secret-key')
+
+from open_webui.retrieval import utils
+
+
+@pytest.mark.asyncio
+async def test_get_sources_from_items_retrieves_web_search_collection(monkeypatch):
+    async def mock_filter_accessible_collections(collection_names, user, access_type='read'):
+        return {name for name in collection_names if name.startswith('web-search-')}
+
+    async def mock_query_collection(request, collection_names, queries, embedding_function, k):
+        assert collection_names == {'web-search-example'}
+        assert queries == ['test query']
+
+        return {
+            'documents': [['search result content']],
+            'metadatas': [[{'source': 'https://example.com', 'title': 'Example'}]],
+        }
+
+    monkeypatch.setattr(utils, 'filter_accessible_collections', mock_filter_accessible_collections)
+    monkeypatch.setattr(utils, 'query_collection', mock_query_collection)
+
+    sources = await utils.get_sources_from_items(
+        request=SimpleNamespace(),
+        items=[
+            {
+                'type': 'web_search',
+                'collection_name': 'web-search-example',
+                'name': 'test query',
+                'urls': ['https://example.com'],
+            }
+        ],
+        queries=['test query'],
+        embedding_function=lambda query, prefix=None: [],
+        k=3,
+        reranking_function=None,
+        k_reranker=3,
+        r=0.0,
+        hybrid_bm25_weight=0.5,
+        hybrid_search=False,
+        user=SimpleNamespace(id='user-id', role='user'),
+    )
+
+    assert sources == [
+        {
+            'source': {
+                'type': 'web_search',
+                'collection_name': 'web-search-example',
+                'name': 'test query',
+                'urls': ['https://example.com'],
+            },
+            'document': ['search result content'],
+            'metadata': [{'source': 'https://example.com', 'title': 'Example'}],
+        }
+    ]

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1404,6 +1404,11 @@ async def get_sources_from_items(
                 'documents': [[doc.get('content') for doc in item.get('docs')]],
                 'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
             }
+        elif item.get('type') == 'web_search':
+            if item.get('collection_name'):
+                collection_names.append(item['collection_name'])
+            elif item.get('collection_names'):
+                collection_names.extend(item['collection_names'])
         elif item.get('collection_name'):
             if BYPASS_RETRIEVAL_ACCESS_CONTROL:
                 collection_names.append(item['collection_name'])

--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -56,9 +56,13 @@ class ChromaClient(VectorDBBase):
             )
 
     def has_collection(self, collection_name: str) -> bool:
-        # Check if the collection exists based on the collection name.
-        collection_names = self.client.list_collections()
-        return collection_name in collection_names
+        # Check the target collection directly. Listing all collections can
+        # fail on older Chroma metadata that lacks newer config fields.
+        try:
+            self.client.get_collection(name=collection_name)
+            return True
+        except Exception:
+            return False
 
     def delete_collection(self, collection_name: str):
         # Delete the collection based on the collection name.

--- a/backend/open_webui/retrieval/vector/dbs/tests/test_chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/tests/test_chroma.py
@@ -1,0 +1,23 @@
+from open_webui.retrieval.vector.dbs.chroma import ChromaClient
+
+
+class FakeChromaClient:
+    def __init__(self, existing_names):
+        self.existing_names = set(existing_names)
+
+    def list_collections(self):
+        raise KeyError('_type')
+
+    def get_collection(self, name):
+        if name not in self.existing_names:
+            raise ValueError('collection not found')
+
+        return object()
+
+
+def test_has_collection_checks_target_collection_without_listing():
+    client = ChromaClient.__new__(ChromaClient)
+    client.client = FakeChromaClient({'web-search-example'})
+
+    assert client.has_collection('web-search-example') is True
+    assert client.has_collection('missing') is False


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [X] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Web search results could be saved but then fail to appear as sources when retrieval handled the generated file metadata. Treat web search items as trusted web-search collections so the existing access filter can retrieve them.

Chroma collection checks now avoid listing every collection because older metadata can fail migration and block saving new web search results.

Fixes #26119

### Fixed

  - Fixed web search results being found but not returned as sources or model context when retrieval access control ignored generated web_search collections.
  - Fixed Chroma collection existence checks blocking web search indexing when older collection metadata cannot be listed or migrated.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
0.6.37