### PR TITLE
fix: render reasoning-only output as a message

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4562,6 +4562,34 @@ async def streaming_chat_response_handler(response, ctx):
                                 )
                                 reasoning_item['status'] = 'completed'
 
+                            # Some providers (e.g. vLLM with reasoning disabled) may
+                            # incorrectly place the actual answer in reasoning_content
+                            # while never emitting content, resulting in an output that
+                            # contains only reasoning items with no message item.  Detect
+                            # this case and convert the reasoning into a regular message.
+                            has_message = any(
+                                item.get('type') == 'message' for item in output
+                            )
+                            if not has_message:
+                                # Extract text from all reasoning content and replace
+                                # with a single message item
+                                text = ''
+                                for item in output:
+                                    for part in item.get('content', []):
+                                        if part.get('type') == 'output_text':
+                                            text += part.get('text', '')
+
+                                output = [
+                                    {
+                                        'type': 'message',
+                                        'id': output_id('msg'),
+                                        'status': 'completed',
+                                        'role': 'assistant',
+                                        'content': [{'type': 'output_text', 'text': text}],
+                                    }
+                                ]
+                                content = text
+
                     if response_tool_calls:
                         tool_calls.append(_split_tool_calls(response_tool_calls))
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #26072.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and its impact are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies are added or updated.
- [ ] **Testing:** Manual testing against an affected vLLM deployment is still required.
- [ ] **No Unchecked AI Code:** Maintainer review and manual validation are still requested.
- [x] **Self-Review:** The change was reviewed after rebasing onto the latest `dev`.
- [x] **Architecture:** The fix is limited to final streaming-output normalization.
- [x] **Git Hygiene:** The branch is based on the latest `dev` and contains one atomic commit.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Some providers can place the actual answer in `reasoning_content` while reasoning is disabled and never emit a normal message item. When a completed stream contains reasoning output but no message output, this change converts the reasoning text into a regular assistant message so it appears in the answer area.

Fixes #26072.

## Changelog Entry

### Fixed

- Render reasoning-only streaming responses as normal answers when no message item is emitted.

## Testing

- Python syntax compilation succeeds.
- The changed block follows the existing output-item structure.
- Manual validation with an affected vLLM reasoning model is still recommended.

## Breaking Changes

- None.

## Additional Information

- Supersedes closed PR #26098 with a clean branch based on the latest `dev`.

## Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
