### PR TITLE
fix: use updated chat timestamp in sidebar

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -570,9 +570,9 @@
 			</div>
 
 			<!-- Time ago indicator -->
-			{#if createdAt && !mouseOver}
+			{#if (updatedAt ?? createdAt) && !mouseOver}
 				<div class="shrink-0 self-center text-[10px] text-gray-400 dark:text-gray-500 pl-2">
-					{formatTimeAgo(createdAt)}
+					{formatTimeAgo(updatedAt ?? createdAt)}
 				</div>
 			{/if}
 		</a>

--- a/src/lib/components/layout/Sidebar/ChatItem.test.ts
+++ b/src/lib/components/layout/Sidebar/ChatItem.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const componentSource = readFileSync(
+	fileURLToPath(new URL('./ChatItem.svelte', import.meta.url)),
+	'utf8'
+);
+
+describe('Sidebar ChatItem timestamp', () => {
+	test('uses updatedAt before falling back to createdAt for the relative time indicator', () => {
+		expect(componentSource).toContain('{#if (updatedAt ?? createdAt) && !mouseOver}');
+		expect(componentSource).toContain('{formatTimeAgo(updatedAt ?? createdAt)}');
+	});
+});


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #26451.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Fixes the sidebar chat relative timestamp so it reflects the chat's last update time rather than the original creation time.

### Added

- Added a focused Vitest regression check for the sidebar timestamp source.

### Changed

- The sidebar chat time indicator now uses `updatedAt ?? createdAt`, so existing chats show the most recent activity time after new messages.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed chat sidebar timestamps staying pinned to `created_at` after a conversation receives new messages.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Root cause: `ChatItem.svelte` received both `createdAt` and `updatedAt`, but rendered the time indicator with `createdAt`. The backend updates `updated_at` when chat content changes, so the UI should use that field for last-activity display.

Validation performed locally:

- `npm_config_engine_strict=false npm run test:frontend -- --run src/lib/components/layout/Sidebar/ChatItem.test.ts` passed.
- `npx prettier --check src/lib/components/layout/Sidebar/ChatItem.svelte src/lib/components/layout/Sidebar/ChatItem.test.ts` passed.
- `git diff --check` passed.

Note: `npm_config_engine_strict=false npm run check` was also attempted, but the current `dev` tree reports existing unrelated `svelte-check` errors across the workspace.

### Screenshots or Videos

- Not applicable; this is a data-source fix for an existing sidebar label.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
