### PR TITLE
fix: resolve workspace model ID to base model on eject/unload

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -877,8 +877,15 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
     """
     model_id = form_data.model
 
-    # --- Ollama provider ---
+    # --- Resolve workspace models to their underlying base model ---
     ollama_models = getattr(request.app.state, 'OLLAMA_MODELS', None) or {}
+    openai_models = getattr(request.app.state, 'OPENAI_MODELS', None) or {}
+    if model_id not in ollama_models and model_id not in openai_models:
+        model_info = await Models.get_model_by_id(model_id)
+        if model_info and model_info.base_model_id:
+            model_id = model_info.base_model_id
+
+    # --- Ollama provider ---
     if model_id in ollama_models:
         ollama_config = await Config.get_many('ollama.base_urls', 'ollama.api_configs')
         ollama_base_urls = ollama_config.get('ollama.base_urls') or []


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem:** Clicking the eject (unload) button on a workspace model that uses an Ollama base model throws a `"Model not found"` error toast instead of unloading the underlying Ollama model.

**Root Cause:** The `/api/models/unload` endpoint receives the workspace model ID from the frontend (e.g., `my-custom-workspace-model`), then looks it up directly in the `OLLAMA_MODELS` and `OPENAI_MODELS` app state dicts. These dicts only contain raw provider models — workspace models are not in them. When the workspace model ID isn't found in either dict, the endpoint falls through to a 404 error.

**Fix:** Before checking the provider model dicts, the endpoint now resolves workspace model IDs by looking them up in the database via `Models.get_model_by_id()`. If the model has a `base_model_id`, the ID is substituted so the unload proceeds against the actual underlying Ollama/OpenAI model.

```diff
     model_id = form_data.model

-    # --- Ollama provider ---
+    # --- Resolve workspace models to their underlying base model ---
     ollama_models = getattr(request.app.state, 'OLLAMA_MODELS', None) or {}
+    openai_models = getattr(request.app.state, 'OPENAI_MODELS', None) or {}
+    if model_id not in ollama_models and model_id not in openai_models:
+        model_info = await Models.get_model_by_id(model_id)
+        if model_info and model_info.base_model_id:
+            model_id = model_info.base_model_id
+
+    # --- Ollama provider ---
     if model_id in ollama_models:
```

This is a surgical 7-line addition in `backend/open_webui/main.py`. No new dependencies, no frontend changes, no breaking changes.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Fixed

- Ejecting a workspace model that uses an Ollama (or OpenAI-compatible) base model now correctly resolves to and unloads the underlying base model instead of throwing a `"Model not found"` error.

---

### Additional Information

- **File changed:** `backend/open_webui/main.py` — the unified `/api/models/unload` endpoint
- **Scope:** 1 file, 8 insertions, 1 deletion
- The existing `Models.get_model_by_id()` method is already imported and used elsewhere in the same file (e.g., in `chat_completion`), so this follows established patterns
- Regular (non-workspace) models are unaffected — the DB lookup only fires when the model ID isn't found in the provider dicts

### Manual Verification Performed

1. Created a workspace model with an Ollama base model (e.g., `qwen3:30b-a3b`)
2. Selected the workspace model in the chat model selector
3. Verified the Ollama base model was loaded (green dot indicator)
4. Clicked the eject button on the workspace model in the model selector
5. **Before fix:** Error toast — `"Model not found"`
6. **After fix:** Model unloads successfully with success toast, green dot disappears

### Screenshots or Videos

#### Before (Error on eject)

<img width="2339" height="489" alt="image" src="https://github.com/user-attachments/assets/de6e655a-0806-4fc9-b26b-4feef78ca9eb" />

#### After (Successful unload)

<img width="2339" height="489" alt="image" src="https://github.com/user-attachments/assets/92482c06-b6eb-4322-8fe5-ff41c5d424ab" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
