### PR TITLE
fix: merge reasoning_details to preserve signatures

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -157,6 +157,40 @@ def output_id(prefix: str) -> str:
     return f'{prefix}_{uuid4().hex[:24]}'
 
 
+def merge_reasoning_details(details: list, chunk) -> list:
+    """Merge streamed reasoning_details fragments in place, keyed by index.
+
+    Concatenates text/summary for matching indexes and overwrites other fields
+    (e.g. signature) so signed/encrypted blocks stay intact instead of
+    fragmenting across chunks.
+    """
+    items = (
+        chunk if isinstance(chunk, list) else ([chunk] if isinstance(chunk, dict) else [])
+    )
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        index = item.get('index')
+        existing = (
+            next((e for e in details if e.get('index') == index), None)
+            if isinstance(index, int) and index >= 0
+            else None
+        )
+        if existing is None:
+            entry = dict(item)
+            entry.setdefault('type', 'reasoning.text')
+            details.append(entry)
+            continue
+        for key, value in item.items():
+            if key in ('text', 'summary'):
+                if isinstance(value, str):
+                    base = existing.get(key)
+                    existing[key] = (base + value) if isinstance(base, str) else value
+            else:
+                existing[key] = value
+    return details
+
+
 def _split_tool_calls(
     tool_calls: list[dict],
 ) -> list[dict]:
@@ -4233,7 +4267,7 @@ async def streaming_chat_response_handler(response, ctx):
                                         or delta.get('thinking')
                                     )
                                     reasoning_details = delta.get('reasoning_details')
-                                    if reasoning_content or reasoning_details:
+                                    if reasoning_content:
                                         if not output or output[-1].get('type') != 'reasoning':
                                             reasoning_item = {
                                                 'type': 'reasoning',
@@ -4250,30 +4284,53 @@ async def streaming_chat_response_handler(response, ctx):
                                         else:
                                             reasoning_item = output[-1]
 
-                                        if reasoning_content:
-                                            # Append to reasoning content
-                                            parts = reasoning_item.get('content', [])
-                                            if parts and parts[-1].get('type') == 'output_text':
-                                                parts[-1]['text'] += reasoning_content
-                                            else:
-                                                reasoning_item['content'] = [
-                                                    {
-                                                        'type': 'output_text',
-                                                        'text': reasoning_content,
-                                                    }
-                                                ]
+                                        # Append to reasoning content
+                                        parts = reasoning_item.get('content', [])
+                                        if parts and parts[-1].get('type') == 'output_text':
+                                            parts[-1]['text'] += reasoning_content
+                                        else:
+                                            reasoning_item['content'] = [
+                                                {
+                                                    'type': 'output_text',
+                                                    'text': reasoning_content,
+                                                }
+                                            ]
 
-                                            data = {
-                                                'output': full_output(),
+                                        data = {
+                                            'output': full_output(),
+                                        }
+                                        delta_type = 'content'
+
+                                    if reasoning_details:
+                                        # Keep signatures attached to their reasoning text
+                                        # (they may stream later); create an item if encrypted.
+                                        reasoning_target = next(
+                                            (
+                                                item
+                                                for item in reversed(output)
+                                                if item.get('type') == 'reasoning'
+                                            ),
+                                            None,
+                                        )
+                                        if reasoning_target is None:
+                                            reasoning_target = {
+                                                'type': 'reasoning',
+                                                'id': output_id('r'),
+                                                'status': 'in_progress',
+                                                'start_tag': '<think>',
+                                                'end_tag': '</think>',
+                                                'attributes': {'type': 'reasoning_content'},
+                                                'content': [],
+                                                'summary': None,
+                                                'started_at': time.time(),
                                             }
-                                            delta_type = 'content'
-
-                                        if reasoning_details:
-                                            reasoning_item.setdefault('reasoning_details', []).extend(
-                                                reasoning_details
-                                                if isinstance(reasoning_details, list)
-                                                else [reasoning_details]
-                                            )
+                                            output.append(reasoning_target)
+                                        merge_reasoning_details(
+                                            reasoning_target.setdefault(
+                                                'reasoning_details', []
+                                            ),
+                                            reasoning_details,
+                                        )
 
                                     if value:
                                         if (


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

OpenRouter streams `reasoning_details` in small chunks that share an `index`, and a block is complete only once the chunks for that index are joined (the shape non-streaming responses return). For Anthropic, a `reasoning.text` block carries a `signature`, and the reasoning replayed on the next turn must match what the model produced.

The stream handler appends each chunk with `list.extend()`, so same-index fragments stay split and the signature lands on a different entry than its text. The next turn no longer matches, and Anthropic returns `400 Invalid signature in thinking block` (via OpenRouter).

`merge_reasoning_details()` joins chunks by index instead, so each block stays whole and keeps its signature.

### Added

- [New features, functionalities, or additions]

### Changed

- [Changes, updates, refactorings, or optimizations]

### Deprecated

- [Deprecated functionality or features]

### Removed

- [Removed features, files, or functionalities]

### Fixed

- OpenRouter reasoning models no longer break multi-turn chats with a `400` signature error (Anthropic).

### Security

- [Security-related changes or vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [Changes affecting compatibility or functionality]

---

### Additional Information

Tested live through OpenRouter on Claude Sonnet 4.6, Gemini 3 Flash, and Kimi K2.6. Each run streams turn 1, then replays the assistant turn with its `reasoning_details` and a follow-up:

- Claude: fails turn 2 with `.extend()`, returns `200` with the merge.
- Gemini and Kimi: `200` both ways, no regression.
- Fragments collapse to one entry per block (Claude 10 to 1, Gemini 3 to 1, Kimi 455 to 1).

### Screenshots or Videos

- [Attach relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
