### PR TITLE
fix: include streamed assistant content for memory review

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5271,7 +5271,21 @@ async def streaming_chat_response_handler(response, ctx):
                     }
                 )
 
+                assistant_content = (
+                    content
+                    or '\n'.join(
+                        message.get('content', '')
+                        for message in convert_output_to_messages(
+                            output,
+                            raw=False,
+                            reasoning_format=get_reasoning_format(model),
+                        )
+                        if message.get('role') == 'assistant' and isinstance(message.get('content'), str)
+                    ).strip()
+                )
+
                 ctx['assistant_message'] = {
+                    'content': assistant_content,
                     'output': output,
                     **({'usage': usage} if usage else {}),
                 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #26651.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** Ensures streamed assistant completions populate `ctx['assistant_message']['content']` before background tasks run, so background memory review can evaluate normal UI chats.
- [ ] **Changelog:** See entry below.
- [ ] **Documentation:** Not applicable; backend bug fix only.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Static/syntax checks were performed locally; see below.
- [x] **No Unchecked AI Code:** The change was manually reviewed and kept minimal.
- [x] **Self-Review:** Confirmed the streaming path now has parity with the non-streaming assistant message shape.
- [x] **Architecture:** Reuses existing output-to-message conversion for Responses API fallback; no new setting.
- [x] **Git Hygiene:** Atomic one-file fix.
- [x] **Title Prefix:** `fix:`

## Description

Fixes background memory review for streamed chats by including assistant text in `ctx['assistant_message']` before outlet filters/background tasks run.

The non-streaming path already sets both `content` and `output` on `ctx['assistant_message']`. The standard streaming path only set `output`, so `review_memory_after_turn()` read an empty `content` field and returned before checking the background review config/interval.

This patch:

- uses the accumulated Chat Completions streaming `content` value when available
- falls back to reconstructing assistant text from OR-aligned `output` with `convert_output_to_messages()` for Responses API streaming events
- keeps `output` and `usage` unchanged

## Tests

- `python3 -m py_compile backend/open_webui/utils/middleware.py backend/open_webui/utils/memory.py`
- `git diff --check`
- `uvx --python 3.11 ruff check --select E9,F63,F7,F82 backend/open_webui/utils/middleware.py`
- `uvx --python 3.11 ruff format --check backend/open_webui/utils/middleware.py`
- full one-file `ruff check backend/open_webui/utils/middleware.py` comparison: 59 baseline findings before/after, no diff
- AST-extracted `convert_output_to_messages()` probes for plain assistant text, Responses API output fallback, and tool-only output
- targeted added-line secret scan: no findings
- CRLF scan: false
- independent pre-PR review: passed, no blockers

# Changelog Entry

### Fixed

- Background memory review now receives assistant content for streamed chat completions.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
