### PR TITLE
fix: await get_content_from_url directly in fetch_url tool

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -8,7 +8,6 @@ IMPORTANT: DO NOT IMPORT THIS MODULE DIRECTLY IN OTHER PARTS OF THE CODEBASE.
 
 from open_webui.tools.knowledge_fs import kb_exec  # noqa: F401 — re-exported
 
-import asyncio
 import json
 import logging
 import time
@@ -262,7 +261,7 @@ async def fetch_url(
         return json.dumps({'error': 'Request context not available'})
 
     try:
-        content, _ = await asyncio.to_thread(get_content_from_url, __request__, url)
+        content, _ = await get_content_from_url(__request__, url)
 
         # Truncate if configured (WEB_FETCH_MAX_CONTENT_LENGTH)
         # Guard: content may be None if the web loader silently failed


### PR DESCRIPTION
## Summary

Fixes #26135

`get_content_from_url` in the `dev` branch is an `async` function. The `fetch_url` built-in tool was calling it via `asyncio.to_thread()`, which is designed for *synchronous* functions only. As a result, `to_thread` submitted the coroutine object to a thread-pool worker without ever awaiting it, returning the unawaited coroutine as the result. Unpacking that coroutine as a `(content, docs)` tuple raised `'cannot unpack non-iterable coroutine object'` and left a `'coroutine get_content_from_url was never awaited'` RuntimeWarning.

## Changes

- `backend/open_webui/tools/builtin.py`: Replace `await asyncio.to_thread(get_content_from_url, __request__, url)` with `await get_content_from_url(__request__, url)`.
- Remove the now-unused `import asyncio` from the same file.

## Testing

- No automated tests exist for this code path in the repository.
- Traced the call path: `fetch_url` → `get_content_from_url` (async in dev). Direct `await` correctly resolves the coroutine and returns the `(content, docs)` tuple.
- Verified `asyncio` is no longer referenced anywhere in `builtin.py` after removal.

---

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
