### PR TITLE
fix(ConfirmDialog): dispatch 'cancel' on backdrop click so awaiting event callbacks resolve

### DIFF
--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -108,6 +108,7 @@
 		in:fade={{ duration: 10 }}
 		on:mousedown={() => {
 			show = false;
+			dispatch('cancel');
 		}}
 	>
 		<div


### PR DESCRIPTION
### Problem

When a Tool or Function uses `__event_call__` with an `input` or `confirmation` dialog, clicking **outside** the dialog (the backdrop) closes it visually but the awaiting backend callback is **never resolved**. The tool/function coroutine then hangs indefinitely and the chat shows a spinner forever. Only the explicit **Cancel** button resolves the callback.

**Steps to reproduce**
1. Create a Tool whose method does `await __event_call__({"type": "input", "data": {...}})`.
2. Trigger it; when the dialog appears, click the backdrop (outside the dialog) instead of a button.
3. The dialog closes but the request never completes — the chat spins indefinitely.

### Root cause

In `src/lib/components/common/ConfirmDialog.svelte`, the backdrop `on:mousedown` handler only hides the modal; it never dispatches `cancel`, so the `eventCallback` wired up in `Chat.svelte` is never invoked. The **Cancel** button, by contrast, does `show = false; dispatch('cancel');`.

### Fix

Make backdrop dismiss behave like Cancel (standard modal semantics):

```svelte
on:mousedown={() => {
    show = false;
    dispatch('cancel');
}}
```

### Why it's safe

- `dispatch('cancel')` with no listener is a harmless no-op, so existing `ConfirmDialog` usages without an `on:cancel` handler are unaffected.
- For `__event_call__` input/confirmation dialogs, `Chat.svelte`'s `on:cancel` resolves the callback with a falsy value — the documented "user declined" result — instead of hanging.
- Backdrop = dismiss = cancel matches conventional modal UX and the existing Escape/Cancel paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
