### PR TITLE
feat: Add notes folder filter and auto-assign from chat context

### DIFF
--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -187,6 +187,10 @@ class NoteTable:
                             )
                         )
 
+                folder = filter.get('folder')
+                if folder:
+                    stmt = stmt.filter(Note.meta['folder'].as_string() == folder)
+
                 view_option = filter.get('view_option')
                 if view_option == 'created':
                     stmt = stmt.filter(Note.user_id == user_id)
@@ -386,6 +390,31 @@ class NoteTable:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(PinnedNote.note_id).filter_by(user_id=user_id))
             return result.scalars().all()
+
+    async def get_distinct_folders(
+        self,
+        user_id: str,
+        permission: str = 'read',
+        db: Optional[AsyncSession] = None,
+    ) -> list[str]:
+        async with get_async_db_context(db) as db:
+            user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
+            user_group_ids = [group.id for group in user_groups]
+
+            stmt = select(Note)
+            stmt = self._has_permission(db, stmt, {'user_id': user_id, 'group_ids': user_group_ids}, permission)
+
+            result = await db.execute(stmt)
+            notes = result.scalars().all()
+
+            folders = set()
+            for note in notes:
+                if note.meta and isinstance(note.meta, dict):
+                    folder = note.meta.get('folder')
+                    if folder:
+                        folders.add(folder)
+
+            return sorted(folders)
 
 
 Notes = NoteTable()

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -20,6 +20,7 @@ from open_webui.models.notes import (
     NoteModel,
     Notes,
     NoteUserResponse,
+    NoteItemResponse,
 )
 from open_webui.models.users import UserResponse, Users
 from open_webui.socket.main import sio
@@ -54,6 +55,7 @@ class NoteItemResponse(BaseModel):
     id: str
     title: str
     data: Optional[dict]
+    meta: Optional[dict] = None
     is_pinned: Optional[bool] = False
     updated_at: int
     created_at: int
@@ -148,6 +150,7 @@ async def get_pinned_notes(
 async def search_notes(
     request: Request,
     query: Optional[str] = None,
+    folder: Optional[str] = None,
     view_option: Optional[str] = None,
     permission: Optional[str] = None,
     order_by: Optional[str] = None,
@@ -173,6 +176,8 @@ async def search_notes(
     filter = {}
     if query:
         filter['query'] = query
+    if folder:
+        filter['folder'] = folder
     if view_option:
         filter['view_option'] = view_option
     if permission:
@@ -195,6 +200,28 @@ async def search_notes(
         note.is_pinned = note.id in pinned_note_ids
         note.data = _truncate_note_data(note.data)
     return result
+
+
+############################
+# GetFolders
+############################
+
+
+@router.get('/folders', response_model=list[str])
+async def get_folders(
+    request: Request,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'features.notes', await Config.get('user.permissions'), db=db
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.UNAUTHORIZED,
+        )
+
+    return await Notes.get_distinct_folders(user.id, 'read', db=db)
 
 
 ############################

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1082,6 +1082,7 @@ async def write_note(
     content: str,
     __request__: Request = None,
     __user__: dict = None,
+    __folder_id__: str = None,
 ) -> str:
     """
     Create a new note with the given title and content.
@@ -1101,9 +1102,18 @@ async def write_note(
 
         user_id = __user__.get('id')
 
+        meta = {}
+        if __folder_id__:
+            from open_webui.models.folders import Folders
+
+            folder = await Folders.get_folder_by_id_and_user_id(__folder_id__, user_id)
+            if folder:
+                meta['folder'] = folder.name
+
         form = NoteForm(
             title=title,
             data={'content': {'md': content}},
+            meta=meta if meta else None,
             access_grants=[],  # Private by default - only owner can access
         )
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2351,6 +2351,10 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if not folder_id:
         folder_id = metadata.get('folder_id', None)
 
+    # Pass resolved folder_id to tools for auto-assignment (e.g., note creation)
+    if folder_id:
+        extra_params['__folder_id__'] = folder_id
+
     if folder_id and user:
         folder = await Folders.get_folder_by_id_and_user_id(folder_id, user.id)
 

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -666,6 +666,7 @@ async def get_builtin_tools(
                 '__event_call__': extra_params.get('__event_call__'),
                 '__metadata__': extra_params.get('__metadata__'),
                 '__chat_id__': extra_params.get('__chat_id__'),
+                '__folder_id__': extra_params.get('__folder_id__'),
                 '__message_id__': extra_params.get('__message_id__'),
                 '__model_knowledge__': model_knowledge,
             },

--- a/src/lib/apis/notes/index.ts
+++ b/src/lib/apis/notes/index.ts
@@ -97,13 +97,18 @@ export const searchNotes = async (
 	viewOption: string | null = null,
 	permission: string | null = null,
 	sortKey: string | null = null,
-	page: number | null = null
+	page: number | null = null,
+	folder: string | null = null
 ) => {
 	let error = null;
 	const searchParams = new URLSearchParams();
 
 	if (query !== null) {
 		searchParams.append('query', query);
+	}
+
+	if (folder !== null) {
+		searchParams.append('folder', folder);
 	}
 
 	if (viewOption !== null) {
@@ -148,6 +153,37 @@ export const searchNotes = async (
 	}
 
 	return res;
+};
+
+export const getFolders = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/notes/folders`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res ?? [];
 };
 
 export const getNoteList = async (token: string = '', page: number | null = null) => {

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -38,7 +38,8 @@
 		getNoteList,
 		searchNotes,
 		toggleNotePinnedStatusById,
-		getPinnedNoteList
+		getPinnedNoteList,
+		getFolders
 	} from '$lib/apis/notes';
 	import { capitalizeFirstLetter, copyToClipboard, getTimeRange } from '$lib/utils';
 	import { downloadPdf, createNoteHandler } from './utils';
@@ -74,6 +75,8 @@
 	let displayOption = null;
 	let viewOption = null;
 	let permission = null;
+	let folder = null;
+	let folders = [];
 
 	let page = 1;
 
@@ -178,6 +181,7 @@
 
 	const init = async () => {
 		reset();
+		folders = await getFolders(localStorage.token).catch(() => []);
 		await getItemsPage();
 	};
 
@@ -190,7 +194,7 @@
 		}, 300);
 	};
 
-	$: if (loaded && sortKey !== undefined && permission !== undefined && viewOption !== undefined) {
+	$: if (loaded && sortKey !== undefined && permission !== undefined && viewOption !== undefined && folder !== undefined) {
 		init();
 	}
 
@@ -207,7 +211,8 @@
 			viewOption,
 			permission,
 			sortKey,
-			page
+			page,
+			folder
 		).catch(() => {
 			return [];
 		});
@@ -293,9 +298,12 @@
 		dragged = false;
 	};
 
-	onMount(() => {
+	onMount(async () => {
 		viewOption = localStorage?.noteViewOption ?? null;
 		displayOption = localStorage?.noteDisplayOption ?? null;
+		folder = localStorage?.noteFolder ?? null;
+
+		folders = await getFolders(localStorage.token).catch(() => []);
 
 		loaded = true;
 
@@ -351,11 +359,12 @@
 					</div>
 				</div>
 
-				<div class="flex w-full justify-end gap-1.5">
+				<div class="flex w-full justify-end gap-1.5 items-center">
 					<button
 						class=" px-2 py-1.5 rounded-xl bg-black text-white dark:bg-white dark:text-black transition font-medium text-sm flex items-center"
 						on:click={async () => {
-							const res = await createNoteHandler(dayjs().format('YYYY-MM-DD'));
+							const currentFolder = localStorage?.noteFolder ?? null;
+							const res = await createNoteHandler(dayjs().format('YYYY-MM-DD'), undefined, undefined, currentFolder);
 
 							if (res) {
 								goto(`/notes/${res.id}`);
@@ -442,6 +451,25 @@
 								]}
 							/>
 						{/if}
+
+						{#if folders.length > 0}
+							<DropdownOptions
+								align="start"
+								className="flex shrink-0 items-center gap-2 px-3 py-1.5 text-sm bg-gray-50 dark:bg-gray-850 rounded-xl placeholder-gray-400 outline-hidden focus:outline-hidden"
+								bind:value={folder}
+								items={[
+									{ value: null, label: $i18n.t('All Folders') },
+									...folders.map((f) => ({ value: f, label: f }))
+								]}
+								onChange={(value) => {
+									if (value) {
+										localStorage.noteFolder = value;
+									} else {
+										delete localStorage.noteFolder;
+									}
+								}}
+							/>
+						{/if}
 					</div>
 				</div>
 
@@ -499,6 +527,12 @@
 																	{note.title}
 																</div>
 															</Tooltip>
+
+															{#if note?.meta?.folder}
+																<div class="shrink-0 px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full">
+																	{note.meta.folder}
+																</div>
+															{/if}
 
 															<div class="flex shrink-0 items-center text-xs gap-2.5">
 																<Tooltip content={dayjs(note.updated_at / 1000000).format('LLLL')}>
@@ -591,6 +625,12 @@
 																<div class=" font-semibold line-clamp-1 capitalize">
 																	{note.title}
 																</div>
+
+																{#if note?.meta?.folder}
+																	<div class="shrink-0 px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-full">
+																		{note.meta.folder}
+																	</div>
+																{/if}
 
 																<div>
 																	<NoteMenu

--- a/src/lib/components/notes/utils.ts
+++ b/src/lib/components/notes/utils.ts
@@ -107,7 +107,7 @@ export const downloadPdf = async (note) => {
 	pdf.save(`${note.title}.pdf`);
 };
 
-export const createNoteHandler = async (title: string, md?: string, html?: string) => {
+export const createNoteHandler = async (title: string, md?: string, html?: string, folder?: string) => {
 	//  $i18n.t('New Note'),
 	const res = await createNewNote(localStorage.token, {
 		// YYYY-MM-DD
@@ -119,7 +119,7 @@ export const createNoteHandler = async (title: string, md?: string, html?: strin
 				md: md || ''
 			}
 		},
-		meta: null,
+		meta: folder ? { folder } : null,
 		access_grants: []
 	}).catch((error) => {
 		toast.error(`${error}`);


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing discussion about notes organization. Relates to community requests for folder-based note filtering.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are preferred over new settings.
- [x] **Git Hygiene:** The PR is atomic and contains no unrelated commits.
- [x] **Title Prefix:** Uses `feat:` prefix for new feature.

---

# Description

Adds a folder-based organization system for notes, allowing users to categorize and filter notes by folder. Users with hundreds of notes can now quickly filter by project/topic (Java, Python, SQL, etc.) using a dropdown filter.

## Key Features
- **Folder filter dropdown** in the Notes list page (appears only when folders exist)
- **Auto-assign folder** when creating notes via AI chat tools — detects the chat's folder context
- **Folder badge** displayed on note cards in both list and grid views
- **New notes inherit** the currently selected folder filter
- **No DB migration** — uses existing `meta` JSON field

---

# Changes

## Backend

- **`backend/open_webui/models/notes.py`**: Add `get_distinct_folders()` method and folder filter to `search_notes()` query
- **`backend/open_webui/routers/notes.py`**: Add `folder` query param to search endpoint, new `GET /notes/folders` endpoint, include `meta` in `NoteItemResponse`
- **`backend/open_webui/tools/builtin.py`**: `write_note` now accepts `__folder_id__` to auto-assign folder name from chat context
- **`backend/open_webui/utils/middleware.py`**: Pass resolved `__folder_id__` to tool extra_params
- **`backend/open_webui/utils/tools.py`**: Include `__folder_id__` in tool context injection

## Frontend

- **`src/lib/apis/notes/index.ts`**: Add `folder` param to `searchNotes()`, new `getFolders()` API function
- **`src/lib/components/notes/Notes.svelte`**: Folder filter dropdown, folder badge on note cards, new notes inherit current folder
- **`src/lib/components/notes/utils.ts`**: `createNoteHandler` accepts optional folder parameter

---

# Changelog Entry

### Added
- Folder filter dropdown in Notes list page to filter notes by folder name
- `GET /notes/folders` API endpoint to retrieve distinct folder names
- Folder badge on note cards showing which folder a note belongs to
- Auto-assignment of folder when creating notes via AI chat tools
- `folder` query parameter for `GET /notes/search` endpoint

### Changed
- `write_note` builtin tool now accepts optional `folder_id` context parameter
- Notes list API responses now include `meta` field for folder information
- New notes created from the Notes page inherit the currently selected folder filter

### Backward Compatible
- All existing behavior preserved (no breaking changes)
- Folder field is optional — notes without folders show in "All" view
- No database migration required

---

# Additional Information

- Folder names are stored as strings in `meta.folder` — flexible and user-defined
- The feature integrates with the existing chat folder system (same folder names)
- Works with both SQLite and PostgreSQL backends

### Screenshots or Videos

- Folder filter dropdown appears in the Notes filter bar
- Blue folder badge shown on each note card
- Filter narrows notes to selected folder only

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
