### PR TITLE
fix: make open_webui/static writable under an arbitrary UID (OpenShift restricted SCC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,6 +184,17 @@ COPY --chown=$UID:$GID --from=build /app/package.json /app/package.json
 # copy backend files
 COPY --chown=$UID:$GID ./backend .
 
+# The backend rewrites its bundled static assets (favicons, splash, manifest,
+# loader.js, ...) under open_webui/static at startup. Make that directory
+# writable by an arbitrary UID -- which under OpenShift's restricted SCC is
+# always a member of GID 0 -- so those writes don't fail with EACCES and crash
+# the boot log with "[Errno 13] Permission denied". `chmod -R g=u` mirrors the
+# owner bits onto the group (the Red Hat arbitrary-UID idiom). This is applied
+# unconditionally because it targets a directory the app writes on every start;
+# the broader, opt-in USE_PERMISSION_HARDENING below covers the rest of /app.
+RUN chgrp -R 0 /app/backend/open_webui/static && \
+    chmod -R g=u /app/backend/open_webui/static
+
 EXPOSE 8080
 
 HEALTHCHECK CMD curl --silent --fail http://localhost:${PORT:-8080}/health | jq -ne 'input.status == true' || exit 1


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - `Closes #26662`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** N/A - Dockerfile-only build change; no user-facing behavior or docs affected.
- [x] **Dependencies:** N/A - no new or updated dependencies.
- [x] **Testing:** Reproduced the failure and verified the fix (see Additional Information). No regression to the default `UID=0/GID=0` run.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. This applies the fix unconditionally (no new flag) to a directory the app writes on every start.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the allowed prefixes.

# Changelog Entry

### Description

- On startup the backend rewrites its bundled static assets (favicons, splash, `site.webmanifest`, `loader.js`, etc.) under `/app/backend/open_webui/static`. When the container runs as an arbitrary non-root UID (like OpenShift's `restricted`/`restricted-v2` SCC does), that UID does not own the root-owned `static/` directory, so every write fails with `EACCES` and the boot log fills with ~19 `[Errno 13] Permission denied: .../static/*` errors.
- This PR gives group 0 the owner's permissions on that directory (`chgrp -R 0` + `chmod -R g=u`), the standard Red Hat arbitrary-UID idiom, so a GID-0 process can write. It is applied unconditionally because the directory is written on every start. No effect on the default `UID=0/GID=0` run (group 0 is already root's group), so it is a safe, targeted improvement that lets the stock image run cleanly under an arbitrary UID without downstream workarounds.

### Fixed

- `[Errno 13] Permission denied` errors on `/app/backend/open_webui/static/*` at startup when running the image as an arbitrary non-root UID (OpenShift restricted SCC / `runAsNonRoot`).

---

### Additional Information

- Follow-up to #16592 (closed), which was resolved by PR #16622 ("Fix/arbitrary uid"). That PR added a `USE_PERMISSION_HARDENING` Dockerfile block that would also cover this. It defaults to `false` and the published images are built without it, so the stock image still isn't arbitrary-UID friendly. If it can be done without breaking the existing behavior having this supported by default would be better.
- **Testing:**
  - Reproduced on the stock image with plain Docker (no OpenShift needed): `docker run --rm --user 1000:0 ghcr.io/open-webui/open-webui:v0.10.2` → repeated `Permission denied` on `open_webui/static/*` at startup.
  - Verified the equivalent group-0-writable static dir eliminates the errors when the process runs as an arbitrary UID in GID 0.
  - Confirmed no change to the default `UID=0/GID=0` run.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
