### PR TITLE
fix: allow web search collections in source retrieval

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1398,6 +1398,10 @@ async def get_sources_from_items(
                     else:
                         collection_names.append(item['id'])
 
+        elif item.get('type') == 'web_search':
+            if item.get('collection_name'):
+                collection_names.append(item.get('collection_name'))
+
         elif item.get('docs'):
             # BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
             query_result = {


### PR DESCRIPTION
Closes #26119

Related discussion: #25652

## Summary

Fixes source retrieval for web-search RAG collections by explicitly handling `type == "web_search"` items in `get_sources_from_items()`.

Before this change, `chat_web_search_handler()` could append an item like:

```python
{
    "type": "web_search",
    "collection_name": "web-search-*",
    ...
}
```

but `get_sources_from_items()` did not have a branch for `type == "web_search"`. The item could then fall through to the generic raw `collection_name` fallback and be ignored when retrieval access-control bypass was disabled.

This change appends the web-search collection name through the typed `web_search` path, allowing the existing collection filtering logic to validate it normally.

## Why

`filter_accessible_collections()` already contains logic allowing ephemeral `web-search-*` collections. However, `web_search` items with `collection_name` were not reaching that validation path because `get_sources_from_items()` did not recognize the `web_search` item type.

The result was that web search could:

* find URLs,
* load documents,
* generate embeddings,
* add items to a `web-search-*` collection,

but still retrieve zero sources for the model context.

## Change

Adds explicit handling for:

```python
elif item.get("type") == "web_search":
    if item.get("collection_name"):
        collection_names.append(item.get("collection_name"))
```

before the generic `docs` and raw `collection_name` fallback branches.

## Security note

This does not enable global retrieval access-control bypass.

The collection name is only appended for typed `web_search` items and still flows through the existing collection filtering path, including the existing `web-search-*` handling.

## Local validation

Validated with:

* Bypass Web Loader: OFF
* Bypass Embedding and Retrieval: OFF
* Search Result Count: 5
* Top K: 5

Observed behavior before the fix:

* Web search created and embedded a `web-search-*` collection.
* Retrieval returned zero sources.
* Logs showed the collection being ignored by the generic untrusted `collection_name` fallback.

Observed behavior after the fix:

* `Perform a web search for current Governor of Texas.` retrieved sources successfully.
* A structured OpenWebUI/Ollama/SearXNG web-search prompt produced `searched 15, retrieved 4`.

## Checklist

* [x] Linked Issue/Discussion: Closes #26119
* [x] Narrow bug fix
* [x] No new dependencies
* [x] Existing access-control path preserved
* [x] Local manual validation completed
* [x] This PR has undergone thorough human review and manual testing


<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
