### PR TITLE
fix(socket): prevent periodic cleanup tasks from exiting permanently on lock failures

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -166,69 +166,80 @@ YDOC_MANAGER = YdocManager(
 
 async def periodic_session_pool_cleanup():
     """Reap orphaned SESSION_POOL entries that missed heartbeats (e.g. crashed instance)."""
-    if not session_aquire_func():
-        log.debug('Session cleanup lock held by another node. Skipping.')
-        return
+    while True:
+        retry_delay = random.uniform(
+            WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT
+        )
+        if not session_aquire_func():
+            log.debug(f"Session cleanup lock held by another node. Retrying in {retry_delay:.1f}s...")
+            await asyncio.sleep(retry_delay)
+            continue
 
-    try:
-        while True:
-            if not session_renew_func():
-                log.error('Unable to renew session cleanup lock. Exiting.')
-                return
+        try:
+            while True:
+                if not session_renew_func():
+                    log.warning("Unable to renew session cleanup lock. Re-acquiring.")
+                    break
 
-            now = int(time.time())
-            for sid in list(SESSION_POOL.keys()):
-                entry = SESSION_POOL.get(sid)
-                if entry and now - entry.get('last_seen_at', 0) > SESSION_POOL_TIMEOUT:
-                    log.warning(f'Reaping orphaned session {sid} (user {entry.get("id")})')
-                    del SESSION_POOL[sid]
-            await asyncio.sleep(SESSION_POOL_TIMEOUT)
-    finally:
-        session_release_func()
+                now = int(time.time())
+                for sid in list(SESSION_POOL.keys()):
+                    entry = SESSION_POOL.get(sid)
+                    if entry and now - entry.get('last_seen_at', 0) > SESSION_POOL_TIMEOUT:
+                        log.warning(f'Reaping orphaned session {sid} (user {entry.get("id")})')
+                        del SESSION_POOL[sid]
+                await asyncio.sleep(SESSION_POOL_TIMEOUT)
+        finally:
+            try:
+                session_release_func()
+            except Exception as e:
+                log.error(f"Error releasing session cleanup lock: {e}")
+
+        await asyncio.sleep(retry_delay)
 
 
 async def periodic_usage_pool_cleanup():
-    max_retries = 2
-    retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
-    for attempt in range(max_retries + 1):
-        if aquire_func():
-            break
-        else:
-            if attempt < max_retries:
-                log.debug(f'Cleanup lock already exists. Retry {attempt + 1} after {retry_delay}s...')
-                await asyncio.sleep(retry_delay)
-            else:
-                log.warning('Failed to acquire cleanup lock after retries. Skipping cleanup.')
-                return
+    while True:
+        retry_delay = random.uniform(
+            WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT
+        )
+        if not aquire_func():
+            log.debug(f"Usage cleanup lock held by another node. Retrying in {retry_delay:.1f}s...")
+            await asyncio.sleep(retry_delay)
+            continue
 
-    log.debug('Running periodic_cleanup')
-    try:
-        while True:
-            if not renew_func():
-                log.error(f'Unable to renew cleanup lock. Exiting usage pool cleanup.')
-                raise Exception('Unable to renew usage pool cleanup lock.')
+        log.debug('Running periodic_cleanup')
+        try:
+            while True:
+                if not renew_func():
+                    log.warning("Unable to renew usage cleanup lock. Re-acquiring.")
+                    break
 
-            now = int(time.time())
-            send_usage = False
-            for model_id, connections in list(USAGE_POOL.items()):
-                # Creating a list of sids to remove if they have timed out
-                expired_sids = [
-                    sid for sid, details in connections.items() if now - details['updated_at'] > TIMEOUT_DURATION
-                ]
+                now = int(time.time())
+                send_usage = False
+                for model_id, connections in list(USAGE_POOL.items()):
+                    # Creating a list of sids to remove if they have timed out
+                    expired_sids = [
+                        sid for sid, details in connections.items() if now - details['updated_at'] > TIMEOUT_DURATION
+                    ]
 
-                for sid in expired_sids:
-                    del connections[sid]
+                    for sid in expired_sids:
+                        del connections[sid]
 
-                if not connections:
-                    log.debug(f'Cleaning up model {model_id} from usage pool')
-                    del USAGE_POOL[model_id]
-                else:
-                    USAGE_POOL[model_id] = connections
+                    if not connections:
+                        log.debug(f'Cleaning up model {model_id} from usage pool')
+                        del USAGE_POOL[model_id]
+                    else:
+                        USAGE_POOL[model_id] = connections
 
-                send_usage = True
-            await asyncio.sleep(TIMEOUT_DURATION)
-    finally:
-        release_func()
+                    send_usage = True
+                await asyncio.sleep(TIMEOUT_DURATION)
+        finally:
+            try:
+                release_func()
+            except Exception as e:
+                log.error(f"Error releasing usage cleanup lock: {e}")
+
+        await asyncio.sleep(retry_delay)
 
 
 app = socketio.ASGIApp(

--- a/backend/tests/test_socket_cleanup.py
+++ b/backend/tests/test_socket_cleanup.py
@@ -1,0 +1,162 @@
+import asyncio
+import time
+from unittest.mock import MagicMock
+import pytest
+import open_webui.socket.main as socket_main
+
+@pytest.mark.asyncio
+async def test_periodic_usage_pool_cleanup_recovery():
+    # Save original functions
+    orig_aquire = socket_main.aquire_func
+    orig_renew = socket_main.renew_func
+    orig_release = socket_main.release_func
+    orig_lock_timeout = socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT
+    orig_timeout_duration = socket_main.TIMEOUT_DURATION
+
+    # Configure short timeouts for tests
+    socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT = 0.02
+    socket_main.TIMEOUT_DURATION = 0.01
+
+    try:
+        # Mock behavior for periodic_usage_pool_cleanup:
+        # 1. First acquire_lock fails
+        # 2. Second acquire_lock succeeds
+        # 3. First renew_lock succeeds
+        # 4. Second renew_lock fails
+        # 5. Subsequent acquire_lock succeeds and renew_lock succeeds
+        
+        acquire_calls = []
+        renew_calls = []
+        release_calls = []
+
+        def mock_acquire():
+            acquire_calls.append(True)
+            if len(acquire_calls) == 1:
+                return False
+            return True
+
+        def mock_renew():
+            renew_calls.append(True)
+            if len(renew_calls) == 2:
+                return False
+            return True
+
+        def mock_release():
+            release_calls.append(True)
+            return True
+
+        socket_main.aquire_func = mock_acquire
+        socket_main.renew_func = mock_renew
+        socket_main.release_func = mock_release
+
+        # Populate USAGE_POOL
+        socket_main.USAGE_POOL = {
+            'model1': {
+                'sid1': {'updated_at': int(time.time()) - 100}
+            }
+        }
+
+        # Start cleanup task
+        task = asyncio.create_task(socket_main.periodic_usage_pool_cleanup())
+
+        # Give it some time to run and trigger a few loops and failures
+        await asyncio.sleep(0.2)
+
+        # Cancel the task
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Assertions
+        assert len(acquire_calls) >= 2, "Should have retried lock acquisition"
+        assert len(renew_calls) >= 2, "Should have called renew"
+        assert len(release_calls) >= 2, "Should have released lock on breakage"
+        assert 'model1' not in socket_main.USAGE_POOL, "Should have cleaned up expired entries"
+
+    finally:
+        # Restore original functions
+        socket_main.aquire_func = orig_aquire
+        socket_main.renew_func = orig_renew
+        socket_main.release_func = orig_release
+        socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT = orig_lock_timeout
+        socket_main.TIMEOUT_DURATION = orig_timeout_duration
+
+
+@pytest.mark.asyncio
+async def test_periodic_session_pool_cleanup_recovery():
+    # Save original functions
+    orig_acquire = socket_main.session_aquire_func
+    orig_renew = socket_main.session_renew_func
+    orig_release = socket_main.session_release_func
+    orig_lock_timeout = socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT
+    orig_session_timeout = socket_main.SESSION_POOL_TIMEOUT
+
+    # Configure short timeouts for tests
+    socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT = 0.02
+    socket_main.SESSION_POOL_TIMEOUT = 0.01
+
+    try:
+        # Mock behavior for periodic_session_pool_cleanup:
+        # 1. First acquire_lock fails
+        # 2. Second acquire_lock succeeds
+        # 3. First renew_lock succeeds
+        # 4. Second renew_lock fails
+        # 5. Subsequent acquire_lock succeeds and renew_lock succeeds
+        
+        acquire_calls = []
+        renew_calls = []
+        release_calls = []
+
+        def mock_acquire():
+            acquire_calls.append(True)
+            if len(acquire_calls) == 1:
+                return False
+            return True
+
+        def mock_renew():
+            renew_calls.append(True)
+            if len(renew_calls) == 2:
+                return False
+            return True
+
+        def mock_release():
+            release_calls.append(True)
+            return True
+
+        socket_main.session_aquire_func = mock_acquire
+        socket_main.session_renew_func = mock_renew
+        socket_main.session_release_func = mock_release
+
+        # Populate SESSION_POOL
+        socket_main.SESSION_POOL = {
+            'sid1': {'id': 'user1', 'last_seen_at': int(time.time()) - 100}
+        }
+
+        # Start cleanup task
+        task = asyncio.create_task(socket_main.periodic_session_pool_cleanup())
+
+        # Give it some time to run and trigger a few loops and failures
+        await asyncio.sleep(0.2)
+
+        # Cancel the task
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        # Assertions
+        assert len(acquire_calls) >= 2, "Should have retried lock acquisition"
+        assert len(renew_calls) >= 2, "Should have called renew"
+        assert len(release_calls) >= 2, "Should have released lock on breakage"
+        assert 'sid1' not in socket_main.SESSION_POOL, "Should have cleaned up expired session"
+
+    finally:
+        # Restore original functions
+        socket_main.session_aquire_func = orig_acquire
+        socket_main.session_renew_func = orig_renew
+        socket_main.session_release_func = orig_release
+        socket_main.WEBSOCKET_REDIS_LOCK_TIMEOUT = orig_lock_timeout
+        socket_main.SESSION_POOL_TIMEOUT = orig_session_timeout


### PR DESCRIPTION
## Description
Currently, both `periodic_usage_pool_cleanup` and `periodic_session_pool_cleanup` are spawned as background tasks at startup. If a transient error occurs during lock acquisition or renewal (e.g. temporary Redis connectivity loss), the tasks log an error or raise and exit permanently. Since there is no watchdog or restart mechanism, this leaves `USAGE_POOL` and `SESSION_POOL` unbounded, leading to memory growth and stale active models lists.

## Fix
- Wrapped both cleanup loops in self-healing outer loops that drop back to lock acquisition and retry with backoff instead of terminating.
- Caught potential exceptions raised during lock release to ensure robust execution.
- Added comprehensive unit tests in `backend/tests/test_socket_cleanup.py` to verify correct recovery behavior under acquisition and renewal failure scenarios.

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have signed the CLA.
- [x] My branch is up-to-date with upstream/dev.