### PR TITLE
fix: Redis task command listener dies on idle socket timeout, breaking Stop

### DIFF
--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -24,21 +24,34 @@ REDIS_PUBSUB_CHANNEL = f'{REDIS_KEY_PREFIX}:tasks:commands'
 
 async def redis_task_command_listener(app):
     redis: Redis = app.state.redis
-    pubsub = redis.pubsub()
-    await pubsub.subscribe(REDIS_PUBSUB_CHANNEL)
-
-    async for message in pubsub.listen():
-        if message['type'] != 'message':
-            continue
+    while True:
+        pubsub = redis.pubsub()
         try:
-            command = json.loads(message['data'])
-            if command.get('action') == 'stop':
-                task_id = command.get('task_id')
-                local_task = tasks.get(task_id)
-                if local_task:
-                    local_task.cancel()
+            await pubsub.subscribe(REDIS_PUBSUB_CHANNEL)
+            while True:
+                # get_message instead of listen(): an idle listen() dies on redis-py 8's 5s default socket_timeout
+                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=5)
+                if message is None or message['type'] != 'message':
+                    continue
+                try:
+                    command = json.loads(message['data'])
+                    if command.get('action') == 'stop':
+                        task_id = command.get('task_id')
+                        local_task = tasks.get(task_id)
+                        if local_task:
+                            local_task.cancel()
+                except Exception as e:
+                    log.exception(f'Error handling distributed task command: {e}')
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
-            log.exception(f'Error handling distributed task command: {e}')
+            log.error(f'Task command listener connection lost, resubscribing in 5s: {e}')
+            await asyncio.sleep(5)
+        finally:
+            try:
+                await pubsub.aclose()
+            except Exception:
+                pass
 
 
 ### ------------------------------


### PR DESCRIPTION
The redis 7.4.0 to 8.0.0 bump in v0.10.2 introduced DEFAULT_SOCKET_TIMEOUT = 5, which now applies to app.state.redis because _socket_options() never overrides socket_timeout. pubsub.listen() blocks in read_response() with that 5 second socket timeout, so the first idle period after boot raises redis.exceptions.TimeoutError inside redis_task_command_listener. Nothing catches it, the fire-and-forget task dies silently, and the Stop button does nothing for the rest of the process lifetime on any multi-worker or Redis deployment.

Replace the bare listen() loop with get_message(timeout=5): with an explicit timeout redis-py returns None on an idle read instead of raising, so the listener no longer depends on the connection's socket_timeout at all. Wrap the whole thing in a reconnect loop that closes the dead pubsub, resubscribes after a short backoff on any connection error (also covering Redis restarts, which previously killed the listener permanently as well), and still propagates CancelledError so shutdown is unaffected.

Fixes #26779

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
