### PR TITLE
feat: per-user and per-group token/message usage quotas with visibility endpoint

### DIFF
--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -543,9 +543,14 @@ class ChatMessageTable:
         start_date: Optional[int] = None,
         end_date: Optional[int] = None,
         group_id: Optional[str] = None,
+        user_id: Optional[str] = None,
         db: Optional[AsyncSession] = None,
     ) -> dict[str, dict]:
-        """Aggregate token usage by user using database-level aggregation."""
+        """Aggregate token usage by user using database-level aggregation.
+
+        When ``user_id`` is provided the result is scoped to that single user,
+        avoiding a full-table scan for per-user quota checks.
+        """
         async with get_async_db_context(db) as db:
             from open_webui.models.groups import GroupMember
 
@@ -572,6 +577,8 @@ class ChatMessageTable:
             if group_id:
                 group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
                 stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            if user_id:
+                stmt = stmt.filter(ChatMessage.user_id == user_id)
 
             stmt = stmt.group_by(ChatMessage.user_id)
             result = await db.execute(stmt)

--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -385,7 +385,7 @@ async def get_group_usage_limits(
 @router.put('/id/{id}/usage-limits')
 async def update_group_usage_limits(
     id: str,
-    form_data: Optional[UsageLimitsConfig] = Body(default=None),
+    form_data: UsageLimitsConfig | None = Body(default=None),
     admin=Depends(get_admin_user),
     db: AsyncSession = Depends(get_async_session),
 ):

--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.internal.db import get_async_session
@@ -21,6 +21,7 @@ from open_webui.models.models import Models
 from open_webui.models.tools import Tools
 from open_webui.models.users import UserInfoResponse, Users
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.usage_limits import UsageLimitsConfig
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -349,3 +350,78 @@ async def preview_group_access(
         },
         'permissions': group.permissions or {},
     }
+
+
+############################
+# GetGroupUsageLimits
+############################
+
+
+@router.get('/id/{id}/usage-limits')
+async def get_group_usage_limits(
+    id: str,
+    admin=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return the usage limits configured for a group, or null if not set."""
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    raw = (group.data or {}).get('usage_limits')
+    if raw is None:
+        return None
+    try:
+        return UsageLimitsConfig.model_validate(raw)
+    except Exception:
+        raise HTTPException(status_code=500, detail='Stored usage_limits config is malformed')
+
+
+############################
+# UpdateGroupUsageLimits
+############################
+
+
+@router.put('/id/{id}/usage-limits')
+async def update_group_usage_limits(
+    id: str,
+    form_data: Optional[UsageLimitsConfig] = Body(default=None),
+    admin=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Set or clear usage limits for a group.
+
+    All members of the group inherit these limits unless they have a user-level
+    override. When a user belongs to multiple groups with limits, the most
+    restrictive combined limit applies.
+
+    Pass ``null`` to remove limits from the group.
+    """
+    group = await Groups.get_group_by_id(id, db=db)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    current_data = dict(group.data or {})
+
+    if form_data is None:
+        current_data.pop('usage_limits', None)
+    else:
+        current_data['usage_limits'] = form_data.model_dump()
+
+    updated = await Groups.update_group_by_id(
+        id,
+        GroupUpdateForm(
+            name=group.name,
+            description=group.description,
+            permissions=group.permissions,
+            data=current_data,
+        ),
+        db=db,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    raw = (updated.data or {}).get('usage_limits')
+    if raw is None:
+        return None
+    return UsageLimitsConfig.model_validate(raw)

--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -357,7 +357,7 @@ async def preview_group_access(
 ############################
 
 
-@router.get('/id/{id}/usage-limits')
+@router.get('/id/{id}/usage-limits', response_model=UsageLimitsConfig | None)
 async def get_group_usage_limits(
     id: str,
     admin=Depends(get_admin_user),
@@ -382,10 +382,10 @@ async def get_group_usage_limits(
 ############################
 
 
-@router.put('/id/{id}/usage-limits')
+@router.put('/id/{id}/usage-limits', response_model=UsageLimitsConfig | None)
 async def update_group_usage_limits(
     id: str,
-    form_data: UsageLimitsConfig | None = Body(default=None),
+    form_data: UsageLimitsConfig | None = Body(...),
     admin=Depends(get_admin_user),
     db: AsyncSession = Depends(get_async_session),
 ):

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import ENABLE_PROFILE_IMAGE_URL_FORWARDING, PROFILE_IMAGE_ALLOWED_MIME_TYPES, STATIC_DIR
@@ -38,6 +38,13 @@ from open_webui.utils.auth import (
     get_password_hash,
     get_verified_user,
     validate_password,
+)
+from open_webui.utils.usage_limits import (
+    QuotaSummary,
+    UsageLimitsConfig,
+    UsageStatus,
+    get_quota_summary,
+    get_usage_status,
 )
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -423,6 +430,106 @@ async def update_user_info_by_session_user(  # PATCH-style merge
             detail=ERROR_MESSAGES.USER_NOT_FOUND,
         )
     return updated.info
+
+
+############################
+# GetCurrentUserQuota
+############################
+
+
+@router.get('/user/quota')
+async def get_current_user_quota(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return a pre-computed quota summary for the current user.
+
+    ``remaining`` is pre-calculated; ``resets_at`` is an ISO 8601 date string
+    (e.g. ``"2026-07-01"``). When no limits are configured, ``unlimited`` is
+    ``true`` and all dimension fields are ``null``.
+    """
+    return await get_quota_summary(user.id, db=db)
+
+
+############################
+# GetCurrentUserUsage
+############################
+
+
+@router.get('/user/usage')
+async def get_current_user_usage(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return raw token/message usage and effective limits for the current user.
+
+    For a human-readable quota card, prefer GET /user/quota instead.
+    """
+    return await get_usage_status(user.id, db=db)
+
+
+############################
+# Admin — GetUserUsageLimits
+############################
+
+
+@router.get('/{user_id}/usage-limits')
+async def get_user_usage_limits(
+    user_id: str,
+    admin=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return the usage limit override configured directly on a user, or null."""
+    target = await Users.get_user_by_id(user_id, db=db)
+    if not target:
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    raw = (target.info or {}).get('usage_limits')
+    if raw is None:
+        return None
+    try:
+        return UsageLimitsConfig.model_validate(raw)
+    except Exception:
+        raise HTTPException(status_code=500, detail='Stored usage_limits config is malformed')
+
+
+############################
+# Admin — UpdateUserUsageLimits
+############################
+
+
+@router.put('/{user_id}/usage-limits')
+async def update_user_usage_limits(
+    user_id: str,
+    form_data: Optional[UsageLimitsConfig] = Body(default=None),
+    admin=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Set or clear the usage limit override for a user.
+
+    Pass ``null`` to remove the user-level override (the user inherits group
+    limits again). Pass ``{"enabled": false}`` to explicitly exempt a user
+    from any group-level limits without configuring new caps.
+    """
+    target = await Users.get_user_by_id(user_id, db=db)
+    if not target:
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    current_info = dict(target.info or {})
+
+    if form_data is None:
+        current_info.pop('usage_limits', None)
+    else:
+        current_info['usage_limits'] = form_data.model_dump()
+
+    updated = await Users.update_user_by_id(user_id, {'info': current_info}, db=db)
+    if not updated:
+        raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    raw = (updated.info or {}).get('usage_limits')
+    if raw is None:
+        return None
+    return UsageLimitsConfig.model_validate(raw)
 
 
 ############################

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -11,10 +11,14 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import ENABLE_PROFILE_IMAGE_URL_FORWARDING, PROFILE_IMAGE_ALLOWED_MIME_TYPES, STATIC_DIR
 from open_webui.internal.db import get_async_session
+from open_webui.models.access_grants import AccessGrants
 from open_webui.models.auths import Auths
 from open_webui.models.config import Config
 from open_webui.models.groups import Groups
+from open_webui.models.knowledge import Knowledges
+from open_webui.models.models import Models
 from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.tools import Tools
 from open_webui.models.users import (
     UserGroupIdsListResponse,
     UserGroupIdsModel,
@@ -27,10 +31,6 @@ from open_webui.models.users import (
     UserStatus,
     UserUpdateForm,
 )
-from open_webui.models.access_grants import AccessGrants
-from open_webui.models.knowledge import Knowledges
-from open_webui.models.models import Models
-from open_webui.models.tools import Tools
 from open_webui.socket.main import disconnect_user_sessions
 from open_webui.utils.access_control import get_permissions, has_permission
 from open_webui.utils.auth import (
@@ -437,7 +437,7 @@ async def update_user_info_by_session_user(  # PATCH-style merge
 ############################
 
 
-@router.get('/user/quota')
+@router.get('/user/quota', response_model=QuotaSummary)
 async def get_current_user_quota(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
@@ -456,7 +456,7 @@ async def get_current_user_quota(
 ############################
 
 
-@router.get('/user/usage')
+@router.get('/user/usage', response_model=UsageStatus)
 async def get_current_user_usage(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
@@ -501,7 +501,7 @@ async def get_user_usage_limits(
 @router.put('/{user_id}/usage-limits')
 async def update_user_usage_limits(
     user_id: str,
-    form_data: Optional[UsageLimitsConfig] = Body(default=None),
+    form_data: UsageLimitsConfig | None = Body(default=None),
     admin=Depends(get_admin_user),
     db: AsyncSession = Depends(get_async_session),
 ):

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -473,7 +473,7 @@ async def get_current_user_usage(
 ############################
 
 
-@router.get('/{user_id}/usage-limits')
+@router.get('/{user_id}/usage-limits', response_model=UsageLimitsConfig | None)
 async def get_user_usage_limits(
     user_id: str,
     admin=Depends(get_admin_user),
@@ -498,10 +498,10 @@ async def get_user_usage_limits(
 ############################
 
 
-@router.put('/{user_id}/usage-limits')
+@router.put('/{user_id}/usage-limits', response_model=UsageLimitsConfig | None)
 async def update_user_usage_limits(
     user_id: str,
-    form_data: UsageLimitsConfig | None = Body(default=None),
+    form_data: UsageLimitsConfig | None = Body(...),
     admin=Depends(get_admin_user),
     db: AsyncSession = Depends(get_async_session),
 ):

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -34,6 +34,7 @@ from open_webui.utils.filter import (
     process_filter_functions,
 )
 from open_webui.utils.models import check_model_access, get_all_models
+from open_webui.utils.usage_limits import check_usage_limits
 from open_webui.utils.payload import convert_payload_openai_to_ollama
 from open_webui.utils.response import (
     convert_response_ollama_to_openai,
@@ -202,6 +203,11 @@ async def generate_chat_completion(
                 await check_model_access(user, model)
             except Exception as e:
                 raise e
+
+        # Enforce per-user / per-group token and message usage quotas.
+        # Only 'user' role is subject to limits; admins are exempt.
+        if not bypass_filter and user.role == 'user':
+            await check_usage_limits(user.id)
 
         # Arena model — sub-model was already resolved by process_chat_payload.
         # Inject selected_model_id into the response for the frontend.

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -28,7 +28,6 @@ Known limitation — cross-period dimension merging:
 """
 
 import logging
-from contextlib import suppress
 from datetime import UTC, datetime, timedelta  # noqa: ICN003
 from typing import Literal
 
@@ -68,7 +67,7 @@ class UsageStatus(BaseModel):
     limits: UsageLimitsConfig | None = None
     period_start: int | None = None
     period_end: int | None = None
-    usage: dict = {}
+    usage: dict = Field(default_factory=dict)
 
 
 class QuotaDimension(BaseModel):
@@ -156,8 +155,8 @@ def _most_restrictive(configs: list[UsageLimitsConfig]) -> UsageLimitsConfig:
         non_none = [v for v in values if v is not None]
         return min(non_none) if non_none else None
 
-    # Sort so the shortest period comes first
-    configs.sort(key=lambda c: _PERIOD_ORDER.get(c.period, 99))
+    # Sort so the shortest period comes first (do not mutate the caller's list)
+    configs = sorted(configs, key=lambda c: _PERIOD_ORDER.get(c.period, 99))
     effective_period = configs[0].period
 
     # Only compare limits from configs that share the most restrictive period
@@ -194,11 +193,11 @@ async def get_effective_usage_limits(
     # ── 1. User-level override ────────────────────────────────────────────
     raw_user_limits = (user.info or {}).get('usage_limits')
     if raw_user_limits is not None:
-        with suppress(Exception):
+        try:
             user_limits = UsageLimitsConfig.model_validate(raw_user_limits)
-            # Explicit user config found — honour it regardless of groups.
             return user_limits if user_limits.enabled else None
-        log.warning('Ignoring malformed usage_limits for user %s', user_id)
+        except Exception:
+            log.warning('Ignoring malformed usage_limits for user %s', user_id)
 
     # ── 2. Group-level limits ─────────────────────────────────────────────
     groups = await Groups.get_groups_by_member_id(user_id, db=db)
@@ -207,12 +206,12 @@ async def get_effective_usage_limits(
         raw_group_limits = (group.data or {}).get('usage_limits')
         if raw_group_limits is None:
             continue
-        with suppress(Exception):
+        try:
             gl = UsageLimitsConfig.model_validate(raw_group_limits)
             if gl.enabled:
                 enabled_group_limits.append(gl)
-            continue
-        log.warning('Ignoring malformed usage_limits for group %s', group.id)
+        except Exception:
+            log.warning('Ignoring malformed usage_limits for group %s', group.id)
 
     if not enabled_group_limits:
         return None
@@ -229,7 +228,7 @@ async def get_user_usage_for_period(
     user_id: str,
     period: str,
     db: AsyncSession | None = None,
-) -> dict:
+) -> dict[str, int]:
     """Return current-period token/message stats for a single user."""
     start_date = get_period_start_ts(period)
     usage_map = await ChatMessages.get_token_usage_by_user(
@@ -279,6 +278,8 @@ async def check_usage_limits(
         usage = await get_user_usage_for_period(user_id, limits.period, db=db)
         period_end = get_period_end_ts(limits.period)
 
+        retry_after = str(max(0, period_end - int(datetime.now(UTC).timestamp())))
+
         def _exceeded(limit: int | None, key: str, label: str) -> None:
             if limit is None:
                 return
@@ -286,6 +287,7 @@ async def check_usage_limits(
             if current >= limit:
                 raise HTTPException(
                     status_code=429,
+                    headers={'Retry-After': retry_after},
                     detail={
                         'error': 'usage_limit_exceeded',
                         'limit_type': label,
@@ -316,7 +318,7 @@ async def get_usage_status(
     user_id: str,
     db: AsyncSession | None = None,
 ) -> UsageStatus:
-    """Build a UsageStatus payload for the /me/usage endpoint (raw numbers)."""
+    """Build a UsageStatus payload for the /user/usage endpoint (raw numbers)."""
     limits = await get_effective_usage_limits(user_id, db=db)
     if not limits or not limits.enabled:
         return UsageStatus()
@@ -346,7 +348,7 @@ async def get_quota_summary(
     user_id: str,
     db: AsyncSession | None = None,
 ) -> QuotaSummary:
-    """Build a clean, pre-computed quota summary for the /me/quota endpoint.
+    """Build a clean, pre-computed quota summary for the /user/quota endpoint.
 
     Returns a flat, human-readable structure with ``remaining`` already
     calculated and ``resets_at`` as an ISO date string so the frontend can

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -8,12 +8,29 @@ a user belongs to multiple groups with limits configured.
 Limits are checked as a pre-flight step inside generate_chat_completion() before
 any LLM call is made. The check fails open on DB errors to avoid blocking
 legitimate users due to transient infrastructure issues.
+
+Known limitation — TOCTOU race condition:
+  The check-then-act pattern (read usage → enforce → LLM call → write usage)
+  means that concurrent requests from the same user can all pass the pre-flight
+  check before any of them write their usage back to the database. The maximum
+  overshoot per burst is bounded by (N_concurrent × tokens_per_request). For
+  typical chat-UI usage (one request at a time), this is negligible. Eliminating
+  it would require an atomic counter (Redis INCR or a dedicated DB row with
+  SELECT FOR UPDATE), which is out of scope for this initial implementation.
+  Treat configured limits as soft caps with a small burst tolerance.
+
+Known limitation — cross-period dimension merging:
+  When a user belongs to groups with different periods (e.g. Group A enforces a
+  daily message cap and Group B enforces a weekly token cap), only the shortest-
+  period group's limits are applied. The longer-period cap is silently ignored.
+  All limits WITHIN the shortest period are merged correctly (minimum across
+  groups for each dimension).
 """
 
 import logging
 from contextlib import suppress
-from datetime import datetime, timedelta, timezone
-from typing import Literal, Optional
+from datetime import UTC, datetime, timedelta  # noqa: ICN003
+from typing import Literal
 
 from fastapi import HTTPException
 from open_webui.models.chat_messages import ChatMessages
@@ -34,23 +51,23 @@ class UsageLimitsConfig(BaseModel):
     """
 
     enabled: bool = False
-    period: Literal["daily", "weekly", "monthly"] = "daily"
+    period: Literal['daily', 'weekly', 'monthly'] = 'daily'
 
     # Optional per-period caps (None = unlimited for that dimension)
-    max_messages: Optional[int] = None
-    max_input_tokens: Optional[int] = None
-    max_output_tokens: Optional[int] = None
-    max_total_tokens: Optional[int] = None
+    max_messages: int | None = None
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_total_tokens: int | None = None
 
-    model_config = {"extra": "ignore"}
+    model_config = {'extra': 'ignore'}
 
 
 class UsageStatus(BaseModel):
     """Current usage snapshot for a user, paired with their effective limits."""
 
-    limits: Optional[UsageLimitsConfig] = None
-    period_start: Optional[int] = None
-    period_end: Optional[int] = None
+    limits: UsageLimitsConfig | None = None
+    period_start: int | None = None
+    period_end: int | None = None
     usage: dict = {}
 
 
@@ -71,59 +88,53 @@ class QuotaSummary(BaseModel):
     """
 
     unlimited: bool = False
-    period: Optional[Literal["daily", "weekly", "monthly"]] = None
-    resets_at: Optional[str] = None  # ISO 8601 date, e.g. "2026-07-01"
+    period: Literal['daily', 'weekly', 'monthly'] | None = None
+    resets_at: str | None = None  # ISO 8601 date, e.g. "2026-07-01"
 
-    total_tokens: Optional[QuotaDimension] = None
-    input_tokens: Optional[QuotaDimension] = None
-    output_tokens: Optional[QuotaDimension] = None
-    messages: Optional[QuotaDimension] = None
+    total_tokens: QuotaDimension | None = None
+    input_tokens: QuotaDimension | None = None
+    output_tokens: QuotaDimension | None = None
+    messages: QuotaDimension | None = None
 
 
 # ---------------------------------------------------------------------------
 # Period helpers
 # ---------------------------------------------------------------------------
 
-_PERIOD_ORDER = {"daily": 0, "weekly": 1, "monthly": 2}
+_PERIOD_ORDER = {'daily': 0, 'weekly': 1, 'monthly': 2}
 
 
 def get_period_start_ts(period: str) -> int:
     """UTC Unix timestamp for the start of the current billing period."""
-    now = datetime.now(timezone.utc)
-    if period == "daily":
+    now = datetime.now(UTC)
+    if period == 'daily':
         start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    elif period == "weekly":
+    elif period == 'weekly':
         # ISO weeks start on Monday
-        start = (now - timedelta(days=now.weekday())).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-    elif period == "monthly":
+        start = (now - timedelta(days=now.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif period == 'monthly':
         start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     else:
-        raise ValueError(f"Unknown period: {period!r}")
+        raise ValueError(f'Unknown period: {period!r}')
     return int(start.timestamp())
 
 
 def get_period_end_ts(period: str) -> int:
     """UTC Unix timestamp for the end of the current billing period (inclusive)."""
-    now = datetime.now(timezone.utc)
-    if period == "daily":
+    now = datetime.now(UTC)
+    if period == 'daily':
         end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
-    elif period == "weekly":
+    elif period == 'weekly':
         days_to_sunday = 6 - now.weekday()
-        end = (now + timedelta(days=days_to_sunday)).replace(
-            hour=23, minute=59, second=59, microsecond=999999
-        )
-    elif period == "monthly":
+        end = (now + timedelta(days=days_to_sunday)).replace(hour=23, minute=59, second=59, microsecond=999999)
+    elif period == 'monthly':
         if now.month == 12:
             first_of_next = now.replace(year=now.year + 1, month=1, day=1)
         else:
             first_of_next = now.replace(month=now.month + 1, day=1)
-        end = (first_of_next - timedelta(seconds=1)).replace(
-            hour=23, minute=59, second=59, microsecond=999999
-        )
+        end = (first_of_next - timedelta(seconds=1)).replace(hour=23, minute=59, second=59, microsecond=999999)
     else:
-        raise ValueError(f"Unknown period: {period!r}")
+        raise ValueError(f'Unknown period: {period!r}')
     return int(end.timestamp())
 
 
@@ -139,7 +150,7 @@ def _most_restrictive(configs: list[UsageLimitsConfig]) -> UsageLimitsConfig:
     - Caps: minimum non-None value across all configs.
     """
 
-    def _min_cap(*values: Optional[int]) -> Optional[int]:
+    def _min_cap(*values: int | None) -> int | None:
         non_none = [v for v in values if v is not None]
         return min(non_none) if non_none else None
 
@@ -162,8 +173,8 @@ def _most_restrictive(configs: list[UsageLimitsConfig]) -> UsageLimitsConfig:
 
 async def get_effective_usage_limits(
     user_id: str,
-    db: Optional[AsyncSession] = None,
-) -> Optional[UsageLimitsConfig]:
+    db: AsyncSession | None = None,
+) -> UsageLimitsConfig | None:
     """Resolve the effective usage limits for a user.
 
     Priority order:
@@ -179,19 +190,19 @@ async def get_effective_usage_limits(
         return None
 
     # ── 1. User-level override ────────────────────────────────────────────
-    raw_user_limits = (user.info or {}).get("usage_limits")
+    raw_user_limits = (user.info or {}).get('usage_limits')
     if raw_user_limits is not None:
         with suppress(Exception):
             user_limits = UsageLimitsConfig.model_validate(raw_user_limits)
             # Explicit user config found — honour it regardless of groups.
             return user_limits if user_limits.enabled else None
-        log.warning("Ignoring malformed usage_limits for user %s", user_id)
+        log.warning('Ignoring malformed usage_limits for user %s', user_id)
 
     # ── 2. Group-level limits ─────────────────────────────────────────────
     groups = await Groups.get_groups_by_member_id(user_id, db=db)
     enabled_group_limits: list[UsageLimitsConfig] = []
     for group in groups:
-        raw_group_limits = (group.data or {}).get("usage_limits")
+        raw_group_limits = (group.data or {}).get('usage_limits')
         if raw_group_limits is None:
             continue
         with suppress(Exception):
@@ -199,7 +210,7 @@ async def get_effective_usage_limits(
             if gl.enabled:
                 enabled_group_limits.append(gl)
             continue
-        log.warning("Ignoring malformed usage_limits for group %s", group.id)
+        log.warning('Ignoring malformed usage_limits for group %s', group.id)
 
     if not enabled_group_limits:
         return None
@@ -215,7 +226,7 @@ async def get_effective_usage_limits(
 async def get_user_usage_for_period(
     user_id: str,
     period: str,
-    db: Optional[AsyncSession] = None,
+    db: AsyncSession | None = None,
 ) -> dict:
     """Return current-period token/message stats for a single user."""
     start_date = get_period_start_ts(period)
@@ -227,10 +238,10 @@ async def get_user_usage_for_period(
     return usage_map.get(
         user_id,
         {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-            "message_count": 0,
+            'input_tokens': 0,
+            'output_tokens': 0,
+            'total_tokens': 0,
+            'message_count': 0,
         },
     )
 
@@ -242,7 +253,7 @@ async def get_user_usage_for_period(
 
 async def check_usage_limits(
     user_id: str,
-    db: Optional[AsyncSession] = None,
+    db: AsyncSession | None = None,
 ) -> None:
     """Pre-flight usage limit check. Call this before invoking the LLM.
 
@@ -266,7 +277,7 @@ async def check_usage_limits(
         usage = await get_user_usage_for_period(user_id, limits.period, db=db)
         period_end = get_period_end_ts(limits.period)
 
-        def _exceeded(limit: Optional[int], key: str, label: str) -> None:
+        def _exceeded(limit: int | None, key: str, label: str) -> None:
             if limit is None:
                 return
             current = usage.get(key, 0)
@@ -274,24 +285,24 @@ async def check_usage_limits(
                 raise HTTPException(
                     status_code=429,
                     detail={
-                        "error": "usage_limit_exceeded",
-                        "limit_type": label,
-                        "period": limits.period,
-                        "limit": limit,
-                        "current": current,
-                        "resets_at": period_end,
+                        'error': 'usage_limit_exceeded',
+                        'limit_type': label,
+                        'period': limits.period,
+                        'limit': limit,
+                        'current': current,
+                        'resets_at': period_end,
                     },
                 )
 
-        _exceeded(limits.max_messages, "message_count", "messages")
-        _exceeded(limits.max_total_tokens, "total_tokens", "total_tokens")
-        _exceeded(limits.max_input_tokens, "input_tokens", "input_tokens")
-        _exceeded(limits.max_output_tokens, "output_tokens", "output_tokens")
+        _exceeded(limits.max_messages, 'message_count', 'messages')
+        _exceeded(limits.max_total_tokens, 'total_tokens', 'total_tokens')
+        _exceeded(limits.max_input_tokens, 'input_tokens', 'input_tokens')
+        _exceeded(limits.max_output_tokens, 'output_tokens', 'output_tokens')
 
     except HTTPException:
         raise
     except Exception:
-        log.exception("Usage limit check failed for user %s — allowing request", user_id)
+        log.exception('Usage limit check failed for user %s — allowing request', user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +312,7 @@ async def check_usage_limits(
 
 async def get_usage_status(
     user_id: str,
-    db: Optional[AsyncSession] = None,
+    db: AsyncSession | None = None,
 ) -> UsageStatus:
     """Build a UsageStatus payload for the /me/usage endpoint (raw numbers)."""
     limits = await get_effective_usage_limits(user_id, db=db)
@@ -319,12 +330,10 @@ async def get_usage_status(
 
 def _period_end_date_str(period: str) -> str:
     """ISO 8601 date string for the last day of the current billing period."""
-    return datetime.fromtimestamp(
-        get_period_end_ts(period), tz=timezone.utc
-    ).date().isoformat()
+    return datetime.fromtimestamp(get_period_end_ts(period), tz=UTC).date().isoformat()
 
 
-def _dimension(used: int, limit: Optional[int]) -> Optional[QuotaDimension]:
+def _dimension(used: int, limit: int | None) -> QuotaDimension | None:
     """Build a QuotaDimension only when the cap is configured."""
     if limit is None:
         return None
@@ -333,7 +342,7 @@ def _dimension(used: int, limit: Optional[int]) -> Optional[QuotaDimension]:
 
 async def get_quota_summary(
     user_id: str,
-    db: Optional[AsyncSession] = None,
+    db: AsyncSession | None = None,
 ) -> QuotaSummary:
     """Build a clean, pre-computed quota summary for the /me/quota endpoint.
 
@@ -363,8 +372,8 @@ async def get_quota_summary(
         unlimited=False,
         period=limits.period,
         resets_at=_period_end_date_str(limits.period),
-        total_tokens=_dimension(usage.get("total_tokens", 0), limits.max_total_tokens),
-        input_tokens=_dimension(usage.get("input_tokens", 0), limits.max_input_tokens),
-        output_tokens=_dimension(usage.get("output_tokens", 0), limits.max_output_tokens),
-        messages=_dimension(usage.get("message_count", 0), limits.max_messages),
+        total_tokens=_dimension(usage.get('total_tokens', 0), limits.max_total_tokens),
+        input_tokens=_dimension(usage.get('input_tokens', 0), limits.max_input_tokens),
+        output_tokens=_dimension(usage.get('output_tokens', 0), limits.max_output_tokens),
+        messages=_dimension(usage.get('message_count', 0), limits.max_messages),
     )

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -1,0 +1,370 @@
+"""
+Per-user and per-group token/message usage quota enforcement.
+
+Usage limits are configured per user (highest priority) or per group (inherited
+when no user-level override exists). The most restrictive group limit wins when
+a user belongs to multiple groups with limits configured.
+
+Limits are checked as a pre-flight step inside generate_chat_completion() before
+any LLM call is made. The check fails open on DB errors to avoid blocking
+legitimate users due to transient infrastructure issues.
+"""
+
+import logging
+from contextlib import suppress
+from datetime import datetime, timedelta, timezone
+from typing import Literal, Optional
+
+from fastapi import HTTPException
+from open_webui.models.chat_messages import ChatMessages
+from open_webui.models.groups import Groups
+from open_webui.models.users import Users
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+
+class UsageLimitsConfig(BaseModel):
+    """Schema for per-user or per-group usage limit configuration.
+
+    Stored in:
+      User.info['usage_limits']   — user-level override (highest priority)
+      Group.data['usage_limits']  — group default (inheritable)
+    """
+
+    enabled: bool = False
+    period: Literal["daily", "weekly", "monthly"] = "daily"
+
+    # Optional per-period caps (None = unlimited for that dimension)
+    max_messages: Optional[int] = None
+    max_input_tokens: Optional[int] = None
+    max_output_tokens: Optional[int] = None
+    max_total_tokens: Optional[int] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class UsageStatus(BaseModel):
+    """Current usage snapshot for a user, paired with their effective limits."""
+
+    limits: Optional[UsageLimitsConfig] = None
+    period_start: Optional[int] = None
+    period_end: Optional[int] = None
+    usage: dict = {}
+
+
+class QuotaDimension(BaseModel):
+    """Quota figures for one trackable dimension (tokens or messages)."""
+
+    used: int
+    limit: int
+    remaining: int
+
+
+class QuotaSummary(BaseModel):
+    """Clean, pre-computed quota summary for the user-facing /me/quota endpoint.
+
+    When no limits are configured, ``unlimited`` is True and all dimension
+    fields are None — the frontend can gate on that flag without inspecting
+    every field.
+    """
+
+    unlimited: bool = False
+    period: Optional[Literal["daily", "weekly", "monthly"]] = None
+    resets_at: Optional[str] = None  # ISO 8601 date, e.g. "2026-07-01"
+
+    total_tokens: Optional[QuotaDimension] = None
+    input_tokens: Optional[QuotaDimension] = None
+    output_tokens: Optional[QuotaDimension] = None
+    messages: Optional[QuotaDimension] = None
+
+
+# ---------------------------------------------------------------------------
+# Period helpers
+# ---------------------------------------------------------------------------
+
+_PERIOD_ORDER = {"daily": 0, "weekly": 1, "monthly": 2}
+
+
+def get_period_start_ts(period: str) -> int:
+    """UTC Unix timestamp for the start of the current billing period."""
+    now = datetime.now(timezone.utc)
+    if period == "daily":
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    elif period == "weekly":
+        # ISO weeks start on Monday
+        start = (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+    elif period == "monthly":
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    else:
+        raise ValueError(f"Unknown period: {period!r}")
+    return int(start.timestamp())
+
+
+def get_period_end_ts(period: str) -> int:
+    """UTC Unix timestamp for the end of the current billing period (inclusive)."""
+    now = datetime.now(timezone.utc)
+    if period == "daily":
+        end = now.replace(hour=23, minute=59, second=59, microsecond=999999)
+    elif period == "weekly":
+        days_to_sunday = 6 - now.weekday()
+        end = (now + timedelta(days=days_to_sunday)).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+    elif period == "monthly":
+        if now.month == 12:
+            first_of_next = now.replace(year=now.year + 1, month=1, day=1)
+        else:
+            first_of_next = now.replace(month=now.month + 1, day=1)
+        end = (first_of_next - timedelta(seconds=1)).replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        )
+    else:
+        raise ValueError(f"Unknown period: {period!r}")
+    return int(end.timestamp())
+
+
+# ---------------------------------------------------------------------------
+# Effective limit resolution
+# ---------------------------------------------------------------------------
+
+
+def _most_restrictive(configs: list[UsageLimitsConfig]) -> UsageLimitsConfig:
+    """Merge a list of enabled UsageLimitsConfig into the tightest combined limit.
+
+    - Period: shortest wins (daily < weekly < monthly).
+    - Caps: minimum non-None value across all configs.
+    """
+
+    def _min_cap(*values: Optional[int]) -> Optional[int]:
+        non_none = [v for v in values if v is not None]
+        return min(non_none) if non_none else None
+
+    # Sort so the shortest period comes first
+    configs.sort(key=lambda c: _PERIOD_ORDER.get(c.period, 99))
+    effective_period = configs[0].period
+
+    # Only compare limits from configs that share the most restrictive period
+    same_period = [c for c in configs if c.period == effective_period]
+
+    return UsageLimitsConfig(
+        enabled=True,
+        period=effective_period,
+        max_messages=_min_cap(*[c.max_messages for c in same_period]),
+        max_input_tokens=_min_cap(*[c.max_input_tokens for c in same_period]),
+        max_output_tokens=_min_cap(*[c.max_output_tokens for c in same_period]),
+        max_total_tokens=_min_cap(*[c.max_total_tokens for c in same_period]),
+    )
+
+
+async def get_effective_usage_limits(
+    user_id: str,
+    db: Optional[AsyncSession] = None,
+) -> Optional[UsageLimitsConfig]:
+    """Resolve the effective usage limits for a user.
+
+    Priority order:
+      1. User-level override (user.info['usage_limits'])
+      2. Most restrictive limit across the user's groups
+      3. None (unlimited)
+
+    If a user has an explicit user-level config with enabled=False, that is
+    treated as "no limit" for this user, even if groups have limits set.
+    """
+    user = await Users.get_user_by_id(user_id, db=db)
+    if not user:
+        return None
+
+    # ── 1. User-level override ────────────────────────────────────────────
+    raw_user_limits = (user.info or {}).get("usage_limits")
+    if raw_user_limits is not None:
+        with suppress(Exception):
+            user_limits = UsageLimitsConfig.model_validate(raw_user_limits)
+            # Explicit user config found — honour it regardless of groups.
+            return user_limits if user_limits.enabled else None
+        log.warning("Ignoring malformed usage_limits for user %s", user_id)
+
+    # ── 2. Group-level limits ─────────────────────────────────────────────
+    groups = await Groups.get_groups_by_member_id(user_id, db=db)
+    enabled_group_limits: list[UsageLimitsConfig] = []
+    for group in groups:
+        raw_group_limits = (group.data or {}).get("usage_limits")
+        if raw_group_limits is None:
+            continue
+        with suppress(Exception):
+            gl = UsageLimitsConfig.model_validate(raw_group_limits)
+            if gl.enabled:
+                enabled_group_limits.append(gl)
+            continue
+        log.warning("Ignoring malformed usage_limits for group %s", group.id)
+
+    if not enabled_group_limits:
+        return None
+
+    return _most_restrictive(enabled_group_limits)
+
+
+# ---------------------------------------------------------------------------
+# Usage query
+# ---------------------------------------------------------------------------
+
+
+async def get_user_usage_for_period(
+    user_id: str,
+    period: str,
+    db: Optional[AsyncSession] = None,
+) -> dict:
+    """Return current-period token/message stats for a single user."""
+    start_date = get_period_start_ts(period)
+    usage_map = await ChatMessages.get_token_usage_by_user(
+        start_date=start_date,
+        user_id=user_id,
+        db=db,
+    )
+    return usage_map.get(
+        user_id,
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "message_count": 0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enforcement
+# ---------------------------------------------------------------------------
+
+
+async def check_usage_limits(
+    user_id: str,
+    db: Optional[AsyncSession] = None,
+) -> None:
+    """Pre-flight usage limit check. Call this before invoking the LLM.
+
+    Raises HTTPException(429) with a structured detail payload when any
+    configured limit is exceeded. The detail dict includes:
+      - error: "usage_limit_exceeded"
+      - limit_type: which dimension was hit
+      - period: "daily" | "weekly" | "monthly"
+      - limit: the configured cap
+      - current: the user's current usage value
+      - resets_at: Unix timestamp when the period resets
+
+    Fails open on unexpected errors to avoid blocking users due to DB
+    transient failures.
+    """
+    try:
+        limits = await get_effective_usage_limits(user_id, db=db)
+        if not limits or not limits.enabled:
+            return
+
+        usage = await get_user_usage_for_period(user_id, limits.period, db=db)
+        period_end = get_period_end_ts(limits.period)
+
+        def _exceeded(limit: Optional[int], key: str, label: str) -> None:
+            if limit is None:
+                return
+            current = usage.get(key, 0)
+            if current >= limit:
+                raise HTTPException(
+                    status_code=429,
+                    detail={
+                        "error": "usage_limit_exceeded",
+                        "limit_type": label,
+                        "period": limits.period,
+                        "limit": limit,
+                        "current": current,
+                        "resets_at": period_end,
+                    },
+                )
+
+        _exceeded(limits.max_messages, "message_count", "messages")
+        _exceeded(limits.max_total_tokens, "total_tokens", "total_tokens")
+        _exceeded(limits.max_input_tokens, "input_tokens", "input_tokens")
+        _exceeded(limits.max_output_tokens, "output_tokens", "output_tokens")
+
+    except HTTPException:
+        raise
+    except Exception:
+        log.exception("Usage limit check failed for user %s — allowing request", user_id)
+
+
+# ---------------------------------------------------------------------------
+# Status helpers (used by self-service endpoints)
+# ---------------------------------------------------------------------------
+
+
+async def get_usage_status(
+    user_id: str,
+    db: Optional[AsyncSession] = None,
+) -> UsageStatus:
+    """Build a UsageStatus payload for the /me/usage endpoint (raw numbers)."""
+    limits = await get_effective_usage_limits(user_id, db=db)
+    if not limits or not limits.enabled:
+        return UsageStatus()
+
+    usage = await get_user_usage_for_period(user_id, limits.period, db=db)
+    return UsageStatus(
+        limits=limits,
+        period_start=get_period_start_ts(limits.period),
+        period_end=get_period_end_ts(limits.period),
+        usage=usage,
+    )
+
+
+def _period_end_date_str(period: str) -> str:
+    """ISO 8601 date string for the last day of the current billing period."""
+    return datetime.fromtimestamp(
+        get_period_end_ts(period), tz=timezone.utc
+    ).date().isoformat()
+
+
+def _dimension(used: int, limit: Optional[int]) -> Optional[QuotaDimension]:
+    """Build a QuotaDimension only when the cap is configured."""
+    if limit is None:
+        return None
+    return QuotaDimension(used=used, limit=limit, remaining=max(0, limit - used))
+
+
+async def get_quota_summary(
+    user_id: str,
+    db: Optional[AsyncSession] = None,
+) -> QuotaSummary:
+    """Build a clean, pre-computed quota summary for the /me/quota endpoint.
+
+    Returns a flat, human-readable structure with ``remaining`` already
+    calculated and ``resets_at`` as an ISO date string so the frontend can
+    render a quota card without any arithmetic.
+
+    Example response when daily token cap is 50 000 and 42 000 are used::
+
+        {
+          "unlimited": false,
+          "period": "daily",
+          "resets_at": "2026-06-20",
+          "total_tokens": {"used": 42000, "limit": 50000, "remaining": 8000},
+          "input_tokens": null,
+          "output_tokens": null,
+          "messages": null
+        }
+    """
+    limits = await get_effective_usage_limits(user_id, db=db)
+    if not limits or not limits.enabled:
+        return QuotaSummary(unlimited=True)
+
+    usage = await get_user_usage_for_period(user_id, limits.period, db=db)
+
+    return QuotaSummary(
+        unlimited=False,
+        period=limits.period,
+        resets_at=_period_end_date_str(limits.period),
+        total_tokens=_dimension(usage.get("total_tokens", 0), limits.max_total_tokens),
+        input_tokens=_dimension(usage.get("input_tokens", 0), limits.max_input_tokens),
+        output_tokens=_dimension(usage.get("output_tokens", 0), limits.max_output_tokens),
+        messages=_dimension(usage.get("message_count", 0), limits.max_messages),
+    )

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -36,7 +36,7 @@ from fastapi import HTTPException
 from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.groups import Groups
 from open_webui.models.users import Users
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -54,10 +54,10 @@ class UsageLimitsConfig(BaseModel):
     period: Literal['daily', 'weekly', 'monthly'] = 'daily'
 
     # Optional per-period caps (None = unlimited for that dimension)
-    max_messages: int | None = None
-    max_input_tokens: int | None = None
-    max_output_tokens: int | None = None
-    max_total_tokens: int | None = None
+    max_messages: int | None = Field(default=None, ge=0)
+    max_input_tokens: int | None = Field(default=None, ge=0)
+    max_output_tokens: int | None = Field(default=None, ge=0)
+    max_total_tokens: int | None = Field(default=None, ge=0)
 
     model_config = {'extra': 'ignore'}
 
@@ -80,7 +80,7 @@ class QuotaDimension(BaseModel):
 
 
 class QuotaSummary(BaseModel):
-    """Clean, pre-computed quota summary for the user-facing /me/quota endpoint.
+    """Clean, pre-computed quota summary for the GET /user/quota endpoint.
 
     When no limits are configured, ``unlimited`` is True and all dimension
     fields are None — the frontend can gate on that flag without inspecting

--- a/backend/open_webui/utils/usage_limits.py
+++ b/backend/open_webui/utils/usage_limits.py
@@ -128,11 +128,13 @@ def get_period_end_ts(period: str) -> int:
         days_to_sunday = 6 - now.weekday()
         end = (now + timedelta(days=days_to_sunday)).replace(hour=23, minute=59, second=59, microsecond=999999)
     elif period == 'monthly':
+        # Reset to midnight before subtracting 1 µs so the result is the last
+        # microsecond of the current month, not the first day of the next month.
         if now.month == 12:
-            first_of_next = now.replace(year=now.year + 1, month=1, day=1)
+            first_of_next = now.replace(year=now.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
         else:
-            first_of_next = now.replace(month=now.month + 1, day=1)
-        end = (first_of_next - timedelta(seconds=1)).replace(hour=23, minute=59, second=59, microsecond=999999)
+            first_of_next = now.replace(month=now.month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
+        end = first_of_next - timedelta(microseconds=1)
     else:
         raise ValueError(f'Unknown period: {period!r}')
     return int(end.timestamp())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,34 @@
+"""
+Stub out open_webui modules that require a live database or heavy system
+dependencies, so unit tests can import and exercise pure logic without a
+running database or full dependency installation.
+
+This file is loaded by pytest before any test collection begins.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def _stub(name: str) -> ModuleType:
+    """Register a fresh stub module under the given dotted name."""
+    m = ModuleType(name)
+    sys.modules[name] = m
+    return m
+
+
+# ── open_webui.models.users ───────────────────────────────────────────────────
+users_mod = _stub("open_webui.models.users")
+users_mod.Users = MagicMock()
+users_mod.UserModel = MagicMock()
+
+# ── open_webui.models.groups ──────────────────────────────────────────────────
+groups_mod = _stub("open_webui.models.groups")
+groups_mod.Groups = MagicMock()
+groups_mod.GroupMember = MagicMock()
+groups_mod.GroupUpdateForm = MagicMock()
+
+# ── open_webui.models.chat_messages ──────────────────────────────────────────
+chat_messages_mod = _stub("open_webui.models.chat_messages")
+chat_messages_mod.ChatMessages = MagicMock()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,16 +19,16 @@ def _stub(name: str) -> ModuleType:
 
 
 # ── open_webui.models.users ───────────────────────────────────────────────────
-users_mod = _stub("open_webui.models.users")
+users_mod = _stub('open_webui.models.users')
 users_mod.Users = MagicMock()
 users_mod.UserModel = MagicMock()
 
 # ── open_webui.models.groups ──────────────────────────────────────────────────
-groups_mod = _stub("open_webui.models.groups")
+groups_mod = _stub('open_webui.models.groups')
 groups_mod.Groups = MagicMock()
 groups_mod.GroupMember = MagicMock()
 groups_mod.GroupUpdateForm = MagicMock()
 
 # ── open_webui.models.chat_messages ──────────────────────────────────────────
-chat_messages_mod = _stub("open_webui.models.chat_messages")
+chat_messages_mod = _stub('open_webui.models.chat_messages')
 chat_messages_mod.ChatMessages = MagicMock()

--- a/backend/tests/test_usage_limits.py
+++ b/backend/tests/test_usage_limits.py
@@ -74,6 +74,18 @@ class TestPeriodHelpers:
         for period in ('daily', 'weekly', 'monthly'):
             assert get_period_end_ts(period) > get_period_start_ts(period)
 
+    def test_monthly_end_is_last_day_of_current_month(self):
+        """Regression: monthly period end must be last day of the current month,
+        not the first day of the next month (TOCTOU with time-of-day offset)."""
+        end_ts = get_period_end_ts('monthly')
+        end_dt = datetime.fromtimestamp(end_ts, tz=UTC)
+        now = datetime.now(UTC)
+        # The end date's month must equal the current month
+        assert end_dt.month == now.month, (
+            f'Monthly period end is {end_dt.date()} but current month is {now.month}; '
+            f'end must be in the same month as today'
+        )
+
     def test_unknown_period_raises(self):
         with pytest.raises(ValueError, match='Unknown period'):
             get_period_start_ts('yearly')

--- a/backend/tests/test_usage_limits.py
+++ b/backend/tests/test_usage_limits.py
@@ -21,6 +21,7 @@ from open_webui.utils.usage_limits import (
     get_quota_summary,
     get_usage_status,
 )
+from pydantic import ValidationError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -697,11 +698,8 @@ class TestAdversarial:
 
     def test_negative_limit_rejected_by_schema(self):
         """Schema must reject negative cap values (ge=0 enforced by Field)."""
-        import pytest as _pytest
-        from pydantic import ValidationError
-
         for field in ('max_messages', 'max_input_tokens', 'max_output_tokens', 'max_total_tokens'):
-            with _pytest.raises(ValidationError):
+            with pytest.raises(ValidationError):
                 UsageLimitsConfig(**{field: -1})
 
     def test_zero_limit_config_is_immediately_blocking(self):

--- a/backend/tests/test_usage_limits.py
+++ b/backend/tests/test_usage_limits.py
@@ -1,0 +1,752 @@
+"""
+Tests for the per-user / per-group usage limit system.
+
+Run with:
+    cd backend && python -m pytest tests/test_usage_limits.py -v
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from open_webui.utils.usage_limits import (
+    QuotaDimension,
+    QuotaSummary,
+    UsageLimitsConfig,
+    UsageStatus,
+    _dimension,
+    _most_restrictive,
+    check_usage_limits,
+    get_effective_usage_limits,
+    get_period_end_ts,
+    get_period_start_ts,
+    get_quota_summary,
+    get_usage_status,
+    get_user_usage_for_period,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_user(info: Optional[dict] = None) -> MagicMock:
+    user = MagicMock()
+    user.id = "user-1"
+    user.info = info
+    return user
+
+
+def make_group(data: Optional[dict] = None) -> MagicMock:
+    group = MagicMock()
+    group.id = "group-1"
+    group.data = data
+    return group
+
+
+def make_limits(**kwargs) -> UsageLimitsConfig:
+    defaults = {"enabled": True, "period": "daily"}
+    return UsageLimitsConfig(**{**defaults, **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# Unit: period helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodHelpers:
+    def test_daily_start_is_midnight_utc(self):
+        ts = get_period_start_ts("daily")
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        assert dt.hour == 0
+        assert dt.minute == 0
+        assert dt.second == 0
+
+    def test_weekly_start_is_monday(self):
+        ts = get_period_start_ts("weekly")
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        assert dt.weekday() == 0  # Monday
+
+    def test_monthly_start_is_first_day(self):
+        ts = get_period_start_ts("monthly")
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        assert dt.day == 1
+        assert dt.hour == 0
+
+    def test_period_end_after_start(self):
+        for period in ("daily", "weekly", "monthly"):
+            assert get_period_end_ts(period) > get_period_start_ts(period)
+
+    def test_unknown_period_raises(self):
+        with pytest.raises(ValueError, match="Unknown period"):
+            get_period_start_ts("yearly")
+
+
+# ---------------------------------------------------------------------------
+# Unit: _most_restrictive
+# ---------------------------------------------------------------------------
+
+
+class TestMostRestrictive:
+    def test_single_config_returned_unchanged(self):
+        cfg = make_limits(period="daily", max_total_tokens=1000)
+        result = _most_restrictive([cfg])
+        assert result.max_total_tokens == 1000
+        assert result.period == "daily"
+
+    def test_daily_wins_over_weekly(self):
+        daily = make_limits(period="daily", max_total_tokens=5000)
+        weekly = make_limits(period="weekly", max_total_tokens=50000)
+        result = _most_restrictive([weekly, daily])
+        assert result.period == "daily"
+        assert result.max_total_tokens == 5000
+
+    def test_min_cap_across_same_period(self):
+        a = make_limits(period="daily", max_total_tokens=10000, max_messages=100)
+        b = make_limits(period="daily", max_total_tokens=5000, max_messages=200)
+        result = _most_restrictive([a, b])
+        assert result.max_total_tokens == 5000  # min(10000, 5000)
+        assert result.max_messages == 100  # min(100, 200)
+
+    def test_none_cap_ignored(self):
+        # If one group has no message cap, the other's cap wins
+        a = make_limits(period="daily", max_total_tokens=1000, max_messages=None)
+        b = make_limits(period="daily", max_total_tokens=2000, max_messages=50)
+        result = _most_restrictive([a, b])
+        assert result.max_messages == 50
+        assert result.max_total_tokens == 1000
+
+    def test_all_none_caps_stay_none(self):
+        a = make_limits(period="daily", max_total_tokens=None)
+        b = make_limits(period="daily", max_total_tokens=None)
+        result = _most_restrictive([a, b])
+        assert result.max_total_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: get_effective_usage_limits
+# ---------------------------------------------------------------------------
+
+
+class TestGetEffectiveLimits:
+    @pytest.mark.asyncio
+    async def test_user_with_no_info_returns_none(self):
+        user = make_user(info=None)
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[])
+            result = await get_effective_usage_limits("user-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_user_level_override_takes_priority(self):
+        user = make_user(
+            info={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 999}}
+        )
+        group = make_group(
+            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 50000}}
+        )
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
+            result = await get_effective_usage_limits("user-1")
+        assert result is not None
+        assert result.max_total_tokens == 999  # user override wins
+
+    @pytest.mark.asyncio
+    async def test_disabled_user_override_bypasses_group_limits(self):
+        # User has enabled=False — they should be exempt even if groups have limits
+        user = make_user(info={"usage_limits": {"enabled": False, "period": "daily"}})
+        group = make_group(
+            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 1000}}
+        )
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
+            result = await get_effective_usage_limits("user-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_group_limits_used_when_no_user_override(self):
+        user = make_user(info={})  # no usage_limits key
+        group = make_group(
+            data={"usage_limits": {"enabled": True, "period": "weekly", "max_total_tokens": 20000}}
+        )
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
+            result = await get_effective_usage_limits("user-1")
+        assert result is not None
+        assert result.period == "weekly"
+        assert result.max_total_tokens == 20000
+
+    @pytest.mark.asyncio
+    async def test_multiple_groups_most_restrictive_wins(self):
+        user = make_user(info={})
+        g1 = make_group(
+            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 10000}}
+        )
+        g2 = make_group(
+            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 5000}}
+        )
+        g2.id = "group-2"
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[g1, g2])
+            result = await get_effective_usage_limits("user-1")
+        assert result is not None
+        assert result.max_total_tokens == 5000  # most restrictive
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_returns_none(self):
+        with patch("open_webui.utils.usage_limits.Users") as mock_users:
+            mock_users.get_user_by_id = AsyncMock(return_value=None)
+            result = await get_effective_usage_limits("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_user_limits_json_falls_through_to_groups(self):
+        user = make_user(info={"usage_limits": "not-a-dict"})
+        group = make_group(
+            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 100}}
+        )
+        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
+            "open_webui.utils.usage_limits.Groups"
+        ) as mock_groups:
+            mock_users.get_user_by_id = AsyncMock(return_value=user)
+            mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
+            result = await get_effective_usage_limits("user-1")
+        # Malformed user config is ignored; group limit is used
+        assert result is not None
+        assert result.max_total_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# Unit: check_usage_limits
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUsageLimits:
+    @pytest.mark.asyncio
+    async def test_no_limits_configured_passes(self):
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=None),
+        ):
+            # Should not raise
+            await check_usage_limits("user-1")
+
+    @pytest.mark.asyncio
+    async def test_limits_disabled_passes(self):
+        disabled = UsageLimitsConfig(enabled=False, period="daily", max_total_tokens=100)
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=disabled),
+        ):
+            await check_usage_limits("user-1")
+
+    @pytest.mark.asyncio
+    async def test_under_limit_passes(self):
+        limits = make_limits(max_total_tokens=1000)
+        usage = {"total_tokens": 500, "message_count": 10, "input_tokens": 300, "output_tokens": 200}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            await check_usage_limits("user-1")
+
+    @pytest.mark.asyncio
+    async def test_token_limit_exceeded_raises_429(self):
+        limits = make_limits(max_total_tokens=1000)
+        usage = {"total_tokens": 1000, "message_count": 5, "input_tokens": 600, "output_tokens": 400}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limits("user-1")
+            assert exc_info.value.status_code == 429
+            detail = exc_info.value.detail
+            assert detail["error"] == "usage_limit_exceeded"
+            assert detail["limit_type"] == "total_tokens"
+            assert detail["limit"] == 1000
+            assert detail["current"] == 1000
+            assert "resets_at" in detail
+
+    @pytest.mark.asyncio
+    async def test_message_limit_exceeded_raises_429(self):
+        limits = make_limits(max_messages=50, max_total_tokens=None)
+        usage = {"total_tokens": 0, "message_count": 50}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limits("user-1")
+            assert exc_info.value.detail["limit_type"] == "messages"
+
+    @pytest.mark.asyncio
+    async def test_db_error_fails_open(self):
+        """DB errors during limit check must NOT block the user (fail open)."""
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(side_effect=RuntimeError("DB connection lost")),
+        ):
+            # Should not raise — fail open
+            await check_usage_limits("user-1")
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_limit_is_blocked(self):
+        """The check uses >=, so exactly hitting the limit is blocked."""
+        limits = make_limits(max_total_tokens=100)
+        usage = {"total_tokens": 100, "message_count": 0}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException):
+                await check_usage_limits("user-1")
+
+    @pytest.mark.asyncio
+    async def test_input_token_limit_checked_independently(self):
+        limits = make_limits(max_input_tokens=200, max_total_tokens=None)
+        usage = {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250, "message_count": 3}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limits("user-1")
+            assert exc_info.value.detail["limit_type"] == "input_tokens"
+
+
+# ---------------------------------------------------------------------------
+# Unit: get_usage_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsageStatus:
+    @pytest.mark.asyncio
+    async def test_no_limits_returns_empty_status(self):
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=None),
+        ):
+            status = await get_usage_status("user-1")
+        assert status.limits is None
+        assert status.usage == {}
+
+    @pytest.mark.asyncio
+    async def test_with_limits_returns_populated_status(self):
+        limits = make_limits(max_total_tokens=5000)
+        usage = {"total_tokens": 1234, "message_count": 7}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            status = await get_usage_status("user-1")
+        assert status.limits is not None
+        assert status.limits.max_total_tokens == 5000
+        assert status.usage["total_tokens"] == 1234
+        assert status.period_start is not None
+        assert status.period_end is not None
+        assert status.period_end > status.period_start
+
+
+# ---------------------------------------------------------------------------
+# Integration: UsageLimitsConfig schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestUsageLimitsConfigSchema:
+    def test_default_is_disabled(self):
+        cfg = UsageLimitsConfig()
+        assert cfg.enabled is False
+
+    def test_extra_fields_ignored(self):
+        # Forward-compatibility: unknown fields should not cause validation errors
+        cfg = UsageLimitsConfig(enabled=True, period="daily", future_field="value")
+        assert cfg.enabled is True
+
+    def test_round_trip_serialization(self):
+        original = UsageLimitsConfig(
+            enabled=True,
+            period="monthly",
+            max_total_tokens=100_000,
+            max_messages=500,
+        )
+        rehydrated = UsageLimitsConfig.model_validate(original.model_dump())
+        assert rehydrated == original
+
+    def test_invalid_period_rejected(self):
+        with pytest.raises(Exception):
+            UsageLimitsConfig(enabled=True, period="yearly")  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Unit: _dimension helper
+# ---------------------------------------------------------------------------
+
+
+class TestDimensionHelper:
+    def test_returns_none_when_limit_is_none(self):
+        assert _dimension(42_000, None) is None
+
+    def test_calculates_remaining(self):
+        d = _dimension(42_000, 50_000)
+        assert d is not None
+        assert d.used == 42_000
+        assert d.limit == 50_000
+        assert d.remaining == 8_000
+
+    def test_remaining_floors_at_zero(self):
+        # User somehow exceeded the limit (race condition, retroactive limit set)
+        d = _dimension(55_000, 50_000)
+        assert d is not None
+        assert d.remaining == 0
+
+    def test_zero_usage(self):
+        d = _dimension(0, 10_000)
+        assert d is not None
+        assert d.remaining == 10_000
+
+
+# ---------------------------------------------------------------------------
+# Unit: get_quota_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGetQuotaSummary:
+    @pytest.mark.asyncio
+    async def test_no_limits_returns_unlimited(self):
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=None),
+        ):
+            summary = await get_quota_summary("user-1")
+        assert summary.unlimited is True
+        assert summary.period is None
+        assert summary.resets_at is None
+        assert summary.total_tokens is None
+        assert summary.messages is None
+
+    @pytest.mark.asyncio
+    async def test_total_token_cap_populates_dimension(self):
+        limits = make_limits(period="daily", max_total_tokens=50_000)
+        usage = {
+            "total_tokens": 42_000,
+            "input_tokens": 30_000,
+            "output_tokens": 12_000,
+            "message_count": 15,
+        }
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            summary = await get_quota_summary("user-1")
+
+        assert summary.unlimited is False
+        assert summary.period == "daily"
+        assert summary.resets_at is not None
+        # resets_at must be a valid ISO date string
+        from datetime import date
+        date.fromisoformat(summary.resets_at)
+
+        assert summary.total_tokens is not None
+        assert summary.total_tokens.used == 42_000
+        assert summary.total_tokens.limit == 50_000
+        assert summary.total_tokens.remaining == 8_000
+
+        # Unconfigured dimensions must be null
+        assert summary.input_tokens is None
+        assert summary.output_tokens is None
+        assert summary.messages is None
+
+    @pytest.mark.asyncio
+    async def test_message_cap_only(self):
+        limits = make_limits(period="weekly", max_messages=100)
+        usage = {"total_tokens": 0, "message_count": 73}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            summary = await get_quota_summary("user-1")
+
+        assert summary.messages is not None
+        assert summary.messages.used == 73
+        assert summary.messages.limit == 100
+        assert summary.messages.remaining == 27
+        assert summary.total_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_multi_dimension_caps(self):
+        limits = make_limits(
+            period="monthly",
+            max_total_tokens=100_000,
+            max_messages=500,
+        )
+        usage = {"total_tokens": 60_000, "message_count": 200}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            summary = await get_quota_summary("user-1")
+
+        assert summary.total_tokens is not None
+        assert summary.total_tokens.remaining == 40_000
+        assert summary.messages is not None
+        assert summary.messages.remaining == 300
+
+    @pytest.mark.asyncio
+    async def test_resets_at_is_valid_iso_date(self):
+        for period in ("daily", "weekly", "monthly"):
+            limits = make_limits(period=period, max_total_tokens=1000)
+            usage = {"total_tokens": 0}
+            with patch(
+                "open_webui.utils.usage_limits.get_effective_usage_limits",
+                new=AsyncMock(return_value=limits),
+            ), patch(
+                "open_webui.utils.usage_limits.get_user_usage_for_period",
+                new=AsyncMock(return_value=usage),
+            ):
+                summary = await get_quota_summary("user-1")
+            from datetime import date
+            assert summary.resets_at is not None
+            # Must parse as a date without raising
+            parsed = date.fromisoformat(summary.resets_at)
+            assert parsed >= date.today()
+
+    @pytest.mark.asyncio
+    async def test_over_limit_remaining_is_zero_not_negative(self):
+        """remaining must floor at 0, not go negative (retroactive limit drop)."""
+        limits = make_limits(max_total_tokens=1_000)
+        usage = {"total_tokens": 5_000, "message_count": 0}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            summary = await get_quota_summary("user-1")
+
+        assert summary.total_tokens is not None
+        assert summary.total_tokens.remaining == 0  # not -4000
+
+
+# ---------------------------------------------------------------------------
+# PHASE 3 — Hostile adversarial tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    """Attempts to break the quota system under edge and hostile conditions."""
+
+    # ── Empty usage history ──────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_empty_usage_history_does_not_block(self):
+        """First request of a period must pass even with no prior messages."""
+        limits = make_limits(max_total_tokens=1000)
+        # Simulate no messages yet: get_token_usage_by_user returns empty dict
+        empty_usage = {"total_tokens": 0, "input_tokens": 0, "output_tokens": 0, "message_count": 0}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=empty_usage),
+        ):
+            await check_usage_limits("user-1")  # must NOT raise
+
+    # ── Missing token metadata ────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_missing_token_fields_treated_as_zero(self):
+        """Messages without usage metadata default to 0 — should not raise KeyError."""
+        limits = make_limits(max_total_tokens=500)
+        # Partial usage dict — no total_tokens key
+        sparse_usage = {"message_count": 3}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=sparse_usage),
+        ):
+            await check_usage_limits("user-1")  # 0 < 500, must pass
+
+    # ── Very large token counts ───────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_very_large_token_count_handled(self):
+        limits = make_limits(max_total_tokens=10_000_000)
+        usage = {"total_tokens": 10_000_001}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limits("user-1")
+            assert exc_info.value.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_over_limit_remaining_never_negative_in_quota(self):
+        limits = make_limits(max_total_tokens=100)
+        usage = {"total_tokens": 99_999_999}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            summary = await get_quota_summary("user-1")
+        assert summary.total_tokens is not None
+        assert summary.total_tokens.remaining == 0
+
+    # ── Invalid / malicious config ────────────────────────────────────────────
+
+    def test_negative_limit_rejected_by_schema(self):
+        """Pydantic should reject negative limits at the boundary."""
+        # Pydantic doesn't add gt=0 by default, but _dimension floors remaining at 0.
+        # Negative limits would behave oddly; verify _dimension handles gracefully.
+        d = _dimension(0, -1)
+        assert d is not None
+        # remaining = max(0, -1 - 0) = 0
+        assert d.remaining == 0
+
+    def test_zero_limit_config_is_immediately_blocking(self):
+        """A limit of 0 tokens means every request is blocked."""
+        d = _dimension(0, 0)
+        assert d is not None
+        assert d.remaining == 0
+
+    # ── Disabled quotas ───────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_disabled_quota_never_queries_db(self):
+        """When enabled=False, usage must not be queried (performance requirement)."""
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=None),
+        ) as mock_limits, patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+        ) as mock_usage:
+            await check_usage_limits("user-1")
+        mock_usage.assert_not_called()
+
+    # ── UTC rollover ──────────────────────────────────────────────────────────
+
+    def test_period_start_and_end_never_overlap(self):
+        """Period start must always be strictly before period end."""
+        for period in ("daily", "weekly", "monthly"):
+            start = get_period_start_ts(period)
+            end = get_period_end_ts(period)
+            assert start < end, f"{period}: start={start} not < end={end}"
+
+    def test_daily_period_covers_exactly_one_day(self):
+        start = get_period_start_ts("daily")
+        end = get_period_end_ts("daily")
+        duration_seconds = end - start
+        # Should be ~86399 seconds (23:59:59), never more than 86400
+        assert 86398 <= duration_seconds <= 86400
+
+    # ── Multiple dimensions: first hit blocks ─────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_message_limit_checked_before_token_limit(self):
+        """When both messages and tokens are limited, messages is checked first."""
+        limits = make_limits(max_messages=10, max_total_tokens=50000)
+        usage = {"message_count": 10, "total_tokens": 100}  # messages hit, tokens fine
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limits("user-1")
+            assert exc_info.value.detail["limit_type"] == "messages"
+
+    # ── Concurrent / idempotency ──────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_check_is_idempotent_under_limit(self):
+        """Calling check_usage_limits multiple times under the limit is safe."""
+        limits = make_limits(max_total_tokens=1000)
+        usage = {"total_tokens": 500, "message_count": 5}
+        with patch(
+            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            new=AsyncMock(return_value=limits),
+        ), patch(
+            "open_webui.utils.usage_limits.get_user_usage_for_period",
+            new=AsyncMock(return_value=usage),
+        ):
+            for _ in range(5):
+                await check_usage_limits("user-1")  # must always pass
+
+    # ── Quota summary edge cases ──────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_quota_summary_resets_at_is_in_future(self):
+        """resets_at must refer to a date >= today (can't be in the past)."""
+        from datetime import date
+        for period in ("daily", "weekly", "monthly"):
+            limits = make_limits(period=period, max_total_tokens=1000)
+            usage = {"total_tokens": 0}
+            with patch(
+                "open_webui.utils.usage_limits.get_effective_usage_limits",
+                new=AsyncMock(return_value=limits),
+            ), patch(
+                "open_webui.utils.usage_limits.get_user_usage_for_period",
+                new=AsyncMock(return_value=usage),
+            ):
+                summary = await get_quota_summary("user-1")
+            assert summary.resets_at is not None
+            assert date.fromisoformat(summary.resets_at) >= date.today()

--- a/backend/tests/test_usage_limits.py
+++ b/backend/tests/test_usage_limits.py
@@ -696,13 +696,13 @@ class TestAdversarial:
     # ── Invalid / malicious config ────────────────────────────────────────────
 
     def test_negative_limit_rejected_by_schema(self):
-        """Pydantic should reject negative limits at the boundary."""
-        # Pydantic doesn't add gt=0 by default, but _dimension floors remaining at 0.
-        # Negative limits would behave oddly; verify _dimension handles gracefully.
-        d = _dimension(0, -1)
-        assert d is not None
-        # remaining = max(0, -1 - 0) = 0
-        assert d.remaining == 0
+        """Schema must reject negative cap values (ge=0 enforced by Field)."""
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        for field in ('max_messages', 'max_input_tokens', 'max_output_tokens', 'max_total_tokens'):
+            with _pytest.raises(ValidationError):
+                UsageLimitsConfig(**{field: -1})
 
     def test_zero_limit_config_is_immediately_blocking(self):
         """A limit of 0 tokens means every request is blocked."""

--- a/backend/tests/test_usage_limits.py
+++ b/backend/tests/test_usage_limits.py
@@ -5,18 +5,13 @@ Run with:
     cd backend && python -m pytest tests/test_usage_limits.py -v
 """
 
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime  # noqa: ICN003
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-
 from open_webui.utils.usage_limits import (
-    QuotaDimension,
-    QuotaSummary,
     UsageLimitsConfig,
-    UsageStatus,
     _dimension,
     _most_restrictive,
     check_usage_limits,
@@ -25,31 +20,29 @@ from open_webui.utils.usage_limits import (
     get_period_start_ts,
     get_quota_summary,
     get_usage_status,
-    get_user_usage_for_period,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
-def make_user(info: Optional[dict] = None) -> MagicMock:
+def make_user(info: dict | None = None) -> MagicMock:
     user = MagicMock()
-    user.id = "user-1"
+    user.id = 'user-1'
     user.info = info
     return user
 
 
-def make_group(data: Optional[dict] = None) -> MagicMock:
+def make_group(data: dict | None = None) -> MagicMock:
     group = MagicMock()
-    group.id = "group-1"
+    group.id = 'group-1'
     group.data = data
     return group
 
 
 def make_limits(**kwargs) -> UsageLimitsConfig:
-    defaults = {"enabled": True, "period": "daily"}
+    defaults = {'enabled': True, 'period': 'daily'}
     return UsageLimitsConfig(**{**defaults, **kwargs})
 
 
@@ -60,30 +53,30 @@ def make_limits(**kwargs) -> UsageLimitsConfig:
 
 class TestPeriodHelpers:
     def test_daily_start_is_midnight_utc(self):
-        ts = get_period_start_ts("daily")
-        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        ts = get_period_start_ts('daily')
+        dt = datetime.fromtimestamp(ts, tz=UTC)
         assert dt.hour == 0
         assert dt.minute == 0
         assert dt.second == 0
 
     def test_weekly_start_is_monday(self):
-        ts = get_period_start_ts("weekly")
-        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        ts = get_period_start_ts('weekly')
+        dt = datetime.fromtimestamp(ts, tz=UTC)
         assert dt.weekday() == 0  # Monday
 
     def test_monthly_start_is_first_day(self):
-        ts = get_period_start_ts("monthly")
-        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        ts = get_period_start_ts('monthly')
+        dt = datetime.fromtimestamp(ts, tz=UTC)
         assert dt.day == 1
         assert dt.hour == 0
 
     def test_period_end_after_start(self):
-        for period in ("daily", "weekly", "monthly"):
+        for period in ('daily', 'weekly', 'monthly'):
             assert get_period_end_ts(period) > get_period_start_ts(period)
 
     def test_unknown_period_raises(self):
-        with pytest.raises(ValueError, match="Unknown period"):
-            get_period_start_ts("yearly")
+        with pytest.raises(ValueError, match='Unknown period'):
+            get_period_start_ts('yearly')
 
 
 # ---------------------------------------------------------------------------
@@ -93,36 +86,36 @@ class TestPeriodHelpers:
 
 class TestMostRestrictive:
     def test_single_config_returned_unchanged(self):
-        cfg = make_limits(period="daily", max_total_tokens=1000)
+        cfg = make_limits(period='daily', max_total_tokens=1000)
         result = _most_restrictive([cfg])
         assert result.max_total_tokens == 1000
-        assert result.period == "daily"
+        assert result.period == 'daily'
 
     def test_daily_wins_over_weekly(self):
-        daily = make_limits(period="daily", max_total_tokens=5000)
-        weekly = make_limits(period="weekly", max_total_tokens=50000)
+        daily = make_limits(period='daily', max_total_tokens=5000)
+        weekly = make_limits(period='weekly', max_total_tokens=50000)
         result = _most_restrictive([weekly, daily])
-        assert result.period == "daily"
+        assert result.period == 'daily'
         assert result.max_total_tokens == 5000
 
     def test_min_cap_across_same_period(self):
-        a = make_limits(period="daily", max_total_tokens=10000, max_messages=100)
-        b = make_limits(period="daily", max_total_tokens=5000, max_messages=200)
+        a = make_limits(period='daily', max_total_tokens=10000, max_messages=100)
+        b = make_limits(period='daily', max_total_tokens=5000, max_messages=200)
         result = _most_restrictive([a, b])
         assert result.max_total_tokens == 5000  # min(10000, 5000)
         assert result.max_messages == 100  # min(100, 200)
 
     def test_none_cap_ignored(self):
         # If one group has no message cap, the other's cap wins
-        a = make_limits(period="daily", max_total_tokens=1000, max_messages=None)
-        b = make_limits(period="daily", max_total_tokens=2000, max_messages=50)
+        a = make_limits(period='daily', max_total_tokens=1000, max_messages=None)
+        b = make_limits(period='daily', max_total_tokens=2000, max_messages=50)
         result = _most_restrictive([a, b])
         assert result.max_messages == 50
         assert result.max_total_tokens == 1000
 
     def test_all_none_caps_stay_none(self):
-        a = make_limits(period="daily", max_total_tokens=None)
-        b = make_limits(period="daily", max_total_tokens=None)
+        a = make_limits(period='daily', max_total_tokens=None)
+        b = make_limits(period='daily', max_total_tokens=None)
         result = _most_restrictive([a, b])
         assert result.max_total_tokens is None
 
@@ -136,100 +129,92 @@ class TestGetEffectiveLimits:
     @pytest.mark.asyncio
     async def test_user_with_no_info_returns_none(self):
         user = make_user(info=None)
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         assert result is None
 
     @pytest.mark.asyncio
     async def test_user_level_override_takes_priority(self):
-        user = make_user(
-            info={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 999}}
-        )
-        group = make_group(
-            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 50000}}
-        )
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        user = make_user(info={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 999}})
+        group = make_group(data={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 50000}})
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         assert result is not None
         assert result.max_total_tokens == 999  # user override wins
 
     @pytest.mark.asyncio
     async def test_disabled_user_override_bypasses_group_limits(self):
         # User has enabled=False — they should be exempt even if groups have limits
-        user = make_user(info={"usage_limits": {"enabled": False, "period": "daily"}})
-        group = make_group(
-            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 1000}}
-        )
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        user = make_user(info={'usage_limits': {'enabled': False, 'period': 'daily'}})
+        group = make_group(data={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 1000}})
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         assert result is None
 
     @pytest.mark.asyncio
     async def test_group_limits_used_when_no_user_override(self):
         user = make_user(info={})  # no usage_limits key
-        group = make_group(
-            data={"usage_limits": {"enabled": True, "period": "weekly", "max_total_tokens": 20000}}
-        )
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        group = make_group(data={'usage_limits': {'enabled': True, 'period': 'weekly', 'max_total_tokens': 20000}})
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         assert result is not None
-        assert result.period == "weekly"
+        assert result.period == 'weekly'
         assert result.max_total_tokens == 20000
 
     @pytest.mark.asyncio
     async def test_multiple_groups_most_restrictive_wins(self):
         user = make_user(info={})
-        g1 = make_group(
-            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 10000}}
-        )
-        g2 = make_group(
-            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 5000}}
-        )
-        g2.id = "group-2"
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        g1 = make_group(data={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 10000}})
+        g2 = make_group(data={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 5000}})
+        g2.id = 'group-2'
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[g1, g2])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         assert result is not None
         assert result.max_total_tokens == 5000  # most restrictive
 
     @pytest.mark.asyncio
     async def test_unknown_user_returns_none(self):
-        with patch("open_webui.utils.usage_limits.Users") as mock_users:
+        with patch('open_webui.utils.usage_limits.Users') as mock_users:
             mock_users.get_user_by_id = AsyncMock(return_value=None)
-            result = await get_effective_usage_limits("nonexistent")
+            result = await get_effective_usage_limits('nonexistent')
         assert result is None
 
     @pytest.mark.asyncio
     async def test_malformed_user_limits_json_falls_through_to_groups(self):
-        user = make_user(info={"usage_limits": "not-a-dict"})
-        group = make_group(
-            data={"usage_limits": {"enabled": True, "period": "daily", "max_total_tokens": 100}}
-        )
-        with patch("open_webui.utils.usage_limits.Users") as mock_users, patch(
-            "open_webui.utils.usage_limits.Groups"
-        ) as mock_groups:
+        user = make_user(info={'usage_limits': 'not-a-dict'})
+        group = make_group(data={'usage_limits': {'enabled': True, 'period': 'daily', 'max_total_tokens': 100}})
+        with (
+            patch('open_webui.utils.usage_limits.Users') as mock_users,
+            patch('open_webui.utils.usage_limits.Groups') as mock_groups,
+        ):
             mock_users.get_user_by_id = AsyncMock(return_value=user)
             mock_groups.get_groups_by_member_id = AsyncMock(return_value=[group])
-            result = await get_effective_usage_limits("user-1")
+            result = await get_effective_usage_limits('user-1')
         # Malformed user config is ignored; group limit is used
         assert result is not None
         assert result.max_total_tokens == 100
@@ -244,109 +229,124 @@ class TestCheckUsageLimits:
     @pytest.mark.asyncio
     async def test_no_limits_configured_passes(self):
         with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            'open_webui.utils.usage_limits.get_effective_usage_limits',
             new=AsyncMock(return_value=None),
         ):
             # Should not raise
-            await check_usage_limits("user-1")
+            await check_usage_limits('user-1')
 
     @pytest.mark.asyncio
     async def test_limits_disabled_passes(self):
-        disabled = UsageLimitsConfig(enabled=False, period="daily", max_total_tokens=100)
+        disabled = UsageLimitsConfig(enabled=False, period='daily', max_total_tokens=100)
         with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            'open_webui.utils.usage_limits.get_effective_usage_limits',
             new=AsyncMock(return_value=disabled),
         ):
-            await check_usage_limits("user-1")
+            await check_usage_limits('user-1')
 
     @pytest.mark.asyncio
     async def test_under_limit_passes(self):
         limits = make_limits(max_total_tokens=1000)
-        usage = {"total_tokens": 500, "message_count": 10, "input_tokens": 300, "output_tokens": 200}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 500, 'message_count': 10, 'input_tokens': 300, 'output_tokens': 200}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            await check_usage_limits("user-1")
+            await check_usage_limits('user-1')
 
     @pytest.mark.asyncio
     async def test_token_limit_exceeded_raises_429(self):
         limits = make_limits(max_total_tokens=1000)
-        usage = {"total_tokens": 1000, "message_count": 5, "input_tokens": 600, "output_tokens": 400}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 1000, 'message_count': 5, 'input_tokens': 600, 'output_tokens': 400}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await check_usage_limits("user-1")
+                await check_usage_limits('user-1')
             assert exc_info.value.status_code == 429
             detail = exc_info.value.detail
-            assert detail["error"] == "usage_limit_exceeded"
-            assert detail["limit_type"] == "total_tokens"
-            assert detail["limit"] == 1000
-            assert detail["current"] == 1000
-            assert "resets_at" in detail
+            assert detail['error'] == 'usage_limit_exceeded'
+            assert detail['limit_type'] == 'total_tokens'
+            assert detail['limit'] == 1000
+            assert detail['current'] == 1000
+            assert 'resets_at' in detail
 
     @pytest.mark.asyncio
     async def test_message_limit_exceeded_raises_429(self):
         limits = make_limits(max_messages=50, max_total_tokens=None)
-        usage = {"total_tokens": 0, "message_count": 50}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 0, 'message_count': 50}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await check_usage_limits("user-1")
-            assert exc_info.value.detail["limit_type"] == "messages"
+                await check_usage_limits('user-1')
+            assert exc_info.value.detail['limit_type'] == 'messages'
 
     @pytest.mark.asyncio
     async def test_db_error_fails_open(self):
         """DB errors during limit check must NOT block the user (fail open)."""
         with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(side_effect=RuntimeError("DB connection lost")),
+            'open_webui.utils.usage_limits.get_effective_usage_limits',
+            new=AsyncMock(side_effect=RuntimeError('DB connection lost')),
         ):
             # Should not raise — fail open
-            await check_usage_limits("user-1")
+            await check_usage_limits('user-1')
 
     @pytest.mark.asyncio
     async def test_exactly_at_limit_is_blocked(self):
         """The check uses >=, so exactly hitting the limit is blocked."""
         limits = make_limits(max_total_tokens=100)
-        usage = {"total_tokens": 100, "message_count": 0}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 100, 'message_count': 0}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException):
-                await check_usage_limits("user-1")
+                await check_usage_limits('user-1')
 
     @pytest.mark.asyncio
     async def test_input_token_limit_checked_independently(self):
         limits = make_limits(max_input_tokens=200, max_total_tokens=None)
-        usage = {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250, "message_count": 3}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'input_tokens': 200, 'output_tokens': 50, 'total_tokens': 250, 'message_count': 3}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await check_usage_limits("user-1")
-            assert exc_info.value.detail["limit_type"] == "input_tokens"
+                await check_usage_limits('user-1')
+            assert exc_info.value.detail['limit_type'] == 'input_tokens'
 
 
 # ---------------------------------------------------------------------------
@@ -358,28 +358,31 @@ class TestGetUsageStatus:
     @pytest.mark.asyncio
     async def test_no_limits_returns_empty_status(self):
         with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            'open_webui.utils.usage_limits.get_effective_usage_limits',
             new=AsyncMock(return_value=None),
         ):
-            status = await get_usage_status("user-1")
+            status = await get_usage_status('user-1')
         assert status.limits is None
         assert status.usage == {}
 
     @pytest.mark.asyncio
     async def test_with_limits_returns_populated_status(self):
         limits = make_limits(max_total_tokens=5000)
-        usage = {"total_tokens": 1234, "message_count": 7}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 1234, 'message_count': 7}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            status = await get_usage_status("user-1")
+            status = await get_usage_status('user-1')
         assert status.limits is not None
         assert status.limits.max_total_tokens == 5000
-        assert status.usage["total_tokens"] == 1234
+        assert status.usage['total_tokens'] == 1234
         assert status.period_start is not None
         assert status.period_end is not None
         assert status.period_end > status.period_start
@@ -397,13 +400,13 @@ class TestUsageLimitsConfigSchema:
 
     def test_extra_fields_ignored(self):
         # Forward-compatibility: unknown fields should not cause validation errors
-        cfg = UsageLimitsConfig(enabled=True, period="daily", future_field="value")
+        cfg = UsageLimitsConfig(enabled=True, period='daily', future_field='value')
         assert cfg.enabled is True
 
     def test_round_trip_serialization(self):
         original = UsageLimitsConfig(
             enabled=True,
-            period="monthly",
+            period='monthly',
             max_total_tokens=100_000,
             max_messages=500,
         )
@@ -412,7 +415,7 @@ class TestUsageLimitsConfigSchema:
 
     def test_invalid_period_rejected(self):
         with pytest.raises(Exception):
-            UsageLimitsConfig(enabled=True, period="yearly")  # type: ignore
+            UsageLimitsConfig(enabled=True, period='yearly')  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -452,10 +455,10 @@ class TestGetQuotaSummary:
     @pytest.mark.asyncio
     async def test_no_limits_returns_unlimited(self):
         with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
+            'open_webui.utils.usage_limits.get_effective_usage_limits',
             new=AsyncMock(return_value=None),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
         assert summary.unlimited is True
         assert summary.period is None
         assert summary.resets_at is None
@@ -464,27 +467,31 @@ class TestGetQuotaSummary:
 
     @pytest.mark.asyncio
     async def test_total_token_cap_populates_dimension(self):
-        limits = make_limits(period="daily", max_total_tokens=50_000)
+        limits = make_limits(period='daily', max_total_tokens=50_000)
         usage = {
-            "total_tokens": 42_000,
-            "input_tokens": 30_000,
-            "output_tokens": 12_000,
-            "message_count": 15,
+            'total_tokens': 42_000,
+            'input_tokens': 30_000,
+            'output_tokens': 12_000,
+            'message_count': 15,
         }
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
 
         assert summary.unlimited is False
-        assert summary.period == "daily"
+        assert summary.period == 'daily'
         assert summary.resets_at is not None
         # resets_at must be a valid ISO date string
-        from datetime import date
+        from datetime import date  # noqa: ICN003
+
         date.fromisoformat(summary.resets_at)
 
         assert summary.total_tokens is not None
@@ -499,16 +506,19 @@ class TestGetQuotaSummary:
 
     @pytest.mark.asyncio
     async def test_message_cap_only(self):
-        limits = make_limits(period="weekly", max_messages=100)
-        usage = {"total_tokens": 0, "message_count": 73}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        limits = make_limits(period='weekly', max_messages=100)
+        usage = {'total_tokens': 0, 'message_count': 73}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
 
         assert summary.messages is not None
         assert summary.messages.used == 73
@@ -519,19 +529,22 @@ class TestGetQuotaSummary:
     @pytest.mark.asyncio
     async def test_multi_dimension_caps(self):
         limits = make_limits(
-            period="monthly",
+            period='monthly',
             max_total_tokens=100_000,
             max_messages=500,
         )
-        usage = {"total_tokens": 60_000, "message_count": 200}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 60_000, 'message_count': 200}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
 
         assert summary.total_tokens is not None
         assert summary.total_tokens.remaining == 40_000
@@ -540,18 +553,22 @@ class TestGetQuotaSummary:
 
     @pytest.mark.asyncio
     async def test_resets_at_is_valid_iso_date(self):
-        for period in ("daily", "weekly", "monthly"):
+        for period in ('daily', 'weekly', 'monthly'):
             limits = make_limits(period=period, max_total_tokens=1000)
-            usage = {"total_tokens": 0}
-            with patch(
-                "open_webui.utils.usage_limits.get_effective_usage_limits",
-                new=AsyncMock(return_value=limits),
-            ), patch(
-                "open_webui.utils.usage_limits.get_user_usage_for_period",
-                new=AsyncMock(return_value=usage),
+            usage = {'total_tokens': 0}
+            with (
+                patch(
+                    'open_webui.utils.usage_limits.get_effective_usage_limits',
+                    new=AsyncMock(return_value=limits),
+                ),
+                patch(
+                    'open_webui.utils.usage_limits.get_user_usage_for_period',
+                    new=AsyncMock(return_value=usage),
+                ),
             ):
-                summary = await get_quota_summary("user-1")
-            from datetime import date
+                summary = await get_quota_summary('user-1')
+            from datetime import date  # noqa: ICN003
+
             assert summary.resets_at is not None
             # Must parse as a date without raising
             parsed = date.fromisoformat(summary.resets_at)
@@ -561,15 +578,18 @@ class TestGetQuotaSummary:
     async def test_over_limit_remaining_is_zero_not_negative(self):
         """remaining must floor at 0, not go negative (retroactive limit drop)."""
         limits = make_limits(max_total_tokens=1_000)
-        usage = {"total_tokens": 5_000, "message_count": 0}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 5_000, 'message_count': 0}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
 
         assert summary.total_tokens is not None
         assert summary.total_tokens.remaining == 0  # not -4000
@@ -590,15 +610,18 @@ class TestAdversarial:
         """First request of a period must pass even with no prior messages."""
         limits = make_limits(max_total_tokens=1000)
         # Simulate no messages yet: get_token_usage_by_user returns empty dict
-        empty_usage = {"total_tokens": 0, "input_tokens": 0, "output_tokens": 0, "message_count": 0}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=empty_usage),
+        empty_usage = {'total_tokens': 0, 'input_tokens': 0, 'output_tokens': 0, 'message_count': 0}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=empty_usage),
+            ),
         ):
-            await check_usage_limits("user-1")  # must NOT raise
+            await check_usage_limits('user-1')  # must NOT raise
 
     # ── Missing token metadata ────────────────────────────────────────────────
 
@@ -607,45 +630,54 @@ class TestAdversarial:
         """Messages without usage metadata default to 0 — should not raise KeyError."""
         limits = make_limits(max_total_tokens=500)
         # Partial usage dict — no total_tokens key
-        sparse_usage = {"message_count": 3}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=sparse_usage),
+        sparse_usage = {'message_count': 3}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=sparse_usage),
+            ),
         ):
-            await check_usage_limits("user-1")  # 0 < 500, must pass
+            await check_usage_limits('user-1')  # 0 < 500, must pass
 
     # ── Very large token counts ───────────────────────────────────────────────
 
     @pytest.mark.asyncio
     async def test_very_large_token_count_handled(self):
         limits = make_limits(max_total_tokens=10_000_000)
-        usage = {"total_tokens": 10_000_001}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 10_000_001}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await check_usage_limits("user-1")
+                await check_usage_limits('user-1')
             assert exc_info.value.status_code == 429
 
     @pytest.mark.asyncio
     async def test_over_limit_remaining_never_negative_in_quota(self):
         limits = make_limits(max_total_tokens=100)
-        usage = {"total_tokens": 99_999_999}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 99_999_999}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
-            summary = await get_quota_summary("user-1")
+            summary = await get_quota_summary('user-1')
         assert summary.total_tokens is not None
         assert summary.total_tokens.remaining == 0
 
@@ -671,27 +703,30 @@ class TestAdversarial:
     @pytest.mark.asyncio
     async def test_disabled_quota_never_queries_db(self):
         """When enabled=False, usage must not be queried (performance requirement)."""
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=None),
-        ) as mock_limits, patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-        ) as mock_usage:
-            await check_usage_limits("user-1")
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+            ) as mock_usage,
+        ):
+            await check_usage_limits('user-1')
         mock_usage.assert_not_called()
 
     # ── UTC rollover ──────────────────────────────────────────────────────────
 
     def test_period_start_and_end_never_overlap(self):
         """Period start must always be strictly before period end."""
-        for period in ("daily", "weekly", "monthly"):
+        for period in ('daily', 'weekly', 'monthly'):
             start = get_period_start_ts(period)
             end = get_period_end_ts(period)
-            assert start < end, f"{period}: start={start} not < end={end}"
+            assert start < end, f'{period}: start={start} not < end={end}'
 
     def test_daily_period_covers_exactly_one_day(self):
-        start = get_period_start_ts("daily")
-        end = get_period_end_ts("daily")
+        start = get_period_start_ts('daily')
+        end = get_period_end_ts('daily')
         duration_seconds = end - start
         # Should be ~86399 seconds (23:59:59), never more than 86400
         assert 86398 <= duration_seconds <= 86400
@@ -702,17 +737,20 @@ class TestAdversarial:
     async def test_message_limit_checked_before_token_limit(self):
         """When both messages and tokens are limited, messages is checked first."""
         limits = make_limits(max_messages=10, max_total_tokens=50000)
-        usage = {"message_count": 10, "total_tokens": 100}  # messages hit, tokens fine
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'message_count': 10, 'total_tokens': 100}  # messages hit, tokens fine
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await check_usage_limits("user-1")
-            assert exc_info.value.detail["limit_type"] == "messages"
+                await check_usage_limits('user-1')
+            assert exc_info.value.detail['limit_type'] == 'messages'
 
     # ── Concurrent / idempotency ──────────────────────────────────────────────
 
@@ -720,33 +758,40 @@ class TestAdversarial:
     async def test_check_is_idempotent_under_limit(self):
         """Calling check_usage_limits multiple times under the limit is safe."""
         limits = make_limits(max_total_tokens=1000)
-        usage = {"total_tokens": 500, "message_count": 5}
-        with patch(
-            "open_webui.utils.usage_limits.get_effective_usage_limits",
-            new=AsyncMock(return_value=limits),
-        ), patch(
-            "open_webui.utils.usage_limits.get_user_usage_for_period",
-            new=AsyncMock(return_value=usage),
+        usage = {'total_tokens': 500, 'message_count': 5}
+        with (
+            patch(
+                'open_webui.utils.usage_limits.get_effective_usage_limits',
+                new=AsyncMock(return_value=limits),
+            ),
+            patch(
+                'open_webui.utils.usage_limits.get_user_usage_for_period',
+                new=AsyncMock(return_value=usage),
+            ),
         ):
             for _ in range(5):
-                await check_usage_limits("user-1")  # must always pass
+                await check_usage_limits('user-1')  # must always pass
 
     # ── Quota summary edge cases ──────────────────────────────────────────────
 
     @pytest.mark.asyncio
     async def test_quota_summary_resets_at_is_in_future(self):
         """resets_at must refer to a date >= today (can't be in the past)."""
-        from datetime import date
-        for period in ("daily", "weekly", "monthly"):
+        from datetime import date  # noqa: ICN003
+
+        for period in ('daily', 'weekly', 'monthly'):
             limits = make_limits(period=period, max_total_tokens=1000)
-            usage = {"total_tokens": 0}
-            with patch(
-                "open_webui.utils.usage_limits.get_effective_usage_limits",
-                new=AsyncMock(return_value=limits),
-            ), patch(
-                "open_webui.utils.usage_limits.get_user_usage_for_period",
-                new=AsyncMock(return_value=usage),
+            usage = {'total_tokens': 0}
+            with (
+                patch(
+                    'open_webui.utils.usage_limits.get_effective_usage_limits',
+                    new=AsyncMock(return_value=limits),
+                ),
+                patch(
+                    'open_webui.utils.usage_limits.get_user_usage_for_period',
+                    new=AsyncMock(return_value=usage),
+                ),
             ):
-                summary = await get_quota_summary("user-1")
+                summary = await get_quota_summary('user-1')
             assert summary.resets_at is not None
             assert date.fromisoformat(summary.resets_at) >= date.today()


### PR DESCRIPTION
> **Community discussion:** #26755 (opened before this PR per contributor guidelines)

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #6692, relates to #23323 and #1430. Community discussion: #26755
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** 54 unit tests; ruff clean; manual test plan listed.
- [x] **No Unchecked AI Code:** Implementation reviewed and validated; Copilot-flagged bug fixed before resubmission.
- [x] **Self-Review:** Performed; code follows project conventions.
- [x] **Architecture:** No new settings UI — limits stored in existing JSON columns; no DB migration required.
- [x] **Git Hygiene:** Rebased on `dev`; logically grouped commits.
- [x] **Title Prefix:** `feat:`

> **History:** PRs #26195 (wrong base branch) and #26196 (missing CLA + wrong base) were closed. PR #26197 was closed without comment — identified the missing Discussion step, opened #26755 first, then resubmitted here. All Copilot review findings from #26196 have been addressed (see "Fixes from review" below).

---

# Changelog Entry

### Description

Issues #6692, #23323, and #1430 request per-user/group usage quotas with visibility. Open WebUI already collects per-message token data in `chat_message` — this PR adds the missing enforcement and self-service visibility layer on top of that existing data.

### Added

- `backend/open_webui/utils/usage_limits.py` — new module:
  - `UsageLimitsConfig` pydantic schema stored in existing `User.info['usage_limits']` / `Group.data['usage_limits']` JSON columns (zero DB migrations)
  - Priority resolution: user-level override → most restrictive group limit → unlimited
  - `check_usage_limits(user_id)`: pre-flight enforcement; raises HTTP 429 with structured payload (`error`, `limit_type`, `period`, `limit`, `current`, `resets_at`)
  - `get_quota_summary(user_id)`: `QuotaSummary` with pre-calculated `remaining` and ISO 8601 `resets_at`
  - Period helpers for daily / weekly / monthly; fail-open on DB errors

- Four new endpoints in `routers/users.py`:
  - `GET /api/v1/users/user/quota` → `QuotaSummary` (any verified user)
  - `GET /api/v1/users/user/usage` → `UsageStatus` (any verified user)
  - `GET /api/v1/users/{user_id}/usage-limits` → admin
  - `PUT /api/v1/users/{user_id}/usage-limits` → admin; `null` body removes override

- Two new endpoints in `routers/groups.py`:
  - `GET /api/v1/groups/id/{id}/usage-limits` → admin
  - `PUT /api/v1/groups/id/{id}/usage-limits` → admin

- `backend/tests/` — 54 unit tests, no live DB required

### Changed

- `utils/chat.py`: `await check_usage_limits(user.id)` after `check_model_access`; skipped for `role == 'admin'` and `bypass_filter=True`
- `models/chat_messages.py`: optional `user_id` filter on `get_token_usage_by_user()` (backward-compatible)

### Fixes from Copilot review on #26196

| Issue | Fix |
|---|---|
| **Monthly period-end bug**: `first_of_next` kept time-of-day offset, so result was first day of next month not last day of current | Reset to midnight before subtracting 1 µs. Regression test added. |
| Formatting: double quotes throughout | `ruff format` applied |
| Unused imports in tests | Removed; `response_model=QuotaSummary/UsageStatus` added to endpoints |
| `Optional[X]` on PUT params (UP045) | Changed to `X \| None` |
| Import ordering in `users.py` (I001) | Fixed |

### Example responses

**`GET /api/v1/users/user/quota`**
```json
{
  "unlimited": false,
  "period": "daily",
  "resets_at": "2026-06-19",
  "total_tokens": { "used": 42000, "limit": 50000, "remaining": 8000 },
  "input_tokens": null,
  "output_tokens": null,
  "messages": null
}
```

**HTTP 429 when limit exceeded**
```json
{
  "detail": {
    "error": "usage_limit_exceeded",
    "limit_type": "total_tokens",
    "period": "daily",
    "limit": 50000,
    "current": 51200,
    "resets_at": 1750377599
  }
}
```

### Known limitations (documented in module docstring)

- **TOCTOU race**: concurrent requests can briefly overshoot by `N_concurrent × tokens_per_request`. Limits are soft caps with small burst tolerance. Eliminating this requires Redis `INCR` or `SELECT FOR UPDATE` — out of scope.
- **Cross-period group merging**: only the shortest-period group's caps are enforced when groups have different periods.

### Test plan

- [x] 54 unit tests: `pytest backend/tests/` — 0 failures
- [x] `ruff check` + `ruff format --check` on all changed files — clean
- [ ] Manual: set `max_total_tokens=100` on a user → send chat → confirm HTTP 429
- [ ] Manual: `GET /api/v1/users/user/quota` shows correct `remaining` and `resets_at`
- [ ] Manual: `PUT` with `null` body removes the override
- [ ] Manual: group limit inherited when no user-level override set; admin always exempt

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.