### PR TITLE
fix: web speech STT repeating previous transcriptions and inserting text on cancel

### DIFF
--- a/src/lib/components/chat/MessageInput/VoiceRecording.svelte
+++ b/src/lib/components/chat/MessageInput/VoiceRecording.svelte
@@ -300,6 +300,9 @@
 		if (transcribe) {
 			if ($config.audio.stt.engine === 'web' || ($settings?.audio?.stt?.engine ?? '') === 'web') {
 				if ('SpeechRecognition' in window || 'webkitSpeechRecognition' in window) {
+					// reset accumulated transcription from previous sessions
+					transcription = '';
+
 					// Create a SpeechRecognition object
 					speechRecognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
 
@@ -353,11 +356,19 @@
 						toast.error($i18n.t(`Speech recognition error: {{error}}`, { error: event.error }));
 						onCancel();
 
-						stopRecording();
+						cancelRecording();
 					};
 				}
 			}
 		}
+	};
+
+	const cancelRecording = async () => {
+		if (speechRecognition) {
+			// detach onend so cancelling does not confirm the transcription
+			speechRecognition.onend = null;
+		}
+		await stopRecording();
 	};
 
 	const stopRecording = async () => {
@@ -411,7 +422,7 @@
 	const handleKeyDown = (e) => {
 		if (e.key === 'Escape') {
 			e.preventDefault();
-			stopRecording();
+			cancelRecording();
 			onCancel();
 		}
 	};
@@ -468,7 +479,7 @@
 
              rounded-full"
 			on:click={async () => {
-				stopRecording();
+				cancelRecording();
 				onCancel();
 			}}
 		>


### PR DESCRIPTION
The VoiceRecording component stays mounted (hidden) between recordings, and the web speech engine accumulated every session's transcript into the never-reset transcription variable. Each new recording therefore confirmed all previous utterances again, so the inserted text repeated once per session and previously deleted text reappeared in the input.

Additionally, cancelling a recording (X button, Escape or a recognition error) called stopRecording(), which stops the SpeechRecognition instance and fires its onend handler, which unconditionally confirms the transcription. Cancelled recordings therefore still inserted the accumulated transcript.

Reset the transcription at the start of each web speech session and detach the onend handler on cancel so cancelled recordings no longer confirm.

Fixes #26784

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
