### PR TITLE
perf: batch tool-call and Responses API stream deltas

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4022,10 +4022,12 @@ async def streaming_chat_response_handler(response, ctx):
                         int(metadata.get('params', {}).get('stream_delta_chunk_size') or 1),
                     )
                     last_delta_data = None
+                    last_delta_data_kind = None
 
                     async def flush_pending_delta_data(threshold: int = 0):
                         nonlocal delta_count
                         nonlocal last_delta_data
+                        nonlocal last_delta_data_kind
 
                         if delta_count >= threshold and last_delta_data:
                             await event_emitter(
@@ -4036,6 +4038,21 @@ async def streaming_chat_response_handler(response, ctx):
                             )
                             delta_count = 0
                             last_delta_data = None
+                            last_delta_data_kind = None
+
+                    async def queue_pending_delta_data(delta_data: dict, delta_data_kind: str):
+                        nonlocal delta_count
+                        nonlocal last_delta_data
+                        nonlocal last_delta_data_kind
+
+                        if last_delta_data_kind and last_delta_data_kind != delta_data_kind:
+                            await flush_pending_delta_data()
+
+                        delta_count += 1
+                        last_delta_data = delta_data
+                        last_delta_data_kind = delta_data_kind
+                        if delta_count >= delta_chunk_size:
+                            await flush_pending_delta_data(delta_chunk_size)
 
                     async for line in response.body_iterator:
                         line = line.decode('utf-8', 'replace') if isinstance(line, bytes) else line
@@ -4084,11 +4101,17 @@ async def streaming_chat_response_handler(response, ctx):
                                     )
                                 # Check for Responses API events (type field starts with "response.")
                                 elif data.get('type', '').startswith('response.'):
+                                    response_event_type = data.get('type', '')
+                                    response_event_is_delta = response_event_type.endswith('.delta')
+
                                     output, response_metadata = handle_responses_streaming_event(data, output)
+
+                                    if not response_event_is_delta:
+                                        await flush_pending_delta_data()
 
                                     # Emit citation sources from finalized output items
                                     # (mirrors Chat Completions annotation handling at delta level)
-                                    if data.get('type') == 'response.output_item.done':
+                                    if response_event_type == 'response.output_item.done':
                                         item = data.get('item', {})
                                         if item.get('type') == 'message':
                                             for part in item.get('content', []):
@@ -4147,12 +4170,23 @@ async def streaming_chat_response_handler(response, ctx):
                                         processed_data.update(response_metadata)
                                         processed_data.pop('done', None)
 
-                                    await event_emitter(
-                                        {
-                                            'type': 'chat:completion',
-                                            'data': processed_data,
-                                        }
-                                    )
+                                    if response_event_is_delta:
+                                        response_delta_type = response_event_type.split('.')[1]
+                                        await queue_pending_delta_data(
+                                            processed_data,
+                                            (
+                                                'tool_call'
+                                                if response_delta_type == 'function_call_arguments'
+                                                else 'content'
+                                            ),
+                                        )
+                                    else:
+                                        await event_emitter(
+                                            {
+                                                'type': 'chat:completion',
+                                                'data': processed_data,
+                                            }
+                                        )
                                     continue
                                 else:
                                     choices = data.get('choices', [])
@@ -4196,6 +4230,7 @@ async def streaming_chat_response_handler(response, ctx):
                                         continue
 
                                     delta = choices[0].get('delta', {})
+                                    delta_data_kind = 'delta'
 
                                     # Handle delta annotations
                                     annotations = delta.get('annotations')
@@ -4263,10 +4298,11 @@ async def streaming_chat_response_handler(response, ctx):
                                                             delta_arguments
                                                         )
 
-                                        # Emit pending tool calls in real-time
+                                        # Queue pending tool calls through the shared delta batching path
                                         if response_tool_calls:
-                                            # Flush any pending text first
-                                            await flush_pending_delta_data()
+                                            # Keep text ahead of tool-call display updates.
+                                            if last_delta_data_kind != 'tool_call':
+                                                await flush_pending_delta_data()
 
                                             # Build pending function_call output items for display
                                             pending_fc_items = []
@@ -4284,14 +4320,10 @@ async def streaming_chat_response_handler(response, ctx):
                                                     }
                                                 )
 
-                                            await event_emitter(
-                                                {
-                                                    'type': 'chat:completion',
-                                                    'data': {
-                                                        'content': serialize_output(full_output() + pending_fc_items),
-                                                    },
-                                                }
-                                            )
+                                            data = {
+                                                'content': serialize_output(full_output() + pending_fc_items),
+                                            }
+                                            delta_data_kind = 'tool_call'
 
                                     image_urls = await get_image_urls(delta.get('images', []), request, metadata, user)
                                     if image_urls:
@@ -4348,8 +4380,10 @@ async def streaming_chat_response_handler(response, ctx):
                                             ]
 
                                         data = {'content': serialize_output(full_output())}
+                                        delta_data_kind = 'content'
 
                                     if value:
+                                        delta_data_kind = 'content'
                                         if (
                                             output
                                             and output[-1].get('type') == 'reasoning'
@@ -4510,8 +4544,12 @@ async def streaming_chat_response_handler(response, ctx):
                                             }
 
                                 if delta:
+                                    if last_delta_data_kind == 'tool_call' and delta_data_kind != 'tool_call':
+                                        await flush_pending_delta_data()
+
                                     delta_count += 1
                                     last_delta_data = data
+                                    last_delta_data_kind = delta_data_kind
                                     if delta_count >= delta_chunk_size:
                                         await flush_pending_delta_data(delta_chunk_size)
                                 else:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Discussion - `Relates to #26200`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No user-facing docs change required (internal streaming behavior only).
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested with native tool-call streaming and Responses API streaming; verified tool-call and text update ordering is preserved and event volume is reduced when `stream_delta_chunk_size` is set.
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Reuses the existing chunk-size setting; no new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `perf` prefix.

## What

Route native Chat Completions `delta.tool_calls` and Responses API
`response.*.delta` events through the existing delta batching path
(`queue_pending_delta_data` / `flush_pending_delta_data`), governed by the same
`stream_delta_chunk_size` / `CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE` threshold
already used for normal assistant text deltas.

## Why

Previously only the Chat Completions text path respected the stream delta chunk
size. Native tool-call argument deltas and Responses API delta events called
`event_emitter` immediately, so large tool-call argument streams produced many
tiny `chat:completion` events - increasing Socket.IO traffic and frontend render
work even when stream delta chunking was configured.

## How

- Added `last_delta_data_kind` tracking and a shared `queue_pending_delta_data()`
  helper that flushes on kind change (content vs tool_call) and emits only when
  `delta_count >= delta_chunk_size`.
- Native tool-call deltas now assign the outgoing payload and flow through the
  shared batching block instead of emitting immediately.
- Responses API `response.*.delta` events are batched
  (`function_call_arguments.delta` -> tool_call, others -> content); non-delta
  lifecycle/finalization events flush pending batches then emit immediately so
  metadata, citations, final output, and errors stay ordered.

No new config; reuses the existing chunk-size settings.

Relates to #26200

# Changelog Entry

### Changed

- Native Chat Completions tool-call argument deltas and Responses API streaming
  deltas now respect the same `stream_delta_chunk_size` batching threshold as
  normal assistant text deltas, reducing `chat:completion` event volume during
  tool-call and Responses API streaming.

---

### Additional Information

- Affects `backend/open_webui/utils/middleware.py` only (+56/-18).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
