### PR TITLE
fix: preserve default model on chat home

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -148,6 +148,60 @@
 	let selectedModels = [''];
 	let atSelectedModel: Model | undefined;
 	let selectedModelIds = [];
+	let appliedDefaultModels: string[] | null = null;
+	let selectedModelsInitializedFromSession = false;
+
+	const getAvailableModelIds = () =>
+		$models.filter((m) => !(m?.info?.meta?.hidden ?? false)).map((m) => m.id);
+
+	const getDefaultModelIds = (availableModels: string[]) => {
+		const userDefaultModels = ($settings?.models ?? []).filter((modelId) =>
+			availableModels.includes(modelId)
+		);
+
+		if (userDefaultModels.length > 0) {
+			return userDefaultModels;
+		}
+
+		const globalDefaultModels = ($config?.default_models ? $config.default_models.split(',') : []).filter(
+			(modelId) => availableModels.includes(modelId)
+		);
+
+		if (globalDefaultModels.length > 0) {
+			return globalDefaultModels;
+		}
+
+		return availableModels.length > 0 ? [availableModels.at(0) ?? ''] : [''];
+	};
+
+	const hasSelectedModels = (modelIds: string[] | null | undefined) =>
+		(modelIds ?? []).filter((modelId) => modelId !== '').length > 0;
+
+	$: if (
+		!chatIdProp &&
+		!$selectedFolder?.data?.model_ids &&
+		!$page.url.searchParams.get('models') &&
+		!$page.url.searchParams.get('model') &&
+		$models.length > 0
+	) {
+		const availableModels = getAvailableModelIds();
+		const defaultModels = getDefaultModelIds(availableModels);
+		const selectedModelsWereAutoApplied =
+			appliedDefaultModels !== null && equal(selectedModels, appliedDefaultModels);
+		const shouldReplaceSessionSelection =
+			selectedModelsInitializedFromSession && hasSelectedModels(defaultModels);
+
+		if (
+			!hasSelectedModels(selectedModels) ||
+			selectedModelsWereAutoApplied ||
+			shouldReplaceSessionSelection
+		) {
+			selectedModels = defaultModels;
+			appliedDefaultModels = defaultModels;
+			selectedModelsInitializedFromSession = false;
+		}
+	}
+
 	$: if (atSelectedModel !== undefined) {
 		selectedModelIds = [atSelectedModel.id];
 	} else {
@@ -328,7 +382,7 @@
 		}
 	};
 
-	$: if (selectedModels && chatIdProp !== '') {
+	$: if (selectedModels && chatIdProp) {
 		saveSessionSelectedModels();
 	}
 
@@ -1413,18 +1467,19 @@
 				// Set from folder model IDs
 				selectedModels = $selectedFolder?.data?.model_ids;
 			} else {
-				if (sessionStorage.selectedModels) {
+				if ($settings?.models) {
+					// Set from user settings
+					selectedModels = $settings?.models;
+					sessionStorage.removeItem('selectedModels');
+				} else if (defaultModels && defaultModels.length > 0) {
+					// Set from default models
+					selectedModels = defaultModels;
+					sessionStorage.removeItem('selectedModels');
+				} else if (sessionStorage.selectedModels) {
 					// Set from session storage (temporary selection)
 					selectedModels = JSON.parse(sessionStorage.selectedModels);
+					selectedModelsInitializedFromSession = true;
 					sessionStorage.removeItem('selectedModels');
-				} else {
-					if ($settings?.models) {
-						// Set from user settings
-						selectedModels = $settings?.models;
-					} else if (defaultModels && defaultModels.length > 0) {
-						// Set from default models
-						selectedModels = defaultModels;
-					}
 				}
 			}
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is a small bug fix for default model selection on the chat home page. The issue was found while testing a deployed Open WebUI instance where changing the default model worked for new chats, but the home page kept showing a stale previous model after refresh.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Fixes chat home page default model initialization when user settings and model data load after the first render.

### Added

- N/A

### Changed

- The chat home page now resolves default models from available models, preferring user defaults before global defaults.
- Temporary `sessionStorage.selectedModels` state is no longer saved from the chat home page without an active chat id.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed a case where the chat home page could show an empty or stale selected model after refresh even after the user clicked “Set as default” on another model.
- Fixed stale session model selection taking precedence over the saved default model on the home page.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

Root cause: default model selection was initialized once during chat home setup. If `$models` or `$settings.models` were not available yet, the selection could remain empty or use stale `sessionStorage.selectedModels`. The home page also persisted temporary selected models even without an active chat id.

Validation:

- `git diff --check -- src/lib/components/chat/Chat.svelte`
- Manual validation against a deployed Open WebUI instance: changing the default model and refreshing the chat home page now keeps the selected model in sync.

I could not run `npm run check` locally because this machine has Node v25.8.2 while the project requires Node `>=18.13.0 <=22.x.x`; `npm ci` also hit a Windows npm cache `EPERM` error in the local environment.

### Screenshots or Videos

- N/A

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.