### PR TITLE
Filter empty assistant placeholders from provider payloads

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2010,6 +2010,9 @@ def process_messages_with_output(
     processed = []
 
     for message in messages:
+        if _is_empty_assistant_message(message):
+            continue
+
         if message.get('role') == 'assistant' and message.get('output'):
             # Use output items for clean OpenAI-format messages
             output_messages = convert_output_to_messages(
@@ -2026,6 +2029,30 @@ def process_messages_with_output(
         processed.append(clean_message)
 
     return processed
+
+
+def _has_message_content(content) -> bool:
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict):
+                return True
+            if part.get('type') != 'text':
+                return True
+            if part.get('text', '').strip():
+                return True
+        return False
+    return content is not None
+
+
+def _is_empty_assistant_message(message: dict) -> bool:
+    return (
+        message.get('role') == 'assistant'
+        and not message.get('output')
+        and not message.get('tool_calls')
+        and not _has_message_content(message.get('content'))
+    )
 
 
 def strip_compaction_fields(messages: list[dict]) -> list[dict]:

--- a/backend/tests/test_middleware_empty_assistant_messages.py
+++ b/backend/tests/test_middleware_empty_assistant_messages.py
@@ -1,0 +1,24 @@
+from open_webui.utils.middleware import process_messages_with_output
+
+
+def test_process_messages_with_output_drops_empty_assistant_placeholders():
+    messages = [
+        {'role': 'user', 'content': 'first prompt'},
+        {'role': 'assistant', 'content': '', 'done': False},
+        {'role': 'user', 'content': 'next prompt'},
+    ]
+
+    assert process_messages_with_output(messages) == [
+        {'role': 'user', 'content': 'first prompt'},
+        {'role': 'user', 'content': 'next prompt'},
+    ]
+
+
+def test_process_messages_with_output_keeps_useful_assistant_messages():
+    messages = [
+        {'role': 'assistant', 'content': 'done'},
+        {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call-1'}]},
+        {'role': 'assistant', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:'}}]},
+    ]
+
+    assert process_messages_with_output(messages) == messages


### PR DESCRIPTION
Fixes #25083

## Summary
- skip assistant placeholder messages that have no content, output, or tool calls before provider payload construction
- preserve useful assistant messages with text, multimodal non-text content, output items, or tool calls
- add regression coverage for persisted empty assistant placeholders

## Testing
- WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_middleware_empty_assistant_messages.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/open-webui-pycache python3 -m py_compile backend/open_webui/utils/middleware.py backend/tests/test_middleware_empty_assistant_messages.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_middleware_empty_assistant_messages.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/utils/middleware.py backend/tests/test_middleware_empty_assistant_messages.py

Note: full ruff check on middleware.py still reports existing baseline issues in that file.