### PR TITLE
fix(web): close Playwright resources on loader failures

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -658,60 +658,88 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
         from playwright.sync_api import sync_playwright
 
         with sync_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    self._safe_process_url_sync(url)
-                    page = browser.new_page()
-                    page.route('**/*', self._intercept_navigation_sync)
-                    response = page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        self._safe_process_url_sync(url)
+                        page = browser.new_page()
+                        page.route('**/*', self._intercept_navigation_sync)
+                        response = page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = self.evaluator.evaluate(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            browser.close()
+                        text = self.evaluator.evaluate(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page is not None:
+                            try:
+                                page.close()
+                            except Exception as e:
+                                log.warning(f'Error closing Playwright page for {url}: {e}')
+            finally:
+                if browser is not None:
+                    try:
+                        browser.close()
+                    except Exception as e:
+                        log.warning(f'Error closing Playwright browser: {e}')
 
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Safely load URLs asynchronously with support for remote browser."""
         from playwright.async_api import async_playwright
 
         async with async_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = await p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = await p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    await self._safe_process_url(url)
-                    page = await browser.new_page()
-                    await page.route('**/*', self._intercept_navigation)
-                    response = await page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        await self._safe_process_url(url)
+                        page = await browser.new_page()
+                        await page.route('**/*', self._intercept_navigation)
+                        response = await page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = await self.evaluator.evaluate_async(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            await browser.close()
+                        text = await self.evaluator.evaluate_async(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page is not None:
+                            try:
+                                await page.close()
+                            except Exception as e:
+                                log.warning(f'Error closing Playwright page for {url}: {e}')
+            finally:
+                if browser is not None:
+                    try:
+                        await browser.close()
+                    except Exception as e:
+                        log.warning(f'Error closing Playwright browser: {e}')
 
 
 class SafeWebBaseLoader(WebBaseLoader):

--- a/backend/tests/test_playwright_loader_cleanup.py
+++ b/backend/tests/test_playwright_loader_cleanup.py
@@ -1,0 +1,158 @@
+import sys
+import types
+
+import pytest
+from open_webui.retrieval.web.utils import SafePlaywrightURLLoader
+
+
+class FakeSyncPage:
+    def __init__(self):
+        self.closed = False
+
+    def route(self, *_args, **_kwargs):
+        return None
+
+    def goto(self, *_args, **_kwargs):
+        raise RuntimeError('navigation failed')
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSyncBrowser:
+    def __init__(self):
+        self.closed = False
+        self.pages = []
+
+    def new_page(self):
+        page = FakeSyncPage()
+        self.pages.append(page)
+        return page
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSyncPlaywright:
+    def __init__(self, browser):
+        self.chromium = types.SimpleNamespace(
+            connect=lambda *_args, **_kwargs: browser,
+            launch=lambda *_args, **_kwargs: browser,
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class FakeAsyncPage:
+    def __init__(self):
+        self.closed = False
+
+    async def route(self, *_args, **_kwargs):
+        return None
+
+    async def goto(self, *_args, **_kwargs):
+        raise RuntimeError('navigation failed')
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeAsyncBrowser:
+    def __init__(self):
+        self.closed = False
+        self.pages = []
+
+    async def new_page(self):
+        page = FakeAsyncPage()
+        self.pages.append(page)
+        return page
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeAsyncPlaywright:
+    def __init__(self, browser):
+        async def connect(*_args, **_kwargs):
+            return browser
+
+        async def launch(*_args, **_kwargs):
+            return browser
+
+        self.chromium = types.SimpleNamespace(
+            connect=connect,
+            launch=launch,
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def install_sync_playwright(monkeypatch, browser):
+    playwright_module = types.ModuleType('playwright')
+    sync_api_module = types.ModuleType('playwright.sync_api')
+    sync_api_module.sync_playwright = lambda: FakeSyncPlaywright(browser)
+    monkeypatch.setitem(sys.modules, 'playwright', playwright_module)
+    monkeypatch.setitem(sys.modules, 'playwright.sync_api', sync_api_module)
+
+
+def install_async_playwright(monkeypatch, browser):
+    playwright_module = types.ModuleType('playwright')
+    async_api_module = types.ModuleType('playwright.async_api')
+    async_api_module.async_playwright = lambda: FakeAsyncPlaywright(browser)
+    monkeypatch.setitem(sys.modules, 'playwright', playwright_module)
+    monkeypatch.setitem(sys.modules, 'playwright.async_api', async_api_module)
+
+
+def make_loader():
+    loader = SafePlaywrightURLLoader.__new__(SafePlaywrightURLLoader)
+    loader.urls = ['https://example.test']
+    loader.playwright_ws_url = None
+    loader.headless = True
+    loader.proxy = None
+    loader.continue_on_failure = False
+    loader.playwright_timeout = 1000
+    loader.evaluator = types.SimpleNamespace(
+        evaluate=lambda *_args, **_kwargs: 'content',
+        evaluate_async=lambda *_args, **_kwargs: 'content',
+    )
+    return loader
+
+
+def test_lazy_load_closes_page_and_browser_when_navigation_raises(monkeypatch):
+    browser = FakeSyncBrowser()
+    install_sync_playwright(monkeypatch, browser)
+    loader = make_loader()
+    monkeypatch.setattr(loader, '_safe_process_url_sync', lambda _url: None)
+
+    with pytest.raises(RuntimeError, match='navigation failed'):
+        list(loader.lazy_load())
+
+    assert browser.closed
+    assert browser.pages[0].closed
+
+
+@pytest.mark.asyncio
+async def test_alazy_load_closes_page_and_browser_when_navigation_raises(monkeypatch):
+    browser = FakeAsyncBrowser()
+    install_async_playwright(monkeypatch, browser)
+    loader = make_loader()
+
+    async def safe_process_url(_url):
+        return None
+
+    monkeypatch.setattr(loader, '_safe_process_url', safe_process_url)
+
+    with pytest.raises(RuntimeError, match='navigation failed'):
+        async for _doc in loader.alazy_load():
+            pass
+
+    assert browser.closed
+    assert browser.pages[0].closed


### PR DESCRIPTION
## Summary
- close each Playwright page in a per-URL finally block for sync and async loaders
- close the browser in an outer finally block so early failures do not leak remote sessions
- add fake-Playwright regression tests for sync and async navigation failures

Fixes #25880

## Tests
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_playwright_loader_cleanup.py -q
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen python -m py_compile backend/open_webui/retrieval/web/utils.py backend/tests/test_playwright_loader_cleanup.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_playwright_loader_cleanup.py
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/retrieval/web/utils.py backend/tests/test_playwright_loader_cleanup.py

Note: full ruff check on backend/open_webui/retrieval/web/utils.py reports pre-existing lint issues unrelated to this change.