### PR TITLE
fix(retrieval): close Playwright pages and browser on failure or completion in SafePlaywrightURLLoader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -658,60 +658,88 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
         from playwright.sync_api import sync_playwright
 
         with sync_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    self._safe_process_url_sync(url)
-                    page = browser.new_page()
-                    page.route('**/*', self._intercept_navigation_sync)
-                    response = page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        self._safe_process_url_sync(url)
+                        page = browser.new_page()
+                        page.route('**/*', self._intercept_navigation_sync)
+                        response = page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = self.evaluator.evaluate(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            browser.close()
+                        text = self.evaluator.evaluate(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page is not None:
+                            try:
+                                page.close()
+                            except Exception:
+                                pass
+            finally:
+                if browser is not None:
+                    try:
+                        browser.close()
+                    except Exception:
+                        pass
 
     async def alazy_load(self) -> AsyncIterator[Document]:
         """Safely load URLs asynchronously with support for remote browser."""
         from playwright.async_api import async_playwright
 
         async with async_playwright() as p:
-            # Use remote browser if ws_endpoint is provided, otherwise use local browser
-            if self.playwright_ws_url:
-                browser = await p.chromium.connect(self.playwright_ws_url)
-            else:
-                browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
+            browser = None
+            try:
+                # Use remote browser if ws_endpoint is provided, otherwise use local browser
+                if self.playwright_ws_url:
+                    browser = await p.chromium.connect(self.playwright_ws_url)
+                else:
+                    browser = await p.chromium.launch(headless=self.headless, proxy=self.proxy)
 
-            for url in self.urls:
-                try:
-                    await self._safe_process_url(url)
-                    page = await browser.new_page()
-                    await page.route('**/*', self._intercept_navigation)
-                    response = await page.goto(url, timeout=self.playwright_timeout)
-                    if response is None:
-                        raise ValueError(f'page.goto() returned None for url {url}')
+                for url in self.urls:
+                    page = None
+                    try:
+                        await self._safe_process_url(url)
+                        page = await browser.new_page()
+                        await page.route('**/*', self._intercept_navigation)
+                        response = await page.goto(url, timeout=self.playwright_timeout)
+                        if response is None:
+                            raise ValueError(f'page.goto() returned None for url {url}')
 
-                    text = await self.evaluator.evaluate_async(page, browser, response)
-                    metadata = {'source': url}
-                    yield Document(page_content=text, metadata=metadata)
-                except Exception as e:
-                    if self.continue_on_failure:
-                        log.exception(f'Error loading {url}: {e}')
-                        continue
-                    raise e
-            await browser.close()
+                        text = await self.evaluator.evaluate_async(page, browser, response)
+                        metadata = {'source': url}
+                        yield Document(page_content=text, metadata=metadata)
+                    except Exception as e:
+                        if self.continue_on_failure:
+                            log.exception(f'Error loading {url}: {e}')
+                            continue
+                        raise e
+                    finally:
+                        if page is not None:
+                            try:
+                                await page.close()
+                            except Exception:
+                                pass
+            finally:
+                if browser is not None:
+                    try:
+                        await browser.close()
+                    except Exception:
+                        pass
 
 
 class SafeWebBaseLoader(WebBaseLoader):


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the fix works.
- [x] **No Unchecked AI Code:** This PR is human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Changelog Entry

### Description

In `SafePlaywrightURLLoader`'s `lazy_load()` and `alazy_load()`, Playwright page instances were created per-URL inside the loop but never closed. Additionally, the outer browser connection/instance close was situated at the end of normal iteration and not protected by `try...finally`. 

If an exception occurred during a URL load (e.g. route timeouts, Cloudflare challenge page hangs) or if the generator caller terminated iteration early (raising `GeneratorExit`), the page and browser instances were leaked. This caused memory leaks and degraded performance on Open WebUI and remote Playwright instances.

This PR wraps page and browser lifecycles inside proper nested `try...finally` blocks to guarantee resource cleanup under all circumstances (normal completion, failure, and early generator termination).

### Fixed

- Properly close each Playwright page in a per-URL `finally` block in `lazy_load()` and `alazy_load()`.
- Properly close the Playwright browser instance in an outer `finally` block in `lazy_load()` and `alazy_load()`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.