### PR TITLE
fix: preserve system prompt across tool calls when memories are enabled

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2198,6 +2198,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             form_data['model'] = selected_model_id
             metadata['selected_model_id'] = selected_model_id
 
+    # Capture the model's default system prompt before apply_params_to_form_data
+    # pops 'params'. The provider layer applies it fresh from model_info.params,
+    # but the native tool-call loop runs with bypass_system_prompt=True and relies
+    # on metadata['system_prompt'] (built below) to carry it forward instead.
+    model_system_prompt = (form_data.get('params') or {}).get('system')
+
     form_data = apply_params_to_form_data(form_data, model)
     log.debug(f'form_data: {form_data}')
 
@@ -2792,13 +2798,17 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # than a snapshot that already has the RAG template baked in.
     system_message = get_system_message(form_data['messages'])
     system_content = get_content_from_message(system_message) if system_message else ''
-    model_system_prompt = await resolve_system_prompt(
-        (form_data.get('params') or {}).get('system'),
+    resolved_model_system_prompt = await resolve_system_prompt(
+        model_system_prompt,
         metadata,
         user,
     )
-    if model_system_prompt:
-        system_content = f'{model_system_prompt}\n{system_content}' if system_content else model_system_prompt
+    if resolved_model_system_prompt:
+        system_content = (
+            f'{resolved_model_system_prompt}\n{system_content}'
+            if system_content
+            else resolved_model_system_prompt
+        )
     metadata['system_prompt'] = system_content or None
     metadata['user_prompt'] = get_last_user_message(form_data['messages'])
     metadata['sources'] = sources[:] if sources else []

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2198,10 +2198,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             form_data['model'] = selected_model_id
             metadata['selected_model_id'] = selected_model_id
 
-    # Capture the model's default system prompt before apply_params_to_form_data
-    # pops 'params'. The provider layer applies it fresh from model_info.params,
-    # but the native tool-call loop runs with bypass_system_prompt=True and relies
-    # on metadata['system_prompt'] (built below) to carry it forward instead.
+    # Captured before apply_params_to_form_data pops 'params'; feeds metadata['system_prompt'] below
     model_system_prompt = (form_data.get('params') or {}).get('system')
 
     form_data = apply_params_to_form_data(form_data, model)


### PR DESCRIPTION
The native tool-call loop runs generate_chat_completion with bypass_system_prompt=True, so the provider layer does not re-apply the model's default system prompt on tool-call iterations. It relies instead on metadata['system_prompt'], captured in process_chat_payload, to carry the full system prompt forward and restore it after RAG injection.

That capture read the model default system prompt from form_data['params']['system'], but apply_params_to_form_data had already popped 'params' from form_data, so model_system_prompt was always empty. metadata['system_prompt'] therefore only captured whatever was already materialized in the messages. With memories enabled, that is the injected <memory_context> system message, so tool-call requests were restored with memory-only system content and the model's system prompt was dropped. Without memories there was no system message to capture at all.

Capture the model default system prompt from form_data['params'] before apply_params_to_form_data pops it, and use that value when building metadata['system_prompt'].

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
