### PR TITLE
fix(utils): recover currentId when it points to a structurally orphaned

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -281,9 +281,18 @@ export const sanitizeHistory = (history) => {
 		message.childrenIds = message.childrenIds.filter((childId) => history.messages[childId]);
 	}
 
-	// Recover currentId if it points to a missing or incomplete node
+	// Recover currentId if it points to a missing, incomplete, or structurally orphaned node.
+	// An orphan is a node that claims to be a root (parentId === null) but has no children
+	// and is not the only message in the chat — indicating it was never wired into the tree.
+	// This can happen when a follow-up suggestion response is saved with content fields but
+	// without its graph fields (role, parentId, timestamp), causing currentId to point at it.
 	const currentMessage = history.messages?.[history.currentId];
-	if (!currentMessage?.id || !currentMessage?.role) {
+	const isOrphan =
+		!!currentMessage &&
+		currentMessage.parentId === null &&
+		currentMessage.childrenIds.length === 0 &&
+		Object.keys(history.messages).length > 1;
+	if (!currentMessage?.id || !currentMessage?.role || isOrphan) {
 		let latestLeafId = null;
 		let latestTimestamp = -1;
 		for (const [id, message] of Object.entries(history.messages)) {


### PR DESCRIPTION
`sanitizeHistory()` already recovers `currentId` when it points to a missing or role-less message. However, role reconstruction runs before the check, so an orphan node that receives a reconstructed role bypasses recovery.

This causes a permanent blank-chat failure when a follow-up suggestion response is saved with AI-content fields (`content`, `sources`, `output`, `followUps`) but without its graph fields (`role`, `parentId`, `timestamp`). `currentId` is set to the orphan; on every subsequent load the chat renders as empty.

Add an `isOrphan` check: a node with `parentId === null`, no children, and sibling messages present was never wired into the conversation tree and is not a legitimate current message. Trigger recovery in this case so the frontend falls back to the last valid leaf message.

Fixes: #26257  
Related: #24157, #20825

---

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #26257
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Provided above
- [x] **Changelog:** See below
- [x] **Documentation:** No documentation changes required — this is a defensive recovery fix with no user-facing behaviour change beyond the existing recovery path
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manually verified against a production database with a corrupted chat (orphaned follow-up response). Chat loaded correctly after fix. Single-message chats and normal multi-message chats unaffected (guarded by `Object.keys(history.messages).length > 1`).
- [x] **No Unchecked AI Code:** Change is 11 lines, human-reviewed and manually tested
- [x] **Self-Review:** Completed
- [x] **Architecture:** No new settings. Pure defensive recovery in existing `sanitizeHistory()` utility
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix`

---

# Changelog Entry

### Description

Fixes a permanent blank-chat failure triggered by clicking a follow-up suggestion button. The AI response was being saved to `history.messages` with content fields intact but missing graph fields (`role`, `parentId`, `timestamp`), producing a structurally orphaned node. Because `sanitizeHistory()` assigns a reconstructed role to orphans before checking `currentId` validity, the existing recovery path never fired and the chat remained permanently unloadable.

### Fixed

- `sanitizeHistory()` now detects structurally orphaned nodes (a node with `parentId === null`, no children, and sibling messages present) and falls back to the last valid leaf message, matching the behaviour of the existing missing/role-less node recovery

---

### Additional Information

The root ordering issue: role reconstruction (lines 254–274 of `src/lib/utils/index.ts`) runs before the `currentId` validity check (line 283). An orphan that gets `role: 'user'` reconstructed appears well-formed, so recovery never triggers. This PR adds a structural reachability check as a second condition rather than reordering the existing logic, which would risk regressions in the role-reconstruction recovery path.

Confirmed still present on the `dev` branch as of 23 June 2026.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.