### PR TITLE
fix: stop leaking raw exception text in router error responses

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -58,6 +58,7 @@ from open_webui.events import EVENTS, publish_event
 from open_webui.models.config import Config
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.utils.misc import strict_match_mime_type
 from open_webui.utils.session_pool import get_session
@@ -1055,7 +1056,7 @@ async def transcribe(request: Request, file_path: str, metadata: Optional[dict] 
             log.exception(e)
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT(e),
+                detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error processing audio file'),
             )
 
     results = []

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -22,6 +22,7 @@ from open_webui.models.functions import (
     FunctionWithValvesModel,
 )
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.plugin import (
     get_functions_cache,
     get_function_module_from_cache,
@@ -538,9 +539,10 @@ async def get_function_user_valves_by_id(
             user_valves = await Functions.get_user_valves_by_id_and_user_id(id, user.id, db=db)
             return user_valves
         except Exception as e:
+            log.exception(f'Error getting function user valves by id {id}: {e}')
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=ERROR_MESSAGES.DEFAULT(e),
+                detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error getting function user valves'),
             )
     else:
         raise HTTPException(

--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -8,6 +8,7 @@ from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_session
+from open_webui.utils.errors import translate_exception
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.groups import (
     GroupForm,
@@ -83,11 +84,13 @@ async def create_new_group(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error creating group'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error creating a new group: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error creating group'),
         )
 
 
@@ -162,11 +165,13 @@ async def get_users_in_group(id: str, user=Depends(get_admin_user), db: AsyncSes
     try:
         users = await Users.get_users_by_group_id(id, db=db)
         return users
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error adding users to group {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error getting group members'),
         )
 
 
@@ -202,11 +207,13 @@ async def update_group_by_id(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error updating group'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error updating group {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error updating group'),
         )
 
 
@@ -245,11 +252,13 @@ async def add_user_to_group(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error adding users to group'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error adding users to group {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error adding users to group'),
         )
 
 
@@ -280,11 +289,13 @@ async def remove_users_from_group(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error removing users from group'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error removing users from group {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error removing users from group'),
         )
 
 
@@ -312,11 +323,13 @@ async def delete_group_by_id(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error deleting group'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Error deleting group {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error deleting group'),
         )
 
 

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -31,6 +31,7 @@ from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 from open_webui.routers.files import get_file_content_by_id, upload_file_handler
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.utils.images.comfyui import (
     ComfyUICreateImageForm,
@@ -166,7 +167,13 @@ async def get_image_model(request):
                 options = await r.json()
             return options['sd_model_checkpoint']
         except Exception as e:
-            raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(e))
+            log.exception(f'Failed to get default model from automatic1111: {e}')
+            raise HTTPException(
+                status_code=400,
+                detail=ERROR_MESSAGES.DEFAULT(
+                    translate_exception(e) or 'Failed to connect to the image generation engine'
+                ),
+            )
 
 
 class ImagesConfig(BaseModel):
@@ -382,8 +389,14 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
                     models,
                 )
             )
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(status_code=400, detail=ERROR_MESSAGES.DEFAULT(e))
+        log.exception(f'Failed to list image generation models: {e}')
+        raise HTTPException(
+            status_code=400,
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Failed to retrieve image generation models'),
+        )
 
 
 class CreateImageForm(BaseModel):

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -118,6 +118,7 @@ from open_webui.storage.provider import Storage
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.misc import (
     calculate_sha256_string,
     sanitize_text_for_db,
@@ -181,8 +182,8 @@ def get_rf(
                 )
 
             except Exception as e:
-                log.error(f'ColBERT: {e}')
-                raise Exception(ERROR_MESSAGES.DEFAULT(e))
+                log.exception(f'ColBERT: {e}')
+                raise Exception(ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error loading reranking model'))
         else:
             if engine == 'external':
                 try:
@@ -195,8 +196,8 @@ def get_rf(
                         timeout=timeout_value,
                     )
                 except Exception as e:
-                    log.error(f'ExternalReranking: {e}')
-                    raise Exception(ERROR_MESSAGES.DEFAULT(e))
+                    log.exception(f'ExternalReranking: {e}')
+                    raise Exception(ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error loading reranking model'))
             else:
                 import sentence_transformers
                 import torch
@@ -605,7 +606,7 @@ async def update_embedding_config(request: Request, form_data: EmbeddingModelUpd
         log.exception(f'Problem updating embedding model: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error updating embedding configuration'),
         )
 
 
@@ -1207,7 +1208,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         log.exception(f'Problem updating reranking model: {e}')
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error updating reranking configuration'),
         )
 
     # Chunking settings
@@ -2654,7 +2655,10 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
             }
     except Exception as e:
         log.exception('Web search content loading failed')
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.DEFAULT(e))
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or ERROR_MESSAGES.WEB_SEARCH_ERROR()),
+        )
 
 
 async def _validate_collection_access(collection_names: list[str], user, access_type: str = 'read') -> None:
@@ -2732,7 +2736,7 @@ async def query_doc_handler(
         log.exception(e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error querying knowledge base'),
         )
 
 
@@ -2798,7 +2802,7 @@ async def query_collection_handler(
         log.exception(e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(e),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error querying knowledge base'),
         )
 
 

--- a/backend/open_webui/routers/skills.py
+++ b/backend/open_webui/routers/skills.py
@@ -6,6 +6,7 @@ from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_session
+from open_webui.utils.errors import translate_exception
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.config import Config
 from open_webui.models.groups import Groups
@@ -209,11 +210,13 @@ async def create_new_skill(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error creating skill'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
         log.exception(f'Failed to create skill: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(str(e)),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error creating skill'),
         )
 
 
@@ -334,10 +337,13 @@ async def update_skill_by_id(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ERROR_MESSAGES.DEFAULT('Error updating skill'),
             )
+    except HTTPException:
+        raise
     except Exception as e:
+        log.exception(f'Failed to update skill {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(str(e)),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error updating skill'),
         )
 
 

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -31,6 +31,7 @@ from open_webui.utils.access_control import (
     has_permission,
 )
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.errors import translate_exception
 from open_webui.utils.plugin import (
     get_tools_cache,
     get_tool_module_from_cache,
@@ -857,9 +858,10 @@ async def get_tools_user_valves_by_id(
         user_valves = await Tools.get_user_valves_by_id_and_user_id(id, user.id, db=db)
         return user_valves
     except Exception as e:
+        log.exception(f'Error getting tool user valves by id {id}: {e}')
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(str(e)),
+            detail=ERROR_MESSAGES.DEFAULT(translate_exception(e) or 'Error getting tool user valves'),
         )
 
 

--- a/backend/open_webui/utils/errors.py
+++ b/backend/open_webui/utils/errors.py
@@ -1,0 +1,32 @@
+import errno
+from typing import Optional
+
+
+class UserFacingError(Exception):
+    """An anticipated error whose message is safe to show to the user verbatim."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+OS_ERRNO_MESSAGES = {
+    errno.ENAMETOOLONG: 'File name is too long.',
+    errno.ENOSPC: 'The server is out of storage space.',
+    errno.EDQUOT: 'Server storage quota exceeded.',
+    errno.EACCES: 'Server storage is not writable.',
+    errno.EPERM: 'Server storage is not writable.',
+    errno.EROFS: 'Server storage is not writable.',
+}
+
+
+def translate_exception(e: Exception) -> Optional[str]:
+    """Map a recognized internal exception to a user-safe message.
+
+    Returns None when the exception is not recognized; callers should then
+    fall back to a generic message and keep details in server logs only.
+    """
+    if isinstance(e, OSError) and e.errno in OS_ERRNO_MESSAGES:
+        return OS_ERRNO_MESSAGES[e.errno]
+    return None


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #26374
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** No documentation changes required — this fix only changes error message contents; no configuration, API surface, or user workflow changes.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests performed (see Additional Information below).
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings introduced; errors are translated by errno with safe fallbacks to contextual generic strings. Approach described in the linked issue.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`, no unrelated changes.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- 20 call sites across 7 router files passed raw exception objects or `str(e)` into the HTTP response `detail` via `ERROR_MESSAGES.DEFAULT(e)`, exposing server-side internals (filesystem paths, backend service URLs, connection strings) to any logged-in user. Full background and site inventory in #26374.

### Added

- `backend/open_webui/utils/errors.py`: `translate_exception()` maps recognized OS errors **by errno** (`ENAMETOOLONG`, `ENOSPC`, `EDQUOT`, `EACCES`, `EPERM`, `EROFS`) to safe, user-readable messages. Returns `None` for unrecognized exceptions so callers fall back to a static contextual string — exception text is never echoed.

### Fixed

- `routers/audio.py`: transcription error no longer leaks raw exception text.
- `routers/functions.py`: valve-fetch error no longer leaks raw exception text; missing `log.exception()` added.
- `routers/groups.py`: all 6 exception sites replaced with contextual messages; inner `HTTPException`s are now re-raised before the generic handler so 401/403/404 responses are not silently converted to 400.
- `routers/images.py`: model-list and default-model errors no longer leak backend URLs; missing `log.exception()` calls added.
- `routers/retrieval.py`: 7 sites replaced; two reranker/embedder sites upgraded from `log.error()` to `log.exception()` so tracebacks are preserved in server logs.
- `routers/skills.py`: 2 sites replaced; inner `HTTPException`s are now re-raised; missing `log.exception()` added.
- `routers/tools.py`: valve-fetch error no longer leaks raw exception text; missing `log.exception()` added.

### Security

- Eliminates 20 server-side information-disclosure paths reachable by any logged-in user.

---

### Additional Information

**Intentionally excluded** (author-facing relays): `ERROR_MESSAGES.DEFAULT(e)` sites that surface plugin code errors, valve validation failures, or tool execution errors to the user who submitted them. These are shown only to their author and relay genuinely useful debug output, so they are left as-is.

Manual testing performed against a live backend (default LocalStorageProvider):

- Image generation models endpoint with unreachable Automatic1111 URL → generic contextual message, no URL in response
- Reranker config update with invalid model path → generic message, no path in response
- Groups create/update/delete with DB error → contextual message, no exception text
- Normal flows for all 7 routers → unaffected, responses unchanged

### Screenshots or Videos

N/A — API-level error message change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.