### PR TITLE
fix: preserve newlines in plain text chat input

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -31,6 +31,7 @@
 
 	import TurndownService from 'turndown';
 	import { gfm } from '@joplin/turndown-plugin-gfm';
+	import { getEditorPlainText } from './RichTextInput/plainText';
 	const turndownService = new TurndownService({
 		codeBlockStyle: 'fenced',
 		headingStyle: 'atx'
@@ -893,18 +894,7 @@
 						)
 						.replace(/\u00a0/g, ' ');
 				} else {
-					mdValue = turndownService
-						.turndown(
-							htmlValue
-								// Replace empty paragraphs with line breaks
-								.replace(/<p><\/p>/g, '<br/>')
-								// Replace multiple spaces with non-breaking spaces
-								.replace(/ {2,}/g, (m) => m.replace(/ /g, '\u00a0'))
-								// Replace tabs with non-breaking spaces (preserve indentation)
-								.replace(/\t/g, '\u00a0\u00a0\u00a0\u00a0') // 1 tab = 4 spaces
-						)
-						// Convert non-breaking spaces back to regular spaces for markdown
-						.replace(/\u00a0/g, ' ');
+					mdValue = getEditorPlainText(editor);
 				}
 
 				onChange({
@@ -1267,14 +1257,16 @@
 
 		const jsonValue = editor.getJSON();
 		const htmlValue = editor.getHTML();
-		let mdValue = turndownService
-			.turndown(
-				(preserveBreaks ? htmlValue.replace(/<p><\/p>/g, '<br/>') : htmlValue).replace(
-					/ {2,}/g,
-					(m) => m.replace(/ /g, '\u00a0')
-				)
-			)
-			.replace(/\u00a0/g, ' ');
+		let mdValue = richText
+			? turndownService
+					.turndown(
+						(preserveBreaks ? htmlValue.replace(/<p><\/p>/g, '<br/>') : htmlValue).replace(
+							/ {2,}/g,
+							(m) => m.replace(/ /g, '\u00a0')
+						)
+					)
+					.replace(/\u00a0/g, ' ')
+			: getEditorPlainText(editor);
 
 		if (value === '') {
 			editor.commands.clearContent(); // Clear content if value is empty

--- a/src/lib/components/common/RichTextInput/plainText.test.ts
+++ b/src/lib/components/common/RichTextInput/plainText.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getEditorPlainText } from './plainText';
+
+describe('getEditorPlainText', () => {
+	it('reads plain text directly from the editor document', () => {
+		const text = 'OS: Ubuntu Linux\n\nShell: zsh\n\nPlease write a command line cheat sheet.';
+		const textBetween = vi.fn(() => text);
+		const editor = {
+			state: {
+				doc: {
+					content: {
+						size: 42
+					},
+					textBetween
+				}
+			}
+		};
+
+		expect(getEditorPlainText(editor)).toBe(text);
+		expect(textBetween).toHaveBeenCalledWith(0, 42, '\n');
+		expect(getEditorPlainText(editor)).not.toContain('  \n');
+	});
+});

--- a/src/lib/components/common/RichTextInput/plainText.ts
+++ b/src/lib/components/common/RichTextInput/plainText.ts
@@ -1,0 +1,14 @@
+type PlainTextEditor = {
+	state: {
+		doc: {
+			content: {
+				size: number;
+			};
+			textBetween: (from: number, to: number, blockSeparator: string) => string;
+		};
+	};
+};
+
+export const getEditorPlainText = (editor: PlainTextEditor) => {
+	return editor.state.doc.textBetween(0, editor.state.doc.content.size, '\n');
+};


### PR DESCRIPTION
## Summary
- read plain text input directly from the ProseMirror document when rich text mode is disabled
- keep the existing Turndown conversion path for rich text mode
- cover the plain text extraction path so double-newline prompts are not rewritten with Markdown hard-break spaces

Fixes #20198

## Tests
- npm run test:frontend -- src/lib/components/common/RichTextInput/plainText.test.ts --run
- npx eslint src/lib/components/common/RichTextInput/plainText.ts src/lib/components/common/RichTextInput/plainText.test.ts
- npx prettier --check src/lib/components/common/RichTextInput/plainText.ts src/lib/components/common/RichTextInput/plainText.test.ts src/lib/components/common/RichTextInput.svelte
- git diff --check

Note: full-file lint for src/lib/components/common/RichTextInput.svelte still reports existing baseline issues unrelated to this change.