### PR TITLE
breaking: sandbox client-side Pyodide at an opaque origin by default

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -1053,6 +1053,13 @@ if OFFLINE_MODE:
     ENABLE_VERSION_UPDATE_CHECK = False
 
 ####################################
+# ENABLE_PYODIDE_FILE_PERSISTENCE
+####################################
+
+# false (default) = opaque-origin sandbox, no persistence; true = same-origin worker with IDBFS persistence
+ENABLE_PYODIDE_FILE_PERSISTENCE = os.getenv('ENABLE_PYODIDE_FILE_PERSISTENCE', 'false').lower() == 'true'
+
+####################################
 # Audit logging
 ####################################
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -92,6 +92,7 @@ from open_webui.env import (
     ENABLE_SCIM,
     ENABLE_SIGNUP_PASSWORD_CONFIRMATION,
     ENABLE_STAR_SESSIONS_MIDDLEWARE,
+    ENABLE_PYODIDE_FILE_PERSISTENCE,
     ENABLE_VERSION_UPDATE_CHECK,
     ENABLE_WEBSOCKET_SUPPORT,
     GLOBAL_LOG_LEVEL,
@@ -269,6 +270,14 @@ class SPAStaticFiles(StaticFiles):
                     return await super().get_response('index.html', scope)
             else:
                 raise ex
+
+
+class CORSStaticFiles(StaticFiles):
+    async def get_response(self, path: str, scope):
+        # Public Pyodide runtime/wheels fetched cross-origin by the sandboxed (opaque-origin) iframe.
+        response = await super().get_response(path, scope)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
 
 
 if LOG_FORMAT != 'json':
@@ -1900,6 +1909,7 @@ async def get_app_config(request: Request):
                     'enable_api_keys': config.get('auth.enable_api_keys'),
                     'enable_password_change_form': config.get('ui.enable_password_change_form'),
                     'enable_version_update_check': ENABLE_VERSION_UPDATE_CHECK,
+                    'enable_pyodide_file_persistence': ENABLE_PYODIDE_FILE_PERSISTENCE,
                     'enable_public_active_users_count': ENABLE_PUBLIC_ACTIVE_USERS_COUNT,
                     'enable_easter_eggs': ENABLE_EASTER_EGGS,
                     'enable_direct_connections': config.get('direct.enable'),
@@ -2580,6 +2590,9 @@ applications.get_swagger_ui_html = swagger_ui_html
 
 if os.path.exists(FRONTEND_BUILD_DIR):
     mimetypes.add_type('text/javascript', '.js')
+    pyodide_dir = os.path.join(FRONTEND_BUILD_DIR, 'pyodide')
+    if os.path.exists(pyodide_dir):
+        app.mount('/pyodide', CORSStaticFiles(directory=pyodide_dir), name='pyodide')
     app.mount(
         '/',
         SPAStaticFiles(directory=FRONTEND_BUILD_DIR, html=True),

--- a/src/lib/components/admin/Settings/CodeExecution.svelte
+++ b/src/lib/components/admin/Settings/CodeExecution.svelte
@@ -71,7 +71,9 @@
 										<option disabled selected value="">{$i18n.t('Select a engine')}</option>
 										{#each engines as engine}
 											<option value={engine}
-												>{engine}{engine === 'jupyter' ? ' (Legacy)' : ''}</option
+												>{engine}{engine === 'jupyter' || engine === 'pyodide'
+													? ' (Legacy)'
+													: ''}</option
 											>
 										{/each}
 									</select>
@@ -82,6 +84,14 @@
 								<div class="text-gray-500 text-xs">
 									{$i18n.t(
 										'Warning: Jupyter execution enables arbitrary code execution, posing severe security risks—proceed with extreme caution.'
+									)}
+								</div>
+							{/if}
+
+							{#if config.CODE_EXECUTION_ENGINE === 'pyodide'}
+								<div class="text-gray-500 text-xs">
+									{$i18n.t(
+										'Pyodide is legacy and runs sandboxed without file persistence by default. Set ENABLE_PYODIDE_FILE_PERSISTENCE=true for same-origin persistence, which re-accepts the shared-chat code-execution risk.'
 									)}
 								</div>
 							{/if}
@@ -200,7 +210,9 @@
 										<option disabled selected value="">{$i18n.t('Select a engine')}</option>
 										{#each engines as engine}
 											<option value={engine}
-												>{engine}{engine === 'jupyter' ? ' (Legacy)' : ''}</option
+												>{engine}{engine === 'jupyter' || engine === 'pyodide'
+													? ' (Legacy)'
+													: ''}</option
 											>
 										{/each}
 									</select>

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -4,7 +4,7 @@
 	import { getContext, onMount, tick, onDestroy } from 'svelte';
 	import { config, pyodideWorker as pyodideWorkerStore } from '$lib/stores';
 
-	import PyodideWorker from '$lib/workers/pyodide.worker?worker';
+	import { createPyodideWorker } from '$lib/pyodide/createPyodideWorker';
 	import { executeCode } from '$lib/apis/utils';
 	import {
 		copyToClipboard,
@@ -244,7 +244,7 @@
 		// Otherwise fall back to a throwaway worker.
 		const sharedWorker = $pyodideWorkerStore;
 		const isShared = !!sharedWorker;
-		const worker = sharedWorker ?? new PyodideWorker();
+		const worker = sharedWorker ?? createPyodideWorker();
 
 		if (!isShared) {
 			localPyodideWorker = worker;

--- a/src/lib/components/chat/PyodideFileNav.svelte
+++ b/src/lib/components/chat/PyodideFileNav.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
 	import { getContext, onMount, onDestroy, tick } from 'svelte';
 	import { pyodideWorker } from '$lib/stores';
-	import PyodideWorkerConstructor from '$lib/workers/pyodide.worker?worker';
+	import { createPyodideWorker } from '$lib/pyodide/createPyodideWorker';
 	import type { FileEntry } from '$lib/apis/terminal';
 
 	import FileNavToolbar from './FileNav/FileNavToolbar.svelte';
@@ -100,7 +100,7 @@
 	function ensureWorker(): Worker {
 		let worker = $pyodideWorker;
 		if (!worker) {
-			worker = new PyodideWorkerConstructor();
+			worker = createPyodideWorker();
 			pyodideWorker.set(worker);
 		}
 		return worker;

--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -15,7 +15,7 @@
 
 	import { onMount, createEventDispatcher, getContext, tick, onDestroy } from 'svelte';
 
-	import PyodideWorker from '$lib/workers/pyodide.worker?worker';
+	import { createPyodideWorker } from '$lib/pyodide/createPyodideWorker';
 
 	import { formatPythonCode } from '$lib/apis/utils';
 	import { toast } from 'svelte-sonner';
@@ -96,7 +96,7 @@
 
 	const getPyodideWorker = () => {
 		if (!pyodideWorkerInstance) {
-			pyodideWorkerInstance = new PyodideWorker(); // Your worker constructor
+			pyodideWorkerInstance = createPyodideWorker();
 		}
 		return pyodideWorkerInstance;
 	};

--- a/src/lib/pyodide/createPyodideWorker.ts
+++ b/src/lib/pyodide/createPyodideWorker.ts
@@ -1,0 +1,12 @@
+import { get } from 'svelte/store';
+import { config } from '$lib/stores';
+import PyodideWorker from '$lib/workers/pyodide.worker?worker';
+import { PyodideSandboxHost } from '$lib/pyodide/pyodideSandboxHost';
+
+// Sandboxed opaque-origin iframe by default; same-origin worker (IDBFS persistence) when the flag is set.
+export const createPyodideWorker = (): Worker => {
+	if (get(config)?.features?.enable_pyodide_file_persistence) {
+		return new PyodideWorker();
+	}
+	return new PyodideSandboxHost() as unknown as Worker;
+};

--- a/src/lib/pyodide/pyodideSandboxHost.ts
+++ b/src/lib/pyodide/pyodideSandboxHost.ts
@@ -1,0 +1,65 @@
+// Worker-shaped Pyodide host in a sandboxed opaque-origin iframe. Never postMessage a token into it.
+type Listener = (event: MessageEvent) => void;
+
+const READY = '__pyodide_sandbox_ready__';
+
+export class PyodideSandboxHost {
+	private iframe: HTMLIFrameElement;
+	private ready = false;
+	private queue: { msg: unknown; transfer: Transferable[] }[] = [];
+	private listeners = new Set<Listener>();
+	public onmessage: Listener | null = null;
+	public onerror: ((event: unknown) => void) | null = null;
+	private onWindowMessage: (e: MessageEvent) => void;
+
+	constructor(src = '/pyodide-sandbox.html') {
+		const iframe = document.createElement('iframe');
+		iframe.setAttribute('sandbox', 'allow-scripts');
+		iframe.setAttribute('aria-hidden', 'true');
+		iframe.setAttribute('title', 'pyodide-sandbox');
+		iframe.style.display = 'none';
+		iframe.src = src;
+		this.iframe = iframe;
+
+		this.onWindowMessage = (e: MessageEvent) => {
+			if (e.source !== iframe.contentWindow) return;
+			const data = e.data;
+			if (data && data.type === READY) {
+				this.ready = true;
+				for (const item of this.queue) this.post(item.msg, item.transfer);
+				this.queue = [];
+				return;
+			}
+			const event = { data } as MessageEvent;
+			this.onmessage?.(event);
+			for (const listener of this.listeners) listener(event);
+		};
+
+		window.addEventListener('message', this.onWindowMessage);
+		document.body.appendChild(iframe);
+	}
+
+	private post(msg: unknown, transfer: Transferable[]) {
+		this.iframe.contentWindow?.postMessage(msg, '*', transfer);
+	}
+
+	postMessage(msg: unknown, transfer: Transferable[] = []) {
+		if (this.ready) this.post(msg, transfer);
+		else this.queue.push({ msg, transfer });
+	}
+
+	addEventListener(_type: 'message', listener: Listener) {
+		this.listeners.add(listener);
+	}
+
+	removeEventListener(_type: 'message', listener: Listener) {
+		this.listeners.delete(listener);
+	}
+
+	terminate() {
+		window.removeEventListener('message', this.onWindowMessage);
+		this.listeners.clear();
+		this.onmessage = null;
+		this.iframe.remove();
+	}
+}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -301,6 +301,7 @@ type Config = {
 		enable_autocomplete_generation: boolean;
 		enable_direct_connections: boolean;
 		enable_version_update_check: boolean;
+		enable_pyodide_file_persistence?: boolean;
 		folder_max_file_count?: number;
 	};
 	oauth: {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { io } from 'socket.io-client';
 	import { spring } from 'svelte/motion';
-	import PyodideWorker from '$lib/workers/pyodide.worker?worker';
+	import { createPyodideWorker } from '$lib/pyodide/createPyodideWorker';
 	import { Toaster, toast } from 'svelte-sonner';
 
 	let loadingProgress = spring(0, {
@@ -237,7 +237,7 @@
 	const getOrCreateWorker = () => {
 		let worker = $pyodideWorker;
 		if (!worker) {
-			worker = new PyodideWorker();
+			worker = createPyodideWorker();
 			pyodideWorker.set(worker);
 		}
 		return worker;

--- a/static/pyodide-sandbox.html
+++ b/static/pyodide-sandbox.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="robots" content="noindex" />
+		<title>Open WebUI Pyodide sandbox</title>
+	</head>
+	<body>
+		<script src="/pyodide/pyodide.js"></script>
+		<script src="/pyodide-sandbox.js"></script>
+	</body>
+</html>

--- a/static/pyodide-sandbox.js
+++ b/static/pyodide-sandbox.js
@@ -1,0 +1,220 @@
+// Pyodide host for a sandboxed opaque-origin iframe; executed Python can't reach app credentials/DOM/endpoints. Never send it a token.
+(function () {
+	let pyodide = null;
+	let pyodideReady = null;
+	let stdout = null;
+	let stderr = null;
+
+	function post(msg, transfer) {
+		parent.postMessage(msg, '*', transfer || []);
+	}
+
+	async function loadPyodideAndPackages(packages) {
+		stdout = null;
+		stderr = null;
+		// eslint-disable-next-line no-undef
+		pyodide = await loadPyodide({
+			indexURL: '/pyodide/',
+			stdout: (text) => {
+				stdout = stdout ? `${stdout}${text}\n` : `${text}\n`;
+			},
+			stderr: (text) => {
+				stderr = stderr ? `${stderr}${text}\n` : `${text}\n`;
+			},
+			packages: ['micropip']
+		});
+		// In-memory upload dir only; no IDBFS mount at an opaque origin.
+		pyodide.FS.mkdirTree('/mnt/uploads');
+		const micropip = pyodide.pyimport('micropip');
+		await micropip.install(packages || []);
+	}
+
+	async function ensurePyodide(packages) {
+		if (!pyodideReady) {
+			pyodideReady = loadPyodideAndPackages(packages);
+		}
+		await pyodideReady;
+		if (packages && packages.length > 0 && pyodide) {
+			const micropip = pyodide.pyimport('micropip');
+			await micropip.install(packages);
+		}
+	}
+
+	function fsUploadFiles(files, dir) {
+		dir = dir || '/mnt/uploads';
+		try {
+			pyodide.FS.stat(dir);
+		} catch {
+			pyodide.FS.mkdirTree(dir);
+		}
+		for (const file of files) {
+			pyodide.FS.writeFile(`${dir}/${file.name}`, new Uint8Array(file.data));
+		}
+	}
+
+	function fsList(path) {
+		const entries = [];
+		try {
+			const items = pyodide.FS.readdir(path).filter((n) => n !== '.' && n !== '..');
+			for (const name of items) {
+				try {
+					const stat = pyodide.FS.stat(`${path}/${name}`);
+					const isDir = pyodide.FS.isDir(stat.mode);
+					entries.push({ name, type: isDir ? 'directory' : 'file', size: isDir ? 0 : stat.size });
+				} catch {
+					// skip inaccessible entries
+				}
+			}
+		} catch {
+			// directory doesn't exist
+		}
+		return entries;
+	}
+
+	function fsRead(path) {
+		const data = pyodide.FS.readFile(path);
+		return data.buffer;
+	}
+
+	function fsDelete(path) {
+		try {
+			const stat = pyodide.FS.stat(path);
+			if (pyodide.FS.isDir(stat.mode)) {
+				const items = pyodide.FS.readdir(path).filter((n) => n !== '.' && n !== '..');
+				for (const item of items) {
+					fsDelete(`${path}/${item}`);
+				}
+				pyodide.FS.rmdir(path);
+			} else {
+				pyodide.FS.unlink(path);
+			}
+		} catch {
+			// already gone
+		}
+	}
+
+	function fsMkdir(path) {
+		pyodide.FS.mkdirTree(path);
+	}
+
+	function processResult(result) {
+		try {
+			if (result == null) return null;
+			if (typeof result === 'string' || typeof result === 'number' || typeof result === 'boolean') {
+				return result;
+			}
+			if (typeof result === 'bigint') return result.toString();
+			if (Array.isArray(result)) return result.map((item) => processResult(item));
+			if (typeof result.toJs === 'function') return processResult(result.toJs());
+			if (typeof result === 'object') {
+				const out = {};
+				for (const key in result) {
+					if (Object.prototype.hasOwnProperty.call(result, key)) {
+						out[key] = processResult(result[key]);
+					}
+				}
+				return out;
+			}
+			return JSON.stringify(result);
+		} catch (err) {
+			return `[processResult error]: ${err && err.message ? err.message : String(err)}`;
+		}
+	}
+
+	async function executeCode(id, code, files) {
+		stdout = null;
+		stderr = null;
+		let result = null;
+
+		if (files && files.length > 0) {
+			fsUploadFiles(files);
+		}
+
+		try {
+			if (code.includes('matplotlib')) {
+				await pyodide.runPythonAsync(`import base64
+import os
+from io import BytesIO
+
+# before importing matplotlib
+# to avoid the wasm backend (which needs js.document', not available here)
+os.environ["MPLBACKEND"] = "AGG"
+
+import matplotlib.pyplot
+
+_old_show = matplotlib.pyplot.show
+assert _old_show, "matplotlib.pyplot.show"
+
+def show(*, block=None):
+	buf = BytesIO()
+	matplotlib.pyplot.savefig(buf, format="png")
+	buf.seek(0)
+	# encode to a base64 str
+	img_str = base64.b64encode(buf.read()).decode('utf-8')
+	matplotlib.pyplot.clf()
+	buf.close()
+	print(f"data:image/png;base64,{img_str}")
+
+matplotlib.pyplot.show = show`);
+			}
+
+			result = processResult(await pyodide.runPythonAsync(code));
+		} catch (error) {
+			stderr = error && error.message ? error.message : String(error);
+		}
+
+		post({ id, result, stdout, stderr });
+	}
+
+	window.addEventListener('message', async (event) => {
+		// Only ever accept messages from our own parent.
+		if (event.source !== parent) return;
+
+		const data = event.data || {};
+		const { id, type } = data;
+
+		if (!type || type === 'execute') {
+			const { code, files, packages } = data;
+			await ensurePyodide(packages || []);
+			await executeCode(id, code, files);
+			return;
+		}
+
+		await ensurePyodide();
+
+		switch (type) {
+			case 'fs:upload':
+				fsUploadFiles(data.files, data.dir);
+				post({ id, type: 'fs:upload', success: true });
+				break;
+			case 'fs:list':
+				post({ id, type: 'fs:list', entries: fsList(data.path) });
+				break;
+			case 'fs:read':
+				try {
+					const buffer = fsRead(data.path);
+					post({ id, type: 'fs:read', data: buffer }, [buffer]);
+				} catch (err) {
+					post({ id, type: 'fs:read', error: err && err.message ? err.message : String(err) });
+				}
+				break;
+			case 'fs:delete':
+				fsDelete(data.path);
+				post({ id, type: 'fs:delete', success: true });
+				break;
+			case 'fs:mkdir':
+				fsMkdir(data.path);
+				post({ id, type: 'fs:mkdir', success: true });
+				break;
+			case 'fs:sync':
+				// no-op: an opaque origin has no persistent backing store
+				post({ id, type: 'fs:sync', success: true });
+				break;
+			default:
+				console.warn('Unknown message type:', type);
+		}
+	});
+
+	// Tell the parent we are wired up and ready to receive work.
+	post({ type: '__pyodide_sandbox_ready__' });
+})();


### PR DESCRIPTION
## Summary

Open WebUI's client-side Python (Pyodide) runs in a Web Worker that shares the app's origin. Because the worker is same-origin, executed Python can issue credentialed requests to the app's own API and reach same-origin browser context. This change runs Pyodide in a sandboxed, opaque-origin iframe by default, so executed Python is isolated from the session cookie, auth token, localStorage, DOM and same-origin endpoints, while full Python, JS and external (cross-origin) fetch keep working.

It also marks Pyodide as legacy in the admin Code Execution settings.

## Changes

- Host Pyodide in a `sandbox="allow-scripts"` iframe (no `allow-same-origin`) so it runs at an opaque origin. New `static/pyodide-sandbox.{html,js}` mirror the worker's `execute` / `fs:*` message protocol (without IDBFS).
- `PyodideSandboxHost`: a `Worker`-shaped wrapper around the iframe, so the call sites are unchanged in shape.
- `createPyodideWorker()` factory selects the host; the four Pyodide spawn sites use it.
- IDBFS file persistence needs a stable origin, so it is gated behind a new `ENABLE_PYODIDE_FILE_PERSISTENCE` flag (default `false`). With it set, the previous same-origin worker is used and persistence works.
- Serve the `/pyodide/` runtime and wheels with `Access-Control-Allow-Origin: *` so the opaque-origin iframe can load them (public assets).
- Mark `pyodide` as `(Legacy)` in the Code Execution and Code Interpreter engine selectors, with a note about the flag.

## Configuration

`ENABLE_PYODIDE_FILE_PERSISTENCE` (env, default `false`):
- `false`: Pyodide runs in the opaque-origin sandbox, no IDBFS persistence. **Breaking** for setups that rely on persisted Pyodide files.
- `true`: Pyodide runs same-origin, persistence works, at the cost of the same-origin reach above.

## Verification

Tested in a browser against a running instance:
- Pyodide loads and executes inside the opaque-origin iframe (the CORS-served runtime loads cross-origin).
- A credentialed request from the sandbox to an app API endpoint does not reach it, while the same call from the app page is authorised normally.
- External cross-origin fetch from the sandbox still works.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
