### PR TITLE
fix: preserve markdown line breaks in formatted clipboard data

### DIFF
--- a/src/lib/utils/clipboard.test.ts
+++ b/src/lib/utils/clipboard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFormattedClipboardItemData } from './clipboard';
+
+describe('createFormattedClipboardItemData', () => {
+	it('puts source markdown in plain text before formatted html', async () => {
+		const markdown = [
+			'# Header Test',
+			'',
+			'## Sub Header',
+			'',
+			'- Bullet 1',
+			'- Bullet 2',
+			'',
+			'| A | B |',
+			'|---|---|',
+			'| 1 | 2 |'
+		].join('\n');
+
+		const data = createFormattedClipboardItemData(markdown, '<h1>Header Test</h1>');
+
+		expect(Object.keys(data)).toEqual(['text/plain', 'text/html']);
+		expect(await data['text/plain'].text()).toBe(markdown);
+		expect(await data['text/html'].text()).toBe('<h1>Header Test</h1>');
+	});
+
+	it('adds a markdown clipboard format when supported', async () => {
+		const markdown = '# Header\n\n- item';
+		const data = createFormattedClipboardItemData(markdown, null, (mimeType) => {
+			return mimeType === 'text/markdown';
+		});
+
+		expect(Object.keys(data).slice(0, 2)).toEqual(['text/plain', 'text/markdown']);
+		expect(await data['text/markdown'].text()).toBe(markdown);
+	});
+});

--- a/src/lib/utils/clipboard.ts
+++ b/src/lib/utils/clipboard.ts
@@ -1,0 +1,100 @@
+import { marked } from 'marked';
+import hljs from 'highlight.js';
+
+import markedExtension from '$lib/utils/marked/extension';
+import markedKatexExtension from '$lib/utils/marked/katex-extension';
+
+const MARKDOWN_CLIPBOARD_TYPE = 'text/markdown';
+
+type SupportsClipboardType = (mimeType: string) => boolean;
+
+const supportsClipboardType: SupportsClipboardType = (mimeType) => {
+	const clipboardItem = globalThis.ClipboardItem as
+		| (typeof ClipboardItem & { supports?: SupportsClipboardType })
+		| undefined;
+
+	return Boolean(clipboardItem?.supports?.(mimeType));
+};
+
+const createFormattedHtml = (text: string) => {
+	const options = {
+		throwOnError: false,
+		highlight: function (code: string, lang: string) {
+			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+			return hljs.highlight(code, { language }).value;
+		}
+	};
+	marked.use(markedKatexExtension(options));
+	marked.use(markedExtension(options));
+	// DEVELOPER NOTE: Go to `$lib/components/chat/Messages/Markdown.svelte` to add extra markdown extensions for rendering.
+
+	const htmlContent = marked.parse(text, { async: false }) as string;
+
+	// Add basic styling to make the content look better when pasted.
+	return `
+			<div>
+				<style>
+					pre {
+						background-color: #f6f8fa;
+						border-radius: 6px;
+						padding: 16px;
+						overflow: auto;
+					}
+					code {
+						font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+						font-size: 14px;
+					}
+					.hljs-keyword { color: #d73a49; }
+					.hljs-string { color: #032f62; }
+					.hljs-comment { color: #6a737d; }
+					.hljs-function { color: #6f42c1; }
+					.hljs-number { color: #005cc5; }
+					.hljs-operator { color: #d73a49; }
+					.hljs-class { color: #6f42c1; }
+					.hljs-title { color: #6f42c1; }
+					.hljs-params { color: #24292e; }
+					.hljs-built_in { color: #005cc5; }
+					blockquote {
+						border-left: 4px solid #dfe2e5;
+						padding-left: 16px;
+						color: #6a737d;
+						margin-left: 0;
+						margin-right: 0;
+					}
+					table {
+						border-collapse: collapse;
+						width: 100%;
+						margin-bottom: 16px;
+					}
+					table, th, td {
+						border: 1px solid #dfe2e5;
+					}
+					th, td {
+						padding: 8px 12px;
+					}
+					th {
+						background-color: #f6f8fa;
+					}
+				</style>
+				${htmlContent}
+			</div>
+		`;
+};
+
+export const createFormattedClipboardItemData = (
+	text: string,
+	html: string | null = null,
+	supportsType: SupportsClipboardType = supportsClipboardType
+) => {
+	const data: Record<string, Blob> = {
+		'text/plain': new Blob([text], { type: 'text/plain' })
+	};
+
+	if (supportsType(MARKDOWN_CLIPBOARD_TYPE)) {
+		data[MARKDOWN_CLIPBOARD_TYPE] = new Blob([text], { type: MARKDOWN_CLIPBOARD_TYPE });
+	}
+
+	data['text/html'] = new Blob([html ?? createFormattedHtml(text)], { type: 'text/html' });
+
+	return data;
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -19,10 +19,7 @@ import { TTS_RESPONSE_SPLIT } from '$lib/types';
 
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
 
-import { marked } from 'marked';
-import markedExtension from '$lib/utils/marked/extension';
-import markedKatexExtension from '$lib/utils/marked/katex-extension';
-import hljs from 'highlight.js';
+import { createFormattedClipboardItemData } from '$lib/utils/clipboard';
 import { decode } from 'html-entities';
 
 //////////////////////////
@@ -495,84 +492,8 @@ export const formatDate = (inputDate) => {
 
 export const copyToClipboard = async (text, html = null, formatted = false) => {
 	if (formatted) {
-		let styledHtml = '';
-		if (!html) {
-			const options = {
-				throwOnError: false,
-				highlight: function (code, lang) {
-					const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-					return hljs.highlight(code, { language }).value;
-				}
-			};
-			marked.use(markedKatexExtension(options));
-			marked.use(markedExtension(options));
-			// DEVELOPER NOTE: Go to `$lib/components/chat/Messages/Markdown.svelte` to add extra markdown extensions for rendering.
-
-			const htmlContent = marked.parse(text);
-
-			// Add basic styling to make the content look better when pasted
-			styledHtml = `
-			<div>
-				<style>
-					pre {
-						background-color: #f6f8fa;
-						border-radius: 6px;
-						padding: 16px;
-						overflow: auto;
-					}
-					code {
-						font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
-						font-size: 14px;
-					}
-					.hljs-keyword { color: #d73a49; }
-					.hljs-string { color: #032f62; }
-					.hljs-comment { color: #6a737d; }
-					.hljs-function { color: #6f42c1; }
-					.hljs-number { color: #005cc5; }
-					.hljs-operator { color: #d73a49; }
-					.hljs-class { color: #6f42c1; }
-					.hljs-title { color: #6f42c1; }
-					.hljs-params { color: #24292e; }
-					.hljs-built_in { color: #005cc5; }
-					blockquote {
-						border-left: 4px solid #dfe2e5;
-						padding-left: 16px;
-						color: #6a737d;
-						margin-left: 0;
-						margin-right: 0;
-					}
-					table {
-						border-collapse: collapse;
-						width: 100%;
-						margin-bottom: 16px;
-					}
-					table, th, td {
-						border: 1px solid #dfe2e5;
-					}
-					th, td {
-						padding: 8px 12px;
-					}
-					th {
-						background-color: #f6f8fa;
-					}
-				</style>
-				${htmlContent}
-			</div>
-		`;
-		} else {
-			// If HTML is provided, use it directly
-			styledHtml = html;
-		}
-
-		// Create a blob with HTML content
-		const blob = new Blob([styledHtml], { type: 'text/html' });
-
 		try {
-			// Create a ClipboardItem with HTML content
-			const data = new ClipboardItem({
-				'text/html': blob,
-				'text/plain': new Blob([text], { type: 'text/plain' })
-			});
+			const data = new ClipboardItem(createFormattedClipboardItemData(text, html));
 
 			// Write to clipboard
 			await navigator.clipboard.write([data]);


### PR DESCRIPTION
## Summary
- move formatted clipboard payload construction into a small helper
- keep source Markdown as the first plain-text clipboard format and add text/markdown when the browser supports it
- preserve the existing formatted HTML clipboard payload for rich-text paste targets

Fixes #24746

## Tests
- npm run test:frontend -- src/lib/utils/clipboard.test.ts --run
- npx eslint src/lib/utils/clipboard.ts src/lib/utils/clipboard.test.ts
- npx prettier --check src/lib/utils/clipboard.ts src/lib/utils/clipboard.test.ts src/lib/utils/index.ts
- git diff --check

Note: npx eslint src/lib/utils/index.ts still reports pre-existing baseline errors elsewhere in the file.