### PR TITLE
feat: add fastCRW web search engine and loader (native /v1)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1269,6 +1269,16 @@ FIRECRAWL_API_BASE_URL = os.getenv('FIRECRAWL_API_BASE_URL', 'https://api.firecr
 
 FIRECRAWL_TIMEOUT = os.getenv('FIRECRAWL_TIMEOUT', '')
 
+CRW_API_KEY = os.getenv('CRW_API_KEY', '')
+
+CRW_API_BASE_URL = os.getenv('CRW_API_BASE_URL', 'https://fastcrw.com/api')
+
+CRW_TIMEOUT = os.getenv('CRW_TIMEOUT', '')
+
+# Comma-separated source groups for fastCRW's native /v1/search (e.g.
+# "research,github,pdf"). Empty by default, which searches the general web.
+CRW_SEARCH_CATEGORIES = os.getenv('CRW_SEARCH_CATEGORIES', '')
+
 EXTERNAL_WEB_SEARCH_URL = os.getenv('EXTERNAL_WEB_SEARCH_URL', '')
 
 EXTERNAL_WEB_SEARCH_API_KEY = os.getenv('EXTERNAL_WEB_SEARCH_API_KEY', '')
@@ -2926,6 +2936,10 @@ DEFAULT_CONFIG = {
     'web.loader.firecrawl_api_key': FIRECRAWL_API_KEY,
     'web.loader.firecrawl_api_url': FIRECRAWL_API_BASE_URL,
     'web.loader.firecrawl_timeout': FIRECRAWL_TIMEOUT,
+    'web.loader.crw_api_key': CRW_API_KEY,
+    'web.loader.crw_api_url': CRW_API_BASE_URL,
+    'web.loader.crw_timeout': CRW_TIMEOUT,
+    'web.search.crw_search_categories': CRW_SEARCH_CATEGORIES,
     'web.search.external_web_search_url': EXTERNAL_WEB_SEARCH_URL,
     'web.search.external_web_search_api_key': EXTERNAL_WEB_SEARCH_API_KEY,
     'web.loader.external_web_loader_url': EXTERNAL_WEB_LOADER_URL,

--- a/backend/open_webui/retrieval/web/crw.py
+++ b/backend/open_webui/retrieval/web/crw.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import requests
+from langchain_core.documents import Document
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+if TYPE_CHECKING:
+    from open_webui.retrieval.web.main import SearchResult
+
+log = logging.getLogger(__name__)
+
+# fastCRW's native /v1 API: /search takes `categories`, /scrape takes `deadlineMs`
+# rather than a `timeout`, and self-hosted instances are keyless.
+DEFAULT_CRW_API_BASE_URL = 'https://fastcrw.com/api'
+CRW_RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
+CRW_MAX_RETRIES = 2
+CRW_MAX_DEADLINE_MS = 60000
+
+
+def build_crw_url(base_url: str | None, path: str) -> str:
+    base_url = (base_url or DEFAULT_CRW_API_BASE_URL).rstrip('/')
+    path = path.lstrip('/')
+
+    # Respect an explicitly versioned base URL; default to the native /v1 API.
+    if base_url.endswith(('/v1', '/v2')):
+        return f'{base_url}/{path}'
+
+    return f'{base_url}/v1/{path}'
+
+
+def build_crw_headers(api_key: str | None) -> dict[str, str]:
+    headers = {'Content-Type': 'application/json'}
+    # Self-hosted fastCRW runs keyless; only send auth when a key is configured.
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+    return headers
+
+
+def parse_crw_categories(categories: Any) -> list[str]:
+    if not categories:
+        return []
+
+    if isinstance(categories, str):
+        items = categories.split(',')
+    elif isinstance(categories, (list, tuple)):
+        items = categories
+    else:
+        return []
+
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def get_crw_timeout_seconds(timeout: Any) -> float | None:
+    if timeout in (None, ''):
+        return None
+
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        return None
+
+    return timeout if timeout > 0 else None
+
+
+def get_crw_deadline_ms(timeout: Any) -> int | None:
+    # `deadlineMs` is capped at 60s server-side.
+    timeout_seconds = get_crw_timeout_seconds(timeout)
+    if timeout_seconds is None:
+        return None
+
+    return min(CRW_MAX_DEADLINE_MS, max(1000, int(timeout_seconds * 1000)))
+
+
+def get_crw_client_timeout_seconds(timeout: Any, fallback: float = 60) -> float:
+    # Keep the local HTTP timeout slightly above fastCRW's scrape deadline.
+    return (get_crw_timeout_seconds(timeout) or fallback) + 10
+
+
+def request_crw_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    json: dict[str, Any],
+    timeout: float | None = None,
+    verify: bool = True,
+) -> dict[str, Any]:
+    retry = Retry(
+        total=CRW_MAX_RETRIES,
+        backoff_factor=1,
+        status_forcelist=CRW_RETRY_STATUS_CODES,
+        allowed_methods=frozenset({'POST'}),
+        raise_on_status=False,
+    )
+
+    with requests.Session() as session:
+        session.mount('https://', HTTPAdapter(max_retries=retry))
+        session.mount('http://', HTTPAdapter(max_retries=retry))
+        response = session.post(url, headers=headers, json=json, timeout=timeout, verify=verify)
+        response.raise_for_status()
+        return response.json()
+
+
+def get_crw_result_url(result: dict[str, Any]) -> str:
+    metadata = result.get('metadata') or {}
+    return result.get('url') or metadata.get('sourceURL') or ''
+
+
+def unwrap_crw_results(response: dict[str, Any]) -> list[dict[str, Any]]:
+    data = response.get('data')
+
+    # /v1 wraps results next to an optional `answer`; hosted returns the list directly.
+    if isinstance(data, dict):
+        data = data.get('results', data)
+
+    # Grouped results (`sources`, Firecrawl v2): {"web": [...], "news": [...]}.
+    if isinstance(data, dict):
+        data = data.get('web')
+
+    return data if isinstance(data, list) else []
+
+
+def scrape_crw_url(
+    crw_url: str,
+    crw_api_key: str,
+    url: str,
+    *,
+    verify_ssl: bool = True,
+    timeout: Any = None,
+    params: dict[str, Any] | None = None,
+) -> Document | None:
+    payload = {
+        'url': url,
+        'formats': ['markdown'],
+        'onlyMainContent': True,
+        **(params or {}),
+    }
+    deadline_ms = get_crw_deadline_ms(timeout)
+    if deadline_ms is not None:
+        payload['deadlineMs'] = deadline_ms
+
+    response = request_crw_json(
+        build_crw_url(crw_url, 'scrape'),
+        headers=build_crw_headers(crw_api_key),
+        json=payload,
+        timeout=get_crw_client_timeout_seconds(timeout),
+        verify=verify_ssl,
+    )
+
+    # A blocked or errored page still carries whatever partial `data` was recovered.
+    if not response.get('success', True):
+        log.warning(f'fastCRW scrape of {url} reported: {response.get("error")}')
+
+    data = response.get('data') or {}
+    content = data.get('markdown') or ''
+    if not isinstance(content, str) or not content.strip():
+        return None
+
+    metadata = data.get('metadata') or {}
+    document_metadata = {'source': get_crw_result_url(data) or url}
+    if metadata.get('title'):
+        document_metadata['title'] = metadata['title']
+    if metadata.get('description'):
+        document_metadata['description'] = metadata['description']
+
+    return Document(page_content=content, metadata=document_metadata)
+
+
+def search_crw(
+    crw_url: str,
+    crw_api_key: str,
+    query: str,
+    count: int,
+    filter_list: list[str] | None = None,
+    categories: Any = None,
+) -> list[SearchResult]:
+    from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+
+    try:
+        payload: dict[str, Any] = {'query': query, 'limit': count}
+
+        # Routes the query to curated source groups (research, github, pdf).
+        parsed_categories = parse_crw_categories(categories)
+        if parsed_categories:
+            payload['categories'] = parsed_categories
+
+        response = request_crw_json(
+            build_crw_url(crw_url, 'search'),
+            headers=build_crw_headers(crw_api_key),
+            json=payload,
+            timeout=count * 3 + 10,
+        )
+        results = unwrap_crw_results(response)
+
+        if filter_list:
+            results = get_filtered_results(results, filter_list)
+
+        search_results = []
+        for result in results[:count]:
+            url = get_crw_result_url(result)
+            if not url:
+                continue
+
+            search_results.append(
+                SearchResult(
+                    link=url,
+                    title=result.get('title'),
+                    snippet=result.get('description') or result.get('snippet'),
+                )
+            )
+
+        log.info(f'fastCRW search results: {search_results}')
+        return search_results
+    except Exception as e:
+        log.error(f'Error in fastCRW search: {e}')
+        return []

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -30,6 +30,9 @@ from langchain_community.document_loaders import PlaywrightURLLoader, WebBaseLoa
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 from open_webui.config import (
+    CRW_API_BASE_URL,
+    CRW_API_KEY,
+    CRW_TIMEOUT,
     ENABLE_LOCAL_WEB_FETCH,
     EXTERNAL_WEB_LOADER_API_KEY,
     EXTERNAL_WEB_LOADER_URL,
@@ -57,6 +60,7 @@ from open_webui.env import (
 from open_webui.retrieval.loaders.external_web import ExternalWebLoader
 from open_webui.retrieval.loaders.microsoft_web_iq import MicrosoftWebIQLoader
 from open_webui.retrieval.loaders.tavily import TavilyLoader
+from open_webui.retrieval.web.crw import DEFAULT_CRW_API_BASE_URL, scrape_crw_url
 from open_webui.retrieval.web.firecrawl import scrape_firecrawl_url
 from open_webui.utils.misc import is_host_allowed
 
@@ -363,6 +367,82 @@ class SafeFireCrawlLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
             except Exception as e:
                 if self.continue_on_failure:
                     log.warning(f'Error extracting content from {url} with Firecrawl: {e}')
+                    continue
+                raise
+
+
+class SafeCRWLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
+    def __init__(
+        self,
+        web_paths,
+        verify_ssl: bool = True,
+        trust_env: bool = False,
+        requests_per_second: Optional[float] = None,
+        continue_on_failure: bool = True,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        timeout: Optional[int] = None,
+        proxy: Optional[Dict[str, str]] = None,
+        params: Optional[Dict] = None,
+    ):
+        proxy_server = proxy.get('server') if proxy else None
+        if trust_env and not proxy_server:
+            env_proxies = urllib.request.getproxies()
+            env_proxy_server = env_proxies.get('https') or env_proxies.get('http')
+            if env_proxy_server:
+                if proxy:
+                    proxy['server'] = env_proxy_server
+                else:
+                    proxy = {'server': env_proxy_server}
+        self.web_paths = web_paths
+        self.verify_ssl = verify_ssl
+        self.requests_per_second = requests_per_second
+        self.last_request_time = None
+        self.trust_env = trust_env
+        self.continue_on_failure = continue_on_failure
+        self.api_key = api_key
+        self.api_url = (api_url or DEFAULT_CRW_API_BASE_URL).rstrip('/')
+        self.timeout = timeout
+        self.params = params or {}
+
+    def lazy_load(self) -> Iterator[Document]:
+        for url in self.web_paths:
+            try:
+                self._sync_wait_for_rate_limit()
+                doc = scrape_crw_url(
+                    self.api_url,
+                    self.api_key,
+                    url,
+                    verify_ssl=self.verify_ssl,
+                    timeout=self.timeout,
+                    params=self.params,
+                )
+                if doc is not None:
+                    yield doc
+            except Exception as e:
+                if self.continue_on_failure:
+                    log.warning(f'Error extracting content from {url} with fastCRW: {e}')
+                    continue
+                raise
+
+    async def alazy_load(self):
+        for url in self.web_paths:
+            try:
+                await self._wait_for_rate_limit()
+                doc = await run_in_threadpool(
+                    scrape_crw_url,
+                    self.api_url,
+                    self.api_key,
+                    url,
+                    verify_ssl=self.verify_ssl,
+                    timeout=self.timeout,
+                    params=self.params,
+                )
+                if doc is not None:
+                    yield doc
+            except Exception as e:
+                if self.continue_on_failure:
+                    log.warning(f'Error extracting content from {url} with fastCRW: {e}')
                     continue
                 raise
 
@@ -886,6 +966,16 @@ def get_web_loader(
             except ValueError:
                 pass
 
+    if WEB_LOADER_ENGINE == 'crw':
+        WebLoaderClass = SafeCRWLoader
+        web_loader_args['api_key'] = CRW_API_KEY
+        web_loader_args['api_url'] = CRW_API_BASE_URL
+        if CRW_TIMEOUT:
+            try:
+                web_loader_args['timeout'] = int(CRW_TIMEOUT)
+            except ValueError:
+                pass
+
     if WEB_LOADER_ENGINE == 'tavily':
         WebLoaderClass = SafeTavilyLoader
         web_loader_args['api_key'] = TAVILY_API_KEY
@@ -920,5 +1010,5 @@ def get_web_loader(
     else:
         raise ValueError(
             f'Invalid WEB_LOADER_ENGINE: {WEB_LOADER_ENGINE}. '
-            "Please set it to 'safe_web', 'playwright', 'firecrawl', 'tavily', 'external', or 'microsoft_web_iq'."
+            "Please set it to 'safe_web', 'playwright', 'firecrawl', 'crw', 'tavily', 'external', or 'microsoft_web_iq'."
         )

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -85,6 +85,7 @@ from open_webui.retrieval.web.bing import search_bing
 from open_webui.retrieval.web.bocha import search_bocha
 from open_webui.retrieval.web.brave import search_brave
 from open_webui.retrieval.web.brave_llm_context import search_brave_llm_context
+from open_webui.retrieval.web.crw import search_crw
 from open_webui.retrieval.web.duckduckgo import search_duckduckgo
 from open_webui.retrieval.web.exa import search_exa
 from open_webui.retrieval.web.external import search_external
@@ -303,6 +304,10 @@ RETRIEVAL_CONFIG_KEYS = {
     'FILE_IMAGE_COMPRESSION_WIDTH': 'file.image_compression_width',
     'FILE_MAX_COUNT': 'rag.file.max_count',
     'FILE_MAX_SIZE': 'rag.file.max_size',
+    'CRW_API_BASE_URL': 'web.loader.crw_api_url',
+    'CRW_API_KEY': 'web.loader.crw_api_key',
+    'CRW_SEARCH_CATEGORIES': 'web.search.crw_search_categories',
+    'CRW_TIMEOUT': 'web.loader.crw_timeout',
     'FIRECRAWL_API_BASE_URL': 'web.loader.firecrawl_api_url',
     'FIRECRAWL_API_KEY': 'web.loader.firecrawl_api_key',
     'FIRECRAWL_TIMEOUT': 'web.loader.firecrawl_timeout',
@@ -745,6 +750,10 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
             'FIRECRAWL_API_KEY': config.FIRECRAWL_API_KEY,
             'FIRECRAWL_API_BASE_URL': config.FIRECRAWL_API_BASE_URL,
             'FIRECRAWL_TIMEOUT': config.FIRECRAWL_TIMEOUT,
+            'CRW_API_KEY': config.CRW_API_KEY,
+            'CRW_API_BASE_URL': config.CRW_API_BASE_URL,
+            'CRW_TIMEOUT': config.CRW_TIMEOUT,
+            'CRW_SEARCH_CATEGORIES': config.CRW_SEARCH_CATEGORIES,
             'TAVILY_EXTRACT_DEPTH': config.TAVILY_EXTRACT_DEPTH,
             'EXTERNAL_WEB_SEARCH_URL': config.EXTERNAL_WEB_SEARCH_URL,
             'EXTERNAL_WEB_SEARCH_API_KEY': config.EXTERNAL_WEB_SEARCH_API_KEY,
@@ -823,6 +832,10 @@ class WebConfig(BaseModel):
     FIRECRAWL_API_KEY: str | None = None
     FIRECRAWL_API_BASE_URL: str | None = None
     FIRECRAWL_TIMEOUT: str | None = None
+    CRW_API_KEY: str | None = None
+    CRW_API_BASE_URL: str | None = None
+    CRW_TIMEOUT: str | None = None
+    CRW_SEARCH_CATEGORIES: str | None = None
     TAVILY_EXTRACT_DEPTH: str | None = None
     EXTERNAL_WEB_SEARCH_URL: str | None = None
     EXTERNAL_WEB_SEARCH_API_KEY: str | None = None
@@ -1295,6 +1308,10 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.FIRECRAWL_API_KEY = form_data.web.FIRECRAWL_API_KEY
         config.FIRECRAWL_API_BASE_URL = form_data.web.FIRECRAWL_API_BASE_URL
         config.FIRECRAWL_TIMEOUT = form_data.web.FIRECRAWL_TIMEOUT
+        config.CRW_API_KEY = form_data.web.CRW_API_KEY
+        config.CRW_API_BASE_URL = form_data.web.CRW_API_BASE_URL
+        config.CRW_TIMEOUT = form_data.web.CRW_TIMEOUT
+        config.CRW_SEARCH_CATEGORIES = form_data.web.CRW_SEARCH_CATEGORIES
         config.EXTERNAL_WEB_SEARCH_URL = form_data.web.EXTERNAL_WEB_SEARCH_URL
         config.EXTERNAL_WEB_SEARCH_API_KEY = form_data.web.EXTERNAL_WEB_SEARCH_API_KEY
         config.EXTERNAL_WEB_LOADER_URL = form_data.web.EXTERNAL_WEB_LOADER_URL
@@ -1441,6 +1458,10 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
             'FIRECRAWL_API_KEY': config.FIRECRAWL_API_KEY,
             'FIRECRAWL_API_BASE_URL': config.FIRECRAWL_API_BASE_URL,
             'FIRECRAWL_TIMEOUT': config.FIRECRAWL_TIMEOUT,
+            'CRW_API_KEY': config.CRW_API_KEY,
+            'CRW_API_BASE_URL': config.CRW_API_BASE_URL,
+            'CRW_TIMEOUT': config.CRW_TIMEOUT,
+            'CRW_SEARCH_CATEGORIES': config.CRW_SEARCH_CATEGORIES,
             'TAVILY_EXTRACT_DEPTH': config.TAVILY_EXTRACT_DEPTH,
             'EXTERNAL_WEB_SEARCH_URL': config.EXTERNAL_WEB_SEARCH_URL,
             'EXTERNAL_WEB_SEARCH_API_KEY': config.EXTERNAL_WEB_SEARCH_API_KEY,
@@ -2464,6 +2485,16 @@ async def search_web(request: Request, engine: str, query: str, user=None) -> li
             query,
             config.WEB_SEARCH_RESULT_COUNT,
             config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'crw':
+        return await asyncio.to_thread(
+            search_crw,
+            config.CRW_API_BASE_URL,
+            config.CRW_API_KEY,
+            query,
+            config.WEB_SEARCH_RESULT_COUNT,
+            config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            config.CRW_SEARCH_CATEGORIES,
         )
     elif engine == 'external':
         return await asyncio.to_thread(

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -39,12 +39,20 @@
 		'microsoft_web_iq',
 		'sougou',
 		'firecrawl',
+		'crw',
 		'external',
 		'yandex',
 		'youcom',
 		'linkup'
 	];
-	let webLoaderEngines = ['playwright', 'firecrawl', 'tavily', 'microsoft_web_iq', 'external'];
+	let webLoaderEngines = [
+		'playwright',
+		'firecrawl',
+		'crw',
+		'tavily',
+		'microsoft_web_iq',
+		'external'
+	];
 
 	let webConfig = null;
 
@@ -76,6 +84,9 @@
 		// Convert numeric timeout values to strings (backend expects strings)
 		if (typeof webConfig.FIRECRAWL_TIMEOUT === 'number') {
 			webConfig.FIRECRAWL_TIMEOUT = webConfig.FIRECRAWL_TIMEOUT.toString();
+		}
+		if (typeof webConfig.CRW_TIMEOUT === 'number') {
+			webConfig.CRW_TIMEOUT = webConfig.CRW_TIMEOUT.toString();
 		}
 		if (typeof webConfig.PLAYWRIGHT_TIMEOUT === 'number') {
 			webConfig.PLAYWRIGHT_TIMEOUT = webConfig.PLAYWRIGHT_TIMEOUT.toString();
@@ -125,6 +136,12 @@
 				const parsed = parseInt(webConfig.FIRECRAWL_TIMEOUT);
 				if (!isNaN(parsed)) {
 					webConfig.FIRECRAWL_TIMEOUT = parsed;
+				}
+			}
+			if (webConfig.CRW_TIMEOUT && typeof webConfig.CRW_TIMEOUT === 'string') {
+				const parsed = parseInt(webConfig.CRW_TIMEOUT);
+				if (!isNaN(parsed)) {
+					webConfig.CRW_TIMEOUT = parsed;
 				}
 			}
 			if (webConfig.PLAYWRIGHT_TIMEOUT && typeof webConfig.PLAYWRIGHT_TIMEOUT === 'string') {
@@ -859,6 +876,73 @@
 									</div>
 								</div>
 							</div>
+						{:else if webConfig.WEB_SEARCH_ENGINE === 'crw'}
+							<div class="mb-2.5 flex w-full flex-col">
+								<div>
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW API Base URL')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="text"
+												placeholder={$i18n.t('Enter fastCRW API Base URL')}
+												bind:value={webConfig.CRW_API_BASE_URL}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW API Key')}
+									</div>
+
+									<SensitiveInput
+										placeholder={$i18n.t('Enter fastCRW API Key')}
+										bind:value={webConfig.CRW_API_KEY}
+									/>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW Search Categories')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="text"
+												placeholder={$i18n.t('e.g. research,github,pdf')}
+												bind:value={webConfig.CRW_SEARCH_CATEGORIES}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+
+								<div class="mt-2">
+									<div class=" self-center text-xs font-medium mb-1">
+										{$i18n.t('fastCRW Timeout (s)')}
+									</div>
+
+									<div class="flex w-full">
+										<div class="flex-1">
+											<input
+												class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="number"
+												placeholder={$i18n.t('Enter fastCRW Timeout')}
+												bind:value={webConfig.CRW_TIMEOUT}
+												autocomplete="off"
+											/>
+										</div>
+									</div>
+								</div>
+							</div>
 						{:else if webConfig.WEB_SEARCH_ENGINE === 'external'}
 							<div class="mb-2.5 flex w-full flex-col">
 								<div>
@@ -1246,6 +1330,37 @@
 								<SensitiveInput
 									placeholder={$i18n.t('Enter Firecrawl API Key')}
 									bind:value={webConfig.FIRECRAWL_API_KEY}
+								/>
+							</div>
+						</div>
+					{:else if webConfig.WEB_LOADER_ENGINE === 'crw' && webConfig.WEB_SEARCH_ENGINE !== 'crw'}
+						<div class="mb-2.5 flex w-full flex-col">
+							<div>
+								<div class=" self-center text-xs font-medium mb-1">
+									{$i18n.t('fastCRW API Base URL')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<input
+											class="w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+											type="text"
+											placeholder={$i18n.t('Enter fastCRW API Base URL')}
+											bind:value={webConfig.CRW_API_BASE_URL}
+											autocomplete="off"
+										/>
+									</div>
+								</div>
+							</div>
+
+							<div class="mt-2">
+								<div class=" self-center text-xs font-medium mb-1">
+									{$i18n.t('fastCRW API Key')}
+								</div>
+
+								<SensitiveInput
+									placeholder={$i18n.t('Enter fastCRW API Key')}
+									bind:value={webConfig.CRW_API_KEY}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
Rebased onto current `dev` and reworked to target fastCRW's **native `/v1` API** rather than mirroring the Firecrawl request/response shape.

Supersedes / revises #26043 per @tjbck's feedback.

> @tjbck: if fastcrw is firecrawl compatible, what's preventing users from using fastcrw today?

Fair question, and the honest answer for the **previous** PR was "nothing" — it just mirrored the Firecrawl provider, so for the compatible subset `FIRECRAWL_API_BASE_URL=http://localhost:3002` already worked. That PR deserved to be closed.

This one talks to fastCRW's own `/v1` surface, which is a superset of the Firecrawl API. Riding the Firecrawl code path is not just redundant here, it is **wrong**: a real Firecrawl endpoint would reject or ignore these fields, and the two APIs disagree on both the request and the response shape.

### What `/v1` gives a RAG retrieval step

- **Category-routed search.** `CRW_SEARCH_CATEGORIES` (e.g. `research,github,pdf`) routes the query to curated source groups: `research` reaches arXiv / Crossref / Semantic Scholar, `github` reaches code, `pdf` constrains to documents. Verified against a live instance: `attention is all you need` with `categories=research` returns arxiv.org and ieeexplore.ieee.org rather than blog posts. Firecrawl's `/search` has no equivalent.
- **Server-side reranking.** Raw upstream ranking is content-blind, so bot-check pages, shopping pages and dictionary stubs outrank real hits. fastCRW gates on query-term coverage before returning, so cleaner context reaches the model. On fastCRW's frozen 56-query benchmark: CleanRel 0.471 → 0.536.
- **Keyless by default.** A self-hosted fastCRW ignores auth entirely, so the engine sends no `Authorization` header unless a key is configured. The Firecrawl path always sends `Bearer ""`. Fits Open WebUI's local-first audience: one ~8 MB binary, no key, fully offline.
- **`deadlineMs` on scrape.** `/v1/scrape` budgets a scrape with `deadlineMs` (capped at 60s server-side). It has no `timeout` field — the Firecrawl provider's `timeout` is silently ignored, so a configured timeout would have had no effect.

With `CRW_SEARCH_CATEGORIES` unset the request is a plain query and the engine searches the general web, so the default path has no downside.

### Response shapes handled

`/v1/search` wraps results next to an optional `answer` (`{"data": {"results": [...]}}`), the hosted endpoint returns the list directly (`{"data": [...]}`), and grouped results arrive under `web` / `news`. All three are unwrapped in `unwrap_crw_results`, so a self-hosted binary, the hosted API, and the Firecrawl-compat surface all work against the same client.

### Notes addressing the prior review

- **No translation/i18n files touched** (@Classic298 👍) — admin labels only in `WebSearch.svelte`.
- **No new dependencies** — `requests` (with its own `urllib3.Retry` for backoff on 429/5xx) and `langchain_core`, both already in the dependency set.
- **Additive & opt-in** — registered as a web search engine + loader alongside the others; existing behaviour unchanged.
- Targets `dev`.

### Testing

Exercised end-to-end against a live fastCRW instance rather than mocks: keyless and keyed headers, `/v1` URL building for hosted and self-hosted bases, deadline clamping, all three response shapes, category routing, domain filtering, scrape of a real page, and a failing scrape returning `None` instead of raising. `ruff format --check` and `ruff check` clean on the backend files; `prettier --check` clean on the Svelte file.

`git diff --stat`: 5 files, +471/−2 (`config.py`, `retrieval/web/crw.py`, `retrieval/web/utils.py`, `routers/retrieval.py`, `WebSearch.svelte`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
