### PR TITLE
Use output text when message content is empty

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -158,14 +158,45 @@ def get_last_user_message_item(messages: list[dict]) -> dict | None:
     return None
 
 
+def get_output_text_from_message(message: dict) -> str | None:
+    output = message.get('output')
+    if not isinstance(output, list):
+        return None
+
+    text_parts = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+
+        if item.get('type') != 'message':
+            continue
+
+        for part in item.get('content') or []:
+            if isinstance(part, dict) and part.get('type') == 'output_text':
+                text = part.get('text')
+                if text:
+                    text_parts.append(text)
+
+    if text_parts:
+        return ''.join(text_parts)
+
+    return None
+
+
 def get_content_from_message(message: dict) -> str | None:
+    content = None
     if isinstance(message.get('content'), list):
         for item in message['content']:
             if item['type'] == 'text':
-                return item['text']
+                content = item['text']
+                break
     else:
-        return message.get('content')
-    return None
+        content = message.get('content')
+
+    if isinstance(content, str) and content.strip():
+        return content
+
+    return get_output_text_from_message(message) or content
 
 
 def reconcile_tool_pairs(messages: list[dict]) -> list[dict]:

--- a/backend/tests/test_message_content_from_output.py
+++ b/backend/tests/test_message_content_from_output.py
@@ -1,0 +1,19 @@
+from open_webui.utils.misc import get_messages_content
+
+
+def test_get_messages_content_uses_output_text_when_content_is_empty():
+    messages = [
+        {'role': 'user', 'content': 'hello'},
+        {
+            'role': 'assistant',
+            'content': '',
+            'output': [
+                {
+                    'type': 'message',
+                    'content': [{'type': 'output_text', 'text': 'Hi there.'}],
+                }
+            ],
+        },
+    ]
+
+    assert get_messages_content(messages) == 'USER: hello\nASSISTANT: Hi there.'


### PR DESCRIPTION
Fixes #26816

## Summary
- fall back to stored output_text when a message content field is empty
- ensures task prompt history, including follow-up generation, includes assistant text from Responses API output items
- add regression coverage for get_messages_content with empty content and populated output

## Testing
- PYTHONDONTWRITEBYTECODE=1 WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_message_content_from_output.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/open-webui-pycache python3 -m py_compile backend/open_webui/utils/misc.py backend/tests/test_message_content_from_output.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_message_content_from_output.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/utils/misc.py backend/tests/test_message_content_from_output.py

Note: full ruff check on misc.py still reports existing baseline issues in that file.