### PR TITLE
fix: sync message.content with structured output items

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -13,7 +13,7 @@ from open_webui.models.automations import AutomationRun
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.folders import Folders
 from open_webui.models.tags import Tag, TagModel, Tags
-from open_webui.utils.misc import sanitize_data_for_db, sanitize_text_for_db
+from open_webui.utils.misc import get_output_text, sanitize_data_for_db, sanitize_text_for_db
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
     JSON,
@@ -755,6 +755,12 @@ class ChatTable:
                 'role': role,
                 'timestamp': message.get('timestamp') or int(time.time()),
             }
+
+        # Keep `content` in sync with structured output for consumers that read `content`
+        if 'output' in message and not (isinstance(message.get('content'), str) and message['content'].strip()):
+            output_text = get_output_text(messages[message_id].get('output'))
+            if output_text:
+                messages[message_id]['content'] = sanitize_text_for_db(output_text)
 
         history['currentId'] = message_id
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -102,6 +102,7 @@ from open_webui.utils.misc import (
     get_last_user_message,
     get_last_user_message_item,
     get_message_list,
+    get_output_text,
     get_system_message,
     is_string_allowed,
     merge_system_messages,
@@ -3339,7 +3340,7 @@ async def outlet_filter_handler(ctx):
                 {
                     'id': m.get('id'),
                     'role': m.get('role'),
-                    'content': m.get('content', ''),
+                    'content': m.get('content') or get_output_text(m.get('output')),
                     'info': m.get('info'),
                     'timestamp': m.get('timestamp'),
                     **({'output': m['output']} if m.get('output') else {}),
@@ -3388,13 +3389,17 @@ async def outlet_filter_handler(ctx):
                     outlet_message_id = message.get('id')
                     if outlet_message_id and outlet_message_id in messages_map:
                         original_message = messages_map[outlet_message_id]
-                        content_changed = original_message.get('content') != message.get('content')
+                        # Compare against the same output-derived baseline the filter received
+                        original_content = original_message.get('content') or get_output_text(
+                            original_message.get('output')
+                        )
+                        content_changed = original_content != message.get('content')
                         output_changed = message.get('output') and message.get('output') != original_message.get(
                             'output'
                         )
                         if content_changed or output_changed:
                             message_update = {
-                                'originalContent': original_message.get('content'),
+                                'originalContent': original_content,
                                 **({'output': message['output']} if output_changed else {}),
                             }
                             if content_changed:

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -230,7 +230,7 @@ def get_output_text(output: list | None) -> str:
         if not isinstance(item, dict) or item.get('type') != 'message':
             continue
         text = ''.join(
-            part.get('text') or ''
+            str(part.get('text') or '')
             for part in item.get('content', [])
             if isinstance(part, dict) and part.get('type') == 'output_text'
         )

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -220,6 +220,26 @@ def reconcile_tool_pairs(messages: list[dict]) -> list[dict]:
     return reconciled_messages
 
 
+def get_output_text(output: list | None) -> str:
+    """Extract the assistant-visible text from output message items."""
+    if not output or not isinstance(output, list):
+        return ''
+
+    texts = []
+    for item in output:
+        if not isinstance(item, dict) or item.get('type') != 'message':
+            continue
+        text = ''.join(
+            part.get('text') or ''
+            for part in item.get('content', [])
+            if isinstance(part, dict) and part.get('type') == 'output_text'
+        )
+        if text.strip():
+            texts.append(text)
+
+    return '\n'.join(texts)
+
+
 def convert_output_to_messages(
     output: list,
     raw: bool = False,


### PR DESCRIPTION
Since the 0.10 rendering refactor, streamed assistant text is stored in the structured output items (output[].content[].text) while message.content is persisted as an empty string. Every consumer that still reads content therefore sees a blank assistant message: the saved chat returned by GET /api/v1/chats/{chat_id}, outlet and action filter payloads, background tasks such as title and follow-up generation, chat search and export. This is most visible with Responses API connections and native tool-calling turns, but it affects any streamed completion once the in-memory frontend state is gone.

Add a get_output_text helper that extracts the assistant-visible text from output message items, mirroring getOutputText on the frontend, and use it to sync message.content inside Chats.upsert_message_to_chat_by_id_and_message_id, the chokepoint every backend message save goes through. An update that explicitly carries non-empty content keeps it, so outlet filters can still override the text. The outlet filter payload additionally falls back to the output-derived text so filters receive the correct content for temp and API chats and for chats saved before this fix, and the outlet change detection compares against that same baseline to avoid writing a spurious originalContent when a filter returns the message unchanged.

Fixes #26436

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
