### PR TITLE
fix: add try/catch around executeTool to prevent indefinite hang

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -394,34 +394,44 @@
 
 		console.log('executeTool', data, toolServer);
 
-		if (toolServer) {
-			const res = await executeToolServer(
-				token,
-				toolServer.url,
-				data?.name,
-				data?.params,
-				toolServerData,
-				chatId
-			);
+		try {
+			if (toolServer) {
+				const res = await executeToolServer(
+					token,
+					toolServer.url,
+					data?.name,
+					data?.params,
+					toolServerData,
+					chatId
+				);
 
-			console.log('executeToolServer', res);
+				console.log('executeToolServer', res);
 
-			if (data?.name === 'display_file' && data?.params?.path) {
-				if (res?.exists !== false) {
-					displayFileHandler(data.params.path, { showControls, showFileNavPath });
+				if (data?.name === 'display_file' && data?.params?.path) {
+					if (res?.exists !== false) {
+						displayFileHandler(data.params.path, { showControls, showFileNavPath });
+					}
+				}
+
+				if (['write_file'].includes(data?.name) && data?.params?.path) {
+					showFileNavDir.set(res?.path ?? data.params.path);
+				}
+
+				if (cb) {
+					cb(structuredClone(res));
+				}
+			} else {
+				if (cb) {
+					cb({ error: 'Tool Server Not Found' });
 				}
 			}
-
-			if (['write_file'].includes(data?.name) && data?.params?.path) {
-				showFileNavDir.set(res?.path ?? data.params.path);
-			}
-
+		} catch (error) {
+			// Ensure cb() always fires - the backend's sio.call blocks waiting for this
+			// callback, so a thrown error here (network failure, bad response, etc.)
+			// would otherwise hang the call indefinitely.
+			console.error('executeTool error', error);
 			if (cb) {
-				cb(structuredClone(res));
-			}
-		} else {
-			if (cb) {
-				cb({ error: 'Tool Server Not Found' });
+				cb({ error: error?.message ?? 'Tool execution failed' });
 			}
 		}
 	};


### PR DESCRIPTION
## Summary
Fixes #25850.

`executeTool()` in `src/routes/+layout.svelte` called `executeToolServer()` with no surrounding error handling. The code comment directly above the call site explains that session-targeted RPC events (including `execute:tool`) must always be answered because the backend's `sio.call` blocks waiting on the `cb()` callback. If `executeToolServer` throws — a network failure, malformed response, etc. — `cb()` is never invoked and the backend call hangs until its own timeout (if any).

## Fix
Wrap the body of `executeTool` in `try/catch`. On error, log it and still invoke `cb()` with an `{ error }` payload, matching the existing pattern used for the `Tool Server Not Found` case.

## Testing
Reviewed all call sites of `executeTool` to confirm `cb` is always optional-chained/guarded the same way as before; behavior on the success path is unchanged. Could not run a full e2e tool-server failure scenario in this sandbox (no live tool server), but traced the exception path manually against the existing `Tool Server Not Found` branch as a reference for correct callback shape.