### PR TITLE
[codex] Fix default model selection on chat home

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -148,6 +148,60 @@
 	let selectedModels = [''];
 	let atSelectedModel: Model | undefined;
 	let selectedModelIds = [];
+	let appliedDefaultModels: string[] | null = null;
+	let selectedModelsInitializedFromSession = false;
+
+	const getAvailableModelIds = () =>
+		$models.filter((m) => !(m?.info?.meta?.hidden ?? false)).map((m) => m.id);
+
+	const getDefaultModelIds = (availableModels: string[]) => {
+		const userDefaultModels = ($settings?.models ?? []).filter((modelId) =>
+			availableModels.includes(modelId)
+		);
+
+		if (userDefaultModels.length > 0) {
+			return userDefaultModels;
+		}
+
+		const globalDefaultModels = ($config?.default_models ? $config.default_models.split(',') : []).filter(
+			(modelId) => availableModels.includes(modelId)
+		);
+
+		if (globalDefaultModels.length > 0) {
+			return globalDefaultModels;
+		}
+
+		return availableModels.length > 0 ? [availableModels.at(0) ?? ''] : [''];
+	};
+
+	const hasSelectedModels = (modelIds: string[] | null | undefined) =>
+		(modelIds ?? []).filter((modelId) => modelId !== '').length > 0;
+
+	$: if (
+		!chatIdProp &&
+		!$selectedFolder?.data?.model_ids &&
+		!$page.url.searchParams.get('models') &&
+		!$page.url.searchParams.get('model') &&
+		$models.length > 0
+	) {
+		const availableModels = getAvailableModelIds();
+		const defaultModels = getDefaultModelIds(availableModels);
+		const selectedModelsWereAutoApplied =
+			appliedDefaultModels !== null && equal(selectedModels, appliedDefaultModels);
+		const shouldReplaceSessionSelection =
+			selectedModelsInitializedFromSession && hasSelectedModels(defaultModels);
+
+		if (
+			!hasSelectedModels(selectedModels) ||
+			selectedModelsWereAutoApplied ||
+			shouldReplaceSessionSelection
+		) {
+			selectedModels = defaultModels;
+			appliedDefaultModels = defaultModels;
+			selectedModelsInitializedFromSession = false;
+		}
+	}
+
 	$: if (atSelectedModel !== undefined) {
 		selectedModelIds = [atSelectedModel.id];
 	} else {
@@ -328,7 +382,7 @@
 		}
 	};
 
-	$: if (selectedModels && chatIdProp !== '') {
+	$: if (selectedModels && chatIdProp) {
 		saveSessionSelectedModels();
 	}
 
@@ -1413,18 +1467,19 @@
 				// Set from folder model IDs
 				selectedModels = $selectedFolder?.data?.model_ids;
 			} else {
-				if (sessionStorage.selectedModels) {
+				if ($settings?.models) {
+					// Set from user settings
+					selectedModels = $settings?.models;
+					sessionStorage.removeItem('selectedModels');
+				} else if (defaultModels && defaultModels.length > 0) {
+					// Set from default models
+					selectedModels = defaultModels;
+					sessionStorage.removeItem('selectedModels');
+				} else if (sessionStorage.selectedModels) {
 					// Set from session storage (temporary selection)
 					selectedModels = JSON.parse(sessionStorage.selectedModels);
+					selectedModelsInitializedFromSession = true;
 					sessionStorage.removeItem('selectedModels');
-				} else {
-					if ($settings?.models) {
-						// Set from user settings
-						selectedModels = $settings?.models;
-					} else if (defaultModels && defaultModels.length > 0) {
-						// Set from default models
-						selectedModels = defaultModels;
-					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Fixes default model selection on the chat home page when user settings and the model list load after the initial component mount.

## Root Cause

The chat home page initialized `selectedModels` once during setup. If the model list or user settings were not loaded yet, the selector could remain empty or keep a stale temporary selection. The page also saved model selections to `sessionStorage.selectedModels` even when no chat id was active, allowing the home page to rehydrate an old model instead of the saved default.

## Changes

- Resolve default model ids from available models, preferring user defaults over global defaults and then the first available model.
- Re-apply defaults on the home page after models/settings become available, while avoiding overwriting manual selections.
- Only persist temporary selected models to `sessionStorage` when an existing chat is active.
- Prefer user/global default models over stale `sessionStorage.selectedModels` during home-page initialization.

## Validation

- `git diff --check -- src/lib/components/chat/Chat.svelte`
- Manual validation against a deployed Open WebUI instance: changing the default model and refreshing the chat home page now keeps the selected default in sync.

## Notes

I could not run `npm run check` locally because this machine has Node v25.8.2 while the project requires Node `>=18.13.0 <=22.x.x`; `npm ci` also hit a Windows npm cache `EPERM` error in the local environment.