### PR TITLE
fix(chat): append compaction summary to system prompt

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2038,6 +2038,19 @@ def strip_compaction_fields(messages: list[dict]) -> list[dict]:
     return stripped
 
 
+def add_context_summary_system_message(
+    messages: list[dict],
+    context_summary: str,
+    system_prompt: str = '',
+) -> list[dict]:
+    messages = [dict(message) for message in messages]
+    summary_content = f'[CONVERSATION SUMMARY]\n{context_summary}'
+    if system_prompt and not get_system_message(messages):
+        messages.insert(0, {'role': 'system', 'content': system_prompt})
+
+    return add_or_update_system_message(summary_content, messages, append=True)
+
+
 def sanitize_tool_pairs(messages: list[dict]) -> list[dict]:
     tool_result_ids = {
         message.get('tool_call_id')
@@ -2278,10 +2291,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 system_prompt,
             )
             if context_summary:
-                form_data['messages'] = add_or_update_system_message(
-                    f'[CONVERSATION SUMMARY]\n{context_summary}',
+                form_data['messages'] = add_context_summary_system_message(
                     form_data['messages'],
-                    append=True,
+                    context_summary,
+                    system_prompt,
                 )
         except Exception:
             log.exception('Context compaction failed; continuing with full chat history')

--- a/backend/tests/test_context_compaction_middleware.py
+++ b/backend/tests/test_context_compaction_middleware.py
@@ -1,0 +1,32 @@
+from open_webui.utils.middleware import add_context_summary_system_message
+
+
+def test_context_summary_appends_to_existing_system_prompt():
+    messages = [
+        {'role': 'user', 'content': 'recent question'},
+        {'role': 'assistant', 'content': 'recent answer'},
+    ]
+
+    result = add_context_summary_system_message(
+        messages,
+        'Earlier turns summarized here.',
+        system_prompt='Always stay in character.',
+    )
+
+    assert result[0] == {
+        'role': 'system',
+        'content': 'Always stay in character.\n[CONVERSATION SUMMARY]\nEarlier turns summarized here.',
+    }
+    assert result[1:] == messages
+
+
+def test_context_summary_stays_system_message_without_system_prompt():
+    messages = [{'role': 'user', 'content': 'recent question'}]
+
+    result = add_context_summary_system_message(messages, 'Earlier turns summarized here.')
+
+    assert result[0] == {
+        'role': 'system',
+        'content': '[CONVERSATION SUMMARY]\nEarlier turns summarized here.',
+    }
+    assert result[1:] == messages


### PR DESCRIPTION
## Summary
- preserve the existing system prompt when automatic context compaction returns only recent messages
- append the conversation summary after the original system prompt
- add regression coverage for compaction with and without a system prompt

Fixes #26710

## Tests
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_context_compaction_middleware.py -q
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/utils/middleware.py backend/tests/test_context_compaction_middleware.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen python -m py_compile backend/open_webui/utils/middleware.py backend/tests/test_context_compaction_middleware.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_context_compaction_middleware.py

Note: ruff check on backend/open_webui/utils/middleware.py still reports existing unrelated lint issues in that file.