### PR TITLE
fix: await get_content_from_url directly in fetch_url tool

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -8,7 +8,6 @@ IMPORTANT: DO NOT IMPORT THIS MODULE DIRECTLY IN OTHER PARTS OF THE CODEBASE.
 
 from open_webui.tools.knowledge_fs import kb_exec  # noqa: F401 — re-exported
 
-import asyncio
 import json
 import logging
 import time
@@ -262,7 +261,7 @@ async def fetch_url(
         return json.dumps({'error': 'Request context not available'})
 
     try:
-        content, _ = await asyncio.to_thread(get_content_from_url, __request__, url)
+        content, _ = await get_content_from_url(__request__, url)
 
         # Truncate if configured (WEB_FETCH_MAX_CONTENT_LENGTH)
         # Guard: content may be None if the web loader silently failed


### PR DESCRIPTION
## Summary
Fixes #26135

## Root Cause
`get_content_from_url` in the `dev` branch is an `async` function. The `fetch_url` built-in tool was calling it via `asyncio.to_thread()`, which is designed for *synchronous* functions only. As a result, `to_thread` submitted the coroutine object to a thread-pool worker without ever awaiting it, returning the unawaited coroutine as the result. Unpacking that coroutine as a `(content, docs)` tuple raised `'cannot unpack non-iterable coroutine object'` and left a `'coroutine get_content_from_url was never awaited'` RuntimeWarning.

## Changes
* `backend/open_webui/tools/builtin.py`: Replace `await asyncio.to_thread(get_content_from_url, __request__, url)` with `await get_content_from_url(__request__, url)`.
* Remove the now-unused `import asyncio` from the same file.

## Testing
* No automated tests exist for this code path in the repository.
* Manually traced the call path: `fetch_url` → `get_content_from_url` (async in dev). Direct `await` correctly resolves the coroutine and returns the `(content, docs)` tuple.
* Verified that `asyncio` is no longer referenced anywhere in `builtin.py` after the removal.

## Notes
The `main` branch has a synchronous version of `get_content_from_url`; this fix is scoped to `dev` where the function was made async.