### PR TITLE
fix: block external resource loading in Vega chart rendering to prevent client-side SSRF

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2023,17 +2023,17 @@ export const renderVegaVisualization = async (spec: string, lang: string = '', i
 		const vegaLite = await import('vega-lite');
 		vegaSpec = vegaLite.compile(parsedSpec).spec;
 	}
-	// Chat content is untrusted: block Vega from fetching external resources so a crafted spec
-	// can't turn a viewer's browser into an SSRF/exfil client. `data.url`/topojson go through
-	// loader.load; `image` mark urls go through loader.sanitize and end up as <image href> in the
-	// SVG (fetched on display), so both paths must reject external URLs.
+	// Specs come from untrusted chat content: block external loads via data.url (loader.load)
+	// and image mark hrefs emitted into the SVG (loader.sanitize).
 	const loader = vega.loader();
 	loader.load = async () => {
 		throw new Error('External resource loading is disabled for rendered visualizations');
 	};
 	const sanitize = loader.sanitize.bind(loader);
 	loader.sanitize = async (uri: string, options: any) => {
-		if (/^(https?:|\/\/)/i.test(uri)) {
+		// Resolve with the browser's URL parser so encoding tricks match what it would fetch
+		const resolved = new URL(uri, document.baseURI);
+		if (resolved.protocol !== 'data:' && resolved.origin !== location.origin) {
 			throw new Error('External resource loading is disabled for rendered visualizations');
 		}
 		return sanitize(uri, options);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2023,7 +2023,22 @@ export const renderVegaVisualization = async (spec: string, lang: string = '', i
 		const vegaLite = await import('vega-lite');
 		vegaSpec = vegaLite.compile(parsedSpec).spec;
 	}
-	const view = new vega.View(vega.parse(vegaSpec), { renderer: 'none' });
+	// Chat content is untrusted: block Vega from fetching external resources so a crafted spec
+	// can't turn a viewer's browser into an SSRF/exfil client. `data.url`/topojson go through
+	// loader.load; `image` mark urls go through loader.sanitize and end up as <image href> in the
+	// SVG (fetched on display), so both paths must reject external URLs.
+	const loader = vega.loader();
+	loader.load = async () => {
+		throw new Error('External resource loading is disabled for rendered visualizations');
+	};
+	const sanitize = loader.sanitize.bind(loader);
+	loader.sanitize = async (uri: string, options: any) => {
+		if (/^(https?:|\/\/)/i.test(uri)) {
+			throw new Error('External resource loading is disabled for rendered visualizations');
+		}
+		return sanitize(uri, options);
+	};
+	const view = new vega.View(vega.parse(vegaSpec), { loader, renderer: 'none' });
 	const svg = await view.toSVG();
 	return svg;
 };


### PR DESCRIPTION
renderVegaVisualization renders vega/vega-lite chart specs that appear in untrusted chat content (shared chats, channel messages, assistant/RAG/tool output) by constructing a Vega View with no restricted loader, so a crafted spec could make a viewer's browser issue arbitrary outbound requests. There are two paths: data.url (and topojson/geo data) is fetched via loader.load at view construction, and image-mark urls are resolved via loader.sanitize and emitted as <image href> into the output SVG, fetched by the browser when the SVG is displayed. Both are client-side SSRF, and against same-origin or CORS-permissive targets allow reading the response back into the page. Pass a loader that rejects external resource loads on both paths, load throws and sanitize rejects http(s)/protocol-relative URIs, so rendered charts can only use inline data. Inline data.values charts are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
