### PR TITLE
fix: detect bare pipe alternation as regex in grep_knowledge_files

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -33,9 +33,9 @@ MAX_GREP_MATCHES = 50
 
 
 def is_regex_pattern(pattern: str) -> bool:
-    """Detect if a pattern looks like regex (\|, .*, .+, \d, \w, \s, [...])."""
+    """Detect if a pattern looks like regex (|, .*, .+, \d, \w, \s, [...])."""
     return (
-        '\|' in pattern
+        '|' in pattern
         or '.*' in pattern
         or '.+' in pattern
         or '.?' in pattern


### PR DESCRIPTION
is_regex_pattern only recognized the BRE-escaped form \| and not a bare |, so a pattern like "Jornak|Silverlake|Orissa" was treated as one literal string (including the pipe characters) and silently returned no matches. This contradicted the tool docstring, which explicitly advertises "error|warn" as an auto-detected regex example, and misled models into concluding the searched terms were absent from the file.

Checking for a bare | also covers the escaped form, since \| contains |, and normalize_regex already converts escaped pipes before compilation. Literal patterns without regex metacharacters are unaffected.

Fixes #26781

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
