### PR TITLE
fix: guard note.data None crash in builtin tool query_knowledge_files

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2597,7 +2597,7 @@ async def query_knowledge_files(
                             permission='read',
                         )
                     ):
-                        content = note.data.get('content', {}).get('md', '')
+                        content = (note.data or {}).get('content', {}).get('md', '')
                         note_results.append(
                             {
                                 'content': content,


### PR DESCRIPTION
### Description

`note.data` is defined as `Optional[dict]` on the `Notes` model (nullable), but the `query_knowledge_files` tool called `note.data.get(...)` without a None guard. When a note has no `data` field populated, this raises `AttributeError: 'NoneType' object has no attribute 'get'`, aborting the whole knowledge retrieval.

Two sibling call sites (builtin.py lines 978 and 1062) already used the correct `note.data and note.data.get(...)` guard. This patch applies the equivalent `(note.data or {}).get(...)` to the `query_knowledge_files` path, matching the established pattern.

### Fixed

- Crash in `query_knowledge_answer_collection` when a referenced note has `data=None`.

### Testing

Verified the repro directly: with `note.data = None`, the old expression raised `AttributeError: 'NoneType' object has no attribute 'get'`, while the patched expression returns `''` (and still returns populated markdown when data is present). Also confirmed the file compiles with `python -m py_compile`.

Relates to: #26880

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.