### PR TITLE
fix: render image MCP EmbeddedResource blobs as model vision input

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1154,12 +1154,26 @@ async def process_tool_result(
                     elif item.get('type') == 'resource':
                         resource = item.get('resource', {})
                         text = resource.get('text', '')
+                        blob = resource.get('blob', '')
                         if isinstance(text, str) and text:
                             try:
                                 text = json.loads(text)
                             except json.JSONDecodeError:
                                 pass
                             tool_response.append(text)
+                        elif blob:
+                            r_mime = resource.get('mimeType', '') or 'application/octet-stream'
+                            if r_mime.startswith('image/'):
+                                # Pass image blobs to the model as vision input.
+                                # Must stay a data URI so the native tool path
+                                # forwards it as an input_image part.
+                                tool_result_files.append(
+                                    {'type': 'image', 'url': f'data:{r_mime};base64,{blob}'}
+                                )
+                            else:
+                                tool_response.append(
+                                    f"[binary resource {resource.get('uri', '')} ({r_mime}) retrieved but not renderable as text]"
+                                )
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
             for item in tool_result:


### PR DESCRIPTION
### Description

MCP tools can return binary content as an `EmbeddedResource` wrapping `BlobResourceContents`
(e.g. image attachments). In `process_tool_result`, the MCP `resource` branch only read
`resource.text`, so binary `blob` payloads were silently dropped and the model received an
empty tool result.

This change handles the `blob` case: `image/*` blobs are routed into `tool_result_files` as
a `data:` URI, which the existing native-tool path then forwards to the model as an
`input_image` part. Non-image blobs get a clear placeholder instead of vanishing.

It must remain a `data:` URI (not `get_file_url_from_base64`) so it passes the existing
`url.startswith('data:')` check that gates `input_image` forwarding.

### Fixed

- MCP `EmbeddedResource` image blobs are now passed to the model as vision input instead of being silently dropped.

### Additional Information

Tested against a Jira MCP server returning PNG attachments via native function calling — the
model now actually sees and describes the images, rather than receiving an empty result.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
