### PR TITLE
fix: keep RAG Template field visible when Bypass Embedding and Retrieval is enabled

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -1351,36 +1351,41 @@
 								</div>
 							{/if}
 						{/if}
-
-						<div class="  mb-2.5 flex flex-col w-full justify-between">
-							<div class=" mb-1 text-xs font-medium">{$i18n.t('RAG Template')}</div>
-							<div class="flex w-full items-center relative">
-								<Tooltip
-									content={$i18n.t(
-										'Leave empty to use the default prompt, or enter a custom prompt'
-									)}
-									placement="top-start"
-									className="w-full"
-								>
-									<Textarea
-										bind:value={RAGConfig.RAG_TEMPLATE}
-										placeholder={$i18n.t(
-											'Leave empty to use the default prompt, or enter a custom prompt'
-										)}
-									/>
-								</Tooltip>
-							</div>
-
-							{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
-								<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-									{$i18n.t(
-										'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
-									)}
-								</div>
-							{/if}
-						</div>
 					</div>
 				{/if}
+
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('RAG Template')}</div>
+
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					<div class="  mb-2.5 flex flex-col w-full justify-between">
+						<div class="flex w-full items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'Leave empty to use the default prompt, or enter a custom prompt'
+								)}
+								placement="top-start"
+								className="w-full"
+							>
+								<Textarea
+									bind:value={RAGConfig.RAG_TEMPLATE}
+									placeholder={$i18n.t(
+										'Leave empty to use the default prompt, or enter a custom prompt'
+									)}
+								/>
+							</Tooltip>
+						</div>
+
+						{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
+							<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								{$i18n.t(
+									'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
+								)}
+							</div>
+						{/if}
+					</div>
+				</div>
 
 				<div class="mb-3">
 					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Files')}</div>


### PR DESCRIPTION
## Summary
Fixes #26126.

When "Bypass Embedding and Retrieval" is enabled in Admin > Settings > Documents, the RAG Template editor was hidden entirely from the UI. However, the backend (`utils/middleware.py`, `utils/task.py`) still always wraps attached file/full-context content using `RAG_TEMPLATE` regardless of `BYPASS_EMBEDDING_AND_RETRIEVAL`. This made an active prompt setting invisible and uneditable in bypass mode.

## Fix
Moved the RAG Template section out of the `{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}` block so it renders unconditionally (matching one of the two remediations suggested in the issue: keep the field visible since the backend still applies it).

## Testing
Verified `{#if}`/`{/if}` nesting is balanced before and after the change (no orphaned blocks), and confirmed via `git diff` that only the RAG Template section moved — no other settings sections were altered. Did not run the full frontend build in this sandbox; recommend CI confirm the Svelte compiles cleanly.