### PR TITLE
fix: strip whitespace from user info headers to prevent MCP connection failures

### DIFF
--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -52,9 +52,9 @@ def include_user_info_headers(headers: dict, user: Optional[Any] = None) -> dict
 
     return {
         **headers,
-        FORWARD_USER_INFO_HEADER_USER_NAME: quote(user.name, safe=' '),
+        FORWARD_USER_INFO_HEADER_USER_NAME: quote(user.name.strip(), safe=' '),
         FORWARD_USER_INFO_HEADER_USER_ID: user.id,
-        FORWARD_USER_INFO_HEADER_USER_EMAIL: user.email,
+        FORWARD_USER_INFO_HEADER_USER_EMAIL: user.email.strip(),
         FORWARD_USER_INFO_HEADER_USER_ROLE: user.role,
     }
 
@@ -77,8 +77,8 @@ def get_custom_headers(custom_headers: dict, user=None, metadata: dict = None) -
         '{{USER_MESSAGE_PARENT_ID}}': user_message_parent_id or '',
         '{{TASK}}': metadata.get('task', '') or '',
         '{{USER_ID}}': (user.id if user else '') or '',
-        '{{USER_NAME}}': (user.name if user else '') or '',
-        '{{USER_EMAIL}}': (user.email if user else '') or '',
+        '{{USER_NAME}}': (user.name.strip() if user else '') or '',
+        '{{USER_EMAIL}}': (user.email.strip() if user else '') or '',
         '{{USER_ROLE}}': (user.role if user else '') or '',
     }
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) -- Closes #26181
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

Users with leading/trailing whitespace in their display name (e.g., ` Ray, William`) cause `httpcore.LocalProtocolError("Illegal header value")` when Open WebUI forwards user info as HTTP headers to MCP servers. This silently kills the MCP connection for affected users while others work fine.

`include_user_info_headers()` passes `user.name` directly to `quote()` without stripping whitespace. A leading space produces an illegal HTTP header value (e.g., `b' Ray%2C William'`), which `httpcore` rejects at the transport layer.

### Fixed

- Add `.strip()` to `user.name` and `user.email` in `include_user_info_headers()` before passing to `quote()` / setting as header values
- Add `.strip()` to `user.name` and `user.email` in `get_custom_headers()` template variable substitution

### Reproduction

1. Create a user with a leading space in their display name
2. Enable `ENABLE_FORWARD_USER_INFO_HEADERS`
3. Have that user trigger any MCP tool call
4. Connection fails with `LocalProtocolError("Illegal header value")`

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.