### PR TITLE
fix: apply default model on fresh page load when models load after chat init

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -888,6 +888,36 @@
 		savedModelIds();
 	}
 
+	// initNewChat() runs on mount via page.subscribe, but $models is loaded
+	// asynchronously (getModels() in the app layout) and this component mounts before
+	// that resolves. So initNewChat() can run while $models is still empty, in which
+	// case none of its precedence branches match and selectedModels is left as [''].
+	// Nothing else re-applies the default afterwards, so the default model never gets
+	// selected on a fresh page load. Re-apply the default once models arrive, for a
+	// brand-new chat that still has no valid model selected.
+	$: if (
+		chatIdProp === '' &&
+		$models.length > 0 &&
+		selectedModels.length === 1 &&
+		selectedModels[0] === '' &&
+		!$page.url.searchParams.get('models') &&
+		!$page.url.searchParams.get('model')
+	) {
+		const availableModels = $models
+			.filter((m) => !(m?.info?.meta?.hidden ?? false))
+			.map((m) => m.id);
+		const defaultModels = $config?.default_models ? $config.default_models.split(',') : [];
+		let next = ($settings?.models?.length ? $settings.models : defaultModels).filter((id) =>
+			availableModels.includes(id)
+		);
+		if (next.length === 0 && availableModels.length > 0) {
+			next = [availableModels[0]];
+		}
+		if (next.length > 0) {
+			selectedModels = next;
+		}
+	}
+
 	const stopAudio = () => {
 		try {
 			speechSynthesis.cancel();


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- `initNewChat()` in `src/lib/components/chat/Chat.svelte` runs on mount via `page.subscribe`, but `$models` is loaded asynchronously and the `Chat` component mounts before that fetch resolves. When `initNewChat()` runs against an empty `$models` list, none of its precedence branches (URL / folder / session / `$settings.models` / `$config.default_models`) match and `selectedModels` is left as `['']`. Nothing re-applies the default afterwards, so the configured default model (`DEFAULT_MODELS` / admin Models → Defaults) is never selected on a fresh full-page load — only via the in-app **New Chat** button once models have loaded.
- This adds a guarded reactive statement that re-applies the default selection once models arrive, for a brand-new chat that still has no valid model selected. It reuses the same `availableModels` / `defaultModels` precedence as `initNewChat` and only fires when the selection is empty and there is no URL model param, so it never overrides a manual pick, a loaded chat, or a folder selection.
- Note on the related refac (commit `b6d4baeb`): that change awaits `setModels()` inside the **layout's** `onMount`. Because child components' `onMount` run before the parent layout's, and `initNewChat` fires from `Chat`'s `page.subscribe` after a single `await tick()`, the one-microtask tick still wins the race against the network `getModels()` fetch. This reactive recovery closes that remaining gap regardless of load timing.

### Fixed

- 🎯 **Default model on first page load.** The configured default model (`DEFAULT_MODELS` env var or Admin → Settings → Models → Defaults) is now selected on a fresh page load even when the model list finishes loading after chat initialization, instead of leaving the model selector empty until you manually pick a model or open a new chat.

---

### Additional Information

- Single-file change in `src/lib/components/chat/Chat.svelte`: a guarded reactive statement that re-applies the default selection once `$models` is populated, only for a brand-new chat (`chatIdProp === ''`) with an empty selection and no `?models=`/`?model=` URL param. It is self-limiting (once a valid model is set, the `selectedModels[0] === ''` guard is false so it does not re-run) and does not override manual selections, loaded chats, or folder-based selections (the latter already handled by the existing `selectedFolder.subscribe`).
- No existing issue/discussion covers this specific gap; happy to open one if the maintainers prefer.

### Screenshots or Videos

- N/A — behavior is only observable against a live model backend; reproduce by setting a global default and doing a hard refresh of the main page as a user with no per-user default.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
