### PR TITLE
fix: workspace models bulk actions and search pagination

### DIFF
--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -228,51 +228,97 @@
 		await updateUserSettings(localStorage.token, { ui: $settings });
 	};
 
+	const fetchAllWorkspaceModels = async () => {
+		// Fetch all workspace models across every page
+		const allModels = [];
+		let currentPage = 1;
+		let fetchedTotal = 0;
+
+		while (true) {
+			const res = await getWorkspaceModels(
+				localStorage.token,
+				query,
+				viewOption,
+				selectedTag,
+				null,
+				null,
+				currentPage
+			);
+			if (!res || !res.items || res.items.length === 0) break;
+			allModels.push(...res.items);
+			fetchedTotal = res.total;
+			if (allModels.length >= fetchedTotal) break;
+			currentPage++;
+		}
+
+		return allModels;
+	};
+
+
+
 	const enableAllHandler = async () => {
-		const modelsToEnable = (models ?? []).filter((m) => !(m.is_active ?? true));
-		// Optimistic UI update
-		modelsToEnable.forEach((m) => (m.is_active = true));
+		const allModels = await fetchAllWorkspaceModels();
+		const modelsToEnable = allModels.filter((m) => !(m.is_active ?? true));
+		if (modelsToEnable.length === 0) return;
+		// Optimistic UI update for current page
+		(models ?? []).forEach((m) => (m.is_active = true));
 		models = models;
 		// Sync with server
 		await Promise.all(modelsToEnable.map((model) => toggleModelById(localStorage.token, model.id)));
+		await getModelList();
 	};
 
 	const disableAllHandler = async () => {
-		const modelsToDisable = (models ?? []).filter((m) => m.is_active ?? true);
-		// Optimistic UI update
-		modelsToDisable.forEach((m) => (m.is_active = false));
+		const allModels = await fetchAllWorkspaceModels();
+		const modelsToDisable = allModels.filter((m) => m.is_active ?? true);
+		if (modelsToDisable.length === 0) return;
+		// Optimistic UI update for current page
+		(models ?? []).forEach((m) => (m.is_active = false));
 		models = models;
 		// Sync with server
 		await Promise.all(
 			modelsToDisable.map((model) => toggleModelById(localStorage.token, model.id))
 		);
+		await getModelList();
 	};
 
 	const showAllHandler = async () => {
-		const modelsToShow = (models ?? []).filter((m) => m?.meta?.hidden === true);
-		// Optimistic UI update
-		modelsToShow.forEach((m) => {
+		const allModels = await fetchAllWorkspaceModels();
+		const modelsToShow = allModels.filter((m) => m?.meta?.hidden === true);
+		if (modelsToShow.length === 0) return;
+		// Optimistic UI update for current page
+		(models ?? []).forEach((m) => {
 			m.meta = { ...m.meta, hidden: false };
 		});
 		models = models;
 		// Sync with server
 		await Promise.all(
-			modelsToShow.map((model) => updateModelById(localStorage.token, model.id, model))
+			modelsToShow.map((model) => {
+				model.meta = { ...model.meta, hidden: false };
+				return updateModelById(localStorage.token, model.id, model);
+			})
 		);
+		await getModelList();
 		toast.success($i18n.t('All models are now visible'));
 	};
 
 	const hideAllHandler = async () => {
-		const modelsToHide = (models ?? []).filter((m) => !(m?.meta?.hidden ?? false));
-		// Optimistic UI update
-		modelsToHide.forEach((m) => {
+		const allModels = await fetchAllWorkspaceModels();
+		const modelsToHide = allModels.filter((m) => !(m?.meta?.hidden ?? false));
+		if (modelsToHide.length === 0) return;
+		// Optimistic UI update for current page
+		(models ?? []).forEach((m) => {
 			m.meta = { ...m.meta, hidden: true };
 		});
 		models = models;
 		// Sync with server
 		await Promise.all(
-			modelsToHide.map((model) => updateModelById(localStorage.token, model.id, model))
+			modelsToHide.map((model) => {
+				model.meta = { ...model.meta, hidden: true };
+				return updateModelById(localStorage.token, model.id, model);
+			})
 		);
+		await getModelList();
 		toast.success($i18n.t('All models are now hidden'));
 	};
 
@@ -453,6 +499,7 @@
 					on:input={() => {
 						clearTimeout(searchDebounceTimer);
 						searchDebounceTimer = setTimeout(() => {
+							page = 1;
 							getModelList();
 						}, 300);
 					}}
@@ -465,6 +512,7 @@
 							aria-label={$i18n.t('Clear search')}
 							on:click={() => {
 								query = '';
+								page = 1;
 								getModelList();
 							}}
 						>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes two pagination bugs in the Workspace Models page that cause bulk actions and search to only affect the current page of results.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a frontend behavioral fix.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or configuration. Uses existing paginated `getModelItems` API.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

---

## Summary

The Workspace Models page (`/workspace/models`) has two pagination bugs:

1. **Bulk actions only affect the current page** — "Enable All", "Disable All", "Show All", and "Hide All" only operate on models visible on the current page (~30 models). With 150+ workspace models spread across 5+ pages, clicking "Hide All" only hides the first 30 models.

2. **Search doesn't reset pagination** — If you're on page 3 and search for a model name (e.g., "Qwen"), the query is sent to the backend but with `page=3`, which may return zero results even though matching models exist on page 1.

## Problem → Root Cause → Fix

### Bug 1: Bulk Actions Pagination

**Problem:** Clicking "Hide All" (or any bulk action) only affects ~30 models instead of all workspace models.

**Root Cause:** All four bulk action handlers operate on the `models` variable, which only contains the current page of results (populated via paginated `getModelItems` API with `PAGE_ITEM_COUNT = 30`).

**Fix:** Added a `fetchAllWorkspaceModels()` helper that iterates through every page of the paginated API, collecting all workspace models. All four handlers now use this helper instead of the local `models` variable. After syncing with the server, each handler calls `getModelList()` to refresh the current page view.

### Bug 2: Search Pagination

**Problem:** Searching for a model while on page 2+ returns no results, even though matching models exist.

**Root Cause:** The search `on:input` handler calls `getModelList()` without resetting `page` to `1`. The API query is sent with the current page number, which may be beyond the result set for the filtered query.

**Fix:** Added `page = 1` before `getModelList()` in both the search input handler and the clear search button handler.

## Key Changes

```diff
--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte

+ // New helper: fetches ALL workspace models across every page
+ const fetchAllWorkspaceModels = async () => {
+     const allModels = [];
+     let currentPage = 1;
+     let fetchedTotal = 0;
+     while (true) {
+         const res = await getWorkspaceModels(localStorage.token, query, viewOption, selectedTag, null, null, currentPage);
+         if (!res || !res.items || res.items.length === 0) break;
+         allModels.push(...res.items);
+         fetchedTotal = res.total;
+         if (allModels.length >= fetchedTotal) break;
+         currentPage++;
+     }
+     return allModels;
+ };

  // Each handler now uses fetchAllWorkspaceModels() instead of local `models`
  const hideAllHandler = async () => {
-     const modelsToHide = (models ?? []).filter(...);
+     const allModels = await fetchAllWorkspaceModels();
+     const modelsToHide = allModels.filter(...);
+     if (modelsToHide.length === 0) return;
      ...
+     await getModelList();
  };

  // Search input now resets page
  on:input={() => {
      clearTimeout(searchDebounceTimer);
      searchDebounceTimer = setTimeout(() => {
+         page = 1;
          getModelList();
      }, 300);
  }}
```

# Changelog Entry

### Description

- Fixed two pagination bugs on the Workspace Models page: bulk actions (Enable/Disable/Show/Hide All) now correctly operate on all workspace models across every page, and search now resets to page 1 to ensure results are visible regardless of the current page.

### Fixed

- **Bulk actions pagination:** "Enable All", "Disable All", "Show All", and "Hide All" now fetch all workspace models across every page before applying the operation, instead of only affecting the ~30 models on the current page.
- **Search pagination:** Searching for a model now resets to page 1, ensuring results are returned even if the user was previously on a later page. Clearing the search also resets to page 1.

---

### Additional Information

- **Scope:** 1 file changed, 62 insertions, 14 deletions.
- **File:** `src/lib/components/workspace/Models.svelte` — the Workspace Models management page.
- **Risk:** Low. The `fetchAllWorkspaceModels()` helper reuses the existing paginated `getModelItems` API — no new backend endpoints. The search `page = 1` reset is a standard pagination pattern. Existing behavior for single-model toggle, individual model edit, and tag filtering is unaffected.
- **Performance note:** For the bulk actions, `fetchAllWorkspaceModels()` makes `ceil(total / 30)` sequential API calls to collect all models before batch-updating. For typical deployments (~50 models), this is 2 calls. For large deployments (~150+ models), this is 5-6 calls. A future optimization could add a dedicated backend bulk endpoint, but this approach is correct and practical for current scale.

### Manual Verification Performed

1. Created 150+ workspace models spanning 5+ pages.
2. Navigated to page 3, clicked "Hide All" — verified all models across all pages were hidden (not just page 3).
3. Clicked "Show All" — verified all models across all pages were restored.
4. Navigated to page 4, typed "Qwen" in search — verified matching models appeared (previously returned empty results from page 4).
5. Cleared search — verified results returned to page 1 showing all models.
6. Tested "Enable All" and "Disable All" — verified all models toggled across all pages.

### Screenshots or Videos

**Before (Hide All only affects current page — other pages still have visible models)**

**After (Hide All correctly hides models across all pages)**

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
