### PR TITLE
fix: match web result filter on hostname, not netloc

### DIFF
--- a/backend/open_webui/retrieval/web/main.py
+++ b/backend/open_webui/retrieval/web/main.py
@@ -19,7 +19,7 @@ def get_filtered_results(results, filter_list):
         if not validators.url(url):
             continue
 
-        domain = urlparse(url).netloc
+        domain = urlparse(url).hostname
         if not domain:
             continue
 

--- a/backend/open_webui/test/util/test_web_filter.py
+++ b/backend/open_webui/test/util/test_web_filter.py
@@ -1,0 +1,41 @@
+"""Regression tests for get_filtered_results host matching.
+
+The web-search domain filter must match on the URL *hostname*, not the raw
+netloc (which carries host:port). Otherwise a blocked host reached over an
+explicit port bypasses the blocklist, and an allowlisted host on a non-default
+port is wrongly dropped (see issue #16735).
+"""
+
+import pytest
+
+from open_webui.retrieval.web import main as web_main
+from open_webui.retrieval.web.main import get_filtered_results
+
+
+@pytest.fixture(autouse=True)
+def _no_dns(monkeypatch):
+    # keep the test hermetic: don't perform real DNS resolution
+    monkeypatch.setattr(web_main, "resolve_hostname", lambda host: ([], []))
+
+
+def _urls(results):
+    return [r["url"] for r in results]
+
+
+def test_blocklist_blocks_host_with_explicit_port():
+    results = [
+        {"url": "https://blocked.example/page"},
+        {"url": "https://blocked.example:8443/page"},
+    ]
+    assert _urls(get_filtered_results(results, ["!blocked.example"])) == []
+
+
+def test_allowlist_keeps_host_with_explicit_port():
+    results = [
+        {"url": "https://corp.com/page"},
+        {"url": "https://corp.com:8080/page"},
+    ]
+    assert set(_urls(get_filtered_results(results, ["corp.com"]))) == {
+        "https://corp.com/page",
+        "https://corp.com:8080/page",
+    }


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #16735 (Domain Filter List results in no urls when set).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** N/A — internal behavior fix, no doc change needed.
- [ ] **Dependencies:** N/A — no dependency changes.
- [x] **Testing:** Verified the real `get_filtered_results` + `is_host_allowed` RED→GREEN (see below); added regression tests.
- [x] **No Unchecked AI Code:** Change has undergone human review and manual verification.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings; behavior-only one-line fix.
- [x] **Git Hygiene:** Atomic, based on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

`get_filtered_results` (web-search domain filtering) derived the host from `urlparse(url).netloc` and passed it to `is_host_allowed`, whose documented contract is to receive a **parsed hostname, never a URL/host:port**. `netloc` carries the port (and optional userinfo), so for any URL with an explicit port the label-boundary match never fires:

- **Blocklist bypass:** a blocked host reached as `https://blocked.example:8443/...` passes the filter and is returned to the model/RAG.
- **Allowlist over-filtering:** with an allowlist, a legitimate result on `https://corp.com:8080/...` is wrongly dropped (the symptom reported in #16735).

`resolve_hostname(domain)` was likewise being fed a `host:port`, so DNS/IP-based matching silently failed for ported URLs.

**Fix:** use `urlparse(url).hostname`, matching the convention already used in `web/utils.py::validate_url`. The function signature is unchanged, so all ~28 provider callers are unaffected.

Verified against the real functions:

```
# before (.netloc)
blocklist ["!blocked.example"]: kept ["https://blocked.example:8443/page"]   # bypass
allowlist ["corp.com"]:         kept ["https://corp.com/page"]                # :8080 dropped
# after (.hostname)
blocklist ["!blocked.example"]: kept []
allowlist ["corp.com"]:         kept ["https://corp.com/page", "https://corp.com:8080/page"]
```

### Fixed

- Web-search result domain filtering now matches on the URL hostname instead of the netloc, so the allow/block filter works for URLs with an explicit port.

### Security

- Fixes a `WEB_FETCH_FILTER_LIST` blocklist bypass: a blocked host reached over an explicit port (`https://blocked.example:8443/`) was incorrectly allowed.

---

### Additional Information

- Relates to #16735.
- Tests added at `backend/open_webui/test/util/test_web_filter.py` covering the blocklist and allowlist cases with an explicit port.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
