### PR TITLE
fix: ignore IME enter in search input

### DIFF
--- a/src/lib/components/layout/Sidebar/SearchInput.svelte
+++ b/src/lib/components/layout/Sidebar/SearchInput.svelte
@@ -48,6 +48,21 @@
 	let loading = false;
 
 	let hovering = false;
+	let isComposing = false;
+	let compositionEndedAt = -2e8;
+
+	const inOrNearComposition = (event: KeyboardEvent) => {
+		if (isComposing || event.isComposing) {
+			return true;
+		}
+
+		if (Math.abs(event.timeStamp - compositionEndedAt) < 500) {
+			compositionEndedAt = -2e8;
+			return true;
+		}
+
+		return false;
+	};
 
 	let filteredOptions = options;
 	$: filteredOptions = options.filter((option) => {
@@ -228,8 +243,21 @@
 					focused = false;
 				}
 			}}
+			on:compositionstart={() => {
+				isComposing = true;
+			}}
+			on:compositionend={(e) => {
+				compositionEndedAt = e.timeStamp;
+				isComposing = false;
+			}}
 			on:keydown={(e) => {
 				if (e.key === 'Enter') {
+					if (inOrNearComposition(e)) {
+						e.preventDefault();
+						e.stopPropagation();
+						return;
+					}
+
 					if (filteredItems.length > 0) {
 						const itemElement = document.getElementById(`search-item-${selectedIdx}`);
 						itemElement.click();


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to #26172.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Prevent the sidebar/search input from treating IME confirmation Enter presses as normal action keys.

### Added

- IME composition state tracking in the shared sidebar search input.

### Changed

- Enter is ignored and stopped while composition is active or has just ended, preventing search option selection or modal-level Enter handling during IME confirmation.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Relates to #26172: Japanese IME Enter confirmation in the search modal no longer starts a new chat or selects search actions.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Validation:
- `git diff --check`

Local blockers:
- `npm run check` is blocked in this checkout because dependencies are not installed and `svelte-kit` is unavailable.
- A local Prettier check is blocked because `prettier-plugin-svelte` is unavailable in this checkout.

### Screenshots or Videos

- Not included; this is a keyboard event handling fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.