### PR TITLE
fix: honor real newlines in kb_exec single-file grep

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -702,7 +702,7 @@ async def _kb_grep(
         elif 'error' in resolved:
             return resolved['error']
         else:
-            lines = resolved['content'].split('\\n')
+            lines = resolved['content'].split('\n')
             matched = []
             for i, line in enumerate(lines, 1):
                 if _matches(line):
@@ -715,7 +715,7 @@ async def _kb_grep(
 
             if not matched:
                 return f'No matches for "{pattern}" in {resolved["filename"]}'
-            return '\\n'.join(matched)
+            return '\n'.join(matched)
 
     # Cross-file grep (optionally scoped to directory)
     accessible = await _get_accessible_files(user, model_knowledge)


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26744
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No docs change needed — this makes `grep` behave as its `kb_exec` help text already advertises.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Before/after verification transcript below (real `_kb_grep`, mocked file resolver); no test files included, per repo convention.
- [x] **No Unchecked AI Code:** Developed with AI assistance (disclosure per CONTRIBUTING); the 2-line diff has been human-reviewed and verified.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings; minimal targeted fix.
- [x] **Git Hygiene:** Atomic single-commit PR on a clean branch off `dev`, no test files.
- [x] **Title Prefix:** `fix`

> Scope note: this fixes the **single-file** `grep` branch (lines ~705/718). The piped-input branch (lines ~689/693) has the same `'\n'` typo; to avoid a conflicting diff it is corrected alongside the `-c`/`-l` fix already open in #26721. Happy to fold both together if preferred.

# Changelog Entry

### Description

In the `kb_exec` knowledge-base filesystem tool, `_kb_grep` split and joined single-file content on the literal two-character string `\n` (Python `'\\n'`) instead of a real newline. Because file content contains real newlines, `content.split('\\n')` returned a single chunk — the whole file — so `grep "pattern" file` matched against the entire file as one line and returned every line (matching or not) under a bogus `1:` prefix, and `grep -c` returned at most `1`.

Every sibling command (`cat`/`head`/`tail`/`wc`) and `grep`'s own cross-file branch already use `'\n'`; this makes the single-file branch consistent. Real `grep` semantics are restored: only matching lines are returned, each with its correct line number, and `-c` returns the true count.

### Fixed

- Fixed `kb_exec` single-file `grep` returning the entire file (under a bogus `1:` prefix) and reporting `-c` counts of at most `1`, caused by splitting/joining on the literal string `\n` instead of a real newline.

---

### Additional Information

Verification — calling the real `_kb_grep` on a 5-line `notes.txt` where `TODO` appears on lines 1, 3, 4, `dev` vs this branch:

```
--- origin/dev (before) ---
grep TODO notes.txt   ->
   1: alpha TODO first
   beta ok
   gamma TODO second
   delta TODO third
   epsilon ok
grep -c TODO notes.txt -> file-123  notes.txt: 1

--- fix/kb-grep-newline-split (after) ---
grep TODO notes.txt   ->
   1: alpha TODO first
   3: gamma TODO second
   4: delta TODO third
grep -c TODO notes.txt -> file-123  notes.txt: 3
```

Disclosure per CONTRIBUTING: located and fixed with AI assistance (Claude); reviewed and verified by the submitter.

### Screenshots or Videos

- N/A (backend-only; verification transcript above)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
