### PR TITLE
feat: expose Memory as a per-model capability toggle

### DIFF
--- a/src/lib/components/workspace/Models/Capabilities.svelte
+++ b/src/lib/components/workspace/Models/Capabilities.svelte
@@ -56,6 +56,10 @@
 			description: $i18n.t(
 				'Automatically inject system tools in native function calling mode (e.g., timestamps, memory, chat history, notes, etc.)'
 			)
+		},
+		memory: {
+			label: $i18n.t('Memory'),
+			description: $i18n.t('Inject stored memories into the conversation context')
 		}
 	};
 
@@ -71,6 +75,7 @@
 		citations?: boolean;
 		status_updates?: boolean;
 		builtin_tools?: boolean;
+		memory?: boolean;
 	} = {};
 
 	// Hide file_context when file_upload is disabled

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -108,7 +108,8 @@ export const DEFAULT_CAPABILITIES = {
 	citations: true,
 	status_updates: true,
 	usage: undefined,
-	builtin_tools: true
+	builtin_tools: true,
+	memory: true
 };
 
 export const PASTED_TEXT_CHARACTER_LIMIT = 1000;


### PR DESCRIPTION
The backend already gates passive memory-context injection per model via capabilities.memory (model_allows_memory / add_memory_context in utils/memory.py), defaulting to true. But `memory` was not listed in the model editor's Capabilities UI or in DEFAULT_CAPABILITIES, so it could only be set by hand-editing the model JSON / models API.

This exposes `memory` as a visible capability checkbox (default on, matching the backend default), letting admins disable stored-memory injection for individual models — e.g. to keep memories out of models with different data-residency requirements.

Relates to #18610

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Open WebUI already gates passive memory-context injection per model: `model_allows_memory()` reads `meta.capabilities.memory` (default `true`) and `add_memory_context()` skips injection when it is `false` (`backend/open_webui/utils/memory.py`). However, `memory` is not exposed in the model editor's Capabilities section, nor included in `DEFAULT_CAPABILITIES`, so today it can only be toggled by hand-editing the model JSON or the models API.
This surfaces `memory` as a regular capability checkbox in the model editor (default on, matching the backend default), so admins can disable stored-memory injection for individual models directly from the UI.
**Motivation:** running a mix of models with different data-residency requirements (e.g. EU- vs. US-hosted models) where stored memories must not be injected into the context of certain models.

### Added

- `memory` capability checkbox in the model editor's Capabilities section (`Capabilities.svelte`), wired to the existing `meta.capabilities.memory` backend gate.

### Changed

- `DEFAULT_CAPABILITIES` now includes `memory: true`, so the new toggle reflects the existing backend default (no behavior change for existing models).

---

### Additional Information

The `Memory` label key already exists in the i18n catalog; the new capability description falls back to English until translations are added (can run `npm run i18n:parse` if preferred).

### Screenshots or Videos

<img width="1853" height="981" alt="image" src="https://github.com/user-attachments/assets/217d1848-622b-4054-baff-5c7b80de68d5" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
