### PR TITLE
fix: dispatch 'cancel' on ConfirmDialog backdrop click so awaiting event callbacks resolve

### DIFF
--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -108,6 +108,7 @@
 		in:fade={{ duration: 10 }}
 		on:mousedown={() => {
 			show = false;
+			dispatch('cancel');
 		}}
 	>
 		<div


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #26417
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** N/A — no user-facing docs affected (internal modal behavior).
- [ ] **Dependencies:** N/A — no dependency changes.
- [ ] **Testing:** Original hang reproduced and root cause confirmed; fix verified by inspection against the existing Cancel-button path (which already does `show = false; dispatch('cancel')`). A local frontend rebuild/runtime test has **not** been performed — flagging for reviewer awareness.
- [ ] **No Unchecked AI Code:** Transparency: the one-line change was drafted with AI assistance and human-reviewed by the contributor. Left unchecked because a manual runtime test has not been performed.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings; standard modal-dismiss semantics.
- [x] **Git Hygiene:** Atomic, single-line change, based on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Tool/Function `input` and `confirmation` dialogs (driven by `__event_call__`) hung indefinitely when dismissed by clicking the backdrop: the modal closed (`show = false`) but `cancel` was never dispatched, so the awaiting backend callback never resolved and the chat spun forever. Only the explicit Cancel button resolved the callback.

### Fixed

- `ConfirmDialog.svelte`: dispatch `cancel` on backdrop dismiss so awaiting `__event_call__` callbacks resolve (matches the Cancel button and conventional modal semantics). Closes #26417.

### Additional Information

`dispatch('cancel')` with no listener is a harmless no-op, so existing `ConfirmDialog` usages without an `on:cancel` handler are unaffected. For `__event_call__` dialogs, `Chat.svelte`'s `on:cancel` resolves the callback with a falsy ("declined") value instead of hanging.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
