### PR TITLE
fix: log ComfyUI workflow at DEBUG to avoid leaking prompt content

### DIFF
--- a/backend/open_webui/utils/images/comfyui.py
+++ b/backend/open_webui/utils/images/comfyui.py
@@ -202,7 +202,7 @@ async def comfyui_create_image(model: str, payload: ComfyUICreateImageForm, clie
         ) as ws:
             log.info('WebSocket connection established.')
             log.info('Sending workflow to WebSocket server.')
-            log.info(f'Workflow: {workflow}')
+            log.debug(f'Workflow: {workflow}')
             images = await _ws_get_images(ws, workflow, client_id, base_url, api_key)
     except aiohttp.WSServerHandshakeError as e:
         log.exception(f'Failed to connect to WebSocket server: {e}')
@@ -243,7 +243,7 @@ async def comfyui_edit_image(model: str, payload: ComfyUIEditImageForm, client_i
         ) as ws:
             log.info('WebSocket connection established.')
             log.info('Sending workflow to WebSocket server.')
-            log.info(f'Workflow: {workflow}')
+            log.debug(f'Workflow: {workflow}')
             images = await _ws_get_images(ws, workflow, client_id, base_url, api_key)
     except aiohttp.WSServerHandshakeError as e:
         log.exception(f'Failed to connect to WebSocket server: {e}')


### PR DESCRIPTION
### Description

The ComfyUI client logged the full resolved workflow graph at INFO in both `comfyui_create_image` and `comfyui_edit_image`. That graph embeds the rendered prompt text, so user prompt content (potential PII) was written to server logs at the default log level on every generation.

This demotes those two lines to DEBUG, matching the existing `queue_prompt data` logging in the same module (event at INFO, payload at DEBUG). Operational visibility is preserved by the adjacent `Sending workflow to WebSocket server` INFO line.

### Fixed

- Avoid logging ComfyUI prompt content at INFO; the full workflow graph (which includes the rendered prompt) is now logged at DEBUG.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.