### PR TITLE
fix: check YDC_API_KEY before YOUCOM_API_KEY for You.com web search

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1262,7 +1262,7 @@ YANDEX_WEB_SEARCH_API_KEY = os.getenv('YANDEX_WEB_SEARCH_API_KEY', '')
 
 YANDEX_WEB_SEARCH_CONFIG = os.getenv('YANDEX_WEB_SEARCH_CONFIG', '')
 
-YOUCOM_API_KEY = os.getenv('YOUCOM_API_KEY', os.getenv('YDC_API_KEY', ''))
+YOUCOM_API_KEY = os.getenv('YDC_API_KEY', os.getenv('YOUCOM_API_KEY', ''))
 
 LINKUP_API_KEY = os.getenv('LINKUP_API_KEY', '')
 


### PR DESCRIPTION
YDC_API_KEY is the standard env var used by the You.com SDK, gpt-oss, and other integrations. open-webui already had a fallback to YDC_API_KEY but checked YOUCOM_API_KEY first.

This swaps the priority so YDC_API_KEY is checked first, with YOUCOM_API_KEY kept as backward-compatible fallback. The internal config key name is unchanged, so no frontend or migration changes are needed.

One-line change in `backend/open_webui/config.py`.