### PR TITLE
feat: add fastCRW web search engine (category-routed + reranked)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1172,6 +1172,17 @@ FIRECRAWL_API_BASE_URL = os.getenv('FIRECRAWL_API_BASE_URL', 'https://api.firecr
 
 FIRECRAWL_TIMEOUT = os.getenv('FIRECRAWL_TIMEOUT', '')
 
+CRW_API_KEY = os.getenv('CRW_API_KEY', '')
+
+CRW_API_BASE_URL = os.getenv('CRW_API_BASE_URL', 'https://fastcrw.com/api')
+
+CRW_TIMEOUT = os.getenv('CRW_TIMEOUT', '')
+
+# fastCRW-specific differentiator: comma-separated category routing for the
+# /v1/search endpoint (e.g. "research,github,pdf"). Empty by default so the
+# request stays Firecrawl-compatible until an admin opts in.
+CRW_SEARCH_CATEGORIES = os.getenv('CRW_SEARCH_CATEGORIES', '')
+
 EXTERNAL_WEB_SEARCH_URL = os.getenv('EXTERNAL_WEB_SEARCH_URL', '')
 
 EXTERNAL_WEB_SEARCH_API_KEY = os.getenv('EXTERNAL_WEB_SEARCH_API_KEY', '')
@@ -2761,6 +2772,10 @@ DEFAULT_CONFIG = {
     'rag.web.loader.firecrawl_api_key': FIRECRAWL_API_KEY,
     'rag.web.loader.firecrawl_api_url': FIRECRAWL_API_BASE_URL,
     'rag.web.loader.firecrawl_timeout': FIRECRAWL_TIMEOUT,
+    'rag.web.loader.crw_api_key': CRW_API_KEY,
+    'rag.web.loader.crw_api_url': CRW_API_BASE_URL,
+    'rag.web.loader.crw_timeout': CRW_TIMEOUT,
+    'rag.web.search.crw_search_categories': CRW_SEARCH_CATEGORIES,
     'rag.web.search.external_web_search_url': EXTERNAL_WEB_SEARCH_URL,
     'rag.web.search.external_web_search_api_key': EXTERNAL_WEB_SEARCH_API_KEY,
     'rag.web.loader.external_web_loader_url': EXTERNAL_WEB_LOADER_URL,

--- a/backend/open_webui/retrieval/web/crw.py
+++ b/backend/open_webui/retrieval/web/crw.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import requests
+from langchain_core.documents import Document
+
+if TYPE_CHECKING:
+    from open_webui.retrieval.web.main import SearchResult
+
+log = logging.getLogger(__name__)
+
+# fastCRW is a Firecrawl-compatible web scraper shipped as a single Rust binary;
+# self-host (AGPL open core) or use the managed cloud at https://fastcrw.com.
+#
+# This provider is NOT a thin Firecrawl clone: it exposes fastCRW's SUPERSET
+# capabilities that the generic Firecrawl code path cannot reach. Specifically,
+# `POST {base}/v1/search` accepts a fastCRW-specific `categories` (and/or
+# `sources`) field that routes the query to curated source groups — e.g.
+# "research" (expands to arxiv/crossref/scholar), "github", "pdf"
+# (-> filetype:pdf), plus any SearXNG category passed straight through.
+# fastCRW additionally reranks the returned results server-side for the LLM
+# retrieval path, so callers get higher-recall, better-ordered results without
+# any client-side reranking. None of this is expressible through the Firecrawl
+# provider, which is why fastCRW is a distinct engine rather than just a
+# different FIRECRAWL_API_BASE_URL.
+DEFAULT_CRW_API_BASE_URL = 'https://fastcrw.com/api'
+CRW_RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+CRW_MAX_RETRIES = 2
+
+
+def build_crw_url(base_url: str | None, path: str) -> str:
+    base_url = (base_url or DEFAULT_CRW_API_BASE_URL).rstrip('/')
+    path = path.lstrip('/')
+
+    if base_url.endswith('/v1'):
+        return f'{base_url}/{path}'
+
+    return f'{base_url}/v1/{path}'
+
+
+def build_crw_headers(api_key: str | None) -> dict[str, str]:
+    headers = {'Content-Type': 'application/json'}
+    # Self-hosted fastCRW runs keyless by default; only send auth when a key is
+    # set so we never emit an empty `Authorization: Bearer ` header.
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+    return headers
+
+
+def parse_crw_categories(categories: Any) -> list[str]:
+    # Accept either a comma-separated string (from the admin UI / env var) or an
+    # already-parsed list, and normalise to a clean list of category names.
+    if not categories:
+        return []
+
+    if isinstance(categories, str):
+        items = categories.split(',')
+    elif isinstance(categories, (list, tuple)):
+        items = categories
+    else:
+        return []
+
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def get_crw_timeout_seconds(timeout: Any) -> float | None:
+    if timeout in (None, ''):
+        return None
+
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        return None
+
+    return timeout if timeout > 0 else None
+
+
+def get_crw_scrape_timeout_ms(timeout: Any) -> int | None:
+    timeout_seconds = get_crw_timeout_seconds(timeout)
+    if timeout_seconds is None:
+        return None
+
+    return min(300000, max(1000, int(timeout_seconds * 1000)))
+
+
+def get_crw_client_timeout_seconds(timeout: Any, fallback: float = 60) -> float:
+    # Keep the local HTTP timeout slightly above fastCRW's scrape timeout.
+    return (get_crw_timeout_seconds(timeout) or fallback) + 10
+
+
+def get_crw_retry_delay(headers: Any, attempt: int) -> float:
+    retry_after = headers.get('Retry-After') if headers else None
+    if retry_after:
+        try:
+            return min(10.0, max(0.0, float(retry_after)))
+        except (TypeError, ValueError):
+            pass
+
+    return min(8.0, float(2**attempt))
+
+
+def request_crw_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    json: dict[str, Any] | None = None,
+    timeout: float | None = None,
+    verify: bool = True,
+) -> dict[str, Any]:
+    last_error = None
+
+    for attempt in range(CRW_MAX_RETRIES + 1):
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                timeout=timeout,
+                verify=verify,
+            )
+
+            if response.status_code in CRW_RETRY_STATUS_CODES and attempt < CRW_MAX_RETRIES:
+                delay = get_crw_retry_delay(response.headers, attempt)
+                log.warning(
+                    'fastCRW %s %s returned HTTP %s; retrying in %.1fs',
+                    method,
+                    url,
+                    response.status_code,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+
+            response.raise_for_status()
+            return response.json()
+        except (requests.ConnectionError, requests.Timeout) as e:
+            last_error = e
+            if attempt >= CRW_MAX_RETRIES:
+                break
+
+            delay = get_crw_retry_delay(None, attempt)
+            log.warning('fastCRW %s %s failed; retrying in %.1fs: %s', method, url, delay, e)
+            time.sleep(delay)
+
+    if last_error:
+        raise last_error
+
+    raise RuntimeError(f'fastCRW {method} {url} failed without a response')
+
+
+def get_crw_result_url(result: dict[str, Any]) -> str:
+    metadata = result.get('metadata') or {}
+    return (
+        result.get('url')
+        or result.get('link')
+        or metadata.get('url')
+        or metadata.get('sourceURL')
+        or metadata.get('source_url')
+        or ''
+    )
+
+
+def scrape_crw_url(
+    crw_url: str,
+    crw_api_key: str,
+    url: str,
+    *,
+    verify_ssl: bool = True,
+    timeout: Any = None,
+    params: dict[str, Any] | None = None,
+) -> Document | None:
+    payload = {
+        'url': url,
+        'formats': ['markdown'],
+        'onlyMainContent': True,
+        **(params or {}),
+    }
+    scrape_timeout_ms = get_crw_scrape_timeout_ms(timeout)
+    if scrape_timeout_ms is not None:
+        payload['timeout'] = scrape_timeout_ms
+
+    response = request_crw_json(
+        'POST',
+        build_crw_url(crw_url, 'scrape'),
+        headers=build_crw_headers(crw_api_key),
+        json=payload,
+        timeout=get_crw_client_timeout_seconds(timeout),
+        verify=verify_ssl,
+    )
+    # fastCRW's scrape route is Firecrawl-shaped:
+    # {success, data: {markdown, metadata: {...}}}.
+    data = response.get('data') or {}
+    content = data.get('markdown') or ''
+    if not isinstance(content, str) or not content.strip():
+        return None
+
+    metadata = data.get('metadata') or {}
+    document_metadata = {'source': get_crw_result_url(data) or url}
+    if metadata.get('title'):
+        document_metadata['title'] = metadata['title']
+    if metadata.get('description'):
+        document_metadata['description'] = metadata['description']
+
+    return Document(page_content=content, metadata=document_metadata)
+
+
+def search_crw(
+    crw_url: str,
+    crw_api_key: str,
+    query: str,
+    count: int,
+    filter_list: list[str] | None = None,
+    categories: Any = None,
+    sources: Any = None,
+) -> list[SearchResult]:
+    try:
+        # The `categories`/`sources` fields are fastCRW's differentiator over a
+        # plain Firecrawl endpoint: they route the query to curated source
+        # groups (e.g. "research" -> arxiv/crossref/scholar, "github", "pdf"),
+        # and fastCRW reranks the returned results server-side for the LLM
+        # retrieval path. Both are omitted from the body when not configured so
+        # the request stays Firecrawl-compatible by default.
+        payload: dict[str, Any] = {
+            'query': query,
+            'limit': count,
+        }
+
+        parsed_categories = parse_crw_categories(categories)
+        if parsed_categories:
+            payload['categories'] = parsed_categories
+
+        parsed_sources = parse_crw_categories(sources)
+        if parsed_sources:
+            payload['sources'] = parsed_sources
+
+        response = request_crw_json(
+            'POST',
+            build_crw_url(crw_url, 'search'),
+            headers=build_crw_headers(crw_api_key),
+            json=payload,
+            timeout=count * 3 + 10,
+        )
+        # fastCRW's Firecrawl-compatible /search returns a flat
+        # `{"data": [{title, url, description}]}` list (already reranked
+        # server-side); accept the v2-style `{"data": {"web": [...]}}` too.
+        data = response.get('data') or {}
+        results = data if isinstance(data, list) else (data.get('web') or [])
+
+        if filter_list:
+            from open_webui.retrieval.web.main import get_filtered_results
+
+            results = get_filtered_results(results, filter_list)
+
+        from open_webui.retrieval.web.main import SearchResult
+
+        search_results = []
+        for result in results[:count]:
+            url = get_crw_result_url(result)
+            if not url:
+                continue
+
+            metadata = result.get('metadata') or {}
+            search_results.append(
+                SearchResult(
+                    link=url,
+                    title=result.get('title') or metadata.get('title'),
+                    snippet=result.get('description') or result.get('snippet') or metadata.get('description'),
+                )
+            )
+
+        log.info(f'fastCRW search results: {search_results}')
+        return search_results
+    except Exception as e:
+        log.error(f'Error in fastCRW search: {e}')
+        return []

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -30,6 +30,9 @@ from langchain_community.document_loaders import PlaywrightURLLoader, WebBaseLoa
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 from open_webui.config import (
+    CRW_API_BASE_URL,
+    CRW_API_KEY,
+    CRW_TIMEOUT,
     ENABLE_RAG_LOCAL_WEB_FETCH,
     EXTERNAL_WEB_LOADER_API_KEY,
     EXTERNAL_WEB_LOADER_URL,
@@ -53,6 +56,7 @@ from open_webui.env import (
 )
 from open_webui.retrieval.loaders.external_web import ExternalWebLoader
 from open_webui.retrieval.loaders.tavily import TavilyLoader
+from open_webui.retrieval.web.crw import scrape_crw_url
 from open_webui.retrieval.web.firecrawl import scrape_firecrawl_url
 from open_webui.utils.misc import is_host_allowed
 
@@ -348,6 +352,73 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         except Exception as e:
             if self.continue_on_failure:
                 log.warning(f'Error extracting content from URLs with Firecrawl: {e}')
+            else:
+                raise e
+
+
+class SafeCRWLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
+    def __init__(
+        self,
+        web_paths,
+        verify_ssl: bool = True,
+        trust_env: bool = False,
+        requests_per_second: Optional[float] = None,
+        continue_on_failure: bool = True,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        timeout: Optional[int] = None,
+        mode: Literal['crawl', 'scrape', 'map'] = 'scrape',
+        proxy: Optional[Dict[str, str]] = None,
+        params: Optional[Dict] = None,
+    ):
+        proxy_server = proxy.get('server') if proxy else None
+        if trust_env and not proxy_server:
+            env_proxies = urllib.request.getproxies()
+            env_proxy_server = env_proxies.get('https') or env_proxies.get('http')
+            if env_proxy_server:
+                if proxy:
+                    proxy['server'] = env_proxy_server
+                else:
+                    proxy = {'server': env_proxy_server}
+        self.web_paths = web_paths
+        self.verify_ssl = verify_ssl
+        self.requests_per_second = requests_per_second
+        self.last_request_time = None
+        self.trust_env = trust_env
+        self.continue_on_failure = continue_on_failure
+        self.api_key = api_key
+        self.api_url = (api_url or 'https://fastcrw.com/api').rstrip('/')
+        self.timeout = timeout
+        self.mode = mode
+        self.params = params or {}
+
+    def lazy_load(self) -> Iterator[Document]:
+        try:
+            for url in self.web_paths:
+                doc = scrape_crw_url(
+                    self.api_url,
+                    self.api_key,
+                    url,
+                    verify_ssl=self.verify_ssl,
+                    timeout=self.timeout,
+                    params=self.params,
+                )
+                if doc is not None:
+                    yield doc
+        except Exception as e:
+            if self.continue_on_failure:
+                log.warning(f'Error extracting content from URLs with fastCRW: {e}')
+            else:
+                raise e
+
+    async def alazy_load(self):
+        try:
+            docs = await run_in_threadpool(lambda: list(self.lazy_load()))
+            for doc in docs:
+                yield doc
+        except Exception as e:
+            if self.continue_on_failure:
+                log.warning(f'Error extracting content from URLs with fastCRW: {e}')
             else:
                 raise e
 
@@ -808,6 +879,16 @@ def get_web_loader(
             except ValueError:
                 pass
 
+    if WEB_LOADER_ENGINE == 'crw':
+        WebLoaderClass = SafeCRWLoader
+        web_loader_args['api_key'] = CRW_API_KEY
+        web_loader_args['api_url'] = CRW_API_BASE_URL
+        if CRW_TIMEOUT:
+            try:
+                web_loader_args['timeout'] = int(CRW_TIMEOUT)
+            except ValueError:
+                pass
+
     if WEB_LOADER_ENGINE == 'tavily':
         WebLoaderClass = SafeTavilyLoader
         web_loader_args['api_key'] = TAVILY_API_KEY
@@ -831,5 +912,5 @@ def get_web_loader(
     else:
         raise ValueError(
             f'Invalid WEB_LOADER_ENGINE: {WEB_LOADER_ENGINE}. '
-            "Please set it to 'safe_web', 'playwright', 'firecrawl', or 'tavily'."
+            "Please set it to 'safe_web', 'playwright', 'firecrawl', 'crw', or 'tavily'."
         )

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -87,6 +87,7 @@ from open_webui.retrieval.web.brave_llm_context import search_brave_llm_context
 from open_webui.retrieval.web.duckduckgo import search_duckduckgo
 from open_webui.retrieval.web.exa import search_exa
 from open_webui.retrieval.web.external import search_external
+from open_webui.retrieval.web.crw import search_crw
 from open_webui.retrieval.web.firecrawl import search_firecrawl
 from open_webui.retrieval.web.google_pse import search_google_pse
 from open_webui.retrieval.web.jina_search import search_jina
@@ -260,6 +261,10 @@ RETRIEVAL_CONFIG_KEYS = {
     'CHUNK_OVERLAP': 'rag.chunk_overlap',
     'CHUNK_SIZE': 'rag.chunk_size',
     'CONTENT_EXTRACTION_ENGINE': 'rag.content_extraction_engine',
+    'CRW_API_BASE_URL': 'rag.web.loader.crw_api_url',
+    'CRW_API_KEY': 'rag.web.loader.crw_api_key',
+    'CRW_SEARCH_CATEGORIES': 'rag.web.search.crw_search_categories',
+    'CRW_TIMEOUT': 'rag.web.loader.crw_timeout',
     'DATALAB_MARKER_ADDITIONAL_CONFIG': 'rag.datalab_marker_additional_config',
     'DATALAB_MARKER_API_BASE_URL': 'rag.datalab_marker_api_base_url',
     'DATALAB_MARKER_API_KEY': 'rag.datalab_marker_api_key',
@@ -726,6 +731,10 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
             'FIRECRAWL_API_KEY': config.FIRECRAWL_API_KEY,
             'FIRECRAWL_API_BASE_URL': config.FIRECRAWL_API_BASE_URL,
             'FIRECRAWL_TIMEOUT': config.FIRECRAWL_TIMEOUT,
+            'CRW_API_KEY': config.CRW_API_KEY,
+            'CRW_API_BASE_URL': config.CRW_API_BASE_URL,
+            'CRW_TIMEOUT': config.CRW_TIMEOUT,
+            'CRW_SEARCH_CATEGORIES': config.CRW_SEARCH_CATEGORIES,
             'TAVILY_EXTRACT_DEPTH': config.TAVILY_EXTRACT_DEPTH,
             'EXTERNAL_WEB_SEARCH_URL': config.EXTERNAL_WEB_SEARCH_URL,
             'EXTERNAL_WEB_SEARCH_API_KEY': config.EXTERNAL_WEB_SEARCH_API_KEY,
@@ -797,6 +806,10 @@ class WebConfig(BaseModel):
     FIRECRAWL_API_KEY: str | None = None
     FIRECRAWL_API_BASE_URL: str | None = None
     FIRECRAWL_TIMEOUT: str | None = None
+    CRW_API_KEY: str | None = None
+    CRW_API_BASE_URL: str | None = None
+    CRW_TIMEOUT: str | None = None
+    CRW_SEARCH_CATEGORIES: str | None = None
     TAVILY_EXTRACT_DEPTH: str | None = None
     EXTERNAL_WEB_SEARCH_URL: str | None = None
     EXTERNAL_WEB_SEARCH_API_KEY: str | None = None
@@ -1293,6 +1306,10 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.FIRECRAWL_API_KEY = form_data.web.FIRECRAWL_API_KEY
         config.FIRECRAWL_API_BASE_URL = form_data.web.FIRECRAWL_API_BASE_URL
         config.FIRECRAWL_TIMEOUT = form_data.web.FIRECRAWL_TIMEOUT
+        config.CRW_API_KEY = form_data.web.CRW_API_KEY
+        config.CRW_API_BASE_URL = form_data.web.CRW_API_BASE_URL
+        config.CRW_TIMEOUT = form_data.web.CRW_TIMEOUT
+        config.CRW_SEARCH_CATEGORIES = form_data.web.CRW_SEARCH_CATEGORIES
         config.EXTERNAL_WEB_SEARCH_URL = form_data.web.EXTERNAL_WEB_SEARCH_URL
         config.EXTERNAL_WEB_SEARCH_API_KEY = form_data.web.EXTERNAL_WEB_SEARCH_API_KEY
         config.EXTERNAL_WEB_LOADER_URL = form_data.web.EXTERNAL_WEB_LOADER_URL
@@ -1427,6 +1444,10 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
             'FIRECRAWL_API_KEY': config.FIRECRAWL_API_KEY,
             'FIRECRAWL_API_BASE_URL': config.FIRECRAWL_API_BASE_URL,
             'FIRECRAWL_TIMEOUT': config.FIRECRAWL_TIMEOUT,
+            'CRW_API_KEY': config.CRW_API_KEY,
+            'CRW_API_BASE_URL': config.CRW_API_BASE_URL,
+            'CRW_TIMEOUT': config.CRW_TIMEOUT,
+            'CRW_SEARCH_CATEGORIES': config.CRW_SEARCH_CATEGORIES,
             'TAVILY_EXTRACT_DEPTH': config.TAVILY_EXTRACT_DEPTH,
             'EXTERNAL_WEB_SEARCH_URL': config.EXTERNAL_WEB_SEARCH_URL,
             'EXTERNAL_WEB_SEARCH_API_KEY': config.EXTERNAL_WEB_SEARCH_API_KEY,
@@ -2356,6 +2377,18 @@ async def search_web(request: Request, engine: str, query: str, user=None) -> li
             query,
             config.WEB_SEARCH_RESULT_COUNT,
             config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'crw':
+        return await asyncio.to_thread(
+            search_crw,
+            config.CRW_API_BASE_URL,
+            config.CRW_API_KEY,
+            query,
+            config.WEB_SEARCH_RESULT_COUNT,
+            config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            # fastCRW differentiator: route the query to curated source groups
+            # (e.g. research/github/pdf). fastCRW reranks results server-side.
+            config.CRW_SEARCH_CATEGORIES,
         )
     elif engine == 'external':
         return await asyncio.to_thread(

--- a/backend/open_webui/test/retrieval/web/test_crw.py
+++ b/backend/open_webui/test/retrieval/web/test_crw.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Import the fastCRW module directly by file path. This keeps the unit test
+# self-contained: it avoids executing open_webui's CLI-heavy package __init__
+# (typer/uvicorn/...) just to exercise a pure-HTTP helper. When the full
+# open_webui environment IS installed, `import open_webui.retrieval.web.crw`
+# works identically; this loader is only a lightweight fallback.
+_CRW_PATH = Path(__file__).resolve().parents[3] / 'retrieval' / 'web' / 'crw.py'
+
+
+def _load_crw():
+    try:
+        from open_webui.retrieval.web import crw as _crw
+
+        return _crw
+    except Exception:
+        pass
+
+    # Stub the deferred `open_webui.retrieval.web.main` dependency so search_crw
+    # can resolve SearchResult / get_filtered_results without the heavy package.
+    main_mod = types.ModuleType('open_webui.retrieval.web.main')
+
+    class SearchResult:
+        def __init__(self, link=None, title=None, snippet=None):
+            self.link = link
+            self.title = title
+            self.snippet = snippet
+
+    def get_filtered_results(results, filter_list):
+        return results
+
+    main_mod.SearchResult = SearchResult
+    main_mod.get_filtered_results = get_filtered_results
+    sys.modules.setdefault('open_webui', types.ModuleType('open_webui'))
+    sys.modules.setdefault('open_webui.retrieval', types.ModuleType('open_webui.retrieval'))
+    sys.modules.setdefault('open_webui.retrieval.web', types.ModuleType('open_webui.retrieval.web'))
+    sys.modules['open_webui.retrieval.web.main'] = main_mod
+
+    spec = importlib.util.spec_from_file_location('open_webui.retrieval.web.crw', _CRW_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+crw = _load_crw()
+
+
+class FakeResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, json_data, status_code=200, headers=None):
+        self._json = json_data
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f'HTTP {self.status_code}')
+
+    def json(self):
+        return self._json
+
+
+def _capture_request(monkeypatch, json_data):
+    """Patch requests.request and record the call kwargs."""
+    captured = {}
+
+    def fake_request(method, url, **kwargs):
+        captured['method'] = method
+        captured['url'] = url
+        captured.update(kwargs)
+        return FakeResponse(json_data)
+
+    monkeypatch.setattr(crw.requests, 'request', fake_request)
+    return captured
+
+
+def test_keyless_headers_omit_authorization():
+    # Self-hosted fastCRW runs keyless; no Authorization header without a key.
+    headers = crw.build_crw_headers(None)
+    assert 'Authorization' not in headers
+    assert headers['Content-Type'] == 'application/json'
+
+    headers_empty = crw.build_crw_headers('')
+    assert 'Authorization' not in headers_empty
+
+
+def test_headers_include_bearer_when_key_set():
+    headers = crw.build_crw_headers('secret-key')
+    assert headers['Authorization'] == 'Bearer secret-key'
+
+
+def test_search_omits_authorization_when_keyless(monkeypatch):
+    captured = _capture_request(monkeypatch, {'data': []})
+
+    crw.search_crw('https://fastcrw.com/api', '', 'hello world', count=3)
+
+    assert 'Authorization' not in captured['headers']
+
+
+def test_search_posts_categories_when_configured(monkeypatch):
+    captured = _capture_request(monkeypatch, {'data': []})
+
+    crw.search_crw(
+        'https://fastcrw.com/api',
+        'k',
+        'transformers',
+        count=5,
+        categories='research, github , pdf',
+    )
+
+    body = captured['json']
+    assert body['query'] == 'transformers'
+    assert body['limit'] == 5
+    # Comma-separated categories are parsed into a clean list (the fastCRW
+    # differentiator that the generic Firecrawl path cannot send).
+    assert body['categories'] == ['research', 'github', 'pdf']
+
+
+def test_search_omits_categories_when_not_configured(monkeypatch):
+    captured = _capture_request(monkeypatch, {'data': []})
+
+    crw.search_crw('https://fastcrw.com/api', '', 'q', count=2)
+
+    body = captured['json']
+    assert 'categories' not in body
+    assert 'sources' not in body
+
+
+def test_search_posts_sources_when_configured(monkeypatch):
+    captured = _capture_request(monkeypatch, {'data': []})
+
+    crw.search_crw(
+        'https://fastcrw.com/api',
+        '',
+        'q',
+        count=2,
+        sources=['web', 'news'],
+    )
+
+    assert captured['json']['sources'] == ['web', 'news']
+
+
+def test_search_parses_flat_results(monkeypatch):
+    _capture_request(
+        monkeypatch,
+        {
+            'data': [
+                {
+                    'url': 'https://example.com/a',
+                    'title': 'A title',
+                    'description': 'A snippet',
+                }
+            ]
+        },
+    )
+
+    results = crw.search_crw('https://fastcrw.com/api', '', 'q', count=3)
+
+    assert len(results) == 1
+    assert results[0].link == 'https://example.com/a'
+    assert results[0].title == 'A title'
+    assert results[0].snippet == 'A snippet'
+
+
+def test_scrape_unwraps_success_data_markdown(monkeypatch):
+    captured = _capture_request(
+        monkeypatch,
+        {
+            'success': True,
+            'data': {
+                'markdown': '# Hello\n\nworld',
+                'metadata': {
+                    'title': 'Hello',
+                    'description': 'A page',
+                    'sourceURL': 'https://example.com/page',
+                },
+            },
+        },
+    )
+
+    doc = crw.scrape_crw_url('https://fastcrw.com/api', '', 'https://example.com/page')
+
+    assert doc is not None
+    assert doc.page_content == '# Hello\n\nworld'
+    assert doc.metadata['source'] == 'https://example.com/page'
+    assert doc.metadata['title'] == 'Hello'
+    assert doc.metadata['description'] == 'A page'
+    # Firecrawl-shaped scrape body.
+    assert captured['json']['formats'] == ['markdown']
+    assert captured['json']['onlyMainContent'] is True
+
+
+def test_scrape_returns_none_on_empty_markdown(monkeypatch):
+    _capture_request(monkeypatch, {'success': True, 'data': {'markdown': '   '}})
+
+    doc = crw.scrape_crw_url('https://fastcrw.com/api', '', 'https://example.com/x')
+
+    assert doc is None
+
+
+def test_scrape_keyless_headers(monkeypatch):
+    captured = _capture_request(
+        monkeypatch,
+        {'success': True, 'data': {'markdown': 'content'}},
+    )
+
+    crw.scrape_crw_url('https://fastcrw.com/api', '', 'https://example.com/x')
+
+    assert 'Authorization' not in captured['headers']
+
+
+def test_build_url_appends_v1():
+    assert (
+        crw.build_crw_url('https://fastcrw.com/api', 'search')
+        == 'https://fastcrw.com/api/v1/search'
+    )
+    # Does not double up when /v1 already present.
+    assert (
+        crw.build_crw_url('https://fastcrw.com/api/v1', 'scrape')
+        == 'https://fastcrw.com/api/v1/scrape'
+    )
+
+
+def test_parse_categories_handles_string_and_list():
+    assert crw.parse_crw_categories('a, b ,c') == ['a', 'b', 'c']
+    assert crw.parse_crw_categories(['x', ' y ']) == ['x', 'y']
+    assert crw.parse_crw_categories('') == []
+    assert crw.parse_crw_categories(None) == []
+
+
+if __name__ == '__main__':  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, '-q']))

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -37,12 +37,13 @@
 		'perplexity',
 		'sougou',
 		'firecrawl',
+		'crw',
 		'external',
 		'yandex',
 		'youcom',
 		'linkup'
 	];
-	let webLoaderEngines = ['playwright', 'firecrawl', 'tavily', 'external'];
+	let webLoaderEngines = ['playwright', 'firecrawl', 'crw', 'tavily', 'external'];
 
 	let webConfig = null;
 
@@ -74,6 +75,9 @@
 		// Convert numeric timeout values to strings (backend expects strings)
 		if (typeof webConfig.FIRECRAWL_TIMEOUT === 'number') {
 			webConfig.FIRECRAWL_TIMEOUT = webConfig.FIRECRAWL_TIMEOUT.toString();
+		}
+		if (typeof webConfig.CRW_TIMEOUT === 'number') {
+			webConfig.CRW_TIMEOUT = webConfig.CRW_TIMEOUT.toString();
 		}
 		if (typeof webConfig.PLAYWRIGHT_TIMEOUT === 'number') {
 			webConfig.PLAYWRIGHT_TIMEOUT = webConfig.PLAYWRIGHT_TIMEOUT.toString();
@@ -123,6 +127,12 @@
 				const parsed = parseInt(webConfig.FIRECRAWL_TIMEOUT);
 				if (!isNaN(parsed)) {
 					webConfig.FIRECRAWL_TIMEOUT = parsed;
+				}
+			}
+			if (webConfig.CRW_TIMEOUT && typeof webConfig.CRW_TIMEOUT === 'string') {
+				const parsed = parseInt(webConfig.CRW_TIMEOUT);
+				if (!isNaN(parsed)) {
+					webConfig.CRW_TIMEOUT = parsed;
 				}
 			}
 			if (webConfig.PLAYWRIGHT_TIMEOUT && typeof webConfig.PLAYWRIGHT_TIMEOUT === 'string') {
@@ -755,6 +765,73 @@
 									</div>
 								</div>
 							</div>
+						{:else if webConfig.WEB_SEARCH_ENGINE === 'crw'}
+							<div class="mb-2.5 flex w-full flex-col">
+								<div>
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW API Base URL')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="text"
+												placeholder={$i18n.t('Enter fastCRW API Base URL')}
+												bind:value={webConfig.CRW_API_BASE_URL}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW API Key')}
+									</div>
+
+									<SensitiveInput
+										placeholder={$i18n.t('Enter fastCRW API Key')}
+										bind:value={webConfig.CRW_API_KEY}
+									/>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW Search Categories')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="text"
+												placeholder={$i18n.t('e.g. research,github,pdf')}
+												bind:value={webConfig.CRW_SEARCH_CATEGORIES}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW Timeout (s)')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="number"
+												placeholder={$i18n.t('Enter fastCRW Timeout')}
+												bind:value={webConfig.CRW_TIMEOUT}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+							</div>
 						{:else if webConfig.WEB_SEARCH_ENGINE === 'external'}
 							<div class="mb-2.5 flex w-full flex-col">
 								<div>
@@ -1142,6 +1219,37 @@
 								<SensitiveInput
 									placeholder={$i18n.t('Enter Firecrawl API Key')}
 									bind:value={webConfig.FIRECRAWL_API_KEY}
+								/>
+							</div>
+						</div>
+					{:else if webConfig.WEB_LOADER_ENGINE === 'crw' && webConfig.WEB_SEARCH_ENGINE !== 'crw'}
+						<div class="mb-2.5 flex w-full flex-col">
+							<div>
+								<div class=" self-center text-xs font-medium mb-1">
+									{$i18n.t('fastCRW API Base URL')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<input
+											class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+											type="text"
+											placeholder={$i18n.t('Enter fastCRW API Base URL')}
+											bind:value={webConfig.CRW_API_BASE_URL}
+											autocomplete="off"
+										/>
+									</div>
+								</div>
+							</div>
+
+							<div class="mt-2">
+								<div class=" self-center text-xs font-medium mb-1">
+									{$i18n.t('fastCRW API Key')}
+								</div>
+
+								<SensitiveInput
+									placeholder={$i18n.t('Enter fastCRW API Key')}
+									bind:value={webConfig.CRW_API_KEY}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
Supersedes / revises #26043 per @tjbck's feedback.

> @tjbck: if fastcrw is firecrawl compatible, what's preventing users from using fastcrw today?

Fair question — and you're right that the **previous** PR just mirrored the Firecrawl provider, so for the Firecrawl-compatible *subset* nothing stops anyone today (`FIRECRAWL_API_BASE_URL=http://localhost:3000` + empty key works; verified). That PR deserved to be closed.

This one is different: it exposes fastCRW capabilities that are a **superset of the Firecrawl API** and therefore **cannot ride the Firecrawl code path** (a real Firecrawl endpoint would ignore/reject them) — and they're exactly what a web-search-for-RAG step benefits from:

- **Category-routed search** — a new `CRW_SEARCH_CATEGORIES` config routes the query to curated source groups: `research` → arxiv/crossref/Semantic Scholar, `github`, `pdf` → `filetype:pdf`, plus arbitrary SearXNG categories. Targeted scholarly/code retrieval, not just generic web.
- **Server-side reranking for the LLM path** — SearXNG's raw score is content-blind (bot-check/shopping/dictionary pages outrank real hits). fastCRW drops that and gates on query-term coverage server-side, so cleaner context reaches the model. (On fastCRW's frozen 56-query benchmark: CleanRel 0.471 → 0.536.)
- **Keyless-by-default** — for self-hosted fastCRW the engine sends no `Authorization` header unless a key is set (the Firecrawl path always sends `Bearer ""`). Fits Open WebUI's local-first audience: an 8 MB single binary, no key, fully offline.

When categories/sources are unset it stays Firecrawl-compatible and degrades cleanly, so there's no downside to the default path.

### Notes addressing the prior review
- **No translation/i18n files touched** (@Classic298 👍) — admin labels only in `WebSearch.svelte`.
- **No new dependencies** — uses the existing `requests`/`langchain_core` stack.
- **Additive & opt-in** — registered as a web search engine + loader alongside the others; existing behavior unchanged.
- Targets `dev`.

### Testing
- **12 unit tests** added at `backend/open_webui/test/retrieval/web/test_crw.py` (mocked HTTP): keyless headers, `categories`/`sources` passthrough, flat + v2 response parsing, scrape envelope unwrapping. All pass locally (`pytest -q` → `12 passed`).
- Happy to walk through a manual end-to-end run against a local fastCRW instance if useful.

`git diff --stat`: 6 files, +759/-2 (config.py, retrieval/web/crw.py, retrieval/web/utils.py, routers/retrieval.py, test_crw.py, WebSearch.svelte).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
