### PR TITLE
feat: render Valves field descriptions as sanitized markdown

### DIFF
--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -6,6 +6,17 @@
 	import Switch from './Switch.svelte';
 	import SensitiveInput from './SensitiveInput.svelte';
 	import MapSelector from './Valves/MapSelector.svelte';
+	import DOMPurify from 'dompurify';
+	import { Marked } from 'marked';
+
+	// Render valve descriptions as markdown. An isolated Marked instance keeps
+	// this independent of the global chat markdown config (KaTeX/custom
+	// extensions), and the output is always sanitized with DOMPurify before being
+	// inserted as HTML — so descriptions may use basic markdown (bold, links,
+	// inline code, lists) with no XSS risk.
+	const descriptionMarkdown = new Marked({ breaks: true });
+	const renderDescription = (text) =>
+		DOMPurify.sanitize(descriptionMarkdown.parse(text ?? '', { async: false }));
 
 	export let valvesSpec = null;
 	export let valves = {};
@@ -213,8 +224,8 @@
 			{/if}
 
 			{#if (valvesSpec.properties[property]?.description ?? null) !== null}
-				<div class="text-xs text-gray-500">
-					{valvesSpec.properties[property].description}
+				<div class="text-xs text-gray-500 valve-description">
+					{@html renderDescription(valvesSpec.properties[property].description)}
 				</div>
 			{/if}
 		</div>
@@ -222,3 +233,26 @@
 {:else}
 	<div class="text-xs">{$i18n.t('No valves')}</div>
 {/if}
+
+<style>
+	/* Keep markdown-rendered valve descriptions compact in their small text area. */
+	.valve-description :global(p) {
+		margin: 0;
+	}
+	.valve-description :global(p + p) {
+		margin-top: 0.25rem;
+	}
+	.valve-description :global(ul),
+	.valve-description :global(ol) {
+		margin: 0.25rem 0;
+		padding-left: 1.25rem;
+		list-style: revert;
+	}
+	.valve-description :global(a) {
+		text-decoration: underline;
+	}
+	.valve-description :global(code) {
+		font-family: ui-monospace, monospace;
+		font-size: 0.95em;
+	}
+</style>


### PR DESCRIPTION
Function/tool Valves descriptions were shown as raw plain text (a bare interpolation), so markdown in a pydantic Field(description=...) appeared literally. Render them as markdown (bold, inline code, links, lists) using a local marked instance, with the output passed through DOMPurify before being inserted as HTML — the same sanitize-then-{@html} pattern already used in the codebase (admin General settings, ChangelogModal). Compact scoped styles keep the rendered output tidy in the small description area.

Safe by construction: DOMPurify strips dangerous protocols (javascript:) and inline event-handler attributes, and the marked instance is local so it does not inherit the global chat markdown extensions (KaTeX/custom).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
