### PR TITLE
fix(tools): handle empty query in search_chats without crashing

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1102,7 +1102,8 @@ async def search_chats(
 
             # Find a matching message snippet
             snippet = ''
-            messages = chat.chat.get('history', {}).get('messages', {})
+            chat_data = getattr(chat, 'chat', None) or {}
+            messages = chat_data.get('history', {}).get('messages', {})
             lower_query = query.lower()
 
             for msg_id, msg in messages.items():


### PR DESCRIPTION
## Summary

- Use `getattr` to safely access `.chat` attribute on chat objects returned by `get_chats_by_user_id_and_search_text`
- When query is empty, the function returns `ChatTitleIdResponse` objects (no `.chat` attribute) instead of `ChatModel`, causing `AttributeError: 'ChatTitleIdResponse' object has no attribute 'chat'`

## Problem

Calling `search_chats` with an empty query crashes because `get_chats_by_user_id_and_search_text` takes a different code path for empty search text, returning `ChatTitleIdResponse` instead of `ChatModel`. The code then tries `chat.chat.get('history', {})` which fails.

Fixes #26310

## Test Plan

- [ ] `search_chats` with non-empty query still works (returns `ChatModel` with `.chat`)
- [ ] `search_chats` with empty query returns recent chats without crashing (returns `ChatTitleIdResponse` without `.chat`)