### PR TITLE
fix: recover detached chat current id

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -254,12 +254,17 @@ export const sanitizeHistory = (history) => {
 		}
 	}
 
+	const detachedMessageIds = new Set();
+
 	// Reconstruct missing parentId and role
 	for (const [id, message] of Object.entries(history.messages)) {
 		// Well-formed: has role and explicit parentId (null is valid for root)
 		if (message.role && message.parentId !== undefined) continue;
 
 		if (message.parentId === undefined) {
+			if (!parentByChildId[id]) {
+				detachedMessageIds.add(id);
+			}
 			message.parentId = parentByChildId[id] ?? null;
 		}
 
@@ -281,17 +286,59 @@ export const sanitizeHistory = (history) => {
 		message.childrenIds = message.childrenIds.filter((childId) => history.messages[childId]);
 	}
 
-	// Recover currentId if it points to a missing or incomplete node
-	const currentMessage = history.messages?.[history.currentId];
-	if (!currentMessage?.id || !currentMessage?.role) {
+	const getReachableMessageIds = (rootIds) => {
+		const reachableIds = new Set();
+		const queue = [...rootIds];
+
+		while (queue.length > 0) {
+			const id = queue.shift();
+			if (reachableIds.has(id) || !history.messages[id]) continue;
+
+			reachableIds.add(id);
+			queue.push(...history.messages[id].childrenIds);
+		}
+
+		return reachableIds;
+	};
+
+	let rootIds = Object.entries(history.messages)
+		.filter(
+			([id, message]) =>
+				(message.parentId === null || message.parentId === undefined) && !detachedMessageIds.has(id)
+		)
+		.map(([id]) => id);
+
+	if (rootIds.length === 0) {
+		rootIds = Object.entries(history.messages)
+			.filter(([, message]) => message.parentId === null || message.parentId === undefined)
+			.map(([id]) => id);
+	}
+
+	const reachableIds = getReachableMessageIds(rootIds);
+	const getLatestLeafId = (candidateIds) => {
 		let latestLeafId = null;
 		let latestTimestamp = -1;
-		for (const [id, message] of Object.entries(history.messages)) {
-			if (message.childrenIds.length === 0 && (message.timestamp ?? 0) > latestTimestamp) {
+
+		for (const id of candidateIds) {
+			const message = history.messages[id];
+			if (!message) continue;
+
+			const hasReachableChildren = message.childrenIds.some((childId) => candidateIds.has(childId));
+			const timestamp = message.timestamp ?? 0;
+			if (!hasReachableChildren && timestamp > latestTimestamp) {
 				latestLeafId = id;
-				latestTimestamp = message.timestamp ?? 0;
+				latestTimestamp = timestamp;
 			}
 		}
+
+		return latestLeafId;
+	};
+
+	// Recover currentId if it points to a missing, incomplete, or detached node
+	const currentMessage = history.messages?.[history.currentId];
+	if (!currentMessage?.id || !currentMessage?.role || !reachableIds.has(history.currentId)) {
+		const latestLeafId =
+			getLatestLeafId(reachableIds) ?? getLatestLeafId(new Set(Object.keys(history.messages)));
 		history.currentId = latestLeafId ?? Object.keys(history.messages)[0] ?? null;
 	}
 };


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to #26257.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the listed prefixes.

# Changelog Entry

### Description

- Recover chat histories when `currentId` points at a detached malformed message after a failed regeneration or suggestion follow-up.

### Added

- Nothing.

### Changed

- `sanitizeHistory` now computes reachable message IDs from valid roots and recovers `currentId` to the latest reachable leaf when the saved current message is missing, incomplete, or detached.

### Deprecated

- Nothing.

### Removed

- Nothing.

### Fixed

- Fixed reload recovery for chats whose saved `currentId` points to an orphaned repaired message, which could otherwise make the valid chat branch appear blank.

### Security

- Nothing.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Relates to #26257.
- Validation: `git diff --check HEAD~1..HEAD` passed.
- Validation: focused Node extraction test against `sanitizeHistory` passed.
- Note: `npm run check` is blocked in this local checkout because `svelte-kit` is not installed.

### Screenshots or Videos

- Not applicable; this is chat history recovery logic.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.