### PR TITLE
fix(tools): handle empty query in search_chats without crashing

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1099,7 +1099,8 @@ async def search_chats(
 
             # Find a matching message snippet
             snippet = ''
-            messages = chat.chat.get('history', {}).get('messages', {})
+            chat_data = getattr(chat, 'chat', None) or {}
+            messages = chat_data.get('history', {}).get('messages', {})
             lower_query = query.lower()
 
             for msg_id, msg in messages.items():


### PR DESCRIPTION
## Description

When `search_chats` is called with an empty query, `get_chats_by_user_id_and_search_text` returns `ChatTitleIdResponse` objects (no `.chat` attribute) instead of `ChatModel`. The code then tries `chat.chat.get('history', {})` which crashes with `AttributeError: 'ChatTitleIdResponse' object has no attribute 'chat'`.

Using `getattr(chat, 'chat', None)` safely handles both types.

Closes #26310

## Changelog

- Fixed `search_chats` tool crash when called with an empty query string

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.