### PR TITLE
feat(logger): set diagnose=False to prevent exposing secrets in Loguru traceback logs

### DIFF
--- a/backend/open_webui/utils/logger.py
+++ b/backend/open_webui/utils/logger.py
@@ -178,6 +178,7 @@ def start_logger():
             _json_sink,
             level=GLOBAL_LOG_LEVEL,
             filter=audit_filter,
+            diagnose=False,
         )
     else:
         logger.add(
@@ -185,6 +186,7 @@ def start_logger():
             level=GLOBAL_LOG_LEVEL,
             format=stdout_format,
             filter=audit_filter,
+            diagnose=False,
         )
     if AUDIT_LOG_LEVEL != 'NONE' and ENABLE_AUDIT_LOGS_FILE:
         try:
@@ -195,6 +197,7 @@ def start_logger():
                 compression='zip',
                 format=file_format,
                 filter=lambda record: record['extra'].get('auditable') is True,
+                diagnose=False,
             )
         except Exception as e:
             logger.error(f'Failed to initialize audit log file handler: {str(e)}')


### PR DESCRIPTION
### Description
Fixes #25767.

Loguru traceback logs evaluate and print local variable values (by default `diagnose=True`), which can easily leak sensitive information (such as API keys, Bearer tokens, DB connections, or passwords) into standard stdout/JSON logs when exceptions occur in production environments.

This PR sets `diagnose=False` on the configured Loguru stdout, JSON, and audit log file sinks, preventing local variable evaluation while retaining the clean formatted traceback.

### Verification
- Wrote and executed a verification script showing that local variable values inside throwing functions are successfully omitted from traceback dumps while maintaining full traceback structures.