### PR TITLE
fix: prevent startup crash when function/tool has null user_id

### DIFF
--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -42,7 +42,7 @@ class FunctionMeta(BaseModel):
 
 class FunctionModel(BaseModel):
     id: str
-    user_id: str
+    user_id: str | None = None  # may be null for legacy/malformed records
     name: str
     type: str
     content: str
@@ -58,7 +58,7 @@ class FunctionModel(BaseModel):
 # --- form / schema definitions ---
 class FunctionWithValvesModel(BaseModel):
     id: str
-    user_id: str
+    user_id: str | None = None  # may be null for legacy/malformed records
     name: str
     type: str
     content: str
@@ -79,7 +79,7 @@ class FunctionWithValvesModel(BaseModel):
 
 class FunctionResponse(BaseModel):
     id: str
-    user_id: str
+    user_id: str | None = None  # may be null for legacy/malformed records
     type: str
     name: str
     meta: FunctionMeta

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -41,7 +41,7 @@ class ToolMeta(BaseModel):
 
 class ToolModel(BaseModel):
     id: str
-    user_id: str
+    user_id: str | None = None  # may be null for legacy/malformed records
     name: str
     content: str
     specs: list[dict]
@@ -65,7 +65,7 @@ class ToolUserModel(ToolModel):
 
 class ToolResponse(BaseModel):
     id: str
-    user_id: str
+    user_id: str | None = None  # may be null for legacy/malformed records
     name: str
     meta: ToolMeta
     access_grants: list[AccessGrantModel] = Field(default_factory=list)


### PR DESCRIPTION
The Function and Tool database columns declare user_id as a nullable String column, but their Pydantic read-models required a non-null string. A record with user_id NULL therefore raised a pydantic ValidationError inside get_functions()/get_tools(), which run during install_tool_and_function_dependencies() at app startup — crashing the whole application and blocking all chat completions.

Make user_id Optional in the read/response models so such records validate gracefully (user is already rendered as None downstream when the id has no matching user) instead of taking down startup.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
