### PR TITLE
fix: stop fabricating 1-hour expiry for non-refreshable OAuth tokens

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -192,6 +192,11 @@ DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
 # (e.g. Slack xoxp user tokens): long-lived until revoked, cannot be refreshed.
 NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
+# Marker key stamped on tokens that carry no expiry metadata and no
+# refresh_token. It flags the token as long-lived so the refresh path can
+# renew the local expiry in place instead of deleting the session (#26141).
+NON_REFRESHABLE_TOKEN_MARKER = 'non_refreshable'
+
 
 # Apereo CAS includes client_id in ID token JWS headers; Authlib 1.7/joserfc
 # rejects unknown headers unless we register the provider extension.
@@ -211,8 +216,9 @@ def _normalize_token_expiry(token: dict) -> dict:
        ``DEFAULT_TOKEN_EXPIRY_SECONDS`` and log a warning so operators can
        identify providers that omit expiration.
     4. Otherwise the token is non-expiring and non-refreshable; use
-       ``NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS`` so the refresh path (which
-       would inevitably fail and delete the session) is not triggered.
+       ``NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS`` and flag it with
+       ``NON_REFRESHABLE_TOKEN_MARKER`` so the refresh path renews the local
+       expiry in place instead of deleting the session.
 
     Also stamps *issued_at* for auditing.
     """
@@ -237,11 +243,33 @@ def _normalize_token_expiry(token: dict) -> dict:
         token['expires_at'] = int(datetime.now().timestamp() + DEFAULT_TOKEN_EXPIRY_SECONDS)
     else:
         log.info(
-            "OAuth token response missing 'expires_in', 'expires_at' and 'refresh_token'; "
-            'treating token as long-lived'
+            "OAuth token response missing 'expires_in', 'expires_at' and 'refresh_token'; treating token as long-lived"
         )
         token['expires_at'] = int(datetime.now().timestamp() + NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS)
+        token[NON_REFRESHABLE_TOKEN_MARKER] = True
     return token
+
+
+def _renew_non_refreshable_token(token_data: dict, session_id: str):
+    """Renew the local expiry of a long-lived, non-refreshable token.
+
+    Providers such as Slack issue user tokens that never expire and never
+    carry a ``refresh_token`` (see ``_normalize_token_expiry`` case 4). When
+    such a token approaches its fabricated expiry it reaches the refresh path,
+    which can only fail — deleting the session and forcing a needless
+    re-authentication (#26141). Instead of failing, re-stamp the local expiry
+    in place so the session keeps renewing itself.
+
+    Returns the (mutated) token dict when it was flagged long-lived, else
+    ``None`` so the caller falls through to its normal no-refresh-token
+    handling (tokens with a real provider-declared expiry are left to expire).
+    """
+    if not token_data.get(NON_REFRESHABLE_TOKEN_MARKER):
+        return None
+
+    token_data['expires_at'] = int(datetime.now().timestamp() + NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS)
+    log.debug(f'Renewing long-lived non-refreshable token for session {session_id}')
+    return token_data
 
 
 FERNET = None
@@ -1070,6 +1098,9 @@ class OAuthClientManager:
         token_data = session.token
 
         if not token_data.get('refresh_token'):
+            renewed = _renew_non_refreshable_token(token_data, session.id)
+            if renewed is not None:
+                return renewed
             log.warning(f'No refresh token available for session {session.id}')
             return None
 
@@ -1349,6 +1380,9 @@ class OAuthManager:
         auth_config = await get_oauth_runtime_config()
 
         if not token_data.get('refresh_token'):
+            renewed = _renew_non_refreshable_token(token_data, session.id)
+            if renewed is not None:
+                return renewed
             log.warning(f'No refresh token available for session {session.id}')
             return None
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -188,6 +188,10 @@ async def get_oauth_runtime_config() -> SimpleNamespace:
 # Matches the value recommended by Authlib's compliance_fix documentation.
 DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
 
+# Fallback for tokens without expiry metadata AND without a refresh_token
+# (e.g. Slack xoxp user tokens): long-lived until revoked, cannot be refreshed.
+NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
+
 
 # Apereo CAS includes client_id in ID token JWS headers; Authlib 1.7/joserfc
 # rejects unknown headers unless we register the provider extension.
@@ -203,8 +207,12 @@ def _normalize_token_expiry(token: dict) -> dict:
     Resolution order:
     1. If *expires_at* is already present and non-None, trust it.
     2. Else if *expires_in* is present and non-None, compute *expires_at*.
-    3. Otherwise fall back to ``DEFAULT_TOKEN_EXPIRY_SECONDS`` and log a
-       warning so operators can identify providers that omit expiration.
+    3. Else if a *refresh_token* is present, fall back to
+       ``DEFAULT_TOKEN_EXPIRY_SECONDS`` and log a warning so operators can
+       identify providers that omit expiration.
+    4. Otherwise the token is non-expiring and non-refreshable; use
+       ``NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS`` so the refresh path (which
+       would inevitably fail and delete the session) is not triggered.
 
     Also stamps *issued_at* for auditing.
     """
@@ -218,12 +226,21 @@ def _normalize_token_expiry(token: dict) -> dict:
         token['expires_at'] = int(datetime.now().timestamp() + token['expires_in'])
         return token
 
-    # Neither field present — conservative fallback
-    log.warning(
-        "OAuth token response missing both 'expires_in' and 'expires_at'; "
-        f'defaulting to {DEFAULT_TOKEN_EXPIRY_SECONDS}s from now'
-    )
-    token['expires_at'] = int(datetime.now().timestamp() + DEFAULT_TOKEN_EXPIRY_SECONDS)
+    # Neither field present — conservative fallback, but only if the token
+    # can actually be refreshed; otherwise a short fabricated expiry would
+    # guarantee session deletion once the impossible refresh fails (#26141)
+    if token.get('refresh_token'):
+        log.warning(
+            "OAuth token response missing both 'expires_in' and 'expires_at'; "
+            f'defaulting to {DEFAULT_TOKEN_EXPIRY_SECONDS}s from now'
+        )
+        token['expires_at'] = int(datetime.now().timestamp() + DEFAULT_TOKEN_EXPIRY_SECONDS)
+    else:
+        log.info(
+            "OAuth token response missing 'expires_in', 'expires_at' and 'refresh_token'; "
+            'treating token as long-lived'
+        )
+        token['expires_at'] = int(datetime.now().timestamp() + NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS)
     return token
 
 

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -188,13 +188,10 @@ async def get_oauth_runtime_config() -> SimpleNamespace:
 # Matches the value recommended by Authlib's compliance_fix documentation.
 DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
 
-# Fallback for tokens without expiry metadata AND without a refresh_token
-# (e.g. Slack xoxp user tokens): long-lived until revoked, cannot be refreshed.
+# Local expiry for tokens without expiry metadata and without a refresh_token (e.g. Slack user tokens)
 NON_REFRESHABLE_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
-# Marker key stamped on tokens that carry no expiry metadata and no
-# refresh_token. It flags the token as long-lived so the refresh path can
-# renew the local expiry in place instead of deleting the session (#26141).
+# Flags such tokens so the refresh path renews the local expiry instead of deleting the session
 NON_REFRESHABLE_TOKEN_MARKER = 'non_refreshable'
 
 
@@ -232,9 +229,7 @@ def _normalize_token_expiry(token: dict) -> dict:
         token['expires_at'] = int(datetime.now().timestamp() + token['expires_in'])
         return token
 
-    # Neither field present — conservative fallback, but only if the token
-    # can actually be refreshed; otherwise a short fabricated expiry would
-    # guarantee session deletion once the impossible refresh fails (#26141)
+    # Fabricating a short expiry for a non-refreshable token would guarantee session deletion (#26141)
     if token.get('refresh_token'):
         log.warning(
             "OAuth token response missing both 'expires_in' and 'expires_at'; "
@@ -251,18 +246,12 @@ def _normalize_token_expiry(token: dict) -> dict:
 
 
 def _renew_non_refreshable_token(token_data: dict, session_id: str):
-    """Renew the local expiry of a long-lived, non-refreshable token.
-
-    Providers such as Slack issue user tokens that never expire and never
-    carry a ``refresh_token`` (see ``_normalize_token_expiry`` case 4). When
-    such a token approaches its fabricated expiry it reaches the refresh path,
-    which can only fail — deleting the session and forcing a needless
-    re-authentication (#26141). Instead of failing, re-stamp the local expiry
-    in place so the session keeps renewing itself.
-
-    Returns the (mutated) token dict when it was flagged long-lived, else
-    ``None`` so the caller falls through to its normal no-refresh-token
-    handling (tokens with a real provider-declared expiry are left to expire).
+    """
+    Re-stamp the local expiry of a token flagged long-lived by
+    ``_normalize_token_expiry``, since refreshing it can only fail and would
+    delete the session (#26141). Returns the mutated token dict, or ``None``
+    when the token is not flagged so the caller falls through to its normal
+    no-refresh-token handling.
     """
     if not token_data.get(NON_REFRESHABLE_TOKEN_MARKER):
         return None


### PR DESCRIPTION
Providers like Slack issue long-lived user tokens whose token response contains neither expires_in nor expires_at and no refresh_token. The _normalize_token_expiry fallback unconditionally stamped such tokens with a 3600s expiry, so roughly an hour later get_oauth_token triggered a refresh that could never succeed (there is no refresh token) and the failed refresh deleted the OAuth session, forcing the user to re-authenticate every hour.

Only apply the conservative 1-hour fallback when the token actually carries a refresh_token so the proactive refresh can rotate it. A token with no expiry metadata and no refresh_token is long-lived by definition, so stamp it with a one-year expiry instead (the sessions table requires a non-null expires_at). Tokens whose provider declares a real expiry but issues no refresh token are intentionally unaffected: those genuinely expire and re-authentication is the only recovery.

Fixes #26141

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
