### PR TITLE
fix: clean task list markdown export

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -101,7 +101,7 @@
 				node.getAttribute('data-checked') === 'false'),
 		replacement: function (content, node) {
 			const checked = node.getAttribute('data-checked') === 'true';
-			content = content.replace(/^\s+/, '');
+			content = content.replace(/^\s*\[[ xX]\]\s*/, '').trim();
 			return `- [${checked ? 'x' : ' '}] ${content}\n`;
 		}
 	});


### PR DESCRIPTION
Updated todo list

Use this PR body exactly, especially the CLA section at the bottom:

```md
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This PR fixes an existing reproducible bug: #26067.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26067.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation update needed; this is a small Notes Markdown export fix.
- [x] **Dependencies:** No dependencies added or changed.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings or architectural changes.
- [x] **Git Hygiene:** The PR is atomic and contains one logical change.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Fix Notes task list Markdown export so task items are not saved or downloaded with duplicate checkbox markers.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed Notes task list export producing malformed Markdown such as `- [ ] [ ]`.
- Fixed checked task items exporting as `- [x] [x]`.
- Fixed extra blank lines caused by the duplicate task marker conversion.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Closes #26067.
- The GFM Turndown plugin already emits `[ ]` / `[x]` from the checkbox input. The custom task-list rule now removes that generated marker before writing Open WebUI's task marker.

### Testing

- Ran a focused end-to-end conversion check from TipTap-style task-list HTML through Turndown/GFM to Markdown.
- Verified output:

```md
- [ ] item 1
- [x] item 2
```

- Checked `src/lib/components/common/RichTextInput.svelte` with VS Code diagnostics: no errors found.
- Full `npm run check` was not run because full dependency install stalled in this local environment.

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
```