### PR TITLE
fix: fall back to structured output text in chat-reference sources

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1304,6 +1304,30 @@ async def filter_accessible_collections(
     return validated
 
 
+def _get_message_text(message: dict) -> str:
+    # Since the 0.10 rendering refactor, streamed assistant text lives in
+    # `output[].content[].text` while `content` is persisted empty; fall back
+    # to it so chat-reference sources don't drop the assistant's reply.
+    content = message.get('content')
+    if isinstance(content, str) and content.strip():
+        return content
+
+    output = message.get('output')
+    if not isinstance(output, list):
+        return content or ''
+
+    texts = [
+        ''.join(
+            part.get('text') or ''
+            for part in item.get('content', [])
+            if isinstance(part, dict) and part.get('type') == 'output_text'
+        )
+        for item in output
+        if isinstance(item, dict) and item.get('type') == 'message'
+    ]
+    return '\n'.join(text for text in texts if text.strip()) or (content or '')
+
+
 async def get_sources_from_items(
     request,
     items,
@@ -1390,7 +1414,7 @@ async def get_sources_from_items(
                     # Reconstruct the message list in order
                     message_list = get_message_list(messages_map, message_id)
                     message_history = '\n'.join(
-                        [f'#### {m.get("role", "user").capitalize()}\n{m.get("content")}\n' for m in message_list]
+                        [f'#### {m.get("role", "user").capitalize()}\n{_get_message_text(m)}\n' for m in message_list]
                     )
 
                     # User has access to the chat


### PR DESCRIPTION
### Linked Issue/Discussion

Relates to #26436. Complements #26799, which syncs `message.content` from structured `output` at the write chokepoint (`Chats.upsert_message_to_chat_by_id_and_message_id`) going forward, plus a read-time fallback in the outlet-filter payload. That fix doesn't backfill messages already persisted with an empty `content` before it merges, and doesn't touch `get_sources_from_items` in `retrieval/utils.py`, the function that builds the source text when a chat is attached as a reference/context source (via drag-and-drop or the "Reference Chats" input-menu option). Any chat saved before #26799 ships still produces a source with the assistant's turn rendered as an empty `#### Assistant` heading, this reproduces on any current chat, not just older data, since this build has no write-time fix yet.

### Description

Add a local fallback (`_get_message_text`) in `retrieval/utils.py` that reads `output[].content[].text` when `content` is empty, mirroring the extraction logic in #26799's `get_output_text` helper (duplicated rather than imported since #26799 isn't merged yet, happy to consolidate into a shared import once it lands). Use it when assembling the `#### {role}\n{content}` block for a referenced chat's message history.

### Changelog Entry

#### Fixed

- Referencing a chat as a context source (drag-and-drop or the "Reference Chats" input menu) no longer drops the assistant's reply when that chat's message was saved with its text in structured `output` instead of `content`.

### Additional Information

Found while testing v0.10.1: dragging a chat into a new chat's input, then asking a question, showed a source containing only the user's message, the assistant's reply was silently missing. Confirmed the root cause against the actual message data: the referenced chat's assistant message had `content: ""` with the real text in `output`. Reproduced this on a chat freshly created on the same build, so it isn't limited to legacy/pre-existing data.

### Testing

Verified with unit-level test cases covering: the exact bug reproduction (from real saved message data), a native tool-call turn (interleaved `function_call`/`function_call_output` items, matching a report on #26436), legacy pre-0.10 messages with populated `content` and no `output` key, and messages with both `content` and `output` present (content wins, e.g. an outlet filter already overwrote it).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.