### PR TITLE
fix: preserve web search context in chat retrieval

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1537,6 +1537,18 @@ async def get_sources_from_items(
                         else:
                             collection_names.append(item['id'])
 
+        elif item.get('type') == 'web_search':
+            if item.get('docs'):
+                # BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
+                query_result = {
+                    'documents': [[doc.get('content') for doc in item.get('docs')]],
+                    'metadatas': [[doc.get('metadata') for doc in item.get('docs')]],
+                }
+            elif item.get('collection_name'):
+                collection_names.append(item['collection_name'])
+            elif item.get('collection_names'):
+                collection_names.extend(item['collection_names'])
+
         elif item.get('docs'):
             # BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
             query_result = {

--- a/backend/tests/retrieval/test_web_search_sources.py
+++ b/backend/tests/retrieval/test_web_search_sources.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import pytest
+
+from open_webui.retrieval import utils
+
+
+@pytest.mark.asyncio
+async def test_get_sources_from_items_queries_web_search_collection(monkeypatch):
+    captured = {}
+
+    async def fake_filter_accessible_collections(collection_names, user):
+        captured['filtered_collection_names'] = collection_names
+        return collection_names
+
+    async def fake_query_collection(request, collection_names, queries, embedding_function, k):
+        captured['queried_collection_names'] = collection_names
+        captured['queries'] = queries
+        return {
+            'documents': [['current web result']],
+            'metadatas': [[{'source': 'https://example.com/news'}]],
+        }
+
+    monkeypatch.setattr(utils, 'filter_accessible_collections', fake_filter_accessible_collections)
+    monkeypatch.setattr(utils, 'query_collection', fake_query_collection)
+
+    user = SimpleNamespace(id='user-id', role='user')
+    sources = await utils.get_sources_from_items(
+        request=SimpleNamespace(),
+        items=[
+            {
+                'type': 'web_search',
+                'collection_name': 'web-search-current-ai-news',
+                'name': 'current AI news',
+            }
+        ],
+        queries=['current AI news'],
+        embedding_function=None,
+        k=3,
+        reranking_function=None,
+        k_reranker=0,
+        r=0.0,
+        hybrid_bm25_weight=0.0,
+        hybrid_search=False,
+        user=user,
+    )
+
+    assert captured['filtered_collection_names'] == {'web-search-current-ai-news'}
+    assert captured['queried_collection_names'] == {'web-search-current-ai-news'}
+    assert captured['queries'] == ['current AI news']
+    assert sources == [
+        {
+            'source': {
+                'type': 'web_search',
+                'collection_name': 'web-search-current-ai-news',
+                'name': 'current AI news',
+            },
+            'document': ['current web result'],
+            'metadata': [{'source': 'https://example.com/news'}],
+        }
+    ]


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #25585.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Not applicable; this is a backend bug fix for an existing web-search retrieval path.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Focused backend regression test and formatting/syntax checks were run locally.
- [ ] **No Unchecked AI Code:** This PR was prepared with AI assistance and should receive human review before merge.
- [x] **Self-Review:** The diff is scoped to web-search retrieval handoff plus a regression test.
- [x] **Architecture:** No new settings or UX changes; this preserves existing web-search behavior.
- [x] **Git Hygiene:** Atomic PR based on `dev` with no unrelated commits.
- [x] **Title Prefix:** Uses `fix:`.

## Description

`chat_web_search_handler` can append a `type: "web_search"` file backed by a generated `web-search-*` collection after `process_web_search` succeeds.

`get_sources_from_items` did not explicitly handle that item type, so collection-backed web-search items fell through to the generic direct `collection_name` path. With retrieval access control enabled, that generic fallback is intentionally ignored as untrusted, which can leave the final chat completion without the web context that was just retrieved.

This change adds an explicit `web_search` branch that:

- passes `collection_name` / `collection_names` through the existing collection filtering/query path
- preserves the existing `docs` behavior for `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL`
- keeps generic client-supplied collection names blocked unless already allowed by existing settings

## Changelog Entry

### Description

- Preserve web-search result context when chat web search produces a generated retrieval collection.

### Added

- Regression test covering `type: "web_search"` collection-backed source retrieval.

### Changed

- `get_sources_from_items` now handles `web_search` file items explicitly.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed a path where successful web search results could be skipped before the final model context was built.

### Security

- No change to the existing collection access filter; web-search collections still pass through the current `filter_accessible_collections` path.

### Breaking Changes

- None.

---

### Additional Information

Local checks run:

```sh
uvx ruff format --check backend/open_webui/retrieval/utils.py backend/tests/retrieval/test_web_search_sources.py
python3.12 -m py_compile backend/open_webui/retrieval/utils.py backend/tests/retrieval/test_web_search_sources.py
WEBUI_SECRET_KEY=test-secret uv run --python 3.12 pytest backend/tests/retrieval/test_web_search_sources.py
```

The first pytest attempt without `WEBUI_SECRET_KEY` exited during import because the backend requires this env var when auth is enabled; it passed after setting a throwaway test value.

### Screenshots or Videos

- Not applicable for this backend retrieval fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
