### PR TITLE
feat(events): add pre-disable and pre-enable lifecycle events for event functions

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -483,6 +483,16 @@ class EventDefinitions(BaseModel):
     FUNCTION_DISABLED: EventDefinition = EventDefinition(
         name='function.disabled', description='A function was disabled.', message='Function disabled'
     )
+    FUNCTION_DISABLING: EventDefinition = EventDefinition(
+        name='function.disabling',
+        description='A function is about to be disabled. Dispatched synchronously before the state change.',
+        message='Function disabling',
+    )
+    FUNCTION_ENABLING: EventDefinition = EventDefinition(
+        name='function.enabling',
+        description='A function is about to be enabled. Dispatched synchronously before the state change.',
+        message='Function enabling',
+    )
     FUNCTION_VALVES_UPDATED: EventDefinition = EventDefinition(
         name='function.valves_updated', description='Function valves were updated.', message='Function valves updated'
     )
@@ -1067,7 +1077,32 @@ class NotificationEventSink:
             schedule_notification_dispatch(app, event)
 
 
-async def dispatch_event_functions(app: Any, event: Event, request: Any | None = None) -> None:
+async def _resolve_extra_event_functions(
+    extra_function_ids: list[str], existing: list,
+) -> list:
+    """Load event functions by ID that aren't already in *existing*.
+
+    Used by ``dispatch_event_functions`` to include functions that are
+    not yet active (e.g. a function about to be enabled).
+    """
+    from open_webui.models.functions import Functions
+
+    seen_ids = {f.id for f in existing}
+    result = list(existing)
+    for fid in extra_function_ids:
+        if fid not in seen_ids:
+            try:
+                extra = await Functions.get_function_by_id(fid)
+                if extra and extra.type == 'event':
+                    result.append(extra)
+            except Exception:
+                log.exception('Extra event function %s could not be loaded', fid)
+    return result
+
+
+async def dispatch_event_functions(
+    app: Any, event: Event, request: Any | None = None, extra_function_ids: list[str] | None = None
+) -> None:
     if not ENABLE_PLUGINS:
         return
 
@@ -1082,6 +1117,9 @@ async def dispatch_event_functions(app: Any, event: Event, request: Any | None =
     except Exception:
         log.exception('Event functions could not be loaded for %s', event.event)
         return
+
+    if extra_function_ids:
+        event_functions = await _resolve_extra_event_functions(extra_function_ids, event_functions)
 
     for function in event_functions:
         try:

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -11,7 +11,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT, ENABLE_PLUGINS
-from open_webui.events import EVENTS, publish_event
+from open_webui.events import (
+    EVENTS,
+    build_event,
+    dispatch_event_functions,
+    publish_event,
+    schedule_webhook_dispatch,
+)
 from open_webui.internal.db import get_async_session
 from open_webui.models.functions import (
     FunctionForm,
@@ -293,6 +299,39 @@ async def toggle_function_by_id(
 ):
     function = await Functions.get_function_by_id(id, db=db)
     if function:
+        if function.is_active:
+            # Dispatch pre-disable event synchronously so event functions
+            # (including the one being disabled) can perform cleanup before
+            # the is_active flag is committed to the database.
+            disabling_event = build_event(
+                request,
+                EVENTS.FUNCTION_DISABLING,
+                actor=user,
+                subject_id=function.id,
+                subject_type='function',
+                data={'type': function.type, 'name': function.name},
+            )
+            await dispatch_event_functions(request.app, disabling_event, request=request)
+            schedule_webhook_dispatch(request.app, disabling_event)
+        else:
+            # Dispatch pre-enable event synchronously so event functions
+            # (including the one being enabled) can perform setup before
+            # the is_active flag is committed to the database.  The function
+            # is still is_active=False, so we pass its ID via
+            # extra_function_ids to include it in the dispatch.
+            enabling_event = build_event(
+                request,
+                EVENTS.FUNCTION_ENABLING,
+                actor=user,
+                subject_id=function.id,
+                subject_type='function',
+                data={'type': function.type, 'name': function.name},
+            )
+            await dispatch_event_functions(
+                request.app, enabling_event, request=request, extra_function_ids=[function.id]
+            )
+            schedule_webhook_dispatch(request.app, enabling_event)
+
         function = await Functions.update_function_by_id(id, {'is_active': not function.is_active}, db=db)
 
         if function:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/26748 — Add pre-disable and pre-enable lifecycle events for Event Functions
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

Event functions that modify persistent server-side state (e.g., injecting content into `index.html`) have no way to clean up after themselves when an admin toggles them off, and no way to immediately re-initialize when toggled back on. This is because the `is_active` flag is committed to the database **before** the post-toggle events (`function.disabled` / `function.enabled`) are dispatched.

**For `function.disabled`:** The dispatcher queries with `active_only=True`, so the just-disabled function is excluded from its own disable event.

**For `function.enabled`:** The function *does* receive `function.enabled` post-commit, but only via the fire-and-forget async path. There's a timing gap where pages can load before the function's `event()` handler runs.

This PR adds two new synchronous lifecycle events that fire **before** the database commit:

| Event | When | Function included? | Mechanism |
|-------|------|-------------------|-----------|
| `function.disabling` | Before `is_active` → `False` | ✅ Still active | Natural — passes `active_only=True` query |
| `function.enabling` | Before `is_active` → `True` | ✅ Explicitly included | New `extra_function_ids` parameter |

Both events are dispatched synchronously (awaited, not fire-and-forget) to guarantee cleanup/setup completes before the state change.

**Key diff in `routers/functions.py`:**

```diff
     function = await Functions.get_function_by_id(id, db=db)
     if function:
+        if function.is_active:
+            # Pre-disable: function is still active, naturally in dispatch list
+            disabling_event = build_event(...)
+            await dispatch_event_functions(request.app, disabling_event, request=request)
+            schedule_webhook_dispatch(request.app, disabling_event)
+        else:
+            # Pre-enable: function is still inactive, explicitly included
+            enabling_event = build_event(...)
+            await dispatch_event_functions(
+                request.app, enabling_event, request=request,
+                extra_function_ids=[function.id],
+            )
+            schedule_webhook_dispatch(request.app, enabling_event)
+
         function = await Functions.update_function_by_id(id, {'is_active': not function.is_active}, db=db)
```

**The `extra_function_ids` parameter on `dispatch_event_functions`:**

```diff
-async def dispatch_event_functions(app, event, request=None):
+async def dispatch_event_functions(app, event, request=None, extra_function_ids=None):
     event_functions = await Functions.get_functions_by_type('event', active_only=True)
+    if extra_function_ids:
+        event_functions = await _resolve_extra_event_functions(extra_function_ids, event_functions)
```

The helper `_resolve_extra_event_functions` loads specified function IDs that aren't in the active set, validates they are `type='event'`, and appends them. This keeps the parameter backward-compatible (defaults to `None`) and the main function under the C901 complexity threshold.

**Design notes:**

- `dispatch_event_functions` is called directly (awaited) rather than going through the fire-and-forget `publish_event` → `EventFunctionSink` path, ensuring work completes before the DB commit.
- `schedule_webhook_dispatch` is called separately for external webhook delivery (fire-and-forget is fine here).
- The existing post-commit `function.disabled` / `function.enabled` events are untouched — downstream consumers that only care about the final state are unaffected.
- Scoped to functions only. Skills have the same pattern but are a separate resource type.

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Added

- New `function.disabling` event — dispatched synchronously before `is_active=False` is committed, giving event functions a cleanup opportunity.
- New `function.enabling` event — dispatched synchronously before `is_active=True` is committed, giving event functions a setup opportunity. Uses the new `extra_function_ids` parameter to include the not-yet-active function in the dispatch.
- New `extra_function_ids` parameter on `dispatch_event_functions` — allows callers to explicitly include specific function IDs in the dispatch regardless of their active state.

### Manual Verification Performed

1. Created a minimal event function that logs receipt of both lifecycle events
2. Toggled the function OFF → verified `function.disabling` fires before DB commit
3. Toggled the function ON → verified `function.enabling` fires before DB commit
4. Verified the function being enabled receives its own `function.enabling` event (via `extra_function_ids`)
5. Verified the existing `function.disabled` / `function.enabled` events still fire post-commit
6. Verified toggling a non-event function (filter/pipe) does not crash
7. Verified Ruff lint/format passes (pre-existing warnings only, no new C901)
8. Verified production build succeeds

---

### Additional Information

- **Use case:** Theme Designer Pro injects a bootloader `<script>` and inline `<style>` into `index.html`. Without lifecycle events, disabling leaves stale injections; re-enabling has a timing gap before re-injection.
- **Scope:** 2 files changed, 56 insertions, 2 deletions. No new dependencies.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
