### PR TITLE
fix(workspace): show human-readable names and remove 8-item cap in model editor selectors

### DIFF
--- a/src/lib/components/workspace/Models/TTSVoiceInput.svelte
+++ b/src/lib/components/workspace/Models/TTSVoiceInput.svelte
@@ -24,17 +24,15 @@
 	let suggestionsOpen = false;
 
 	$: query = value.trim().toLowerCase();
-	$: filteredVoices = (voices ?? [])
-		.filter((voice) => {
-			const id = voice.id.toLowerCase();
-			const name = (voice.name ?? '').toLowerCase();
-			const description = (voice.description ?? voice.meta?.description ?? '').toLowerCase();
+	$: filteredVoices = (voices ?? []).filter((voice) => {
+		const id = voice.id.toLowerCase();
+		const name = (voice.name ?? '').toLowerCase();
+		const description = (voice.description ?? voice.meta?.description ?? '').toLowerCase();
 
-			return (
-				query === '' || id.includes(query) || name.includes(query) || description.includes(query)
-			);
-		})
-		.slice(0, 8);
+		return (
+			query === '' || id.includes(query) || name.includes(query) || description.includes(query)
+		);
+	});
 	$: if (suggestionsOpen && filteredVoices.length > 0) {
 		tick().then(positionPopup);
 	}
@@ -139,9 +137,9 @@
 					selectVoice(voice);
 				}}
 			>
-				<span class="truncate">{voice.id}</span>
+				<span class="truncate">{voice.name ?? voice.id}</span>
 				{#if voice.name && voice.name !== voice.id}
-					<span class="truncate text-gray-500 dark:text-gray-400">{voice.name}</span>
+					<span class="truncate text-gray-500 dark:text-gray-400">{voice.id}</span>
 				{/if}
 			</button>
 		{/each}


### PR DESCRIPTION
## Summary

Fixes #26758

Fixes two bugs in the Workspace Model Editor selectors (Tools, Skills, Filters, Actions) introduced when `TTSVoiceInput` was reused as a generic typeahead.

## Root Cause

`TTSVoiceInput.svelte` was originally built for TTS voice selection — a context where the `id` field (`alloy`, `echo`) is also the human-readable label and lists are naturally short. When it was reused via `TypeaheadSelector` for Tools/Skills/Filters/Actions, two TTS-specific assumptions carried over and broke the selector UX:

1. `.slice(0, 8)` — capped every dropdown to 8 entries regardless of list size
2. `{voice.id}` as primary label — showed internal identifiers (e.g. `tool_calculator`) instead of human-readable names (e.g. `Calculator`)

## Changes

**File modified:** `src/lib/components/workspace/Models/TTSVoiceInput.svelte`

### 1. Remove hard-coded 8-item cap

```diff
- .slice(0, 8);

Before:

Dropdown capped at 8 items
Internal ID (e.g. codeguard_tool) shown as bold primary label
Human-readable name (e.g. CodeGuard) shown dimmed and secondary
After:

All matching items shown, scrollable
Human-readable name shown as primary label
Internal ID shown dimmed on the right (only when it differs from the name)
Backward Compatibility
✅ TTS voice selectors (Admin → Settings → Audio, Model Editor TTS Voice) — unaffected. TTS voices have no separate name field, so name ?? id renders identically to before.
✅ Selection, search, keyboard navigation, ARIA attributes — all unchanged.
✅ Stored value is still voice.id — data layer untouched.
Testing
eslint TTSVoiceInput.svelte → 0 errors
npm run test:frontend (vitest) → pass
npm run build → ✓ 1614 modules compiled successfully
svelte-check → 0 errors in modified file (pre-existing errors in 376 unrelated files)
Manual: verified Tools, Skills, Filters, Actions selectors show names and full lists
Manual: verified TTS voice selector behaviour unchanged
Fixes: #26758 Related: #26666, #24873