### PR TITLE
fix: enforce the verified-user role gate on the terminal WebSocket resolver

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -230,6 +230,10 @@ async def _resolve_authenticated_connection(ws: WebSocket, server_id: str):
         if user is None:
             await ws.close(code=4001, reason='User not found')
             return None
+        # Match the HTTP terminal routes' get_verified_user gate: pending/deactivated roles are not verified users.
+        if user.role not in {'user', 'admin'}:
+            await ws.close(code=4003, reason='Access prohibited')
+            return None
     except (asyncio.TimeoutError, json.JSONDecodeError):
         await ws.close(code=4001, reason='Auth timeout or invalid payload')
         return None

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -350,7 +350,8 @@ async def connect(sid, environ, auth):
         if data is not None and 'id' in data and await is_valid_token(data, redis):
             user = await Users.get_user_by_id(data['id'])
 
-        if user:
+        # Parity with HTTP get_verified_user: only verified roles get a realtime session.
+        if user and user.role in {'user', 'admin'}:
             SESSION_POOL[sid] = {
                 **user.model_dump(
                     exclude=[
@@ -381,7 +382,7 @@ async def user_join(sid, data):
         return
 
     user = await Users.get_user_by_id(token_data['id'])
-    if not user:
+    if not user or user.role not in {'user', 'admin'}:
         return
 
     SESSION_POOL[sid] = {
@@ -432,7 +433,7 @@ async def join_channel(sid, data):
         return
 
     user = await Users.get_user_by_id(data['id'])
-    if not user:
+    if not user or user.role not in {'user', 'admin'}:
         return
 
     # Join all the channels only if user has channels permission
@@ -458,7 +459,7 @@ async def join_note(sid, data):
         return
 
     user = await Users.get_user_by_id(token_data['id'])
-    if not user:
+    if not user or user.role not in {'user', 'admin'}:
         return
 
     note = await Notes.get_note_by_id(data['note_id'])


### PR DESCRIPTION
The HTTP terminal routes depend on get_verified_user, which rejects any role that is not user or admin, but the terminal WebSocket resolver _resolve_authenticated_connection only checked that the token was valid and the user existed before evaluating connection access grants. A pending or deactivated account holding a valid JWT could therefore reach a terminal server granted to user:* or to a group it still belongs to, bypassing the account-approval boundary the HTTP siblings enforce. Apply the same role gate immediately after loading the user, so the WebSocket path denies unverified accounts before terminal connection grants are checked.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
