### PR TITLE
fix: Milvus multitenancy scalar index creation on Milvus Lite

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
@@ -146,7 +146,19 @@ class MilvusClient(VectorDBBase):
             index_params['params'] = {'nlist': MILVUS_IVF_FLAT_NLIST}
 
         collection.create_index('vector', index_params)
-        collection.create_index(RESOURCE_ID_FIELD)
+        try:
+            # A Milvus server auto-selects the scalar index type; embedded
+            # Milvus Lite requires an explicit one.
+            collection.create_index(RESOURCE_ID_FIELD)
+        except MilvusException:
+            try:
+                collection.create_index(RESOURCE_ID_FIELD, {'index_type': 'INVERTED'})
+            except MilvusException as e:
+                # The index only accelerates resource_id filters; never fail
+                # collection creation over it.
+                log.warning(
+                    f'Could not create {RESOURCE_ID_FIELD} index on {mt_collection_name}: {e}'
+                )
         log.info(f'Created shared collection: {mt_collection_name}')
         return collection
 


### PR DESCRIPTION
Enabling ENABLE_MILVUS_MULTITENANCY_MODE with the default MILVUS_URI (embedded Milvus Lite at DATA_DIR/vector_db/milvus.db) fails on the first embedding write: _create_shared_collection calls collection.create_index(RESOURCE_ID_FIELD) with no index params. A Milvus server auto-selects a scalar index type in that case, but Milvus Lite rejects the call with "create_index missing required 'index_type' parameter", so shared collection creation raises and every embedding write 500s (memory add, file upload, knowledge writes).

Keep the parameterless call as the first attempt so behavior on Milvus servers is unchanged, fall back to an explicit INVERTED scalar index, and if that also fails log a warning and continue. The scalar index only accelerates resource_id filters; inserts and filtered queries work without it, so a missing index must not break collection creation.

Verified against embedded Milvus Lite: shared collections now create (with the warning), and memory add, file upload and memory query succeed end to end. Against a Milvus server the first attempt is identical to the current code, so nothing changes where it works today.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
