### PR TITLE
feat: add keyboard shortcuts for chat navigation and controls toggle

### DIFF
--- a/src/lib/components/chat/ShortcutsModal.svelte
+++ b/src/lib/components/chat/ShortcutsModal.svelte
@@ -75,10 +75,13 @@
 						<!-- {$i18n.t('Delete Chat')} -->
 						<!-- {$i18n.t('Open Model Selector')} -->
 						<!-- {$i18n.t('Toggle Dictation')} -->
+						<!-- {$i18n.t('Navigate to Previous Chat')} -->
+						<!-- {$i18n.t('Navigate to Next Chat')} -->
 						<!-- {$i18n.t('Search')} -->
 						<!-- {$i18n.t('Open Settings')} -->
 						<!-- {$i18n.t('Show Shortcuts')} -->
 						<!-- {$i18n.t('Toggle Sidebar')} -->
+						<!-- {$i18n.t('Toggle Controls')} -->
 						<!-- {$i18n.t('Close Modal')} -->
 						<!-- {$i18n.t('Focus Chat Input')} -->
 						<!-- {$i18n.t('Accept Autocomplete Generation\nJump to Prompt Variable')} -->

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -18,12 +18,15 @@ export enum Shortcut {
 	DELETE_CHAT = 'deleteChat',
 	OPEN_MODEL_SELECTOR = 'openModelSelector',
 	TOGGLE_DICTATION = 'toggleDictation',
+	NAVIGATE_CHAT_UP = 'navigateChatUp',
+	NAVIGATE_CHAT_DOWN = 'navigateChatDown',
 
 	//Global
 	SEARCH = 'search',
 	OPEN_SETTINGS = 'openSettings',
 	SHOW_SHORTCUTS = 'showShortcuts',
 	TOGGLE_SIDEBAR = 'toggleSidebar',
+	TOGGLE_CONTROLS = 'toggleControls',
 	CLOSE_MODAL = 'closeModal',
 
 	//Input
@@ -73,6 +76,16 @@ export const shortcuts: ShortcutRegistry = {
 		keys: ['mod', 'shift', 'L'],
 		category: 'Chat'
 	},
+	[Shortcut.NAVIGATE_CHAT_UP]: {
+		name: 'Navigate to Previous Chat',
+		keys: ['alt', 'ArrowUp'],
+		category: 'Chat'
+	},
+	[Shortcut.NAVIGATE_CHAT_DOWN]: {
+		name: 'Navigate to Next Chat',
+		keys: ['alt', 'ArrowDown'],
+		category: 'Chat'
+	},
 
 	//Global
 	[Shortcut.SEARCH]: {
@@ -93,6 +106,11 @@ export const shortcuts: ShortcutRegistry = {
 	[Shortcut.TOGGLE_SIDEBAR]: {
 		name: 'Toggle Sidebar',
 		keys: ['mod', 'shift', 'S'],
+		category: 'Global'
+	},
+	[Shortcut.TOGGLE_CONTROLS]: {
+		name: 'Toggle Controls',
+		keys: ['mod', 'shift', 'I'],
 		category: 'Global'
 	},
 	[Shortcut.CLOSE_MODAL]: {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -39,7 +39,9 @@
 		showSearch,
 		showSidebar,
 		showControls,
-		mobile
+		mobile,
+		chatId,
+		chats
 	} from '$lib/stores';
 
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
@@ -315,6 +317,34 @@
 					console.log('Shortcut triggered: REGENERATE_RESPONSE');
 					event.preventDefault();
 					[...document.getElementsByClassName('regenerate-response-button')]?.at(-1)?.click();
+				} else if (isShortcutMatch(event, shortcuts[Shortcut.NAVIGATE_CHAT_UP])) {
+					console.log('Shortcut triggered: NAVIGATE_CHAT_UP');
+					event.preventDefault();
+					if ($chats && $chats.length > 0) {
+						const currentIndex = $chats.findIndex((c) => c.id === $chatId);
+						if (currentIndex > 0) {
+							await goto(`/c/${$chats[currentIndex - 1].id}`);
+						} else if (currentIndex === -1) {
+							// No chat selected, go to the first chat
+							await goto(`/c/${$chats[0].id}`);
+						}
+					}
+				} else if (isShortcutMatch(event, shortcuts[Shortcut.NAVIGATE_CHAT_DOWN])) {
+					console.log('Shortcut triggered: NAVIGATE_CHAT_DOWN');
+					event.preventDefault();
+					if ($chats && $chats.length > 0) {
+						const currentIndex = $chats.findIndex((c) => c.id === $chatId);
+						if (currentIndex !== -1 && currentIndex < $chats.length - 1) {
+							await goto(`/c/${$chats[currentIndex + 1].id}`);
+						} else if (currentIndex === -1) {
+							// No chat selected, go to the first chat
+							await goto(`/c/${$chats[0].id}`);
+						}
+					}
+				} else if (isShortcutMatch(event, shortcuts[Shortcut.TOGGLE_CONTROLS])) {
+					console.log('Shortcut triggered: TOGGLE_CONTROLS');
+					event.preventDefault();
+					showControls.set(!$showControls);
 				}
 			});
 		};


### PR DESCRIPTION
## Summary
Adds three new keyboard shortcuts addressing #1008:
- **Alt+↑/↓**: Navigate between chats in sidebar
- **Ctrl/Cmd+Shift+I**: Toggle controls panel

## Changes
- `src/lib/shortcuts.ts`: Add `NAVIGATE_CHAT_UP`, `NAVIGATE_CHAT_DOWN`, `TOGGLE_CONTROLS` to enum and registry
- `src/routes/(app)/+layout.svelte`: Add event handlers with proper context guards
- `src/lib/components/chat/ShortcutsModal.svelte`: Add i18n extraction comments

## Key Design Decisions
- `Alt+↑/↓` follows VS Code/Slack/Discord tab navigation patterns — no browser shortcut conflicts
- Chat navigation uses `chats` store + `goto()` (programmatic, not DOM clicks)
- Controls toggle uses existing `showControls` store
- Web search toggle was considered but `webSearchEnabled` is a local component variable, not a store — too invasive for a first contribution

Addresses #1008

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.