### PR TITLE
fix: accumulate usage across tool-call loop iterations

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3953,6 +3953,32 @@ async def streaming_chat_response_handler(response, ctx):
                     output = []
 
             usage = None
+
+            def accumulate_usage(new_usage: dict):
+                """Accumulate token counts across multiple LLM calls in a tool loop.
+
+                During native function-calling loops the same assistant message
+                may require several upstream LLM calls. Each call returns its
+                own usage object, but only the last one was persisted, causing
+                analytics to undercount. This helper merges new counts into the
+                running total so the final persisted usage reflects the whole
+                tool loop.
+                """
+                nonlocal usage
+                if not new_usage:
+                    return new_usage
+                if usage is None:
+                    usage = new_usage
+                    return new_usage
+                # Sum the standardised token fields
+                usage = {
+                    **new_usage,
+                    'input_tokens': usage.get('input_tokens', 0) + new_usage.get('input_tokens', 0),
+                    'output_tokens': usage.get('output_tokens', 0) + new_usage.get('output_tokens', 0),
+                    'total_tokens': usage.get('total_tokens', 0) + new_usage.get('total_tokens', 0),
+                }
+                return usage
+
             prior_output = []
             last_response_id = None
 
@@ -4142,7 +4168,7 @@ async def streaming_chat_response_handler(response, ctx):
                                         # Normalize and capture usage for DB persistence
                                         if response_metadata.get('usage'):
                                             response_metadata['usage'] = normalize_usage(response_metadata['usage'])
-                                            usage = response_metadata['usage']
+                                            accumulate_usage(response_metadata['usage'])
 
                                         processed_data.update(response_metadata)
                                         processed_data.pop('done', None)
@@ -4161,7 +4187,8 @@ async def streaming_chat_response_handler(response, ctx):
                                     raw_usage = data.get('usage', {}) or {}
                                     raw_usage.update(data.get('timings', {}))  # llama.cpp
                                     if raw_usage:
-                                        usage = normalize_usage(raw_usage)
+                                        normalized = normalize_usage(raw_usage)
+                                        accumulate_usage(normalized)
                                         await event_emitter(
                                             {
                                                 'type': 'chat:completion',


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #25617.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and its impact are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies are added or updated.
- [ ] **Testing:** Manual multi-tool-loop testing is still required.
- [ ] **No Unchecked AI Code:** Maintainer review and manual validation are still requested.
- [x] **Self-Review:** The change was reviewed after rebasing onto the latest `dev`.
- [x] **Architecture:** The fix preserves normalized usage objects and only changes aggregation.
- [x] **Git Hygiene:** The branch is based on the latest `dev` and contains one atomic commit.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Accumulate normalized token usage across every LLM request made during a native tool-calling loop. Previously each response replaced the stored usage object, so only the final request was persisted and tool-heavy conversations were undercounted.

Fixes #25617.

## Changelog Entry

### Fixed

- Persist the combined token usage of all LLM calls in a tool-calling loop.

## Testing

- Python syntax compilation succeeds.
- Both Responses API and Chat Completions usage paths feed the same accumulator.
- Manual testing with multiple sequential native tool calls is still recommended.

## Breaking Changes

- None.

## Additional Information

- Supersedes closed PR #26100 with a clean branch based on the latest `dev`.

## Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
