### PR TITLE
fix: prevent Enter key symbol rendering as emoji on iOS in Keyboard Shortcuts modal

### DIFF
--- a/src/lib/components/chat/ShortcutItem.svelte
+++ b/src/lib/components/chat/ShortcutItem.svelte
@@ -46,7 +46,7 @@
 			case 'escape':
 				return 'Esc';
 			case 'enter':
-				return isMac ? '↩' : 'Enter';
+				return isMac ? '↩\uFE0E' : 'Enter';
 			case 'tab':
 				return isMac ? '⇥' : 'Tab';
 			case 'arrowup':

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -613,7 +613,7 @@
 					<div class=" self-center mr-3">
 						<Keyboard className="size-5" />
 					</div>
-					<div class=" self-center truncate">{$i18n.t('Keyboard shortcuts')}</div>
+					<div class=" self-center truncate">{$i18n.t('Keyboard Shortcuts')}</div>
 				</button>
 			{/if}
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Two minor keyboard shortcuts UI bugs — the Enter key symbol renders as a colorful emoji on iOS, and the user menu label uses inconsistent capitalization.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed for this bug fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions. Verified on iOS (iPhone 13 Pro) and desktop.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No architectural changes — one is a single-character addition, the other is a capitalization fix in an i18n key reference.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

---

## Summary

Two minor visual bugs in the Keyboard Shortcuts feature:

1. **Enter key emoji on iOS:** The `↩` character (U+21A9) used to represent the Enter key in the Keyboard Shortcuts modal renders as a colorful blue emoji on iOS/iPadOS instead of a plain text glyph.
2. **Inconsistent capitalization:** The user menu displays "Keyboard shortcuts" (lowercase 's') while the modal title uses "Keyboard Shortcuts" (capital 'S').

## Changes

### 1. Enter key emoji fix

**Problem:** On iOS (iPhone 13 Pro), the Enter key badge in the Keyboard Shortcuts modal displays as a blue emoji instead of a plain keyboard-style glyph.

**Root cause:** The Unicode character `↩` (U+21A9) is in Apple's emoji presentation set. Without an explicit presentation selector, iOS chooses the emoji variant.

**Fix:** Append the Unicode **text variation selector** `U+FE0E` to force text-style rendering. This is the standard Unicode mechanism ([UTR #51](https://www.unicode.org/reports/tr51/#Emoji_Variation_Sequences)) and has no visual effect on platforms that already render the character as text.

```diff
# src/lib/components/chat/ShortcutItem.svelte (line 49)
-			return isMac ? '↩' : 'Enter';
+			return isMac ? '↩\uFE0E' : 'Enter';
```

### 2. Menu capitalization fix

**Problem:** The user menu item reads "Keyboard shortcuts" while the modal it opens is titled "Keyboard Shortcuts".

**Fix:** Use the existing `'Keyboard Shortcuts'` i18n key (which already exists in the translation files) instead of the lowercase variant.

```diff
# src/lib/components/layout/Sidebar/UserMenu.svelte (line 616)
-					<div class=" self-center truncate">{$i18n.t('Keyboard shortcuts')}</div>
+					<div class=" self-center truncate">{$i18n.t('Keyboard Shortcuts')}</div>
```

## Files Changed (2 files, 2 lines)

| File | Change |
|---|---|
| `src/lib/components/chat/ShortcutItem.svelte` | Line 49: Appended `\uFE0E` text variation selector to `↩` |
| `src/lib/components/layout/Sidebar/UserMenu.svelte` | Line 616: `'Keyboard shortcuts'` → `'Keyboard Shortcuts'` |

# Changelog Entry

### Description

- Fixed two minor visual bugs in the Keyboard Shortcuts feature: the Enter key symbol rendering as a colorful emoji on iOS, and inconsistent capitalization between the user menu label and the modal title.

### Fixed

- Enter key badge in Keyboard Shortcuts modal no longer renders as an emoji on iOS/iPadOS — it now displays as a plain text glyph consistent with all other key symbols.
- "Keyboard shortcuts" in the user menu now reads "Keyboard Shortcuts" (capital S), matching the modal title and standard English title case.

---

### Additional Information

- Other keyboard symbols in `formatKey` (`⌫`, `⇥`, `↑`, `↓`) are not affected — they are not in Apple's emoji presentation set.
- The `U+FE0E` variation selector is invisible on platforms that already render `↩` as text — fully backward-compatible.
- Both `'Keyboard shortcuts'` and `'Keyboard Shortcuts'` i18n keys already exist in the translation files; this change simply uses the correctly capitalized one.

### Screenshots or Videos

- **Before (iOS):** The Enter key badge shows a blue emoji square in the "Generate Message Pair" row, and the user menu reads "Keyboard shortcuts".

<img width="1170" height="956" alt="image" src="https://github.com/user-attachments/assets/59ec42c5-957a-445a-85cb-baa2918696f5" />

<img width="264" height="513" alt="image" src="https://github.com/user-attachments/assets/046b854b-8351-41b5-bb8e-93bd1cb5e131" />

- **After (iOS):** The Enter key badge shows a plain `↩` text glyph, and the user menu reads "Keyboard Shortcuts".

<img width="264" height="513" alt="image" src="https://github.com/user-attachments/assets/612e99a4-a378-4e58-99ad-f1dc8295d497" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
