### PR TITLE
fix: prevent query duplication in custom RAG templates

### DIFF
--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -279,12 +279,12 @@ async def rag_template(template: str, context: str, query: str):
         )
 
     query_placeholders = []
-    if '[query]' in context:
+    if '[query]' in template:
         query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
         template = template.replace('[query]', query_placeholder)
         query_placeholders.append((query_placeholder, '[query]'))
 
-    if '{{QUERY}}' in context:
+    if '{{QUERY}}' in template:
         query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
         template = template.replace('{{QUERY}}', query_placeholder)
         query_placeholders.append((query_placeholder, '{{QUERY}}'))
@@ -295,8 +295,8 @@ async def rag_template(template: str, context: str, query: str):
     template = template.replace('[query]', query)
     template = template.replace('{{QUERY}}', query)
 
-    for query_placeholder, original_placeholder in query_placeholders:
-        template = template.replace(query_placeholder, original_placeholder)
+    for query_placeholder, _original_placeholder in query_placeholders:
+        template = template.replace(query_placeholder, query)
 
     return template
 


### PR DESCRIPTION
Closes #26127

When a custom RAG template contained [query] or {{QUERY}}, the template engine was checking if these placeholders existed in the context instead of the template. This caused the query to be inserted twice: once via the placeholder and once via the original user message.

This fixes the placeholder detection to check the template, and ensures the placeholders are replaced with the actual query value.

### Fixed

- Custom RAG templates with [query] or {{QUERY}} placeholders no longer duplicate the user query

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
