### PR TITLE
fix: always complete failed per-user tool callbacks

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -414,38 +414,45 @@
 	};
 
 	const executeTool = async (data, cb, chatId) => {
-		const { toolServer, toolServerData, token } = resolveToolServer(data.server?.url);
+		try {
+			const { toolServer, toolServerData, token } = resolveToolServer(data.server?.url);
 
-		console.log('executeTool', data, toolServer);
+			console.log('executeTool', data, toolServer);
 
-		if (toolServer) {
-			const res = await executeToolServer(
-				token,
-				toolServer.url,
-				data?.name,
-				data?.params,
-				toolServerData,
-				chatId
-			);
+			if (toolServer) {
+				const res = await executeToolServer(
+					token,
+					toolServer.url,
+					data?.name,
+					data?.params,
+					toolServerData,
+					chatId
+				);
 
-			console.log('executeToolServer', res);
+				console.log('executeToolServer', res);
 
-			if (data?.name === 'display_file' && data?.params?.path) {
-				if (res?.exists !== false) {
-					displayFileHandler(data.params.path, { showControls, showFileNavPath });
+				if (data?.name === 'display_file' && data?.params?.path) {
+					if (res?.exists !== false) {
+						displayFileHandler(data.params.path, { showControls, showFileNavPath });
+					}
+				}
+
+				if (['write_file'].includes(data?.name) && data?.params?.path) {
+					showFileNavDir.set(res?.path ?? data.params.path);
+				}
+
+				if (cb) {
+					cb(structuredClone(res));
+				}
+			} else {
+				if (cb) {
+					cb({ error: 'Tool Server Not Found' });
 				}
 			}
-
-			if (['write_file'].includes(data?.name) && data?.params?.path) {
-				showFileNavDir.set(res?.path ?? data.params.path);
-			}
-
+		} catch (error) {
+			console.error('executeTool error:', error);
 			if (cb) {
-				cb(structuredClone(res));
-			}
-		} else {
-			if (cb) {
-				cb({ error: 'Tool Server Not Found' });
+				cb({ error: error?.message ?? 'Tool execution failed' });
 			}
 		}
 	};


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #25850.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and its impact are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies are added or updated.
- [ ] **Testing:** Manual tool-server testing is still required.
- [ ] **No Unchecked AI Code:** Maintainer review and manual validation are still requested.
- [x] **Self-Review:** The change was reviewed after rebasing onto the latest `dev`.
- [x] **Architecture:** The fix preserves the existing tool execution flow and callback contract.
- [x] **Git Hygiene:** The branch is based on the latest `dev` and contains one atomic commit.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Wrap `executeTool` in error handling that always invokes its callback. Previously, an unexpected exception such as a failed tool-server resolution or `structuredClone` error could leave the backend's socket call waiting indefinitely.

Closes #25850.

## Changelog Entry

### Fixed

- Prevent per-user tool execution errors from leaving WebSocket requests hanging indefinitely.

## Testing

- Prettier check passes for `src/routes/+layout.svelte`.
- The repository's targeted ESLint command reports pre-existing errors elsewhere in the same file.
- Manual testing with a failing per-user tool server is still recommended.

## Breaking Changes

- None.

## Additional Information

- Supersedes closed PR #26095 with a clean branch based on the latest `dev`.

## Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
