### PR TITLE
fix: pass user context and add null guard to EMBEDDING_FUNCTION in query_knowledge_files and query_knowledge_bases

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2545,9 +2545,11 @@ async def query_knowledge_files(
         user_role = __user__.get('role', 'user')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
 
-        embedding_function = __request__.app.state.EMBEDDING_FUNCTION
-        if not embedding_function:
+        _raw_embedding = __request__.app.state.EMBEDDING_FUNCTION
+        if not _raw_embedding:
             return json.dumps({'error': 'Embedding function not configured'})
+        user_model = UserModel(**__user__) if __user__ else None
+        embedding_function = lambda query, prefix=None: _raw_embedding(query, prefix=prefix, user=user_model)
 
         collection_names = []
         external_knowledges = []
@@ -2738,7 +2740,11 @@ async def query_knowledge_bases(
 
         user_id = __user__.get('id')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
-        query_embedding = await __request__.app.state.EMBEDDING_FUNCTION(query)
+        _raw_embedding = __request__.app.state.EMBEDDING_FUNCTION
+        if not _raw_embedding:
+            return json.dumps({'error': 'Embedding function not configured'})
+        user_model = UserModel(**__user__) if __user__ else None
+        query_embedding = await _raw_embedding(query, user=user_model)
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results
         top_results_heap = []


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your pr.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) —Relates to #26676 
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Two built-in tool functions, `query_knowledge_files` and `query_knowledge_bases`, were not correctly integrating user context when calling `app.state.EMBEDDING_FUNCTION`.

`query_knowledge_files` called the embedding function without extracting it to a local variable first, without guarding against it being unset, and without passing a `UserModel` — meaning any per-user embedding model routing (e.g. user-specific API keys or model overrides) was silently bypassed.

`query_knowledge_bases` had the same problems: it called `EMBEDDING_FUNCTION` directly with no null check and no user context.

Both functions now follow the same pattern already established in the rest of the retrieval stack: extract to a local variable, guard against `None`, construct a `UserModel` from `__user__`, and pass it through to the embedding call.

### Fixed

- `query_knowledge_files`: extracts `EMBEDDING_FUNCTION` into `_raw_embedding`, returns an error early if unset, constructs `UserModel` from `__user__`, and passes `user` via a wrapper lambda that also forwards `prefix`
- `query_knowledge_bases`: extracts `EMBEDDING_FUNCTION` into `_raw_embedding`, returns an error early if unset, constructs `UserModel` from `__user__`, and passes `user` directly to the embedding call

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
