### PR TITLE
fix: avoid duplicating nested table rows on paste

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -31,6 +31,7 @@
 
 	import TurndownService from 'turndown';
 	import { gfm } from '@joplin/turndown-plugin-gfm';
+	import { getDirectTableCells, getDirectTableRows } from './RichTextInput/tableNodes';
 	const turndownService = new TurndownService({
 		codeBlockStyle: 'fenced',
 		headingStyle: 'atx'
@@ -65,13 +66,13 @@
 		filter: 'table',
 		replacement: function (content, node) {
 			// Extract rows
-			const rows = Array.from(node.querySelectorAll('tr'));
+			const rows = getDirectTableRows(node);
 			if (rows.length === 0) return content;
 
 			let markdown = '\n';
 
 			rows.forEach((row, rowIndex) => {
-				const cells = Array.from(row.querySelectorAll('th, td'));
+				const cells = getDirectTableCells(row);
 				const cellContents = cells.map((cell) => {
 					// Get the text content and clean it up
 					let cellContent = turndownService.turndown(cell.innerHTML).trim();

--- a/src/lib/components/common/RichTextInput/tableNodes.test.ts
+++ b/src/lib/components/common/RichTextInput/tableNodes.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDirectTableCells, getDirectTableRows } from './tableNodes';
+
+type FakeElement = {
+	tagName: string;
+	children: FakeElement[];
+	matches: (selector: string) => boolean;
+};
+
+const node = (tagName: string, children: FakeElement[] = []): FakeElement => ({
+	tagName,
+	children,
+	matches: (selector) => {
+		const selectors = selector.split(',').map((part) => part.trim().toLowerCase());
+		return selectors.includes(tagName.toLowerCase());
+	}
+});
+
+describe('table node helpers', () => {
+	it('ignores rows and cells from nested tables', () => {
+		const nestedTable = node('table', [
+			node('tbody', [node('tr', [node('td', [node('p')]), node('td')])])
+		]);
+		const table = node('table', [
+			node('tbody', [node('tr', [node('td', [nestedTable]), node('td')])])
+		]);
+
+		const rows = getDirectTableRows(table);
+		const cells = getDirectTableCells(rows[0]);
+
+		expect(rows).toHaveLength(1);
+		expect(cells).toHaveLength(2);
+	});
+
+	it('keeps rows that are direct table children', () => {
+		const table = node('table', [node('tr', [node('th'), node('td')])]);
+
+		const rows = getDirectTableRows(table);
+		const cells = getDirectTableCells(rows[0]);
+
+		expect(rows).toHaveLength(1);
+		expect(cells.map((cell) => cell.tagName)).toEqual(['th', 'td']);
+	});
+});

--- a/src/lib/components/common/RichTextInput/tableNodes.ts
+++ b/src/lib/components/common/RichTextInput/tableNodes.ts
@@ -1,0 +1,24 @@
+type ElementLike = {
+	children: ArrayLike<ElementLike>;
+	matches: (selector: string) => boolean;
+};
+
+const childrenOf = <T extends ElementLike>(node: T): T[] => Array.from(node.children) as T[];
+
+export const getDirectTableRows = <T extends ElementLike>(table: T): T[] => {
+	return childrenOf(table).flatMap((child) => {
+		if (child.matches('tr')) {
+			return [child];
+		}
+
+		if (child.matches('thead, tbody, tfoot')) {
+			return childrenOf(child).filter((row) => row.matches('tr'));
+		}
+
+		return [];
+	});
+};
+
+export const getDirectTableCells = <T extends ElementLike>(row: T): T[] => {
+	return childrenOf(row).filter((child) => child.matches('th, td'));
+};


### PR DESCRIPTION
## Summary
- limit the rich text input table conversion rule to direct table rows and cells
- avoid treating rows and cells inside nested email/newsletter tables as additional outer table content
- add focused tests for nested and direct table children

Fixes #24657

## Tests
- npm run test:frontend -- src/lib/components/common/RichTextInput/tableNodes.test.ts --run
- npx eslint src/lib/components/common/RichTextInput/tableNodes.ts src/lib/components/common/RichTextInput/tableNodes.test.ts
- npx prettier --check src/lib/components/common/RichTextInput/tableNodes.ts src/lib/components/common/RichTextInput/tableNodes.test.ts src/lib/components/common/RichTextInput.svelte
- git diff --check

Notes: full-file lint for src/lib/components/common/RichTextInput.svelte and full npm run check still report existing baseline issues unrelated to this change.