### PR TITLE
fix: task list items serialize to markdown with duplicate checkbox brackets

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -101,7 +101,13 @@
 				node.getAttribute('data-checked') === 'false'),
 		replacement: function (content, node) {
 			const checked = node.getAttribute('data-checked') === 'true';
-			content = content.replace(/^\s+/, '');
+			// The GFM plugin's own taskListItems rule already converts the
+			// underlying <input type="checkbox"> (nested inside <label>) into a
+			// "[ ] "/"[x] " marker, since turndown converts child nodes before
+			// this LI-level rule runs. Strip that duplicate marker, plus any
+			// blank lines left over from paragraph wrapping, so we don't end up
+			// with "- [ ] [ ] text" or extra blank lines inside the item.
+			content = content.replace(/^\s*\[[ xX]\]\s*/, '').trim();
 			return `- [${checked ? 'x' : ' '}] ${content}\n`;
 		}
 	});


### PR DESCRIPTION
## Summary
Fixes #26067.

When exporting/saving a Note containing a task list, each item serialized as `- [ ] [ ] text` (duplicate brackets) with stray blank lines around the text, e.g.:
```
- [ ] [ ] 

item 1

- [ ] [ ] 

item 2
```

## Root cause
TipTap's `TaskItem` node renders as:
```html
<li data-type="taskItem" data-checked="false">
  <label><input type="checkbox"><span></span></label>
  <div><p>item 1</p></div>
</li>
```
`RichTextInput.svelte` has a custom Turndown rule that matches the `<li data-checked=...>` and prepends `- [ ] ` / `- [x] `. But `@joplin/turndown-plugin-gfm` (used via `turndownService.use(gfm)`) registers its *own* rule that converts the nested `<input type="checkbox">` into a `[ ] `/`[x] ` marker. Turndown converts child nodes before running the LI-level rule, so by the time our rule runs, `content` already contains that marker - producing `- [ ] ` + `[ ] ` + text. The paragraph-wrapping rule (`singleNewlineParagraphs`) then adds the extra blank lines around the inner `<p>` text.

## Fix
Strip the duplicate marker (`/^\s*\[[ xX]\]\s*/`) and trim leftover blank lines in the LI replacement function, so only our own `- [ ] `/`- [x] ` marker remains.

## Testing
Reproduced and verified the fix in isolation against the real `turndown` + `@joplin/turndown-plugin-gfm` packages with TipTap-shaped HTML:
- **Before:** `- [ ] [ ] \n\nitem 1\n\n- [x] [x] \n\nitem 2`
- **After:** `- [ ] item 1\n- [x] item 2`

(Script available on request; not included in the diff since it's a throwaway verification harness, not a permanent test.)