### PR TITLE
docs: mention TokenLab as OpenAI-compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 
 - 🚀 **Effortless Setup**: Install seamlessly via pip, uv, Docker, or Kubernetes (kubectl, kustomize, or helm), with `:ollama` and `:cuda` tagged images available for container deployments.
 
-- 🤝 **Broad Model & API Integration**: Connect any OpenAI-compatible API alongside local Ollama models. Point the API URL at **LMStudio, GroqCloud, Mistral, OpenRouter, vLLM, and more** to mix and match providers freely.
+- 🤝 **Broad Model & API Integration**: Connect any OpenAI-compatible API alongside local Ollama models. Point the API URL at **LMStudio, GroqCloud, Mistral, OpenRouter, TokenLab, vLLM, and more** to mix and match providers freely.
 
 - 🔐 **Granular RBAC & User Groups**: Administrators define detailed roles, groups, and permissions, giving each user exactly the access they need. Secure by default, with tailored experiences per group.
 


### PR DESCRIPTION
## Summary
- mention TokenLab in the README list of OpenAI-compatible API examples
- keep the change docs-only since Open WebUI already supports custom OpenAI-compatible API URLs

## Validation
- `git diff --check`

TokenLab docs: https://docs.tokenlab.sh/
