### PR TITLE
fix: matplotlib SyntaxError in sandboxed Pyodide code execution

### DIFF
--- a/src/lib/pyodide/pyodideSandboxHost.ts
+++ b/src/lib/pyodide/pyodideSandboxHost.ts
@@ -116,13 +116,14 @@ const sandboxScript = String.raw`
 			'_old_show = matplotlib.pyplot.show',
 			'assert _old_show, "matplotlib.pyplot.show"',
 			'def show(*, block=None):',
-			'\\tbuf = BytesIO()',
-			'\\tmatplotlib.pyplot.savefig(buf, format="png")',
-			'\\tbuf.seek(0)',
-			'\\timg_str = base64.b64encode(buf.read()).decode("utf-8")',
-			'\\tmatplotlib.pyplot.clf()',
-			'\\tbuf.close()',
-			'\\tprint(f"data:image/png;base64,{img_str}")',
+			// String.raw keeps \t as-is; the sandbox's JS parser turns it into a real tab
+			'\tbuf = BytesIO()',
+			'\tmatplotlib.pyplot.savefig(buf, format="png")',
+			'\tbuf.seek(0)',
+			'\timg_str = base64.b64encode(buf.read()).decode("utf-8")',
+			'\tmatplotlib.pyplot.clf()',
+			'\tbuf.close()',
+			'\tprint(f"data:image/png;base64,{img_str}")',
 			'matplotlib.pyplot.show = show'
 		].join('\n'));
 	}


### PR DESCRIPTION
The sandboxed Pyodide host (used when ENABLE_PYODIDE_FILE_PERSISTENCE is disabled, the default) embeds its script in a String.raw template. The matplotlib show() override was written with '\\t' escapes as if in a normal string context, but String.raw preserves them verbatim, so the iframe's script parser turns them into literal backslash-t characters in the generated Python source. Pyodide then fails to compile any code that triggers the matplotlib patch with "SyntaxError: unexpected character after line continuation character", which is why matplotlib only worked with the file persistence worker path enabled.

Use single '\t' escapes instead: String.raw keeps them as-is in the script text and the sandbox's JS parser produces real tab indentation, matching the working implementation in pyodide.worker.ts.

Fixes #26660

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
