### PR TITLE
fix: clean task list markdown export

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -101,7 +101,7 @@
 				node.getAttribute('data-checked') === 'false'),
 		replacement: function (content, node) {
 			const checked = node.getAttribute('data-checked') === 'true';
-			content = content.replace(/^\s+/, '');
+			content = content.replace(/^\s*\[[ xX]\]\s*/, '').trim();
 			return `- [${checked ? 'x' : ' '}] ${content}\n`;
 		}
 	});


### PR DESCRIPTION
### Description

Fixes #26067.

Notes task lists were exported with duplicate checkbox markers, for example:

```
- [ ] [ ]

item 1
```

The task item conversion now removes the checkbox marker generated by the GFM Turndown plugin before writing Open WebUI's own task marker.

**Fixed**

- Prevents Notes task list items from exporting as - [ ] [ ]
- Keeps checked task items exporting as - [x] item
- Removes the extra blank lines caused by the duplicate marker/content conversion

**Testing**

- Ran a focused end-to-end conversion check from TipTap-style task-list HTML through Turndown/GFM to Markdown.
- Verified output:
```
- [ ] item 1
- [x] item 2
```

- Checked [src/lib/components/common/RichTextInput.svelte](vscode-file://vscode-app/c:/Users/karanyadav/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with VS Code diagnostics: no errors found.
