### PR TITLE
fix(chat): hide empty completed reasoning details

### DIFF
--- a/src/lib/components/chat/Messages/structuredOutput.test.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildOutputDisplayItems } from './structuredOutput';
+
+describe('buildOutputDisplayItems', () => {
+	test('skips completed reasoning items with no text', () => {
+		const displayItems = buildOutputDisplayItems([
+			{
+				type: 'reasoning',
+				status: 'completed',
+				summary: []
+			},
+			{
+				type: 'message',
+				id: 'message-1',
+				content: [{ type: 'output_text', text: 'Final answer' }]
+			}
+		]);
+
+		expect(displayItems).toEqual([
+			{
+				type: 'message',
+				id: 'message-1',
+				text: 'Final answer'
+			}
+		]);
+	});
+
+	test('keeps completed reasoning items that contain text', () => {
+		const displayItems = buildOutputDisplayItems([
+			{
+				type: 'reasoning',
+				status: 'completed',
+				summary: [{ type: 'summary_text', text: 'Checked the constraints.' }]
+			}
+		]);
+
+		expect(displayItems).toHaveLength(1);
+		expect(displayItems[0]).toMatchObject({
+			type: 'detail_single',
+			token: {
+				attributes: { type: 'reasoning', done: 'true' },
+				text: '> Checked the constraints.'
+			}
+		});
+	});
+});

--- a/src/lib/components/chat/Messages/structuredOutput.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.ts
@@ -146,7 +146,13 @@ function buildToolCallToken(item: OutputItem, toolOutputByCallId: Record<string,
 function buildReasoningToken(item: OutputItem, isLastItem: boolean) {
 	const duration = item.duration ?? '';
 	const isDone = isDoneStatus(item.status) || item.duration !== undefined || !isLastItem;
-	const text = getReasoningText(item)
+	const rawText = getReasoningText(item);
+
+	if (isDone && !rawText.trim()) {
+		return null;
+	}
+
+	const text = rawText
 		.split('\n')
 		.map((line) => (line.startsWith('>') ? line : `> ${line}`))
 		.join('\n');


### PR DESCRIPTION
## Summary
- skip completed reasoning output items when they contain no reasoning text
- keep non-empty completed reasoning details unchanged
- add structured output regression coverage for empty and non-empty reasoning items

Fixes #26645

## Tests
- npm run test:frontend -- src/lib/components/chat/Messages/structuredOutput.test.ts --run
- npx eslint src/lib/components/chat/Messages/structuredOutput.ts src/lib/components/chat/Messages/structuredOutput.test.ts
- npx prettier --check src/lib/components/chat/Messages/structuredOutput.ts src/lib/components/chat/Messages/structuredOutput.test.ts