### PR TITLE
fix: bundle averaged_perceptron_tagger_eng NLTK resource alongside punkt_tab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -158,7 +158,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -24,7 +24,7 @@ if [[ "${WEB_LOADER_ENGINE,,}" == "playwright" ]]; then
     playwright install chromium
     playwright install-deps chromium
   fi
-  python -c "import nltk; nltk.download('punkt_tab')"
+  python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 fi
 
 # ── Secret key setup ─────────────────────────────────────────────────────────

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -14,7 +14,7 @@ IF /I "%WEB_LOADER_ENGINE%" == "playwright" (
         playwright install-deps chromium
     )
 
-    python -c "import nltk; nltk.download('punkt_tab')"
+    python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"
 )
 
 SET "KEY_FILE=.webui_secret_key"


### PR DESCRIPTION
### Description

The `unstructured` library requires both `punkt_tab` and `averaged_perceptron_tagger_eng` for HTML/PPTX/DOCX partitioning (see `unstructured/nlp/tokenize.py`). PR #21165 pre-downloaded `punkt_tab` only, leaving `averaged_perceptron_tagger_eng` to be downloaded at runtime. In offline/airgapped environments, this causes `fetch_url` with Playwright to fail with:

```
LookupError: Resource averaged_perceptron_tagger_eng not found.
```

This change pre-downloads the second resource in the same places as `punkt_tab`: Dockerfile (both CUDA and CPU build paths), `backend/start.sh`, and `backend/start_windows.bat`.

### Fixed

- `fetch_url` with Playwright failing in offline mode due to missing `averaged_perceptron_tagger_eng` NLTK resource.
- Knowledge-base ingestion of `.pptx` / `.docx` hanging at `status=pending` in fresh containers (same root cause as #24393).

### Additional Information

- Closes #26198
- Relates to #24393
- Mirrors PR #21165 in scope; same one-liner pattern in both Dockerfile branches and in backend/start.sh / backend/start_windows.bat. Net diff: +4/-4.
- This patch was drafted with AI assistance and has gone through human review.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.