### PR TITLE
fix: malformed WEB_FETCH_FILTER_LIST entry blocking all web fetches

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -28,18 +28,26 @@ def deep_update(d, u):
     return d
 
 
+def _strip_filter_entry(entry):
+    # Compose list-form env syntax passes surrounding quotes through verbatim
+    return (entry or '').strip().strip('"\'').strip()
+
+
 def get_allow_block_lists(filter_list):
     allow_list = []
     block_list = []
 
-    if filter_list:
-        for d in filter_list:
-            if d.startswith('!'):
-                # Domains starting with "!" → blocked
-                block_list.append(d[1:].strip())
-            else:
-                # Domains starting without "!" → allowed
-                allow_list.append(d.strip())
+    for raw_entry in filter_list or []:
+        entry = _strip_filter_entry(raw_entry)
+        is_blocked = entry.startswith('!')
+        if is_blocked:
+            entry = _strip_filter_entry(entry[1:])
+        if not entry:
+            continue
+        if is_blocked:
+            block_list.append(entry)
+        else:
+            allow_list.append(entry)
 
     return allow_list, block_list
 


### PR DESCRIPTION
Docker compose list-form environment syntax passes quotes through verbatim, so WEB_FETCH_FILTER_LIST="" reaches the backend as two literal quote characters rather than an empty string. Config parsing turned that into the filter entry '""', which has no "!" prefix and therefore landed in the allow list. A non-empty allow list requires every host to match one of its entries, and a quotes-only pattern can never match a hostname, so every fetch_url and web loader request was rejected with "URL blocked by filter list" and surfaced to the user as "The URL you provided is invalid".

get_allow_block_lists now strips surrounding quote characters from each entry and drops entries that are empty after normalisation. Quoted but otherwise valid entries such as "example.com" or !"example.com" now behave as their unquoted forms, and garbage entries no longer convert the default blocklist into a match-nothing allowlist that blocks everything.

Fixes #26908

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
