### PR TITLE
feat: add directory browsing and selection to knowledge pickers

### DIFF
--- a/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
+++ b/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
@@ -131,6 +131,15 @@
 								type: 'file',
 								data: data
 							});
+						} else if (type === 'knowledge-directory') {
+							insertTextHandler('');
+
+							for (const file of data.files ?? []) {
+								onUpload({
+									type: 'file',
+									data: file
+								});
+							}
 						} else if (type === 'web') {
 							insertTextHandler('');
 

--- a/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
+++ b/src/lib/components/chat/MessageInput/CommandSuggestionList.svelte
@@ -160,6 +160,15 @@
 								type: 'file',
 								data: data
 							});
+						} else if (type === 'knowledge-directory') {
+							insertTextHandler('');
+
+							for (const file of data.files ?? []) {
+								onUpload({
+									type: 'file',
+									data: file
+								});
+							}
 						} else if (type === 'web') {
 							insertTextHandler('');
 

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -8,7 +8,11 @@
 
 	import { folders } from '$lib/stores';
 	import { getFolders } from '$lib/apis/folders';
-	import { searchKnowledgeBases, searchKnowledgeFiles } from '$lib/apis/knowledge';
+	import {
+		searchKnowledgeBases,
+		searchKnowledgeFiles,
+		searchKnowledgeFilesById
+	} from '$lib/apis/knowledge';
 	import { removeLastWordFromString, isValidHttpUrl, isYoutubeUrl, decodeString } from '$lib/utils';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -17,6 +21,10 @@
 	import GlobeAlt from '$lib/components/icons/GlobeAlt.svelte';
 	import Youtube from '$lib/components/icons/Youtube.svelte';
 	import Folder from '$lib/components/icons/Folder.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -27,21 +35,51 @@
 	let items = [];
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
+	// --- Browsing state ---
+	let browsingCollection = null;
+	let currentDirectoryId = null; // null = root level of the KB
+	let browsingFiles = [];
+	let browsingDirectories = [];
+	let browsingBreadcrumbs = [];
+	let browsingLoading = false;
+
 	export let filteredItems = [];
-	$: filteredItems = [
-		...(query.startsWith('http')
-			? isYoutubeUrl(query)
-				? [{ type: 'youtube', name: query, description: query }]
-				: [
-						{
-							type: 'web',
-							name: query,
-							description: query
-						}
-					]
-			: []),
-		...items
-	];
+	$: {
+		if (browsingCollection) {
+			const dirItems = browsingDirectories.map((d) => ({
+				...d,
+				type: 'directory'
+			}));
+			const fItems = browsingFiles.map((f) => ({
+				...f,
+				type: 'file',
+				name: f?.meta?.name || f.filename
+			}));
+			const combined = [...dirItems, ...fItems];
+			// Always keep at least one placeholder so the dropdown stays visible
+			filteredItems =
+				combined.length > 0
+					? combined
+					: browsingLoading
+						? [{ type: 'browsing-loading', name: '' }]
+						: [{ type: 'browsing-empty', name: '' }];
+		} else {
+			filteredItems = [
+				...(query.startsWith('http')
+					? isYoutubeUrl(query)
+						? [{ type: 'youtube', name: query, description: query }]
+						: [
+								{
+									type: 'web',
+									name: query,
+									description: query
+								}
+							]
+					: []),
+				...items
+			];
+		}
+	}
 
 	$: if (query) {
 		selectedIdx = 0;
@@ -73,7 +111,11 @@
 	$: if (query !== undefined) {
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
-			getItems();
+			if (browsingCollection) {
+				loadBrowsingItems();
+			} else {
+				getItems();
+			}
 		}, 200);
 	}
 
@@ -130,6 +172,131 @@
 		}
 	};
 
+	// --- Browsing functions ---
+
+	const browseIntoCollection = async (collection) => {
+		browsingCollection = collection;
+		currentDirectoryId = null;
+		selectedIdx = 0;
+		await loadBrowsingItems();
+	};
+
+	const browseIntoDirectory = async (dir) => {
+		currentDirectoryId = dir.id;
+		selectedIdx = 0;
+		await loadBrowsingItems();
+	};
+
+	const navigateBack = async () => {
+		if (browsingBreadcrumbs.length > 0) {
+			// Go up one level — parent is the second-to-last breadcrumb
+			const parentCrumb =
+				browsingBreadcrumbs.length >= 2
+					? browsingBreadcrumbs[browsingBreadcrumbs.length - 2]
+					: null;
+			currentDirectoryId = parentCrumb ? parentCrumb.id : null;
+			selectedIdx = 0;
+			await loadBrowsingItems();
+		} else {
+			// Back to top-level view
+			browsingCollection = null;
+			currentDirectoryId = null;
+			browsingFiles = [];
+			browsingDirectories = [];
+			browsingBreadcrumbs = [];
+			selectedIdx = 0;
+		}
+	};
+
+	const loadBrowsingItems = async () => {
+		if (!browsingCollection) return;
+		browsingLoading = true;
+
+		const res = await searchKnowledgeFilesById(
+			localStorage.token,
+			browsingCollection.id,
+			query || null,
+			null,
+			null,
+			null,
+			1,
+			currentDirectoryId
+		).catch(() => null);
+
+		if (res) {
+			browsingFiles = res.items || [];
+			browsingDirectories = res.directories || [];
+			browsingBreadcrumbs = res.breadcrumbs || [];
+		}
+
+		browsingLoading = false;
+	};
+
+	const selectDirectory = async (dir) => {
+		// Fetch all files directly in this directory
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				browsingCollection.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		if (allFiles.length === 0) {
+			toast.info($i18n.t('No files in this directory.'));
+			return;
+		}
+
+		onSelect({
+			type: 'knowledge-directory',
+			data: {
+				files: allFiles.map((file) => ({
+					...file,
+					type: 'file',
+					name: file?.meta?.name || file.filename,
+					collection: { name: browsingCollection.name }
+				}))
+			}
+		});
+	};
+
+	const selectBrowsingFile = (file) => {
+		onSelect({
+			type: 'knowledge',
+			data: {
+				...file,
+				type: 'file',
+				name: file?.meta?.name || file.filename,
+				collection: { name: browsingCollection.name }
+			}
+		});
+	};
+
+	const selectEntireCollection = () => {
+		onSelect({
+			type: 'knowledge',
+			data: { ...browsingCollection, type: 'collection' }
+		});
+	};
+
+	// Derived: current location name for the header
+	$: currentLocationName =
+		browsingBreadcrumbs.length > 0
+			? browsingBreadcrumbs[browsingBreadcrumbs.length - 1]?.name
+			: (browsingCollection?.name ?? '');
+
 	onMount(async () => {
 		if ($folders === null) {
 			await folders.set(await getFolders(localStorage.token));
@@ -139,7 +306,161 @@
 	});
 </script>
 
-{#if filteredItems.length > 0 || query.startsWith('http')}
+{#if browsingCollection}
+	<!-- Browsing view: inside a knowledge base -->
+	<div class="px-2 py-1.5 flex items-center gap-1.5 border-b border-gray-100 dark:border-gray-800">
+		<button
+			type="button"
+			class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+			on:click={navigateBack}
+		>
+			<ArrowLeft className="size-3.5" strokeWidth="2" />
+		</button>
+
+		<div class="flex-1 min-w-0">
+			<div class="text-xs text-gray-500 dark:text-gray-400 truncate flex items-center gap-0.5">
+				<button
+					type="button"
+					class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+					on:click={() => {
+						if (browsingBreadcrumbs.length > 0) {
+							currentDirectoryId = null;
+							selectedIdx = 0;
+							loadBrowsingItems();
+						}
+					}}
+				>
+					{decodeString(browsingCollection?.name)}
+				</button>
+				{#each browsingBreadcrumbs as crumb, i}
+					<span class="flex-shrink-0">/</span>
+					<button
+						type="button"
+						class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+						on:click={() => {
+							currentDirectoryId = crumb.id;
+							selectedIdx = 0;
+							loadBrowsingItems();
+						}}
+					>
+						{crumb.name}
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<Tooltip
+			content={browsingBreadcrumbs.length > 0
+				? $i18n.t('Select directory')
+				: $i18n.t('Select collection')}
+			placement="top"
+		>
+			<button
+				type="button"
+				class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition opacity-60 hover:opacity-100"
+				on:click={() => {
+					if (browsingBreadcrumbs.length > 0) {
+						selectDirectory({
+							id: currentDirectoryId,
+							name: currentLocationName
+						});
+					} else {
+						selectEntireCollection();
+					}
+				}}
+			>
+				<Plus className="size-3.5" />
+			</button>
+		</Tooltip>
+	</div>
+
+	{#if browsingLoading}
+		<div class="flex justify-center py-3">
+			<Spinner className="size-3.5" />
+		</div>
+	{:else if browsingDirectories.length === 0 && browsingFiles.length === 0}
+		<div class="px-2 py-3 text-center text-xs text-gray-400 dark:text-gray-500 italic">
+			{$i18n.t('This directory is empty.')}
+		</div>
+	{:else}
+		{@const allBrowsingItems = [
+			...browsingDirectories.map((d) => ({ ...d, _itemType: 'directory' })),
+			...browsingFiles.map((f) => ({
+				...f,
+				_itemType: 'file',
+				name: f?.meta?.name || f.filename
+			}))
+		]}
+
+		{#each allBrowsingItems as item, idx}
+			{#if idx === 0 || item._itemType !== allBrowsingItems[idx - 1]?._itemType}
+				<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+					{#if item._itemType === 'directory'}
+						{$i18n.t('Directories')}
+					{:else}
+						{$i18n.t('Files')}
+					{/if}
+				</div>
+			{/if}
+
+			{#if item._itemType === 'directory'}
+				<div
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[13px] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+				>
+					<button
+						type="button"
+						class="flex min-w-0 flex-1 items-center gap-1.5 text-left text-black dark:text-gray-100"
+						data-selected={idx === selectedIdx}
+						on:click={() => browseIntoDirectory(item)}
+						on:mousemove={() => {
+							selectedIdx = idx;
+						}}
+					>
+						<Folder className="size-3.5" />
+						<Tooltip content={item.name} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">{item.name}</div>
+						</Tooltip>
+					</button>
+
+					<div class="ml-1 flex items-center gap-0.5">
+						<Tooltip content={$i18n.t('Select directory')} placement="top">
+							<button
+								type="button"
+								class="rounded p-0.5 opacity-40 transition hover:bg-gray-200 hover:opacity-100 dark:hover:bg-gray-700"
+								on:click|stopPropagation={() => selectDirectory(item)}
+							>
+								<Plus className="size-3" />
+							</button>
+						</Tooltip>
+						<ChevronRight className="size-3 opacity-30" />
+					</div>
+				</div>
+			{:else}
+				<button
+					class="flex h-[1.6875rem] w-full items-center gap-1.5 rounded-xl px-2 text-left text-[13px] text-black hover:bg-gray-50/40 dark:text-gray-100 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+					type="button"
+					data-selected={idx === selectedIdx}
+					on:click={() => selectBrowsingFile(item)}
+					on:mousemove={() => {
+						selectedIdx = idx;
+					}}
+				>
+					<DocumentPage className="size-3.5" />
+					<Tooltip content={decodeString(item.name)} placement="top-start">
+						<div class="min-w-0 flex-1 truncate">{decodeString(item.name)}</div>
+					</Tooltip>
+				</button>
+			{/if}
+		{/each}
+	{/if}
+{:else if filteredItems.length > 0 || query.startsWith('http')}
+	<!-- Top-level view -->
 	{#each filteredItems as item, idx}
 		{#if idx === 0 || item?.type !== items[idx - 1]?.type}
 			<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
@@ -154,51 +475,97 @@
 		{/if}
 
 		{#if !['youtube', 'web'].includes(item.type)}
-			<button
-				class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[13px] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
-				selectedIdx
-					? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
-					: ''}"
-				type="button"
-				on:click={() => {
-					console.log(item);
-					onSelect({
-						type: 'knowledge',
-						data: item
-					});
-				}}
-				on:mousemove={() => {
-					selectedIdx = idx;
-				}}
-				data-selected={idx === selectedIdx}
-			>
-				<div class="flex min-w-0 items-center gap-1.5 text-black dark:text-gray-100">
-					<Tooltip
-						content={item?.legacy
-							? $i18n.t('Legacy')
-							: item?.type === 'file'
-								? `${item?.collection?.name} > ${$i18n.t('File')}`
-								: item?.type === 'collection'
-									? $i18n.t('Collection')
-									: ''}
-						placement="top"
+			{#if item.type === 'collection'}
+				<div
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[13px] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+				>
+					<button
+						type="button"
+						class="flex min-w-0 flex-1 items-center gap-1.5 text-left text-black dark:text-gray-100"
+						data-selected={idx === selectedIdx}
+						on:click={() => browseIntoCollection(item)}
+						on:mousemove={() => {
+							selectedIdx = idx;
+						}}
 					>
-						{#if item?.type === 'collection'}
+						<Tooltip
+							content={item?.legacy ? $i18n.t('Legacy') : $i18n.t('Collection')}
+							placement="top"
+						>
 							<Database className="size-3.5" />
-						{:else if item?.type === 'folder'}
-							<Folder className="size-3.5" />
-						{:else}
-							<DocumentPage className="size-3.5" />
-						{/if}
-					</Tooltip>
+						</Tooltip>
 
-					<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
-						<div class="min-w-0 flex-1 truncate">
-							{decodeString(item?.name)}
-						</div>
-					</Tooltip>
+						<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">
+								{decodeString(item?.name)}
+							</div>
+						</Tooltip>
+					</button>
+
+					<div class="ml-1 flex items-center gap-0.5">
+						<Tooltip content={$i18n.t('Select collection')} placement="top">
+							<button
+								type="button"
+								class="rounded p-0.5 opacity-40 transition hover:bg-gray-200 hover:opacity-100 dark:hover:bg-gray-700"
+								on:click|stopPropagation={() => {
+									onSelect({
+										type: 'knowledge',
+										data: { ...item, type: 'collection' }
+									});
+								}}
+							>
+								<Plus className="size-3" />
+							</button>
+						</Tooltip>
+						<ChevronRight className="size-3 opacity-30" />
+					</div>
 				</div>
-			</button>
+			{:else}
+				<button
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[13px] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+					type="button"
+					on:click={() => {
+						console.log(item);
+						onSelect({
+							type: 'knowledge',
+							data: item
+						});
+					}}
+					on:mousemove={() => {
+						selectedIdx = idx;
+					}}
+					data-selected={idx === selectedIdx}
+				>
+					<div class="flex min-w-0 items-center gap-1.5 text-black dark:text-gray-100">
+						<Tooltip
+							content={item?.legacy
+								? $i18n.t('Legacy')
+								: item?.type === 'file'
+									? `${item?.collection?.name} > ${$i18n.t('File')}`
+									: ''}
+							placement="top"
+						>
+							{#if item?.type === 'folder'}
+								<Folder className="size-3.5" />
+							{:else}
+								<DocumentPage className="size-3.5" />
+							{/if}
+						</Tooltip>
+
+						<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">
+								{decodeString(item?.name)}
+							</div>
+						</Tooltip>
+					</div>
+				</button>
+			{/if}
 		{/if}
 	{/each}
 

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -8,7 +8,11 @@
 
 	import { folders } from '$lib/stores';
 	import { getFolders } from '$lib/apis/folders';
-	import { searchKnowledgeBases, searchKnowledgeFiles } from '$lib/apis/knowledge';
+	import {
+		searchKnowledgeBases,
+		searchKnowledgeFiles,
+		searchKnowledgeFilesById
+	} from '$lib/apis/knowledge';
 	import { removeLastWordFromString, isValidHttpUrl, isYoutubeUrl, decodeString } from '$lib/utils';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -17,6 +21,10 @@
 	import GlobeAlt from '$lib/components/icons/GlobeAlt.svelte';
 	import Youtube from '$lib/components/icons/Youtube.svelte';
 	import Folder from '$lib/components/icons/Folder.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -27,21 +35,49 @@
 	let items = [];
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 
+	let browsingCollection = null;
+	let currentDirectoryId = null;
+	let browsingFiles = [];
+	let browsingDirectories = [];
+	let browsingBreadcrumbs = [];
+	let browsingLoading = false;
+
 	export let filteredItems = [];
-	$: filteredItems = [
-		...(query.startsWith('http')
-			? isYoutubeUrl(query)
-				? [{ type: 'youtube', name: query, description: query }]
-				: [
-						{
-							type: 'web',
-							name: query,
-							description: query
-						}
-					]
-			: []),
-		...items
-	];
+	$: {
+		if (browsingCollection) {
+			const dirItems = browsingDirectories.map((d) => ({
+				...d,
+				type: 'directory'
+			}));
+			const fItems = browsingFiles.map((f) => ({
+				...f,
+				type: 'file',
+				name: f?.meta?.name || f.filename
+			}));
+			const combined = [...dirItems, ...fItems];
+			filteredItems =
+				combined.length > 0
+					? combined
+					: browsingLoading
+						? [{ type: 'browsing-loading', name: '' }]
+						: [{ type: 'browsing-empty', name: '' }];
+		} else {
+			filteredItems = [
+				...(query.startsWith('http')
+					? isYoutubeUrl(query)
+						? [{ type: 'youtube', name: query, description: query }]
+						: [
+								{
+									type: 'web',
+									name: query,
+									description: query
+								}
+							]
+					: []),
+				...items
+			];
+		}
+	}
 
 	$: if (query) {
 		selectedIdx = 0;
@@ -73,7 +109,11 @@
 	$: if (query !== undefined) {
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
-			getItems();
+			if (browsingCollection) {
+				loadBrowsingItems();
+			} else {
+				getItems();
+			}
 		}, 200);
 	}
 
@@ -130,6 +170,125 @@
 		}
 	};
 
+	const browseIntoCollection = async (collection) => {
+		browsingCollection = collection;
+		currentDirectoryId = null;
+		selectedIdx = 0;
+		await loadBrowsingItems();
+	};
+
+	const browseIntoDirectory = async (dir) => {
+		currentDirectoryId = dir.id;
+		selectedIdx = 0;
+		await loadBrowsingItems();
+	};
+
+	const navigateBack = async () => {
+		if (browsingBreadcrumbs.length > 0) {
+			const parentCrumb =
+				browsingBreadcrumbs.length >= 2
+					? browsingBreadcrumbs[browsingBreadcrumbs.length - 2]
+					: null;
+			currentDirectoryId = parentCrumb ? parentCrumb.id : null;
+			selectedIdx = 0;
+			await loadBrowsingItems();
+		} else {
+			browsingCollection = null;
+			currentDirectoryId = null;
+			browsingFiles = [];
+			browsingDirectories = [];
+			browsingBreadcrumbs = [];
+			selectedIdx = 0;
+		}
+	};
+
+	const loadBrowsingItems = async () => {
+		if (!browsingCollection) return;
+		browsingLoading = true;
+
+		const res = await searchKnowledgeFilesById(
+			localStorage.token,
+			browsingCollection.id,
+			query || null,
+			null,
+			null,
+			null,
+			1,
+			currentDirectoryId
+		).catch(() => null);
+
+		if (res) {
+			browsingFiles = res.items || [];
+			browsingDirectories = res.directories || [];
+			browsingBreadcrumbs = res.breadcrumbs || [];
+		}
+
+		browsingLoading = false;
+	};
+
+	const selectDirectory = async (dir) => {
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				browsingCollection.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		if (allFiles.length === 0) {
+			toast.info($i18n.t('No files in this directory.'));
+			return;
+		}
+
+		onSelect({
+			type: 'knowledge-directory',
+			data: {
+				files: allFiles.map((file) => ({
+					...file,
+					type: 'file',
+					name: file?.meta?.name || file.filename,
+					collection: { name: browsingCollection.name }
+				}))
+			}
+		});
+	};
+
+	const selectBrowsingFile = (file) => {
+		onSelect({
+			type: 'knowledge',
+			data: {
+				...file,
+				type: 'file',
+				name: file?.meta?.name || file.filename,
+				collection: { name: browsingCollection.name }
+			}
+		});
+	};
+
+	const selectEntireCollection = () => {
+		onSelect({
+			type: 'knowledge',
+			data: { ...browsingCollection, type: 'collection' }
+		});
+	};
+
+	$: currentLocationName =
+		browsingBreadcrumbs.length > 0
+			? browsingBreadcrumbs[browsingBreadcrumbs.length - 1]?.name
+			: (browsingCollection?.name ?? '');
+
 	onMount(async () => {
 		if ($folders === null) {
 			await folders.set(await getFolders(localStorage.token));
@@ -139,7 +298,159 @@
 	});
 </script>
 
-{#if filteredItems.length > 0 || query.startsWith('http')}
+{#if browsingCollection}
+	<div class="px-2 py-1.5 flex items-center gap-1.5 border-b border-gray-100 dark:border-gray-800">
+		<button
+			type="button"
+			class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+			on:click={navigateBack}
+		>
+			<ArrowLeft className="size-3.5" strokeWidth="2" />
+		</button>
+
+		<div class="flex-1 min-w-0">
+			<div class="text-xs text-gray-500 dark:text-gray-400 truncate flex items-center gap-0.5">
+				<button
+					type="button"
+					class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+					on:click={() => {
+						if (browsingBreadcrumbs.length > 0) {
+							currentDirectoryId = null;
+							selectedIdx = 0;
+							loadBrowsingItems();
+						}
+					}}
+				>
+					{decodeString(browsingCollection?.name)}
+				</button>
+				{#each browsingBreadcrumbs as crumb, i}
+					<span class="flex-shrink-0">/</span>
+					<button
+						type="button"
+						class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+						on:click={() => {
+							currentDirectoryId = crumb.id;
+							selectedIdx = 0;
+							loadBrowsingItems();
+						}}
+					>
+						{crumb.name}
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		<Tooltip
+			content={browsingBreadcrumbs.length > 0
+				? $i18n.t('Select directory')
+				: $i18n.t('Select collection')}
+			placement="top"
+		>
+			<button
+				type="button"
+				class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition opacity-60 hover:opacity-100"
+				on:click={() => {
+					if (browsingBreadcrumbs.length > 0) {
+						selectDirectory({
+							id: currentDirectoryId,
+							name: currentLocationName
+						});
+					} else {
+						selectEntireCollection();
+					}
+				}}
+			>
+				<Plus className="size-3.5" />
+			</button>
+		</Tooltip>
+	</div>
+
+	{#if browsingLoading}
+		<div class="flex justify-center py-3">
+			<Spinner className="size-3.5" />
+		</div>
+	{:else if browsingDirectories.length === 0 && browsingFiles.length === 0}
+		<div class="px-2 py-3 text-center text-xs text-gray-400 dark:text-gray-500 italic">
+			{$i18n.t('This directory is empty.')}
+		</div>
+	{:else}
+		{@const allBrowsingItems = [
+			...browsingDirectories.map((d) => ({ ...d, _itemType: 'directory' })),
+			...browsingFiles.map((f) => ({
+				...f,
+				_itemType: 'file',
+				name: f?.meta?.name || f.filename
+			}))
+		]}
+
+		{#each allBrowsingItems as item, idx}
+			{#if idx === 0 || item._itemType !== allBrowsingItems[idx - 1]?._itemType}
+				<div class="px-2 py-1 text-[0.6875rem] text-gray-500 dark:text-gray-400">
+					{#if item._itemType === 'directory'}
+						{$i18n.t('Directories')}
+					{:else}
+						{$i18n.t('Files')}
+					{/if}
+				</div>
+			{/if}
+
+			{#if item._itemType === 'directory'}
+				<div
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[0.8125rem] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+				>
+					<button
+						type="button"
+						class="flex min-w-0 flex-1 items-center gap-1.5 text-left text-black dark:text-gray-100"
+						data-selected={idx === selectedIdx}
+						on:click={() => browseIntoDirectory(item)}
+						on:mousemove={() => {
+							selectedIdx = idx;
+						}}
+					>
+						<Folder className="size-3.5" />
+						<Tooltip content={item.name} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">{item.name}</div>
+						</Tooltip>
+					</button>
+
+					<div class="ml-1 flex items-center gap-0.5">
+						<Tooltip content={$i18n.t('Select directory')} placement="top">
+							<button
+								type="button"
+								class="rounded p-0.5 opacity-40 transition hover:bg-gray-200 hover:opacity-100 dark:hover:bg-gray-700"
+								on:click|stopPropagation={() => selectDirectory(item)}
+							>
+								<Plus className="size-3" />
+							</button>
+						</Tooltip>
+						<ChevronRight className="size-3 opacity-30" />
+					</div>
+				</div>
+			{:else}
+				<button
+					class="flex h-[1.6875rem] w-full items-center gap-1.5 rounded-xl px-2 text-left text-[0.8125rem] text-black hover:bg-gray-50/40 dark:text-gray-100 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+					type="button"
+					data-selected={idx === selectedIdx}
+					on:click={() => selectBrowsingFile(item)}
+					on:mousemove={() => {
+						selectedIdx = idx;
+					}}
+				>
+					<DocumentPage className="size-3.5" />
+					<Tooltip content={decodeString(item.name)} placement="top-start">
+						<div class="min-w-0 flex-1 truncate">{decodeString(item.name)}</div>
+					</Tooltip>
+				</button>
+			{/if}
+		{/each}
+	{/if}
+{:else if filteredItems.length > 0 || query.startsWith('http')}
 	{#each filteredItems as item, idx}
 		{#if idx === 0 || item?.type !== items[idx - 1]?.type}
 			<div class="px-2 py-1 text-[0.6875rem] text-gray-500 dark:text-gray-400">
@@ -154,51 +465,97 @@
 		{/if}
 
 		{#if !['youtube', 'web'].includes(item.type)}
-			<button
-				class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[0.8125rem] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
-				selectedIdx
-					? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
-					: ''}"
-				type="button"
-				on:click={() => {
-					console.log(item);
-					onSelect({
-						type: 'knowledge',
-						data: item
-					});
-				}}
-				on:mousemove={() => {
-					selectedIdx = idx;
-				}}
-				data-selected={idx === selectedIdx}
-			>
-				<div class="flex min-w-0 items-center gap-1.5 text-black dark:text-gray-100">
-					<Tooltip
-						content={item?.legacy
-							? $i18n.t('Legacy')
-							: item?.type === 'file'
-								? `${item?.collection?.name} > ${$i18n.t('File')}`
-								: item?.type === 'collection'
-									? $i18n.t('Collection')
-									: ''}
-						placement="top"
+			{#if item.type === 'collection'}
+				<div
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[0.8125rem] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+				>
+					<button
+						type="button"
+						class="flex min-w-0 flex-1 items-center gap-1.5 text-left text-black dark:text-gray-100"
+						data-selected={idx === selectedIdx}
+						on:click={() => browseIntoCollection(item)}
+						on:mousemove={() => {
+							selectedIdx = idx;
+						}}
 					>
-						{#if item?.type === 'collection'}
+						<Tooltip
+							content={item?.legacy ? $i18n.t('Legacy') : $i18n.t('Collection')}
+							placement="top"
+						>
 							<Database className="size-3.5" />
-						{:else if item?.type === 'folder'}
-							<Folder className="size-3.5" />
-						{:else}
-							<DocumentPage className="size-3.5" />
-						{/if}
-					</Tooltip>
+						</Tooltip>
 
-					<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
-						<div class="min-w-0 flex-1 truncate">
-							{decodeString(item?.name)}
-						</div>
-					</Tooltip>
+						<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">
+								{decodeString(item?.name)}
+							</div>
+						</Tooltip>
+					</button>
+
+					<div class="ml-1 flex items-center gap-0.5">
+						<Tooltip content={$i18n.t('Select collection')} placement="top">
+							<button
+								type="button"
+								class="rounded p-0.5 opacity-40 transition hover:bg-gray-200 hover:opacity-100 dark:hover:bg-gray-700"
+								on:click|stopPropagation={() => {
+									onSelect({
+										type: 'knowledge',
+										data: { ...item, type: 'collection' }
+									});
+								}}
+							>
+								<Plus className="size-3" />
+							</button>
+						</Tooltip>
+						<ChevronRight className="size-3 opacity-30" />
+					</div>
 				</div>
-			</button>
+			{:else}
+				<button
+					class="flex h-[1.6875rem] w-full items-center justify-between rounded-xl px-2 text-left text-[0.8125rem] hover:bg-gray-50/40 dark:hover:bg-gray-800/40 {idx ===
+					selectedIdx
+						? 'bg-gray-50/40 dark:bg-gray-800/40 dark:text-gray-100 selected-command-option-button'
+						: ''}"
+					type="button"
+					on:click={() => {
+						console.log(item);
+						onSelect({
+							type: 'knowledge',
+							data: item
+						});
+					}}
+					on:mousemove={() => {
+						selectedIdx = idx;
+					}}
+					data-selected={idx === selectedIdx}
+				>
+					<div class="flex min-w-0 items-center gap-1.5 text-black dark:text-gray-100">
+						<Tooltip
+							content={item?.legacy
+								? $i18n.t('Legacy')
+								: item?.type === 'file'
+									? `${item?.collection?.name} > ${$i18n.t('File')}`
+									: ''}
+							placement="top"
+						>
+							{#if item?.type === 'folder'}
+								<Folder className="size-3.5" />
+							{:else}
+								<DocumentPage className="size-3.5" />
+							{/if}
+						</Tooltip>
+
+						<Tooltip content={`${decodeString(item?.name)}`} placement="top-start">
+							<div class="min-w-0 flex-1 truncate">
+								{decodeString(item?.name)}
+							</div>
+						</Tooltip>
+					</div>
+				</button>
+			{/if}
 		{/if}
 	{/each}
 

--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -7,11 +7,14 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Database from '$lib/components/icons/Database.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
+	import Folder from '$lib/components/icons/Folder.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Loader from '$lib/components/common/Loader.svelte';
 	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import SearchInput from './SearchInput.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -23,6 +26,11 @@
 
 	let selectedItem = null;
 
+	// --- Directory browsing state within expanded KB ---
+	let currentDirectoryId = null; // null = root level of the KB
+	let selectedFileDirectories = [];
+	let selectedFileBreadcrumbs = [];
+
 	let selectedFileItemsPage = 1;
 
 	let selectedFileItems = null;
@@ -33,6 +41,9 @@
 	let selectedFileRequestId = 0;
 
 	$: if (selectedItem) {
+		currentDirectoryId = null;
+		selectedFileDirectories = [];
+		selectedFileBreadcrumbs = [];
 		initSelectedFileItems();
 	}
 
@@ -64,7 +75,8 @@
 			null,
 			null,
 			null,
-			selectedFileItemsPage
+			selectedFileItemsPage,
+			currentDirectoryId
 		).catch(() => {
 			return null;
 		});
@@ -72,6 +84,8 @@
 
 		if (res) {
 			selectedFileItemsTotal = res.total;
+			selectedFileDirectories = res.directories || [];
+			selectedFileBreadcrumbs = res.breadcrumbs || [];
 			const pageItems = res.items;
 
 			if ((pageItems ?? []).length === 0) {
@@ -91,6 +105,48 @@
 
 		selectedFileItemsLoading = false;
 		return res;
+	};
+
+	const navigateToDirectory = async (dirId) => {
+		currentDirectoryId = dirId;
+		selectedFileItemsPage = 1;
+		selectedFileItems = null;
+		selectedFileItemsTotal = null;
+		selectedFileAllItemsLoaded = false;
+		selectedFileItemsLoading = false;
+		await tick();
+		await getSelectedFileItemsPage();
+	};
+
+	const selectDirectory = async (dir) => {
+		// Fetch all files directly in this directory and select them all
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				selectedItem.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		for (const file of allFiles) {
+			onSelect({
+				type: 'file',
+				name: file?.meta?.name,
+				...file
+			});
+		}
 	};
 
 	let page = 1;
@@ -266,11 +322,77 @@
 								<div class=" py-1 flex justify-center">
 									<Spinner className="size-3" />
 								</div>
-							{:else if selectedFileItemsTotal === 0}
+							{:else if selectedFileItemsTotal === 0 && selectedFileDirectories.length === 0}
 								<div class=" text-xs text-gray-500 dark:text-gray-400 italic py-0.5 px-2">
 									{$i18n.t('No files in this knowledge base.')}
 								</div>
 							{:else}
+								{#if selectedFileBreadcrumbs.length > 0}
+									<div
+										class="px-2 py-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+									>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+											on:click={() => navigateToDirectory(null)}
+										>
+											<ArrowLeft className="size-3" strokeWidth="2" />
+										</button>
+
+										<button
+											type="button"
+											class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+											on:click={() => navigateToDirectory(null)}
+										>
+											{decodeString(selectedItem?.name)}
+										</button>
+										{#each selectedFileBreadcrumbs as crumb, i}
+											<span class="flex-shrink-0">/</span>
+											<button
+												type="button"
+												class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+												on:click={() => navigateToDirectory(crumb.id)}
+											>
+												{crumb.name}
+											</button>
+										{/each}
+									</div>
+								{/if}
+
+								{#each selectedFileDirectories as dir (dir.id)}
+									<div
+										class="h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center text-[13px] font-normal hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
+									>
+										<button
+											type="button"
+											class="flex-1 flex min-w-0 items-center gap-1.5"
+											on:click={() => navigateToDirectory(dir.id)}
+										>
+											<Tooltip content={$i18n.t('Directory')} placement="top">
+												<Folder className="size-3.5" />
+											</Tooltip>
+											<Tooltip content={dir.name} placement="top-start">
+												<div class="line-clamp-1 flex-1 text-[13px]">
+													{dir.name}
+												</div>
+											</Tooltip>
+										</button>
+
+										<div class="flex items-center gap-0.5 ml-1">
+											<Tooltip content={$i18n.t('Select directory')} placement="top">
+												<button
+													type="button"
+													class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+													on:click|stopPropagation={() => selectDirectory(dir)}
+												>
+													<Plus className="size-3" />
+												</button>
+											</Tooltip>
+											<ChevronRight className="size-3 opacity-30" />
+										</div>
+									</div>
+								{/each}
+
 								{#each selectedFileItems as file, fileIdx (file.id)}
 									<button
 										class=" h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[13px] font-normal hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
@@ -285,7 +407,7 @@
 										}}
 									>
 										<div class=" flex items-center gap-1.5">
-											<Tooltip content={$i18n.t('Collection')} placement="top">
+											<Tooltip content={$i18n.t('File')} placement="top">
 												<DocumentPage className="size-3.5" />
 											</Tooltip>
 

--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -7,11 +7,14 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Database from '$lib/components/icons/Database.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
+	import Folder from '$lib/components/icons/Folder.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Loader from '$lib/components/common/Loader.svelte';
 	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import SearchInput from './SearchInput.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -23,6 +26,10 @@
 
 	let selectedItem = null;
 
+	let currentDirectoryId = null;
+	let selectedFileDirectories = [];
+	let selectedFileBreadcrumbs = [];
+
 	let selectedFileItemsPage = 1;
 
 	let selectedFileItems = null;
@@ -33,6 +40,9 @@
 	let selectedFileRequestId = 0;
 
 	$: if (selectedItem) {
+		currentDirectoryId = null;
+		selectedFileDirectories = [];
+		selectedFileBreadcrumbs = [];
 		initSelectedFileItems();
 	}
 
@@ -64,7 +74,8 @@
 			null,
 			null,
 			null,
-			selectedFileItemsPage
+			selectedFileItemsPage,
+			currentDirectoryId
 		).catch(() => {
 			return null;
 		});
@@ -72,6 +83,8 @@
 
 		if (res) {
 			selectedFileItemsTotal = res.total;
+			selectedFileDirectories = res.directories || [];
+			selectedFileBreadcrumbs = res.breadcrumbs || [];
 			const pageItems = res.items;
 
 			if ((pageItems ?? []).length === 0) {
@@ -91,6 +104,47 @@
 
 		selectedFileItemsLoading = false;
 		return res;
+	};
+
+	const navigateToDirectory = async (dirId) => {
+		currentDirectoryId = dirId;
+		selectedFileItemsPage = 1;
+		selectedFileItems = null;
+		selectedFileItemsTotal = null;
+		selectedFileAllItemsLoaded = false;
+		selectedFileItemsLoading = false;
+		await tick();
+		await getSelectedFileItemsPage();
+	};
+
+	const selectDirectory = async (dir) => {
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				selectedItem.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		for (const file of allFiles) {
+			onSelect({
+				type: 'file',
+				name: file?.meta?.name,
+				...file
+			});
+		}
 	};
 
 	let page = 1;
@@ -268,11 +322,77 @@
 								<div class=" py-1 flex justify-center">
 									<Spinner className="size-3" />
 								</div>
-							{:else if selectedFileItemsTotal === 0}
+							{:else if selectedFileItemsTotal === 0 && selectedFileDirectories.length === 0}
 								<div class=" text-xs text-gray-500 dark:text-gray-400 italic py-0.5 px-2">
 									{$i18n.t('No files in this knowledge base.')}
 								</div>
 							{:else}
+								{#if selectedFileBreadcrumbs.length > 0}
+									<div
+										class="px-2 py-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+									>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+											on:click={() => navigateToDirectory(null)}
+										>
+											<ArrowLeft className="size-3" strokeWidth="2" />
+										</button>
+
+										<button
+											type="button"
+											class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+											on:click={() => navigateToDirectory(null)}
+										>
+											{decodeString(selectedItem?.name)}
+										</button>
+										{#each selectedFileBreadcrumbs as crumb, i}
+											<span class="flex-shrink-0">/</span>
+											<button
+												type="button"
+												class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+												on:click={() => navigateToDirectory(crumb.id)}
+											>
+												{crumb.name}
+											</button>
+										{/each}
+									</div>
+								{/if}
+
+								{#each selectedFileDirectories as dir (dir.id)}
+									<div
+										class="h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center text-[0.8125rem] font-normal hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
+									>
+										<button
+											type="button"
+											class="flex-1 flex min-w-0 items-center gap-1.5"
+											on:click={() => navigateToDirectory(dir.id)}
+										>
+											<Tooltip content={$i18n.t('Directory')} placement="top">
+												<Folder className="size-3.5" />
+											</Tooltip>
+											<Tooltip content={dir.name} placement="top-start">
+												<div class="line-clamp-1 flex-1 text-[0.8125rem]">
+													{dir.name}
+												</div>
+											</Tooltip>
+										</button>
+
+										<div class="flex items-center gap-0.5 ml-1">
+											<Tooltip content={$i18n.t('Select directory')} placement="top">
+												<button
+													type="button"
+													class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+													on:click|stopPropagation={() => selectDirectory(dir)}
+												>
+													<Plus className="size-3" />
+												</button>
+											</Tooltip>
+											<ChevronRight className="size-3 opacity-30" />
+										</div>
+									</div>
+								{/each}
+
 								{#each selectedFileItems as file, fileIdx (file.id)}
 									<button
 										class=" h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[0.8125rem] font-normal hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
@@ -287,7 +407,7 @@
 										}}
 									>
 										<div class=" flex items-center gap-1.5">
-											<Tooltip content={$i18n.t('Collection')} placement="top">
+											<Tooltip content={$i18n.t('File')} placement="top">
 												<DocumentPage className="size-3.5" />
 											</Tooltip>
 

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -27,7 +27,7 @@
 	let filesInputElement = null;
 	let inputFiles = null;
 
-	$: if (selectedItems === null) {
+	$: if (selectedItems === null || selectedItems === undefined) {
 		selectedItems = [];
 	}
 
@@ -178,10 +178,11 @@
 						<KnowledgeSelector
 							on:select={(e) => {
 								const item = e.detail;
+								const current = selectedItems ?? [];
 
-								if (!selectedItems.find((k) => k.id === item.id)) {
+								if (!current.find((k) => k.id === item.id)) {
 									selectedItems = [
-										...selectedItems,
+										...current,
 										{
 											...item
 										}

--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import dayjs from 'dayjs';
 
-	import { onMount, onDestroy, getContext, createEventDispatcher } from 'svelte';
+	import { onMount, onDestroy, getContext, createEventDispatcher, tick } from 'svelte';
 	import { searchNotes } from '$lib/apis/notes';
-	import { searchKnowledgeBases, searchKnowledgeFiles } from '$lib/apis/knowledge';
+	import {
+		searchKnowledgeBases,
+		searchKnowledgeFiles,
+		searchKnowledgeFilesById
+	} from '$lib/apis/knowledge';
 
 	import { decodeString } from '$lib/utils';
 
@@ -15,6 +19,10 @@
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import PageEdit from '$lib/components/icons/PageEdit.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
+	import Folder from '$lib/components/icons/Folder.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -34,10 +42,22 @@
 
 	$: items = [...noteItems, ...knowledgeItems, ...fileItems];
 
+	// --- Browsing state ---
+	let browsingCollection = null;
+	let currentDirectoryId = null;
+	let browsingFiles = [];
+	let browsingDirectories = [];
+	let browsingBreadcrumbs = [];
+	let browsingLoading = false;
+
 	const handleSearchInput = () => {
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
-			getItems();
+			if (browsingCollection) {
+				loadBrowsingItems();
+			} else {
+				getItems();
+			}
 		}, 300);
 	};
 
@@ -100,6 +120,99 @@
 		}
 	};
 
+	// --- Browsing functions ---
+
+	const browseIntoCollection = async (collection) => {
+		browsingCollection = collection;
+		currentDirectoryId = null;
+		await loadBrowsingItems();
+	};
+
+	const browseIntoDirectory = async (dir) => {
+		currentDirectoryId = dir.id;
+		await loadBrowsingItems();
+	};
+
+	const navigateBack = async () => {
+		if (browsingBreadcrumbs.length > 0) {
+			const parentCrumb =
+				browsingBreadcrumbs.length >= 2
+					? browsingBreadcrumbs[browsingBreadcrumbs.length - 2]
+					: null;
+			currentDirectoryId = parentCrumb ? parentCrumb.id : null;
+			await loadBrowsingItems();
+		} else {
+			browsingCollection = null;
+			currentDirectoryId = null;
+			browsingFiles = [];
+			browsingDirectories = [];
+			browsingBreadcrumbs = [];
+		}
+	};
+
+	const loadBrowsingItems = async () => {
+		if (!browsingCollection) return;
+		browsingLoading = true;
+
+		const res = await searchKnowledgeFilesById(
+			localStorage.token,
+			browsingCollection.id,
+			query || null,
+			null,
+			null,
+			null,
+			1,
+			currentDirectoryId
+		).catch(() => null);
+
+		if (res) {
+			browsingFiles = res.items || [];
+			browsingDirectories = res.directories || [];
+			browsingBreadcrumbs = res.breadcrumbs || [];
+		}
+
+		browsingLoading = false;
+	};
+
+	const selectDirectory = async (dir) => {
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				browsingCollection.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		for (const file of allFiles) {
+			dispatch('select', {
+				...file,
+				type: 'file',
+				name: file?.meta?.name || file.filename
+			});
+		}
+		show = false;
+	};
+
+	const resetBrowsing = () => {
+		browsingCollection = null;
+		currentDirectoryId = null;
+		browsingFiles = [];
+		browsingDirectories = [];
+		browsingBreadcrumbs = [];
+	};
+
 	onMount(async () => {
 		getItems();
 	});
@@ -112,6 +225,7 @@
 			onClose();
 			query = '';
 			handleSearchInput();
+			resetBrowsing();
 		}
 	}}
 >
@@ -136,11 +250,181 @@
 			</div>
 
 			<div class="max-h-56 overflow-y-scroll gap-0.5 flex flex-col">
-				{#if items.length === 0}
+				{#if browsingCollection}
+					<!-- Browsing view: inside a knowledge base -->
+					<div
+						class="px-2 py-1.5 flex items-center gap-1.5 border-b border-gray-100 dark:border-gray-800"
+					>
+						<button
+							type="button"
+							class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+							on:click={navigateBack}
+						>
+							<ArrowLeft className="size-3" strokeWidth="2" />
+						</button>
+
+						<div class="flex-1 min-w-0">
+							<div
+								class="text-xs text-gray-500 dark:text-gray-400 truncate flex items-center gap-0.5"
+							>
+								<button
+									type="button"
+									class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+									on:click={() => {
+										if (browsingBreadcrumbs.length > 0) {
+											currentDirectoryId = null;
+											loadBrowsingItems();
+										}
+									}}
+								>
+									{decodeString(browsingCollection?.name)}
+								</button>
+								{#each browsingBreadcrumbs as crumb, i}
+									<span class="flex-shrink-0">/</span>
+									<button
+										type="button"
+										class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+										on:click={() => {
+											currentDirectoryId = crumb.id;
+											loadBrowsingItems();
+										}}
+									>
+										{crumb.name}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<Tooltip
+							content={browsingBreadcrumbs.length > 0
+								? $i18n.t('Select directory')
+								: $i18n.t('Select collection')}
+							placement="top"
+							tippyOptions={{ zIndex: 100000 }}
+						>
+							<button
+								type="button"
+								class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition opacity-60 hover:opacity-100"
+								on:click={() => {
+									if (browsingBreadcrumbs.length > 0) {
+										selectDirectory({
+											id: currentDirectoryId,
+											name:
+												browsingBreadcrumbs.length > 0
+													? browsingBreadcrumbs[browsingBreadcrumbs.length - 1]?.name
+													: browsingCollection?.name
+										});
+									} else {
+										dispatch('select', {
+											...browsingCollection,
+											type: 'collection'
+										});
+										show = false;
+									}
+								}}
+							>
+								<Plus className="size-3.5" />
+							</button>
+						</Tooltip>
+					</div>
+
+					{#if browsingLoading}
+						<div class="flex justify-center py-3">
+							<Spinner className="size-3.5" />
+						</div>
+					{:else if browsingDirectories.length === 0 && browsingFiles.length === 0}
+						<div class="px-2 py-3 text-center text-xs text-gray-400 dark:text-gray-500 italic">
+							{$i18n.t('This directory is empty.')}
+						</div>
+					{:else}
+						{#if browsingDirectories.length > 0}
+							<div class="px-1.5 text-[11px] text-gray-500 py-0.5">
+								{$i18n.t('Directories')}
+							</div>
+						{/if}
+
+						{#each browsingDirectories as dir (dir.id)}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center text-[13px] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
+							>
+								<button
+									type="button"
+									class="flex-1 flex min-w-0 items-center gap-1 text-black dark:text-gray-100"
+									on:click={() => browseIntoDirectory(dir)}
+								>
+									<Folder className="size-3.5 flex-shrink-0" />
+									<Tooltip
+										content={dir.name}
+										placement="top-start"
+										tippyOptions={{ zIndex: 100000 }}
+									>
+										<div class="line-clamp-1 flex-1 text-[13px] text-left">{dir.name}</div>
+									</Tooltip>
+								</button>
+
+								<div class="flex items-center gap-0.5 ml-1">
+									<Tooltip
+										content={$i18n.t('Select directory')}
+										placement="top"
+										tippyOptions={{ zIndex: 100000 }}
+									>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+											on:click|stopPropagation={() => selectDirectory(dir)}
+										>
+											<Plus className="size-3" />
+										</button>
+									</Tooltip>
+									<ChevronRight className="size-3 opacity-30" />
+								</div>
+							</div>
+						{/each}
+
+						{#if browsingFiles.length > 0}
+							<div class="px-1.5 text-[11px] text-gray-500 py-0.5">
+								{$i18n.t('Files')}
+							</div>
+						{/if}
+
+						{#each browsingFiles as file (file.id)}
+							<button
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center gap-1 text-[13px] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 text-black dark:text-gray-100"
+								type="button"
+								on:click={() => {
+									dispatch('select', {
+										...file,
+										type: 'file',
+										name: file?.meta?.name || file.filename
+									});
+									show = false;
+								}}
+							>
+								<Tooltip
+									content={$i18n.t('File')}
+									placement="top"
+									tippyOptions={{ zIndex: 100000 }}
+								>
+									<DocumentPage className="size-3.5 flex-shrink-0" />
+								</Tooltip>
+								<Tooltip
+									content={decodeString(file?.meta?.name || file.filename)}
+									placement="top-start"
+									tippyOptions={{ zIndex: 100000 }}
+								>
+									<div class="line-clamp-1 flex-1 text-[13px] text-left">
+										{decodeString(file?.meta?.name || file.filename)}
+									</div>
+								</Tooltip>
+							</button>
+						{/each}
+					{/if}
+				{:else if items.length === 0}
 					<div class="text-center text-xs text-gray-500 dark:text-gray-400 pt-4 pb-6">
 						{$i18n.t('No knowledge found')}
 					</div>
 				{:else}
+					<!-- Top-level view -->
 					{#each items as item, i}
 						{#if i === 0 || item?.type !== items[i - 1]?.type}
 							<div class="px-1.5 text-[11px] text-gray-500 py-0.5">
@@ -154,27 +438,16 @@
 							</div>
 						{/if}
 
-						<div
-							class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[13px] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
-						>
-							<button
-								class="w-full flex-1"
-								type="button"
-								on:click={() => {
-									dispatch('select', item);
-									show = false;
-								}}
+						{#if item.type === 'collection'}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[13px] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
 							>
-								<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
-									{#if item.type === 'note'}
-										<Tooltip
-											content={$i18n.t('Note')}
-											placement="top"
-											tippyOptions={{ zIndex: 100000 }}
-										>
-											<PageEdit className="size-3.5" />
-										</Tooltip>
-									{:else if item.type === 'collection'}
+								<button
+									class="w-full flex-1"
+									type="button"
+									on:click={() => browseIntoCollection(item)}
+								>
+									<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
 										<Tooltip
 											content={$i18n.t('Collection')}
 											placement="top"
@@ -182,28 +455,83 @@
 										>
 											<Database className="size-3.5" />
 										</Tooltip>
-									{:else if item.type === 'file'}
+
 										<Tooltip
-											content={$i18n.t('File')}
-											placement="top"
+											content={item.description || decodeString(item?.name)}
+											placement="top-start"
 											tippyOptions={{ zIndex: 100000 }}
 										>
-											<DocumentPage className="size-3.5" />
+											<div class="line-clamp-1 flex-1 text-[13px] text-left">
+												{decodeString(item?.name)}
+											</div>
 										</Tooltip>
-									{/if}
+									</div>
+								</button>
 
+								<div class="flex items-center gap-0.5 ml-1">
 									<Tooltip
-										content={item.description || decodeString(item?.name)}
-										placement="top-start"
+										content={$i18n.t('Select collection')}
+										placement="top"
 										tippyOptions={{ zIndex: 100000 }}
 									>
-										<div class="line-clamp-1 flex-1 text-[13px] text-left">
-											{decodeString(item?.name)}
-										</div>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+											on:click|stopPropagation={() => {
+												dispatch('select', item);
+												show = false;
+											}}
+										>
+											<Plus className="size-3" />
+										</button>
 									</Tooltip>
+									<ChevronRight className="size-3 opacity-30" />
 								</div>
-							</button>
-						</div>
+							</div>
+						{:else}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[13px] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
+							>
+								<button
+									class="w-full flex-1"
+									type="button"
+									on:click={() => {
+										dispatch('select', item);
+										show = false;
+									}}
+								>
+									<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
+										{#if item.type === 'note'}
+											<Tooltip
+												content={$i18n.t('Note')}
+												placement="top"
+												tippyOptions={{ zIndex: 100000 }}
+											>
+												<PageEdit className="size-3.5" />
+											</Tooltip>
+										{:else if item.type === 'file'}
+											<Tooltip
+												content={$i18n.t('File')}
+												placement="top"
+												tippyOptions={{ zIndex: 100000 }}
+											>
+												<DocumentPage className="size-3.5" />
+											</Tooltip>
+										{/if}
+
+										<Tooltip
+											content={item.description || decodeString(item?.name)}
+											placement="top-start"
+											tippyOptions={{ zIndex: 100000 }}
+										>
+											<div class="line-clamp-1 flex-1 text-[13px] text-left">
+												{decodeString(item?.name)}
+											</div>
+										</Tooltip>
+									</div>
+								</button>
+							</div>
+						{/if}
 					{/each}
 				{/if}
 			</div>

--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import dayjs from 'dayjs';
 
-	import { onMount, onDestroy, getContext, createEventDispatcher } from 'svelte';
+	import { onMount, onDestroy, getContext, createEventDispatcher, tick } from 'svelte';
 	import { searchNotes } from '$lib/apis/notes';
-	import { searchKnowledgeBases, searchKnowledgeFiles } from '$lib/apis/knowledge';
+	import {
+		searchKnowledgeBases,
+		searchKnowledgeFiles,
+		searchKnowledgeFilesById
+	} from '$lib/apis/knowledge';
 
 	import { decodeString } from '$lib/utils';
 
@@ -15,6 +19,10 @@
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import PageEdit from '$lib/components/icons/PageEdit.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
+	import Folder from '$lib/components/icons/Folder.svelte';
+	import ArrowLeft from '$lib/components/icons/ArrowLeft.svelte';
+	import Plus from '$lib/components/icons/Plus.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -34,10 +42,21 @@
 
 	$: items = [...noteItems, ...knowledgeItems, ...fileItems];
 
+	let browsingCollection = null;
+	let currentDirectoryId = null;
+	let browsingFiles = [];
+	let browsingDirectories = [];
+	let browsingBreadcrumbs = [];
+	let browsingLoading = false;
+
 	const handleSearchInput = () => {
 		clearTimeout(searchDebounceTimer);
 		searchDebounceTimer = setTimeout(() => {
-			getItems();
+			if (browsingCollection) {
+				loadBrowsingItems();
+			} else {
+				getItems();
+			}
 		}, 300);
 	};
 
@@ -100,6 +119,97 @@
 		}
 	};
 
+	const browseIntoCollection = async (collection) => {
+		browsingCollection = collection;
+		currentDirectoryId = null;
+		await loadBrowsingItems();
+	};
+
+	const browseIntoDirectory = async (dir) => {
+		currentDirectoryId = dir.id;
+		await loadBrowsingItems();
+	};
+
+	const navigateBack = async () => {
+		if (browsingBreadcrumbs.length > 0) {
+			const parentCrumb =
+				browsingBreadcrumbs.length >= 2
+					? browsingBreadcrumbs[browsingBreadcrumbs.length - 2]
+					: null;
+			currentDirectoryId = parentCrumb ? parentCrumb.id : null;
+			await loadBrowsingItems();
+		} else {
+			browsingCollection = null;
+			currentDirectoryId = null;
+			browsingFiles = [];
+			browsingDirectories = [];
+			browsingBreadcrumbs = [];
+		}
+	};
+
+	const loadBrowsingItems = async () => {
+		if (!browsingCollection) return;
+		browsingLoading = true;
+
+		const res = await searchKnowledgeFilesById(
+			localStorage.token,
+			browsingCollection.id,
+			query || null,
+			null,
+			null,
+			null,
+			1,
+			currentDirectoryId
+		).catch(() => null);
+
+		if (res) {
+			browsingFiles = res.items || [];
+			browsingDirectories = res.directories || [];
+			browsingBreadcrumbs = res.breadcrumbs || [];
+		}
+
+		browsingLoading = false;
+	};
+
+	const selectDirectory = async (dir) => {
+		const allFiles = [];
+		let page = 1;
+		while (true) {
+			const res = await searchKnowledgeFilesById(
+				localStorage.token,
+				browsingCollection.id,
+				null,
+				null,
+				null,
+				null,
+				page,
+				dir.id
+			).catch(() => null);
+
+			if (!res || !res.items || res.items.length === 0) break;
+			allFiles.push(...res.items);
+			if (allFiles.length >= res.total) break;
+			page++;
+		}
+
+		for (const file of allFiles) {
+			dispatch('select', {
+				...file,
+				type: 'file',
+				name: file?.meta?.name || file.filename
+			});
+		}
+		show = false;
+	};
+
+	const resetBrowsing = () => {
+		browsingCollection = null;
+		currentDirectoryId = null;
+		browsingFiles = [];
+		browsingDirectories = [];
+		browsingBreadcrumbs = [];
+	};
+
 	onMount(async () => {
 		getItems();
 	});
@@ -112,6 +222,7 @@
 			onClose();
 			query = '';
 			handleSearchInput();
+			resetBrowsing();
 		}
 	}}
 >
@@ -136,7 +247,175 @@
 			</div>
 
 			<div class="max-h-56 overflow-y-scroll gap-0.5 flex flex-col">
-				{#if items.length === 0}
+				{#if browsingCollection}
+					<div
+						class="px-2 py-1.5 flex items-center gap-1.5 border-b border-gray-100 dark:border-gray-800"
+					>
+						<button
+							type="button"
+							class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+							on:click={navigateBack}
+						>
+							<ArrowLeft className="size-3" strokeWidth="2" />
+						</button>
+
+						<div class="flex-1 min-w-0">
+							<div
+								class="text-xs text-gray-500 dark:text-gray-400 truncate flex items-center gap-0.5"
+							>
+								<button
+									type="button"
+									class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+									on:click={() => {
+										if (browsingBreadcrumbs.length > 0) {
+											currentDirectoryId = null;
+											loadBrowsingItems();
+										}
+									}}
+								>
+									{decodeString(browsingCollection?.name)}
+								</button>
+								{#each browsingBreadcrumbs as crumb, i}
+									<span class="flex-shrink-0">/</span>
+									<button
+										type="button"
+										class="hover:text-gray-700 dark:hover:text-gray-200 transition truncate"
+										on:click={() => {
+											currentDirectoryId = crumb.id;
+											loadBrowsingItems();
+										}}
+									>
+										{crumb.name}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<Tooltip
+							content={browsingBreadcrumbs.length > 0
+								? $i18n.t('Select directory')
+								: $i18n.t('Select collection')}
+							placement="top"
+							tippyOptions={{ zIndex: 100000 }}
+						>
+							<button
+								type="button"
+								class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition opacity-60 hover:opacity-100"
+								on:click={() => {
+									if (browsingBreadcrumbs.length > 0) {
+										selectDirectory({
+											id: currentDirectoryId,
+											name:
+												browsingBreadcrumbs.length > 0
+													? browsingBreadcrumbs[browsingBreadcrumbs.length - 1]?.name
+													: browsingCollection?.name
+										});
+									} else {
+										dispatch('select', {
+											...browsingCollection,
+											type: 'collection'
+										});
+										show = false;
+									}
+								}}
+							>
+								<Plus className="size-3.5" />
+							</button>
+						</Tooltip>
+					</div>
+
+					{#if browsingLoading}
+						<div class="flex justify-center py-3">
+							<Spinner className="size-3.5" />
+						</div>
+					{:else if browsingDirectories.length === 0 && browsingFiles.length === 0}
+						<div class="px-2 py-3 text-center text-xs text-gray-400 dark:text-gray-500 italic">
+							{$i18n.t('This directory is empty.')}
+						</div>
+					{:else}
+						{#if browsingDirectories.length > 0}
+							<div class="px-1.5 text-[0.6875rem] text-gray-500 py-0.5">
+								{$i18n.t('Directories')}
+							</div>
+						{/if}
+
+						{#each browsingDirectories as dir (dir.id)}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center text-[0.8125rem] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
+							>
+								<button
+									type="button"
+									class="flex-1 flex min-w-0 items-center gap-1 text-black dark:text-gray-100"
+									on:click={() => browseIntoDirectory(dir)}
+								>
+									<Folder className="size-3.5 flex-shrink-0" />
+									<Tooltip
+										content={dir.name}
+										placement="top-start"
+										tippyOptions={{ zIndex: 100000 }}
+									>
+										<div class="line-clamp-1 flex-1 text-[0.8125rem] text-left">{dir.name}</div>
+									</Tooltip>
+								</button>
+
+								<div class="flex items-center gap-0.5 ml-1">
+									<Tooltip
+										content={$i18n.t('Select directory')}
+										placement="top"
+										tippyOptions={{ zIndex: 100000 }}
+									>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+											on:click|stopPropagation={() => selectDirectory(dir)}
+										>
+											<Plus className="size-3" />
+										</button>
+									</Tooltip>
+									<ChevronRight className="size-3 opacity-30" />
+								</div>
+							</div>
+						{/each}
+
+						{#if browsingFiles.length > 0}
+							<div class="px-1.5 text-[0.6875rem] text-gray-500 py-0.5">
+								{$i18n.t('Files')}
+							</div>
+						{/if}
+
+						{#each browsingFiles as file (file.id)}
+							<button
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex items-center gap-1 text-[0.8125rem] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 text-black dark:text-gray-100"
+								type="button"
+								on:click={() => {
+									dispatch('select', {
+										...file,
+										type: 'file',
+										name: file?.meta?.name || file.filename
+									});
+									show = false;
+								}}
+							>
+								<Tooltip
+									content={$i18n.t('File')}
+									placement="top"
+									tippyOptions={{ zIndex: 100000 }}
+								>
+									<DocumentPage className="size-3.5 flex-shrink-0" />
+								</Tooltip>
+								<Tooltip
+									content={decodeString(file?.meta?.name || file.filename)}
+									placement="top-start"
+									tippyOptions={{ zIndex: 100000 }}
+								>
+									<div class="line-clamp-1 flex-1 text-[0.8125rem] text-left">
+										{decodeString(file?.meta?.name || file.filename)}
+									</div>
+								</Tooltip>
+							</button>
+						{/each}
+					{/if}
+				{:else if items.length === 0}
 					<div class="text-center text-xs text-gray-500 dark:text-gray-400 pt-4 pb-6">
 						{$i18n.t('No knowledge found')}
 					</div>
@@ -154,27 +433,16 @@
 							</div>
 						{/if}
 
-						<div
-							class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[0.8125rem] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
-						>
-							<button
-								class="w-full flex-1"
-								type="button"
-								on:click={() => {
-									dispatch('select', item);
-									show = false;
-								}}
+						{#if item.type === 'collection'}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[0.8125rem] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
 							>
-								<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
-									{#if item.type === 'note'}
-										<Tooltip
-											content={$i18n.t('Note')}
-											placement="top"
-											tippyOptions={{ zIndex: 100000 }}
-										>
-											<PageEdit className="size-3.5" />
-										</Tooltip>
-									{:else if item.type === 'collection'}
+								<button
+									class="w-full flex-1"
+									type="button"
+									on:click={() => browseIntoCollection(item)}
+								>
+									<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
 										<Tooltip
 											content={$i18n.t('Collection')}
 											placement="top"
@@ -182,28 +450,83 @@
 										>
 											<Database className="size-3.5" />
 										</Tooltip>
-									{:else if item.type === 'file'}
+
 										<Tooltip
-											content={$i18n.t('File')}
-											placement="top"
+											content={item.description || decodeString(item?.name)}
+											placement="top-start"
 											tippyOptions={{ zIndex: 100000 }}
 										>
-											<DocumentPage className="size-3.5" />
+											<div class="line-clamp-1 flex-1 text-[0.8125rem] text-left">
+												{decodeString(item?.name)}
+											</div>
 										</Tooltip>
-									{/if}
+									</div>
+								</button>
 
+								<div class="flex items-center gap-0.5 ml-1">
 									<Tooltip
-										content={item.description || decodeString(item?.name)}
-										placement="top-start"
+										content={$i18n.t('Select collection')}
+										placement="top"
 										tippyOptions={{ zIndex: 100000 }}
 									>
-										<div class="line-clamp-1 flex-1 text-[0.8125rem] text-left">
-											{decodeString(item?.name)}
-										</div>
+										<button
+											type="button"
+											class="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition opacity-40 hover:opacity-100"
+											on:click|stopPropagation={() => {
+												dispatch('select', item);
+												show = false;
+											}}
+										>
+											<Plus className="size-3" />
+										</button>
 									</Tooltip>
+									<ChevronRight className="size-3 opacity-30" />
 								</div>
-							</button>
-						</div>
+							</div>
+						{:else}
+							<div
+								class="min-h-[1.6875rem] px-2 rounded-xl w-full text-left flex justify-between items-center text-[0.8125rem] bg-transparent transition-colors hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100 selected-command-option-button"
+							>
+								<button
+									class="w-full flex-1"
+									type="button"
+									on:click={() => {
+										dispatch('select', item);
+										show = false;
+									}}
+								>
+									<div class="  text-black dark:text-gray-100 flex items-center gap-1 shrink-0">
+										{#if item.type === 'note'}
+											<Tooltip
+												content={$i18n.t('Note')}
+												placement="top"
+												tippyOptions={{ zIndex: 100000 }}
+											>
+												<PageEdit className="size-3.5" />
+											</Tooltip>
+										{:else if item.type === 'file'}
+											<Tooltip
+												content={$i18n.t('File')}
+												placement="top"
+												tippyOptions={{ zIndex: 100000 }}
+											>
+												<DocumentPage className="size-3.5" />
+											</Tooltip>
+										{/if}
+
+										<Tooltip
+											content={item.description || decodeString(item?.name)}
+											placement="top-start"
+											tippyOptions={{ zIndex: 100000 }}
+										>
+											<div class="line-clamp-1 flex-1 text-[0.8125rem] text-left">
+												{decodeString(item?.name)}
+											</div>
+										</Tooltip>
+									</div>
+								</button>
+							</div>
+						{/if}
 					{/each}
 				{/if}
 			</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28140, the proposal to surface knowledge base directory structure in the knowledge pickers.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

---

## Summary

Open WebUI supports organizing files within knowledge bases into directories, but this directory structure was invisible in every knowledge picker UI, the `#` command dropdown, the Attach Knowledge (`+` button) menu, and the model editor knowledge selector all displayed a flat list of files. Users had no way to navigate, browse, or select a specific directory when attaching knowledge to a chat or model.

This PR surfaces the existing directory structure in **all three** knowledge picker UIs by leveraging the `searchKnowledgeFilesById` API's existing `directoryId` parameter, no backend changes required.

### Why this matters

- **Discoverability**: Knowledge bases with many files organized into directories are now navigable instead of an overwhelming flat list
- **Precision**: Users can attach a specific directory's files as context rather than the entire knowledge base, leading to more focused and relevant model responses
- **Consistency**: All three knowledge pickers now share the same browsing interaction pattern, users learn one paradigm

## Approach

The core idea is simple: instead of calling `searchKnowledgeFilesById` without a `directoryId` (which returns every file in the KB flat), pass `directoryId` to scope results to a specific level. The API already returns `directories`, `breadcrumbs`, and `items` in its response, the frontend was simply ignoring the first two.

Each modified component adds:
1. **Browsing state** (`browsingCollection`, `currentDirectoryId`, `browsingBreadcrumbs`, etc.), local component state tracking where the user is navigating
2. **Navigation functions** (`browseIntoCollection`, `browseIntoDirectory`, `navigateBack`), drive the browsing state and re-fetch scoped results
3. **Directory selection** (`selectDirectory`), fetches all files directly in a directory and attaches them individually as chat context
4. **Updated template**, renders directories with folder icons above files, breadcrumb navigation with back arrow, and `+` buttons for both "select entire collection" and "select directory"

### Interaction changes

| Element | Before | After |
|---|---|---|
| Collection row (all pickers) | Click → immediately selects entire collection | Click → navigates into the collection to browse its structure |
| Collection "select all" | N/A (was the only behavior) | `+` button on the right side of the row selects the entire collection |
| Directories | Not visible anywhere | Shown with 📁 folder icon, click to navigate into, `+` to select all files |
| Files inside a KB | Flat list of everything | Scoped to current directory level |
| Navigation | None | Back arrow + clickable breadcrumb path segments |

## Files Changed (5)

### `src/lib/components/chat/MessageInput/Commands/Knowledge.svelte`
The `#` command dropdown, the most-used knowledge picker. Added full browsing state, navigation logic, and a two-mode template (top-level flat view vs. browsing view). Collections now show a chevron and `+` button; clicking navigates in. The browsing view renders a header with back/breadcrumbs/select-all, then directories grouped above files.

### `src/lib/components/chat/MessageInput/CommandSuggestionList.svelte`
Handles the `onSelect` callback from the `#` command Knowledge component. Added a new `knowledge-directory` event type handler that iterates through all resolved files and calls `onUpload` for each one, enabling batch attachment of an entire directory's files.

### `src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte`
The Attach Knowledge panel (via `+` button). Previously called `searchKnowledgeFilesById` without a `directoryId`, resulting in a flat file dump. Now passes `currentDirectoryId` to scope results, tracks `selectedFileDirectories` and `selectedFileBreadcrumbs` from the response, and renders directories with navigation and selection above the file list within each expanded KB.

### `src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte`
The knowledge picker dropdown in the model editor (used for both base and workspace models). Same pattern as the `#` command dropdown, adapted for the `Dropdown` component and `createEventDispatcher` pattern. Collections are now browsable; directories appear with navigation and selection. Browsing state resets when the dropdown closes.

## Key design decisions

1. **No backend changes**: The `searchKnowledgeFilesById` API already supports `directoryId` filtering and returns `directories`/`breadcrumbs` in every response. All changes are frontend-only.

2. **Non-recursive directory selection**: Selecting a directory attaches only files directly within it, not files in nested subdirectories. This gives users precise control, they can navigate deeper and select subdirectories individually.

3. **Collection click behavior change**: Clicking a collection row now navigates into it instead of immediately selecting it. The old "select entire collection" behavior is preserved via a `+` button. This tradeoff favors browsability (the common case when you have directories) while keeping immediate selection one click away.

4. **All strings wrapped in `$i18n.t()`**: New user-facing strings (`'Directories'`, `'This directory is empty.'`, `'Select directory'`, `'Select collection'`, `'Directory'`) are all i18n-ready.

> *This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

# Changelog Entry

### Description

- Add directory browsing and selection support to all three knowledge picker UIs (`#` command dropdown, Attach Knowledge menu, model editor knowledge selector), allowing users to navigate into knowledge base directory structures, browse files at each level, and selectively attach individual files or entire directories as context

### Added

- Directory navigation UI in the `#` command dropdown with back button, breadcrumb trail, and directory/file listing
- Directory navigation UI in the Attach Knowledge (`+` button) menu within expanded knowledge bases
- Directory navigation UI in the model editor KnowledgeSelector dropdown
- `knowledge-directory` event type in `CommandSuggestionList` for batch file attachment from directory selection
- `+` button on collection and directory rows for quick selection without navigating into them

---

### Additional Information

- Zero new dependencies, all changes use existing APIs and icon components
- The `searchKnowledgeFilesById` API already returned `directories` and `breadcrumbs` in its response; the frontend was simply not using them
- All UI changes follow existing design patterns: same Tailwind classes, icon components (`Folder`, `ArrowLeft`, `ChevronRight`, `Plus`), Tooltip wrapping, and hover/dark-mode styling as the rest of the codebase
- Relates to #28140. #27011 requested the same capability and was closed, along with #27012, after both were identified as overlapping with this PR.

### Screenshots or Videos

#### `#` Command Dropdown

| Before | After |
|---|---|
| ![Flat list of collections and files with no directory structure](https://github.com/user-attachments/assets/4bb47dba-8c8f-4a79-ba71-babf28990ade) | ![Collections now show browse-in chevron; clicking navigates into directory structure](https://github.com/user-attachments/assets/980ace00-e370-4e57-bd88-05ec31bfa8fd) |

#### Attach Knowledge (`+` Button) Menu

| Before | After |
|---|---|
| ![Expanding a KB shows a flat list of all files](https://github.com/user-attachments/assets/44e2858c-d016-4d25-9b5b-73825006122b) | ![Expanding a KB now shows directories above files with navigation](https://github.com/user-attachments/assets/a6d2a9e4-bf48-478e-aa63-f09235dede77) |

#### Model Editor Knowledge Selector

| Before | After |
|---|---|
| ![Knowledge selector shows flat collections and files](https://github.com/user-attachments/assets/2dedd064-474c-48e9-bd26-c64b7bb7965d) | ![Collections are now browsable with directory navigation and selection](https://github.com/user-attachments/assets/89cd72bf-e6d3-449e-a07d-f220a8383c39) |

### Manual Verification Performed

1. **`#` command dropdown**: Typed `#` in chat input → verified collections show chevron → clicked collection → saw directories and files at root level → navigated into a directory → verified breadcrumbs update → clicked back arrow → returned to root → clicked `+` on a directory → verified all files in that directory attached to chat → clicked `+` on header → verified entire collection selected
2. **Attach Knowledge menu**: Clicked `+` → Knowledge → expanded a KB → verified directories appear above files → clicked a directory → navigated in with breadcrumbs → clicked a file → verified it attached → used `+` on a directory → verified batch attachment
3. **Model editor knowledge picker**: Opened model editor → clicked "Select Knowledge" → verified collections show browse-in behavior → navigated into a collection → browsed directories → selected a directory via `+` → verified all files added to model knowledge without errors
4. **Regression**: Verified folders (chat folders), notes, files, YouTube URLs, and web URLs all still work correctly in the `#` dropdown with no behavioral changes

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.



