### PR TITLE
fix: preserve llama.cpp timing usage

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -112,7 +112,7 @@ from open_webui.utils.misc import (
 )
 from open_webui.utils.payload import apply_system_prompt_to_body
 from open_webui.utils.plugin import load_function_module_by_id
-from open_webui.utils.response import merge_usage, normalize_usage
+from open_webui.utils.response import extract_usage, merge_usage
 from open_webui.utils.sanitize import sanitize_code
 from open_webui.utils.task import (
     get_task_model_id,
@@ -3605,7 +3605,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     )
 
                     # Save message in the database
-                    usage = normalize_usage(response_data.get('usage', {}) or {})
+                    usage = extract_usage(response_data)
 
                     if not metadata.get('chat_id', '').startswith('channel:'):
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
@@ -4159,8 +4159,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     choices = data.get('choices', [])
 
                                     # Normalize usage data to standard format
-                                    raw_usage = data.get('usage', {}) or {}
-                                    raw_usage.update(data.get('timings', {}))  # llama.cpp
+                                    raw_usage = extract_usage(data)
                                     if raw_usage:
                                         usage = merge_usage(usage, raw_usage)
                                         await event_emitter(

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -51,6 +51,29 @@ def normalize_usage(usage: dict) -> dict:
     return result
 
 
+def extract_usage(data: dict) -> dict:
+    """
+    Extract usage metadata from provider response payloads.
+
+    OpenAI-compatible providers usually return token counts in `usage`.
+    llama.cpp additionally returns timing/token metadata in `timings`, and
+    some responses only include that object.
+    """
+    if not data:
+        return {}
+
+    raw_usage = {}
+    usage = data.get('usage')
+    if isinstance(usage, dict):
+        raw_usage.update(usage)
+
+    timings = data.get('timings')
+    if isinstance(timings, dict):
+        raw_usage.update(timings)
+
+    return normalize_usage(raw_usage) if raw_usage else {}
+
+
 USAGE_TOKEN_KEYS = {
     'input_tokens',
     'output_tokens',


### PR DESCRIPTION
Summary\n- Add a shared usage extractor that merges OpenAI-compatible usage with llama.cpp timings.\n- Use it for both streaming and non-streaming chat persistence so Analyse can see llama.cpp token counts when timings are the only usage source.\n\nTests\n- python3 -m py_compile backend/open_webui/utils/response.py backend/open_webui/utils/middleware.py\n- git diff --check\n\nNotes\n- A direct Python import sample is blocked in this shell because the system Python is missing project dependency typer.\n\nFixes #26324