### PR TITLE
fix: resolve MCP OAuth authorize_url discovery and fail clearly (#26647)

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -196,7 +196,7 @@ async def register_oauth_client(
         log.debug(f'Failed to register OAuth client: {e}')
         raise HTTPException(
             status_code=400,
-            detail=f'Failed to register OAuth client',
+            detail=f'Failed to register OAuth client: {e}',
         )
 
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -536,6 +536,20 @@ async def get_oauth_client_info_with_dynamic_client_registration(
                             log.error(f'Error parsing OAuth metadata from {url}: {e}')
                             continue
 
+        # Fail fast if authorization server metadata discovery did not resolve an
+        # authorization endpoint. Otherwise registration can still "succeed" (via
+        # the /register fallback below) while issuer/server_metadata stay unset,
+        # which later crashes at authorize time with authlib's
+        # RuntimeError: Missing "authorize_url" value. (#26647)
+        if oauth_server_metadata is None or not oauth_server_metadata.authorization_endpoint:
+            log.error(f'OAuth authorization server metadata discovery failed for {oauth_server_url}')
+            raise Exception(
+                'Could not discover the OAuth authorization server metadata '
+                f'(authorization_endpoint) for {oauth_server_url}. The MCP server must '
+                'expose RFC 8414 / RFC 9728 discovery documents so Open WebUI can '
+                'resolve where to send users to authorize.'
+            )
+
         registration_url = None
         if oauth_server_metadata and oauth_server_metadata.registration_endpoint:
             registration_url = str(oauth_server_metadata.registration_endpoint)
@@ -801,6 +815,17 @@ class OAuthClientManager:
             },
             'server_metadata_url': (oauth_client_info.issuer if oauth_client_info.issuer else None),
         }
+
+        # Defense-in-depth: when the server metadata is already known, pass the
+        # authorization/token endpoints explicitly so authlib does not rely solely
+        # on refetching server_metadata_url (which may be missing/unreachable) to
+        # resolve them. Prevents RuntimeError: Missing "authorize_url". (#26647)
+        server_metadata = oauth_client_info.server_metadata
+        if server_metadata is not None:
+            if getattr(server_metadata, 'authorization_endpoint', None):
+                kwargs['authorize_url'] = str(server_metadata.authorization_endpoint)
+            if getattr(server_metadata, 'token_endpoint', None):
+                kwargs['access_token_url'] = str(server_metadata.token_endpoint)
 
         # Default to S256 for OAuth 2.1 (PKCE is mandatory per RFC 9700)
         kwargs['code_challenge_method'] = 'S256'
@@ -1138,7 +1163,22 @@ class OAuthClientManager:
         redirect_uri_str = str(redirect_uri) if redirect_uri else None
         # Pass explicit scope/resource parameters for providers that require them.
         kwargs = build_oauth_request_params(client_info)
-        return await client.authorize_redirect(request, redirect_uri_str, **kwargs)
+        try:
+            return await client.authorize_redirect(request, redirect_uri_str, **kwargs)
+        except RuntimeError as e:
+            # authlib raises RuntimeError('Missing "authorize_url" value') when the
+            # authorization endpoint could not be resolved from server metadata.
+            # Surface a clear 400 instead of an uncaught 500 for clients that were
+            # registered before discovery was validated. (#26647)
+            log.error(f'OAuth authorize failed for client {client_id}: {e}')
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    'OAuth authorization endpoint could not be resolved for this '
+                    'client. Re-register the MCP server; its OAuth discovery '
+                    'documents may be missing or unreachable.'
+                ),
+            )
 
     async def handle_callback(self, request, client_id: str, user_id: str, response):
         client = await self.get_client(client_id)


### PR DESCRIPTION
### What happens

Connecting a Remote MCP server that uses OAuth 2.1 fails with an HTTP 500 and `RuntimeError: Missing "authorize_url" value` when you try to authorize — even though registering the client appeared to succeed.

### Why

The OAuth flow has two steps:

1. **Register** the client : Open WebUI discovers the OAuth server's details, then registers.
2. **Authorize** : Open WebUI redirects the user to the server's login page to approve access.

The bug is that step 1 was allowed to "succeed" even when discovery never found the server's **authorization endpoint** (the login URL). Registration fell back to a generic `/register` call and saved a client with no login URL attached. Nothing looked wrong yet — the error only appeared in step 2, when authlib tried to build the redirect and had no URL to use. That's why it looked like an authorize bug when the real problem was back in registration.

### The fix

Three small changes, from the root cause outward:

- **Fail fast at registration** — if discovery can't find the authorization endpoint, stop with a clear error instead of saving a broken client. (`get_oauth_client_info_with_dynamic_client_registration`)
- **Pass the endpoints directly** — when Open WebUI already knows the server's login/token URLs, hand them to authlib explicitly instead of hoping it can re-fetch them later. (`OAuthClientManager.add_client`)
- **Fail gracefully at authorize** — for any client that was already saved in a broken state before this fix, return a clear HTTP 400 instead of an uncaught 500. (`handle_authorize`)

### Scope & limitations

This PR implements the **"fail gracefully with a descriptive error"** option requested in the issue. It is intentionally focused and does **not** change OAuth discovery itself.

For servers where discovery already resolves the authorization endpoint, this also removes a failure mode by passing the endpoints to authlib explicitly. But for a server whose metadata Open WebUI cannot discover at all (likely the reporter's case, since the same server works in Claude), this PR turns the confusing 500 into a clear, actionable error at registration time — it does not by itself make that server connect.

Making such servers connect requires completing the MCP discovery chain (`WWW-Authenticate → Protected Resource Metadata → Authorization Server Metadata`), which is tracked separately in #19794 and #21183 and is a larger, higher-risk change best kept out of this PR.

Addresses #26647 (graceful-failure path). Discovery-chain fix tracked in #19794 / #21183.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️

1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — Addresses #26647 (graceful-failure path; see Scope & limitations).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** N/A — bug fix; no documented behavior changes.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified with mock-based unit tests (no live OAuth server required). The tests and their results are documented below.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings or endpoints. Behavior change is limited to failing early/clearly and passing already-known endpoints to authlib explicitly.
- [x] **Git Hygiene:** The PR is atomic (one logical change), branched on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Connecting a Remote MCP server over OAuth 2.1 could register a client even when the authorization server metadata (and therefore the authorization endpoint) was never discovered. This stored a client with no authorization endpoint, so starting the OAuth flow crashed with an uncaught `RuntimeError: Missing "authorize_url" value` (HTTP 500).

### Changed

- Dynamic client registration now **fails fast with a descriptive error** when authorization-server metadata cannot be discovered, instead of registering an unusable client.
- `OAuthClientManager.add_client()` now passes `authorize_url` / `access_token_url` to authlib explicitly when the server metadata is already known, rather than relying solely on refetching `server_metadata_url`.

### Fixed

- MCP OAuth 2.1 authorization no longer returns an uncaught HTTP 500 (`Missing "authorize_url" value`). Registration surfaces the real reason, and the authorize endpoint returns a clear HTTP 400 for clients that were registered before this validation (#26647).

---

### Additional Information

Backend-only change in `backend/open_webui/utils/oauth.py` and the registration error detail in `backend/open_webui/routers/configs.py`.

### How this was tested

Verified locally with three mock-based unit tests (no live OAuth/MCP server needed) — one per change. All three pass:

```
test_dynamic_registration_fails_fast_when_authorization_endpoint_undiscovered PASSED
test_handle_authorize_returns_400_when_authorize_url_missing               PASSED
test_add_client_passes_explicit_endpoints_from_server_metadata            PASSED
3 passed
```

**Test 1 — registration fails fast when the authorization endpoint isn't discovered.**
Simulates a server whose discovery yields no authorization-server metadata. Asserts that dynamic registration now raises a descriptive error (naming `authorization_endpoint`) instead of returning a broken client. This is the root-cause guard.

```python
async def run():
    resource_metadata = SimpleNamespace(
        resource='https://mcp.example.com',
        scopes_supported=None,
        get_discovery_urls=lambda url: [],  # discovery finds nothing
    )
    with patch.object(oauth.Config, 'get', new=AsyncMock(return_value='https://owui.example.com')), \
         patch.object(oauth, 'get_protected_resource_metadata', new=AsyncMock(return_value=resource_metadata)):
        with pytest.raises(Exception) as exc_info:
            await oauth.get_oauth_client_info_with_dynamic_client_registration(
                request=MagicMock(), client_id='mcp:example', oauth_server_url='https://mcp.example.com',
            )
    assert 'authorization_endpoint' in str(exc_info.value)
```

**Test 2 — authorize returns HTTP 400, not an uncaught 500.**
Simulates a client that was already saved in a broken state (authlib raises `Missing "authorize_url"`). Asserts `handle_authorize()` converts it into a clear `HTTPException(400)` instead of a raw 500.

```python
async def run():
    manager = OAuthClientManager(MagicMock())
    fake_client = SimpleNamespace(
        authorize_redirect=AsyncMock(side_effect=RuntimeError('Missing "authorize_url" value'))
    )
    manager.get_client = AsyncMock(return_value=fake_client)
    manager.get_client_info = AsyncMock(return_value=SimpleNamespace(redirect_uris=['https://owui.example.com/cb']))
    with patch.object(oauth, 'build_oauth_request_params', return_value={}):
        with pytest.raises(HTTPException) as exc_info:
            await manager.handle_authorize(MagicMock(), 'mcp:example')
    assert exc_info.value.status_code == 400
```

**Test 3 — endpoints are passed to authlib explicitly (even when `issuer` is `None`).**
Reproduces the exact bug scenario: `issuer` is `None` but server metadata is known. Asserts `add_client()` hands `authorize_url` / `access_token_url` straight to authlib, so the flow works without relying on a later re-fetch.

```python
manager = OAuthClientManager(MagicMock())
manager.oauth = MagicMock()
server_metadata = SimpleNamespace(
    authorization_endpoint='https://as.example.com/authorize',
    token_endpoint='https://as.example.com/token',
    code_challenge_methods_supported=['S256'],
)
client_info = SimpleNamespace(
    client_id='cid', client_secret='secret', scope=None,
    token_endpoint_auth_method=None, issuer=None, server_metadata=server_metadata,
)
manager.add_client('mcp:example', client_info)
kwargs = manager.oauth.register.call_args.kwargs
assert kwargs['authorize_url'] == 'https://as.example.com/authorize'
assert kwargs['access_token_url'] == 'https://as.example.com/token'
```

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
-->

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [[Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.