### PR TITLE
fix(kb): split grep content on real newlines

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -686,12 +686,12 @@ async def _kb_grep(
 
     # Grep on piped input
     if piped_input is not None:
-        lines = piped_input.split('\\n')
+        lines = piped_input.split('\n')
         matched = []
         for i, line in enumerate(lines, 1):
             if _matches(line):
                 matched.append(f'{i}: {line}')
-        return '\\n'.join(matched) if matched else f'No matches for "{pattern}"'
+        return '\n'.join(matched) if matched else f'No matches for "{pattern}"'
 
     # Single file grep
     if file_ref and not dir_scope:
@@ -702,7 +702,7 @@ async def _kb_grep(
         elif 'error' in resolved:
             return resolved['error']
         else:
-            lines = resolved['content'].split('\\n')
+            lines = resolved['content'].split('\n')
             matched = []
             for i, line in enumerate(lines, 1):
                 if _matches(line):
@@ -715,7 +715,7 @@ async def _kb_grep(
 
             if not matched:
                 return f'No matches for "{pattern}" in {resolved["filename"]}'
-            return '\\n'.join(matched)
+            return '\n'.join(matched)
 
     # Cross-file grep (optionally scoped to directory)
     accessible = await _get_accessible_files(user, model_knowledge)

--- a/backend/tests/test_knowledge_fs_grep.py
+++ b/backend/tests/test_knowledge_fs_grep.py
@@ -1,0 +1,26 @@
+import pytest
+from open_webui.tools import knowledge_fs
+
+
+@pytest.mark.asyncio
+async def test_kb_grep_count_uses_real_newlines_for_single_file(monkeypatch):
+    async def resolve_file(file_ref, user, model_knowledge):
+        assert file_ref == 'sample.txt'
+        return {
+            'id': 'file-sample',
+            'filename': 'sample.txt',
+            'content': 'alpha\nbeta\ngamma',
+        }
+
+    monkeypatch.setattr(knowledge_fs, '_resolve_file', resolve_file)
+
+    result = await knowledge_fs._kb_grep(['', 'sample.txt'], {'c'}, {}, None)
+
+    assert result == 'file-sample  sample.txt: 3'
+
+
+@pytest.mark.asyncio
+async def test_kb_grep_piped_input_uses_real_newlines():
+    result = await knowledge_fs._kb_grep([''], set(), {}, None, piped_input='alpha\nbeta\ngamma')
+
+    assert result == '1: alpha\n2: beta\n3: gamma'


### PR DESCRIPTION
## Summary
- split kb_exec grep piped and single-file content on real newline characters
- return real newline-delimited grep matches instead of literal \n joins
- add regression coverage for single-file grep -c and piped grep line numbering

Fixes #26661

## Tests
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_knowledge_fs_grep.py -q
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen python -m py_compile backend/open_webui/tools/knowledge_fs.py backend/tests/test_knowledge_fs_grep.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_knowledge_fs_grep.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/tools/knowledge_fs.py backend/tests/test_knowledge_fs_grep.py

Note: full ruff check on backend/open_webui/tools/knowledge_fs.py reports pre-existing lint issues unrelated to this change.