### PR TITLE
fix: harden MinerU ZIP result handling

### DIFF
--- a/backend/open_webui/retrieval/loaders/mineru.py
+++ b/backend/open_webui/retrieval/loaders/mineru.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import PurePosixPath
 import tempfile
 import time
 import zipfile
@@ -10,6 +11,10 @@ from fastapi import HTTPException, status
 from langchain_core.documents import Document
 
 log = logging.getLogger(__name__)
+
+MAX_ZIP_ENTRIES = 1000
+MAX_ZIP_UNCOMPRESSED_SIZE = 100 * 1024 * 1024
+MAX_MARKDOWN_SIZE = 20 * 1024 * 1024
 
 
 class MinerULoader:
@@ -37,11 +42,11 @@ class MinerULoader:
 
         # Parse params dict with defaults
         self.params = params or {}
-        self.enable_ocr = params.get('enable_ocr', False)
-        self.enable_formula = params.get('enable_formula', True)
-        self.enable_table = params.get('enable_table', True)
-        self.language = params.get('language', 'en')
-        self.model_version = params.get('model_version', 'pipeline')
+        self.enable_ocr = self.params.get('enable_ocr', False)
+        self.enable_formula = self.params.get('enable_formula', True)
+        self.enable_table = self.params.get('enable_table', True)
+        self.language = self.params.get('language', 'en')
+        self.model_version = self.params.get('model_version', 'pipeline')
 
         self.page_ranges = self.params.pop('page_ranges', '')
 
@@ -435,67 +440,118 @@ class MinerULoader:
                 detail=f'Error downloading results: {str(e)}',
             )
 
-        # Save ZIP to temporary file and extract
+        # Save ZIP to temporary file before reading.
+        tmp_zip_path = None
+        markdown_content = None
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as tmp_zip:
                 tmp_zip.write(response.content)
                 tmp_zip_path = tmp_zip.name
 
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                # Extract ZIP
-                with zipfile.ZipFile(tmp_zip_path, 'r') as zip_ref:
-                    zip_ref.extractall(tmp_dir)
+            with zipfile.ZipFile(tmp_zip_path, 'r') as zip_ref:
+                members = zip_ref.infolist()
 
-                # Find markdown file - search recursively for any .md file
-                markdown_content = None
-                found_md_path = None
+                if len(members) > MAX_ZIP_ENTRIES:
+                    raise HTTPException(
+                        status.HTTP_502_BAD_GATEWAY,
+                        detail=f'Results ZIP contains too many entries: {len(members)}',
+                    )
 
-                # First, list all files in the ZIP for debugging
-                all_files = []
-                for root, dirs, files in os.walk(tmp_dir):
-                    for file in files:
-                        full_path = os.path.join(root, file)
-                        all_files.append(full_path)
-                        # Look for any .md file
-                        if file.endswith('.md'):
-                            found_md_path = full_path
-                            log.info(f'Found markdown file at: {full_path}')
-                            try:
-                                with open(full_path, 'r', encoding='utf-8') as f:
-                                    markdown_content = f.read()
-                                if markdown_content:  # Use the first non-empty markdown file
-                                    break
-                            except Exception as e:
-                                log.warning(f'Failed to read {full_path}: {e}')
+                total_uncompressed_size = 0
+                md_members = []
+
+                for member in members:
+                    member_path = PurePosixPath(member.filename)
+                    if (
+                        not member.filename
+                        or member_path.is_absolute()
+                        or '..' in member_path.parts
+                        or '\\' in member.filename
+                    ):
+                        raise HTTPException(
+                            status.HTTP_502_BAD_GATEWAY,
+                            detail=f'Unsafe file path in results ZIP: {member.filename}',
+                        )
+
+                    if member.is_dir():
+                        continue
+
+                    total_uncompressed_size += member.file_size
+                    if total_uncompressed_size > MAX_ZIP_UNCOMPRESSED_SIZE:
+                        raise HTTPException(
+                            status.HTTP_502_BAD_GATEWAY,
+                            detail='Results ZIP is too large after extraction',
+                        )
+
+                    if member.filename.endswith('.md'):
+                        md_members.append(member)
+
+                if not md_members:
+                    available_files = [member.filename for member in members]
+                    log.error(f'Available files in ZIP: {available_files}')
+                    raise HTTPException(
+                        status.HTTP_502_BAD_GATEWAY,
+                        detail=f'No .md files found in ZIP. Available files: {available_files}',
+                    )
+
+                read_errors = []
+                for member in md_members:
+                    if member.file_size > MAX_MARKDOWN_SIZE:
+                        raise HTTPException(
+                            status.HTTP_502_BAD_GATEWAY,
+                            detail=f'Markdown file in results ZIP is too large: {member.filename}',
+                        )
+
+                    log.info(f'Found markdown file in ZIP: {member.filename}')
+                    try:
+                        with zip_ref.open(member, 'r') as f:
+                            content = f.read(MAX_MARKDOWN_SIZE + 1)
+                        if len(content) > MAX_MARKDOWN_SIZE:
+                            raise HTTPException(
+                                status.HTTP_502_BAD_GATEWAY,
+                                detail=f'Markdown file in results ZIP is too large: {member.filename}',
+                            )
+                        markdown_content = content.decode('utf-8')
+                    except UnicodeDecodeError as e:
+                        read_errors.append(f'{member.filename}: {e}')
+                        log.warning(f'Failed to decode {member.filename}: {e}')
+                        continue
+                    except HTTPException:
+                        raise
+                    except Exception as e:
+                        read_errors.append(f'{member.filename}: {e}')
+                        log.warning(f'Failed to read {member.filename}: {e}')
+                        continue
+
                     if markdown_content:
                         break
 
                 if markdown_content is None:
-                    log.error(f'Available files in ZIP: {all_files}')
-                    # Try to provide more helpful error message
-                    md_files = [f for f in all_files if f.endswith('.md')]
-                    if md_files:
-                        error_msg = f"Found .md files but couldn't read them: {md_files}"
-                    else:
-                        error_msg = f'No .md files found in ZIP. Available files: {all_files}'
                     raise HTTPException(
                         status.HTTP_502_BAD_GATEWAY,
-                        detail=error_msg,
+                        detail=f"Found .md files but couldn't read them: {read_errors}",
                     )
-
-            # Clean up temporary ZIP file
-            os.unlink(tmp_zip_path)
 
         except zipfile.BadZipFile as e:
             raise HTTPException(
                 status.HTTP_502_BAD_GATEWAY,
                 detail=f'Invalid ZIP file received: {e}',
             )
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f'Error extracting ZIP: {str(e)}',
             )
+        finally:
+            if tmp_zip_path:
+                try:
+                    os.unlink(tmp_zip_path)
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    log.warning(f'Failed to remove temporary ZIP file {tmp_zip_path}: {e}')
 
         if not markdown_content:
             raise HTTPException(

--- a/test/retrieval/loaders/test_mineru_loader.py
+++ b/test/retrieval/loaders/test_mineru_loader.py
@@ -1,0 +1,243 @@
+from io import BytesIO
+import zipfile
+
+import pytest
+from fastapi import HTTPException
+
+import open_webui.retrieval.loaders.mineru as mineru_module
+from open_webui.retrieval.loaders.mineru import MinerULoader
+
+
+class FakeResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+def make_zip_bytes(entries: dict[str, str]) -> bytes:
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zip_file:
+        for name, content in entries.items():
+            zip_file.writestr(name, content)
+    return buffer.getvalue()
+
+
+def make_loader() -> MinerULoader:
+    return MinerULoader(
+        file_path="input.pdf",
+        api_mode="cloud",
+        api_url="http://example.invalid",
+        api_key="test-api-key",
+        params={},
+    )
+
+
+def patch_zip_download(monkeypatch, tmp_path, zip_bytes: bytes):
+    temp_zip_path = tmp_path / "mineru-result.zip"
+
+    def fake_get(url, timeout):
+        assert url == "http://example.invalid/result.zip"
+        assert timeout == 60
+        return FakeResponse(zip_bytes)
+
+    class FixedNamedTemporaryFile:
+        def __init__(self, delete=False, suffix=""):
+            self.name = str(temp_zip_path)
+            self._file = open(self.name, "wb")
+
+        def write(self, data):
+            return self._file.write(data)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            self._file.close()
+
+    monkeypatch.setattr(mineru_module.requests, "get", fake_get)
+    monkeypatch.setattr(
+        mineru_module.tempfile,
+        "NamedTemporaryFile",
+        FixedNamedTemporaryFile,
+    )
+
+    return temp_zip_path
+
+
+def test_mineru_loader_accepts_none_params():
+    loader = MinerULoader(
+        file_path="input.pdf",
+        api_mode="cloud",
+        api_url="http://example.invalid",
+        api_key="test-api-key",
+        params=None,
+    )
+
+    assert loader.params == {}
+    assert loader.enable_ocr is False
+    assert loader.enable_formula is True
+    assert loader.enable_table is True
+    assert loader.language == "en"
+    assert loader.model_version == "pipeline"
+
+
+def test_download_and_extract_zip_returns_markdown(monkeypatch, tmp_path):
+    zip_bytes = make_zip_bytes({"result.md": "hello mineru"})
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    content = make_loader()._download_and_extract_zip(
+        "http://example.invalid/result.zip",
+        "input.pdf",
+    )
+
+    assert content == "hello mineru"
+
+
+def test_download_and_extract_zip_bad_zip_cleans_temp_file(monkeypatch, tmp_path):
+    temp_zip_path = patch_zip_download(monkeypatch, tmp_path, b"not a zip")
+
+    with pytest.raises(HTTPException) as exc_info:
+        make_loader()._download_and_extract_zip(
+            "http://example.invalid/result.zip",
+            "input.pdf",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert not temp_zip_path.exists()
+
+
+def test_download_and_extract_zip_does_not_extract_unexpected_files(monkeypatch, tmp_path):
+    zip_bytes = make_zip_bytes(
+        {
+            "unexpected.txt": "not consumed by the loader",
+            "result.md": "hello mineru",
+        }
+    )
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    content = make_loader()._download_and_extract_zip(
+        "http://example.invalid/result.zip",
+        "input.pdf",
+    )
+
+    assert content == "hello mineru"
+    assert not (tmp_path / "unexpected.txt").exists()
+
+
+def test_download_and_extract_zip_uses_first_non_empty_markdown(monkeypatch, tmp_path):
+    zip_bytes = make_zip_bytes(
+        {
+            "a.md": "first markdown",
+            "b.md": "second markdown",
+        }
+    )
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    content = make_loader()._download_and_extract_zip(
+        "http://example.invalid/result.zip",
+        "input.pdf",
+    )
+
+    assert content == "first markdown"
+
+
+def test_download_and_extract_zip_allows_reasonable_entry_count(monkeypatch, tmp_path):
+    entries = {f"extras/file_{index}.txt": "x" for index in range(100)}
+    entries["result.md"] = "hello mineru"
+    zip_bytes = make_zip_bytes(entries)
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    content = make_loader()._download_and_extract_zip(
+        "http://example.invalid/result.zip",
+        "input.pdf",
+    )
+
+    assert content == "hello mineru"
+
+
+def test_download_and_extract_zip_rejects_too_many_entries(monkeypatch, tmp_path):
+    entries = {f"extras/file_{index}.txt": "x" for index in range(mineru_module.MAX_ZIP_ENTRIES + 1)}
+    entries["result.md"] = "hello mineru"
+    zip_bytes = make_zip_bytes(entries)
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    with pytest.raises(HTTPException) as exc_info:
+        make_loader()._download_and_extract_zip(
+            "http://example.invalid/result.zip",
+            "input.pdf",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "too many entries" in exc_info.value.detail
+
+
+def test_download_and_extract_zip_reads_markdown_within_size_limit(monkeypatch, tmp_path):
+    markdown = "x" * (1024 * 1024)
+    zip_bytes = make_zip_bytes({"result.md": markdown})
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    content = make_loader()._download_and_extract_zip(
+        "http://example.invalid/result.zip",
+        "input.pdf",
+    )
+
+    assert content == markdown
+    assert len(content) == 1024 * 1024
+
+
+def test_download_and_extract_zip_rejects_parent_components(monkeypatch, tmp_path):
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    zip_bytes = make_zip_bytes(
+        {
+            "../outside/parent_marker.txt": "outside marker",
+            "result.md": "hello mineru",
+        }
+    )
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    with pytest.raises(HTTPException) as exc_info:
+        make_loader()._download_and_extract_zip(
+            "http://example.invalid/result.zip",
+            "input.pdf",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "Unsafe file path" in exc_info.value.detail
+    assert list(outside_dir.iterdir()) == []
+
+
+def test_download_and_extract_zip_rejects_backslash_entry(monkeypatch, tmp_path):
+    zip_bytes = make_zip_bytes(
+        {
+            "safe_backslash_marker\\nested.txt": "backslash marker",
+            "result.md": "hello mineru",
+        }
+    )
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    with pytest.raises(HTTPException) as exc_info:
+        make_loader()._download_and_extract_zip(
+            "http://example.invalid/result.zip",
+            "input.pdf",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "Unsafe file path" in exc_info.value.detail
+
+
+def test_download_and_extract_zip_rejects_large_markdown(monkeypatch, tmp_path):
+    markdown = "x" * (mineru_module.MAX_MARKDOWN_SIZE + 1)
+    zip_bytes = make_zip_bytes({"result.md": markdown})
+    patch_zip_download(monkeypatch, tmp_path, zip_bytes)
+
+    with pytest.raises(HTTPException) as exc_info:
+        make_loader()._download_and_extract_zip(
+            "http://example.invalid/result.zip",
+            "input.pdf",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "too large" in exc_info.value.detail


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This PR is a small defensive hardening fix for MinerU ZIP result handling.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** No existing issue or discussion found for this small defensive hardening fix.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable; this is a scoped backend loader hardening change.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Local unit tests were performed to verify the fix does not introduce regressions.
- [x] **No Unchecked AI Code:** The changes have undergone local review and local test validation.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Uses the existing loader flow with safer archive handling and no new settings.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Harden MinerU result ZIP handling by validating ZIP members before reading Markdown output.

### Added

- Focused local tests for MinerU ZIP handling behavior.

### Changed

- Avoid `ZipFile.extractall()` for MinerU result ZIPs.
- Validate ZIP member names before processing.
- Read validated Markdown members directly from the archive instead of extracting the whole ZIP.
- Add limits for ZIP entry count, total uncompressed size, and Markdown member size.
- Make Markdown selection deterministic.
- Ensure temporary ZIP files are cleaned up on error paths.

### Deprecated

- None.

### Removed

- Whole-archive extraction for MinerU result ZIPs.

### Fixed

- Fix `MinerULoader` initialization when `params=None`.

### Security

- Reject unsafe MinerU ZIP member names and oversized ZIP/Markdown inputs before reading output.

### Breaking Changes

- None.

---

### Additional Information

## Summary

This PR hardens MinerU result ZIP handling by avoiding wholesale archive extraction and validating ZIP members before reading Markdown output.

## Tests

```bash
PYTHONPATH=backend .venv-test/bin/python -m pytest test/retrieval/loaders/test_mineru_loader.py -q
```

Result:

```text
11 passed in 0.16s
```

The tests use local mocked ZIP responses and do not call the real MinerU Cloud API or any external service.

### Screenshots or Videos

- Not applicable.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
