### PR TITLE
fix: validate direct-model attached knowledge against the caller

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1004,6 +1004,15 @@ async def embeddings(request: Request, form_data: dict, user=Depends(get_verifie
     return await generate_embeddings(request, form_data, user)
 
 
+async def _restrict_direct_model_knowledge(model_item: dict, user) -> None:
+    # Direct models are request-defined and skip persisted models' create-time file/KB access check; drop refs the caller can't read.
+    knowledge_items = ((model_item.get('info') or {}).get('meta') or {}).get('knowledge')
+    if knowledge_items:
+        from open_webui.utils.access_control.files import get_accessible_folder_files
+
+        model_item['info']['meta']['knowledge'] = await get_accessible_folder_files(knowledge_items, user)
+
+
 @app.post('/api/chat/completions')
 @app.post('/api/v1/chat/completions')  # Experimental: Compatibility with OpenAI API
 async def chat_completion(
@@ -1036,6 +1045,7 @@ async def chat_completion(
                     raise e
         else:
             model = model_item
+            await _restrict_direct_model_knowledge(model, user)
 
             request.state.direct = True
             request.state.model = model
@@ -1737,6 +1747,7 @@ async def chat_completed(request: Request, form_data: dict, user=Depends(get_ver
         model_item = form_data.pop('model_item', {})
 
         if model_item.get('direct', False):
+            await _restrict_direct_model_knowledge(model_item, user)
             request.state.direct = True
             request.state.model = model_item
 
@@ -1754,6 +1765,7 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user=De
         model_item = form_data.pop('model_item', {})
 
         if model_item.get('direct', False):
+            await _restrict_direct_model_knowledge(model_item, user)
             request.state.direct = True
             request.state.model = model_item
 


### PR DESCRIPTION
A request-scoped direct model (model_item.direct=true on the chat endpoints) carries client-supplied info.meta.knowledge that becomes the runtime model and is bound into the builtin knowledge tools as __model_knowledge__. Unlike persisted models, which validate attached file references against the author at create/update/import time, direct models skipped that check, so a caller could reference another user's file id and have builtin tools such as query_knowledge_files return chunks from it. Filter a direct model's attached knowledge to the entries the caller can actually read (get_accessible_folder_files) before it is used, so forged file or knowledge-base references are dropped. Persisted-model file sharing and knowledge-base access controls are unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
