### PR TITLE
fix: recover unlinked pending files in knowledge bases and cap the pending poll timer

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1495,24 +1495,45 @@ async def update_file_from_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
+    is_linked = await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db)
 
-    # Remove content from the vector database
-    await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=knowledge.id, filter={'file_id': form_data.file_id})
-
-    # Add content to the vector database
     try:
-        await process_file(
-            request,
-            ProcessFileForm(file_id=form_data.file_id, collection_name=id),
-            user=user,
-            db=db,
-        )
+        if is_linked:
+            # File is already in the knowledge base — delete stale vectors and
+            # re-embed from the existing file-level collection.
+            await ASYNC_VECTOR_DB_CLIENT.delete(
+                collection_name=knowledge.id, filter={'file_id': form_data.file_id}
+            )
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+                db=db,
+            )
+        else:
+            # File exists but was never linked (e.g. processing crashed before
+            # the knowledge_file row was created).  Re-process from source so
+            # the file-level collection is (re)created, then copy into the KB
+            # collection and create the join-table link.
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id),
+                user=user,
+                db=db,
+            )
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+                db=db,
+            )
+            await Knowledges.add_file_to_knowledge_by_id(
+                knowledge_id=id,
+                file_id=form_data.file_id,
+                user_id=user.id,
+                directory_id=form_data.directory_id,
+                db=db,
+            )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1585,14 +1606,12 @@ async def remove_file_from_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    await Knowledges.remove_file_from_knowledge_by_id(knowledge_id=id, file_id=form_data.file_id, db=db)
+    # Unlink from knowledge base if the join-table row exists.
+    # Files still being processed (pending/processing) may not have been
+    # linked yet; allow cleanup to proceed regardless so they don't become
+    # permanently stuck in the UI.
+    if await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+        await Knowledges.remove_file_from_knowledge_by_id(knowledge_id=id, file_id=form_data.file_id, db=db)
 
     # Remove content from the vector database
     try:

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1495,24 +1495,39 @@ async def update_file_from_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
+    is_linked = await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db)
 
-    # Remove content from the vector database
-    await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=knowledge.id, filter={'file_id': form_data.file_id})
-
-    # Add content to the vector database
     try:
-        await process_file(
-            request,
-            ProcessFileForm(file_id=form_data.file_id, collection_name=id),
-            user=user,
-            db=db,
-        )
+        if is_linked:
+            await ASYNC_VECTOR_DB_CLIENT.delete(
+                collection_name=knowledge.id, filter={'file_id': form_data.file_id}
+            )
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+                db=db,
+            )
+        else:
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id),
+                user=user,
+                db=db,
+            )
+            await process_file(
+                request,
+                ProcessFileForm(file_id=form_data.file_id, collection_name=id),
+                user=user,
+                db=db,
+            )
+            await Knowledges.add_file_to_knowledge_by_id(
+                knowledge_id=id,
+                file_id=form_data.file_id,
+                user_id=user.id,
+                directory_id=form_data.directory_id,
+                db=db,
+            )
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1585,14 +1600,8 @@ async def remove_file_from_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    await Knowledges.remove_file_from_knowledge_by_id(knowledge_id=id, file_id=form_data.file_id, db=db)
+    if await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+        await Knowledges.remove_file_from_knowledge_by_id(knowledge_id=id, file_id=form_data.file_id, db=db)
 
     # Remove content from the vector database
     try:

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -139,6 +139,7 @@
 	let deleteDirectoryContents = true;
 
 	let pendingPollTimer: ReturnType<typeof setInterval> | null = null;
+	let pendingPollCount = 0;
 	let externalTestQuery = '';
 	let externalTestResult: {
 		documents?: string[];
@@ -228,15 +229,20 @@
 
 						// Start polling for completion (if not already polling)
 						if (!pendingPollTimer) {
+							pendingPollCount = 0;
 							pendingPollTimer = setInterval(async () => {
+								pendingPollCount++;
 								try {
 									const still = await getPendingKnowledgeFiles(localStorage.token, knowledgeId);
-									if (!still || still.length === 0) {
+									if (!still || still.length === 0 || pendingPollCount >= 60) {
 										clearInterval(pendingPollTimer);
 										pendingPollTimer = null;
 										init();
 									}
-								} catch {}
+								} catch {
+									clearInterval(pendingPollTimer);
+									pendingPollTimer = null;
+								}
 							}, 5000);
 						}
 					}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a bug where files become permanently stuck in knowledge base file lists after file processing crashes or stalls mid-flight. Relates to #28093, which covers the per-file Reindex UI split out of this PR.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a bug fix.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No architectural changes — minimal modifications to existing logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem:** Files can become permanently stuck in the knowledge base file list with a spinning wheel icon, and cannot be deleted, reindexed, or managed. This happens when file processing crashes or stalls mid-flight (e.g., due to tiktoken errors, embedding service timeouts, or connection pool exhaustion). Three separate issues compound to make this a dead-end:

1. **Backend (`file/remove`):** When a file exists in the `file` table but has not yet been linked to the `knowledge_file` join table (it was still processing when the crash occurred), the `POST /knowledge/{id}/file/remove` endpoint returns `400 Bad Request` ("We could not find what you're looking for") because the `has_file()` check fails. The file can never be deleted through the UI.

2. **Backend (`file/update`):** The `POST /knowledge/{id}/file/update` (reindex) endpoint has the same `has_file()` gate — stuck files can't be reindexed either, even though the file record and source data are intact.

3. **Frontend (pending poll timer):** The `setInterval` timer that polls `GET /knowledge/{id}/files/pending` every 5 seconds has no upper bound. If file processing stalls permanently, the timer runs forever — generating continuous API traffic for as long as the page is open.

The missing per-file Reindex UI was originally part of this PR and has been split out into its own change, discussed in #28093, so that each concern can be reviewed on its own. This PR no longer contains it.

**Fix 1 — Backend:** Changed the `has_file()` check from a hard gate to a conditional. If the file IS in the join table, unlink it; if not, skip the unlink and proceed directly to vector DB cleanup and file deletion. This allows pending/stuck files to be removed from the UI.

```diff
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    await Knowledges.remove_file_from_knowledge_by_id(...)
+    if await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+        await Knowledges.remove_file_from_knowledge_by_id(...)
```

**Fix 2 — Frontend:** Added a `pendingPollCount` counter that caps the polling timer at 60 iterations (~5 minutes). Also added error-case cleanup so the timer always terminates, even if `getPendingKnowledgeFiles` throws.

```diff
+let pendingPollCount = 0;
 ...
 if (!pendingPollTimer) {
+    pendingPollCount = 0;
     pendingPollTimer = setInterval(async () => {
+        pendingPollCount++;
         try {
             const still = await getPendingKnowledgeFiles(...);
-            if (!still || still.length === 0) {
+            if (!still || still.length === 0 || pendingPollCount >= 60) {
                 clearInterval(pendingPollTimer);
                 ...
             }
-        } catch {}
+        } catch {
+            clearInterval(pendingPollTimer);
+            pendingPollTimer = null;
+        }
     }, 5000);
 }
```

**Fix 3 — Backend (`file/update` reindex as retry):** The reindex endpoint now handles two cases:
- **Linked files** (already in the join table): existing behavior — delete stale vectors, re-embed from the file-level collection
- **Unlinked files** (stuck pending/failed): re-process from source (full document extraction from disk), copy vectors to the KB collection, and create the join-table link — effectively retrying the failed initial processing

```diff
-    if not await Knowledges.has_file(...):  # hard gate
-        raise HTTPException(status_code=400, ...)
+    is_linked = await Knowledges.has_file(...)
+    if is_linked:
+        ...  # delete stale vectors, re-embed from file-level collection
+    else:
+        ...  # re-process from source, copy to KB, create join-table link
```

### Fixed

- Fixed files becoming permanently undeletable in knowledge base when file processing crashes before the `knowledge_file` join-table link is created
- Fixed reindex/retry for stuck files: `file/update` now re-processes from source and creates the join-table link for unlinked files
- Fixed pending files polling timer running indefinitely when file processing stalls, generating continuous API traffic

---

### Additional Information

**The three states a file can be in, and why each is handled differently.** A file already linked to the knowledge base has its stale vectors deleted and is re-embedded from the existing file level collection. A file that exists but was never linked, which happens when processing crashed before the `knowledge_file` row was created, is re-processed from source so the file level collection is recreated, then copied into the knowledge base collection and given its join table link. On cleanup, the unlink step runs whether or not the join table row exists, because files still in `pending` or `processing` may never have been linked, and refusing to clean those up is what leaves them permanently stuck in the UI.

- **Scope:** 3 files changed, 79 insertions, 26 deletions
- **Reproduction:** Upload files to a knowledge base via [oikb](https://github.com/open-webui/oikb) or the UI. If processing crashes (e.g., tiktoken special token error, embedding service timeout), the files become stuck with a spinning wheel icon and cannot be removed.
- **Root cause of the stuck state:** The upload pipeline creates a `file` record with `meta.data.knowledge_id` and `status: 'pending'`. The background `process_file` task processes the file, then `add_file_to_knowledge` creates the `knowledge_file` join-table entry. If `process_file` crashes, the join-table entry is never created, but the file still appears in the pending files list — and the `file/remove` endpoint refuses to delete it because `has_file()` returns false.
- Relates to https://github.com/open-webui/open-webui/issues/24566

### Screenshots

#### Before — Stuck files cannot be deleted (400 error)

Files stuck with a spinning wheel icon after processing failure. Clicking Delete returns `400 Bad Request`:

<img width="2560" height="762" alt="image" src="https://github.com/user-attachments/assets/daefdd57-db85-47ff-a5e4-c94b206ee964" />

<details>
<summary>Console error detail</summary>

```
POST /api/v1/knowledge/8aa6d957-.../file/remove → 400 Bad Request
Object { detail: "We could not find what you're looking for :/" }
```

The `file/remove` endpoint rejects deletion because the file was never linked to the `knowledge_file` join table — `has_file()` returns false, and the endpoint treats this as "not found".
The browser console also shows the pending files endpoint being polled every 5 seconds indefinitely:
```
GET .../files/pending 200 OK   (repeats every 5s, never stops)
```
</details>

#### After — Stuck files can be deleted, polling stops

<img width="1225" height="703" alt="image" src="https://github.com/user-attachments/assets/f85fc190-309e-47be-9c64-84dc6d7fe59b" />

### Manual Verification Performed

1. Created a knowledge base and triggered file processing failures to produce stuck pending files
2. Verified the stuck files (spinning wheel icon) could NOT be deleted before the fix (400 error)
3. Applied the fix and verified stuck files can now be deleted via the 3-dot menu
4. Verified normally-linked files (completed status) can still be deleted as before
5. Verified the pending poll timer stops after the max iteration count
6. Verified the poll timer clears properly on API errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

