### PR TITLE
fix: don't mutate caller's payload when resolving a pipe base model

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -203,6 +203,10 @@ async def generate_function_chat_completion(request, form_data, user, models: di
 
         return params
 
+    # Copy so the base-model substitution below doesn't leak into the caller's
+    # payload, which the tool-call continuation re-submits. Mirrors the routers.
+    form_data = {**form_data}
+
     model_id = form_data.get('model')
     model_info = await Models.get_model_by_id(model_id)
 


### PR DESCRIPTION
generate_function_chat_completion rewrote form_data['model'] to the base model id in place. Because that dict is the same object process_chat_response later re-submits for the post-tool-call continuation, the continuation was access-checked against the base model instead of the user-facing preset. For a public preset over a private/unregistered pipe base, a non-admin's first message succeeded but the continuation after a native tool call was denied and silently swallowed, aborting the response (admins skip the user-only check, so they were unaffected).

Operate on a shallow copy of form_data, mirroring the openai/ollama routers which already substitute the base model on a copy. The continuation now re-checks the preset the user actually has access to.

https://github.com/open-webui/open-webui/issues/26900

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
