### PR TITLE
fix: speak full reply in call mode with fast local model streams (LM Studio/Ollama/MLX)

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1841,21 +1841,19 @@
 						);
 						messageContentParts.pop();
 
-						// dispatch only last sentence and make sure it hasn't been dispatched before
-						if (
-							messageContentParts.length > 0 &&
-							messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-						) {
-							message.lastSentence = messageContentParts[messageContentParts.length - 1];
+						// Dispatch ALL newly-completed sentences since the last tick — not just the
+						// final one. A fast stream (local models like LM Studio/Ollama) can finish
+						// several sentences within a single update; sending only the last silently
+						// drops the ones in between, so they are never spoken in call mode.
+						const dispatchedCount = message.dispatchedSentenceCount ?? 0;
+						for (let i = dispatchedCount; i < messageContentParts.length; i++) {
 							eventTarget.dispatchEvent(
 								new CustomEvent('chat', {
-									detail: {
-										id: message.id,
-										content: messageContentParts[messageContentParts.length - 1]
-									}
+									detail: { id: message.id, content: messageContentParts[i] }
 								})
 							);
 						}
+						message.dispatchedSentenceCount = messageContentParts.length;
 					}
 				}
 			}
@@ -1877,21 +1875,19 @@
 				);
 				messageContentParts.pop();
 
-				// dispatch only last sentence and make sure it hasn't been dispatched before
-				if (
-					messageContentParts.length > 0 &&
-					messageContentParts[messageContentParts.length - 1] !== message.lastSentence
-				) {
-					message.lastSentence = messageContentParts[messageContentParts.length - 1];
+				// Dispatch ALL newly-completed sentences since the last tick — not just the
+				// final one. A fast stream (local models like LM Studio/Ollama) can finish
+				// several sentences within a single update; sending only the last silently
+				// drops the ones in between, so they are never spoken in call mode.
+				const dispatchedCount = message.dispatchedSentenceCount ?? 0;
+				for (let i = dispatchedCount; i < messageContentParts.length; i++) {
 					eventTarget.dispatchEvent(
 						new CustomEvent('chat', {
-							detail: {
-								id: message.id,
-								content: messageContentParts[messageContentParts.length - 1]
-							}
+							detail: { id: message.id, content: messageContentParts[i] }
 						})
 					);
 				}
+				message.dispatchedSentenceCount = messageContentParts.length;
 			}
 		}
 
@@ -1920,18 +1916,24 @@
 
 			// Emit chat event for TTS (only when call overlay is active)
 			if ($showCallOverlay) {
-				let lastMessageContentPart =
-					getMessageContentParts(
-						removeAllDetails(message.content),
-						$config?.audio?.tts?.split_on ?? 'punctuation'
-					)?.at(-1) ?? '';
-				if (lastMessageContentPart) {
-					eventTarget.dispatchEvent(
-						new CustomEvent('chat', {
-							detail: { id: message.id, content: lastMessageContentPart }
-						})
-					);
+				const finalParts = getMessageContentParts(
+					removeAllDetails(message.content),
+					$config?.audio?.tts?.split_on ?? 'punctuation'
+				);
+				// Flush any sentences not yet dispatched during streaming — including the
+				// final one, which is always held back as the incomplete tail — so the
+				// whole reply is spoken.
+				const doneDispatched = message.dispatchedSentenceCount ?? 0;
+				for (let i = doneDispatched; i < finalParts.length; i++) {
+					if (finalParts[i]) {
+						eventTarget.dispatchEvent(
+							new CustomEvent('chat', {
+								detail: { id: message.id, content: finalParts[i] }
+							})
+						);
+					}
 				}
+				message.dispatchedSentenceCount = finalParts.length;
 			}
 			eventTarget.dispatchEvent(
 				new CustomEvent('chat:finish', {

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -483,6 +483,9 @@
 	// Audio cache map where key is the content and value is the Audio object.
 	const audioCache = new Map();
 	const emojiCache = new Map();
+	// Content whose TTS fetch outright FAILED (vs. still generating). The play loop skips
+	// these immediately instead of waiting, so one failure can't stall the whole queue.
+	const failedContent = new Set();
 
 	const fetchAudio = async (content) => {
 		if (!audioCache.has(content)) {
@@ -521,12 +524,15 @@
 						const blob = await res.blob();
 						const blobUrl = URL.createObjectURL(blob);
 						audioCache.set(content, new Audio(blobUrl));
+					} else {
+						failedContent.add(content); // TTS request failed — don't wait on it
 					}
 				} else {
 					audioCache.set(content, true);
 				}
 			} catch (error) {
 				console.error('Error synthesizing speech:', error);
+				failedContent.add(content);
 			}
 		}
 
@@ -536,6 +542,7 @@
 	let messages = {};
 
 	const monitorAndPlayAudio = async (id, signal) => {
+		const audioWaitCounts = {};
 		while (!signal.aborted) {
 			if (messages[id] && messages[id].length > 0) {
 				// Retrieve the next content string from the queue
@@ -570,12 +577,22 @@
 						await speakSpeechSynthesisHandler(content);
 					}
 				} else {
-					// If not available in the cache, push it back to the queue and delay
-					messages[id].unshift(content); // Re-queue the content at the start
-					console.log(`Audio for "${content}" not yet available in the cache, re-queued...`);
-					await new Promise((resolve) => setTimeout(resolve, 200)); // Wait before retrying to reduce tight loop
+					// Not cached yet. If its TTS fetch FAILED, drop it immediately so it can't
+					// block the queue. Otherwise it's still generating — a single-GPU TTS
+					// serializes long replies, so keep waiting (with a generous ~60s backstop
+					// so a truly stalled request still can't hang the turn forever).
+					audioWaitCounts[content] = (audioWaitCounts[content] ?? 0) + 1;
+					if (
+						failedContent.has(content) ||
+						(finishedMessages[id] && audioWaitCounts[content] > 300)
+					) {
+						console.warn(`No audio for "${content}"; skipping.`);
+					} else {
+						messages[id].unshift(content); // Re-queue and keep waiting for the audio
+						await new Promise((resolve) => setTimeout(resolve, 200));
+					}
 				}
-			} else if (finishedMessages[id] && messages[id] && messages[id].length === 0) {
+			} else if (finishedMessages[id]) {
 				// If the message is finished and there are no more messages to process, break the loop
 				assistantSpeaking = false;
 				break;


### PR DESCRIPTION
# Pull Request Checklist

**Honest note (per the "No Unchecked AI Code" rule):** First-time contributor, not a JS dev. I hit this bug, ran it to root cause and a fix with my Claude Code instance ("Lyra"), and **manually tested it live for hours across multiple providers**. Formatted with your Prettier. Take it, adapt it, or close it — sharing because it silently bites anyone on a fast local model. I searched open/closed issues and discussions and found none for this specific bug; happy to open a Discussion instead if that's the preferred channel.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** searched — no existing issue/discussion found for this specific bug. Glad to open one if preferred.
- [x] **Target branch:** targets the `dev` branch.
- [x] **Description:** a concise description is provided below.
- [x] **Changelog:** entry included below.
- [ ] **Documentation:** n/a — behavioral bug fix, no doc change.
- [x] **Dependencies:** no new or updated dependencies.
- [x] **Testing:** manual tests performed (see below).
- [x] **No Unchecked AI Code:** AI-assisted AND thoroughly human-tested (disclosed above).
- [x] **Self-Review:** performed.
- [x] **Architecture:** no new settings; fixes existing behavior; local state only.
- [x] **Git Hygiene:** atomic — one logical change, two files, no unrelated commits.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

In call/voice mode the spoken reply **cuts off after the first sentence**, or **hangs and never returns the mic**, when the backing model streams *fast* — local backends like LM Studio, Ollama, MLX. Cloud providers stream slowly enough to mask it.

Two causes, both in the call-mode TTS path:
1. **`Chat.svelte`** dispatched only the *last* completed sentence per stream tick (deduped on `message.lastSentence`). That assumes ≤1 sentence finishes per tick — false for a fast local stream where several land at once, so the in-between sentences were never sent to TTS.
2. **`CallOverlay.svelte`** → `monitorAndPlayAudio` re-queued a sentence until its audio cached and only broke when the queue emptied, so a never-queued (fast-stream race) or failed sentence hung the turn (`assistantSpeaking` stuck `true`).

### Fixed

- Call mode now dispatches **all** newly-completed sentences (tracked by a per-message index, remainder flushed at `done`), so fast local streams no longer drop sentences.
- The playback loop now distinguishes a **failed** TTS fetch (skip immediately) from a **slow** one (keep waiting — single-GPU local TTS serializes long replies), with a backstop so a stalled request can't hang the turn, and releases the mic when finished.

### Additional Information

**Repro:** point a connection at LM Studio/Ollama, open call mode, ask for a multi-sentence reply → before: first sentence only or a hang; after: full reply. Tested live against a local MLX/Chatterbox OpenAI-compatible TTS server with **LM Studio (Gemma)** and **DeepInfra (Gemma)** backends — full replies start-to-finish across both, mic returns every turn. Root-cause detail is in the commit message.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
