### PR TITLE
fix: pass pgvector query embedding as vector

### DIFF
--- a/backend/open_webui/retrieval/external.py
+++ b/backend/open_webui/retrieval/external.py
@@ -207,6 +207,7 @@ async def _retrieve_milvus(connection, auth_config, knowledge, query, count, emb
 async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, embedding_function) -> list[dict]:
     try:
         import psycopg
+        from pgvector import Vector
         from pgvector.psycopg import register_vector
         from psycopg.rows import dict_row
     except ImportError as exc:
@@ -230,6 +231,7 @@ async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, e
     document_id_field = source_config.get('document_id_field') or 'id'
 
     vector = await embedding_function(query)
+    query_vector = vector if isinstance(vector, Vector) else Vector(vector)
 
     def _search():
         from psycopg import sql
@@ -274,7 +276,7 @@ async def _retrieve_pgvector(connection, auth_config, knowledge, query, count, e
                         table_name=table_identifier,
                         collection=collection_identifier,
                     ),
-                    (vector, collection_name, count),
+                    (query_vector, collection_name, count),
                 )
                 return cur.fetchall()
 

--- a/backend/tests/retrieval/test_external_pgvector.py
+++ b/backend/tests/retrieval/test_external_pgvector.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.retrieval.external import _retrieve_pgvector
+
+
+@pytest.mark.asyncio
+async def test_retrieve_pgvector_passes_query_embedding_as_pgvector_vector(monkeypatch):
+    import pgvector.psycopg
+    import psycopg
+    from pgvector import Vector
+
+    captured = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params):
+            captured['params'] = params
+
+        def fetchall(self):
+            return [
+                {
+                    'id': 'doc-1',
+                    'content': 'matched content',
+                    'metadata': {},
+                    'distance': 0.1,
+                }
+            ]
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    monkeypatch.setattr(psycopg, 'connect', lambda *args, **kwargs: FakeConnection())
+    monkeypatch.setattr(pgvector.psycopg, 'register_vector', lambda conn: None)
+
+    async def embedding_function(query):
+        return [0.1, 0.2, 0.3]
+
+    knowledge = SimpleNamespace(
+        id='knowledge-1',
+        name='External KB',
+        meta={
+            'external': {
+                'source': {
+                    'name': 'support_docs',
+                    'config': {
+                        'table_name': 'public.document_chunks',
+                        'vector_field': 'embedding',
+                    },
+                }
+            }
+        },
+    )
+
+    result = await _retrieve_pgvector(
+        {'endpoint': 'postgresql://example/db', 'config': {}},
+        {},
+        knowledge,
+        'reset password',
+        1,
+        embedding_function,
+    )
+
+    assert isinstance(captured['params'][0], Vector)
+    assert result[0]['content'] == 'matched content'


### PR DESCRIPTION
## Summary
- pass the pgvector query embedding as a vector parameter instead of stringifying it
- add coverage for the generated external vector search query parameters

## Tests
- WEBUI_SECRET_KEY=codex-local-test-secret uv run --frozen pytest backend/tests/retrieval/test_external_pgvector.py -q