### PR TITLE
fix: hide workspace models from model selector when base model is unavailable

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -187,6 +187,12 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
             base_model = base_model_lookup.get(custom_model.base_model_id)
             if base_model is None:
                 base_model = base_model_lookup.get(custom_model.base_model_id.split(':')[0])
+            if base_model is None:
+                # Base model is not available (e.g. provider disabled,
+                # connection unreachable).  Skip this workspace model so
+                # it does not appear in the selector as a non-functional
+                # entry.
+                continue
             if base_model:
                 owned_by = base_model.get('owned_by', 'unknown')
                 if 'pipe' in base_model:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a bug where workspace models remain visible and selectable in the model selector even when their underlying base model is unavailable (e.g. Ollama API disabled, connection unreachable).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a backend behavioral fix with no new configuration.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or configuration. Uses existing `base_model_lookup` resolution path.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

---

## Summary

Workspace models whose base model is unavailable (e.g. the Ollama API is disabled, a connection endpoint is unreachable, or the base model was removed) currently still appear in the model selector. This makes them visible and selectable by users, even though selecting one would result in a non-functional model since the backend cannot resolve the underlying provider.

This PR adds a single guard in `get_all_models()` that skips workspace models when their `base_model_id` cannot be resolved against the available base models.

## How This Was Discovered

I built an [Ollama model card generator tool](https://openwebui.com/t/silentoplayz/ollama_model_card_generator) for Open WebUI that automatically creates workspace models from every base Ollama model — generating profile images, descriptions, and metadata from Ollama's model library. After running this tool against my full Ollama model library (~150 models), I noticed that disabling the Ollama API in Admin Settings → Connections did not hide any of the resulting workspace models from the model selector. They remained fully visible and selectable, even though they couldn't function without their Ollama base models being available.

## Problem → Root Cause → Fix

**Problem:** Workspace models appear in the model selector even when their base model provider is disabled or unreachable. Users can select these models but they cannot function.

**Root Cause:** In `get_all_models()`, the workspace model resolution path (the `elif custom_model.is_active` branch) attempts to look up the base model via `base_model_lookup`, but when the lookup returns `None`, the workspace model is still appended to the `models` list unconditionally — just with a fallback `owned_by='openai'`.

**Fix:** After the two-step base model lookup (exact ID, then base name without tag), check if `base_model` is still `None`. If so, `continue` to skip the workspace model entirely.

## Key Change

```diff
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -187,6 +187,12 @@
             base_model = base_model_lookup.get(custom_model.base_model_id)
             if base_model is None:
                 base_model = base_model_lookup.get(custom_model.base_model_id.split(':')[0])
+            if base_model is None:
+                # Base model is not available (e.g. provider disabled,
+                # connection unreachable).  Skip this workspace model so
+                # it does not appear in the selector as a non-functional
+                # entry.
+                continue
             if base_model:
                 owned_by = base_model.get('owned_by', 'unknown')
```

# Changelog Entry

### Description

- Workspace models are now hidden from the model selector when their base model is unavailable (provider disabled, connection unreachable, or base model removed). Previously, these models appeared as selectable entries even though they could not function, since the backend had no provider to route inference requests to.

### Fixed

- Workspace models no longer appear in the model selector when their underlying base model cannot be resolved against available providers. This prevents users from selecting non-functional models when a provider (e.g. Ollama) is disabled or a connection is unreachable.

---

### Screenshots or Videos

## Preparedness Actions

<img width="2344" height="1279" alt="image" src="https://github.com/user-attachments/assets/c725fee8-c534-4d32-8755-cb74782ce0b7" />

<img width="2344" height="1277" alt="image" src="https://github.com/user-attachments/assets/66b63b24-d116-4c05-8ec2-9d676c4b6950" />

<img width="2344" height="1277" alt="image" src="https://github.com/user-attachments/assets/d768c6d7-7387-402e-837a-6ff411390ba6" />

<img width="2344" height="1279" alt="image" src="https://github.com/user-attachments/assets/e7b4a66a-f576-457f-873d-ba28f49aa1b2" />

## Before:

<img width="548" height="398" alt="image" src="https://github.com/user-attachments/assets/f79ecb6f-ac63-47e2-b13a-371da060302f" />

<img width="553" height="396" alt="image" src="https://github.com/user-attachments/assets/e69ed730-3233-4390-bd29-1d6ba7d4c3d9" />

<img width="2344" height="382" alt="image" src="https://github.com/user-attachments/assets/86697d10-6e34-4f48-bcb2-2d6a2a9b848d" />

## After:

<img width="2344" height="382" alt="image" src="https://github.com/user-attachments/assets/25386bc2-c36d-4619-a373-f12cef7fb468" />

### Additional Information

- **Scope:** 1 file changed, 6 lines added.
- **File:** `backend/open_webui/utils/models.py` — the `get_all_models()` function that builds the model list for the `/api/models` endpoint.
- **Risk:** Minimal. The guard only affects workspace models (entries with `base_model_id` set). Base model overrides (`base_model_id=None`) and raw base models from providers are completely unaffected. The existing two-step lookup (exact ID → base name without tag) is preserved.
- **Edge cases considered:**
  - Workspace models referencing OpenAI/pipe base models: unaffected (those base models are still in `base_model_lookup` when their provider is enabled).
  - Workspace models referencing other workspace models as base: not a pattern currently used in production, and would already fail today since workspace models are not added to `base_model_lookup`.
  - Re-enabling a provider: workspace models automatically reappear in the selector on the next `get_all_models()` call since their base models are back in `base_model_lookup`.

### Manual Verification Performed

1. Used the [Ollama model card generator tool](https://openwebui.com/posts/ollama_model_card_generator_ee80d7a1) to create 150+ workspace models wrapping every Ollama base model.
2. Disabled the Ollama API in Admin Settings → Connections.
3. Verified via `GET /api/models` that **zero** Ollama-based workspace models appeared in the selector (down from 89).
4. Confirmed that one non-Ollama workspace model (`clone`) correctly remained visible.
5. Re-enabled the Ollama API and verified all workspace models reappeared with correct metadata.
6. Toggled individual workspace models off/on and confirmed they correctly disappear/reappear from the selector.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
