### PR TITLE
fix: split kb_exec grep on real newlines

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -686,12 +686,12 @@ async def _kb_grep(
 
     # Grep on piped input
     if piped_input is not None:
-        lines = piped_input.split('\\n')
+        lines = piped_input.split('\n')
         matched = []
         for i, line in enumerate(lines, 1):
             if _matches(line):
                 matched.append(f'{i}: {line}')
-        return '\\n'.join(matched) if matched else f'No matches for "{pattern}"'
+        return '\n'.join(matched) if matched else f'No matches for "{pattern}"'
 
     # Single file grep
     if file_ref and not dir_scope:
@@ -702,7 +702,7 @@ async def _kb_grep(
         elif 'error' in resolved:
             return resolved['error']
         else:
-            lines = resolved['content'].split('\\n')
+            lines = resolved['content'].split('\n')
             matched = []
             for i, line in enumerate(lines, 1):
                 if _matches(line):
@@ -715,7 +715,7 @@ async def _kb_grep(
 
             if not matched:
                 return f'No matches for "{pattern}" in {resolved["filename"]}'
-            return '\\n'.join(matched)
+            return '\n'.join(matched)
 
     # Cross-file grep (optionally scoped to directory)
     accessible = await _get_accessible_files(user, model_knowledge)

--- a/tests/test_knowledge_fs_grep.py
+++ b/tests/test_knowledge_fs_grep.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from open_webui.tools import knowledge_fs
+
+
+def test_kb_grep_counts_real_newlines_in_single_file(monkeypatch):
+    async def fake_resolve_file(file_ref, user, model_knowledge):
+        return {
+            'id': 'file-sample',
+            'filename': file_ref,
+            'content': 'alpha\nbeta\ngamma',
+        }
+
+    monkeypatch.setattr(knowledge_fs, '_resolve_file', fake_resolve_file)
+
+    result = asyncio.run(
+        knowledge_fs._kb_grep(
+            ['.*', 'sample.txt'],
+            {'E', 'c'},
+            user={},
+            model_knowledge=[],
+        )
+    )
+
+    assert result == 'file-sample  sample.txt: 3'
+
+
+def test_kb_grep_preserves_real_newlines_in_piped_output():
+    result = asyncio.run(
+        knowledge_fs._kb_grep(
+            ['.*'],
+            {'E'},
+            user={},
+            model_knowledge=[],
+            piped_input='alpha\nbeta\ngamma',
+        )
+    )
+
+    assert result == '1: alpha\n2: beta\n3: gamma'


### PR DESCRIPTION
# Pull Request Checklist

- [x] Linked Issue/Discussion: Closes #26661
- [x] Target branch: `dev`
- [x] Description: Fix `kb_exec grep` to split real newline characters in single-file and piped-input searches.
- [x] Changelog: Included below.
- [x] Dependencies: No dependency changes.
- [x] Testing: Local targeted tests were run.
- [x] Self-Review: The change is scoped to newline handling in `grep`.
- [x] Title Prefix: `fix`

# Changelog Entry

### Description

- Fix `kb_exec grep` so multi-line Knowledge file content is treated as separate lines.

### Fixed

- `grep -c` now counts matches across real newline-separated lines instead of treating the whole file as one line.

---

### Additional Information

Validation:

- `PYTHONPATH=backend python3 -m pytest tests/test_knowledge_fs_grep.py -q`
- `python3 -m ruff check tests/test_knowledge_fs_grep.py`
- `python3 -m ruff format --check tests/test_knowledge_fs_grep.py`
- `python3 -m py_compile backend/open_webui/tools/knowledge_fs.py tests/test_knowledge_fs_grep.py`
- `git diff --check`

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
