### PR TITLE
fix: continue Firecrawl loading after per-URL errors

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -322,8 +322,9 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         self.params = params or {}
 
     def lazy_load(self) -> Iterator[Document]:
-        try:
-            for url in self.web_paths:
+        for url in self.web_paths:
+            try:
+                self._safe_process_url_sync(url)
                 doc = scrape_firecrawl_url(
                     self.api_url,
                     self.api_key,
@@ -334,22 +335,16 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
                 )
                 if doc is not None:
                     yield doc
-        except Exception as e:
-            if self.continue_on_failure:
-                log.warning(f'Error extracting content from URLs with Firecrawl: {e}')
-            else:
+            except Exception as e:
+                if self.continue_on_failure:
+                    log.warning(f'Error extracting content from {url} with Firecrawl: {e}')
+                    continue
                 raise e
 
     async def alazy_load(self):
-        try:
-            docs = await run_in_threadpool(lambda: list(self.lazy_load()))
-            for doc in docs:
-                yield doc
-        except Exception as e:
-            if self.continue_on_failure:
-                log.warning(f'Error extracting content from URLs with Firecrawl: {e}')
-            else:
-                raise e
+        docs = await run_in_threadpool(lambda: list(self.lazy_load()))
+        for doc in docs:
+            yield doc
 
 
 class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #26079.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and its impact are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies are added or updated.
- [ ] **Testing:** Manual Firecrawl integration testing is still required.
- [ ] **No Unchecked AI Code:** Maintainer review and manual validation are still requested.
- [x] **Self-Review:** The change was reviewed after rebasing onto the latest `dev`.
- [x] **Architecture:** The implementation reuses the existing URL safety and rate-limit helpers.
- [x] **Git Hygiene:** The branch is based on the latest `dev` and contains one atomic commit.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Move Firecrawl error handling inside the per-URL loop so one failed URL does not silently discard every remaining URL. The loader now also invokes the existing synchronous URL safety and rate-limit helper before each request.

Fixes #26079.

## Changelog Entry

### Fixed

- Continue processing Firecrawl URLs after an individual URL fails.
- Apply the configured request rate limit to Firecrawl loading.

## Testing

- Python syntax compilation succeeds.
- The implementation follows the existing synchronous loader safety path.
- Manual testing with a mixed successful/failing URL batch is still recommended.

## Breaking Changes

- None.

## Additional Information

- Supersedes closed PR #26099 with a clean branch based on the latest `dev`.

## Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
