### PR TITLE
fix: Channels model replies saved/shown blank on v0.10.x

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -857,7 +857,7 @@ async def _make_channel_emitter(request_info):
     channel_id = request_info['chat_id'].removeprefix('channel:')
     message_id = request_info['message_id']
 
-    state = {'last_emit_at': 0.0}
+    state = {'last_emit_at': 0.0, 'content': ''}
     THROTTLE_INTERVAL = 0.15  # ~6 updates/sec
 
     async def _emit_channel_update(content: str, done: bool = False):
@@ -896,9 +896,13 @@ async def _make_channel_emitter(request_info):
         event_type = event_data.get('type')
 
         if event_type == 'chat:completion':
+            from open_webui.utils.misc import get_content_from_completion_event
+
             data = event_data.get('data', {})
-            content = data.get('content', '')
             done = data.get('done', False)
+
+            state['content'] = get_content_from_completion_event(data, state['content'])
+            content = state['content']
 
             if not content and not done:
                 return

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -1142,3 +1142,38 @@ def stream_chunks_handler(stream: aiohttp.StreamReader):
             yield buffer + b'\n'
 
     return yield_safe_stream_chunks()
+
+
+def get_content_from_completion_event(data: dict, current_content: str = '') -> str:
+    """Resolve the assistant reply text carried by a `chat:completion` event.
+
+    The reply text location varies by event shape: legacy events carry a
+    cumulative top-level `content`, streaming events carry incremental
+    `choices[0].delta.content` (or a full `choices[0].message.content`),
+    and done events may carry the reply only inside OR-style `output` items.
+    `current_content` is the text accumulated from previous events; it is
+    returned unchanged when the event carries no reply text.
+    """
+    content = current_content
+
+    top_level = data.get('content')
+    if isinstance(top_level, str) and top_level:
+        content = top_level
+
+    choices = data.get('choices') or []
+    if choices and isinstance(choices[0], dict):
+        delta_text = (choices[0].get('delta') or {}).get('content')
+        message_text = (choices[0].get('message') or {}).get('content')
+        if isinstance(delta_text, str) and delta_text:
+            content = current_content + delta_text
+        elif isinstance(message_text, str) and message_text:
+            content = message_text
+
+    if data.get('output'):
+        output_text = '\n'.join(
+            m['content'] for m in convert_output_to_messages(data['output']) if m.get('content')
+        )
+        if output_text:
+            content = output_text
+
+    return content


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26707
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No docs change needed — restores documented Channels behavior.
- [x] **Dependencies:** No new dependencies.
- [ ] **Testing:** End-to-end before/after proof attached below (real Ollama model, screenshots), as requested by @Classic298 in #26717.
- [x] **No Unchecked AI Code:** Developed with AI assistance (disclosure per CONTRIBUTING); reviewed and verified end-to-end by the submitter.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings; reuses the existing `convert_output_to_messages` helper.
- [x] **Git Hygiene:** Atomic single-commit PR on a clean branch off `dev`, no test files.
- [x] **Title Prefix:** `fix`

> Supersedes #26717 (closed): that PR contained test files; they were removed on the branch but GitHub freezes a closed PR's diff, so per @Classic298's request this is a fresh PR — single clean commit, no test files, proof of testing attached.

# Changelog Entry

### Description

Model replies in Channels are saved and shown blank on v0.10.x (regression from 0.9.6, reported and root-caused in #26707 — credit to the reporter for the excellent analysis).

`__channel_emitter__` read the reply text from `data['content']`, but on v0.10.x the `chat:completion` done event carries the reply only inside OR-style `output` items, and streaming events carry it in `choices[0].delta.content`. The emitter therefore always persisted `''`.

Fix:

- New helper `get_content_from_completion_event(data, current_content)` in `utils/misc.py` resolves the reply text across all event shapes: legacy cumulative `content` → streaming `choices[0].delta.content` (accumulated) / full `choices[0].message.content` → done-event `output` (extracted via the existing `convert_output_to_messages`, authoritative).
- The channel emitter tracks accumulated content in its existing `state` dict, so throttled intermediate updates show progressive text and the final saved message always contains the full reply.

Normal (non-channel) chat persistence is untouched.

### Fixed

- Fixed Channels model replies being saved/shown blank on v0.10.x: the channel emitter now resolves reply text from all `chat:completion` event shapes (legacy `content`, streaming `choices` deltas, done-event `output`) instead of only the removed top-level `content` field.

---

### Additional Information

- Root-cause analysis by the issue reporter in #26707; this PR implements their suggested fix direction with an added accumulation state for streaming deltas.
- Disclosure per CONTRIBUTING: implemented and verified with AI assistance (Claude); reviewed by the submitter.

### Screenshots or Videos

**Test setup:** open-webui `0.10.2` (pip install) on Windows + Ollama `qwen3:4b`. Created a channel, @mentioned the model with "Reply with exactly: The quick brown fox jumps over the lazy dog.", opened the reply thread. Then applied exactly this PR's two-file change to the installed package, restarted, and repeated the identical flow in a fresh channel.

**Before (stock 0.10.2)** — the model's thread reply is blank:

![before: blank model reply](https://raw.githubusercontent.com/yuki4266/open-webui/assets/channel-fix-proof/channel-reply-before.png)

**After (with this fix)** — the same flow shows the full reply text:

![after: reply text visible](https://raw.githubusercontent.com/yuki4266/open-webui/assets/channel-fix-proof/channel-reply-after.png)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
