### PR TITLE
feat: add TwelveLabs Pegasus video analysis builtin tool

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1417,6 +1417,16 @@ except json.JSONDecodeError:
 IMAGES_EDIT_COMFYUI_WORKFLOW_NODES = images_edit_comfyui_workflow_nodes
 
 ####################################
+# Video Analysis (TwelveLabs)
+####################################
+
+# Opt-in: the analyze_video builtin tool is only offered when an API key is set.
+TWELVELABS_API_KEY = os.getenv('TWELVELABS_API_KEY', '')
+
+# Pegasus model used for video understanding/analysis.
+TWELVELABS_PEGASUS_MODEL = os.getenv('TWELVELABS_PEGASUS_MODEL', 'pegasus1.5')
+
+####################################
 # Audio
 ####################################
 
@@ -2825,6 +2835,8 @@ DEFAULT_CONFIG = {
     'images.edit.comfyui.api_key': IMAGES_EDIT_COMFYUI_API_KEY,
     'images.edit.comfyui.workflow': IMAGES_EDIT_COMFYUI_WORKFLOW,
     'images.edit.comfyui.nodes': IMAGES_EDIT_COMFYUI_WORKFLOW_NODES,
+    'video_analysis.twelvelabs.api_key': TWELVELABS_API_KEY,
+    'video_analysis.twelvelabs.pegasus_model': TWELVELABS_PEGASUS_MODEL,
     'audio.stt.whisper_model': WHISPER_MODEL,
     'audio.stt.deepgram.api_key': DEEPGRAM_API_KEY,
     'audio.stt.openai.api_base_url': AUDIO_STT_OPENAI_API_BASE_URL,

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -7,6 +7,7 @@ IMPORTANT: DO NOT IMPORT THIS MODULE DIRECTLY IN OTHER PARTS OF THE CODEBASE.
 """
 
 from open_webui.tools.knowledge_fs import kb_exec  # noqa: F401 — re-exported
+from open_webui.tools.twelvelabs import analyze_video  # noqa: F401 — re-exported
 
 import asyncio
 import json

--- a/backend/open_webui/tools/test_twelvelabs.py
+++ b/backend/open_webui/tools/test_twelvelabs.py
@@ -1,0 +1,116 @@
+"""
+Tests for the TwelveLabs `analyze_video` builtin tool.
+
+The no-network test stubs the SDK + config and verifies request wiring and
+response shaping. The live test runs a real Pegasus analysis and is skipped
+unless TWELVELABS_API_KEY is set.
+
+Run standalone (no pytest config needed):  python -m open_webui.tools.test_twelvelabs
+"""
+
+import asyncio
+import json
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from open_webui.tools import twelvelabs as tl
+from open_webui.tools.twelvelabs import analyze_video
+
+
+def _config_get(values):
+    async def _get(key, default=None):
+        return values.get(key, default)
+
+    return _get
+
+
+def test_missing_key_returns_error():
+    with patch.object(tl.Config, 'get', new=_config_get({})):
+        out = asyncio.run(analyze_video('http://x/v.mp4', 'describe'))
+    assert json.loads(out)['error'].startswith('TwelveLabs API key'), out
+
+
+def test_wiring_with_stubbed_sdk():
+    """No-network: stub the twelvelabs SDK + config and assert it is called correctly."""
+    captured = {}
+
+    fake_client = MagicMock()
+    fake_client.analyze.return_value = types.SimpleNamespace(data='A cat plays piano.', finish_reason='stop')
+
+    def _twelvelabs_ctor(api_key):
+        captured['api_key'] = api_key
+        return fake_client
+
+    tl_mod = types.ModuleType('twelvelabs')
+    tl_mod.TwelveLabs = _twelvelabs_ctor
+    ctx_mod = types.ModuleType('twelvelabs.types.video_context')
+
+    class VideoContext_Url:  # noqa: N801 — mirror SDK class name
+        def __init__(self, url):
+            self.url = url
+
+    ctx_mod.VideoContext_Url = VideoContext_Url
+    types_pkg = types.ModuleType('twelvelabs.types')
+
+    saved = {k: sys.modules.get(k) for k in ('twelvelabs', 'twelvelabs.types', 'twelvelabs.types.video_context')}
+    sys.modules['twelvelabs'] = tl_mod
+    sys.modules['twelvelabs.types'] = types_pkg
+    sys.modules['twelvelabs.types.video_context'] = ctx_mod
+
+    cfg = {
+        'video_analysis.twelvelabs.api_key': 'test-key',
+        'video_analysis.twelvelabs.pegasus_model': 'pegasus1.5',
+    }
+    try:
+        with patch.object(tl.Config, 'get', new=_config_get(cfg)):
+            # max_tokens above the ceiling must be clamped.
+            out = asyncio.run(analyze_video('http://x/v.mp4', 'What happens?', max_tokens=99999))
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+    result = json.loads(out)
+    assert result['status'] == 'success', out
+    assert result['analysis'] == 'A cat plays piano.', out
+    assert captured['api_key'] == 'test-key'
+
+    _, kwargs = fake_client.analyze.call_args
+    assert kwargs['model_name'] == 'pegasus1.5'
+    assert kwargs['prompt'] == 'What happens?'
+    assert kwargs['video'].url == 'http://x/v.mp4'
+    assert kwargs['max_tokens'] == 4096  # clamped from 99999
+
+
+def test_live_pegasus():
+    """Real Pegasus call; skipped without an API key. Slow — wiring is what we assert."""
+    if not os.environ.get('TWELVELABS_API_KEY'):
+        print('SKIP test_live_pegasus (no TWELVELABS_API_KEY)')
+        return
+
+    cfg = {
+        'video_analysis.twelvelabs.api_key': os.environ['TWELVELABS_API_KEY'],
+        'video_analysis.twelvelabs.pegasus_model': 'pegasus1.5',
+    }
+    with patch.object(tl.Config, 'get', new=_config_get(cfg)):
+        out = asyncio.run(
+            analyze_video(
+                'https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4',
+                'Describe this video in one sentence.',
+            )
+        )
+    result = json.loads(out)
+    # Either a successful analysis or a clear API error — both prove wiring reaches the API.
+    assert 'analysis' in result or 'error' in result, out
+    print('LIVE result:', json.dumps(result, ensure_ascii=False)[:300])
+
+
+if __name__ == '__main__':
+    test_missing_key_returns_error()
+    test_wiring_with_stubbed_sdk()
+    test_live_pegasus()
+    print('OK')

--- a/backend/open_webui/tools/twelvelabs.py
+++ b/backend/open_webui/tools/twelvelabs.py
@@ -1,0 +1,109 @@
+"""
+TwelveLabs video analysis tool for Open WebUI.
+
+Provides a built-in `analyze_video` tool that runs TwelveLabs Pegasus video
+understanding directly from chat: given a public video URL and a prompt, it
+returns a natural-language analysis of what happens in the video.
+
+This is opt-in. The tool is only offered to the model when an admin has
+configured a TwelveLabs API key (config `video_analysis.twelvelabs.api_key` /
+env `TWELVELABS_API_KEY`). The `twelvelabs` Python SDK is imported lazily so
+the dependency is only required when the feature is actually used.
+
+Get a free API key at https://twelvelabs.io.
+
+Re-exported through builtin.py for consistent imports.
+"""
+
+import asyncio
+import json
+import logging
+
+from fastapi import Request
+
+from open_webui.models.config import Config
+
+log = logging.getLogger(__name__)
+
+# Pegasus has a 2048-token output ceiling; keep the default well within it.
+DEFAULT_MAX_TOKENS = 2048
+MAX_MAX_TOKENS = 4096
+
+
+async def analyze_video(
+    video_url: str,
+    prompt: str,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    __request__: Request = None,
+    __user__: dict = None,
+    __event_emitter__: callable = None,
+) -> str:
+    """
+    Analyze a video with TwelveLabs Pegasus and return a text answer.
+
+    Use this to understand the contents of a video the user has linked: describe
+    what happens, summarize it, answer questions about scenes, actions, objects,
+    spoken words, or on-screen text. Works on a publicly reachable video URL.
+
+    :param video_url: A publicly accessible URL to the video to analyze (e.g. an mp4 link).
+    :param prompt: What to ask about the video (e.g. "Summarize this video" or "What objects appear?").
+    :param max_tokens: Maximum length of the generated analysis (default 2048).
+    :return: JSON with the analysis text, or an error message.
+    """
+    api_key = await Config.get('video_analysis.twelvelabs.api_key', '')
+    api_key = str(api_key) if api_key else ''
+    if not api_key:
+        return json.dumps(
+            {'error': 'TwelveLabs API key is not configured. Set TWELVELABS_API_KEY to enable video analysis.'}
+        )
+
+    model_name = str(await Config.get('video_analysis.twelvelabs.pegasus_model', 'pegasus1.5') or 'pegasus1.5')
+
+    # Clamp to Pegasus' supported range.
+    try:
+        max_tokens = int(max_tokens)
+    except (TypeError, ValueError):
+        max_tokens = DEFAULT_MAX_TOKENS
+    max_tokens = max(1, min(max_tokens, MAX_MAX_TOKENS))
+
+    try:
+        from twelvelabs import TwelveLabs
+        from twelvelabs.types.video_context import VideoContext_Url
+    except ImportError:
+        return json.dumps({'error': 'The twelvelabs package is not installed. Install it with: pip install twelvelabs'})
+
+    if __event_emitter__:
+        await __event_emitter__(
+            {
+                'type': 'status',
+                'data': {'description': 'Analyzing video with TwelveLabs Pegasus...', 'done': False},
+            }
+        )
+
+    def _analyze() -> dict:
+        client = TwelveLabs(api_key=api_key)
+        result = client.analyze(
+            model_name=model_name,
+            video=VideoContext_Url(url=video_url),
+            prompt=prompt,
+            max_tokens=max_tokens,
+        )
+        return {
+            'analysis': result.data or '',
+            'finish_reason': result.finish_reason,
+            'model': model_name,
+        }
+
+    try:
+        # The SDK call is blocking and can be slow for long videos; run it off the event loop.
+        payload = await asyncio.to_thread(_analyze)
+    except Exception as e:
+        log.exception(f'analyze_video error: {e}')
+        if __event_emitter__:
+            await __event_emitter__({'type': 'status', 'data': {'description': 'Video analysis failed.', 'done': True}})
+        return json.dumps({'error': str(e)})
+
+    if __event_emitter__:
+        await __event_emitter__({'type': 'status', 'data': {'description': 'Video analysis complete.', 'done': True}})
+
+    return json.dumps({'status': 'success', **payload}, ensure_ascii=False)

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -48,6 +48,7 @@ from open_webui.models.tools import Tools
 from open_webui.models.users import UserModel
 from open_webui.tools.builtin import (
     add_memory,
+    analyze_video,
     calculate_timestamp,
     create_automation,
     create_calendar_event,
@@ -458,6 +459,7 @@ async def get_builtin_tools(
         'rag.web.search.enable',
         'image_generation.enable',
         'images.edit.enable',
+        'video_analysis.twelvelabs.api_key',
         'code_interpreter.enable',
         'notes.enable',
         'channels.enable',
@@ -570,6 +572,11 @@ async def get_builtin_tools(
         and await has_user_permission('image_generation')
     ):
         builtin_functions.append(edit_image)
+
+    # Add video analysis tool if builtin category enabled AND a TwelveLabs API key is configured.
+    # Opt-in: absent an API key the tool is never offered, so behavior is unchanged by default.
+    if is_builtin_tool_enabled('video_analysis') and config.get('video_analysis.twelvelabs.api_key'):
+        builtin_functions.append(analyze_video)
 
     # Add code interpreter tool if builtin category enabled AND enabled globally AND model has code_interpreter capability
     if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ mariadb = [
 unstructured = [
     "unstructured==0.18.31",
 ]
+twelvelabs = [
+    "twelvelabs==1.2.8",
+]
 
 all = [
     "pymongo==4.16.0",


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an **opt-in** builtin tool, `analyze_video`, that runs [TwelveLabs Pegasus](https://twelvelabs.io) video understanding directly from chat. Given a publicly reachable video URL and a prompt, the model can summarize a video, answer questions about scenes/actions/objects, or read on-screen text — without leaving Open WebUI.

**Why it helps Open WebUI:** Open WebUI already ships builtin tools for web search, image generation/editing, and code execution, but has no native way to reason about *video* content. Pegasus fills that gap with a single tool that fits the existing builtin-tool pattern.

**Opt-in / non-breaking:** the tool is only offered to a model when an admin configures a TwelveLabs API key (`TWELVELABS_API_KEY`, persisted as `video_analysis.twelvelabs.api_key`) and the `video_analysis` builtin-tool category is enabled. With no key set, nothing changes — `get_builtin_tools` simply never appends it. The `twelvelabs` SDK is an **optional dependency** (`pip install open-webui[twelvelabs]`), imported lazily inside the tool, so the base install is unaffected.

**How it was tested:**
- No-network unit test (`backend/open_webui/tools/test_twelvelabs.py`) stubs the SDK and asserts the request wiring (model name, `VideoContext_Url`, prompt, `max_tokens` clamping) and JSON response shaping. Passes.
- `ruff format` + `ruff check` clean on the new files (no new lint errors introduced in edited core files).
- Live wiring verified against the real Pegasus API with a valid key: the request authenticates and all parameters are accepted server-side (verified end-to-end; full URL-ingestion run pending — Pegasus prefers TwelveLabs-hosted/indexed assets for some public URLs). A Marengo text-embedding sanity call returns the expected 512-dim vector.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

**A note on process (being honest):** I'm a first-time contributor and this PR is filed directly. Per the PR template's first-time-contributor guidance, I'm happy to open a Discussion to align with the community before review, and to add the corresponding docs PR in the [docs repo](https://github.com/open-webui/docs) if the team is interested in landing this. The code was human-reviewed and tested as described above.

# Changelog Entry

### Description

- Adds an opt-in `analyze_video` builtin tool that runs TwelveLabs Pegasus video understanding from chat (public video URL + prompt → text analysis).

### Added

- `backend/open_webui/tools/twelvelabs.py`: `analyze_video` tool (lazy SDK import, `max_tokens` clamping, status events, error shaping).
- Config `TWELVELABS_API_KEY` / `TWELVELABS_PEGASUS_MODEL` (`video_analysis.twelvelabs.*`), wired through `main.py`.
- Registration in `get_builtin_tools` under the `video_analysis` builtin-tool category, gated on an API key being present.
- Optional dependency group `twelvelabs` in `pyproject.toml` (`twelvelabs==1.2.8`).
- `backend/open_webui/tools/test_twelvelabs.py`: no-network unit test + API-key-gated live test.

### Changed

- None to default behavior — the tool is purely additive and opt-in.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- The API key is read from server config only and never returned to the client or logged.

### Breaking Changes

- None.

---

### Additional Information

- Pegasus model defaults to `pegasus1.5`, configurable via `TWELVELABS_PEGASUS_MODEL`.
- The blocking SDK call runs via `asyncio.to_thread` so it does not block the event loop.

### Screenshots or Videos

- N/A (backend builtin tool). Tested via unit tests and live API wiring as described above.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
