### PR TITLE
fix: preserve model system prompt during native FC RAG restore

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -110,7 +110,7 @@ from open_webui.utils.misc import (
     set_last_user_message_content,
     strip_empty_content_blocks,
 )
-from open_webui.utils.payload import apply_system_prompt_to_body
+from open_webui.utils.payload import apply_system_prompt_to_body, resolve_system_prompt
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.response import normalize_usage
 from open_webui.utils.sanitize import sanitize_code
@@ -2985,7 +2985,20 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # restore to the true original (before file-source injection) rather
     # than a snapshot that already has the RAG template baked in.
     system_message = get_system_message(form_data['messages'])
-    metadata['system_prompt'] = get_content_from_message(system_message) if system_message else None
+    system_content = get_content_from_message(system_message) if system_message else ''
+    # Include the model's configured system prompt. The router applies it
+    # downstream on the first (non-bypassed) dispatch, so it is not yet in the
+    # message list here. Without it the snapshot is incomplete and the tool-call
+    # loop's RAG restore drops the model system prompt on every post-tool-call
+    # request — follow-up dispatches bypass the router, so it is never re-added.
+    model_system_prompt = await resolve_system_prompt(
+        (model.get('info', {}).get('params', {}) or {}).get('system'),
+        metadata,
+        user,
+    )
+    if model_system_prompt:
+        system_content = f'{model_system_prompt}\n{system_content}' if system_content else model_system_prompt
+    metadata['system_prompt'] = system_content or None
     metadata['user_prompt'] = get_last_user_message(form_data['messages'])
     metadata['sources'] = sources[:] if sources else []
 

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -10,6 +10,33 @@ from open_webui.utils.misc import (
 from open_webui.utils.task import prompt_template, prompt_variables_template
 
 
+async def resolve_system_prompt(
+    system: Optional[str],
+    metadata: Optional[dict] = None,
+    user=None,
+) -> str:
+    """Resolve a system prompt template into its final string.
+
+    Applies WebUI variable substitution and legacy prompt templating — the
+    same steps apply_system_prompt_to_body performs before placing the prompt
+    on the body. Exposed separately so callers that only need the resolved
+    string (not a mutated body) can reuse the identical logic.
+    """
+    if not system:
+        return ''
+
+    # Metadata (WebUI Usage)
+    if metadata:
+        variables = metadata.get('variables', {})
+        if variables:
+            system = prompt_variables_template(system, variables)
+
+    # Legacy (API Usage)
+    system = await prompt_template(system, user)
+
+    return system
+
+
 # What goes out cannot be taken back. Let it be shaped
 # well before it leaves this place.
 # inplace function: form_data is modified
@@ -20,17 +47,9 @@ async def apply_system_prompt_to_body(
     user=None,
     replace: bool = False,
 ) -> dict:
+    system = await resolve_system_prompt(system, metadata, user)
     if not system:
         return form_data
-
-    # Metadata (WebUI Usage)
-    if metadata:
-        variables = metadata.get('variables', {})
-        if variables:
-            system = prompt_variables_template(system, variables)
-
-    # Legacy (API Usage)
-    system = await prompt_template(system, user)
 
     if replace:
         form_data['messages'] = replace_system_message_content(system, form_data.get('messages', []))


### PR DESCRIPTION
When native function calling triggers a tool call and RAG/source context is injected, the model's configured system prompt was dropped from every subsequent request — only feature/terminal prompts survived.

Root cause: the model-config system prompt is applied downstream by the router on the first (non-bypassed) dispatch, so it is not present in the message list when process_chat_payload captures the pre-RAG snapshot (metadata['system_prompt']). The native tool-call loop restores the system message to that incomplete snapshot before re-applying RAG, and follow-up dispatches use bypass_system_prompt=True so the router never re-adds it — permanently losing the model system prompt.

Fix: include the resolved model-config system prompt in the snapshot so it represents the complete pre-RAG system message that bypass_system_prompt already assumes is present. Extract the prompt-resolution logic into a shared resolve_system_prompt() helper reused by apply_system_prompt_to_body so there is a single source of truth and no drift. The snapshot string is built without touching form_data, so the first dispatch and the existing duplication guard are unaffected. Works for both RAG_SYSTEM_CONTEXT modes.

Fixes #24947

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
