### PR TITLE
Add docker-compose PoC and .env example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "3000:8080"
+    volumes:
+      - open-webui:/app/backend/data
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-0}
+    restart: always
+    # 如果需要 GPU，请确保 Docker 支持 GPU 并启用下面一行（可选）
+    gpus: all
+
+volumes:
+  open-webui:


### PR DESCRIPTION
This PR adds a minimal Docker Compose proof-of-concept and a .env.example with placeholders for quick local testing of Open WebUI.

Included:

docker-compose.yml — runs ghcr.io/open-webui/open-webui:main on port 3000 and mounts persistent volume.
.env.example — placeholders for OPENAI_API_KEY, OLLAMA_BASE_URL, HF_HUB_OFFLINE and other optional configs.
Usage:

Copy .env.example to .env and fill in your secrets locally (do NOT commit real secrets).
docker compose up -d
Visit http://localhost:3000/ to access the UI.
Notes:

This is intended as a PoC only. For production, replace SQLite with Postgres, use Redis for sessions, use proper secret management (Docker secrets / GitHub Secrets), and consider Kubernetes/Helm deployment.
See README in upstream open-webui for additional deployment options (Ollama integration, GPU images, Helm charts).