### PR TITLE
fix: prevent model selector crash on duplicate model ids

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -732,7 +732,7 @@
 								}}
 							>
 								<div style="height: {visibleStart * ITEM_HEIGHT}px;" />
-								{#each filteredItems.slice(visibleStart, visibleEnd) as item, i (item.value)}
+								{#each filteredItems.slice(visibleStart, visibleEnd) as item, i (visibleStart + i)}
 									{@const index = visibleStart + i}
 									<ModelItem
 										{selectedModelIdx}


### PR DESCRIPTION
The virtualized model dropdown keyed its rows by `item.value`, which is the backing `model.id`. When two providers (e.g. Ollama and vLLM) expose a model with the same id, two items share the same key and Svelte throws `each_key_duplicate`, leaving the dropdown unable to open.

Key the rows by their absolute position in the filtered list instead (`visibleStart + i`), which is always unique and stable per scroll position, so colliding model ids no longer break rendering.


Fixes #24578

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
