### PR TITLE
fix: prevent SocketIO Redis pubsub disconnect loop by setting socket_timeout=None

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -64,7 +64,12 @@ if WEBSOCKET_MANAGER == 'redis':
         if sentinel_hosts
         else WEBSOCKET_REDIS_URL
     )
-    redis_manager = socketio.AsyncRedisManager(ws_redis_url, redis_options=WEBSOCKET_REDIS_OPTIONS)
+    # PubSub connections require an infinite socket timeout — redis-py >= 8 applies
+    # a default socket_timeout that causes the blocking pubsub listen() loop to raise
+    # TimeoutError every few seconds.  Explicit None keeps the connection alive.
+    redis_options = dict(WEBSOCKET_REDIS_OPTIONS or {})
+    redis_options.setdefault('socket_timeout', None)
+    redis_manager = socketio.AsyncRedisManager(ws_redis_url, redis_options=redis_options)
     sio = socketio.AsyncServer(
         cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode='asgi',


### PR DESCRIPTION
## Root Cause

`redis-py >= 8.0.0` applies a default `socket_timeout` (typically 10s) when creating connections via `Redis.from_url()`. The `AsyncRedisManager` in `python-socketio` uses `pubsub.listen()`, a blocking async generator that waits indefinitely for new messages on the PubSub connection. With a finite socket timeout, this `listen()` call raises `TimeoutError` every few seconds, which is caught by the retry loop in `_redis_listen_with_retries()`, resulting in the continuous error:

```
Cannot receive from redis... retrying in 1 secs
```

This was introduced in v0.10.1 when the `redis` dependency was bumped from `7.4.0` to `8.0.0` in commit b295a20b9.

## Fix

Instead of passing `WEBSOCKET_REDIS_OPTIONS` directly (which is `None` by default, causing `AsyncRedisManager` to fall back to `{}`, which means no options → redis-py uses its default socket_timeout), we now merge the user-provided options with a `socket_timeout=None` default:

```python
redis_options = dict(WEBSOCKET_REDIS_OPTIONS or {})
redis_options.setdefault(socket_timeout, None)
```

This ensures the PubSub connection blocks indefinitely, which is the correct behaviour for a long-lived pubsub listener. Users who set `WEBSOCKET_REDIS_OPTIONS` explicitly still override this default.

## Verification

Before the fix, deploy with `REDIS_URL=redis://redis:6379 WEBSOCKET_MANAGER=redis` and observe the logs fill with:
```
Cannot receive from redis... retrying in 1 secs
```

After the fix, the error stops. Users who previously worked around this with `WEBSOCKET_REDIS_OPTIONS={"socket_timeout":null}` can remove that workaround.

Closes #26425