### PR TITLE
fix: strip whitespace from user info headers to prevent MCP connection failures

### DIFF
--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -52,9 +52,9 @@ def include_user_info_headers(headers: dict, user: Optional[Any] = None) -> dict
 
     return {
         **headers,
-        FORWARD_USER_INFO_HEADER_USER_NAME: quote(user.name, safe=' '),
+        FORWARD_USER_INFO_HEADER_USER_NAME: quote(user.name.strip(), safe=' '),
         FORWARD_USER_INFO_HEADER_USER_ID: user.id,
-        FORWARD_USER_INFO_HEADER_USER_EMAIL: user.email,
+        FORWARD_USER_INFO_HEADER_USER_EMAIL: user.email.strip(),
         FORWARD_USER_INFO_HEADER_USER_ROLE: user.role,
     }
 
@@ -68,8 +68,8 @@ def get_custom_headers(custom_headers: dict, user=None, metadata: dict = None) -
         '{{CHAT_ID}}': metadata.get('chat_id', '') or '',
         '{{MESSAGE_ID}}': metadata.get('message_id', '') or '',
         '{{USER_ID}}': (user.id if user else '') or '',
-        '{{USER_NAME}}': (user.name if user else '') or '',
-        '{{USER_EMAIL}}': (user.email if user else '') or '',
+        '{{USER_NAME}}': (user.name.strip() if user else '') or '',
+        '{{USER_EMAIL}}': (user.email.strip() if user else '') or '',
         '{{USER_ROLE}}': (user.role if user else '') or '',
     }
 


### PR DESCRIPTION
## Summary

Users with leading/trailing whitespace in their display name (e.g., ` Ray, William`) cause `httpcore.LocalProtocolError("Illegal header value")` when Open WebUI forwards user info as HTTP headers to MCP servers. This silently kills the MCP connection for affected users while other users work fine.

**Root cause:** `include_user_info_headers()` in `backend/open_webui/utils/headers.py` passes `user.name` directly to `quote()` without stripping whitespace. A leading space produces an illegal HTTP header value (e.g., `b' Ray%2C William'`), which `httpcore` rejects at the transport layer.

**Fix:** Add `.strip()` to `user.name` and `user.email` in both `include_user_info_headers()` and `get_custom_headers()` before they are used as HTTP header values or template substitutions.

## Reproduction

1. Create a user with a leading space in their display name (e.g., ` Ray, William`)
2. Enable `ENABLE_FORWARD_USER_INFO_HEADERS`
3. Have that user trigger any MCP tool call
4. The MCP connection fails with `LocalProtocolError("Illegal header value")`
5. User sees "Failed to connect to MCP server" error

## Test plan

- [x] Verify `.strip()` applied to `user.name` in `include_user_info_headers()`
- [x] Verify `.strip()` applied to `user.email` in `include_user_info_headers()`
- [x] Verify `.strip()` applied to `user.name` in `get_custom_headers()` template vars
- [x] Verify `.strip()` applied to `user.email` in `get_custom_headers()` template vars
- [ ] Users with normal names (no whitespace) are unaffected
- [ ] Users with leading/trailing whitespace in name can now use MCP tools