### PR TITLE
feat(calendar): show event indicators in mini calendar

### DIFF
--- a/src/lib/components/calendar/CalendarSidebar.svelte
+++ b/src/lib/components/calendar/CalendarSidebar.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import type { CalendarModel } from '$lib/apis/calendar';
+	import type { CalendarEventModel, CalendarModel } from '$lib/apis/calendar';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+	import {
+		miniCalendarDayKey,
+		miniCalendarEventIndicators,
+		miniCalendarVisibleRange
+	} from './calendarEventIndicators';
 
 	const i18n = getContext('i18n');
 
 	export let calendars: CalendarModel[] = [];
+	export let events: CalendarEventModel[] = [];
 	export let visibleCalendarIds: Set<string> = new Set();
 	export let currentDate: Date = new Date();
 	export let onToggle: (id: string) => void = () => {};
 	export let onCreateCalendar: () => void = () => {};
 	export let onDeleteCalendar: (id: string) => void = () => {};
 	export let onDateSelect: (date: Date) => void = () => {};
+	export let onVisibleRangeChange: (start: string, end: string) => void | Promise<void> = () => {};
 
 	// Delete confirmation state
 	let showDeleteConfirm = false;
@@ -38,12 +45,8 @@
 	$: miniMonth = currentDate.getMonth();
 	$: miniYear = currentDate.getFullYear();
 
-	$: miniMonthStart = new Date(miniYear, miniMonth, 1);
-	$: miniCalStart = (() => {
-		const d = new Date(miniMonthStart);
-		d.setDate(d.getDate() - d.getDay());
-		return d;
-	})();
+	$: miniVisibleRange = miniCalendarVisibleRange(new Date(miniYear, miniMonth, 1));
+	$: miniCalStart = miniVisibleRange.start;
 
 	$: miniDays = (() => {
 		const days: Date[] = [];
@@ -54,6 +57,17 @@
 		}
 		return days;
 	})();
+	$: calendarColorMap = new Map(calendars.map((calendar) => [calendar.id, calendar.color]));
+	$: eventIndicators = miniCalendarEventIndicators(events, visibleCalendarIds, calendarColorMap);
+
+	let lastVisibleRangeKey = '';
+	$: {
+		const rangeKey = `${miniVisibleRange.start.toISOString()}|${miniVisibleRange.end.toISOString()}`;
+		if (rangeKey !== lastVisibleRangeKey) {
+			lastVisibleRangeKey = rangeKey;
+			onVisibleRangeChange(miniVisibleRange.start.toISOString(), miniVisibleRange.end.toISOString());
+		}
+	}
 
 	$: miniMonthNames = [
 		'January',
@@ -155,8 +169,9 @@
 
 		<div class="grid grid-cols-7 text-center text-[10px]">
 			{#each miniDays as day}
+				{@const eventColors = eventIndicators.get(miniCalendarDayKey(day)) ?? []}
 				<button
-					class="w-6 h-6 flex items-center justify-center rounded-full transition
+					class="relative w-6 h-6 flex items-center justify-center rounded-full transition
 						{day.getMonth() !== miniMonth ? 'text-gray-300 dark:text-gray-600' : ''}
 						{isToday(day) ? 'bg-blue-500 text-white' : ''}
 						{day.toDateString() === currentDate.toDateString() && !isToday(day)
@@ -168,6 +183,16 @@
 					on:click={() => onDateSelect(day)}
 				>
 					{day.getDate()}
+					{#if eventColors.length > 0}
+						<span class="absolute bottom-px left-1/2 -translate-x-1/2 flex gap-px">
+							{#each eventColors.slice(0, 3) as color}
+								<span
+									class="size-1 rounded-full {isToday(day) ? 'ring-1 ring-white/80' : ''}"
+									style="background-color: {color};"
+								></span>
+							{/each}
+						</span>
+					{/if}
 				</button>
 			{/each}
 		</div>

--- a/src/lib/components/calendar/calendarEventIndicators.test.ts
+++ b/src/lib/components/calendar/calendarEventIndicators.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+	miniCalendarEventIndicators,
+	miniCalendarVisibleRange
+} from './calendarEventIndicators';
+
+const NS = 1_000_000;
+
+function atLocalNoon(year: number, monthIndex: number, day: number): number {
+	return new Date(year, monthIndex, day, 12, 0, 0, 0).getTime() * NS;
+}
+
+describe('miniCalendarEventIndicators', () => {
+	it('returns one visible color dot per calendar color by local calendar day', () => {
+		const indicators = miniCalendarEventIndicators(
+			[
+				{
+					calendar_id: 'personal',
+					start_at: atLocalNoon(2026, 5, 22),
+					end_at: null,
+					color: null
+				},
+				{
+					calendar_id: 'personal',
+					start_at: atLocalNoon(2026, 5, 22),
+					end_at: null,
+					color: null
+				},
+				{
+					calendar_id: 'care',
+					start_at: atLocalNoon(2026, 5, 22),
+					end_at: null,
+					color: '#ef4444'
+				},
+				{
+					calendar_id: 'hidden',
+					start_at: atLocalNoon(2026, 5, 23),
+					end_at: null,
+					color: null
+				}
+			],
+			new Set(['personal', 'care']),
+			new Map([
+				['personal', '#3b82f6'],
+				['care', '#22c55e'],
+				['hidden', '#f59e0b']
+			])
+		);
+
+		expect(indicators.get(new Date(2026, 5, 22).getTime().toString())).toEqual([
+			'#3b82f6',
+			'#ef4444'
+		]);
+		expect(indicators.has(new Date(2026, 5, 23).getTime().toString())).toBe(false);
+	});
+});
+
+describe('miniCalendarVisibleRange', () => {
+	it('returns the six-week mini calendar grid range for the selected month', () => {
+		const range = miniCalendarVisibleRange(new Date(2026, 5, 22));
+
+		expect(range.start.getFullYear()).toBe(2026);
+		expect(range.start.getMonth()).toBe(4);
+		expect(range.start.getDate()).toBe(31);
+		expect(range.end.getFullYear()).toBe(2026);
+		expect(range.end.getMonth()).toBe(6);
+		expect(range.end.getDate()).toBe(12);
+	});
+});

--- a/src/lib/components/calendar/calendarEventIndicators.ts
+++ b/src/lib/components/calendar/calendarEventIndicators.ts
@@ -1,0 +1,62 @@
+import type { CalendarEventModel } from '$lib/apis/calendar';
+
+const NS = 1_000_000;
+const DEFAULT_CALENDAR_COLOR = '#3b82f6';
+
+type MiniCalendarEvent = Pick<
+	CalendarEventModel,
+	'calendar_id' | 'start_at' | 'end_at' | 'color'
+>;
+
+function dayKey(date: Date): string {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime().toString();
+}
+
+export function miniCalendarVisibleRange(date: Date): { start: Date; end: Date } {
+	const monthStart = new Date(date.getFullYear(), date.getMonth(), 1);
+	const start = new Date(monthStart);
+	start.setDate(start.getDate() - start.getDay());
+	start.setHours(0, 0, 0, 0);
+
+	const end = new Date(start);
+	end.setDate(end.getDate() + 42);
+	end.setHours(0, 0, 0, 0);
+
+	return { start, end };
+}
+
+export function miniCalendarEventIndicators(
+	events: MiniCalendarEvent[],
+	visibleCalendarIds: Set<string>,
+	calendarColors: Map<string, string | null | undefined> = new Map()
+): Map<string, string[]> {
+	const indicators = new Map<string, string[]>();
+
+	for (const event of events) {
+		if (!visibleCalendarIds.has(event.calendar_id)) {
+			continue;
+		}
+
+		const color = event.color || calendarColors.get(event.calendar_id) || DEFAULT_CALENDAR_COLOR;
+		const startDate = new Date(event.start_at / NS);
+		const endDate = new Date((event.end_at || event.start_at) / NS);
+		const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+		const last = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()).getTime();
+
+		while (cursor.getTime() <= last) {
+			const key = dayKey(cursor);
+			const colors = indicators.get(key) ?? [];
+			if (!colors.includes(color)) {
+				colors.push(color);
+				indicators.set(key, colors);
+			}
+			cursor.setDate(cursor.getDate() + 1);
+		}
+	}
+
+	return indicators;
+}
+
+export function miniCalendarDayKey(date: Date): string {
+	return dayKey(date);
+}

--- a/src/routes/(app)/calendar/+page.svelte
+++ b/src/routes/(app)/calendar/+page.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/apis/calendar';
 	import CalendarView from '$lib/components/calendar/CalendarView.svelte';
 	import CalendarSidebar from '$lib/components/calendar/CalendarSidebar.svelte';
+	import { miniCalendarVisibleRange } from '$lib/components/calendar/calendarEventIndicators';
 	import CalendarEventModal from '$lib/components/calendar/CalendarEventModal.svelte';
 	import CreateCalendarModal from '$lib/components/calendar/CreateCalendarModal.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
@@ -27,6 +28,7 @@
 	let loaded = false;
 	let calendars: CalendarModel[] = [];
 	let events: CalendarEventModel[] = [];
+	let miniCalendarEvents: CalendarEventModel[] = [];
 	let visibleCalendarIds: Set<string> = new Set();
 
 	let view: 'month' | 'week' | 'day' = 'month';
@@ -36,6 +38,9 @@
 	let editEvent: CalendarEventModel | null = null;
 	let defaultStartAt: number | null = null;
 	let showCreateCalendarModal = false;
+	let miniRangeStart: string | null = null;
+	let miniRangeEnd: string | null = null;
+	let miniEventsLoaded = false;
 
 	const MONTH_NAMES = [
 		'January',
@@ -100,8 +105,33 @@
 		}
 	}
 
+	function getMiniVisibleRange(date: Date): { start: string; end: string } {
+		const range = miniCalendarVisibleRange(date);
+		return {
+			start: range.start.toISOString(),
+			end: range.end.toISOString()
+		};
+	}
+
+	async function loadMiniEvents(start?: string, end?: string) {
+		try {
+			const range =
+				start && end
+					? { start, end }
+					: miniRangeStart && miniRangeEnd
+						? { start: miniRangeStart, end: miniRangeEnd }
+						: getMiniVisibleRange(currentDate);
+			miniRangeStart = range.start;
+			miniRangeEnd = range.end;
+			miniCalendarEvents = await getCalendarEvents(localStorage.token, range.start, range.end);
+			miniEventsLoaded = true;
+		} catch (err) {
+			toast.error(`${err}`);
+		}
+	}
+
 	async function refresh() {
-		await loadEvents();
+		await Promise.all([loadEvents(), loadMiniEvents()]);
 	}
 
 	function toggleCalendar(id: string) {
@@ -159,6 +189,13 @@
 		currentDate = date;
 		await tick();
 		refresh();
+	}
+
+	async function handleMiniVisibleRangeChange(start: string, end: string) {
+		if (miniEventsLoaded && miniRangeStart === start && miniRangeEnd === end) {
+			return;
+		}
+		await loadMiniEvents(start, end);
 	}
 
 	function handleCreateCalendar() {
@@ -360,12 +397,14 @@
 			<div class="hidden md:flex flex-col w-56 shrink-0 pr-1.5 pl-3 overflow-y-auto">
 				<CalendarSidebar
 					{calendars}
+					events={miniCalendarEvents}
 					{visibleCalendarIds}
 					{currentDate}
 					onToggle={toggleCalendar}
 					onCreateCalendar={handleCreateCalendar}
 					onDeleteCalendar={handleDeleteCalendar}
 					onDateSelect={handleDateSelect}
+					onVisibleRangeChange={handleMiniVisibleRangeChange}
 				/>
 			</div>
 


### PR DESCRIPTION
## Summary

- Add color-coded event indicators to the sidebar mini calendar.
- Load events for the mini calendar visible range so indicators are available even when the main view is on a different range.
- Respect visible calendar toggles and use event color, calendar color, or the default calendar color.
- Add unit coverage for indicator grouping and mini calendar visible range calculation.

## Testing

- `git diff --check`
- `npx vitest run src/lib/components/calendar/calendarEventIndicators.test.ts`

Note: `npm run check` was also attempted locally, but the current local environment uses Node 26 while this project requires Node <=22. It reported existing repository-wide diagnostics unrelated to this calendar change.