### PR TITLE
fix: apply merged model params to provider payloads

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -40,6 +40,7 @@ from open_webui.utils.access_control import check_model_access
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
 from open_webui.utils.misc import calculate_sha256
+from open_webui.utils.model_params import pop_model_params_from_payload
 from open_webui.utils.payload import (
     apply_model_params_to_body_ollama,
     apply_model_params_to_body_openai,
@@ -1107,16 +1108,16 @@ async def generate_chat_completion(
             base_model_id = request.base_model_id if hasattr(request, 'base_model_id') else model_info.base_model_id
             payload['model'] = base_model_id
 
-        params = model_info.params.model_dump()
-        if params:
-            system = params.pop('system', None)
-            payload = apply_model_params_to_body_ollama(params, payload)
-            if not bypass_system_prompt:
-                payload = await apply_system_prompt_to_body(system, payload, metadata, user)
-
         await check_model_access(user, model_info, bypass_filter)
     else:
         await check_model_access(user, None, bypass_filter)
+
+    params = pop_model_params_from_payload(payload, model_info)
+    if params:
+        system = params.pop('system', None)
+        payload = apply_model_params_to_body_ollama(params, payload)
+        if not bypass_system_prompt:
+            payload = await apply_system_prompt_to_body(system, payload, metadata, user)
 
     url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), url_idx, url)
@@ -1199,12 +1200,13 @@ async def generate_openai_completion(
     if model_info is not None:
         if model_info.base_model_id:
             payload['model'] = model_info.base_model_id
-        params = model_info.params.model_dump()
-        if params:
-            payload = apply_model_params_to_body_openai(params, payload)
         await check_model_access(user, model_info)
     else:
         await check_model_access(user, None)
+
+    params = pop_model_params_from_payload(payload, model_info)
+    if params:
+        payload = apply_model_params_to_body_openai(params, payload)
 
     url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), url_idx, url)
@@ -1255,15 +1257,15 @@ async def generate_openai_chat_completion(
         if model_info.base_model_id:
             payload['model'] = model_info.base_model_id
 
-        params = model_info.params.model_dump()
-        if params:
-            system = params.pop('system', None)
-            payload = apply_model_params_to_body_openai(params, payload)
-            payload = await apply_system_prompt_to_body(system, payload, metadata, user)
-
         await check_model_access(user, model_info)
     else:
         await check_model_access(user, None)
+
+    params = pop_model_params_from_payload(payload, model_info)
+    if params:
+        system = params.pop('system', None)
+        payload = apply_model_params_to_body_openai(params, payload)
+        payload = await apply_system_prompt_to_body(system, payload, metadata, user)
 
     url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
     api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), url_idx, url)

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -47,6 +47,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     stream_chunks_handler,
 )
+from open_webui.utils.model_params import pop_model_params_from_payload
 from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
@@ -1138,18 +1139,16 @@ async def generate_chat_completion(
             payload['model'] = base_model_id
             model_id = base_model_id
 
-        params = model_info.params.model_dump()
-
-        if params:
-            system = params.pop('system', None)
-
-            payload = apply_model_params_to_body_openai(params, payload)
-            if not bypass_system_prompt:
-                payload = await apply_system_prompt_to_body(system, payload, metadata, user)
-
         await check_model_access(user, model_info, bypass_filter)
     else:
         await check_model_access(user, None, bypass_filter)
+
+    params = pop_model_params_from_payload(payload, model_info)
+    if params:
+        system = params.pop('system', None)
+        payload = apply_model_params_to_body_openai(params, payload)
+        if not bypass_system_prompt:
+            payload = await apply_system_prompt_to_body(system, payload, metadata, user)
 
     # Check if model is already in app state cache to avoid expensive get_all_models() call
     models = request.app.state.OPENAI_MODELS

--- a/backend/open_webui/utils/model_params.py
+++ b/backend/open_webui/utils/model_params.py
@@ -1,0 +1,20 @@
+def _dump_model_params(model_info) -> dict:
+    params = getattr(model_info, 'params', None)
+    if not params:
+        return {}
+
+    if hasattr(params, 'model_dump'):
+        return params.model_dump()
+
+    return dict(params)
+
+
+def pop_model_params_from_payload(payload: dict, model_info=None) -> dict:
+    payload_params = payload.pop('params', None) or {}
+    if not isinstance(payload_params, dict):
+        payload_params = {}
+
+    return {
+        **_dump_model_params(model_info),
+        **payload_params,
+    }

--- a/backend/tests/test_model_params_payload.py
+++ b/backend/tests/test_model_params_payload.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from open_webui.utils.model_params import pop_model_params_from_payload
+
+
+class Params:
+    def __init__(self, data):
+        self.data = data
+
+    def model_dump(self):
+        return dict(self.data)
+
+
+def test_pop_model_params_from_payload_prefers_payload_params():
+    payload = {'model': 'test-model', 'params': {'max_tokens': 99999, 'temperature': 0.2}}
+    model_info = SimpleNamespace(params=Params({'max_tokens': 2048, 'top_p': 0.9, 'system': 'model system'}))
+
+    params = pop_model_params_from_payload(payload, model_info)
+
+    assert params == {
+        'max_tokens': 99999,
+        'temperature': 0.2,
+        'top_p': 0.9,
+        'system': 'model system',
+    }
+    assert 'params' not in payload
+
+
+def test_pop_model_params_from_payload_supports_payload_without_model_info():
+    payload = {'model': 'external-model', 'params': {'seed': 42}}
+
+    assert pop_model_params_from_payload(payload, None) == {'seed': 42}
+    assert 'params' not in payload


### PR DESCRIPTION
## Summary
- apply the merged request/model/default params from payload['params'] to OpenAI and Ollama provider payloads
- remove the internal params wrapper before forwarding requests upstream
- keep per-request params overriding per-model params while preserving model params as the base layer

Fixes #24930

## Tests
- PYTHONDONTWRITEBYTECODE=1 WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_model_params_payload.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/open-webui-pycache python3 -m py_compile backend/open_webui/utils/model_params.py backend/open_webui/routers/openai.py backend/open_webui/routers/ollama.py backend/tests/test_model_params_payload.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/open_webui/utils/model_params.py backend/tests/test_model_params_payload.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/open_webui/utils/model_params.py backend/tests/test_model_params_payload.py backend/open_webui/routers/openai.py backend/open_webui/routers/ollama.py
- git diff --check

Notes: ruff check on the full router files still reports existing baseline issues (complexity/import-block/unused-import items) outside this change.