### PR TITLE
fix: coerce persisted boolean config strings

### DIFF
--- a/backend/open_webui/models/config.py
+++ b/backend/open_webui/models/config.py
@@ -91,6 +91,20 @@ def _json_value(value: Any) -> Any:
     return jsonable_encoder(value)
 
 
+_CONFIG_DEFAULT_MISSING = object()
+
+
+def _coerce_value_for_key(key: str, value: Any, default: Any = _CONFIG_DEFAULT_MISSING) -> Any:
+    expected_value = Config.DEFAULTS[key] if key in Config.DEFAULTS else default
+    if isinstance(expected_value, bool) and isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == 'true':
+            return True
+        if normalized == 'false':
+            return False
+    return value
+
+
 # ── Model ────────────────────────────────────────────────────────────────────
 
 
@@ -140,7 +154,8 @@ class Config(Base):
             return Config.default_value(key, default)
         async with get_async_db() as db:
             row = await db.get(Config, key)
-            return row.value if row else Config.default_value(key, default)
+            value = row.value if row else Config.default_value(key, default)
+            return _coerce_value_for_key(key, value, default)
 
     @staticmethod
     async def get_many(*keys: str) -> dict:
@@ -155,7 +170,10 @@ class Config(Base):
             return disabled_values
         async with get_async_db() as db:
             result = await db.execute(select(Config).where(Config.key.in_(enabled_keys)))
-            values = {row.key: row.value for row in result.scalars().all()}
+            values = {
+                row.key: _coerce_value_for_key(row.key, row.value)
+                for row in result.scalars().all()
+            }
             return {
                 key: values.get(key, Config.default_value(key))
                 for key in keys
@@ -174,7 +192,10 @@ class Config(Base):
             return default_values
         async with get_async_db() as db:
             result = await db.execute(select(Config).where(Config.key.like(f'{namespace}.%')))
-            values = {row.key: row.value for row in result.scalars().all()}
+            values = {
+                row.key: _coerce_value_for_key(row.key, row.value)
+                for row in result.scalars().all()
+            }
             values.update(default_values)
             return values
 
@@ -185,7 +206,10 @@ class Config(Base):
             return dict(Config.DEFAULTS)
         async with get_async_db() as db:
             result = await db.execute(select(Config))
-            values = {row.key: row.value for row in result.scalars().all()}
+            values = {
+                row.key: _coerce_value_for_key(row.key, row.value)
+                for row in result.scalars().all()
+            }
             if not Config.OAUTH_PERSISTENT_ENABLED:
                 values.update({key: value for key, value in Config.DEFAULTS.items() if key.startswith('oauth.')})
             return values

--- a/test/models/test_config.py
+++ b/test/models/test_config.py
@@ -1,0 +1,152 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+from open_webui.models import config as config_module
+from open_webui.models.config import Config
+
+
+class FakeResult:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.rows
+
+
+class FakeDB:
+    def __init__(self, rows):
+        self.rows = {row.key: row for row in rows}
+
+    async def get(self, model, key):
+        return self.rows.get(key)
+
+    async def execute(self, statement):
+        return FakeResult(list(self.rows.values()))
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    defaults = dict(Config.DEFAULTS)
+    persistent_enabled = Config.PERSISTENT_ENABLED
+    oauth_persistent_enabled = Config.OAUTH_PERSISTENT_ENABLED
+    yield
+    Config.configure(
+        defaults=defaults,
+        enable_persistent=persistent_enabled,
+        enable_oauth_persistent=oauth_persistent_enabled,
+    )
+
+
+def patch_db(monkeypatch, rows):
+    @asynccontextmanager
+    async def fake_get_async_db():
+        yield FakeDB(rows)
+
+    monkeypatch.setattr(config_module, 'get_async_db', fake_get_async_db)
+
+
+def row(key, value):
+    return SimpleNamespace(key=key, value=value)
+
+
+@pytest.mark.asyncio
+async def test_get_coerces_string_boolean_for_boolean_config(monkeypatch):
+    Config.configure(
+        defaults={
+            'memories.system_context.enable': True,
+            'ui.name': 'Open WebUI',
+        },
+        enable_persistent=True,
+    )
+    patch_db(
+        monkeypatch,
+        [
+            row('memories.system_context.enable', 'false'),
+            row('ui.name', 'false'),
+            row('custom.flag', 'false'),
+        ],
+    )
+
+    assert await Config.get('memories.system_context.enable') is False
+    assert await Config.get('ui.name') == 'false'
+    assert await Config.get('custom.flag', False) is False
+
+
+@pytest.mark.asyncio
+async def test_get_many_coerces_boolean_config_values(monkeypatch):
+    Config.configure(
+        defaults={
+            'memories.system_context.enable': True,
+            'auth.enable_api_keys': False,
+            'ui.name': 'Open WebUI',
+        },
+        enable_persistent=True,
+    )
+    patch_db(
+        monkeypatch,
+        [
+            row('memories.system_context.enable', 'false'),
+            row('auth.enable_api_keys', 'true'),
+            row('ui.name', 'false'),
+        ],
+    )
+
+    values = await Config.get_many('memories.system_context.enable', 'auth.enable_api_keys', 'ui.name')
+
+    assert values == {
+        'memories.system_context.enable': False,
+        'auth.enable_api_keys': True,
+        'ui.name': 'false',
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_namespace_coerces_boolean_config_values(monkeypatch):
+    Config.configure(
+        defaults={
+            'memories.system_context.enable': True,
+            'memories.background_review.enable': False,
+        },
+        enable_persistent=True,
+    )
+    patch_db(
+        monkeypatch,
+        [
+            row('memories.system_context.enable', 'false'),
+            row('memories.background_review.enable', 'true'),
+        ],
+    )
+
+    values = await Config.get_namespace('memories')
+
+    assert values == {
+        'memories.system_context.enable': False,
+        'memories.background_review.enable': True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_all_coerces_boolean_config_values(monkeypatch):
+    Config.configure(
+        defaults={
+            'ui.enable_signup': True,
+            'ui.name': 'Open WebUI',
+        },
+        enable_persistent=True,
+    )
+    patch_db(
+        monkeypatch,
+        [
+            row('ui.enable_signup', 'false'),
+            row('ui.name', 'false'),
+        ],
+    )
+
+    values = await Config.get_all()
+
+    assert values['ui.enable_signup'] is False
+    assert values['ui.name'] == 'false'


### PR DESCRIPTION
﻿# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes #26761.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Coerces persisted string boolean values for boolean-backed config keys.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes needed for this backend bug fix.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Added and ran focused config model tests.
- [ ] **No Unchecked AI Code:** Please review before merge.
- [x] **Self-Review:** The code path and tests have been reviewed locally.
- [x] **Architecture:** Uses existing config defaults to infer boolean-backed keys; no new settings.
- [x] **Git Hygiene:** Atomic branch rebased on `dev`.
- [x] **Title Prefix:** Uses `fix:`.

# Changelog Entry

### Description

- Normalize persisted boolean config values when reading from the per-key config table.

### Added

- Focused tests for `Config.get`, `Config.get_many`, `Config.get_namespace`, and `Config.get_all` when boolean config rows contain string values.

### Changed

- Boolean-backed config keys now coerce persisted string values of `"true"` and `"false"` to real Python booleans on read.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed boolean feature flags such as `memories.system_context.enable` remaining truthy when a persisted DB value is the string `"false"`.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Test command: `pytest test/models/test_config.py -q`
- Lint command: `ruff check backend/open_webui/models/config.py test/models/test_config.py --ignore C901`

### Screenshots or Videos

- Not applicable; backend config handling fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

