### PR TITLE
fix(chat): include assistant output in action payloads

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -53,6 +53,7 @@
 	} from '$lib/stores';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import { toChatActionMessage } from './actionPayload';
 
 	import {
 		convertMessagesToHistory,
@@ -1769,14 +1770,7 @@
 
 		const res = await chatAction(localStorage.token, actionId, {
 			model: modelId,
-			messages: messages.map((m) => ({
-				id: m.id,
-				role: m.role,
-				content: m.content,
-				info: m.info ? m.info : undefined,
-				timestamp: m.timestamp,
-				...(m.sources ? { sources: m.sources } : {})
-			})),
+			messages: messages.map(toChatActionMessage),
 			...(event ? { event: event } : {}),
 			model_item: $models.find((m) => m.id === modelId),
 			chat_id: _chatId,

--- a/src/lib/components/chat/actionPayload.test.ts
+++ b/src/lib/components/chat/actionPayload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { toChatActionMessage } from './actionPayload';
+
+describe('toChatActionMessage', () => {
+	it('uses structured assistant output as action message content', () => {
+		const message = {
+			id: 'assistant-1',
+			role: 'assistant',
+			content: '',
+			timestamp: 123,
+			output: [
+				{
+					type: 'message',
+					content: [{ type: 'output_text', text: 'The answer is 2.' }]
+				}
+			]
+		};
+
+		expect(toChatActionMessage(message)).toEqual({
+			id: 'assistant-1',
+			role: 'assistant',
+			content: 'The answer is 2.',
+			info: undefined,
+			timestamp: 123,
+			output: message.output
+		});
+	});
+
+	it('keeps plain message content unchanged', () => {
+		const message = {
+			id: 'user-1',
+			role: 'user',
+			content: '1 + 1',
+			timestamp: 122
+		};
+
+		expect(toChatActionMessage(message)).toEqual({
+			id: 'user-1',
+			role: 'user',
+			content: '1 + 1',
+			info: undefined,
+			timestamp: 122
+		});
+	});
+});

--- a/src/lib/components/chat/actionPayload.ts
+++ b/src/lib/components/chat/actionPayload.ts
@@ -1,0 +1,26 @@
+import { getOutputText, type OutputItem } from './Messages/structuredOutput';
+
+type ChatHistoryMessage = {
+	id?: string;
+	role?: string;
+	content?: string;
+	info?: unknown;
+	timestamp?: number;
+	sources?: unknown;
+	output?: OutputItem[];
+};
+
+export const toChatActionMessage = (message: ChatHistoryMessage) => {
+	const outputContent =
+		message.role === 'assistant' && message.output?.length ? getOutputText(message.output) : '';
+
+	return {
+		id: message.id,
+		role: message.role,
+		content: outputContent || message.content || '',
+		info: message.info ? message.info : undefined,
+		timestamp: message.timestamp,
+		...(message.role === 'assistant' && message.output?.length ? { output: message.output } : {}),
+		...(message.sources ? { sources: message.sources } : {})
+	};
+};


### PR DESCRIPTION
## Summary
- serialize assistant structured output into the action payload content field
- keep the structured output payload available for actions that need it
- add focused frontend coverage for action message serialization

Fixes #26672

## Tests
- npm run test:frontend -- src/lib/components/chat/actionPayload.test.ts --run
- npx prettier --check src/lib/components/chat/actionPayload.ts src/lib/components/chat/actionPayload.test.ts src/lib/components/chat/Chat.svelte
- npx eslint src/lib/components/chat/actionPayload.ts src/lib/components/chat/actionPayload.test.ts

Note: npm run check still reports existing unrelated diagnostics in RichTextInput and ManageOllama files outside this change.