### PR TITLE
fix: ignore IME composition Enter in chat search (#26172)

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -176,6 +176,12 @@
 	}
 
 	const onKeyDown = (e) => {
+		// Ignore keydown fired while confirming an IME composition (e.g. Japanese/Chinese/Korean)
+		// so confirming the composition with Enter doesn't trigger search actions (#26172).
+		if (e.isComposing || e.keyCode === 229) {
+			return;
+		}
+
 		const searchOptions = document.getElementById('search-options-container');
 		if (searchOptions || !show) {
 			return;

--- a/src/lib/components/layout/Sidebar/SearchInput.svelte
+++ b/src/lib/components/layout/Sidebar/SearchInput.svelte
@@ -229,6 +229,12 @@
 				}
 			}}
 			on:keydown={(e) => {
+				// Ignore keydown fired while confirming an IME composition (e.g. Japanese/Chinese/Korean)
+				// so confirming the composition with Enter doesn't trigger search actions (#26172).
+				if (e.isComposing || e.keyCode === 229) {
+					return;
+				}
+
 				if (e.key === 'Enter') {
 					if (filteredItems.length > 0) {
 						const itemElement = document.getElementById(`search-item-${selectedIdx}`);


### PR DESCRIPTION

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #26172`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- The chat search modal and the sidebar search input treated the **Enter that confirms an IME composition** (e.g. Japanese / Chinese / Korean) as a normal Enter. As a result, confirming the composed text fired a search action — most visibly, it **started a new chat** with the half-composed text instead of just confirming it. This is the same class of problem as #16608 / #17141, but on the search input path rather than the main message input.
- The fix guards the search keydown handlers to ignore a keydown fired while an IME composition is in progress, using `e.isComposing` (with a `keyCode === 229` fallback) — mirroring the existing `inOrNearComposition` guard in `MessageInput.svelte`. A second Enter, after the composition is confirmed, still triggers the action as before (no regression).
- Files changed: `src/lib/components/layout/Sidebar/SearchInput.svelte` (`on:keydown`) and `src/lib/components/layout/SearchModal.svelte` (document-level `onKeyDown`).

### Fixed

- Confirming an IME composition (e.g. Japanese / Chinese / Korean) with Enter in the chat search modal and the sidebar search input no longer triggers a search action such as starting a new chat; the composition-confirming Enter is now ignored, matching the message input's behavior. (#26172)

---

### Additional Information

- Mirrors the existing `inOrNearComposition` IME guard used by `MessageInput.svelte`. Related prior IME issues on the message-input path: #16608, #17141.
- Scope is limited to the two search keydown handlers: no new settings, and no documentation or dependency changes are required.

### Screenshots or Videos

Japanese IME — pressing Enter to confirm the composition, before vs. after the fix:

https://github.com/user-attachments/assets/09bb959b-0f6e-422a-b40c-c73f6e114f4f


https://github.com/user-attachments/assets/b8e926bd-73b8-49d0-b6ff-38dbff87733a


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

