### PR TITLE
fix(web-search): prefer YDC_API_KEY for You.com (keep YOUCOM_API_KEY fallback)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1924,7 +1924,8 @@ YANDEX_WEB_SEARCH_CONFIG = ConfigVar(
 YOUCOM_API_KEY = ConfigVar(
     'YOUCOM_API_KEY',
     'rag.web.search.youcom_api_key',
-    os.getenv('YOUCOM_API_KEY', ''),
+    # YDC_API_KEY is You.com's canonical env var; YOUCOM_API_KEY kept as fallback.
+    os.getenv('YDC_API_KEY') or os.getenv('YOUCOM_API_KEY', ''),
 )
 
 LINKUP_API_KEY = ConfigVar(


### PR DESCRIPTION
## What

Make `YDC_API_KEY` the preferred environment variable for the You.com web search provider, keeping `YOUCOM_API_KEY` as a backward-compatible fallback.

## Why

`YDC_API_KEY` is You.com's canonical API key environment variable — it's what You.com's own docs, examples, and SDK use, along with the LangChain, CrewAI, and DSPy integrations. Open WebUI currently only reads `YOUCOM_API_KEY` from the environment, which is inconsistent with the rest of the ecosystem.

## Change

A single line in `backend/open_webui/config.py`:

```python
os.getenv('YDC_API_KEY') or os.getenv('YOUCOM_API_KEY', '')
```

`YDC_API_KEY` is used when set; otherwise `YOUCOM_API_KEY` is honored exactly as before.

## Compatibility

Intentionally minimal and non-breaking:
- The persisted config key (`rag.web.search.youcom_api_key`), the API/form field, and the admin UI binding are **unchanged**, so saved keys and existing setups keep working.
- Only the environment-variable lookup gains the canonical name.

Part of a cross-ecosystem standardization effort: youdotcom-oss/integration-tracking#30
