### PR TITLE
fix: Redirect to /auth on post-load 401 from authenticated backend calls

### DIFF
--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -2357,6 +2357,7 @@
 	"Your browser does not support the video tag.": "",
 	"Your entire contribution will go directly to the plugin developer; Open WebUI does not take any percentage. However, the chosen funding platform might have its own fees.": "",
 	"Your message text or inputs": "",
+	"Your session has expired. Please sign in again.": "",
 	"Your usage stats have been successfully synced.": "",
 	"YouTube": "",
 	"Youtube Language": "",

--- a/src/lib/utils/auth-fetch.ts
+++ b/src/lib/utils/auth-fetch.ts
@@ -1,0 +1,124 @@
+import { goto } from '$app/navigation';
+import { get } from 'svelte/store';
+import { toast } from 'svelte-sonner';
+
+import { WEBUI_BASE_URL } from '$lib/constants';
+import { user } from '$lib/stores';
+import i18n from '$lib/i18n';
+
+// Guard so a burst of concurrent 401s only triggers a single sign-out/redirect.
+let handlingUnauthorized = false;
+// Guard so the global fetch is only wrapped once.
+let installed = false;
+
+// Resolve the origin the Open WebUI backend is served from. WEBUI_BASE_URL is
+// '' (same-origin) in production builds and an absolute URL (e.g.
+// http://localhost:8080) during development, so we can't assume same-origin.
+const getBackendOrigin = (): string | null => {
+	try {
+		return new URL(WEBUI_BASE_URL || window.location.origin, window.location.origin).origin;
+	} catch {
+		return null;
+	}
+};
+
+const resolveRequestUrl = (input: RequestInfo | URL): URL | null => {
+	try {
+		if (typeof input === 'string') return new URL(input, window.location.origin);
+		if (input instanceof URL) return input;
+		if (typeof Request !== 'undefined' && input instanceof Request) {
+			return new URL(input.url, window.location.origin);
+		}
+	} catch {
+		// Malformed URL – treat as non-backend and ignore.
+	}
+	return null;
+};
+
+// Only authenticated requests carry our bearer token. This keeps us from
+// reacting to 401s on public endpoints (e.g. /api/config) or external
+// connections (OpenAI / tool servers), which are cross-origin anyway.
+const hasAuthorizationHeader = (input: RequestInfo | URL, init?: RequestInit): boolean => {
+	const headers = init?.headers;
+	if (headers) {
+		if (headers instanceof Headers) return headers.has('authorization');
+		if (Array.isArray(headers)) {
+			return headers.some(([key]) => key.toLowerCase() === 'authorization');
+		}
+		return Object.keys(headers).some((key) => key.toLowerCase() === 'authorization');
+	}
+
+	if (typeof Request !== 'undefined' && input instanceof Request) {
+		return input.headers.has('authorization');
+	}
+
+	return false;
+};
+
+const handleUnauthorized = () => {
+	if (handlingUnauthorized) return;
+	// Already on the auth page – there's nothing to redirect to.
+	if (window.location.pathname === '/auth') return;
+
+	handlingUnauthorized = true;
+
+	// `user` is typed SessionUser | undefined; undefined is the logged-out state
+	// and every consumer treats null/undefined identically.
+	user.set(undefined);
+	try {
+		localStorage.removeItem('token');
+	} catch {
+		// localStorage may be unavailable; redirect regardless.
+	}
+
+	try {
+		toast.error(get(i18n).t('Your session has expired. Please sign in again.'));
+	} catch {
+		// i18n/toaster might not be ready yet; the redirect is what matters.
+	}
+
+	const currentUrl = `${window.location.pathname}${window.location.search}`;
+	// Re-arm once navigation settles so a later session (after re-login) is
+	// still protected. While we're on /auth the guard above short-circuits.
+	goto(`/auth?redirect=${encodeURIComponent(currentUrl)}`).finally(() => {
+		handlingUnauthorized = false;
+	});
+};
+
+/**
+ * Install a global fetch wrapper that signs the user out and redirects to /auth
+ * when an authenticated request to the Open WebUI backend returns 401 after the
+ * initial page load.
+ *
+ * Without this, such 401s are only console.error'd by the individual API
+ * helpers (e.g. getModels -> setModels().catch(console.error)), leaving the UI
+ * stuck in a broken "logged-in" state with no redirect or notification.
+ *
+ * Idempotent: safe to call multiple times.
+ */
+export const installFetchAuthInterceptor = () => {
+	if (typeof window === 'undefined') return;
+	if (installed) return;
+	installed = true;
+
+	const originalFetch = window.fetch.bind(window);
+
+	window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const response = await originalFetch(input, init);
+
+		try {
+			if (response.status === 401 && localStorage.token && hasAuthorizationHeader(input, init)) {
+				const url = resolveRequestUrl(input);
+				const backendOrigin = getBackendOrigin();
+				if (url && backendOrigin && url.origin === backendOrigin) {
+					handleUnauthorized();
+				}
+			}
+		} catch (error) {
+			// The interceptor must never break the underlying request.
+			console.error('Fetch auth interceptor error:', error);
+		}
+
+		return response;
+	}) as typeof window.fetch;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,6 +65,7 @@
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
 	import { bestMatchingLanguage, displayFileHandler, getUserTimezone } from '$lib/utils';
 	import { setTextScale } from '$lib/utils/text-scale';
+	import { installFetchAuthInterceptor } from '$lib/utils/auth-fetch';
 
 	import NotificationToast from '$lib/components/NotificationToast.svelte';
 	import AppSidebar from '$lib/components/app/AppSidebar.svelte';
@@ -882,6 +883,11 @@
 	};
 
 	onMount(async () => {
+		// Catch 401s on authenticated backend calls that happen after page load
+		// (e.g. token revoked/expired server-side) and redirect to /auth instead
+		// of leaving the UI stuck in a broken "logged-in" state.
+		installFetchAuthInterceptor();
+
 		window.addEventListener('message', windowMessageEventHandler);
 
 		let touchstartY = 0;


### PR DESCRIPTION
A 401 returned by an authenticated API call after initial page load was silently swallowed (at most console.error'd by individual API helpers, e.g. getModels -> setModels().catch(console.error)). No global handling existed: checkTokenExpiry only inspects the local expires_at claim, getSessionUser runs only at page load, and there was no fetch wrapper. The UI therefore stayed in a broken "logged-in" state after server-side token revocation or expiry.

Add a global fetch interceptor, installed from the root layout onMount, that detects 401 responses to authenticated backend requests, clears the token, notifies the user via a toast, and redirects to /auth?redirect=<current-url>. External connections (OpenAI / tool servers) and public endpoints are excluded by matching the backend origin and requiring an Authorization header; a guard collapses bursts of concurrent 401s into a single redirect.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
