### PR TITLE
fix: pinned note sidebar drag-and-drop into chat context

### DIFF
--- a/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
+++ b/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
@@ -28,6 +28,16 @@
 		if (pinnedNotesList && !$mobile) {
 			new Sortable(pinnedNotesList, {
 				animation: 150,
+				setData: function (dataTransfer, dragEl) {
+					dataTransfer.setData(
+						'text/plain',
+						JSON.stringify({
+							type: 'note',
+							id: dragEl.dataset.id
+						})
+					);
+					dataTransfer.setData('application/x-open-webui-drag', '');
+				},
 				onUpdate: async (event) => {
 					const noteId = event.item.dataset.id;
 					const newIndex = event.newIndex;
@@ -54,16 +64,6 @@
 		<div
 			class="flex items-center text-gray-800 dark:text-gray-200 cursor-grab relative group rounded-xl px-2.5 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-900 transition"
 			data-id={note.id}
-			draggable="true"
-			on:dragstart={(e) => {
-				e.dataTransfer.setData(
-					'text/plain',
-					JSON.stringify({
-						type: 'note',
-						id: note.id
-					})
-				);
-			}}
 		>
 			<a
 				class="grow flex items-center gap-2.5 text-sm"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #25771 — pinned note sidebar drag-and-drop into chat context was silently failing
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed — this is a bug fix for existing behavior.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or major architectural changes — this fix aligns existing behavior with the established drag-and-drop pattern.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> *This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.*

# Changelog Entry

### Description

Hotfix for #25771 — dragging pinned notes from the sidebar into the chat area was silently failing. The notes would not attach as context references despite the feature being implemented in #25771.

**Problem:** Dragging a pinned note from the sidebar into the chat area did nothing — no drop overlay appeared and the note was not added as a context reference.

**Root Cause (two issues):**

1. **SortableJS data conflict:** The note drag data was set via a native `on:dragstart` handler, but the notes are children of a SortableJS container. Without a custom `setData` callback, SortableJS's default behavior overwrites `text/plain` with the element's raw text content (e.g. `"Open WebUI ..."`) instead of the expected JSON (`{"type":"note","id":"..."}`). This caused `JSON.parse()` in the drop handler to throw, and the catch block silently swallowed the error.

2. **Missing custom MIME type:** The `on:dragstart` handler did not set the `application/x-open-webui-drag` MIME type. The `onDragOver` handler in `MessageInput.svelte` only activates the drop overlay when this type (or `Files`) is present in the drag event. Without it, the drop zone never visually activated.

**Fix:** Moved note drag data into SortableJS's `setData` callback (matching the existing `PinnedModelList` pattern), added the missing `application/x-open-webui-drag` MIME type, and removed the redundant native `draggable` / `on:dragstart` from the DOM element — consistent with how `ChatItem.svelte` and `RecursiveFolder.svelte` already handle it.

```diff
--- a/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
+++ b/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
 new Sortable(pinnedNotesList, {
     animation: 150,
+    setData: function (dataTransfer, dragEl) {
+        dataTransfer.setData(
+            'text/plain',
+            JSON.stringify({
+                type: 'note',
+                id: dragEl.dataset.id
+            })
+        );
+        dataTransfer.setData('application/x-open-webui-drag', '');
+    },
     onUpdate: async (event) => {

 <div
     class="..."
     data-id={note.id}
-    draggable="true"
-    on:dragstart={(e) => {
-        e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'note', id: note.id }));
-    }}
 >
```

### Fixed

- Pinned notes can now be dragged from the sidebar into the chat area to attach as context references, matching the existing "Attach Notes" menu behavior

---

### Additional Information

- **Scope:** 1 file changed, 10 insertions, 10 deletions
- **File:** `PinnedNoteList.svelte`
- **Related:** Hotfix for #25771 which introduced this drag-and-drop feature

### Manual Verification Performed

1. Pinned a note in the sidebar
2. Dragged the pinned note from the sidebar over the chat area — verified the drop overlay appears
3. Dropped the note — verified it attaches as a context reference chip in the message input
4. Verified pinned note reorder (drag within the sidebar list) still works correctly
5. Verified existing chat drag-and-drop from sidebar still works
6. Production build passes with no errors

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
