### PR TITLE
feat: add Workspace filter tag to model selector

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -195,6 +195,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.info?.base_model_id;
 						}
 					})
 			: items
@@ -215,6 +217,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.info?.base_model_id;
 						}
 					})
 	).filter((item) => !(item.model?.info?.meta?.hidden ?? false));
@@ -608,7 +612,7 @@
 									class="flex gap-1 w-fit text-center text-sm rounded-full bg-transparent px-1.5 whitespace-nowrap"
 									bind:this={tagsContainerElement}
 								>
-									{#if items.find((item) => item.model?.connection_type === 'local') || items.find((item) => item.model?.connection_type === 'external') || items.find((item) => item.model?.direct) || tags.length > 0}
+									{#if items.find((item) => item.model?.connection_type === 'local') || items.find((item) => item.model?.connection_type === 'external') || items.find((item) => item.model?.direct) || items.find((item) => item.model?.info?.base_model_id) || tags.length > 0}
 										<button
 											class="min-w-fit outline-none px-1.5 py-0.5 {selectedTag === '' &&
 											selectedConnectionType === ''
@@ -669,6 +673,22 @@
 											}}
 										>
 											{$i18n.t('Direct')}
+										</button>
+									{/if}
+
+									{#if items.find((item) => item.model?.info?.base_model_id)}
+										<button
+											class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType ===
+											'workspace'
+												? ''
+												: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
+											aria-pressed={selectedConnectionType === 'workspace'}
+											on:click={() => {
+												selectedTag = '';
+												selectedConnectionType = 'workspace';
+											}}
+										>
+											{$i18n.t('Workspace')}
 										</button>
 									{/if}
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Adds a **Workspace** filter tag to the model selector's tag bar, sitting alongside the existing Local, External, and Direct filters. When clicked, it filters the model list to show only workspace models (models with a `base_model_id`). The tag only appears when workspace models are available in the selector.

**What it does:**

- Adds a `'workspace'` value to the existing `selectedConnectionType` filter system
- Filters items by checking `item.model?.info?.base_model_id` (the field that distinguishes workspace models from provider models)
- Renders the "Workspace" button between "Direct" and user-defined tags, matching the exact styling/behavior of existing filter buttons
- Conditionally shows the button only when at least one workspace model exists in the items list

```diff
+  } else if (selectedConnectionType === 'workspace') {
+      return item.model?.info?.base_model_id;
   }
```

The `$i18n.t('Workspace')` key already exists in the English locale, so no translation file changes are needed. The button follows the identical pattern as Local/External/Direct — same Tailwind classes, same `selectedTag = ''` reset, same `aria-pressed` attribute.

**Scope:** 1 file, 21 insertions, 1 deletion — entirely within `Selector.svelte`.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- "Workspace" filter tag in the model selector that appears when workspace models are available, allowing users to quickly filter to only workspace models.

---

### Additional Information

- No new dependencies
- No backend changes — purely frontend
- Follows the existing `selectedConnectionType` pattern used by Local, External, and Direct filters
- The `"Workspace"` i18n key already exists in `en-US/translation.json`

### Manual Verification Performed

1. Verified that the "Workspace" tag appears in the model selector when workspace models exist
2. Verified that clicking "Workspace" filters the list to only show workspace models
3. Verified that clicking "All" resets the filter and shows all models again
4. Verified that the "Workspace" tag does not appear when no workspace models exist
5. Verified that existing filters (Local, External, Direct, user tags) continue to work correctly
6. Verified the button styling matches existing filter buttons in both light and dark modes

### Screenshots or Videos

#### Before (No Workspace filter available)

<img width="546" height="388" alt="image" src="https://github.com/user-attachments/assets/016770ad-3790-4829-8fc4-7f8d783f6f52" />

#### After (Workspace filter tag added)

<img width="546" height="388" alt="image" src="https://github.com/user-attachments/assets/7d7c13b6-1d5d-4ba7-a17a-b6020f50c6c3" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
