### PR TITLE
fix: sidebar chat list wiped after collapsing and reopening the sidebar

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2935,8 +2935,8 @@
 
 			await tick();
 
-			await chats.set(await getChatList(localStorage.token, $currentChatPage));
 			currentChatPage.set(1);
+			await chats.set(await getChatList(localStorage.token, 1));
 
 			selectedFolder.set(null);
 		} else {

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -107,12 +107,12 @@
 					folder={$selectedFolder}
 					readOnly={folderNotOwned}
 					onUpdate={async (folder) => {
-						await chats.set(await getChatList(localStorage.token, $currentChatPage));
 						currentChatPage.set(1);
+						await chats.set(await getChatList(localStorage.token, 1));
 					}}
 					onDelete={async () => {
-						await chats.set(await getChatList(localStorage.token, $currentChatPage));
 						currentChatPage.set(1);
+						await chats.set(await getChatList(localStorage.token, 1));
 
 						selectedFolder.set(null);
 					}}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -352,7 +352,9 @@
 			})(),
 			(async () => {
 				console.log('Init chat list');
-				const _chats = await getChatList(localStorage.token, $currentChatPage);
+				// pass the page explicitly: $currentChatPage can still hold a stale
+				// value here when initChatList runs inside a store subscriber flush
+				const _chats = await getChatList(localStorage.token, 1);
 				await chats.set(_chats);
 			})()
 		]);
@@ -364,11 +366,12 @@
 	const loadMoreChats = async () => {
 		chatListLoading = true;
 
-		currentChatPage.set($currentChatPage + 1);
+		const page = $currentChatPage + 1;
+		currentChatPage.set(page);
 
 		let newChatList = [];
 
-		newChatList = await getChatList(localStorage.token, $currentChatPage);
+		newChatList = await getChatList(localStorage.token, page);
 
 		// once the bottom of the list has been reached (no results) there is no need to continue querying
 		allChatsLoaded = newChatList.length === 0;


### PR DESCRIPTION
When the sidebar is reopened, initChatList runs synchronously inside the showSidebar.set() subscriber flush. Its currentChatPage.set(1) call is deferred by svelte/store's nested set queue, so the $currentChatPage value it passes to getChatList still holds the previous page rather than 1. Once the list has paginated past page 1 (by scrolling it, or by the pagination loader remounting when the Chats section is collapsed and expanded), reopening the sidebar therefore fetches that stale page instead of page 1 and replaces the whole chats store with the result. If the stale page is past the end of the list, the store is replaced with an empty array and the Chats section stays empty until a full page reload; otherwise it shows only the oldest chats. Reproduced against 0.10.2 with a paginated chat list, where reopening the sidebar issued requests for pages 2 and 3 but never page 1.

Pass the target page to getChatList explicitly instead of re-reading the store right after setting it, in both initChatList and loadMoreChats. Also fix the reversed fetch and reset order in the folder title callbacks and in new chat creation, which refreshed the list with the current page before resetting it to 1 and could corrupt the list the same way.

Re: https://github.com/open-webui/open-webui/issues/26712

FULLY tested

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
