### PR TITLE
fix: solve-valves-icon-disappear-issue

### DIFF
--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -35,6 +35,7 @@ class Tool(Base):  # database table definition
 class ToolMeta(BaseModel):
     description: str | None = None
     manifest: dict | None = {}
+    has_user_valves: bool = False
 
 
 class ToolModel(BaseModel):

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -74,11 +74,15 @@ async def get_tools(
     tools_cache = get_tools_cache(request)
     for tool in await Tools.get_tools(defer_content=True, db=db):
         tool_module = tools_cache.get(tool.id)
+        has_user_valves = (
+            hasattr(tool_module, 'UserValves') if tool_module
+            else (tool.meta.has_user_valves if tool.meta else False)
+        )
         tools.append(
             ToolUserResponse(
                 **{
                     **tool.model_dump(),
-                    'has_user_valves': (hasattr(tool_module, 'UserValves') if tool_module else False),
+                    'has_user_valves': has_user_valves,
                 }
             )
         )
@@ -369,6 +373,7 @@ async def create_new_tools(
             form_data.content = replace_imports(form_data.content)
             tool_module, frontmatter = await load_tool_module_by_id(form_data.id, content=form_data.content)
             form_data.meta.manifest = frontmatter
+            form_data.meta.has_user_valves = hasattr(tool_module, 'UserValves')
 
             TOOLS = get_tools_cache(request)
             TOOLS[form_data.id] = tool_module
@@ -499,6 +504,7 @@ async def update_tools_by_id(
         form_data.content = replace_imports(form_data.content)
         tool_module, frontmatter = await load_tool_module_by_id(id, content=form_data.content)
         form_data.meta.manifest = frontmatter
+        form_data.meta.has_user_valves = hasattr(tool_module, 'UserValves')
 
         TOOLS = get_tools_cache(request)
         TOOLS[id] = tool_module


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [X] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/discussions/22857) or [Discussion](https://github.com/open-webui/open-webui/discussions/22857) 
- [X] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [X] **Description:** A concise description of the changes is provided below.
- [X] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [X] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [X] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [X] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [X] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [X] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [X] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [X] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [X] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Tool User Valves (the knob icon in the integrations menu) intermittently disappear from the UI. They reappear after a hard refresh (Ctrl+Shift+R / Cmd+Shift+R) without any changes being made. This affects any tool that defines a UserValves class.


### Fixed

  Priority 1: Live module check (if tool is loaded)
  - ✅ Always accurate
  - ✅ Reflects current state (even if code was manually edited)
  - ✅ Handles tools that fail to load correctly

  Priority 2: Database fallback (if tool not loaded)
  - ✅ Avoids loading all modules on every request
  - ✅ Works across multiple uvicorn workers
  - ✅ Shows correct value immediately after save



<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.