### PR TITLE
Limit PaddleOCR loader to supported file types

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -88,6 +88,8 @@ known_source_ext = [
     'toml',
 ]
 
+paddleocr_vl_supported_ext = ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'tiff', 'tif', 'webp']
+
 
 class ExcelLoader:
     """Fallback Excel loader using pandas when unstructured is not installed."""
@@ -555,7 +557,11 @@ class Loader:
                 file_path=file_path,
                 use_base64=self.kwargs.get('MISTRAL_OCR_USE_BASE64', False),
             )
-        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
+        elif (
+            self.engine == 'paddleocr_vl'
+            and self.kwargs.get('PADDLEOCR_VL_TOKEN') != ''
+            and file_ext in paddleocr_vl_supported_ext
+        ):
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),

--- a/backend/open_webui/retrieval/loaders/paddleocr_vl.py
+++ b/backend/open_webui/retrieval/loaders/paddleocr_vl.py
@@ -46,7 +46,7 @@ class PaddleOCRVLLoader:
 
         # Detect fileType based on file extension
         ext = self.file_path.lower().split('.')[-1]
-        image_extensions = ['png', 'jpg', 'jpeg', 'bmp', 'tiff', 'webp']
+        image_extensions = ['png', 'jpg', 'jpeg', 'bmp', 'tiff', 'tif', 'webp']
         file_type = 1 if ext in image_extensions else 0
 
         payload = {

--- a/backend/tests/test_paddleocr_loader_selection.py
+++ b/backend/tests/test_paddleocr_loader_selection.py
@@ -1,0 +1,33 @@
+from langchain_community.document_loaders import TextLoader
+from open_webui.retrieval.loaders.main import Loader
+from open_webui.retrieval.loaders.paddleocr_vl import PaddleOCRVLLoader
+
+
+def test_paddleocr_vl_falls_back_to_text_loader_for_markdown(tmp_path):
+    file_path = tmp_path / 'notes.md'
+    file_path.write_text('# Notes\n\nPlain markdown should not be sent to OCR.', encoding='utf-8')
+
+    loader = Loader(
+        engine='paddleocr_vl',
+        PADDLEOCR_VL_BASE_URL='http://paddleocr.example',
+        PADDLEOCR_VL_TOKEN='token',
+    )
+
+    selected_loader = loader._get_loader('notes.md', 'text/markdown', str(file_path))
+
+    assert isinstance(selected_loader, TextLoader)
+
+
+def test_paddleocr_vl_handles_supported_pdf_files(tmp_path):
+    file_path = tmp_path / 'paper.pdf'
+    file_path.write_bytes(b'%PDF-1.4\n')
+
+    loader = Loader(
+        engine='paddleocr_vl',
+        PADDLEOCR_VL_BASE_URL='http://paddleocr.example',
+        PADDLEOCR_VL_TOKEN='token',
+    )
+
+    selected_loader = loader._get_loader('paper.pdf', 'application/pdf', str(file_path))
+
+    assert isinstance(selected_loader, PaddleOCRVLLoader)


### PR DESCRIPTION
Fixes #24988

## Summary
- restrict the PaddleOCR-VL loader path to PDF and image extensions
- let text-based files such as Markdown fall back to the regular text loader
- treat .tif files as images when PaddleOCR-VL builds its payload

## Testing
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_paddleocr_loader_selection.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/open-webui-pycache python3 -m py_compile backend/open_webui/retrieval/loaders/main.py backend/open_webui/retrieval/loaders/paddleocr_vl.py backend/tests/test_paddleocr_loader_selection.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_paddleocr_loader_selection.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/retrieval/loaders/main.py backend/open_webui/retrieval/loaders/paddleocr_vl.py backend/tests/test_paddleocr_loader_selection.py

Note: full ruff check on the touched loader files still reports existing issues in those files (unused YoutubeLoader import, Tika boolean comparison, _get_loader complexity, and legacy typing in paddleocr_vl.py).