### PR TITLE
fix: preserve terminal selection on chat refresh

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -41,6 +41,7 @@
 		skills,
 		toolServers,
 		terminalServers,
+		terminalServersLoaded,
 		functions,
 		selectedFolder,
 		pinnedChats,
@@ -503,7 +504,7 @@
 				// Set Default Terminal — only if the referenced terminal actually exists
 				if (model?.info?.meta?.terminalId) {
 					const tid = model.info.meta.terminalId;
-					if (isTerminalAvailable(tid)) {
+					if (!$terminalServersLoaded || isTerminalAvailable(tid)) {
 						selectedTerminalId.set(tid);
 					}
 				}
@@ -933,18 +934,19 @@
 
 		// Restore direct terminal enabled states based on persisted selectedTerminalId
 		if ($settings?.terminalServers?.length) {
-			settings.set({
-				...$settings,
-				terminalServers: ($settings.terminalServers ?? []).map((s) => ({
-					...s,
-					enabled: $selectedTerminalId !== null && s.url === $selectedTerminalId
-				}))
-			});
-		}
+			const enabledDirectTerminal = ($settings.terminalServers ?? []).find((s) => s.enabled);
 
-		// Clear stale selectedTerminalId if the referenced terminal no longer exists
-		if ($selectedTerminalId && !isTerminalAvailable($selectedTerminalId)) {
-			selectedTerminalId.set(null);
+			if (!$selectedTerminalId && enabledDirectTerminal?.url) {
+				selectedTerminalId.set(enabledDirectTerminal.url);
+			} else if ($selectedTerminalId) {
+				settings.set({
+					...$settings,
+					terminalServers: ($settings.terminalServers ?? []).map((s) => ({
+						...s,
+						enabled: s.url === $selectedTerminalId
+					}))
+				});
+			}
 		}
 
 		const pageSubscribe = page.subscribe(async (p) => {
@@ -1050,6 +1052,14 @@
 			}
 		};
 	});
+
+	$: if (
+		$terminalServersLoaded &&
+		$selectedTerminalId &&
+		!isTerminalAvailable($selectedTerminalId)
+	) {
+		selectedTerminalId.set(null);
+	}
 
 	// File upload functions
 

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -20,6 +20,7 @@
 		settings,
 		showFileNavPath,
 		selectedTerminalId,
+		terminalServersLoaded,
 		user
 	} from '$lib/stores';
 
@@ -71,11 +72,16 @@
 	$: hasMessages = history?.messages && Object.keys(history.messages).length > 0;
 
 	$: showControlsTab = $user?.role === 'admin' || ($user?.permissions?.chat?.controls ?? true);
+	$: hasDirectToolServerAccess =
+		$user?.role === 'admin' || ($user?.permissions?.features?.direct_tool_servers ?? true);
+	$: selectedSystemTerminalAvailable = ($terminalServers ?? []).some(
+		(t) => t.id && t.id === $selectedTerminalId
+	);
+	$: selectedDirectTerminalAvailable = ($settings?.terminalServers ?? []).some(
+		(s) => s.url === $selectedTerminalId
+	);
 	$: showFilesTab =
-		($selectedTerminalId &&
-			(($terminalServers ?? []).some((t) => t.id && t.id === $selectedTerminalId) ||
-				$user?.role === 'admin' ||
-				($user?.permissions?.features?.direct_tool_servers ?? true))) ||
+		($selectedTerminalId && (selectedSystemTerminalAvailable || hasDirectToolServerAccess)) ||
 		(codeInterpreterEnabled && $config?.code?.interpreter_engine !== 'jupyter');
 	$: showOverviewTab = hasMessages;
 
@@ -106,11 +112,15 @@
 		}
 	}
 
-	// Clear selected direct terminal if user lost permission
+	$: if ($selectedTerminalId && selectedDirectTerminalAvailable && !hasDirectToolServerAccess) {
+		selectedTerminalId.set(null);
+	}
+
 	$: if (
+		$terminalServersLoaded &&
 		$selectedTerminalId &&
-		!($terminalServers ?? []).some((t) => t.id && t.id === $selectedTerminalId) &&
-		!($user?.role === 'admin' || ($user?.permissions?.features?.direct_tool_servers ?? true))
+		!selectedSystemTerminalAvailable &&
+		!selectedDirectTerminalAvailable
 	) {
 		selectedTerminalId.set(null);
 	}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -73,8 +73,9 @@ export const tools = writable(null);
 export const skills = writable(null);
 export const functions = writable(null);
 
-export const toolServers = writable([]);
-export const terminalServers = writable([]);
+export const toolServers: Writable<any[]> = writable([]);
+export const terminalServers: Writable<any[]> = writable([]);
+export const terminalServersLoaded = writable(false);
 
 // Persistent Pyodide worker for code interpreter FS
 export const pyodideWorker: Writable<Worker | null> = writable(null);
@@ -180,7 +181,8 @@ type OllamaModelDetails = {
 
 type Settings = {
 	pinnedModels?: never[];
-	toolServers?: never[];
+	toolServers?: any[];
+	terminalServers?: any[];
 	detectArtifacts?: boolean;
 	showUpdateToast?: boolean;
 	showChangelog?: boolean;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -35,6 +35,7 @@
 		temporaryChatEnabled,
 		toolServers,
 		terminalServers,
+		terminalServersLoaded,
 		selectedTerminalId,
 		showSearch,
 		showSidebar,
@@ -123,65 +124,70 @@
 	};
 
 	const setToolServers = async () => {
-		let toolServersData = await getToolServersData($settings?.toolServers ?? []);
-		toolServersData = toolServersData.filter((data) => {
-			if (!data || data.error) {
-				toast.error(
-					$i18n.t(`Failed to connect to {{URL}} OpenAPI tool server`, {
-						URL: data?.url
-					})
+		terminalServersLoaded.set(false);
+		try {
+			let toolServersData = await getToolServersData($settings?.toolServers ?? []);
+			toolServersData = toolServersData.filter((data) => {
+				if (!data || data.error) {
+					toast.error(
+						$i18n.t(`Failed to connect to {{URL}} OpenAPI tool server`, {
+							URL: data?.url
+						})
+					);
+					return false;
+				}
+				return true;
+			});
+			toolServers.set(toolServersData);
+
+			// Inject enabled terminal servers as always-on tool servers
+			const enabledTerminals = ($settings?.terminalServers ?? []).filter((s) => s.enabled);
+			if (enabledTerminals.length > 0) {
+				let terminalServersData = await getToolServersData(
+					enabledTerminals.map((t) => ({
+						url: t.url,
+						auth_type: t.auth_type ?? 'bearer',
+						key: t.key ?? '',
+						path: t.path ?? '/openapi.json',
+						config: { enable: true }
+					}))
 				);
-				return false;
+				terminalServersData = terminalServersData
+					.filter((data) => {
+						if (!data || data.error) {
+							toast.error(
+								$i18n.t(`Failed to connect to {{URL}} terminal server`, {
+									URL: data?.url
+								})
+							);
+							return false;
+						}
+						return true;
+					})
+					.map((data, i) => ({
+						...data,
+						key: enabledTerminals[i]?.key ?? ''
+					}));
+
+				terminalServers.set(terminalServersData);
+			} else {
+				terminalServers.set([]);
 			}
-			return true;
-		});
-		toolServers.set(toolServersData);
 
-		// Inject enabled terminal servers as always-on tool servers
-		const enabledTerminals = ($settings?.terminalServers ?? []).filter((s) => s.enabled);
-		if (enabledTerminals.length > 0) {
-			let terminalServersData = await getToolServersData(
-				enabledTerminals.map((t) => ({
-					url: t.url,
-					auth_type: t.auth_type ?? 'bearer',
-					key: t.key ?? '',
-					path: t.path ?? '/openapi.json',
-					config: { enable: true }
-				}))
-			);
-			terminalServersData = terminalServersData
-				.filter((data) => {
-					if (!data || data.error) {
-						toast.error(
-							$i18n.t(`Failed to connect to {{URL}} terminal server`, {
-								URL: data?.url
-							})
-						);
-						return false;
-					}
-					return true;
-				})
-				.map((data, i) => ({
-					...data,
-					key: enabledTerminals[i]?.key ?? ''
+			// Fetch terminal servers the user has access to (for FileNav + terminal_id)
+			const systemTerminals = await getTerminalServers(localStorage.token);
+			if (systemTerminals.length > 0) {
+				// Store with proxy URL and session key for FileNav file browsing
+				const terminalEntries = systemTerminals.map((t) => ({
+					id: t.id,
+					url: `${WEBUI_API_BASE_URL}/terminals/${t.id}`,
+					name: t.name,
+					key: localStorage.token
 				}));
-
-			terminalServers.set(terminalServersData);
-		} else {
-			terminalServers.set([]);
-		}
-
-		// Fetch terminal servers the user has access to (for FileNav + terminal_id)
-		const systemTerminals = await getTerminalServers(localStorage.token);
-		if (systemTerminals.length > 0) {
-			// Store with proxy URL and session key for FileNav file browsing
-			const terminalEntries = systemTerminals.map((t) => ({
-				id: t.id,
-				url: `${WEBUI_API_BASE_URL}/terminals/${t.id}`,
-				name: t.name,
-				key: localStorage.token
-			}));
-			terminalServers.update((existing) => [...existing, ...terminalEntries]);
+				terminalServers.update((existing) => [...existing, ...terminalEntries]);
+			}
+		} finally {
+			terminalServersLoaded.set(true);
 		}
 	};
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes open-webui/open-webui#26677.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Preserve terminal selection while terminal server data is still loading during chat refresh.
- [x] **Changelog:** Added below.
- [x] **Documentation:** Not required for this frontend bug fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Formatting was checked; full `svelte-check` was attempted and fails on existing unrelated project diagnostics.
- [x] **No Unchecked AI Code:** The change has been reviewed against the reported code path.
- [x] **Self-Review:** Self-reviewed the diff for scope and regressions.
- [x] **Architecture:** Uses existing Svelte stores and local UI state.
- [x] **Git Hygiene:** Atomic branch based on `dev`.
- [x] **Title Prefix:** Uses `fix:`.

# Changelog Entry

### Description

- Prevent chat refresh from clearing model/default terminal selection before terminal servers finish loading.

### Added

- Added a `terminalServersLoaded` store to distinguish an empty terminal list from terminal data that is still loading.

### Changed

- Delay stale terminal selection cleanup until terminal server loading completes.
- Preserve an already-enabled direct terminal instead of disabling it when `selectedTerminalId` has not been restored yet.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed terminal toggle being cleared after refreshing an existing chat.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Validation:

- `npx prettier --check src/lib/stores/index.ts 'src/routes/(app)/+layout.svelte' src/lib/components/chat/Chat.svelte src/lib/components/chat/ChatControls.svelte` passed.
- `npm run check` was attempted after `npm ci`; it still fails on existing unrelated diagnostics such as missing `file-saver` declarations and implicit `any` errors in other components.

### Screenshots or Videos

- Not included; this is a state restoration fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
