### PR TITLE
perf: non-blocking model and tool server loading for unreachable connections

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -336,8 +336,10 @@ async def get_all_models(request: Request, user: UserModel | None = None):
 
     # Fan-out tag requests to every backend
     tasks = []
-    for idx, url in enumerate(await Config.get('ollama.base_urls', [])):
-        api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), idx, url)
+    base_urls = await Config.get('ollama.base_urls', [])
+    api_configs = await Config.get('ollama.api_configs', {})
+    for idx, url in enumerate(base_urls):
+        api_config = resolve_api_config(api_configs, idx, url)
         if not api_config:
             tasks.append(send_get_request(f'{url}/api/tags', user=user))
         elif api_config.get('enable', True):
@@ -347,12 +349,16 @@ async def get_all_models(request: Request, user: UserModel | None = None):
 
     responses = await asyncio.gather(*tasks)
 
+    # Track which backends failed so we can skip them for /api/ps
+    failed_idxs: set[int] = set()
+
     # Post-process each response: apply prefix_id, tags, model filtering
     for idx, response in enumerate(responses):
         if not response:
+            failed_idxs.add(idx)
             continue
-        url = (await Config.get('ollama.base_urls', []))[idx]
-        api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), idx, url)
+        url = base_urls[idx]
+        api_config = resolve_api_config(api_configs, idx, url)
 
         connection_type = api_config.get('connection_type', 'local')
         prefix_id = api_config.get('prefix_id')
@@ -374,7 +380,7 @@ async def get_all_models(request: Request, user: UserModel | None = None):
 
     # Annotate with expiry info from loaded-model state
     try:
-        loaded = await get_ollama_loaded_models(request, user=user)
+        loaded = await get_ollama_loaded_models(request, user=user, skip_idxs=failed_idxs)
         expires_map = {m['model']: m['expires_at'] for m in loaded['models'] if 'expires_at' in m}
         for m in models_dict['models']:
             if m['model'] in expires_map:
@@ -436,14 +442,20 @@ async def get_ollama_tags(
 async def get_ollama_loaded_models(
     request: Request,
     user=Depends(get_admin_user),
+    skip_idxs: set[int] | None = None,
 ) -> dict:
     """List models currently loaded in Ollama memory across all backends."""
     if not await Config.get('ollama.enable'):
         return {'models': []}
 
     tasks = []
-    for idx, url in enumerate(await Config.get('ollama.base_urls', [])):
-        api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), idx, url)
+    base_urls = await Config.get('ollama.base_urls', [])
+    api_configs = await Config.get('ollama.api_configs', {})
+    for idx, url in enumerate(base_urls):
+        if skip_idxs and idx in skip_idxs:
+            tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
+            continue
+        api_config = resolve_api_config(api_configs, idx, url)
         if not api_config:
             tasks.append(send_get_request(f'{url}/api/ps', user=user))
         elif api_config.get('enable', True):
@@ -456,7 +468,7 @@ async def get_ollama_loaded_models(
     for idx, response in enumerate(responses):
         if not response:
             continue
-        api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), idx, (await Config.get('ollama.base_urls', []))[idx])
+        api_config = resolve_api_config(api_configs, idx, base_urls[idx])
         prefix_id = api_config.get('prefix_id')
         if prefix_id:
             for m in response.get('models', []):

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1475,7 +1475,7 @@
 														($settings?.promptAutocomplete ?? false)}
 													generateAutoCompletion={async (text) => {
 														if (selectedModelIds.length === 0 || !selectedModelIds.at(0)) {
-															toast.error($i18n.t('Please select a model first.'));
+															return null;
 														}
 
 														const res = await generateAutoCompletion(

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -87,7 +87,7 @@
 		}
 	};
 
-	const setUserSettings = async (cb: () => Promise<void>) => {
+	const setUserSettings = async (cb?: () => Promise<void>) => {
 		let userSettings = await getUserSettings(localStorage.token).catch((error) => {
 			console.error(error);
 			return null;
@@ -209,13 +209,14 @@
 			checkLocalDBChats(),
 			setBanners().catch((e) => console.error('Failed to load banners:', e)),
 			setTools().catch((e) => console.error('Failed to load tools:', e)),
-			setUserSettings(async () => {
-				await Promise.all([
-					setModels().catch((e) => console.error('Failed to load models:', e)),
-					setToolServers().catch((e) => console.error('Failed to load tool servers:', e))
-				]);
-			}).catch((e) => console.error('Failed to load user settings:', e))
+			setUserSettings().catch((e) => console.error('Failed to load user settings:', e))
 		]);
+
+		// Load models and tool servers in the background — don't block page render.
+		// These contact external services (Ollama, OpenAI, tool servers, terminal
+		// servers) that may be slow or unreachable.
+		setModels().catch((e) => console.error('Failed to load models:', e));
+		setToolServers().catch((e) => console.error('Failed to load tool servers:', e));
 
 		// Helper function to check if the pressed keys match the shortcut definition
 		const isShortcutMatch = (event: KeyboardEvent, shortcut): boolean => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR fixes a performance issue where unreachable connections block the entire UI on page refresh for 5–20 seconds while the backend waits for connection timeouts.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a behavioral performance fix.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings. Uses smart defaults — the page renders immediately while models load asynchronously.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `perf`

---

## Summary

When connections that aren't reachable are toggled on in Admin Settings → Connections, refreshing Open WebUI causes a full UI lockup — a spinner blocks all page content and navigation for 5–20 seconds while the backend waits for connection timeouts to expire. The same problem occurs with unreachable tool servers and terminal servers.

This PR eliminates the lockup with four targeted changes that work together: make model and tool server loading non-blocking on the frontend, skip redundant backend timeout rounds for already-failed connections, and silence a toast notification that was surfacing during the transient loading state.

## Problem → Root Cause → Fix

### Why the UI locks up

The page load lifecycle chains through several `await` calls before setting `loaded = true`, which gates all page content. Two of these calls contact external services:

1. **`setModels()`** — fans out to all configured Ollama/OpenAI endpoints via `GET /api/models`
2. **`setToolServers()`** — contacts every configured tool server and terminal server

When any of these external services are unreachable, the backend waits up to 10 seconds per connection for timeouts. The frontend refuses to render **anything** until both complete — users see a spinner and can't navigate, read chat history, or interact with the UI at all.

**Worse for Ollama:** The Ollama router makes two sequential fan-out rounds — first to `/api/tags` (model listing), then to `/api/ps` (loaded models). If an Ollama backend is unreachable, both rounds hit the full 10-second timeout, totaling **~20 seconds** of blocking time. The second round (`/api/ps`) is purely redundant for backends that already failed in the first round — they're obviously still unreachable.

### The four fixes

**1. Non-blocking model and tool server loading (frontend)**

`setModels()` and `setToolServers()` were both `await`-ed inside the `Promise.all` chain that gates `loaded = true`. Moving them both out of the chain means the page renders immediately. Models populate the selector in the background when the fetch completes — the `$models` store starts empty and reactively updates when data arrives. The model selector already handles an empty array gracefully (shows a "Select a model" placeholder). Tool servers and terminal servers similarly populate their stores once their fetches complete.

**2. Skip `/api/ps` for failed Ollama backends (backend)**

After the `/api/tags` fan-out completes, the code now tracks which backend indices returned `None` (unreachable). This `failed_idxs` set is passed to `get_ollama_loaded_models()`, which skips `/api/ps` requests for those backends entirely. This eliminates a redundant second 10-second timeout for every unreachable Ollama connection, halving the worst-case backend latency from ~20s to ~10s.

As a side benefit, the `base_urls` and `api_configs` values are now fetched once and reused throughout the function instead of making redundant `Config.get()` calls in each loop iteration.

**3. Silence autocomplete toast during loading (frontend)**

The `generateAutoCompletion` callback in `MessageInput.svelte` checks if a model is selected before requesting a completion. With non-blocking loading, models haven't arrived yet when the input gets focus, so `selectedModelIds` is empty. The old code showed a `toast.error('Please select a model first.')` — which is incorrect because the user hasn't done anything wrong; models are just still loading. Changed to `return null` to silently skip autocomplete until models are available.

## Key Changes

### `src/routes/(app)/+layout.svelte`

```diff
 await Promise.all([
     checkLocalDBChats(),
     setBanners().catch(…),
     setTools().catch(…),
-    setUserSettings(async () => {
-        await Promise.all([
-            setModels().catch(…),
-            setToolServers().catch(…)
-        ]);
-    }).catch(…)
+    setUserSettings().catch(…)
 ]);

+// Load models and tool servers in the background — don't block page render.
+// These contact external services (Ollama, OpenAI, tool servers, terminal
+// servers) that may be slow or unreachable.
+setModels().catch(…);
+setToolServers().catch(…);
+
 await tick();
 loaded = true;
```

### `backend/open_webui/routers/ollama.py`

```diff
 responses = await asyncio.gather(*tasks)

+# Track which backends failed so we can skip them for /api/ps
+failed_idxs: set[int] = set()
+
 for idx, response in enumerate(responses):
     if not response:
+        failed_idxs.add(idx)
         continue

 # ...

-loaded = await get_ollama_loaded_models(request, user=user)
+loaded = await get_ollama_loaded_models(request, user=user, skip_idxs=failed_idxs)
```

```diff
 async def get_ollama_loaded_models(
     request: Request,
     user=Depends(get_admin_user),
+    skip_idxs: set[int] | None = None,
 ) -> dict:

     for idx, url in enumerate(base_urls):
+        if skip_idxs and idx in skip_idxs:
+            tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
+            continue
```

### `src/lib/components/chat/MessageInput.svelte`

```diff
 generateAutoCompletion={async (text) => {
     if (selectedModelIds.length === 0 || !selectedModelIds.at(0)) {
-        toast.error($i18n.t('Please select a model first.'));
+        return null;
     }
```

# Changelog Entry

### Description

- Unreachable connections or tool servers no longer block the entire UI on page refresh. The page renders immediately while models and tool servers load asynchronously in the background.

### Fixed

- **UI lockup on page load with unreachable connections:** The `loaded` gate in the app layout no longer waits for model fetching or tool server initialization to complete. Both load in the background and populate their stores when available, eliminating a 5–20 second full-UI spinner.
- **UI lockup on page load with unreachable tool/terminal servers:** `setToolServers()` was also inside the `loaded` gate and contacts external tool servers and terminal servers. It is now fire-and-forget, same as `setModels()`.
- **Redundant Ollama timeout for unreachable backends:** When an Ollama backend fails to respond to `/api/tags`, the subsequent `/api/ps` fan-out now skips that backend entirely, halving the worst-case backend latency for unreachable Ollama connections (~20s → ~10s).
- **Spurious "Please select a model first" toast:** The prompt autocomplete callback now returns `null` silently when no model is selected (transient state during background model loading) instead of showing an error toast that the user cannot act on.

---

### Additional Information

- **Scope:** 3 files changed, 29 insertions, 16 deletions.
- **Files:**
  - `src/routes/(app)/+layout.svelte` — `onMount` initialization chain (both `setModels` and `setToolServers` moved out of `loaded` gate)
  - `backend/open_webui/routers/ollama.py` — `get_all_models` and `get_ollama_loaded_models`
  - `src/lib/components/chat/MessageInput.svelte` — `generateAutoCompletion` callback
- **Risk:** Low. The model selector already handles an empty `$models` array gracefully (placeholder text). Tool servers populate their stores asynchronously — the UI renders correctly without them and updates reactively when they arrive. The backend change only affects the internal `get_all_models → get_ollama_loaded_models` call path — the `/api/ps` REST endpoint is unaffected (the new `skip_idxs` parameter defaults to `None`). The toast change only affects the no-model transient state during loading.
- **No new settings:** The fix uses smart defaults. Users with all-reachable connections will notice no difference — `setModels()` and `setToolServers()` complete near-instantly so everything appears before the user can interact. Users with unreachable connections or tool servers get an immediately-responsive page instead of a multi-second spinner.

### Manual Verification Performed

1. Added an unreachable Ollama connection (e.g., `http://192.0.2.1:11434`) in Admin Settings → Connections.
2. Refreshed the page — verified the UI renders immediately with no spinner lockup.
3. Verified the model selector populates once reachable connections respond.
4. Verified navigation between pages works during model loading.
5. Verified no "Please select a model first" toast appears during page refresh or when opening the model selector.
6. Removed the unreachable connection — verified no behavior change from baseline (models appear instantly as before).
7. Ran `npm run build` — clean with no errors.

### Screenshots or Videos

**Before (unreachable connection enabled — full UI lockup with spinner):**

[Screencast from 2026-06-24 12-37-38.webm](https://github.com/user-attachments/assets/9d40943e-e136-4ee4-8bb5-3e647cc1ffc8)

**After (unreachable connection enabled — page renders immediately):**

[Screencast from 2026-06-24 12-40-19.webm](https://github.com/user-attachments/assets/118f3cb2-001c-452f-9075-34718ed8ac32)

> Yes, I did fix the notification toast issue seen at the end of the "after" video in this PR as well.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.