### PR TITLE
fix: add image normalization toggle for edits

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1384,6 +1384,8 @@ IMAGE_EDIT_MODEL = os.getenv('IMAGE_EDIT_MODEL', '')
 
 IMAGE_EDIT_SIZE = os.getenv('IMAGE_EDIT_SIZE', '')
 
+IMAGE_EDIT_NORMALIZE = os.getenv('IMAGE_EDIT_NORMALIZE', 'true').lower() == 'true'
+
 IMAGES_EDIT_OPENAI_API_BASE_URL = os.getenv('IMAGES_EDIT_OPENAI_API_BASE_URL', OPENAI_API_BASE_URL)
 IMAGES_EDIT_OPENAI_API_VERSION = os.getenv('IMAGES_EDIT_OPENAI_API_VERSION', '')
 
@@ -2795,6 +2797,7 @@ DEFAULT_CONFIG = {
     'images.edit.engine': IMAGE_EDIT_ENGINE,
     'images.edit.model': IMAGE_EDIT_MODEL,
     'images.edit.size': IMAGE_EDIT_SIZE,
+    'images.edit.normalize': IMAGE_EDIT_NORMALIZE,
     'images.edit.openai.api_base_url': IMAGES_EDIT_OPENAI_API_BASE_URL,
     'images.edit.openai.api_version': IMAGES_EDIT_OPENAI_API_VERSION,
     'images.edit.openai.api_key': IMAGES_EDIT_OPENAI_API_KEY,

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -77,6 +77,7 @@ IMAGE_CONFIG_KEYS = {
     'IMAGE_EDIT_ENGINE': 'images.edit.engine',
     'IMAGE_EDIT_MODEL': 'images.edit.model',
     'IMAGE_EDIT_SIZE': 'images.edit.size',
+    'IMAGE_EDIT_NORMALIZE': 'images.edit.normalize',
     'IMAGES_EDIT_OPENAI_API_BASE_URL': 'images.edit.openai.api_base_url',
     'IMAGES_EDIT_OPENAI_API_KEY': 'images.edit.openai.api_key',
     'IMAGES_EDIT_OPENAI_API_VERSION': 'images.edit.openai.api_version',
@@ -198,6 +199,7 @@ class ImagesConfig(BaseModel):
     ENABLE_IMAGE_EDIT: bool
     IMAGE_EDIT_ENGINE: str
     IMAGE_EDIT_MODEL: str
+    IMAGE_EDIT_NORMALIZE: bool = True
     IMAGE_EDIT_SIZE: str | None
 
     IMAGES_EDIT_OPENAI_API_BASE_URL: str
@@ -445,6 +447,39 @@ async def get_image_data(data: str, headers=None, trusted_base_url: str | None =
     except Exception as e:
         log.exception(f'Error loading image data: {e}')
         return None, None
+
+
+def normalize_image_data_url(data_url: str):
+    if not data_url.startswith('data:') or ',' not in data_url:
+        return data_url
+
+    header, encoded = data_url.split(',', 1)
+    content_type = header.split(';')[0].lstrip('data:')
+
+    if not content_type.startswith('image/'):
+        return data_url
+
+    try:
+        image_bytes = base64.b64decode(encoded)
+        with Image.open(io.BytesIO(image_bytes)) as image:
+            image = ImageOps.exif_transpose(image)
+
+            if image.mode in ('RGBA', 'LA', 'P'):
+                rgba_image = image.convert('RGBA')
+                background = Image.new('RGBA', rgba_image.size, (255, 255, 255, 255))
+                image = Image.alpha_composite(background, rgba_image).convert('RGB')
+            elif image.mode != 'RGB':
+                image = image.convert('RGB')
+
+            output = io.BytesIO()
+            image.save(output, format='JPEG', quality=95, optimize=True)
+            output.seek(0)
+            normalized_image = base64.b64encode(output.read()).decode('utf-8')
+            return f'data:image/jpeg;base64,{normalized_image}'
+    except Exception as e:
+        log.debug(f'Image normalization skipped: {e}')
+
+    return data_url
 
 
 async def upload_image(request, image_data, content_type, metadata, user, db=None):
@@ -878,6 +913,12 @@ async def image_edits(
 
     try:
         if image_config.IMAGE_EDIT_ENGINE == 'openai':
+            if image_config.IMAGE_EDIT_NORMALIZE:
+                if isinstance(form_data.image, str):
+                    form_data.image = normalize_image_data_url(form_data.image)
+                elif isinstance(form_data.image, list):
+                    form_data.image = [normalize_image_data_url(img) for img in form_data.image]
+
             headers = {
                 'Authorization': f'Bearer {image_config.IMAGES_EDIT_OPENAI_API_KEY}',
             }

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -900,6 +900,21 @@
 						</div>
 					</div>
 
+					<div class="mb-2.5">
+						<div class="flex w-full justify-between items-center">
+							<div class="text-xs pr-2">
+								<div class="">
+									{$i18n.t('Normalize image uploads')}
+								</div>
+								<div class="text-[0.65rem] text-gray-500 dark:text-gray-400">
+									{$i18n.t('Converts phone photos to a provider-friendly format so image edits work reliably.')}
+								</div>
+							</div>
+
+							<Switch bind:state={config.IMAGE_EDIT_NORMALIZE} />
+						</div>
+					</div>
+
 					{#if config?.ENABLE_IMAGE_GENERATION && config?.ENABLE_IMAGE_EDIT}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26249
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description
- Normalize image edit uploads before sending them to upstream providers
- Add an admin toggle for the normalization behavior

### Added
- `images.edit.normalize` config flag
- `Normalize image uploads` toggle in Admin > Settings > Images

### Changed
- Image edit upload handling now flattens weird iPhone image variants into provider-friendly JPEGs

### Fixed
- Image edits that failed with phone-origin MPO/JPEG variants

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/dev/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
