### PR TITLE
fix: stop marking collection_names as legacy

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -33,6 +33,7 @@
 	import TTSVoiceInput from './TTSVoiceInput.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
 	import LockClosed from '$lib/components/icons/LockClosed.svelte';
+	import { normalizeModelKnowledge } from './utils';
 
 	const i18n = getContext('i18n');
 
@@ -359,24 +360,7 @@
 					)
 				: null;
 
-			knowledge = (model?.meta?.knowledge ?? []).map((item) => {
-				if (item?.collection_name && item?.type !== 'file') {
-					return {
-						id: item.collection_name,
-						name: item.name,
-						legacy: true
-					};
-				} else if (item?.collection_names) {
-					return {
-						name: item.name,
-						type: 'collection',
-						collection_names: item.collection_names,
-						legacy: true
-					};
-				} else {
-					return item;
-				}
-			});
+			knowledge = normalizeModelKnowledge(model?.meta?.knowledge ?? []);
 
 			toolIds = model?.meta?.toolIds ?? [];
 			skillIds = model?.meta?.skillIds ?? [];

--- a/src/lib/components/workspace/Models/utils.test.ts
+++ b/src/lib/components/workspace/Models/utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeModelKnowledge } from './utils';
+
+describe('normalizeModelKnowledge', () => {
+	it('marks singular collection_name entries as legacy', () => {
+		expect(
+			normalizeModelKnowledge([
+				{
+					collection_name: 'legacy-collection-id',
+					name: 'Legacy knowledge'
+				}
+			])
+		).toEqual([
+			{
+				id: 'legacy-collection-id',
+				name: 'Legacy knowledge',
+				legacy: true
+			}
+		]);
+	});
+
+	it('does not mark collection_names entries as legacy', () => {
+		expect(
+			normalizeModelKnowledge([
+				{
+					collection_names: ['collection-id'],
+					name: 'Current knowledge'
+				}
+			])
+		).toEqual([
+			{
+				name: 'Current knowledge',
+				type: 'collection',
+				collection_names: ['collection-id'],
+				legacy: false
+			}
+		]);
+	});
+
+	it('leaves file knowledge entries unchanged', () => {
+		const fileItem = {
+			collection_name: 'file-id',
+			name: 'Uploaded file',
+			type: 'file'
+		};
+
+		expect(normalizeModelKnowledge([fileItem])).toEqual([fileItem]);
+	});
+});

--- a/src/lib/components/workspace/Models/utils.ts
+++ b/src/lib/components/workspace/Models/utils.ts
@@ -1,0 +1,30 @@
+export type ModelKnowledgeItem = {
+	collection_name?: string;
+	collection_names?: string[];
+	id?: string;
+	legacy?: boolean;
+	name?: string;
+	type?: string;
+	[key: string]: unknown;
+};
+
+export const normalizeModelKnowledge = (items: ModelKnowledgeItem[] = []): ModelKnowledgeItem[] => {
+	return items.map((item) => {
+		if (item?.collection_name && item?.type !== 'file') {
+			return {
+				id: item.collection_name,
+				name: item.name,
+				legacy: true
+			};
+		} else if (item?.collection_names) {
+			return {
+				name: item.name,
+				type: 'collection',
+				collection_names: item.collection_names,
+				legacy: false
+			};
+		} else {
+			return item;
+		}
+	});
+};


### PR DESCRIPTION
Fixes #26035

## Summary

This moves the Model Editor knowledge normalization into a small helper and fixes the `collection_names` branch so current-format knowledge collections are not marked as legacy.

Old `collection_name` entries still return `legacy: true`. File entries still pass through unchanged.

## Testing

Passed:

```bash
npx -y -p node@22 npm exec vitest -- run src/lib/components/workspace/Models/utils.test.ts
npx -y -p node@22 npm exec prettier -- --check src/lib/components/workspace/Models/ModelEditor.svelte src/lib/components/workspace/Models/utils.ts src/lib/components/workspace/Models/utils.test.ts
git diff --check
```

Also checked:

```bash
npx -y -p node@22 npm run check
```

This currently fails on existing `svelte-check` errors outside this change, including `src/lib/components/common/RichTextInput/AutoCompletion.js`, `src/lib/components/common/RichTextInput/listDragHandlePlugin.js`, `src/routes/auth/+page.svelte`, and `src/routes/s/[id]/+page.svelte`.

## CLA

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
