### PR TITLE
fix: Prevent Crashes

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -835,7 +835,7 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
 
         models.append(model)
 
-    model_order_list = await Config.get('models.order_list')
+    model_order_list = await Config.get('ui.model_order_list')
     if model_order_list:
         model_order_dict = {model_id: i for i, model_id in enumerate(model_order_list)}
         # Sort models by order list priority, with fallback for those not in the list

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -23,6 +23,7 @@ from open_webui.models.functions import (
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.plugin import (
     get_function_module_from_cache,
+    get_functions_cache,
     load_function_module_by_id,
     replace_imports,
     resolve_valves_schema_options,
@@ -205,7 +206,7 @@ async def create_new_function(
             )
             form_data.meta.manifest = frontmatter
 
-            FUNCTIONS = request.app.state.FUNCTIONS
+            FUNCTIONS = get_functions_cache(request)
             FUNCTIONS[form_data.id] = function_module
 
             function = await Functions.insert_new_function(user.id, function_type, form_data, db=db)
@@ -322,7 +323,7 @@ async def update_function_by_id(
         function_module, function_type, frontmatter = await load_function_module_by_id(id, content=form_data.content)
         form_data.meta.manifest = frontmatter
 
-        FUNCTIONS = request.app.state.FUNCTIONS
+        FUNCTIONS = get_functions_cache(request)
         FUNCTIONS[id] = function_module
 
         updated = {**form_data.model_dump(exclude={'id'}), 'type': function_type}
@@ -363,7 +364,7 @@ async def delete_function_by_id(
     result = await Functions.delete_function_by_id(id, db=db)
 
     if result:
-        FUNCTIONS = request.app.state.FUNCTIONS
+        FUNCTIONS = get_functions_cache(request)
         if id in FUNCTIONS:
             del FUNCTIONS[id]
 

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -773,14 +773,15 @@ async def edit_images(request: Request, form_data: EditImageForm, user=Depends(g
     # global image-edit switch and the per-user image-generation permission. The internal
     # callers (edit_image tool, chat middleware) gate themselves and call image_edits()
     # directly, so they are unaffected by this wrapper.
-    if not request.app.state.config.ENABLE_IMAGE_EDIT:
+    image_config = await get_image_config()
+    if not image_config.ENABLE_IMAGE_EDIT:
         raise HTTPException(
             status_code=403,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
     if user.role != 'admin' and not await has_permission(
-        user.id, 'features.image_generation', request.app.state.config.USER_PERMISSIONS
+        user.id, 'features.image_generation', image_config.USER_PERMISSIONS
     ):
         raise HTTPException(
             status_code=403,

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -532,11 +532,7 @@ async def get_model_profile_image(
 
     # Fallback: check arena models stored in config (not in the DB)
     if not profile_image_url:
-        arena_models = getattr(
-            getattr(request.app.state, 'config', None),
-            'EVALUATION_ARENA_MODELS',
-            [],
-        )
+        arena_models = await Config.get('evaluation.arena.models', []) or []
         for arena_model in arena_models:
             if arena_model.get('id') == id:
                 profile_image_url = arena_model.get('meta', {}).get('profile_image_url')

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -632,7 +632,8 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                                     error_detail = f'External Error: {res["error"]}'
                             except Exception:
                                 pass
-                            raise Exception(error_detail)
+                            log.error(f'Error fetching models from {url}: {error_detail}')
+                            raise HTTPException(status_code=500, detail=error_detail)
 
                         response_data = await r.json()
 
@@ -654,6 +655,10 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                             ]
 
                         models = response_data
+            except HTTPException:
+                # Expected, already-formatted errors (e.g. non-200 from the
+                # upstream provider) pass through without a noisy stack trace.
+                raise
             except aiohttp.ClientError as e:
                 # ClientError covers all aiohttp requests issues
                 log.exception(f'Client error: {str(e)}')

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -32,6 +32,7 @@ from open_webui.utils.access_control import (
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.plugin import (
     get_tool_module_from_cache,
+    get_tools_cache,
     load_tool_module_by_id,
     replace_imports,
     resolve_valves_schema_options,
@@ -71,7 +72,7 @@ async def get_tools(
 
     # Local Tools
     for tool in await Tools.get_tools(defer_content=True, db=db):
-        tool_module = request.app.state.TOOLS.get(tool.id) if hasattr(request.app.state, 'TOOLS') else None
+        tool_module = get_tools_cache(request).get(tool.id)
         tools.append(
             ToolUserResponse(
                 **{
@@ -368,7 +369,7 @@ async def create_new_tools(
             tool_module, frontmatter = await load_tool_module_by_id(form_data.id, content=form_data.content)
             form_data.meta.manifest = frontmatter
 
-            TOOLS = request.app.state.TOOLS
+            TOOLS = get_tools_cache(request)
             TOOLS[form_data.id] = tool_module
 
             specs = get_tool_specs(TOOLS[form_data.id])
@@ -498,7 +499,7 @@ async def update_tools_by_id(
         tool_module, frontmatter = await load_tool_module_by_id(id, content=form_data.content)
         form_data.meta.manifest = frontmatter
 
-        TOOLS = request.app.state.TOOLS
+        TOOLS = get_tools_cache(request)
         TOOLS[id] = tool_module
 
         specs = get_tool_specs(TOOLS[id])
@@ -624,7 +625,7 @@ async def delete_tools_by_id(
 
     result = await Tools.delete_tool_by_id(id, db=db)
     if result:
-        TOOLS = request.app.state.TOOLS
+        TOOLS = get_tools_cache(request)
         if id in TOOLS:
             del TOOLS[id]
 
@@ -708,11 +709,12 @@ async def get_tools_valves_spec_by_id(
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    if id in request.app.state.TOOLS:
-        tools_module = request.app.state.TOOLS[id]
+    tools_cache = get_tools_cache(request)
+    if id in tools_cache:
+        tools_module = tools_cache[id]
     else:
         tools_module, _ = await load_tool_module_by_id(id)
-        request.app.state.TOOLS[id] = tools_module
+        tools_cache[id] = tools_module
 
     if hasattr(tools_module, 'Valves'):
         Valves = tools_module.Valves
@@ -759,11 +761,12 @@ async def update_tools_valves_by_id(
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    if id in request.app.state.TOOLS:
-        tools_module = request.app.state.TOOLS[id]
+    tools_cache = get_tools_cache(request)
+    if id in tools_cache:
+        tools_module = tools_cache[id]
     else:
         tools_module, _ = await load_tool_module_by_id(id)
-        request.app.state.TOOLS[id] = tools_module
+        tools_cache[id] = tools_module
 
     if not hasattr(tools_module, 'Valves'):
         raise HTTPException(
@@ -858,11 +861,12 @@ async def get_tools_user_valves_spec_by_id(
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    if id in request.app.state.TOOLS:
-        tools_module = request.app.state.TOOLS[id]
+    tools_cache = get_tools_cache(request)
+    if id in tools_cache:
+        tools_module = tools_cache[id]
     else:
         tools_module, _ = await load_tool_module_by_id(id)
-        request.app.state.TOOLS[id] = tools_module
+        tools_cache[id] = tools_module
 
     if hasattr(tools_module, 'UserValves'):
         UserValves = tools_module.UserValves
@@ -904,11 +908,12 @@ async def update_tools_user_valves_by_id(
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    if id in request.app.state.TOOLS:
-        tools_module = request.app.state.TOOLS[id]
+    tools_cache = get_tools_cache(request)
+    if id in tools_cache:
+        tools_module = tools_cache[id]
     else:
         tools_module, _ = await load_tool_module_by_id(id)
-        request.app.state.TOOLS[id] = tools_module
+        tools_cache[id] = tools_module
 
     if hasattr(tools_module, 'UserValves'):
         UserValves = tools_module.UserValves

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -22,6 +22,7 @@ from open_webui.socket.utils import RedisDict
 from open_webui.utils.access_control import has_access, has_base_model_access
 from open_webui.utils.plugin import (
     get_function_module_from_cache,
+    get_functions_cache,
     load_function_module_by_id,
 )
 
@@ -325,7 +326,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     def get_action_priority(action_id):
         try:
-            function_module = request.app.state.FUNCTIONS.get(action_id)
+            function_module = get_functions_cache(request).get(action_id)
             if function_module and hasattr(function_module, 'Valves'):
                 valves_db = all_function_valves.get(action_id)
                 valves = function_module.Valves(**(valves_db if valves_db else {}))
@@ -355,7 +356,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                 log.info(f'Action not found: {action_id}')
                 continue
 
-            function_module = request.app.state.FUNCTIONS.get(action_id)
+            function_module = get_functions_cache(request).get(action_id)
             if function_module is None:
                 log.info(f'Failed to load action module: {action_id}')
                 continue
@@ -368,7 +369,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                 log.info(f'Filter not found: {filter_id}')
                 continue
 
-            function_module = request.app.state.FUNCTIONS.get(filter_id)
+            function_module = get_functions_cache(request).get(filter_id)
             if function_module is None:
                 log.info(f'Failed to load filter module: {filter_id}')
                 continue

--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -298,7 +298,35 @@ async def load_function_module_by_id(function_id: str, content: str | None = Non
         os.unlink(temp_file.name)
 
 
+def _state_cache(request, name: str) -> dict:
+    # Single owner of the in-process plugin module caches. Lazily creates the
+    # dict on first access so callers never touch request.app.state.<name>
+    # directly and can never reach it before initialization.
+    if not hasattr(request.app.state, name):
+        setattr(request.app.state, name, {})
+    return getattr(request.app.state, name)
+
+
+def get_tools_cache(request) -> dict:
+    return _state_cache(request, 'TOOLS')
+
+
+def get_tool_contents_cache(request) -> dict:
+    return _state_cache(request, 'TOOL_CONTENTS')
+
+
+def get_functions_cache(request) -> dict:
+    return _state_cache(request, 'FUNCTIONS')
+
+
+def get_function_contents_cache(request) -> dict:
+    return _state_cache(request, 'FUNCTION_CONTENTS')
+
+
 async def get_tool_module_from_cache(request, tool_id, load_from_db=True):
+    tools_cache = get_tools_cache(request)
+    tool_contents_cache = get_tool_contents_cache(request)
+
     if load_from_db:
         # Always load from the database by default
         tool = await Tools.get_tool_by_id(tool_id)
@@ -312,27 +340,19 @@ async def get_tool_module_from_cache(request, tool_id, load_from_db=True):
             # Update the tool content in the database
             await Tools.update_tool_by_id(tool_id, {'content': content})
 
-        if (hasattr(request.app.state, 'TOOL_CONTENTS') and tool_id in request.app.state.TOOL_CONTENTS) and (
-            hasattr(request.app.state, 'TOOLS') and tool_id in request.app.state.TOOLS
-        ):
-            if request.app.state.TOOL_CONTENTS[tool_id] == content:
-                return request.app.state.TOOLS[tool_id], None
+        if tool_id in tool_contents_cache and tool_id in tools_cache:
+            if tool_contents_cache[tool_id] == content:
+                return tools_cache[tool_id], None
 
         tool_module, frontmatter = await load_tool_module_by_id(tool_id, content)
     else:
-        if hasattr(request.app.state, 'TOOLS') and tool_id in request.app.state.TOOLS:
-            return request.app.state.TOOLS[tool_id], None
+        if tool_id in tools_cache:
+            return tools_cache[tool_id], None
 
         tool_module, frontmatter = await load_tool_module_by_id(tool_id)
 
-    if not hasattr(request.app.state, 'TOOLS'):
-        request.app.state.TOOLS = {}
-
-    if not hasattr(request.app.state, 'TOOL_CONTENTS'):
-        request.app.state.TOOL_CONTENTS = {}
-
-    request.app.state.TOOLS[tool_id] = tool_module
-    request.app.state.TOOL_CONTENTS[tool_id] = content
+    tools_cache[tool_id] = tool_module
+    tool_contents_cache[tool_id] = content
 
     return tool_module, frontmatter
 
@@ -340,6 +360,9 @@ async def get_tool_module_from_cache(request, tool_id, load_from_db=True):
 async def get_function_module_from_cache(
     request, function_id, function: FunctionModel | None = None, load_from_db=True
 ):
+    functions_cache = get_functions_cache(request)
+    function_contents_cache = get_function_contents_cache(request)
+
     if load_from_db:
         # Always load from the database by default
         # This is useful for hooks like "inlet" or "outlet" where the content might change
@@ -357,30 +380,22 @@ async def get_function_module_from_cache(
             # Update the function content in the database
             await Functions.update_function_by_id(function_id, {'content': content})
 
-        if (
-            hasattr(request.app.state, 'FUNCTION_CONTENTS') and function_id in request.app.state.FUNCTION_CONTENTS
-        ) and (hasattr(request.app.state, 'FUNCTIONS') and function_id in request.app.state.FUNCTIONS):
-            if request.app.state.FUNCTION_CONTENTS[function_id] == content:
-                return request.app.state.FUNCTIONS[function_id], None, None
+        if function_id in function_contents_cache and function_id in functions_cache:
+            if function_contents_cache[function_id] == content:
+                return functions_cache[function_id], None, None
 
         function_module, function_type, frontmatter = await load_function_module_by_id(function_id, content)
     else:
         # Load from cache (e.g. "stream" hook)
         # This is useful for performance reasons
 
-        if hasattr(request.app.state, 'FUNCTIONS') and function_id in request.app.state.FUNCTIONS:
-            return request.app.state.FUNCTIONS[function_id], None, None
+        if function_id in functions_cache:
+            return functions_cache[function_id], None, None
 
         function_module, function_type, frontmatter = await load_function_module_by_id(function_id)
 
-    if not hasattr(request.app.state, 'FUNCTIONS'):
-        request.app.state.FUNCTIONS = {}
-
-    if not hasattr(request.app.state, 'FUNCTION_CONTENTS'):
-        request.app.state.FUNCTION_CONTENTS = {}
-
-    request.app.state.FUNCTIONS[function_id] = function_module
-    request.app.state.FUNCTION_CONTENTS[function_id] = content
+    functions_cache[function_id] = function_module
+    function_contents_cache[function_id] = content
 
     return function_module, function_type, frontmatter
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -95,7 +95,7 @@ from open_webui.tools.builtin import (
 from open_webui.utils.access_control import has_access, has_connection_access, has_permission
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
 from open_webui.utils.misc import is_string_allowed
-from open_webui.utils.plugin import load_tool_module_by_id
+from open_webui.utils.plugin import get_tool_contents_cache, get_tools_cache, load_tool_module_by_id
 from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 
@@ -250,11 +250,13 @@ async def get_tools(request: Request, tool_ids: list[str], user: UserModel, extr
                 log.warning(f'Access denied to tool {tool_id} for user {user.id}')
                 continue
 
-            module = request.app.state.TOOLS.get(tool_id)
-            if module is None or request.app.state.TOOL_CONTENTS.get(tool_id) != tool.content:
+            tools_cache = get_tools_cache(request)
+            tool_contents_cache = get_tool_contents_cache(request)
+            module = tools_cache.get(tool_id)
+            if module is None or tool_contents_cache.get(tool_id) != tool.content:
                 module, _ = await load_tool_module_by_id(tool_id, content=tool.content)
-                request.app.state.TOOLS[tool_id] = module
-                request.app.state.TOOL_CONTENTS[tool_id] = tool.content
+                tools_cache[tool_id] = module
+                tool_contents_cache[tool_id] = tool.content
 
             __user__ = {
                 **extra_params['__user__'],


### PR DESCRIPTION
Five runtime/functional regressions introduced by the refac series (config moved to async Config.get; plugin module caches moved to lazy init):

1) Tool/function module cache: refac 5cdcdbaee dropped the eager
   app.state.{TOOLS,TOOL_CONTENTS,FUNCTIONS,FUNCTION_CONTENTS} init, but the
   tools/functions CRUD routers and utils/models.py + utils/tools.py still
   read those dicts raw -> "AttributeError: 'State' object has no attribute
   'FUNCTIONS'" -> 400 on a fresh server (POST /api/v1/functions/create,
   /api/v1/tools/create, the update/delete/valves-spec endpoints, and the
   action/filter + tool-exec paths). Rather than re-add the eager init, give
   the cache a single owner: lazy hasattr-guarded accessors in utils/plugin.py
   (get_tools_cache / get_tool_contents_cache / get_functions_cache /
   get_function_contents_cache) and route every reader through them. There is
   no init line to forget and no raw app.state.<cache> read left anywhere, so
   this bug class is structurally impossible to reintroduce.

2) routers/images.py edit_images (POST /api/v1/images/edit): read the removed
   request.app.state.config for ENABLE_IMAGE_EDIT / USER_PERMISSIONS ->
   AttributeError every call. Fetch via await get_image_config() like
   generate_images.

3) routers/models.py get_model_profile_image: the arena-model fallback read
   app.state.config via getattr(..., None), so it silently resolved to [] and
   arena models never served a profile image. Use
   await Config.get('evaluation.arena.models', []) or [].

4) main.py get_all_base_models (GET /api/models): read the admin model ordering
   via Config.get('models.order_list') — a key that exists nowhere. The value
   is written under 'ui.model_order_list' (routers/configs.py), so the
   configured model order was silently ignored. Read the correct key.

5) routers/openai.py get_models: an external non-200 was raised as a bare
   Exception and re-logged via log.exception, dumping a full stack trace for an
   expected, already-handled error. Raise HTTPException with a clean log.error
   and add an `except HTTPException: raise` passthrough (also stops legitimate
   HTTPExceptions from being swallowed and re-wrapped as a generic 500).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
