### PR TITLE
feat: expose chat-attached knowledge to builtin tools when File Context is off

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2357,7 +2357,7 @@ async def list_knowledge(
     __model_knowledge__: Optional[list[dict]] = None,
 ) -> str:
     """
-    List knowledge bases, files, and notes attached to the current model.
+    List knowledge bases, files, and notes attached to this chat (via the model, folder, or chat).
     Use this first to discover what knowledge is available before querying or reading files.
     Without knowledge_id: returns KB summaries (name, description, file_count)
     plus standalone files and notes — no file listing inside KBs.
@@ -2501,6 +2501,8 @@ async def query_knowledge_files(
     """
     Search knowledge base files using semantic/vector search. Searches across collections (KBs),
     individual files, and notes that the user has access to.
+    Knowledge available to this chat is listed in the <attached_knowledge> block when present;
+    those items are searched automatically, no ids needed.
     Helpful for internal documentation, uploaded knowledge, and attached model knowledge.
 
     :param query: The search query to find semantically relevant content

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1505,9 +1505,13 @@ async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
     return image_urls
 
 
-async def add_file_context(messages: list, chat_id: str, user) -> list:
+async def add_file_context(messages: list, chat_id: str, user, include_knowledge: bool = False) -> list:
     """
     Add file URLs to messages for native function calling.
+    include_knowledge surfaces chat-attached resources that carry no file URL (collections,
+    notes, referenced chats, and KB-selected files) so the model can reach them via the
+    builtin tools instead of the disabled RAG path; used when File Context is off. Metadata
+    only: each id is access-checked server-side when a tool actually reads it.
     """
     if not chat_id or chat_id.startswith('local:') or chat_id.startswith('channel:'):
         return messages
@@ -1527,6 +1531,12 @@ async def add_file_context(messages: list, chat_id: str, user) -> list:
             attrs += f' name="{file["name"]}"'
         return f'<file {attrs}/>'
 
+    def format_knowledge_tag(item):
+        attrs = f'type="{item["type"]}" id="{item["id"]}"'
+        if item.get('name'):
+            attrs += f' name="{item["name"]}"'
+        return f'<file {attrs}/>'
+
     # Pair only user-role messages from both lists to avoid misalignment.
     # After process_messages_with_output(), assistant messages with tool calls
     # are expanded into multiple messages (assistant + tool results), making
@@ -1537,16 +1547,27 @@ async def add_file_context(messages: list, chat_id: str, user) -> list:
     stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
 
     for message, stored_message in zip(user_messages, stored_user_messages):
-        files_with_urls = [
-            file
-            for file in stored_message.get('files', [])
+        stored_files = stored_message.get('files', [])
+        tags = [
+            format_file_tag(file)
+            for file in stored_files
             if file.get('url') and not file.get('url').startswith('data:')
         ]
-        if not files_with_urls:
+        if include_knowledge:
+            # URL-less chat attachments (collections, notes, referenced chats, KB-selected
+            # files); URL-bearing files are already tagged above. Access is re-checked per id
+            # inside each tool, so surfacing the id here grants nothing.
+            tags += [
+                format_knowledge_tag(item)
+                for item in stored_files
+                if item.get('id')
+                and not item.get('url')
+                and item.get('type') in ('collection', 'note', 'chat', 'file')
+            ]
+        if not tags:
             continue
 
-        file_tags = [format_file_tag(file) for file in files_with_urls]
-        file_context = '<attached_files>\n' + '\n'.join(file_tags) + '\n</attached_files>\n\n'
+        file_context = '<attached_files>\n' + '\n'.join(tags) + '\n</attached_files>\n\n'
 
         content = message.get('content', '')
         if isinstance(content, list):
@@ -2600,6 +2621,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     }
     form_data['metadata'] = metadata
 
+    # Check if file context extraction is enabled for this model (default True)
+    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
+
     # When the caller provides an explicit `tools` key in the request body,
     # skip all server-side tool resolution and pass the caller's tools through
     # unchanged.  Sending `tools: []` explicitly opts out of builtin injection.
@@ -2738,9 +2762,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         # Only inject when the request originates from the UI (identified by session_id).
         # API callers don't expect hidden tools; they can explicitly request tools via tool_ids.
         if use_builtin_tools:
-            # Add file context to user messages
+            # Add file context to user messages; when File Context is off, also surface
+            # chat-attached collections and notes so the model can query them via builtin tools.
             chat_id = metadata.get('chat_id')
-            form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            form_data['messages'] = await add_file_context(
+                form_data.get('messages', []), chat_id, user, include_knowledge=not file_context_enabled
+            )
             builtin_tools = await get_builtin_tools(
                 request,
                 {
@@ -2776,9 +2803,6 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     sources.extend(flags.get('sources', []))
                 except Exception as e:
                     log.exception(e)
-
-    # Check if file context extraction is enabled for this model (default True)
-    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
 
     if file_context_enabled:
         try:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1512,8 +1512,10 @@ async def add_file_context(
     """
     Add file URLs to messages for native function calling.
     knowledge lists the items reachable via the builtin knowledge tools (model-, folder-,
-    and chat-attached); it is surfaced once, on the last user message, in an
-    <attached_knowledge> block so the model knows there is something to query.
+    and chat-attached); it is appended to the system message once as an
+    <attached_knowledge> block so the model knows there is something to query. System
+    placement keeps user messages untouched, so the prompt prefix stays cache-stable
+    across turns as long as the attached knowledge does not change.
     include_knowledge additionally surfaces URL-less chat attachments (referenced chats,
     KB-selected files) per message; used when File Context is off. Metadata only:
     each id is access-checked server-side when a tool actually reads it.
@@ -1534,16 +1536,16 @@ async def add_file_context(
             attrs += f' source="{item["source"]}"'
         return f'<knowledge {attrs}/>'
 
-    user_messages = [m for m in messages if m.get('role') == 'user']
-
-    # Chat-level scope, so surface once on the last user message. Independent of the
-    # stored chat record: temporary (local:) chats can still carry folder knowledge.
-    if knowledge and user_messages:
+    # Chat-level scope, appended to the system message like skill manifests and terminal
+    # prompts. Independent of the stored chat record: temporary (local:) chats can still
+    # carry folder knowledge.
+    if knowledge:
         knowledge_tags = [format_knowledge_tag(item) for item in knowledge if item.get('id') and item.get('type')]
         if knowledge_tags:
-            prepend_context(
-                user_messages[-1],
-                '<attached_knowledge>\n' + '\n'.join(knowledge_tags) + '\n</attached_knowledge>\n\n',
+            messages = add_or_update_system_message(
+                '<attached_knowledge>\n' + '\n'.join(knowledge_tags) + '\n</attached_knowledge>',
+                messages,
+                append=True,
             )
 
     if not chat_id or chat_id.startswith('local:') or chat_id.startswith('channel:'):
@@ -1576,6 +1578,7 @@ async def add_file_context(
     # the payload message list longer than the stored message list. A naive
     # positional zip() would pair user messages with wrong stored messages,
     # causing later images to lose their file context (see #21878).
+    user_messages = [m for m in messages if m.get('role') == 'user']
     stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
 
     for message, stored_message in zip(user_messages, stored_user_messages):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -122,6 +122,7 @@ from open_webui.utils.task import (
 from open_webui.utils.tools import (
     build_tool_server_headers,
     get_builtin_tools,
+    get_effective_model_knowledge,
     get_terminal_tools,
     get_tools,
     get_updated_tool_function,
@@ -1505,14 +1506,46 @@ async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
     return image_urls
 
 
-async def add_file_context(messages: list, chat_id: str, user, include_knowledge: bool = False) -> list:
+async def add_file_context(
+    messages: list, chat_id: str, user, include_knowledge: bool = False, knowledge: list = None
+) -> list:
     """
     Add file URLs to messages for native function calling.
-    include_knowledge surfaces chat-attached resources that carry no file URL (collections,
-    notes, referenced chats, and KB-selected files) so the model can reach them via the
-    builtin tools instead of the disabled RAG path; used when File Context is off. Metadata
-    only: each id is access-checked server-side when a tool actually reads it.
+    knowledge lists the items reachable via the builtin knowledge tools (model-, folder-,
+    and chat-attached); it is surfaced once, on the last user message, in an
+    <attached_knowledge> block so the model knows there is something to query.
+    include_knowledge additionally surfaces URL-less chat attachments (referenced chats,
+    KB-selected files) per message; used when File Context is off. Metadata only:
+    each id is access-checked server-side when a tool actually reads it.
     """
+
+    def prepend_context(message, context):
+        content = message.get('content', '')
+        if isinstance(content, list):
+            message['content'] = [{'type': 'text', 'text': context}] + content
+        else:
+            message['content'] = context + content
+
+    def format_knowledge_tag(item):
+        attrs = f'type="{item["type"]}" id="{item["id"]}"'
+        if item.get('name'):
+            attrs += f' name="{item["name"]}"'
+        if item.get('source'):
+            attrs += f' source="{item["source"]}"'
+        return f'<knowledge {attrs}/>'
+
+    user_messages = [m for m in messages if m.get('role') == 'user']
+
+    # Chat-level scope, so surface once on the last user message. Independent of the
+    # stored chat record: temporary (local:) chats can still carry folder knowledge.
+    if knowledge and user_messages:
+        knowledge_tags = [format_knowledge_tag(item) for item in knowledge if item.get('id') and item.get('type')]
+        if knowledge_tags:
+            prepend_context(
+                user_messages[-1],
+                '<attached_knowledge>\n' + '\n'.join(knowledge_tags) + '\n</attached_knowledge>\n\n',
+            )
+
     if not chat_id or chat_id.startswith('local:') or chat_id.startswith('channel:'):
         return messages
 
@@ -1531,7 +1564,7 @@ async def add_file_context(messages: list, chat_id: str, user, include_knowledge
             attrs += f' name="{file["name"]}"'
         return f'<file {attrs}/>'
 
-    def format_knowledge_tag(item):
+    def format_chat_item_tag(item):
         attrs = f'type="{item["type"]}" id="{item["id"]}"'
         if item.get('name'):
             attrs += f' name="{item["name"]}"'
@@ -1543,7 +1576,6 @@ async def add_file_context(messages: list, chat_id: str, user, include_knowledge
     # the payload message list longer than the stored message list. A naive
     # positional zip() would pair user messages with wrong stored messages,
     # causing later images to lose their file context (see #21878).
-    user_messages = [m for m in messages if m.get('role') == 'user']
     stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
 
     for message, stored_message in zip(user_messages, stored_user_messages):
@@ -1554,26 +1586,18 @@ async def add_file_context(messages: list, chat_id: str, user, include_knowledge
             if file.get('url') and not file.get('url').startswith('data:')
         ]
         if include_knowledge:
-            # URL-less chat attachments (collections, notes, referenced chats, KB-selected
-            # files); URL-bearing files are already tagged above. Access is re-checked per id
-            # inside each tool, so surfacing the id here grants nothing.
+            # URL-less chat attachments (referenced chats, KB-selected files); collections
+            # and notes are covered by the <attached_knowledge> block instead. Access is
+            # re-checked per id inside each tool, so surfacing the id here grants nothing.
             tags += [
-                format_knowledge_tag(item)
+                format_chat_item_tag(item)
                 for item in stored_files
-                if item.get('id')
-                and not item.get('url')
-                and item.get('type') in ('collection', 'note', 'chat', 'file')
+                if item.get('id') and not item.get('url') and item.get('type') in ('chat', 'file')
             ]
         if not tags:
             continue
 
-        file_context = '<attached_files>\n' + '\n'.join(tags) + '\n</attached_files>\n\n'
-
-        content = message.get('content', '')
-        if isinstance(content, list):
-            message['content'] = [{'type': 'text', 'text': file_context}] + content
-        else:
-            message['content'] = file_context + content
+        prepend_context(message, '<attached_files>\n' + '\n'.join(tags) + '\n</attached_files>\n\n')
 
     return messages
 
@@ -2762,11 +2786,19 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         # Only inject when the request originates from the UI (identified by session_id).
         # API callers don't expect hidden tools; they can explicitly request tools via tool_ids.
         if use_builtin_tools:
-            # Add file context to user messages; when File Context is off, also surface
-            # chat-attached collections and notes so the model can query them via builtin tools.
+            # Surface chat-attached files per message, and the knowledge reachable via the
+            # builtin knowledge tools (model/folder scope, plus chat scope when File Context
+            # is off) so the model knows what it can query.
             chat_id = metadata.get('chat_id')
+            knowledge_tools_enabled = (model.get('info', {}).get('meta', {}).get('builtinTools') or {}).get(
+                'knowledge', True
+            )
             form_data['messages'] = await add_file_context(
-                form_data.get('messages', []), chat_id, user, include_knowledge=not file_context_enabled
+                form_data.get('messages', []),
+                chat_id,
+                user,
+                include_knowledge=not file_context_enabled,
+                knowledge=get_effective_model_knowledge(model, metadata) if knowledge_tools_enabled else None,
             )
             builtin_tools = await get_builtin_tools(
                 request,

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -462,6 +462,29 @@ async def get_tools(request: Request, tool_ids: list[str], user: UserModel, extr
     return tools_dict
 
 
+def get_effective_model_knowledge(model: dict, metadata: dict) -> list[dict]:
+    """
+    Knowledge reachable by the builtin knowledge tools, annotated with its source:
+    model knowledge, folder-attached knowledge, and (when File Context is off)
+    chat-attached collections and notes. Chat items are collections/notes only:
+    their access is re-resolved and re-checked per id inside each tool, so trusting
+    the client id here grants nothing. Chat-attached files are excluded (they'd
+    short-circuit _has_read_access_to_file).
+    """
+    knowledge = [{**item, 'source': 'model'} for item in (model.get('info', {}).get('meta', {}).get('knowledge') or [])]
+    knowledge += [{**item, 'source': 'folder'} for item in (metadata.get('folder_knowledge') or [])]
+
+    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
+    if not file_context_enabled:
+        existing_ids = {item.get('id') for item in knowledge}
+        knowledge += [
+            {'type': item['type'], 'id': item['id'], 'name': item.get('name'), 'source': 'chat'}
+            for item in (metadata.get('files') or [])
+            if item.get('type') in ('collection', 'note') and item.get('id') and item['id'] not in existing_ids
+        ]
+    return knowledge
+
+
 async def get_builtin_tools(
     request: Request, extra_params: dict, features: dict = None, model: dict = None
 ) -> dict[str, dict]:
@@ -510,29 +533,10 @@ async def get_builtin_tools(
     if is_builtin_tool_enabled('time'):
         builtin_functions.extend([get_current_timestamp, calculate_timestamp])
 
-    # Knowledge base tools - conditional injection based on model knowledge
-    # If model has attached knowledge (any type), only provide query_knowledge_files
+    # Knowledge base tools - conditional injection based on attached knowledge
+    # If any knowledge is attached (any type), only provide query_knowledge_files
     # Otherwise, provide all KB browsing tools
-    model_knowledge = model.get('info', {}).get('meta', {}).get('knowledge', [])
-    # Merge folder-attached knowledge so builtin tools can search it
-    folder_knowledge = extra_params.get('__metadata__', {}).get('folder_knowledge')
-    if folder_knowledge:
-        model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
-    # When File Context is off, expose chat-attached collections and notes (selected via
-    # the chat input) to the builtin knowledge tools so the model can query them on demand
-    # instead of the disabled legacy RAG path. Collections/notes only: their access is
-    # re-resolved and re-checked per id inside each tool, so trusting the client id here
-    # grants nothing. Files are excluded (they'd short-circuit _has_read_access_to_file).
-    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
-    if not file_context_enabled:
-        existing_ids = {item.get('id') for item in (model_knowledge or [])}
-        chat_knowledge = [
-            {'type': item['type'], 'id': item['id'], 'name': item.get('name')}
-            for item in (extra_params.get('__metadata__', {}).get('files') or [])
-            if item.get('type') in ('collection', 'note') and item.get('id') and item['id'] not in existing_ids
-        ]
-        if chat_knowledge:
-            model_knowledge = list(model_knowledge or []) + chat_knowledge
+    model_knowledge = get_effective_model_knowledge(model, extra_params.get('__metadata__', {}))
     if is_builtin_tool_enabled('knowledge'):
         from open_webui.env import ENABLE_KB_EXEC
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -518,6 +518,21 @@ async def get_builtin_tools(
     folder_knowledge = extra_params.get('__metadata__', {}).get('folder_knowledge')
     if folder_knowledge:
         model_knowledge = list(model_knowledge or []) + list(folder_knowledge)
+    # When File Context is off, expose chat-attached collections and notes (selected via
+    # the chat input) to the builtin knowledge tools so the model can query them on demand
+    # instead of the disabled legacy RAG path. Collections/notes only: their access is
+    # re-resolved and re-checked per id inside each tool, so trusting the client id here
+    # grants nothing. Files are excluded (they'd short-circuit _has_read_access_to_file).
+    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
+    if not file_context_enabled:
+        existing_ids = {item.get('id') for item in (model_knowledge or [])}
+        chat_knowledge = [
+            {'type': item['type'], 'id': item['id'], 'name': item.get('name')}
+            for item in (extra_params.get('__metadata__', {}).get('files') or [])
+            if item.get('type') in ('collection', 'note') and item.get('id') and item['id'] not in existing_ids
+        ]
+        if chat_knowledge:
+            model_knowledge = list(model_knowledge or []) + chat_knowledge
     if is_builtin_tool_enabled('knowledge'):
         from open_webui.env import ENABLE_KB_EXEC
 


### PR DESCRIPTION
Under native function calling, model- and folder-attached knowledge is reachable through the builtin knowledge tools but announced nowhere in the prompt. The model therefore has no reason to ever call `query_knowledge_files`, and attached knowledge goes unused. This is the root cause of #27232 and of the older class of reports like #22181.

This PR makes attached knowledge discoverable and keeps tool routing unambiguous:

- Every item reachable by the builtin knowledge tools is announced in the system prompt inside an `<attached_knowledge>` block: `<knowledge type="collection|file|note" id=".." name=".." source="model|folder|chat"/>`. The block maps 1:1 to the knowledge tools (`query_knowledge_files` and friends, docstrings updated to say so), while the per-message `<attached_files>` block keeps meaning chat-attached files.
- The list is built by a single shared helper (`get_effective_model_knowledge`) that also feeds `__model_knowledge__` in `get_builtin_tools`, so the knowledge the model is told about and the knowledge the tools can actually reach cannot drift apart.
- Model and folder scope are announced unconditionally under native FC, because they are never RAG-injected there regardless of the File Context capability. Chat-attached collections and notes remain gated on File Context being off and move from `<attached_files>` into `<attached_knowledge>`.
- System-prompt placement follows the existing pattern for chat-level context (skill manifests, terminal prompts) and keeps the prompt prefix cache-stable across turns: the block only changes when the attached knowledge itself changes, and user messages are never rewritten.

Security: announced ids grant nothing by themselves; every id is access-checked server-side when a tool reads it. Chat-attached file ids still never enter `__model_knowledge__`, since membership there bypasses the per-file access check; on-demand access to chat-attached files is handled separately by #26902.

Fixes #27232
Fixes #26708

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.