### PR TITLE
fix(automations): authenticate session-auth tools/terminals in headle…

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -31,7 +31,9 @@ from open_webui.models.automations import AutomationModel, AutomationRuns, Autom
 from open_webui.models.chats import ChatForm, Chats
 from open_webui.models.config import Config
 from open_webui.models.users import Users
+from open_webui.utils.misc import parse_duration
 from open_webui.utils.task import prompt_template
+from fastapi.security import HTTPAuthorizationCredentials
 from starlette.datastructures import Headers
 
 log = logging.getLogger(__name__)
@@ -203,11 +205,15 @@ async def scheduler_worker_loop(app) -> None:
 ####################
 
 
-def _build_request(app) -> Request:
+def _build_request(app, token: Optional[str] = None) -> Request:
     """Build a minimal ASGI Request for chat_completion.
 
     Mirrors the mock-request pattern used in main.py lifespan
     (model pre-fetch, tool server init) for consistency.
+
+    When *token* is provided it is attached as request.state.token so
+    session-authenticated tool servers / terminals work in headless
+    execution (the pipeline reads request.state.token.credentials).
     """
     scope = {
         'type': 'http',
@@ -215,15 +221,16 @@ def _build_request(app) -> Request:
         'method': 'POST',
         'path': '/api/v1/automations/internal',
         'query_string': b'',
-        'headers': Headers({}).raw,
+        'headers': Headers({'Authorization': f'Bearer {token}'} if token else {}).raw,
         'client': ('127.0.0.1', 0),
         'server': ('127.0.0.1', 80),
         'scheme': 'http',
         'app': app,
     }
     request = Request(scope)
-    # Ensure request.state is initialized with required attributes
-    request.state.token = None
+    # Ensure request.state is initialized with required attributes.
+    # token is an HTTPAuthorizationCredentials (has .credentials) or None.
+    request.state.token = HTTPAuthorizationCredentials(scheme='Bearer', credentials=token) if token else None
     request.state.enable_api_keys = False
     return request
 
@@ -470,7 +477,12 @@ async def execute_automation(app, automation: AutomationModel) -> None:
 
         # Call the full chat completion pipeline (same as POST /api/chat/completions).
         # The handler reference is stored on app.state to avoid circular imports.
-        request = _build_request(app)
+        # Mint a short-lived token for the owner so session-auth tool servers /
+        # terminals can authenticate (pipeline reads request.state.token.credentials).
+        from open_webui.utils.auth import create_token
+
+        token = create_token(data={'id': user.id}, expires_delta=parse_duration(await Config.get('auth.jwt_expiry')))
+        request = _build_request(app, token=token)
         await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
 
         # Notify user


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26137 
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [ ] **Documentation:** N/A — internal bug fix, no user-facing docs changes required.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually verified an automation with a session-auth tool server / terminal now runs headless without error; runs without session-auth tools are unaffected.
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings introduced; reuses existing `auth.jwt_expiry` and token minting.
- [x] **Git Hygiene:** The PR is atomic (one logical change).
- [x] **Title Prefix:** Uses the `fix` prefix.

# Changelog Entry

### Description

- Automations run headless through a synthetic request (`_build_request`) that set `request.state.token = None`. The chat pipeline reads `request.state.token.credentials` to authenticate session-auth tool servers and terminals (`utils/tools.py`, `routers/terminals.py`), so headless runs raised `'NoneType' object has no attribute 'credentials'` and aborted whenever the chat used a session-authenticated tool server or terminal.
- This change mints a short-lived JWT for the automation's owner (respecting `auth.jwt_expiry`) and attaches it as `HTTPAuthorizationCredentials` on `request.state.token`, so session-auth connections authenticate as the owner during scheduled/headless execution.

### Fixed

- Fixed scheduled automations failing with `'NoneType' object has no attribute 'credentials'` when the underlying chat used session-authenticated tool servers or terminals.

---

### Additional Information

- Scope is limited to `backend/open_webui/utils/automations.py` (17 insertions, 5 deletions).
- The minted token is owner-scoped and short-lived (bounded by the configured `auth.jwt_expiry`); when no token is needed, behavior is unchanged (`request.state.token` remains `None`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.