### PR TITLE
fix(middleware): decouple outlet filters using strong-referenced async tasks to fix streaming latency

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -130,6 +130,9 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 
+# Global set holding strong references to fire-and-forget background tasks.
+# Prevents Python's GC from reclaiming Task objects before they complete.
+BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 # We believe in one maker of all models, seen and unseen,
 # and in the reasoning which proceeds from the architect.
@@ -3421,6 +3424,23 @@ async def outlet_filter_handler(ctx):
         log.debug(f'Error running outlet filters: {e}')
 
 
+async def _run_post_stream_tasks(ctx: dict) -> None:
+    """Run outlet filter + background tasks without blocking the HTTP response.
+
+    Intended to be invoked via ``asyncio.create_task()`` or as a
+    ``StreamingResponse`` background callback so the initial real-time
+    chunk delivery is never delayed.
+    """
+    chat_id = ctx.get('metadata', {}).get('chat_id', 'unknown')
+    print(f'🚀 [BACKGROUND_TASK] Started post-stream processing for chat: {chat_id}')
+    try:
+        await outlet_filter_handler(ctx)
+        await background_tasks_handler(ctx)
+        print(f'✅ [BACKGROUND_TASK] Successfully completed all post-stream tasks for chat: {chat_id}')
+    except Exception as e:
+        print(f'❌ [BACKGROUND_TASK] Error encountered during post-stream tasks for chat {chat_id}: {e}')
+
+
 async def non_streaming_chat_response_handler(response, ctx):
     request = ctx['request']
 
@@ -3552,8 +3572,12 @@ async def non_streaming_chat_response_handler(response, ctx):
                         'output': response_output,
                         **({'usage': usage} if usage else {}),
                     }
-                    await outlet_filter_handler(ctx)
-                    await background_tasks_handler(ctx)
+                    # Fire post-stream tasks without blocking the HTTP response.
+                    # Keep a strong reference in BACKGROUND_TASKS to prevent GC
+                    # from reclaiming the un-awaited Task under high concurrency.
+                    _task = asyncio.create_task(_run_post_stream_tasks(ctx))
+                    BACKGROUND_TASKS.add(_task)
+                    _task.add_done_callback(BACKGROUND_TASKS.discard)
 
             response = build_response_object(response, merge_events_into_response(response_data, events))
         except Exception as e:
@@ -5173,8 +5197,12 @@ async def streaming_chat_response_handler(response, ctx):
                     'output': output,
                     **({'usage': usage} if usage else {}),
                 }
-                await outlet_filter_handler(ctx)
-                await background_tasks_handler(ctx)
+                # Fire post-stream tasks without blocking the HTTP response.
+                # Keep a strong reference in BACKGROUND_TASKS to prevent GC
+                # from reclaiming the un-awaited Task under high concurrency.
+                _task = asyncio.create_task(_run_post_stream_tasks(ctx))
+                BACKGROUND_TASKS.add(_task)
+                _task.add_done_callback(BACKGROUND_TASKS.discard)
             except asyncio.CancelledError:
                 log.warning('Task was cancelled!')
 
@@ -5249,10 +5277,19 @@ async def streaming_chat_response_handler(response, ctx):
                 if data:
                     yield data
 
+        # Chain the original background (if any) with post-stream tasks
+        # so outlet filters and background tasks still run for pure HTTP clients.
+        async def _combined_background():
+            try:
+                if response.background:
+                    await response.background()
+            finally:
+                await _run_post_stream_tasks(ctx)
+
         return StreamingResponse(
             stream_wrapper(response.body_iterator, events),
             headers=dict(response.headers),
-            background=response.background,
+            background=_combined_background,
         )
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to streaming performance and middleware buffering.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Verified existing documentation; no changes required for this internal refactor.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Manually tested in a PowerShell/Windows environment using live streaming and custom outlet filters. Checked concurrency and execution order via custom stdout telemetry.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Followed standard `asyncio` best practices for un-awaited fire-and-forget tasks using global strong references.
- [x] **Git Hygiene:** The PR is atomic and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description
Refactored the middleware's request-response lifecycle handler to completely decouple `outlet_filter_handler` and `background_tasks_handler` from the main streaming token yield path. Previously, outlet filters could cause significant latency or block immediate chunk-yielding to the client. They are now offloaded to a non-blocking background task.

### Added
- Implemented a module-level global set `BACKGROUND_TASKS: set[asyncio.Task]` to maintain **strong references** to fire-and-forget background tasks, preventing Python's Garbage Collector from prematurely destroying running tasks during high-concurrency requests.
- Added explicit telemetry logging statements (`[BACKGROUND_TASK]`) to trace async initialization and successful/failed completion cycles.

### Changed
- Refactored both `non_streaming_chat_response_handler` and `streaming_chat_response_handler` call sites to utilize `asyncio.create_task` wrapped with a safe `.add_done_callback(BACKGROUND_TASKS.discard)` for automated memory cleanup.
- Maintained inline `await` behavior exclusively for the `_combined_background` non-WebSocket fallback route where the framework natively retains references.

### Fixed
- Fixed initial response latency and chunk-buffering bugs introduced when executing blocking or heavy custom outlet pipeline filters during stream delivery.

---

### Additional Information
The implementation follows the official Python `asyncio` documentation standards regarding fire-and-forget task patterns to ensure memory safety without dropping context data or breaking database persistency hooks.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.