### PR TITLE
fix: persist RAG config changes to database on save

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1308,6 +1308,8 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.LINKUP_API_KEY = form_data.web.LINKUP_API_KEY
         config.LINKUP_SEARCH_PARAMS = form_data.web.LINKUP_SEARCH_PARAMS
 
+    await config.save()
+
     return {
         'status': True,
         # RAG settings


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a bug where all Admin Settings → Documents page settings revert after navigating away, despite clicking Save.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed for this bug fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No architectural changes — this adds a single missing `save()` call that already exists in the sibling endpoint.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

---

## Summary

The `update_rag_config` endpoint (`POST /api/v1/retrieval/config/update`) mutates all RAG config values in memory but never persists them to the database. This causes **every** setting on the Admin Settings → Documents page to silently revert when the user navigates away and returns — including Content Extraction Engine, chunking settings, web search settings, file upload limits, and all other options on that page.

## Problem → Root Cause → Fix

**Problem:** Changing the Content Extraction Engine (or any other Documents setting) to a new value, clicking Save, and then navigating away causes the setting to revert to its previous value.

**Root cause:** The `update_rag_config` function creates a `RetrievalConfig` object, sets attributes on it (which tracks changes in an internal `_updates` dict), but **never calls `await config.save()`** to flush those changes to the database. When the page reloads, `get_rag_config` fetches from DB — which still has the old values.

The sibling endpoint `update_embedding_config` (line 571) correctly calls `await config.save()`, confirming this was an oversight.

**Fix:** Add `await config.save()` before the return statement in `update_rag_config`.

```diff
# backend/open_webui/routers/retrieval.py
         config.LINKUP_API_KEY = form_data.web.LINKUP_API_KEY
         config.LINKUP_SEARCH_PARAMS = form_data.web.LINKUP_SEARCH_PARAMS

+    await config.save()
+
     return {
         'status': True,
```

## Files Changed (1 file, 2 lines)

| File | Change |
|---|---|
| `backend/open_webui/routers/retrieval.py` | Added `await config.save()` before the return in `update_rag_config` |

# Changelog Entry

### Description

- Fixed all Admin Settings → Documents page settings silently reverting after save due to a missing database persistence call.

### Fixed

- Admin Settings → Documents page settings (Content Extraction Engine, chunking, web search, file upload limits, etc.) now correctly persist to the database when saved, surviving page navigation and server restarts.

---

### Additional Information

- The `RetrievalConfig` class (line 393) uses `__setattr__` to track all attribute mutations in `_updates`, and `save()` flushes them to the DB via `Config.upsert()`. The tracking was working correctly — only the final `save()` call was missing.
- The `update_embedding_config` endpoint (line 571) already calls `save()` correctly, confirming this was an oversight specific to `update_rag_config`.
- **Scope of impact:** This bug affects *every* setting on the Documents admin page, not just Content Extraction Engine. All settings were only persisted in memory until server restart.

### Screenshots or Videos

## Before:

[Screencast from 2026-06-24 11-30-24.webm](https://github.com/user-attachments/assets/2845124d-c708-4338-abd2-2968056ee55b)

## After:

[Screencast from 2026-06-24 11-31-54.webm](https://github.com/user-attachments/assets/789f889b-1d7f-4b85-b52f-cb735b38b98d)

### Manual Verification Performed

1. Navigated to Admin Settings → Documents.
2. Changed Content Extraction Engine from "Default" to "Docling".
3. Clicked Save.
4. Navigated away to a different admin tab, then returned to Documents.
5. **Before fix:** Content Extraction Engine reverted to "Default".
6. **After fix:** Content Extraction Engine remained "Docling" as expected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
