### PR TITLE
fix: include input_tokens in Anthropic streaming message_delta usage

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -743,7 +743,7 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
             'stop_reason': stop_reason,
             'stop_sequence': None,
         },
-        'usage': {'output_tokens': output_tokens},
+        'usage': {'input_tokens': input_tokens, 'output_tokens': output_tokens},
     }
     yield f'event: message_delta\ndata: {json.dumps(message_delta)}\n\n'.encode()
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [[Issue](https://github.com/open-webui/open-webui/issues)](https://github.com/open-webui/open-webui/issues) or [[Discussion](https://github.com/open-webui/open-webui/discussions)](https://github.com/open-webui/open-webui/discussions) — Closes #XXXXX
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Documentation:** N/A — spec-compliance bug fix, no user-facing configuration or documented behavior changes.
- [x] **Dependencies:** N/A — no dependency changes.
- [x] **Changelog:** A changelog entry following [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) format is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the **fix** prefix.

# Changelog Entry

### Description

- The Anthropic-compatible streaming converter (`openai_stream_to_anthropic_stream` in `backend/open_webui/utils/anthropic.py`) tracks `prompt_tokens` from upstream OpenAI usage chunks into its `input_tokens` variable, but the final `message_delta` event only emits `output_tokens`. Since `message_start` is emitted before upstream usage is known (and therefore carries `input_tokens: 0`), the final `message_delta` is the only event where a client can receive the real input token count — and it was missing. As a result, every Anthropic-format client received `input_tokens = 0` on all streamed responses. For Claude Code pointed at Open WebUI via `ANTHROPIC_BASE_URL`, this broke the context meter (`/context` read near-empty regardless of prompt size), prevented auto-compaction from ever triggering, and undercounted cost, since the prompt is typically the majority of billed tokens.
- 

### Added

- N/A

### Changed

- This change adds the already-tracked input_tokens variable to the emitted message_delta usage object — a one-line diff. It also makes the streaming path consistent with the non-streaming converter (openai_response_to_anthropic), which already maps prompt_tokens → input_tokens correctly.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Anthropic-compatible streaming responses now include `input_tokens` in the final `message_delta` usage object, matching the Anthropic Messages streaming specification and the existing non-streaming converter. This fixes context tracking, auto-compaction, and cost accounting in Anthropic-format clients such as Claude Code.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Root cause: `message_delta` was emitted as `'usage': {'output_tokens': output_tokens}` while `input_tokens` was captured from upstream usage chunks a few lines earlier but never included in the emitted event.
- The non-streaming path already emits `input_tokens` correctly, so this is an internal consistency fix rather than a behavior change.
- No new settings, no dependency changes, single-line diff.
- Searched existing issues/PRs for duplicates; none found. Nearest related (all closed, different layers): #23322 (usage-key normalization in chat persistence), #21347 (analytics token tracking), #22861 (Anthropic compat endpoint availability on the Ollama proxy). None address the streaming translator's `message_delta` usage.

### Screenshots or Videos

Streaming request through `/api/v1/messages` against an OpenAI-compatible backend that reports usage.

Before (real input token count never reaches the client):

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_...", "type": "message", "role": "assistant", "content": [], "model": "...", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0}}}

event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens", "stop_sequence": null}, "usage": {"output_tokens": 32}}
```

After:

```
event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens", "stop_sequence": null}, "usage": {"input_tokens": 17, "output_tokens": 32}}
```

Verified end-to-end with Claude Code configured against Open WebUI via `ANTHROPIC_BASE_URL`: the context meter and cost reporting now reflect real prompt size, and auto-compaction has a real value to trigger against.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [[Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.