### PR TITLE
fix: allow special tokens in document text during chunk measurement

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1490,7 +1490,7 @@ def merge_docs_to_target_size(
     measure: Callable[[str], int] = len
     if config.TEXT_SPLITTER == 'token':
         encoding = tiktoken.get_encoding(str(config.TIKTOKEN_ENCODING_NAME))
-        measure = lambda text: len(encoding.encode(text))
+        measure = lambda text: len(encoding.encode(text, disallowed_special=()))
 
     def _merge_backward(result: list[Document], content: str, chunk: Document) -> bool:
         """Try to append content into the last emitted chunk. Returns True on success."""


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a bug where documents containing LLM special token strings (e.g., `<|endoftext|>`) fail to be indexed during RAG processing.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is an internal bug fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No architectural changes — single-line parameter addition.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** When uploading documents that contain LLM special token strings as literal text (e.g., `<|endoftext|>`, `<|im_start|>`), the RAG pipeline crashes with a `ValueError` during chunk size measurement. This prevents the entire file from being indexed into the vector database.

**Root Cause:** The `merge_docs_to_target_size()` function in `retrieval.py` uses tiktoken's `encoding.encode()` to measure chunk sizes when the token-based text splitter is active. By default, tiktoken raises a `ValueError` when it encounters strings matching special tokens like `<|endoftext|>` — a safety mechanism designed for LLM input sanitization. However, this is a document content measurement context, not an LLM input context, so the check is inappropriate here.

**Fix:** Pass `disallowed_special=()` to `encoding.encode()` to disable the special token check, allowing all text to be treated as normal content during chunk size measurement.

This is especially relevant for AI/LLM documentation (which commonly contains special token examples in code blocks) and for tools like [oikb](https://github.com/open-webui/oikb) that sync documentation repositories into knowledge bases.

```diff
-        measure = lambda text: len(encoding.encode(text))
+        measure = lambda text: len(encoding.encode(text, disallowed_special=()))
```

### Fixed

- Fixed `ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'` crash when indexing documents containing LLM special token strings during RAG chunk measurement

---

### Additional Information

- Scope: 1 file changed, 1 line modified
- The fix only affects the `merge_docs_to_target_size()` chunk measurement lambda — it does not change any LLM input encoding paths
- Reproducible by uploading any `.md`/`.mdx` file containing `<|endoftext|>` with the token-based text splitter enabled

### Screenshots or Videos

<img width="2560" height="1395" alt="image" src="https://github.com/user-attachments/assets/18dac6f8-238a-4523-9ce5-a3f2ea99e3bf" />

### Manual Verification Performed

1. Uploaded a markdown document containing `<|endoftext|>` as literal text (e.g., Open WebUI's own `context-window.mdx` documentation)
2. Verified the file is processed and indexed into the vector database without errors
3. Verified that regular documents (without special tokens) continue to be processed correctly
4. Verified chunk sizes are measured accurately with `disallowed_special=()` enabled

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
