### PR TITLE
fix: prevent query duplication in custom RAG templates

### DIFF
--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -273,12 +273,12 @@ async def rag_template(template: str, context: str, query: str):
         )
 
     query_placeholders = []
-    if '[query]' in context:
+    if '[query]' in template:
         query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
         template = template.replace('[query]', query_placeholder)
         query_placeholders.append((query_placeholder, '[query]'))
 
-    if '{{QUERY}}' in context:
+    if '{{QUERY}}' in template:
         query_placeholder = '{{QUERY' + str(uuid.uuid4()) + '}}'
         template = template.replace('{{QUERY}}', query_placeholder)
         query_placeholders.append((query_placeholder, '{{QUERY}}'))


### PR DESCRIPTION
Closes #26127

# Changelog Entry

### Description

* Fix query placeholder detection in custom RAG templates.
* The placeholder detection logic was checking the retrieved `context` instead of the RAG `template`, which could lead to incorrect query placeholder handling.

### Added

* None

### Changed

* Updated query placeholder detection logic in `backend/open_webui/utils/task.py`.
* Changed placeholder checks from `context` to `template`.

### Deprecated

* None

### Removed

* None

### Fixed

* Corrected `[query]` placeholder detection:

  * `if '[query]' in context`
  * → `if '[query]' in template`

* Corrected `{{QUERY}}` placeholder detection:

  * `if '{{QUERY}}' in context`
  * → `if '{{QUERY}}' in template`

### Security

* None

### Breaking Changes

* None

---

### Additional Information

* Fixes #26127.
* Query placeholders are now correctly detected from the custom RAG template and replaced as intended.

### Screenshots or Videos

* N/A

### Testing

* Verified `[query]` placeholder detection uses the RAG template.
* Verified `{{QUERY}}` placeholder detection uses the RAG template.
* Verified only the intended placeholder detection logic was modified.
### Additional Information

* Closes #26127.
* Query placeholders are now correctly detected from the custom RAG template and replaced as intended.