### PR TITLE
Fix artifact panel reopening after outlet content updates

### DIFF
--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -4,6 +4,7 @@
 
 	import Markdown from './Markdown.svelte';
 	import StructuredOutputRenderer from './StructuredOutputRenderer.svelte';
+	import { getArtifactCodeBlockSignature, isArtifactCodeToken } from './artifacts';
 	import {
 		artifactCode,
 		chatId,
@@ -129,22 +130,43 @@
 				)
 			: messageContent;
 
+	let contentArtifactSignature = null;
+	let openedArtifactSignature = null;
+
+	const openArtifactsPanel = async () => {
+		await tick();
+		showArtifacts.set(true);
+		showControls.set(true);
+	};
+
 	const markdownUpdateHandler = /** @type {any} */ (
 		async (/** @type {{ lang?: string; text?: string }} */ token) => {
 			const { lang = '', text: code = '' } = token;
 
 			if (
 				($settings?.detectArtifacts ?? true) &&
-				(['html', 'svg'].includes(lang) || (lang === 'xml' && code.includes('svg'))) &&
+				isArtifactCodeToken({ lang, text: code }) &&
 				!$mobile &&
 				$chatId
 			) {
-				await tick();
-				showArtifacts.set(true);
-				showControls.set(true);
+				await openArtifactsPanel();
 			}
 		}
 	);
+
+	$: contentArtifactSignature =
+		($settings?.detectArtifacts ?? true) && !$mobile && $chatId
+			? getArtifactCodeBlockSignature(content)
+			: null;
+
+	$: {
+		if (!contentArtifactSignature) {
+			openedArtifactSignature = null;
+		} else if (contentArtifactSignature !== openedArtifactSignature) {
+			openedArtifactSignature = contentArtifactSignature;
+			openArtifactsPanel();
+		}
+	}
 
 	const previewHandler = /** @type {any} */ (
 		async (/** @type {string} */ value) => {

--- a/src/lib/components/chat/Messages/artifacts.test.ts
+++ b/src/lib/components/chat/Messages/artifacts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { getArtifactCodeBlockSignature, isArtifactCodeToken } from './artifacts';
+
+describe('artifact code block detection', () => {
+	it('detects html code blocks in completed message content', () => {
+		const content = [
+			'Here is a preview:',
+			'',
+			'```html',
+			'<div>Rendered after an outlet filter</div>',
+			'```'
+		].join('\n');
+
+		expect(getArtifactCodeBlockSignature(content)).toBe(
+			'html\n<div>Rendered after an outlet filter</div>'
+		);
+	});
+
+	it('ignores non-artifact code blocks', () => {
+		expect(getArtifactCodeBlockSignature('```markdown\n# Title\n```')).toBeNull();
+		expect(isArtifactCodeToken({ lang: 'json', text: '{"svg": true}' })).toBe(false);
+	});
+
+	it('detects svg artifacts emitted as xml', () => {
+		expect(isArtifactCodeToken({ lang: 'xml', text: '<svg viewBox="0 0 1 1"></svg>' })).toBe(true);
+	});
+});

--- a/src/lib/components/chat/Messages/artifacts.ts
+++ b/src/lib/components/chat/Messages/artifacts.ts
@@ -1,0 +1,63 @@
+import { marked } from 'marked';
+
+type ArtifactCodeToken = {
+	type?: string;
+	lang?: string | null;
+	text?: string | null;
+	raw?: string | null;
+};
+
+export const isArtifactCodeToken = (token: ArtifactCodeToken) => {
+	const lang = (token.lang ?? '').trim().toLowerCase();
+	const text = token.text ?? '';
+
+	return lang === 'html' || lang === 'svg' || (lang === 'xml' && text.includes('svg'));
+};
+
+const findArtifactCodeToken = (value: unknown): ArtifactCodeToken | null => {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const token = findArtifactCodeToken(item);
+			if (token) {
+				return token;
+			}
+		}
+
+		return null;
+	}
+
+	if (!value || typeof value !== 'object') {
+		return null;
+	}
+
+	const token = value as ArtifactCodeToken & Record<string, unknown>;
+
+	if (token.type === 'code' && (token.raw ?? '').includes('```') && isArtifactCodeToken(token)) {
+		return token;
+	}
+
+	for (const child of Object.values(token)) {
+		if (Array.isArray(child)) {
+			const nestedToken = findArtifactCodeToken(child);
+			if (nestedToken) {
+				return nestedToken;
+			}
+		}
+	}
+
+	return null;
+};
+
+export const getArtifactCodeBlockSignature = (content = '') => {
+	if (!content.includes('```')) {
+		return null;
+	}
+
+	const token = findArtifactCodeToken(marked.lexer(content));
+
+	if (!token) {
+		return null;
+	}
+
+	return `${(token.lang ?? '').trim().toLowerCase()}\n${token.text ?? ''}`;
+};


### PR DESCRIPTION
Fixes #25752

## Summary
- extract artifact code block detection into a shared helper
- reuse the helper for streaming tokens and completed content changes
- open the artifact panel when outlet filters replace message content with an HTML/SVG fenced block

## Testing
- npm run test:frontend -- src/lib/components/chat/Messages/artifacts.test.ts --run
- npx eslint src/lib/components/chat/Messages/artifacts.ts src/lib/components/chat/Messages/artifacts.test.ts
- npx prettier --check src/lib/components/chat/Messages/artifacts.ts src/lib/components/chat/Messages/artifacts.test.ts src/lib/components/chat/Messages/ContentRenderer.svelte
- npx eslint src/lib/components/chat/Messages/ContentRenderer.svelte (fails on existing unused import/export/default callback issues in this file)