### PR TITLE
fix: ignore IME enter in search input

### DIFF
--- a/src/lib/components/layout/Sidebar/SearchInput.svelte
+++ b/src/lib/components/layout/Sidebar/SearchInput.svelte
@@ -48,6 +48,21 @@
 	let loading = false;
 
 	let hovering = false;
+	let isComposing = false;
+	let compositionEndedAt = -2e8;
+
+	const inOrNearComposition = (event: KeyboardEvent) => {
+		if (isComposing || event.isComposing) {
+			return true;
+		}
+
+		if (Math.abs(event.timeStamp - compositionEndedAt) < 500) {
+			compositionEndedAt = -2e8;
+			return true;
+		}
+
+		return false;
+	};
 
 	let filteredOptions = options;
 	$: filteredOptions = options.filter((option) => {
@@ -228,8 +243,21 @@
 					focused = false;
 				}
 			}}
+			on:compositionstart={() => {
+				isComposing = true;
+			}}
+			on:compositionend={(e) => {
+				compositionEndedAt = e.timeStamp;
+				isComposing = false;
+			}}
 			on:keydown={(e) => {
 				if (e.key === 'Enter') {
+					if (inOrNearComposition(e)) {
+						e.preventDefault();
+						e.stopPropagation();
+						return;
+					}
+
 					if (filteredItems.length > 0) {
 						const itemElement = document.getElementById(`search-item-${selectedIdx}`);
 						itemElement.click();


### PR DESCRIPTION
Summary
- Track IME composition state in the sidebar/search input.
- Ignore and stop propagation for Enter while composition is active or has just ended.
- Keeps IME confirmation from selecting search options or bubbling to the search modal's Enter handler.

Tests
- git diff --check

Notes
- npm run check is blocked locally because this checkout has no node_modules and svelte-kit is not installed.
- npx prettier check is blocked locally because prettier-plugin-svelte is not installed in this checkout.