### PR TITLE
fix: hide empty reasoning details

### DIFF
--- a/src/lib/components/chat/Messages/structuredOutput.test.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildOutputDisplayItems } from './structuredOutput';
+
+describe('buildOutputDisplayItems', () => {
+	it('does not render empty completed reasoning details', () => {
+		const items = buildOutputDisplayItems([
+			{
+				type: 'message',
+				id: 'msg-1',
+				content: [{ type: 'output_text', text: 'Answer' }]
+			},
+			{
+				type: 'reasoning',
+				id: 'reasoning-empty',
+				status: 'completed',
+				content: [{ type: 'output_text', text: '' }]
+			}
+		]);
+
+		expect(items).toEqual([
+			{
+				type: 'message',
+				id: 'msg-1',
+				text: 'Answer'
+			}
+		]);
+	});
+
+	it('still renders reasoning details when reasoning text is present', () => {
+		const items = buildOutputDisplayItems([
+			{
+				type: 'reasoning',
+				id: 'reasoning-1',
+				status: 'completed',
+				duration: 3,
+				content: [{ type: 'output_text', text: 'Actual reasoning' }]
+			},
+			{
+				type: 'message',
+				id: 'msg-1',
+				content: [{ type: 'output_text', text: 'Answer' }]
+			}
+		]);
+
+		expect(items[0]).toMatchObject({
+			type: 'detail_single',
+			token: {
+				summary: 'Thought for 3 seconds',
+				text: '> Actual reasoning',
+				attributes: {
+					type: 'reasoning',
+					done: 'true',
+					duration: '3'
+				}
+			}
+		});
+		expect(items[1]).toEqual({
+			type: 'message',
+			id: 'msg-1',
+			text: 'Answer'
+		});
+	});
+});

--- a/src/lib/components/chat/Messages/structuredOutput.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.ts
@@ -146,7 +146,12 @@ function buildToolCallToken(item: OutputItem, toolOutputByCallId: Record<string,
 function buildReasoningToken(item: OutputItem, isLastItem: boolean) {
 	const duration = item.duration ?? '';
 	const isDone = isDoneStatus(item.status) || item.duration !== undefined || !isLastItem;
-	const text = getReasoningText(item)
+	const reasoningText = getReasoningText(item);
+	if (isDone && !reasoningText.trim()) {
+		return null;
+	}
+
+	const text = reasoningText
 		.split('\n')
 		.map((line) => (line.startsWith('>') ? line : `> ${line}`))
 		.join('\n');


### PR DESCRIPTION
## Summary
- skip completed reasoning output items when they contain no actual reasoning text
- keep in-progress empty reasoning visible so streaming can still show the Thinking state
- add frontend coverage for empty and populated reasoning output rendering

Fixes #26645

## Tests
- npm run test:frontend -- src/lib/components/chat/Messages/structuredOutput.test.ts --run
- npx prettier --check src/lib/components/chat/Messages/structuredOutput.ts src/lib/components/chat/Messages/structuredOutput.test.ts
- npx eslint src/lib/components/chat/Messages/structuredOutput.ts src/lib/components/chat/Messages/structuredOutput.test.ts
- git diff --check