### PR TITLE
fix(tools): return callback errors for tool execution failures

### DIFF
--- a/src/lib/utils/executeTool.test.ts
+++ b/src/lib/utils/executeTool.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { executeToolRequest } from './executeTool';
+
+describe('executeToolRequest', () => {
+	test('returns an error callback when the tool server is missing', async () => {
+		const cb = vi.fn();
+		const executeToolServer = vi.fn();
+
+		await executeToolRequest({
+			data: {
+				name: 'list_deals',
+				params: {},
+				server: { url: 'https://tools.example.test' }
+			},
+			chatId: 'chat-1',
+			resolved: {
+				toolServer: undefined,
+				toolServerData: undefined,
+				token: null
+			},
+			executeToolServer,
+			cb,
+			logger: {
+				log: vi.fn(),
+				error: vi.fn()
+			}
+		});
+
+		expect(executeToolServer).not.toHaveBeenCalled();
+		expect(cb).toHaveBeenCalledWith({ error: 'Tool Server Not Found' });
+	});
+
+	test('returns the tool server response on success', async () => {
+		const cb = vi.fn();
+		const executeToolServer = vi.fn().mockResolvedValue({ result: { ok: true } });
+
+		await executeToolRequest({
+			data: {
+				name: 'list_deals',
+				params: { limit: 10 },
+				server: { url: 'https://tools.example.test' }
+			},
+			chatId: 'chat-1',
+			resolved: {
+				toolServer: {
+					url: 'https://tools.example.test'
+				},
+				toolServerData: { openapi: {}, info: {}, specs: {} },
+				token: 'token'
+			},
+			executeToolServer,
+			cb,
+			logger: {
+				log: vi.fn(),
+				error: vi.fn()
+			}
+		});
+
+		expect(executeToolServer).toHaveBeenCalledWith(
+			'token',
+			'https://tools.example.test',
+			'list_deals',
+			{ limit: 10 },
+			{ openapi: {}, info: {}, specs: {} },
+			'chat-1'
+		);
+		expect(cb).toHaveBeenCalledWith({ result: { ok: true } });
+	});
+
+	test('returns an error callback when the tool server call throws', async () => {
+		const cb = vi.fn();
+
+		await executeToolRequest({
+			data: {
+				name: 'list_deals',
+				params: {},
+				server: { url: 'https://tools.example.test' }
+			},
+			chatId: 'chat-1',
+			resolved: {
+				toolServer: {
+					url: 'https://tools.example.test'
+				},
+				toolServerData: undefined,
+				token: 'token'
+			},
+			executeToolServer: vi.fn().mockRejectedValue(new Error('tool server unavailable')),
+			cb,
+			logger: {
+				log: vi.fn(),
+				error: vi.fn()
+			}
+		});
+
+		expect(cb).toHaveBeenCalledWith({ error: 'tool server unavailable' });
+	});
+});

--- a/src/lib/utils/executeTool.ts
+++ b/src/lib/utils/executeTool.ts
@@ -1,0 +1,101 @@
+import type { executeToolServer as executeToolServerApi } from '$lib/apis';
+
+type ExecuteToolServer = typeof executeToolServerApi;
+type ToolServerData = Parameters<ExecuteToolServer>[4];
+
+type ToolServer = {
+	url: string;
+};
+
+type ResolvedToolServer = {
+	toolServer?: ToolServer | null;
+	toolServerData?: ToolServerData;
+	token?: string | null | undefined;
+};
+
+type Logger = {
+	log?: (...args: unknown[]) => void;
+	error?: (...args: unknown[]) => void;
+};
+
+type ExecuteToolRequestParams = {
+	data: {
+		name?: string;
+		params?: Parameters<ExecuteToolServer>[3];
+		server?: {
+			url?: string;
+		};
+	};
+	chatId?: string;
+	resolved: ResolvedToolServer;
+	executeToolServer: ExecuteToolServer;
+	cb?: (result: unknown) => void;
+	onDisplayFile?: (path: string, result: unknown) => void;
+	onWriteFile?: (path: string) => void;
+	logger?: Logger;
+};
+
+const getErrorMessage = (error: unknown) => {
+	if (error instanceof Error && error.message) {
+		return error.message;
+	}
+
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof (error as { message?: unknown }).message === 'string'
+	) {
+		return (error as { message: string }).message;
+	}
+
+	return 'Tool execution failed';
+};
+
+export const executeToolRequest = async ({
+	data,
+	chatId,
+	resolved,
+	executeToolServer,
+	cb,
+	onDisplayFile,
+	onWriteFile,
+	logger = console
+}: ExecuteToolRequestParams) => {
+	try {
+		const { toolServer, toolServerData, token } = resolved;
+
+		if (!toolServer) {
+			cb?.({ error: 'Tool Server Not Found' });
+			return;
+		}
+
+		const res = await executeToolServer(
+			token ?? '',
+			toolServer.url,
+			data?.name ?? '',
+			data?.params ?? {},
+			toolServerData as ToolServerData,
+			chatId
+		);
+
+		logger.log?.('executeToolServer', res);
+
+		if (data?.name === 'display_file' && typeof data?.params?.path === 'string') {
+			const result = res as { exists?: boolean };
+			if (result?.exists !== false) {
+				onDisplayFile?.(data.params.path, res);
+			}
+		}
+
+		if (data?.name === 'write_file' && typeof data?.params?.path === 'string') {
+			const result = res as { path?: string };
+			onWriteFile?.(result?.path ?? data.params.path);
+		}
+
+		cb?.(structuredClone(res));
+	} catch (error) {
+		logger.error?.('executeTool error:', error);
+		cb?.({ error: getErrorMessage(error) });
+	}
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -61,6 +61,7 @@
 		addTerminalConnection,
 		removeTerminalConnection
 	} from '$lib/utils/connections';
+	import { executeToolRequest } from '$lib/utils/executeTool';
 
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
 	import {
@@ -422,40 +423,23 @@
 	};
 
 	const executeTool = async (data, cb, chatId) => {
-		const { toolServer, toolServerData, token } = resolveToolServer(data.server?.url);
+		const resolvedToolServer = resolveToolServer(data.server?.url);
 
-		console.log('executeTool', data, toolServer);
+		console.log('executeTool', data, resolvedToolServer.toolServer);
 
-		if (toolServer) {
-			const res = await executeToolServer(
-				token,
-				toolServer.url,
-				data?.name,
-				data?.params,
-				toolServerData,
-				chatId
-			);
-
-			console.log('executeToolServer', res);
-
-			if (data?.name === 'display_file' && data?.params?.path) {
-				if (res?.exists !== false) {
-					displayFileHandler(data.params.path, { showControls, showFileNavPath });
-				}
+		await executeToolRequest({
+			data,
+			chatId,
+			resolved: resolvedToolServer,
+			executeToolServer,
+			cb,
+			onDisplayFile: (path) => {
+				displayFileHandler(path, { showControls, showFileNavPath });
+			},
+			onWriteFile: (path) => {
+				showFileNavDir.set(path);
 			}
-
-			if (['write_file'].includes(data?.name) && data?.params?.path) {
-				showFileNavDir.set(res?.path ?? data.params.path);
-			}
-
-			if (cb) {
-				cb(structuredClone(res));
-			}
-		} else {
-			if (cb) {
-				cb({ error: 'Tool Server Not Found' });
-			}
-		}
+		});
 	};
 
 	const chatEventHandler = async (event, cb) => {


### PR DESCRIPTION
## Summary
- move tool execution callback handling into a testable helper
- make executeTool always call the socket callback with an error response when tool server execution throws
- preserve existing success, missing-server, display_file, and write_file behavior

Fixes #25850

## Tests
- npm run test:frontend -- src/lib/utils/executeTool.test.ts --run
- npx eslint src/lib/utils/executeTool.ts src/lib/utils/executeTool.test.ts
- npx prettier --check src/lib/utils/executeTool.ts src/lib/utils/executeTool.test.ts src/routes/+layout.svelte
- npm run check 2>&1 | rg "executeTool|\+layout\.svelte" -C 2

Notes:
- npm run check still reports pre-existing diagnostics in src/routes/+layout.svelte and other unrelated files; the filtered run shows no remaining src/lib/utils/executeTool.ts diagnostics.
- npx eslint src/routes/+layout.svelte also reports pre-existing unrelated errors in that file.