### PR TITLE
fix: resolve workspace model ID to base model on delete from model selector

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -14,6 +14,7 @@
 	import { goto } from '$app/navigation';
 
 	import { deleteModel, getOllamaVersion, pullModel } from '$lib/apis/ollama';
+	import { deleteModelById } from '$lib/apis/models';
 	import { unloadModel } from '$lib/apis';
 
 	import {
@@ -448,12 +449,25 @@
 		const model = deleteModelTarget;
 		if (!model) return;
 
-		const res = await deleteModel(localStorage.token, model.id).catch((error) => {
-			toast.error($i18n.t('Error deleting model: {{error}}', { error }));
-		});
+		let success = false;
 
-		if (res) {
-			// $i18n.t('Model {{modelId}} not found')
+		if (model?.info?.base_model_id) {
+			// Workspace model: only delete the workspace model record, not the underlying base model
+			const res = await deleteModelById(localStorage.token, model.id).catch((error) => {
+				toast.error($i18n.t('Error deleting model: {{error}}', { error }));
+				return null;
+			});
+			success = !!res;
+		} else {
+			// Base Ollama model: delete from Ollama directly
+			const res = await deleteModel(localStorage.token, model.id).catch((error) => {
+				toast.error($i18n.t('Error deleting model: {{error}}', { error }));
+				return null;
+			});
+			success = !!res;
+		}
+
+		if (success) {
 			toast.success(
 				$i18n.t('Model {{modelName}} deleted successfully', { modelName: model.name ?? model.id })
 			);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to #26269 (companion fix for the same workspace model ID resolution issue, this time on the delete path in the model selector).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

## Description

### Problem

When a user creates a workspace model (e.g., "Clone") that wraps an Ollama model, then tries to **delete** it from the 3-dot menu in the model selector, the deletion fails with:

> **Error deleting model: Model 'clone' was not found**

This is because the `confirmDeleteModel` function passes the **workspace model ID** (e.g., `clone`) directly to the Ollama `deleteModel` API, which only recognizes base model IDs (e.g., `llama3.2:latest`).

### Root Cause

In `Selector.svelte`, `confirmDeleteModel()` unconditionally calls the Ollama `deleteModel` API with `model.id`. It does not distinguish between workspace models and base Ollama models. For workspace models, `model.id` is the workspace alias — Ollama has no record of it.

### Fix

The code now branches based on whether the model is a workspace model (has `base_model_id`) or a base Ollama model:

- **Workspace model** → Deletes only the workspace model record via `deleteModelById` (WebUI models API). The underlying Ollama base model is **intentionally preserved** — other workspace models may depend on it.
- **Base Ollama model** → Calls Ollama's `deleteModel` directly, same as before.

```diff
 const confirmDeleteModel = async () => {
     const model = deleteModelTarget;
     if (!model) return;

-    const res = await deleteModel(localStorage.token, model.id).catch((error) => {
-        toast.error($i18n.t('Error deleting model: {{error}}', { error }));
-    });
-
-    if (res) {
+    let success = false;
+
+    if (model?.info?.base_model_id) {
+        // Workspace model: only delete the workspace model record
+        const res = await deleteModelById(localStorage.token, model.id).catch((error) => {
+            toast.error($i18n.t('Error deleting model: {{error}}', { error }));
+            return null;
+        });
+        success = !!res;
+    } else {
+        // Base Ollama model: delete from Ollama directly
+        const res = await deleteModel(localStorage.token, model.id).catch((error) => {
+            toast.error($i18n.t('Error deleting model: {{error}}', { error }));
+            return null;
+        });
+        success = !!res;
+    }
+
+    if (success) {
```

> This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

# Changelog Entry

### Description

- Fix deletion of workspace models from the model selector 3-dot menu. Workspace models now correctly delete only the workspace record (preserving the underlying base model), while base Ollama models continue to be deleted from Ollama directly.

### Fixed

- Deleting a workspace model from the model selector 3-dot menu no longer fails with "Model 'X' was not found". Workspace models are now deleted via the WebUI models API instead of being incorrectly passed to the Ollama delete API.

---

### Additional Information

- **Files changed:** 1 file (`src/lib/components/chat/ModelSelector/Selector.svelte`), 19 insertions, 5 deletions
- Companion fix to PR #26269 which resolved the same workspace model ID issue for the eject/unload path

### Manual Verification Performed

1. Created a workspace model (e.g., "Clone") wrapping an Ollama base model
2. Opened the model selector dropdown
3. Clicked the 3-dot menu on the workspace model → **Delete**
4. Confirmed deletion in the dialog
5. **Before fix:** Error toast "Model 'clone' was not found"
6. **After fix:** Workspace model deleted successfully; underlying Ollama base model preserved
7. Verified deleting an actual base Ollama model (no `base_model_id`) still works as expected

### Screenshots or Videos

#### Before fix: Error toast "Model 'clone' was not found"

<img width="2346" height="390" alt="image" src="https://github.com/user-attachments/assets/13a77345-d91c-4951-a175-a03f513c3efd" />

#### After fix: Workspace model deleted successfully; underlying Ollama base model preserved

<img width="2346" height="390" alt="image" src="https://github.com/user-attachments/assets/2ad68e0b-a4e8-4a98-a067-d269ca8937a2" />

<img width="2346" height="390" alt="image" src="https://github.com/user-attachments/assets/805f57cb-7569-43ad-9133-2b9ba1862e23" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
