### PR TITLE
fix: restore prompt confirmation for sandboxed tool result embeds

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -113,6 +113,7 @@
 	import FilesOverlay from './MessageInput/FilesOverlay.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
 	import Spinner from '../common/Spinner.svelte';
+	import { isEmbedWindow } from '../common/FullHeightIframe.svelte';
 	import Tooltip from '../common/Tooltip.svelte';
 	import Sidebar from '../icons/Sidebar.svelte';
 	import Image from '../common/Image.svelte';
@@ -791,18 +792,18 @@
 
 	const onMessageHandler = async (event: {
 		origin: string;
+		source: unknown;
 		data: { type: string; text: string };
 	}) => {
 		const isSameOrigin = event.origin === window.origin;
 		const type = event.data?.type;
 
-		// Prompt-driving message types let an embedding page control the chat
-		// input / submission.  Cross-origin sources are only trusted when the
-		// user has explicitly opted in via the "iframe Sandbox Allow Same
-		// Origin" interface setting (the same toggle that governs whether
-		// rendered iframes receive `allow-same-origin`).
+		// Prompt-driving types are trusted only same-origin, from our own embed iframes
+		// (opaque srcdoc origin, submission still confirmed below) or via explicit opt-in.
 		const promptTypes = ['input:prompt', 'input:prompt:submit', 'action:submit'];
-		const isTrusted = isSameOrigin || ($settings?.iframeSandboxAllowSameOrigin ?? false);
+		const isOwnEmbed = isEmbedWindow(event.source);
+		const isTrusted =
+			isSameOrigin || isOwnEmbed || ($settings?.iframeSandboxAllowSameOrigin ?? false);
 
 		// Non-prompt message types are always restricted to same-origin only.
 		if (!isSameOrigin && !promptTypes.includes(type)) {

--- a/src/lib/components/common/FullHeightIframe.svelte
+++ b/src/lib/components/common/FullHeightIframe.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+	// contentWindows of embeds rendered here; Chat.svelte trusts prompt messages from these
+	const embedWindows = new Set<Window>();
+
+	export const isEmbedWindow = (source: unknown): boolean => embedWindows.has(source as Window);
+</script>
+
 <script lang="ts">
 	import { onDestroy, onMount, tick } from 'svelte';
 	import { config } from '$lib/stores';
@@ -28,6 +35,7 @@
 	let iframe: HTMLIFrameElement | null = null;
 	let iframeSrc: string | null = null;
 	let iframeDoc: string | null = null;
+	let registeredWindow: Window | null = null;
 
 	// Derived: build sandbox attribute from flags
 	$: sandbox =
@@ -175,6 +183,14 @@ window.Chart = parent.Chart; // Chart previously assigned on parent
 	const onLoad = async () => {
 		requestAnimationFrame(resizeSameOrigin);
 
+		if (iframe?.contentWindow && iframe.contentWindow !== registeredWindow) {
+			if (registeredWindow) {
+				embedWindows.delete(registeredWindow);
+			}
+			registeredWindow = iframe.contentWindow;
+			embedWindows.add(registeredWindow);
+		}
+
 		// if arguments are provided, inject them into the iframe window
 		if (args && iframe?.contentWindow) {
 			(iframe.contentWindow as any).args = args;
@@ -188,6 +204,9 @@ window.Chart = parent.Chart; // Chart previously assigned on parent
 
 	onDestroy(() => {
 		window.removeEventListener('message', onMessage);
+		if (registeredWindow) {
+			embedWindows.delete(registeredWindow);
+		}
 	});
 </script>
 


### PR DESCRIPTION
Tool result embeds are rendered by FullHeightIframe as srcdoc iframes without allow-same-origin by default, so their postMessage events carry the opaque origin "null". The trust gate in Chat.svelte's onMessageHandler only accepted same-origin sources or the global iframeSandboxAllowSameOrigin opt-in, so input:prompt, input:prompt:submit and action:submit from Open WebUI's own embeds were silently dropped before reaching the "Confirm Prompt from Embed" dialog that exists for exactly this cross-origin case. The documented Rich UI flow (confirmation dialog on submit, no same-origin access required) was unreachable either way: with the setting off the message was dropped, and with it on the embed became same-origin and submitted immediately without confirmation.

FullHeightIframe now registers its iframes' contentWindow in a module-level set and Chat.svelte additionally trusts a prompt message when event.source is in that set. Window identity cannot be forged: windows of external pages embedding or opening Open WebUI are never in the set, so they remain blocked exactly as before, and prompt submission from own embeds still requires the user to accept the existing confirmation dialog.

Fixes #26912

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
