### PR TITLE
fix: socket reconnect recovery never runs for chats started from the home page

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -629,7 +629,7 @@
 				} else if (type === 'chat:active') {
 					if (!data?.active) {
 						taskIds = null;
-						if (chatIdProp && !$temporaryChatEnabled && hasPendingAssistantLeaf()) {
+						if ($chatId && !$temporaryChatEnabled && hasPendingAssistantLeaf()) {
 							await loadChat();
 						}
 					}
@@ -902,7 +902,8 @@
 		);
 
 	const handleSocketConnect = async () => {
-		if (!chatIdProp || $temporaryChatEnabled) {
+		// Gate on $chatId, not chatIdProp: chats started from the home page keep an empty chatIdProp
+		if (!$chatId || $temporaryChatEnabled) {
 			return;
 		}
 
@@ -1585,7 +1586,8 @@
 	};
 
 	const loadChat = async () => {
-		chatId.set(chatIdProp);
+		// chatIdProp is empty for chats started from the home page (URL set via replaceState)
+		chatId.set(chatIdProp || $chatId);
 
 		if ($temporaryChatEnabled) {
 			temporaryChatEnabled.set(false);


### PR DESCRIPTION
When a chat is started from the home page, the URL is switched to /c/{id} with history.replaceState, so the Chat component is never remounted and chatIdProp stays empty for the lifetime of that view. Both websocket recovery paths, handleSocketConnect and the chat:active fallback, are gated on chatIdProp and therefore never run for these chats. After any websocket drop during a response (mobile backgrounding, VPN or IP change, wake from sleep) the completed response is never fetched and the chat stays stuck in a loading state until a manual page refresh. Chats opened directly via /c/{id} recover fine, which is why the bug only reproduces reliably on freshly started chats.

Gate both recovery paths on the chatId store instead, which is set for every persisted chat, and let loadChat fall back to it so the recovery reload also works when chatIdProp is empty. Chats opened via /c/{id} behave exactly as before and temporary chats stay excluded.

The same gate likely explains the remaining reports in #26315.

Fixes #26844

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
