### PR TITLE
fix: convert BannerModel to dict before storing in config defaults

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2080,7 +2080,7 @@ class BannerModel(BaseModel):
 
 try:
     banners = json.loads(os.getenv('WEBUI_BANNERS', '[]'))
-    banners = [BannerModel(**banner) for banner in banners]
+    banners = [BannerModel(**banner).model_dump(mode='json') for banner in banners]
 except Exception as e:
     log.exception(f'Error loading WEBUI_BANNERS: {e}')
     banners = []


### PR DESCRIPTION
### Description

Fix JSON serialization crash when `WEBUI_BANNERS` environment variable is set. The banners are parsed from JSON and validated against `BannerModel` schema, but then stored as raw Pydantic `BaseModel` instances in the config defaults dict. When `Config.seed_defaults()` writes these values to the database JSON column at startup, `json.dumps()` fails because Pydantic objects are not natively JSON serializable.

### Fixed

- Added `.model_dump(mode='json')` after `BannerModel` validation in the `WEBUI_BANNERS` env var parser (`backend/open_webui/config.py`), so the stored values are plain JSON-serializable dicts

### Additional Information

This fix follows the same serialization pattern already used by the `set_banners` API endpoint (`routers/configs.py:801`), which correctly calls `model_dump()` before persisting data.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.