### PR TITLE
fix: don't seed non-persistent config keys (oauth.* with flag off)

### DIFF
--- a/backend/open_webui/models/config.py
+++ b/backend/open_webui/models/config.py
@@ -247,6 +247,10 @@ class Config(Base):
             now = int(time.time())
             new_count = 0
             for key, value in defaults.items():
+                # Skip keys the DB is not authoritative for (e.g. oauth.* while
+                # ENABLE_OAUTH_PERSISTENT_CONFIG is off), matching the read paths.
+                if not Config.persistent_enabled_for(key):
+                    continue
                 if key not in existing_keys:
                     value = _json_value(value)
                     db.add(Config(key=key, value=value, updated_at=now))


### PR DESCRIPTION
seed_defaults inserted a row for every key in DEFAULT_CONFIG regardless of whether the DB is authoritative for it. With ENABLE_OAUTH_PERSISTENT_CONFIG off, the oauth.* keys were seeded from the then-current (often empty) env values. Enabling the flag later made those stale rows override live env vars (e.g. ENABLE_OAUTH_SIGNUP=true stopped taking effect) and further env changes were never picked up.

Skip keys where persistent_enabled_for() is false, matching the masking the read paths (get/get_many/get_namespace/get_all) already apply.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
