### PR TITLE
fix: add global keyboard focus indicator (WCAG 2.4.7)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -839,3 +839,53 @@ body {
 #note-content-container .ProseMirror {
 	padding-bottom: 2rem; /* space for the bottom toolbar */
 }
+
+/*
+  Accessibility: global keyboard focus indicator (WCAG 2.1 SC 2.4.7 Focus Visible).
+
+  Many interactive elements apply Tailwind's `outline-hidden` / `outline-none`,
+  which strips the browser's default focus ring, leaving keyboard and assistive
+  technology users with no visible indication of focus. We restore a visible
+  indicator using an inset `box-shadow` (not `outline`): an inset ring is painted
+  inside the element's own box, so it cannot be clipped by an ancestor's
+  `overflow` (e.g. horizontally scrollable toolbars). `:focus-visible` scopes it
+  to keyboard / AT navigation so mouse clicks don't get a persistent ring, and
+  `!important` ensures per-element shadow utilities can't hide it.
+*/
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible,
+[role='button']:focus-visible,
+[role='link']:focus-visible,
+[role='menuitem']:focus-visible,
+[role='tab']:focus-visible,
+[role='checkbox']:focus-visible,
+[role='switch']:focus-visible,
+[role='option']:focus-visible,
+[contenteditable='true']:focus-visible {
+	outline: 2px solid transparent; /* visible in Windows High Contrast / forced-colors mode */
+	box-shadow: inset 0 0 0 2px #3b82f6 !important; /* blue-500 */
+	border-radius: 2px;
+}
+
+html.dark a:focus-visible,
+html.dark button:focus-visible,
+html.dark input:focus-visible,
+html.dark select:focus-visible,
+html.dark textarea:focus-visible,
+html.dark summary:focus-visible,
+html.dark [tabindex]:focus-visible,
+html.dark [role='button']:focus-visible,
+html.dark [role='link']:focus-visible,
+html.dark [role='menuitem']:focus-visible,
+html.dark [role='tab']:focus-visible,
+html.dark [role='checkbox']:focus-visible,
+html.dark [role='switch']:focus-visible,
+html.dark [role='option']:focus-visible,
+html.dark [contenteditable='true']:focus-visible {
+	box-shadow: inset 0 0 0 2px #60a5fa !important; /* blue-400, brighter for dark backgrounds */
+}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #2790 (accessibility).
- [x] **Target branch:** `dev`.
- [x] **Description:** provided below.
- [x] **Changelog:** included below.
- [x] **Testing:** manual keyboard + screen-reader testing performed (details below).
- [x] **No Unchecked AI Code:** human-reviewed and manually tested.
- [x] **Self-Review:** performed.
- [x] **Git Hygiene:** atomic single-file change, rebased on `dev`.

## Summary

Adds a global keyboard focus indicator so keyboard and assistive-technology users can see which element is focused. **WCAG 2.1 SC 2.4.7 Focus Visible (Level AA).**

## Problem

Many interactive elements across the app apply Tailwind's `outline-hidden` / `outline-none`, which removes the browser's default focus ring. There is no global replacement, so when navigating by keyboard there is often **no visible indication of which control is focused** — a failure of SC 2.4.7 and a significant barrier for keyboard-only and low-vision users.

## Fix

A single addition to `src/app.css`: a `:focus-visible` rule that restores a visible focus ring on interactive elements (links, buttons, inputs, selects, textareas, `summary`, `[tabindex]`, and common ARIA roles).

Design choices:
- **`box-shadow` (inset), not `outline`** — an inset ring is painted inside the element's own box, so it cannot be clipped by an ancestor's `overflow` (e.g. horizontally scrollable toolbars, where an outset ring gets cut off).
- **`:focus-visible`** — scopes the ring to keyboard/AT navigation, so mouse clicks don't get a persistent ring.
- **`!important`** — ensures per-element shadow utilities can't suppress the focus indicator.
- **Dark-theme variant** — uses a brighter blue (`#60a5fa`) for contrast on dark backgrounds; light theme uses `#3b82f6`. Both exceed the 3:1 non-text contrast minimum (SC 1.4.11).
- A transparent `outline` is included so the indicator remains visible in Windows High Contrast / forced-colors mode.

## Before / After

- **Before:** Tabbing through the sidebar, chat input, message actions, and menus shows no visible focus; users cannot tell where they are.
- **After:** Every focused interactive element shows a clear blue ring in both light and dark themes.

## Testing

- Built and ran this branch locally (`vite dev`) against a v0.10.2 backend.
- **Keyboard-only:** tabbed through login, sidebar navigation, chat input, and message controls — focus ring visible on every interactive element.
- **Themes:** verified in both light and dark mode.
- **Screen reader:** macOS VoiceOver used alongside keyboard navigation.
- CSS-only change; `prettier --check` passes.

## Context

This stems from deploying Open WebUI for university coursework, where the platform must meet institutional digital-accessibility obligations (ADA Title II / Section 508, WCAG 2.1 AA). Sharing the fixes upstream so the whole community benefits.

# Changelog Entry

### Description

- Add a global keyboard focus indicator for interactive elements (WCAG 2.4.7 Focus Visible).

### Fixed

- Keyboard focus was not visible on many controls because `outline-hidden`/`outline-none` removed the default focus ring with no replacement.
