### PR TITLE
fix: sync note editor after external tool updates

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1126,6 +1126,26 @@ async def write_note(
         return json.dumps({'error': str(e)})
 
 
+async def sync_note_document_after_external_update(note, ydoc_manager=None, socket=None) -> None:
+    document_id = f'note:{note.id}'
+
+    if ydoc_manager is None or socket is None:
+        from open_webui.socket.main import YDOC_MANAGER, sio
+
+        ydoc_manager = ydoc_manager or YDOC_MANAGER
+        socket = socket or sio
+
+    try:
+        await ydoc_manager.clear_document(document_id)
+        await socket.emit(
+            'note-events',
+            note.model_dump(),
+            to=document_id,
+        )
+    except Exception as e:
+        log.exception(f'Failed to sync note document after external update: {e}')
+
+
 async def replace_note_content(
     note_id: str,
     content: str,
@@ -1180,6 +1200,8 @@ async def replace_note_content(
 
         if not updated_note:
             return json.dumps({'error': 'Failed to update note'})
+
+        await sync_note_document_after_external_update(updated_note)
 
         return json.dumps(
             {

--- a/backend/tests/test_note_tool_sync.py
+++ b/backend/tests/test_note_tool_sync.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+import pytest
+from open_webui.tools.builtin import sync_note_document_after_external_update
+
+
+class FakeYdocManager:
+    def __init__(self):
+        self.cleared = []
+
+    async def clear_document(self, document_id):
+        self.cleared.append(document_id)
+
+
+class FakeSocket:
+    def __init__(self):
+        self.emitted = []
+
+    async def emit(self, event, data, to=None):
+        self.emitted.append((event, data, to))
+
+
+@pytest.mark.asyncio
+async def test_sync_note_document_after_external_update_clears_ydoc_and_emits_note():
+    ydoc_manager = FakeYdocManager()
+    socket = FakeSocket()
+    note = SimpleNamespace(
+        id='note-id',
+        model_dump=lambda: {'id': 'note-id', 'data': {'content': {'md': '# Updated'}}},
+    )
+
+    await sync_note_document_after_external_update(
+        note,
+        ydoc_manager=ydoc_manager,
+        socket=socket,
+    )
+
+    assert ydoc_manager.cleared == ['note:note-id']
+    assert socket.emitted == [
+        (
+            'note-events',
+            {'id': 'note-id', 'data': {'content': {'md': '# Updated'}}},
+            'note:note-id',
+        )
+    ]

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -41,6 +41,7 @@
 	} from '$lib/stores';
 
 	import { downloadPdf } from './utils';
+	import { resolveNoteEventContent } from './events';
 
 	import Controls from './NoteEditor/Controls.svelte';
 	import Chat from './NoteEditor/Chat.svelte';
@@ -799,6 +800,19 @@ Provide the enhanced notes in markdown format. Use markdown syntax for headings,
 		if (_note.data && _note.data.files) {
 			files = _note.data.files;
 			note.data.files = files;
+		}
+
+		if (_note.data?.content) {
+			const content = resolveNoteEventContent(
+				note.data.content ?? {},
+				_note.data.content,
+				(md) => marked.parse(md, { async: false }) as string
+			);
+
+			if (!equal(content, note.data.content)) {
+				note.data.content = content;
+				editor?.commands.setContent(content.json ?? content.html);
+			}
 		}
 
 		if (_note.title && _note.title) {

--- a/src/lib/components/notes/events.test.ts
+++ b/src/lib/components/notes/events.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveNoteEventContent } from './events';
+
+describe('resolveNoteEventContent', () => {
+	it('builds editor content from markdown-only note events', () => {
+		const content = resolveNoteEventContent(
+			{
+				md: '# Original',
+				html: '<h1>Original</h1>',
+				json: { type: 'doc', content: [] }
+			},
+			{
+				md: '# LLM Edit'
+			},
+			(md) => `<h1>${md.replace('# ', '')}</h1>`
+		);
+
+		expect(content).toEqual({
+			md: '# LLM Edit',
+			html: '<h1>LLM Edit</h1>',
+			json: null
+		});
+	});
+});

--- a/src/lib/components/notes/events.ts
+++ b/src/lib/components/notes/events.ts
@@ -1,0 +1,25 @@
+type NoteContent = {
+	md?: string;
+	html?: string;
+	json?: unknown;
+	[key: string]: unknown;
+};
+
+export const resolveNoteEventContent = (
+	currentContent: NoteContent,
+	incomingContent: NoteContent,
+	renderMarkdown: (markdown: string) => string
+) => {
+	const md = incomingContent.md ?? currentContent.md ?? '';
+	const html =
+		incomingContent.html ??
+		(incomingContent.md !== undefined ? renderMarkdown(md) : (currentContent.html ?? ''));
+
+	return {
+		...currentContent,
+		...incomingContent,
+		md,
+		html,
+		json: incomingContent.json ?? null
+	};
+};


### PR DESCRIPTION
## Summary
- clear stale Yjs note state and emit note-events after replace_note_content writes to the DB
- update open NoteEditor instances when a note event carries content changes
- render markdown-only note events into editor-ready HTML and clear stale JSON state

Fixes #25916

## Tests
- PYTHONDONTWRITEBYTECODE=1 WEBUI_SECRET_KEY=codex-local-test-secret UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen pytest backend/tests/test_note_tool_sync.py -q
- npm run test:frontend -- src/lib/components/notes/events.test.ts --run
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff check backend/tests/test_note_tool_sync.py
- UV_CACHE_DIR=/private/tmp/uv-cache-open-webui uv run --frozen ruff format --check backend/tests/test_note_tool_sync.py backend/open_webui/tools/builtin.py
- npx eslint src/lib/components/notes/events.ts src/lib/components/notes/events.test.ts
- npx prettier --check src/lib/components/notes/events.ts src/lib/components/notes/events.test.ts src/lib/components/notes/NoteEditor.svelte
- PYTHONPYCACHEPREFIX=/private/tmp/open-webui-pycache python3 -m py_compile backend/open_webui/tools/builtin.py backend/tests/test_note_tool_sync.py
- git diff --check