### PR TITLE
fix(workspace): show human-readable names and remove 8-item cap in model editor selectors

### DIFF
--- a/src/lib/components/workspace/Models/TTSVoiceInput.svelte
+++ b/src/lib/components/workspace/Models/TTSVoiceInput.svelte
@@ -24,17 +24,15 @@
 	let suggestionsOpen = false;
 
 	$: query = value.trim().toLowerCase();
-	$: filteredVoices = (voices ?? [])
-		.filter((voice) => {
-			const id = voice.id.toLowerCase();
-			const name = (voice.name ?? '').toLowerCase();
-			const description = (voice.description ?? voice.meta?.description ?? '').toLowerCase();
+	$: filteredVoices = (voices ?? []).filter((voice) => {
+		const id = voice.id.toLowerCase();
+		const name = (voice.name ?? '').toLowerCase();
+		const description = (voice.description ?? voice.meta?.description ?? '').toLowerCase();
 
-			return (
-				query === '' || id.includes(query) || name.includes(query) || description.includes(query)
-			);
-		})
-		.slice(0, 8);
+		return (
+			query === '' || id.includes(query) || name.includes(query) || description.includes(query)
+		);
+	});
 	$: if (suggestionsOpen && filteredVoices.length > 0) {
 		tick().then(positionPopup);
 	}
@@ -139,9 +137,9 @@
 					selectVoice(voice);
 				}}
 			>
-				<span class="truncate">{voice.id}</span>
+				<span class="truncate">{voice.name ?? voice.id}</span>
 				{#if voice.name && voice.name !== voice.id}
-					<span class="truncate text-gray-500 dark:text-gray-400">{voice.name}</span>
+					<span class="truncate text-gray-500 dark:text-gray-400">{voice.id}</span>
 				{/if}
 			</button>
 		{/each}


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #26758
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Testing:** Manual tests have been performed.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Description

Fixes two bugs in the Workspace Model Editor selectors (Tools, Skills, Filters, Actions) introduced when `TTSVoiceInput` was reused as a generic typeahead:

1. `.slice(0, 8)` capped every dropdown to 8 entries.
2. `{voice.id}` as primary label showed internal identifiers (e.g. `tool_calculator`) instead of human-readable names (e.g. `Calculator`).

### Changes

- Removed `.slice(0, 8)` from `TTSVoiceInput.svelte`.
- Swapped label order to show `voice.name ?? voice.id` as primary, and `voice.id` as secondary.

# Changelog Entry

### Changed
- Swapped label rendering order in `TTSVoiceInput` to show friendly names as primary and internal IDs as secondary.

### Fixed
- Fixed 8-item truncation cap in workspace models dropdown selectors.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.