### PR TITLE
feat(workspace): searchable base model picker in model editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,10 @@ dist
 cypress/videos
 cypress/screenshots
 .vscode/settings.json
+
+# IDE's and Agents
+*.code-workspace
+.vscode/
+.cursor/
+.claude/
+.codex/

--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -29,6 +29,7 @@
 	export let deleteModelHandler: (model: any) => void = () => {};
 
 	export let onClick: () => void = () => {};
+	export let selectionOnly = false;
 
 	const copyLinkHandler = async (model) => {
 		const baseUrl = window.location.origin;
@@ -237,46 +238,48 @@
 	</div>
 
 	<div class="ml-auto pl-2 pr-1 flex items-center gap-1.5 shrink-0">
-		{#if $user?.role === 'admin' && item.model.loaded}
-			<Tooltip
-				content={`${$i18n.t('Eject')}`}
-				className="flex-shrink-0 group-hover/item:opacity-100 opacity-0 "
+		{#if !selectionOnly}
+			{#if $user?.role === 'admin' && item.model.loaded}
+				<Tooltip
+					content={`${$i18n.t('Eject')}`}
+					className="flex-shrink-0 group-hover/item:opacity-100 opacity-0 "
+				>
+					<button
+						class="flex"
+						aria-label={$i18n.t('Eject model')}
+						on:click={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							unloadModelHandler(item.value);
+						}}
+					>
+						<ArrowUpTray className="size-3" />
+					</button>
+				</Tooltip>
+			{/if}
+
+			<ModelItemMenu
+				bind:show={showMenu}
+				model={item.model}
+				{pinModelHandler}
+				{deleteModelHandler}
+				copyLinkHandler={() => {
+					copyLinkHandler(item.model);
+				}}
 			>
 				<button
+					aria-label={`${$i18n.t('More Options')}`}
 					class="flex"
-					aria-label={$i18n.t('Eject model')}
 					on:click={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
-						unloadModelHandler(item.value);
+						showMenu = !showMenu;
 					}}
 				>
-					<ArrowUpTray className="size-3" />
+					<EllipsisHorizontal />
 				</button>
-			</Tooltip>
+			</ModelItemMenu>
 		{/if}
-
-		<ModelItemMenu
-			bind:show={showMenu}
-			model={item.model}
-			{pinModelHandler}
-			{deleteModelHandler}
-			copyLinkHandler={() => {
-				copyLinkHandler(item.model);
-			}}
-		>
-			<button
-				aria-label={`${$i18n.t('More Options')}`}
-				class="flex"
-				on:click={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					showMenu = !showMenu;
-				}}
-			>
-				<EllipsisHorizontal />
-			</button>
-		</ModelItemMenu>
 
 		{#if value === item.value}
 			<div>

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -59,6 +59,9 @@
 	export let triggerClassName = 'text-lg';
 
 	export let pinModelHandler: (modelId: string) => void = () => {};
+	export let selectionOnly = false;
+	export let ariaInvalid = false;
+	export let ariaDescribedBy = '';
 
 	let tagsContainerElement;
 
@@ -398,7 +401,7 @@
 		}
 	});
 
-	$: if (show) {
+	$: if (show && !selectionOnly) {
 		setOllamaVersion();
 	}
 
@@ -511,8 +514,11 @@
 		aria-label={selectedModel
 			? $i18n.t('Selected model: {{modelName}}', { modelName: selectedModel.label })
 			: placeholder}
+		role="combobox"
 		aria-haspopup="listbox"
 		aria-expanded={show}
+		aria-invalid={ariaInvalid ? 'true' : undefined}
+		aria-describedby={ariaDescribedBy || undefined}
 		id="model-selector-{id}-button"
 		type="button"
 		on:click={toggleOpen}
@@ -523,12 +529,14 @@
 				? 'dark:placeholder-gray-100 placeholder-gray-800'
 				: 'placeholder-gray-400'}"
 			on:mouseenter={async () => {
-				models.set(
-					await getModels(
-						localStorage.token,
-						$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
-					)
-				);
+				if (!selectionOnly) {
+					models.set(
+						await getModels(
+							localStorage.token,
+							$config?.features?.enable_direct_connections && ($settings?.directConnections ?? null)
+						)
+					);
+				}
 			}}
 		>
 			{#if selectedModel}
@@ -735,6 +743,7 @@
 								{#each filteredItems.slice(visibleStart, visibleEnd) as item, i (item.value)}
 									{@const index = visibleStart + i}
 									<ModelItem
+										{selectionOnly}
 										{selectedModelIdx}
 										{item}
 										{index}
@@ -745,7 +754,6 @@
 										onClick={() => {
 											value = item.value;
 											selectedModelIdx = index;
-
 											show = false;
 										}}
 									/>
@@ -754,7 +762,7 @@
 							</div>
 						{/if}
 
-						{#if !(searchValue.trim() in $MODEL_DOWNLOAD_POOL) && searchValue && ollamaVersion && $user?.role === 'admin'}
+						{#if !selectionOnly && !(searchValue.trim() in $MODEL_DOWNLOAD_POOL) && searchValue && ollamaVersion && $user?.role === 'admin'}
 							<Tooltip
 								content={$i18n.t(`Pull "{{searchValue}}" from Ollama.com`, {
 									searchValue: searchValue
@@ -776,67 +784,69 @@
 							</Tooltip>
 						{/if}
 
-						{#each Object.keys($MODEL_DOWNLOAD_POOL) as model}
-							<div
-								class="flex w-full justify-between font-medium select-none rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-hidden transition-all duration-75 rounded-xl cursor-pointer data-highlighted:bg-muted"
-							>
-								<div class="flex">
-									<div class="mr-2.5 translate-y-0.5">
-										<Spinner />
-									</div>
-
-									<div class="flex flex-col self-start">
-										<div class="flex gap-1">
-											<div class="line-clamp-1">
-												Downloading "{model}"
-											</div>
-
-											<div class="shrink-0">
-												{'pullProgress' in $MODEL_DOWNLOAD_POOL[model]
-													? `(${$MODEL_DOWNLOAD_POOL[model].pullProgress}%)`
-													: ''}
-											</div>
+						{#if !selectionOnly}
+							{#each Object.keys($MODEL_DOWNLOAD_POOL) as model}
+								<div
+									class="flex w-full justify-between font-medium select-none rounded-button py-2 pl-3 pr-1.5 text-sm text-gray-700 dark:text-gray-100 outline-hidden transition-all duration-75 rounded-xl cursor-pointer data-highlighted:bg-muted"
+								>
+									<div class="flex">
+										<div class="mr-2.5 translate-y-0.5">
+											<Spinner />
 										</div>
 
-										{#if 'digest' in $MODEL_DOWNLOAD_POOL[model] && $MODEL_DOWNLOAD_POOL[model].digest}
-											<div class="-mt-1 h-fit text-[0.7rem] dark:text-gray-500 line-clamp-1">
-												{$MODEL_DOWNLOAD_POOL[model].digest}
+										<div class="flex flex-col self-start">
+											<div class="flex gap-1">
+												<div class="line-clamp-1">
+													Downloading "{model}"
+												</div>
+
+												<div class="shrink-0">
+													{'pullProgress' in $MODEL_DOWNLOAD_POOL[model]
+														? `(${$MODEL_DOWNLOAD_POOL[model].pullProgress}%)`
+														: ''}
+												</div>
 											</div>
-										{/if}
+
+											{#if 'digest' in $MODEL_DOWNLOAD_POOL[model] && $MODEL_DOWNLOAD_POOL[model].digest}
+												<div class="-mt-1 h-fit text-[0.7rem] dark:text-gray-500 line-clamp-1">
+													{$MODEL_DOWNLOAD_POOL[model].digest}
+												</div>
+											{/if}
+										</div>
+									</div>
+
+									<div class="mr-2 ml-1 translate-y-0.5">
+										<Tooltip content={$i18n.t('Cancel')}>
+											<button
+												class="text-gray-800 dark:text-gray-100"
+												aria-label={$i18n.t('Cancel download of {{model}}', { model: model })}
+												on:click={() => {
+													cancelModelPullHandler(model);
+												}}
+											>
+												<svg
+													class="w-4 h-4 text-gray-800 dark:text-white"
+													aria-hidden="true"
+													xmlns="http://www.w3.org/2000/svg"
+													width="24"
+													height="24"
+													fill="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path
+														stroke="currentColor"
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M6 18 17.94 6M18 18 6.06 6"
+													/>
+												</svg>
+											</button>
+										</Tooltip>
 									</div>
 								</div>
-
-								<div class="mr-2 ml-1 translate-y-0.5">
-									<Tooltip content={$i18n.t('Cancel')}>
-										<button
-											class="text-gray-800 dark:text-gray-100"
-											aria-label={$i18n.t('Cancel download of {{model}}', { model: model })}
-											on:click={() => {
-												cancelModelPullHandler(model);
-											}}
-										>
-											<svg
-												class="w-4 h-4 text-gray-800 dark:text-white"
-												aria-hidden="true"
-												xmlns="http://www.w3.org/2000/svg"
-												width="24"
-												height="24"
-												fill="currentColor"
-												viewBox="0 0 24 24"
-											>
-												<path
-													stroke="currentColor"
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M6 18 17.94 6M18 18 6.06 6"
-												/>
-											</svg>
-										</button>
-									</Tooltip>
-								</div>
-							</div>
-						{/each}
+							{/each}
+						{/if}
 					</div>
 
 					<div class="pb-2.5"></div>

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -26,6 +26,13 @@
 	import DefaultFeatures from './DefaultFeatures.svelte';
 	import BuiltinTools from './BuiltinTools.svelte';
 	import PromptSuggestions from './PromptSuggestions.svelte';
+	import Selector from '$lib/components/chat/ModelSelector/Selector.svelte';
+	import {
+		buildBaseModelPickerItems,
+		fromBaseModelSelectorValue,
+		normalizeSavedBaseModelId,
+		toBaseModelSelectorValue
+	} from './baseModelPicker';
 	import TerminalSelector from './TerminalSelector.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
@@ -108,6 +115,15 @@
 	let terminalId = '';
 	let tts = { voice: '' };
 
+	let baseModelSelectorValue = '';
+	let baseModelValidationError = false;
+
+	$: baseModelPickerContext = { editingModelId: model?.id ?? null };
+	$: baseModelItems = buildBaseModelPickerItems($models, baseModelPickerContext);
+	$: info.base_model_id = fromBaseModelSelectorValue(baseModelSelectorValue);
+	$: if (baseModelSelectorValue) {
+		baseModelValidationError = false;
+	}
 	const submitHandler = async () => {
 		loading = true;
 
@@ -124,6 +140,15 @@
 		if (name === '') {
 			toast.error($i18n.t('Model Name is required.'));
 			loading = false;
+
+			return;
+		}
+
+		if (preset && !info.base_model_id) {
+			baseModelValidationError = true;
+			toast.error($i18n.t('Select a base model'));
+			loading = false;
+			document.getElementById('model-selector-workspace-base-model-button')?.focus();
 
 			return;
 		}
@@ -278,17 +303,11 @@
 			enableDescription = model?.meta?.description !== null;
 
 			if (model.base_model_id) {
-				const base_model = $models
-					.filter((m) => !m?.preset && !(m?.arena ?? false))
-					.find((m) => [model.base_model_id, `${model.base_model_id}:latest`].includes(m.id));
-
-				console.log('base_model', base_model);
-
-				if (base_model) {
-					model.base_model_id = base_model.id;
-				} else {
-					model.base_model_id = null;
-				}
+				model.base_model_id = normalizeSavedBaseModelId(
+					model.base_model_id,
+					$models,
+					baseModelPickerContext
+				);
 			}
 
 			system = model?.params?.system ?? '';
@@ -348,7 +367,7 @@
 				)
 			};
 
-			console.log(model);
+			baseModelSelectorValue = toBaseModelSelectorValue(info.base_model_id);
 		}
 
 		loaded = true;
@@ -608,19 +627,27 @@
 									</div>
 
 									<div>
-										<select
-											class="text-sm w-full bg-transparent outline-hidden"
-											placeholder={$i18n.t('Select a base model (e.g. llama3, gpt-4o)')}
-											bind:value={info.base_model_id}
-											required
-										>
-											<option value={null} class=" text-gray-900"
-												>{$i18n.t('Select a base model')}</option
+										<Selector
+											id="workspace-base-model"
+											bind:value={baseModelSelectorValue}
+											items={baseModelItems}
+											placeholder={$i18n.t('Select a base model')}
+											searchPlaceholder={$i18n.t('Search a model')}
+											className="w-[32rem]"
+											triggerClassName="text-sm"
+											selectionOnly
+											ariaInvalid={baseModelValidationError}
+											ariaDescribedBy={baseModelValidationError ? 'workspace-base-model-error' : ''}
+										/>
+										{#if baseModelValidationError}
+											<div
+												id="workspace-base-model-error"
+												class="text-xs text-red-500 mt-1"
+												role="alert"
 											>
-											{#each $models.filter((m) => (model ? m.id !== model.id : true) && !m?.preset && m?.owned_by !== 'arena' && !(m?.direct ?? false)) as model}
-												<option value={model.id} class=" text-gray-900">{model.name}</option>
-											{/each}
-										</select>
+												{$i18n.t('Select a base model')}
+											</div>
+										{/if}
 									</div>
 								</div>
 							{/if}

--- a/src/lib/components/workspace/Models/baseModelPicker.test.ts
+++ b/src/lib/components/workspace/Models/baseModelPicker.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	BASE_MODEL_PICKER_LAYER_B_DECISION,
+	buildBaseModelPickerItems,
+	fromBaseModelSelectorValue,
+	isEligibleBaseModel,
+	normalizeSavedBaseModelId,
+	toBaseModelSelectorValue
+} from './baseModelPicker';
+
+const baseModel = (overrides: Record<string, unknown> = {}) =>
+	({
+		id: 'gpt-4o',
+		name: 'GPT-4o',
+		owned_by: 'openai',
+		...overrides
+	}) as Parameters<typeof isEligibleBaseModel>[0];
+
+describe('baseModelPicker eligibility', () => {
+	it('includes a standard external model', () => {
+		expect(isEligibleBaseModel(baseModel())).toBe(true);
+	});
+
+	it('excludes the workspace model currently being edited', () => {
+		expect(
+			isEligibleBaseModel(baseModel({ id: 'my-preset' }), { editingModelId: 'my-preset' })
+		).toBe(false);
+	});
+
+	it('excludes preset, arena, and direct models', () => {
+		expect(isEligibleBaseModel(baseModel({ preset: true }))).toBe(false);
+		expect(isEligibleBaseModel(baseModel({ arena: true }))).toBe(false);
+		expect(isEligibleBaseModel(baseModel({ owned_by: 'arena' }))).toBe(false);
+		expect(isEligibleBaseModel(baseModel({ direct: true }))).toBe(false);
+	});
+});
+
+describe('baseModelPicker value bridge', () => {
+	it('maps nullish ids to an empty selector value', () => {
+		expect(toBaseModelSelectorValue(null)).toBe('');
+		expect(toBaseModelSelectorValue(undefined)).toBe('');
+		expect(toBaseModelSelectorValue('openrouter/owl-alpha')).toBe('openrouter/owl-alpha');
+	});
+
+	it('maps empty selector values back to null', () => {
+		expect(fromBaseModelSelectorValue('')).toBe(null);
+		expect(fromBaseModelSelectorValue('openrouter/owl-alpha')).toBe('openrouter/owl-alpha');
+	});
+});
+
+describe('baseModelPicker normalization', () => {
+	const catalog = [
+		baseModel({ id: 'llama3', name: 'Llama 3' }),
+		baseModel({ id: 'llama3:latest', name: 'Llama 3 Latest' }),
+		baseModel({ id: 'my-preset', name: 'My Preset', preset: true })
+	];
+
+	it('resolves :latest aliases against eligible models', () => {
+		expect(normalizeSavedBaseModelId('llama3', catalog)).toBe('llama3');
+		expect(normalizeSavedBaseModelId('llama3:latest', catalog)).toBe('llama3:latest');
+	});
+
+	it('clears saved ids that are no longer eligible', () => {
+		expect(normalizeSavedBaseModelId('my-preset', catalog)).toBe(null);
+		expect(normalizeSavedBaseModelId('missing-model', catalog)).toBe(null);
+	});
+});
+
+describe('baseModelPicker items', () => {
+	it('builds selector items from eligible models only', () => {
+		const items = buildBaseModelPickerItems(
+			[
+				baseModel({ id: 'a', name: 'Alpha' }),
+				baseModel({ id: 'b', name: 'Beta', direct: true }),
+				baseModel({ id: 'c', name: 'Current' })
+			],
+			{ editingModelId: 'c' }
+		);
+
+		expect(items).toEqual([
+			{
+				value: 'a',
+				label: 'Alpha',
+				model: expect.objectContaining({ id: 'a' })
+			}
+		]);
+	});
+});
+
+describe('baseModelPicker layer B gate', () => {
+	it('records a no-go decision until connection identity exists in model payloads', () => {
+		expect(BASE_MODEL_PICKER_LAYER_B_DECISION).toBe('no-go');
+	});
+});

--- a/src/lib/components/workspace/Models/baseModelPicker.ts
+++ b/src/lib/components/workspace/Models/baseModelPicker.ts
@@ -1,0 +1,53 @@
+import type { Model } from '$lib/stores';
+
+export type BaseModelPickerContext = {
+	editingModelId?: string | null;
+};
+
+/**
+ * Layer B metadata gate: model payloads expose connection_type, owned_by, direct,
+ * name, id, and tags. There is no verified per-connection display name on the model
+ * object, so connection-name-level grouping requires a separate API/store contract.
+ * Degraded owner/type grouping would add little beyond existing Selector chips.
+ */
+export const BASE_MODEL_PICKER_LAYER_B_DECISION = 'no-go' as const;
+
+export const isEligibleBaseModel = (
+	candidate: Model,
+	context: BaseModelPickerContext = {}
+): boolean =>
+	(!context.editingModelId || candidate.id !== context.editingModelId) &&
+	!candidate?.preset &&
+	!(candidate?.arena ?? false) &&
+	candidate?.owned_by !== 'arena' &&
+	!(candidate?.direct ?? false);
+
+export const toBaseModelSelectorValue = (baseModelId: string | null | undefined): string =>
+	baseModelId ?? '';
+
+export const fromBaseModelSelectorValue = (value: string): string | null => value || null;
+
+export const normalizeSavedBaseModelId = (
+	savedId: string | null | undefined,
+	models: Model[],
+	context: BaseModelPickerContext = {}
+): string | null => {
+	if (!savedId) {
+		return null;
+	}
+
+	const match = models
+		.filter((candidate) => isEligibleBaseModel(candidate, context))
+		.find((candidate) => [savedId, `${savedId}:latest`].includes(candidate.id));
+
+	return match?.id ?? null;
+};
+
+export const buildBaseModelPickerItems = (models: Model[], context: BaseModelPickerContext = {}) =>
+	models
+		.filter((candidate) => isEligibleBaseModel(candidate, context))
+		.map((candidate) => ({
+			value: candidate.id,
+			label: candidate.name,
+			model: candidate
+		}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
@@ -28,5 +28,8 @@ export default defineConfig({
 	},
 	esbuild: {
 		pure: process.env.ENV === 'dev' ? [] : ['console.log', 'console.debug', 'console.error']
+	},
+	test: {
+		include: ['src/**/*.{test,spec}.{js,ts}']
 	}
 });


### PR DESCRIPTION
## Summary

- Adds a `selectionOnly` mode to the shared chat `Selector` / `ModelItem` so embedded pickers get search, keyboard navigation, and filters without chat-side model management actions or global model-store refresh.
- Replaces the Workspace preset editor native `<select>` with that picker, unifies base-model eligibility/normalization, and restores required-field validation with accessible error feedback.
- Adds focused unit tests for base-model picker helpers.

Fully addresses the unified searchable picker request in #24576. Partially addresses provider-context concerns tracked in #21501 / discussion #21502, #18719, and #19033 — Layer B (grouping/deduplication) is deferred pending connection identity in model payloads (`BASE_MODEL_PICKER_LAYER_B_DECISION = no-go` in `baseModelPicker.ts`).

## Approach

- `selectionOnly` suppresses hover refresh, Ollama pull UI, eject, and item menus while keeping search and Local/External/Direct filters.
- Workspace uses `baseModelPicker.ts` helpers for eligibility, `:latest` normalization, and null/string bridging.
- Failed preset validation sets `aria-invalid`, shows an inline error, and focuses the combobox trigger.

## Test plan

- [x] `npm run test:frontend -- --run` (9 tests in `baseModelPicker.test.ts`)
- [x] `npm run build`
- [ ] Manual: `/workspace/models` create/edit preset — search, select, save round-trips `base_model_id`
- [ ] Manual: chat model picker still shows pin/delete/pull actions
- [ ] Manual: mobile + keyboard (open, type, arrows, Enter, Escape)
- [ ] Source build: `docker build` from this branch (Docker daemon was unavailable in CI agent environment)

## Local testing with Portainer

Deploy from fork branch `feat/workspace-searchable-base-model-picker` with a source build (not `ghcr.io/open-webui/open-webui:main`):

```yaml
services:
  open-webui-picker-test:
    container_name: open-webui-picker-test
    build:
      context: .
      dockerfile: Dockerfile
    ports:
      - "11480:8080"
    environment:
      TZ: America/Los_Angeles
      OLLAMA_BASE_URLS: ""
      WEBUI_SECRET_KEY: ${WEBUI_SECRET_KEY:?Set a long random test-stack secret}
    volumes:
      - open-webui-picker-test-data:/app/backend/data
    extra_hosts:
      - host.docker.internal:host-gateway
    restart: unless-stopped

volumes:
  open-webui-picker-test-data:
```

Verify at `http://<host>:11480/workspace/models` that the base-model field is searchable.