### PR TITLE
fix: speak full reply in call mode with fast local model streams (LM Studio/Ollama/MLX)

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1841,21 +1841,19 @@
 						);
 						messageContentParts.pop();
 
-						// dispatch only last sentence and make sure it hasn't been dispatched before
-						if (
-							messageContentParts.length > 0 &&
-							messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-						) {
-							message.lastSentence = messageContentParts[messageContentParts.length - 1];
+						// Dispatch ALL newly-completed sentences since the last tick — not just the
+						// final one. A fast stream (local models like LM Studio/Ollama) can finish
+						// several sentences within a single update; sending only the last silently
+						// drops the ones in between, so they are never spoken in call mode.
+						const dispatchedCount = message.dispatchedSentenceCount ?? 0;
+						for (let i = dispatchedCount; i < messageContentParts.length; i++) {
 							eventTarget.dispatchEvent(
 								new CustomEvent('chat', {
-									detail: {
-										id: message.id,
-										content: messageContentParts[messageContentParts.length - 1]
-									}
+									detail: { id: message.id, content: messageContentParts[i] }
 								})
 							);
 						}
+						message.dispatchedSentenceCount = messageContentParts.length;
 					}
 				}
 			}
@@ -1877,21 +1875,19 @@
 				);
 				messageContentParts.pop();
 
-				// dispatch only last sentence and make sure it hasn't been dispatched before
-				if (
-					messageContentParts.length > 0 &&
-					messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-				) {
-					message.lastSentence = messageContentParts[messageContentParts.length - 1];
+				// Dispatch ALL newly-completed sentences since the last tick — not just the
+				// final one. A fast stream (local models like LM Studio/Ollama) can finish
+				// several sentences within a single update; sending only the last silently
+				// drops the ones in between, so they are never spoken in call mode.
+				const dispatchedCount = message.dispatchedSentenceCount ?? 0;
+				for (let i = dispatchedCount; i < messageContentParts.length; i++) {
 					eventTarget.dispatchEvent(
 						new CustomEvent('chat', {
-							detail: {
-								id: message.id,
-								content: messageContentParts[messageContentParts.length - 1]
-							}
+							detail: { id: message.id, content: messageContentParts[i] }
 						})
 					);
 				}
+				message.dispatchedSentenceCount = messageContentParts.length;
 			}
 		}
 
@@ -1920,18 +1916,24 @@
 
 			// Emit chat event for TTS (only when call overlay is active)
 			if ($showCallOverlay) {
-				let lastMessageContentPart =
-					getMessageContentParts(
-						removeAllDetails(message.content),
-						$config?.audio?.tts?.split_on ?? 'punctuation'
-					)?.at(-1) ?? '';
-				if (lastMessageContentPart) {
-					eventTarget.dispatchEvent(
-						new CustomEvent('chat', {
-							detail: { id: message.id, content: lastMessageContentPart }
-						})
-					);
+				const finalParts = getMessageContentParts(
+					removeAllDetails(message.content),
+					$config?.audio?.tts?.split_on ?? 'punctuation'
+				);
+				// Flush any sentences not yet dispatched during streaming — including the
+				// final one, which is always held back as the incomplete tail — so the
+				// whole reply is spoken.
+				const doneDispatched = message.dispatchedSentenceCount ?? 0;
+				for (let i = doneDispatched; i < finalParts.length; i++) {
+					if (finalParts[i]) {
+						eventTarget.dispatchEvent(
+							new CustomEvent('chat', {
+								detail: { id: message.id, content: finalParts[i] }
+							})
+						);
+					}
 				}
+				message.dispatchedSentenceCount = finalParts.length;
 			}
 			eventTarget.dispatchEvent(
 				new CustomEvent('chat:finish', {

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -483,6 +483,9 @@
 	// Audio cache map where key is the content and value is the Audio object.
 	const audioCache = new Map();
 	const emojiCache = new Map();
+	// Content whose TTS fetch outright FAILED (vs. still generating). The play loop skips
+	// these immediately instead of waiting, so one failure can't stall the whole queue.
+	const failedContent = new Set();
 
 	const fetchAudio = async (content) => {
 		if (!audioCache.has(content)) {
@@ -521,12 +524,15 @@
 						const blob = await res.blob();
 						const blobUrl = URL.createObjectURL(blob);
 						audioCache.set(content, new Audio(blobUrl));
+					} else {
+						failedContent.add(content); // TTS request failed — don't wait on it
 					}
 				} else {
 					audioCache.set(content, true);
 				}
 			} catch (error) {
 				console.error('Error synthesizing speech:', error);
+				failedContent.add(content);
 			}
 		}
 
@@ -536,6 +542,7 @@
 	let messages = {};
 
 	const monitorAndPlayAudio = async (id, signal) => {
+		const audioWaitCounts = {};
 		while (!signal.aborted) {
 			if (messages[id] && messages[id].length > 0) {
 				// Retrieve the next content string from the queue
@@ -570,12 +577,22 @@
 						await speakSpeechSynthesisHandler(content);
 					}
 				} else {
-					// If not available in the cache, push it back to the queue and delay
-					messages[id].unshift(content); // Re-queue the content at the start
-					console.log(`Audio for "${content}" not yet available in the cache, re-queued...`);
-					await new Promise((resolve) => setTimeout(resolve, 200)); // Wait before retrying to reduce tight loop
+					// Not cached yet. If its TTS fetch FAILED, drop it immediately so it can't
+					// block the queue. Otherwise it's still generating — a single-GPU TTS
+					// serializes long replies, so keep waiting (with a generous ~60s backstop
+					// so a truly stalled request still can't hang the turn forever).
+					audioWaitCounts[content] = (audioWaitCounts[content] ?? 0) + 1;
+					if (
+						failedContent.has(content) ||
+						(finishedMessages[id] && audioWaitCounts[content] > 300)
+					) {
+						console.warn(`No audio for "${content}"; skipping.`);
+					} else {
+						messages[id].unshift(content); // Re-queue and keep waiting for the audio
+						await new Promise((resolve) => setTimeout(resolve, 200));
+					}
 				}
-			} else if (finishedMessages[id] && messages[id] && messages[id].length === 0) {
+			} else if (finishedMessages[id]) {
 				// If the message is finished and there are no more messages to process, break the loop
 				assistantSpeaking = false;
 				break;


### PR DESCRIPTION
**Honest disclosure up front (per the "no unchecked AI code" rule):** I'm one guy, not a JS dev, and I won't pretend otherwise. I hit this bug, pointed my Claude Code instance (I call her Lyra) at it, and we spent a day running it to root cause and a fix. It's **thoroughly, manually tested** — live, for hours, across multiple providers — and formatted with your Prettier. Take it, adapt it, or close it, no hard feelings — putting it in front of you because it silently bites anyone running a fast local model. 🐬

## What's broken
In call/voice mode the spoken reply **cuts off after the first sentence**, or **hangs and never gives the mic back**, when the backing model streams *fast* — local backends like LM Studio, Ollama, MLX. Cloud providers stream slowly enough to mask it, which is the tell.

## Root cause (two issues, both in the call-mode TTS path)
1. **Only the last completed sentence is dispatched per stream tick.** In `Chat.svelte`, the `$showCallOverlay` blocks split the growing reply and dispatch only `messageContentParts[length - 1]`, deduped on `message.lastSentence`. That assumes ≤1 sentence finishes per tick — true for a slow cloud drip, false for a fast local stream where several land in one update. The in-between sentences are never dispatched → never spoken.
2. **The playback loop can wait forever.** `CallOverlay.svelte` → `monitorAndPlayAudio` re-queues a sentence until its audio caches and only breaks when the queue is empty. A never-queued (fast-stream race) or failed sentence leaves the queue non-empty forever → `assistantSpeaking` stays `true` → mic stays suppressed → the call hangs and the turn never returns.

## The fix
- `Chat.svelte`: dispatch **all** newly-completed sentences since the last tick (tracked by a per-message `dispatchedSentenceCount` index), and flush any remainder at `done`.
- `CallOverlay.svelte`: distinguish a **failed** TTS fetch (skip immediately so it can't block the queue) from a **slow** one (keep waiting — single-GPU local TTS serializes long replies), with a generous backstop so a truly stalled request can't hang the turn; and release `assistantSpeaking` when finished.

## Reproduce
1. Point a model connection at a fast local backend (LM Studio / Ollama).
2. Open call mode and ask for a multi-sentence reply.
3. Before: first sentence only, or a hang. Same persona/voice on a cloud provider speaks the whole thing.

## Testing
Manually tested live for hours against a local MLX/Chatterbox OpenAI-compatible TTS server, with **LM Studio (Gemma)** and **DeepInfra (Gemma)** as the chat backends. Before: cut off / hung. After: full replies start-to-finish across both providers, mic returns every turn. No new dependencies.

---

- [x] Targets `dev`
- [x] Atomic — one logical change, two files, no unrelated edits
- [x] Manually tested (above); no new/updated dependencies
- [x] AI-assisted **and** thoroughly human-tested (disclosed at top)
- [x] I agree to the Contributor License Agreement
