### PR TITLE
fix: prevent chat input expand button overlap

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -134,6 +134,8 @@
 
 	export let prompt = '';
 	export let files = [];
+	let canExpandInput = false;
+	$: canExpandInput = prompt.split('\n').length > 2;
 
 	export let selectedToolIds = [];
 	export let selectedSkillIds = [];
@@ -1487,33 +1489,32 @@
 								</div>
 							{/if}
 
-							<div class="px-2.5">
+							<div class="px-2.5 relative">
+								{#if canExpandInput}
+									<div class="absolute top-2 ltr:right-3 rtl:left-3 z-20">
+										<button
+											type="button"
+											class="p-1 rounded-lg hover:bg-gray-100/50 dark:hover:bg-gray-800/50"
+											aria-label="Expand input"
+											on:click={async () => {
+												showInputModal = true;
+											}}
+										>
+											<Expand />
+										</button>
+									</div>
+								{/if}
+
 								<div
-									class="scrollbar-hidden rtl:text-right ltr:text-left bg-transparent dark:text-gray-100 outline-hidden w-full pb-1 px-1 resize-none h-fit max-h-96 overflow-auto {files.length ===
-									0
+									class="scrollbar-hidden rtl:text-right ltr:text-left bg-transparent dark:text-gray-100 outline-hidden w-full pb-1 pl-1 {canExpandInput
+										? 'ltr:pr-9 rtl:pl-9 rtl:pr-1'
+										: 'pr-1'} resize-none h-fit max-h-96 overflow-auto {files.length === 0
 										? atSelectedModel !== undefined
 											? 'pt-1.5'
 											: 'pt-2.5'
 										: ''}"
 									id="chat-input-container"
 								>
-									{#if prompt.split('\n').length > 2}
-										<div class="fixed top-0 right-0 z-20">
-											<div class="mt-2.5 mr-3">
-												<button
-													type="button"
-													class="p-1 rounded-lg hover:bg-gray-100/50 dark:hover:bg-gray-800/50"
-													aria-label="Expand input"
-													on:click={async () => {
-														showInputModal = true;
-													}}
-												>
-													<Expand />
-												</button>
-											</div>
-										</div>
-									{/if}
-
 									{#if suggestions}
 										{#key $settings?.richTextInput ?? true}
 											{#key $settings?.showFormattingToolbar ?? false}


### PR DESCRIPTION
## Summary
- keep the prompt expand button positioned inside the input area instead of fixed to the container corner
- reserve inline padding for the expand control when the prompt spans more than two lines
- preserve RTL placement by mirroring the control and padding

Fixes #26736

## Tests
- npx prettier --check src/lib/components/chat/MessageInput.svelte
- git diff --check

Note: 
/Users/bytedance/Documents/New project 3/open-webui/src/lib/components/chat/MessageInput.svelte
    16:25  error  'getAuthToken' is defined but never used                                                                                                                                                                       @typescript-eslint/no-unused-vars
    35:3   error  'showSettings' is defined but never used                                                                                                                                                                       @typescript-eslint/no-unused-vars
    58:11  error  'deleteFileById' is defined but never used                                                                                                                                                                     @typescript-eslint/no-unused-vars
    64:11  error  'WEBUI_BASE_URL' is defined but never used                                                                                                                                                                     @typescript-eslint/no-unused-vars
    96:9   error  'Dropdown' is defined but never used                                                                                                                                                                           @typescript-eslint/no-unused-vars
   110:23  error  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type                                                                                        @typescript-eslint/no-unsafe-function-type
   110:35  error  'e' is defined but never used                                                                                                                                                                                  @typescript-eslint/no-unused-vars
   111:23  error  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type                                                                                        @typescript-eslint/no-unsafe-function-type
   112:32  error  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type                                                                                        @typescript-eslint/no-unsafe-function-type
   114:32  error  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type                                                                                        @typescript-eslint/no-unsafe-function-type
   115:27  error  The `Function` type accepts any function-like value.
Prefer explicitly defining any function parameters and return type                                                                                        @typescript-eslint/no-unsafe-function-type
   152:64  error  Unexpected any. Specify a different type                                                                                                                                                                       @typescript-eslint/no-explicit-any
   162:37  error  'variableValues' is defined but never used                                                                                                                                                                     @typescript-eslint/no-unused-vars
   216:70  error  'err' is defined but never used                                                                                                                                                                                @typescript-eslint/no-unused-vars
   246:13  error  'error' is defined but never used                                                                                                                                                                              @typescript-eslint/no-unused-vars
   335:54  error  Unexpected any. Specify a different type                                                                                                                                                                       @typescript-eslint/no-explicit-any
   415:11  error  'word' is assigned a value but never used                                                                                                                                                                      @typescript-eslint/no-unused-vars
   461:6   error  'chatInputContainerElement' is defined but never used                                                                                                                                                          @typescript-eslint/no-unused-vars
   465:6   error  'commandsElement' is defined but never used                                                                                                                                                                    @typescript-eslint/no-unused-vars
   474:6   error  'user' is assigned a value but never used                                                                                                                                                                      @typescript-eslint/no-unused-vars
   954:13  error  '_' is defined but never used                                                                                                                                                                                  @typescript-eslint/no-unused-vars
  1126:17  error  'e' is defined but never used                                                                                                                                                                                  @typescript-eslint/no-unused-vars
  1145:17  error  'e' is defined but never used                                                                                                                                                                                  @typescript-eslint/no-unused-vars
  1249:8   error  Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
https://svelte.dev/e/a11y_consider_explicit_label(a11y_consider_explicit_label)                   svelte/valid-compile
  1310:23  error  'filename' is assigned a value but never used                                                                                                                                                                  @typescript-eslint/no-unused-vars
  1332:7   error  Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
https://svelte.dev/e/a11y_consider_explicit_label(a11y_consider_explicit_label)                   svelte/valid-compile
  1332:7   error  Self-closing HTML tags for non-void elements are ambiguous — use `<button ...></button>` rather than `<button ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)  svelte/valid-compile
  1752:11  error  Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)           svelte/valid-compile
  2009:13  error  Buttons and links should either contain text or have an `aria-label`, `aria-labelledby` or `title` attribute
https://svelte.dev/e/a11y_consider_explicit_label(a11y_consider_explicit_label)                   svelte/valid-compile
  2158:25  error  'err' is defined but never used                                                                                                                                                                                @typescript-eslint/no-unused-vars
  2213:9   error  `{@html}` can lead to XSS attack                                                                                                                                                                               svelte/no-at-html-tags
  2216:8   error  Self-closing HTML tags for non-void elements are ambiguous — use `<div ...></div>` rather than `<div ... />`
https://svelte.dev/e/element_invalid_self_closing_tag(element_invalid_self_closing_tag)           svelte/valid-compile

✖ 32 problems (32 errors, 0 warnings) is still blocked by existing lint errors in this large file (unused imports/handlers, existing self-closing non-void elements, and related baseline issues).