### PR TITLE
fix: apply default model on fresh page load when models load after chat init

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -888,6 +888,36 @@
 		savedModelIds();
 	}
 
+	// initNewChat() runs on mount via page.subscribe, but $models is loaded
+	// asynchronously (getModels() in the app layout) and this component mounts before
+	// that resolves. So initNewChat() can run while $models is still empty, in which
+	// case none of its precedence branches match and selectedModels is left as [''].
+	// Nothing else re-applies the default afterwards, so the default model never gets
+	// selected on a fresh page load. Re-apply the default once models arrive, for a
+	// brand-new chat that still has no valid model selected.
+	$: if (
+		chatIdProp === '' &&
+		$models.length > 0 &&
+		selectedModels.length === 1 &&
+		selectedModels[0] === '' &&
+		!$page.url.searchParams.get('models') &&
+		!$page.url.searchParams.get('model')
+	) {
+		const availableModels = $models
+			.filter((m) => !(m?.info?.meta?.hidden ?? false))
+			.map((m) => m.id);
+		const defaultModels = $config?.default_models ? $config.default_models.split(',') : [];
+		let next = ($settings?.models?.length ? $settings.models : defaultModels).filter((id) =>
+			availableModels.includes(id)
+		);
+		if (next.length === 0 && availableModels.length > 0) {
+			next = [availableModels[0]];
+		}
+		if (next.length > 0) {
+			selectedModels = next;
+		}
+	}
+
 	const stopAudio = () => {
 		try {
 			speechSynthesis.cancel();


### PR DESCRIPTION
## Problem

When an admin configures a global default model — via the `DEFAULT_MODELS` env var **or** the admin UI (Admin → Settings → Models → Settings → **Defaults** → *Selected Models*) — no model is selected on a **fresh full-page load**. The model selector comes up empty.

The tell-tale symptom (confirmed in the wild): hard-refresh the main page → no model selected; but clicking the in-app **New Chat** button *after* the page has finished loading *does* select the configured default.

## Root cause

`initNewChat()` in `src/lib/components/chat/Chat.svelte` is triggered on mount via `page.subscribe` (`if (p.url.pathname === '/') { await tick(); initNewChat(); }`). Its entire model-selection precedence — URL param → folder → `sessionStorage` → `$settings.models` → `$config.default_models` → first available — is computed against `availableModels`, derived from the `$models` store.

But `$models` is loaded asynchronously (`getModels()` in `src/routes/(app)/+layout.svelte`), and this component mounts **before** that fetch resolves (child `onMount` runs before the parent layout's). So `initNewChat()` frequently runs while `$models` is still `[]`:

- `availableModels` is `[]`
- every precedence branch fails
- `selectedModels` is left as `['']`

And **nothing re-applies the selection when `$models` later populates** — the only assignments to `selectedModels` are in `initNewChat`, `loadChat`, the folder subscription, and `submitHandler`; none react to `$models`. So the empty selection sticks, and the configured default is effectively ignored on every fresh load. The slower the model backend, the more reliably the race is lost.

This is purely a frontend timing issue — `$config.default_models` is populated correctly from both the env var and the admin UI.

## Fix

Add a single guarded reactive statement that re-applies the default selection once models arrive, for a brand-new chat that still has no valid model selected:

- Fires only when `chatIdProp === ''`, `$models` is non-empty, `selectedModels` is `['']`, and there's no `?models=`/`?model=` URL param.
- Reuses the exact `availableModels` / `defaultModels` precedence from `initNewChat` (`$settings.models` → `$config.default_models` → first available).
- Once it sets a valid non-empty selection, its own `selectedModels[0] === ''` guard becomes false, so it doesn't re-run or loop.
- Never overrides a manual pick, a loaded chat, or a folder selection (folder selection is already re-applied by the existing `selectedFolder.subscribe` handler).

## Testing

1. Set a global default via `DEFAULT_MODELS` or Admin → Settings → Models → Settings → Defaults.
2. As a user with no per-user default (`settings.models` unset), hard-refresh the main page → the default model is now selected once models finish loading.
3. Regressions checked: manual model selection persists; existing chats still show their saved model; `?models=<id>` deep-links still work; in-folder new chats still use the folder's `model_ids`.
