### PR TITLE
fix: guard model capabilities access against None value

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -267,7 +267,7 @@ async def _resolve_model_features(app, model_id: str) -> dict:
     if not default_feature_ids:
         return {}
 
-    capabilities = meta.get('capabilities', {})
+    capabilities = meta.get('capabilities') or {}
     features = {}
 
     # code_interpreter is excluded: it requires the frontend event emitter

--- a/backend/open_webui/utils/memory.py
+++ b/backend/open_webui/utils/memory.py
@@ -284,7 +284,7 @@ def validate_memory_operations(form_data) -> list[dict]:
 
 
 def model_allows_memory(model: dict | None) -> bool:
-    return (model or {}).get('info', {}).get('meta', {}).get('capabilities', {}).get('memory', True)
+    return ((model or {}).get('info', {}).get('meta', {}).get('capabilities') or {}).get('memory', True)
 
 
 async def add_memory_context(request, form_data: dict, user, model: dict | None = None):


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #26412. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [ ] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Fixed `AttributeError: 'NoneType' object has no attribute 'get'` in `model_allows_memory()` that occurred when a model's `meta.capabilities` was stored as `null`. When the key exists with a `None` value, Python's `.get(key, {})` returns `None` instead of the default — the subsequent `.get()` call on `None` crashes. The fix adds the `or {}` guard that every other capabilities access site in the codebase already uses.

### Fixed

- **Fixed `model_allows_memory()` crash when model capabilities is null.** When a model's `meta.capabilities` is `null` (key exists, value is `None`), the chained `.get('capabilities', {}).get('memory', True)` raises `AttributeError`, preventing the chat from responding. The fix uses `(.get('capabilities') or {})` to correctly handle both missing keys and `None` values, matching the pattern used in `models.py`, `tools.py`, and `middleware.py`.
- **Fixed same unguarded pattern in `_resolve_model_features()`.** The `backend/open_webui/utils/automations.py` function had the identical `.get('capabilities', {})` pattern that would crash if `defaultFeatureIds` was set and `capabilities` was null.

---

Closes #26412

### Additional Information

The root cause is a subtle Python dict behavior: `d.get('capabilities', {})` returns `{}` when the key is missing, but returns `None` when the key exists with value `None`. This is confirmed by the 7 other access sites in the codebase that already use the `or {}` guard pattern.

### Screenshots or Videos

N/A — logic-only fix, no visual changes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
