### PR TITLE
fix: meet 4.5:1 text contrast for muted grays in light theme (WCAG 1.4.3)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -839,3 +839,26 @@ body {
 #note-content-container .ProseMirror {
 	padding-bottom: 2rem; /* space for the bottom toolbar */
 }
+
+/*
+  Accessibility: light-theme text contrast (WCAG 2.1 SC 1.4.3 Contrast Minimum, 4.5:1).
+
+  The muted grays used for secondary text fail 4.5:1 on white in light mode
+  (gray-500 = 2.77:1, gray-400 = 2.07:1, gray-300 = 1.58:1). The shared
+  --color-gray-* tokens are NOT darkened globally, because those same grays are
+  used for secondary text on the dark background where they already pass (e.g.
+  gray-500 on gray-900 = 6.53:1); darkening the tokens would regress dark mode.
+
+  Instead we remap only the muted TEXT color utilities, scoped to html.light, to
+  luminances that clear 4.5:1 on white while preserving the visual ordering
+  (500 darker than 400 darker than 300). Backgrounds and borders are untouched.
+*/
+html.light .text-gray-500 {
+	color: oklch(0.52 0 0); /* 5.51:1 on white */
+}
+html.light .text-gray-400 {
+	color: oklch(0.54 0 0); /* 5.06:1 on white */
+}
+html.light .text-gray-300 {
+	color: oklch(0.56 0 0); /* 4.65:1 on white */
+}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #2790 (accessibility).
- [x] **Target branch:** `dev`.
- [x] **Description:** provided below.
- [x] **Changelog:** included below.
- [x] **Testing:** manual verification with contrast math + light/dark check (details below).
- [x] **No Unchecked AI Code:** human-reviewed and manually tested.
- [x] **Self-Review:** performed.
- [x] **Git Hygiene:** atomic single-file change, rebased on `dev`.

## Summary

Brings muted secondary text up to the 4.5:1 minimum contrast ratio in light theme. **WCAG 2.1 SC 1.4.3 Contrast (Minimum) (Level AA).**

## Problem

Secondary text (timestamps, hints, placeholders, muted labels) uses `text-gray-300` / `text-gray-400` / `text-gray-500`. On the light-theme white background these fail 4.5:1:

| Utility | Contrast on white | Result |
|---|---|---|
| `text-gray-500` | 2.77:1 | ❌ |
| `text-gray-400` | 2.07:1 | ❌ |
| `text-gray-300` | 1.58:1 | ❌ |

## Fix (`src/app.css`)

Remap only the muted **text** color utilities, scoped to `html.light`, to luminances that clear 4.5:1 on white while preserving the visual ordering (500 darker than 400 darker than 300):

| Utility (light theme) | New value | Contrast on white |
|---|---|---|
| `text-gray-500` | `oklch(0.52 0 0)` | 5.51:1 ✅ |
| `text-gray-400` | `oklch(0.54 0 0)` | 5.06:1 ✅ |
| `text-gray-300` | `oklch(0.56 0 0)` | 4.65:1 ✅ |

**Why not darken the palette tokens?** The same grays are used for secondary text on the dark background, where they already pass (e.g. `text-gray-500` on `gray-900` = 6.53:1). Darkening the shared `--color-gray-*` tokens would regress dark mode. Scoping the override to `html.light` fixes light mode without touching dark mode, backgrounds, or borders.

## Testing

- Built and ran this branch locally (`vite dev`) against a v0.10.2 backend.
- **Light theme:** muted text (timestamps, hints, placeholders) renders in a darker, readable gray.
- **Dark theme:** unchanged (override is `html.light`-scoped).
- Contrast ratios computed against the project's `--color-gray-*` oklch palette; all three now exceed 4.5:1.
- `prettier --check` passes.

## Context

This stems from deploying Open WebUI for university coursework, where the platform must meet institutional digital-accessibility obligations (ADA Title II / Section 508, WCAG 2.1 AA). Sharing the fixes upstream so the whole community benefits.

# Changelog Entry

### Description

- Fix muted secondary text failing 4.5:1 contrast on white in light theme (WCAG 1.4.3).

### Fixed

- `text-gray-300/400/500` did not meet the 4.5:1 minimum contrast on the light-theme background; remapped under `html.light` without affecting dark theme.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
