### PR TITLE
fix: keep RAG Template visible when Bypass Embedding and Retrieval is enabled

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -1500,36 +1500,36 @@
 								</div>
 							{/if}
 						{/if}
-
-						<div class="  mb-2.5 flex flex-col w-full justify-between">
-							<div class=" mb-1 text-xs font-medium">{$i18n.t('RAG Template')}</div>
-							<div class="flex w-full items-center relative">
-								<Tooltip
-									content={$i18n.t(
-										'Leave empty to use the default prompt, or enter a custom prompt'
-									)}
-									placement="top-start"
-									className="w-full"
-								>
-									<Textarea
-										bind:value={RAGConfig.RAG_TEMPLATE}
-										placeholder={$i18n.t(
-											'Leave empty to use the default prompt, or enter a custom prompt'
-										)}
-									/>
-								</Tooltip>
-							</div>
-
-							{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
-								<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-									{$i18n.t(
-										'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
-									)}
-								</div>
-							{/if}
-						</div>
 					</div>
 				{/if}
+
+				<div class="mb-3">
+					<div class="  mb-2.5 flex flex-col w-full justify-between">
+						<div class=" mb-1 text-xs font-medium">{$i18n.t('RAG Template')}</div>
+						<div class="flex w-full items-center relative">
+							<Tooltip
+								content={$i18n.t('Leave empty to use the default prompt, or enter a custom prompt')}
+								placement="top-start"
+								className="w-full"
+							>
+								<Textarea
+									bind:value={RAGConfig.RAG_TEMPLATE}
+									placeholder={$i18n.t(
+										'Leave empty to use the default prompt, or enter a custom prompt'
+									)}
+								/>
+							</Tooltip>
+						</div>
+
+						{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
+							<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								{$i18n.t(
+									'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
+								)}
+							</div>
+						{/if}
+					</div>
+				</div>
 
 				<div class="mb-3">
 					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Files')}</div>


### PR DESCRIPTION
In **Admin > Settings > Documents**, enabling **Bypass Embedding and Retrieval** hid the **RAG Template** editor, even though the template is still applied to document content in bypass mode. The field was nested inside the `{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}` block alongside the embedding/chunking/retrieval settings.

On the backend, `apply_source_context_to_messages()` in `backend/open_webui/utils/middleware.py` calls `rag_template(...)` unconditionally, so in bypass mode the full document is loaded and still wrapped with the template. The setting therefore stayed active while being hidden and uneditable.

This PR moves **only** the RAG Template into its own always-visible section, outside the bypass conditional. The embedding, chunking, and retrieval settings remain gated, since they genuinely have no effect under bypass. No backend changes are needed.

Closes #26126

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️

1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — Closes #26126 .
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** N/A — UI visibility fix only; no documented behavior changes.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests performed (see below). Screenshots included.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings added; this only changes the visibility of an existing setting. Existing gating for embedding/retrieval settings is preserved.
- [x] **Git Hygiene:** The PR is atomic (one logical change), branched on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Enabling **Bypass Embedding and Retrieval** hid the **RAG Template** editor in Admin > Settings > Documents, even though the template is still applied to the full document content in bypass mode. This left an active setting hidden and uneditable.

### Changed

- Moved the **RAG Template** field into its own always-visible section so it is shown whether or not bypass mode is enabled. Embedding, chunking, and retrieval settings remain hidden under bypass (no effect in that mode).

### Fixed

- The **RAG Template** is now visible and editable when **Bypass Embedding and Retrieval** is enabled (#26126).

---

### Additional Information

- Frontend-only change in `src/lib/components/admin/Settings/Documents.svelte`, formatted with the project's Prettier config. No backend change: the backend already applies the template correctly in both modes.

### Screenshots or Videos

**Admin > Settings > Documents — the fix**

Bypass **disabled** — RAG Template visible (unchanged):

<img width="1122" height="519" alt="Admin panel — bypass disabled" src="https://github.com/user-attachments/assets/ee171727-f79d-422e-9ab9-de06d01eb920" />

Bypass **enabled** — RAG Template still visible; embedding/chunking/retrieval settings correctly hidden:

<img width="1122" height="519" alt="Admin panel — bypass enabled" src="https://github.com/user-attachments/assets/b19f514d-52d2-44fc-b510-ae1a721e4a41" />

**Chat behavior — why the template must stay visible under bypass**

Bypass **disabled** — retrieval returns ranked top-k chunks (note relevance scores in the source):

<img width="1031" height="555" alt="Chat — bypass disabled" src="https://github.com/user-attachments/assets/82262ad9-790a-4642-bdb0-6e31cdd7ee20" />

<img width="560" height="267" alt="Source — bypass disabled (top-k chunks with scores)" src="https://github.com/user-attachments/assets/c6bd2c81-0991-458a-9d33-03ef874fb3db" />

Bypass **enabled** — retrieval skipped; the full document is injected and still wrapped by the RAG template (source shows the whole document, no relevance scores):

<img width="1091" height="534" alt="Chat — bypass enabled" src="https://github.com/user-attachments/assets/b46a90fc-8942-4352-9899-3d2839cf058e" />

<img width="1091" height="534" alt="Source — bypass enabled (full document)" src="https://github.com/user-attachments/assets/a0901d28-ef58-42ca-9605-03cd5e29d7c6" />

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [[Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.