### PR TITLE
Reset image generation toggle when unavailable

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -69,6 +69,7 @@
 
 	import InputMenu from './MessageInput/InputMenu.svelte';
 	import VoiceRecording from './MessageInput/VoiceRecording.svelte';
+	import { getAvailableFeatureToggleState } from './MessageInput/features';
 
 	import ToolServersModal from './ToolServersModal.svelte';
 	import SkillsModal from './SkillsModal.svelte';
@@ -552,6 +553,11 @@
 		selectedModelIds.length === imageGenerationCapableModels.length &&
 		$config?.features?.enable_image_generation &&
 		($_user.role === 'admin' || $_user?.permissions?.features?.image_generation);
+
+	$: imageGenerationEnabled = getAvailableFeatureToggleState(
+		imageGenerationEnabled,
+		showImageGenerationButton
+	);
 
 	let showCodeInterpreterButton = false;
 	$: showCodeInterpreterButton =

--- a/src/lib/components/chat/MessageInput/features.test.ts
+++ b/src/lib/components/chat/MessageInput/features.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAvailableFeatureToggleState } from './features';
+
+describe('getAvailableFeatureToggleState', () => {
+	it('turns off enabled feature state when the feature control is unavailable', () => {
+		expect(getAvailableFeatureToggleState(true, false)).toBe(false);
+	});
+
+	it('preserves feature state when the feature control is available', () => {
+		expect(getAvailableFeatureToggleState(true, true)).toBe(true);
+		expect(getAvailableFeatureToggleState(false, true)).toBe(false);
+	});
+});

--- a/src/lib/components/chat/MessageInput/features.ts
+++ b/src/lib/components/chat/MessageInput/features.ts
@@ -1,0 +1,2 @@
+export const getAvailableFeatureToggleState = (enabled: boolean, available: unknown) =>
+	available ? enabled : false;


### PR DESCRIPTION
Fixes #26842

## Summary
- reset the local image generation enabled state when the image generation control is no longer available
- prevents the selected blue Image chip from lingering after image generation is disabled by config or permissions
- add focused coverage for the feature-toggle state helper

## Testing
- npm run test:frontend -- src/lib/components/chat/MessageInput/features.test.ts --run
- npx eslint src/lib/components/chat/MessageInput/features.ts src/lib/components/chat/MessageInput/features.test.ts
- npx prettier --check src/lib/components/chat/MessageInput/features.ts src/lib/components/chat/MessageInput/features.test.ts src/lib/components/chat/MessageInput.svelte

Note: full eslint on MessageInput.svelte still reports existing baseline issues in that file.