### PR TITLE
fix: skip forced memory injection when native function calling is enabled

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2428,7 +2428,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 )
 
         if 'memory' in features and features['memory']:
-            form_data = await add_memory_context(request, form_data, user, model)
+            # Skip forced memory injection when native FC is enabled - model can use memory tools
+            if metadata.get('params', {}).get('function_calling') != 'native':
+                form_data = await add_memory_context(request, form_data, user, model)
 
         if 'web_search' in features and features['web_search']:
             # Skip forced RAG web search when native FC is enabled - model can use web_search tool


### PR DESCRIPTION
Since the v0.10.0 memory overhaul, `add_memory_context` is injected into the system message on every request whenever the memory feature is enabled, regardless of the model's function-calling mode. The injected `<memory_context>` block is rebuilt per request from a vector search over the latest user turns, so the system prefix changes on every call. This defeats provider prompt caching (Anthropic, OpenAI), reverse-proxy caching, and any downstream caching layer, and adds the DB/vector-search latency on each request.

Models using native function calling already have the `search_memories`, `add_memory`, `update_memory` and `replace_memory_content` builtin tools, so they can read and write memory directly via tool calls. Forced system-prompt injection is redundant for them.

Restore the pre-v0.10.0 guard so memory context is only injected when native function calling is not in use, matching the existing behaviour for web search and image generation in the same block. Legacy and default modes are unaffected.

Fixes #26393

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
