### PR TITLE
feat: add response auto-scroll setting

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -130,6 +130,9 @@
 
 	let autoScroll = true;
 	let isNearTop = true;
+	$: responseAutoScroll = $settings?.chatResponseAutoScroll ?? true;
+
+	const shouldAutoScrollResponse = () => autoScroll && responseAutoScroll;
 	let processing = '';
 	let messagesContainerElement: HTMLDivElement;
 
@@ -671,7 +674,7 @@
 				} else if (type === 'chat:message:follow_ups') {
 					message.followUps = data.follow_ups;
 
-					if (autoScroll) {
+					if (shouldAutoScrollResponse()) {
 						scrollToBottom('smooth');
 					}
 				} else if (type === 'chat:outlet') {
@@ -1880,7 +1883,7 @@
 
 			await tick();
 
-			if (autoScroll) {
+			if (shouldAutoScrollResponse()) {
 				scrollToBottom();
 			}
 
@@ -1944,7 +1947,7 @@
 		history.currentId = currentParentId;
 		await tick();
 
-		if (autoScroll) {
+		if (shouldAutoScrollResponse()) {
 			scrollToBottom();
 		}
 
@@ -2043,7 +2046,7 @@
 			history.messages[message.id] = message;
 
 			await tick();
-			if (autoScroll) {
+			if (shouldAutoScrollResponse()) {
 				scrollToBottom();
 			}
 
@@ -2064,7 +2067,7 @@
 		console.log(data);
 		await tick();
 
-		if (autoScroll) {
+		if (shouldAutoScrollResponse()) {
 			scheduleScrollToBottom();
 		}
 	};
@@ -2746,7 +2749,7 @@
 
 			history.messages[history.currentId] = responseMessage;
 
-			if (autoScroll) {
+			if (shouldAutoScrollResponse()) {
 				scrollToBottom();
 			}
 		}
@@ -2894,7 +2897,7 @@
 						history.messages[messageId] = message;
 					}
 
-					if (autoScroll) {
+					if (shouldAutoScrollResponse()) {
 						scheduleScrollToBottom();
 					}
 				}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -131,7 +131,7 @@
 
 	$: handleHistoryChange(history.currentId, history.messages);
 
-	$: if (autoScroll && bottomPadding) {
+	$: if (autoScroll && bottomPadding && ($settings?.chatResponseAutoScroll ?? true)) {
 		(async () => {
 			await tick();
 			scrollToBottom();

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -31,6 +31,7 @@
 	let responseAutoCopy = false;
 	let widescreenMode = false;
 	let splitLargeChunks = false;
+	let chatResponseAutoScroll = true;
 	let scrollOnBranchChange = true;
 	let showFilesOnTerminalSelect = true;
 	let userLocation = false;
@@ -244,6 +245,7 @@
 		chatBubble = $settings?.chatBubble ?? true;
 		widescreenMode = $settings?.widescreenMode ?? false;
 		splitLargeChunks = $settings?.splitLargeChunks ?? false;
+		chatResponseAutoScroll = $settings?.chatResponseAutoScroll ?? true;
 		scrollOnBranchChange = $settings?.scrollOnBranchChange ?? true;
 		showFilesOnTerminalSelect = $settings?.showFilesOnTerminalSelect ?? true;
 
@@ -762,6 +764,25 @@
 					</div>
 				</div>
 			{/if}
+
+			<div>
+				<div class=" py-0.5 flex w-full justify-between">
+					<div id="chat-response-auto-scroll-label" class=" self-center text-xs">
+						{$i18n.t('Auto-scroll Responses')}
+					</div>
+
+					<div class="flex items-center gap-2 p-1">
+						<Switch
+							ariaLabelledbyId="chat-response-auto-scroll-label"
+							tooltip={true}
+							bind:state={chatResponseAutoScroll}
+							on:change={() => {
+								saveSettings({ chatResponseAutoScroll });
+							}}
+						/>
+					</div>
+				</div>
+			</div>
 
 			<div>
 				<div class=" py-0.5 flex w-full justify-between">


### PR DESCRIPTION
## Summary
- add a user setting to enable/disable automatic response scrolling
- keep the existing behavior enabled by default
- gate response/follow-up streaming scrolls behind the new setting while preserving manual/user-message scroll behavior

Closes / addresses discussion #19372: https://github.com/open-webui/open-webui/discussions/19372

## Verification
- `git diff --check`
- `npm run check -- --output machine` *(fails due existing repo-wide diagnostics; no diagnostics for changed files)*
- `npm run build`
- `npm run test:frontend` *(no test files found, exits 0)*
