### PR TITLE
fix: deny chained access to unregistered base models for non-admins

### DIFF
--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -260,6 +260,7 @@ async def has_base_model_access(
     user_id: str,
     model_info,
     *,
+    user_role: str | None = None,
     user_group_ids: set[str] | None = None,
     db=None,
 ) -> bool:
@@ -267,9 +268,11 @@ async def has_base_model_access(
     Walk the ``base_model_id`` chain and verify the caller has read access
     at every hop.
 
-    Returns ``True`` when access is granted (or the chain ends at a raw
-    provider model that has no per-model ACL).  Returns ``False`` the
-    moment a registered base model denies access.
+    A base model without a ``model`` table row is admin-only, matching how
+    unregistered models are treated for direct use (``get_filtered_models``
+    hides them from non-admins and ``check_model_access`` rejects them), so
+    a shared preset cannot be used to reach a base model the caller could
+    not use directly.  Returns ``False`` the moment any hop denies access.
     """
     from open_webui.models.access_grants import AccessGrants
     from open_webui.models.models import Models
@@ -280,7 +283,7 @@ async def has_base_model_access(
         seen.add(base_model_id)
         base_model_info = await Models.get_model_by_id(base_model_id, db=db)
         if base_model_info is None:
-            break  # Raw provider model — no per-model ACL
+            return user_role == 'admin'
         if not (
             user_id == base_model_info.user_id
             or await AccessGrants.has_access(
@@ -339,7 +342,9 @@ async def check_model_access(
                 raise HTTPException(status_code=403, detail='Model not found')
 
             # Enforce access on chained base models
-            if not await has_base_model_access(user.id, model_info, user_group_ids=user_group_ids):
+            if not await has_base_model_access(
+                user.id, model_info, user_role=user.role, user_group_ids=user_group_ids
+            ):
                 raise HTTPException(status_code=403, detail='Model not found')
     else:
         if user.role != 'admin':

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -411,7 +411,7 @@ async def check_model_access(user, model, db=None):
             raise Exception('Model not found')
 
         # Enforce access on chained base models
-        if not await has_base_model_access(user.id, model_info, db=db):
+        if not await has_base_model_access(user.id, model_info, user_role=user.role, db=db):
             raise Exception('Model not found')
 
 


### PR DESCRIPTION
A workspace model shared publicly could be used by any user even when its base model was private. Unregistered base models (no row in the model table) are admin-only for direct use — get_filtered_models hides them from non-admins and check_model_access rejects them — but has_base_model_access treated a missing row as "no ACL" and allowed the chained request through.

has_base_model_access now takes the caller's role and only allows an unregistered base model hop for admins, so a shared preset can no longer reach a base model the caller could not use directly. Registered base models keep their existing grant-based enforcement.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
