### PR TITLE
fix: pass pgvector query embeddings as vector parameters

### DIFF
--- a/backend/open_webui/retrieval/external.py
+++ b/backend/open_webui/retrieval/external.py
@@ -207,6 +207,7 @@ async def _retrieve_milvus(connection, auth_config, knowledge, query, count, emb
 async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, embedding_function) -> list[dict]:
     try:
         import psycopg
+        from pgvector import Vector
         from pgvector.psycopg import register_vector
         from psycopg.rows import dict_row
     except ImportError as exc:
@@ -230,6 +231,7 @@ async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, e
     document_id_field = source_config.get('document_id_field') or 'id'
 
     vector = await embedding_function(query)
+    query_vector = vector if isinstance(vector, Vector) else Vector(vector)
 
     def _search():
         from psycopg import sql
@@ -274,7 +276,7 @@ async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, e
                         table_name=table_identifier,
                         collection=collection_identifier,
                     ),
-                    (vector, collection_name, count),
+                    (query_vector, collection_name, count),
                 )
                 return cur.fetchall()
 

--- a/backend/tests/retrieval/test_external_pgvector.py
+++ b/backend/tests/retrieval/test_external_pgvector.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.retrieval.external import _retrieve_pgvector
+
+
+@pytest.mark.asyncio
+async def test_retrieve_pgvector_passes_query_embedding_as_pgvector_vector(monkeypatch):
+    import pgvector.psycopg
+    import psycopg
+    from pgvector import Vector
+
+    captured = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params):
+            captured['params'] = params
+
+        def fetchall(self):
+            return [
+                {
+                    'id': 'doc-1',
+                    'content': 'matched content',
+                    'metadata': {},
+                    'distance': 0.1,
+                }
+            ]
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    monkeypatch.setattr(psycopg, 'connect', lambda *args, **kwargs: FakeConnection())
+    monkeypatch.setattr(pgvector.psycopg, 'register_vector', lambda conn: None)
+
+    async def embedding_function(query):
+        return [0.1, 0.2, 0.3]
+
+    knowledge = SimpleNamespace(
+        id='knowledge-1',
+        name='External KB',
+        meta={
+            'external': {
+                'source': {
+                    'name': 'support_docs',
+                    'config': {
+                        'table_name': 'public.document_chunks',
+                        'vector_field': 'embedding',
+                    },
+                }
+            }
+        },
+    )
+
+    result = await _retrieve_pgvector(
+        {'endpoint': 'postgresql://example/db', 'config': {}},
+        {},
+        knowledge,
+        'reset password',
+        1,
+        embedding_function,
+    )
+
+    assert isinstance(captured['params'][0], Vector)
+    assert result[0]['content'] == 'matched content'


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #26663.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Fixes pgvector external knowledge retrieval by passing query embeddings as pgvector `Vector` parameters.
- [x] **Changelog:** Included below.
- [x] **Documentation:** Not needed; this fixes backend parameter adaptation behavior without changing user-facing configuration.
- [x] **Dependencies:** No new dependencies; uses the existing `pgvector` package already required for pgvector retrieval.
- [x] **Testing:** Automated tests and lint checks listed below.
- [x] **No Unchecked AI Code:** I reviewed and tested this change.
- [x] **Self-Review:** Self-review completed.
- [x] **Architecture:** Keeps existing pgvector retrieval flow and changes only the query parameter type.
- [x] **Git Hygiene:** Atomic change, rebased on `dev`, no unrelated commits.
- [x] **Title Prefix:** Uses `fix:`.

## Description

The pgvector external knowledge retrieval path passed the embedding function's Python list directly to psycopg. In affected environments, PostgreSQL receives that parameter as `double precision[]`, so `<=>` cannot compare it with a `vector` column and raises:

```text
operator does not exist: vector <=> double precision[]
```

This PR wraps the query embedding with `pgvector.Vector` before executing the search query, so psycopg sends a pgvector-compatible parameter. The focused unit test mocks the pgvector connection path and asserts the first SQL parameter is a `Vector`.

## Test Plan

- `WEBUI_SECRET_KEY=test-secret uv run --extra postgres --group dev pytest backend/tests/retrieval/test_external_pgvector.py -q`
  - Before the fix, this failed because the first SQL parameter was a plain Python `list`.
- `uv run --group dev ruff check --select I,F,Q backend/open_webui/retrieval/external.py backend/tests/retrieval/test_external_pgvector.py`
- `uv run --group dev ruff format --check backend/open_webui/retrieval/external.py backend/tests/retrieval/test_external_pgvector.py`

Note: A full `ruff check` on `backend/open_webui/retrieval/external.py` currently reports pre-existing UP045/E501 issues unrelated to this change, so the lint command above targets import/pyflakes/quote checks for the touched lines and new test.

# Changelog Entry

### Description

- Fix pgvector external knowledge retrieval query parameter adaptation.

### Added

- Added a unit test for the pgvector retrieval SQL parameter type.

### Changed

- Wrap pgvector query embeddings in `pgvector.Vector` before executing the similarity query.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed pgvector external knowledge configuration tests failing with `operator does not exist: vector <=> double precision[]`.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Closes #26663.

### Screenshots or Videos

- Not applicable; backend retrieval fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
