### PR TITLE
fix: prefer YDC_API_KEY for You.com web search (keep YOUCOM_API_KEY fallback)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1196,7 +1196,8 @@ YANDEX_WEB_SEARCH_API_KEY = os.getenv('YANDEX_WEB_SEARCH_API_KEY', '')
 
 YANDEX_WEB_SEARCH_CONFIG = os.getenv('YANDEX_WEB_SEARCH_CONFIG', '')
 
-YOUCOM_API_KEY = os.getenv('YOUCOM_API_KEY', '')
+# YDC_API_KEY is You.com's canonical env var; YOUCOM_API_KEY kept as a fallback.
+YOUCOM_API_KEY = os.getenv('YDC_API_KEY') or os.getenv('YOUCOM_API_KEY', '')
 
 LINKUP_API_KEY = os.getenv('LINKUP_API_KEY', '')
 


### PR DESCRIPTION
# Pull Request

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** No existing issue/discussion yet — happy to open one if preferred. Context: this is part of a cross-ecosystem env-var standardization (see Additional Information).
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Documentation:** Companion docs PR opened at open-webui/docs#1307.
- [x] **Dependencies:** No new or changed dependencies.
- [x] **Testing:** `python -m py_compile` passes; behavior verified by reading `os.getenv` precedence (`YDC_API_KEY` first, else `YOUCOM_API_KEY`, else `''`).
- [x] **No Unchecked AI Code:** AI-assisted and human-reviewed + manually verified. The change is a single, backward-compatible line.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings; smart default (env-var lookup gains the canonical name, persisted config key/UI field unchanged).
- [x] **Git Hygiene:** Atomic, rebased on `dev`, no unrelated commits.
- [x] **Title Prefix:** `fix:`.

# Changelog Entry

### Description

Make `YDC_API_KEY` the preferred environment variable for the You.com web search provider, keeping `YOUCOM_API_KEY` as a backward-compatible fallback. `YDC_API_KEY` is You.com's canonical API key env var — used by You.com's own docs, examples, and SDK, plus the LangChain/CrewAI/DSPy integrations. Open WebUI previously only read `YOUCOM_API_KEY`, which is inconsistent with the rest of the ecosystem.

### Changed

- You.com web search now reads `YDC_API_KEY` from the environment when set, falling back to `YOUCOM_API_KEY` otherwise (`backend/open_webui/config.py`). The persisted config key, API/form field, and admin UI binding are unchanged, so existing setups and saved keys keep working.

---

### Additional Information

- Single-line, fully backward-compatible change. Replaces the earlier #26295, which was auto-closed for targeting `main` and missing this template/CLA.
- Part of a cross-ecosystem standardization effort tracked at youdotcom-oss/integration-tracking#30.
- Disclosure: this contribution was AI-assisted and reviewed/authorized by a human maintainer at You.com before submission.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
