### PR TITLE
feat: add TOTP two-factor authentication (2FA) support

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -67,6 +67,11 @@ class User(Base):  # identity & profile
     status_message = Column(Text, nullable=True)
     status_expires_at = Column(BigInteger, nullable=True)
 
+    # Two-factor authentication (TOTP)
+    totp_secret = Column(Text, nullable=True)  # base32-encoded TOTP secret
+    totp_enabled = Column(Boolean, default=False)  # whether 2FA is active
+    totp_backup_codes = Column(JSON, nullable=True)  # hashed backup codes
+
     # Metadata
     info = Column(JSON, nullable=True)
     settings = Column(JSON, nullable=True)
@@ -103,6 +108,10 @@ class UserModel(BaseModel):
     status_emoji: str | None = None
     status_message: str | None = None
     status_expires_at: int | None = None
+
+    totp_secret: str | None = None
+    totp_enabled: bool = False
+    totp_backup_codes: list[str] | None = None
 
     info: dict | None = None
     settings: UserSettings | None = None
@@ -672,6 +681,63 @@ class UsersTable:
                 return None
             for key, value in updated.items():
                 setattr(user, key, value)
+            await session.commit()
+            await session.refresh(user)
+            return UserModel.model_validate(user)
+
+    async def enable_totp(self, id: str, secret: str, db: AsyncSession | None = None) -> UserModel | None:
+        """Enable TOTP for a user and store the secret."""
+        async with get_async_db_context(db) as session:
+            user = await session.get(User, id)
+            if not user:
+                return None
+            user.totp_secret = secret
+            user.totp_enabled = True
+            user.updated_at = int(time.time())
+            await session.commit()
+            await session.refresh(user)
+            return UserModel.model_validate(user)
+
+    async def disable_totp(self, id: str, db: AsyncSession | None = None) -> UserModel | None:
+        """Disable TOTP for a user and clear the secret."""
+        async with get_async_db_context(db) as session:
+            user = await session.get(User, id)
+            if not user:
+                return None
+            user.totp_secret = None
+            user.totp_enabled = False
+            user.totp_backup_codes = None
+            user.updated_at = int(time.time())
+            await session.commit()
+            await session.refresh(user)
+            return UserModel.model_validate(user)
+
+    async def set_totp_backup_codes(
+        self, id: str, codes: list[str], db: AsyncSession | None = None
+    ) -> UserModel | None:
+        """Store hashed backup codes for a user."""
+        async with get_async_db_context(db) as session:
+            user = await session.get(User, id)
+            if not user:
+                return None
+            user.totp_backup_codes = codes
+            user.updated_at = int(time.time())
+            await session.commit()
+            await session.refresh(user)
+            return UserModel.model_validate(user)
+
+    async def remove_totp_backup_code(self, id: str, index: int, db: AsyncSession | None = None) -> UserModel | None:
+        """Remove a used backup code at the given index."""
+        async with get_async_db_context(db) as session:
+            user = await session.get(User, id)
+            if not user or not user.totp_backup_codes:
+                return None
+            codes = list(user.totp_backup_codes)
+            if index < 0 or index >= len(codes):
+                return None
+            codes.pop(index)
+            user.totp_backup_codes = codes
+            user.updated_at = int(time.time())
             await session.commit()
             await session.refresh(user)
             return UserModel.model_validate(user)

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -73,6 +73,14 @@ from open_webui.utils.groups import apply_default_group_assignment
 from open_webui.utils.misc import parse_duration, validate_email_format
 from open_webui.utils.rate_limit import RateLimiter
 from open_webui.utils.redis import get_redis_client
+from open_webui.utils.totp import (
+    generate_backup_codes,
+    generate_totp_secret,
+    get_totp_uri,
+    hash_backup_codes,
+    verify_backup_code,
+    verify_totp,
+)
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -211,9 +219,40 @@ async def create_session_response(
 ############################
 
 
+class TOTPSetupResponse(BaseModel):
+    secret: str
+    uri: str
+    backup_codes: list[str]
+
+
+class TOTPVerifyForm(BaseModel):
+    code: str
+    session_id: str | None = None
+
+
+class TOTPSetupVerifyForm(BaseModel):
+    secret: str
+    code: str
+
+
+class TOTPDisableForm(BaseModel):
+    password: str
+    code: str | None = None
+
+
+class TOTPBackupCodesResponse(BaseModel):
+    backup_codes: list[str]
+
+
 class SessionUserResponse(Token, UserProfileImageResponse):
     expires_at: int | None = None
     permissions: dict | None = None
+
+
+class SigninTOTPResponse(BaseModel):
+    totp_required: bool = True
+    session_id: str
+    email: str
 
 
 class SessionUserInfoResponse(SessionUserResponse, UserStatus):
@@ -396,6 +435,178 @@ async def update_password(
             raise HTTPException(400, detail=ERROR_MESSAGES.INCORRECT_PASSWORD)
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
+
+
+############################
+# TOTP / Two-Factor Authentication
+############################
+
+
+@router.get('/totp/setup', response_model=TOTPSetupResponse)
+async def totp_setup(
+    request: Request,
+    session_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if not session_user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if session_user.totp_enabled:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='TOTP is already enabled')
+
+    secret = generate_totp_secret()
+    email = session_user.email
+    uri = get_totp_uri(secret, email)
+    backup_codes = generate_backup_codes()
+
+    return TOTPSetupResponse(
+        secret=secret,
+        uri=uri,
+        backup_codes=backup_codes,
+    )
+
+
+@router.post('/totp/setup', response_model=SessionUserResponse)
+async def totp_verify_and_enable(
+    request: Request,
+    response: Response,
+    form_data: TOTPSetupVerifyForm,
+    session_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if not session_user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if not verify_totp(form_data.secret, form_data.code):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Invalid TOTP code')
+
+    secret = form_data.secret
+    backup_codes = hash_backup_codes(generate_backup_codes())
+
+    user = await Users.enable_totp(session_user.id, secret, db=db)
+    if not user:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail='Failed to enable TOTP')
+
+    await Users.set_totp_backup_codes(session_user.id, backup_codes, db=db)
+
+    user_permissions = await get_permissions(user.id, await Config.get('user.permissions'), db=db)
+    expires_delta = parse_duration(await Config.get('auth.jwt_expiry'))
+    token = create_token(data={'id': user.id}, expires_delta=expires_delta)
+
+    return {
+        'token': token,
+        'token_type': 'Bearer',
+        'id': user.id,
+        'email': user.email,
+        'name': user.name,
+        'role': user.role,
+        'profile_image_url': f'/api/v1/users/{user.id}/profile/image',
+        'permissions': user_permissions,
+    }
+
+
+@router.post('/totp/disable', response_model=SessionUserResponse)
+async def totp_disable(
+    request: Request,
+    response: Response,
+    form_data: TOTPDisableForm,
+    session_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if not session_user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if WEBUI_AUTH_TRUSTED_EMAIL_HEADER:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.ACTION_PROHIBITED)
+
+    if not session_user.totp_enabled:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='TOTP is not enabled')
+
+    user = await Auths.authenticate_user(
+        session_user.email,
+        lambda pw: verify_password(form_data.password, pw),
+        db=db,
+    )
+    if not user:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INCORRECT_PASSWORD)
+
+    if form_data.code:
+        if not verify_totp(user.totp_secret, form_data.code):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Invalid TOTP code')
+
+    disabled_user = await Users.disable_totp(user.id, db=db)
+    if not disabled_user:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail='Failed to disable TOTP')
+
+    user_permissions = await get_permissions(disabled_user.id, await Config.get('user.permissions'), db=db)
+    expires_delta = parse_duration(await Config.get('auth.jwt_expiry'))
+    token = create_token(data={'id': disabled_user.id}, expires_delta=expires_delta)
+
+    return {
+        'token': token,
+        'token_type': 'Bearer',
+        'id': disabled_user.id,
+        'email': disabled_user.email,
+        'name': disabled_user.name,
+        'role': disabled_user.role,
+        'profile_image_url': f'/api/v1/users/{disabled_user.id}/profile/image',
+        'permissions': user_permissions,
+    }
+
+
+@router.post('/totp/generate-backup-codes', response_model=TOTPBackupCodesResponse)
+async def totp_generate_backup_codes(
+    request: Request,
+    session_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    if not session_user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if not session_user.totp_enabled:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='TOTP is not enabled')
+
+    backup_codes = generate_backup_codes()
+    hashed = hash_backup_codes(backup_codes)
+    await Users.set_totp_backup_codes(session_user.id, hashed, db=db)
+
+    return TOTPBackupCodesResponse(backup_codes=backup_codes)
+
+
+@router.post('/totp/authenticate', response_model=SessionUserResponse)
+async def totp_authenticate(
+    request: Request,
+    response: Response,
+    form_data: TOTPVerifyForm,
+    db: AsyncSession = Depends(get_async_session),
+):
+    if not form_data.session_id:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Missing session_id')
+
+    data = decode_token(form_data.session_id)
+    if not data:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if not data.get('totp'):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Invalid session token')
+
+    user = await Users.get_user_by_id(data['id'], db=db)
+    if not user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
+    if not user.totp_enabled:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='TOTP is not enabled for this user')
+
+    if user.totp_backup_codes:
+        code_index = verify_backup_code(form_data.code, user.totp_backup_codes)
+        if code_index is not None:
+            await Users.remove_totp_backup_code(user.id, code_index, db=db)
+            return await create_session_response(request, user, db, response, set_cookie=True, source='password')
+
+    if not verify_totp(user.totp_secret, form_data.code):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail='Invalid TOTP or backup code')
+
+    return await create_session_response(request, user, db, response, set_cookie=True, source='password')
 
 
 ############################
@@ -750,6 +961,20 @@ async def signin(
         )
 
     if user:
+        if user.totp_enabled and auth_source == 'password':
+            session_id = create_token(
+                data={'id': user.id, 'totp': True},
+                expires_delta=datetime.timedelta(minutes=5),
+            )
+            return JSONResponse(
+                status_code=status.HTTP_202_ACCEPTED,
+                content={
+                    'totp_required': True,
+                    'session_id': session_id,
+                    'email': user.email,
+                },
+            )
+
         return await create_session_response(request, user, db, response, set_cookie=True, source=auth_source)
     else:
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)

--- a/backend/open_webui/utils/totp.py
+++ b/backend/open_webui/utils/totp.py
@@ -1,0 +1,105 @@
+"""TOTP (Time-based One-Time Password) utilities for 2FA."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import struct
+import time
+import base64
+import os
+from typing import Tuple
+
+TOTP_INTERVAL = 30
+TOTP_DIGITS = 6
+TOTP_ALGORITHM = 'sha1'
+
+
+def generate_totp_secret() -> str:
+    """Generate a new base32-encoded TOTP secret (20 bytes = 160 bits)."""
+    return base64.b32encode(os.urandom(20)).decode('utf-8')
+
+
+def _hotp(secret: bytes, counter: int, digits: int = TOTP_DIGITS) -> str:
+    """HMAC-based one-time password (RFC 4226)."""
+    msg = struct.pack('>Q', counter)
+    h = hmac.new(secret, msg, hashlib.sha1).digest()
+    offset = h[-1] & 0x0F
+    code = (struct.unpack('>I', h[offset:offset + 4])[0] & 0x7FFFFFFF) % (10 ** digits)
+    return str(code).zfill(digits)
+
+
+def _totp_value(secret_base32: str, for_time: int | None = None, interval: int = TOTP_INTERVAL) -> str:
+    """Compute the current TOTP value for a given base32 secret."""
+    if for_time is None:
+        for_time = int(time.time())
+    secret = base64.b32decode(secret_base32.upper())
+    counter = for_time // interval
+    return _hotp(secret, counter)
+
+
+def verify_totp(secret_base32: str, code: str, window: int = 1) -> bool:
+    """Verify a TOTP code with a ±window tolerance.
+
+    Each window step is one TOTP_INTERVAL (30s), so window=1 checks
+    the current, previous, and next intervals.
+    """
+    code = code.strip()
+    if not code.isdigit() or len(code) != TOTP_DIGITS:
+        return False
+    now = int(time.time())
+    for offset in range(-window, window + 1):
+        expected = _totp_value(secret_base32, now + offset * TOTP_INTERVAL)
+        if hmac.compare_digest(expected, code):
+            return True
+    return False
+
+
+def get_totp_uri(secret_base32: str, email: str, issuer: str = 'Open WebUI') -> str:
+    """Generate an otpauth:// URI for QR code display.
+
+    Compatible with Google Authenticator, Authy, 1Password, etc.
+    """
+    import urllib.parse
+    params = urllib.parse.urlencode({
+        'secret': secret_base32,
+        'issuer': issuer,
+        'algorithm': TOTP_ALGORITHM.upper(),
+        'digits': TOTP_DIGITS,
+        'period': TOTP_INTERVAL,
+    })
+    label = urllib.parse.quote(f'{issuer}:{email}')
+    return f'otpauth://totp/{label}?{params}'
+
+
+def generate_backup_codes(count: int = 8) -> list[str]:
+    """Generate a list of single-use backup codes.
+
+    Each code is a 12-character alphanumeric string (lowercase hex).
+    """
+    codes = []
+    for _ in range(count):
+        code = os.urandom(6).hex()  # 12 hex chars
+        codes.append(code)
+    return codes
+
+
+def hash_backup_codes(codes: list[str]) -> list[str]:
+    """Hash backup codes for secure storage.
+
+    Uses SHA-256 so backup codes can be verified without storing plaintext.
+    """
+    return [hashlib.sha256(code.encode()).hexdigest() for code in codes]
+
+
+def verify_backup_code(code: str, hashed_codes: list[str]) -> int | None:
+    """Verify a backup code against a list of hashed codes.
+
+    Returns the index of the matched code, or None if no match.
+    The caller should remove the matched code after use.
+    """
+    code_hash = hashlib.sha256(code.strip().encode()).hexdigest()
+    for i, stored_hash in enumerate(hashed_codes):
+        if hmac.compare_digest(code_hash, stored_hash):
+            return i
+    return None


### PR DESCRIPTION
## Description

Implements RFC 6238 Time-based One-Time Password (TOTP) two-factor authentication. Closes #1225.

### Backend changes

- **New `utils/totp.py`**: Pure-Python TOTP implementation using only stdlib (`hmac`, `hashlib`, `base64`, struct). Generates base32 secrets, verifies codes with configurable time-window tolerance, and supports backup codes (SHA-256 hashed for storage).

- **User model**: New columns `totp_secret`, `totp_enabled`, `totp_backup_codes` on the `user` table. New `UsersTable` methods: `enable_totp`, `disable_totp`, `set_totp_backup_codes`, `remove_totp_backup_code`.

- **Auth router endpoints**:
  | Method | Path | Auth | Description |
  |--------|------|------|-------------|
  | GET | `/api/v1/auths/totp/setup` | session | Generate TOTP secret + QR URI + backup codes |
  | POST | `/api/v1/auths/totp/setup` | session | Verify code and enable 2FA |
  | POST | `/api/v1/auths/totp/disable` | session + password | Disable 2FA |
  | POST | `/api/v1/auths/totp/authenticate` | session_id token | Second-factor step after password signin |
  | POST | `/api/v1/auths/totp/generate-backup-codes` | session | Regenerate backup codes |

- **Modified signin flow**: When a user has TOTP enabled, `POST /signin` returns HTTP 202 with `{"totp_required": true, "session_id": "...", "email": "..."}` and a short-lived (5 min) session token. The frontend then calls `POST /totp/authenticate` with the code and session_id to complete login.

### Security considerations

- Backup codes are stored as SHA-256 hashes, never in plaintext
- TOTP setup requires code verification before enabling
- TOTP disable requires password confirmation (+ optional TOTP code)
- Uses constant-time comparison (`hmac.compare_digest`) for all verification
- TOTP only applies to password-based auth (not trusted-header, no-auth, or LDAP flows)

### No external dependencies

The entire TOTP implementation uses only Python stdlib modules. No `pyotp` or other third-party packages needed.

## Related issues
- Closes #1225
- Closes #2209