### PR TITLE
feat: add public shared chat access

### DIFF
--- a/backend/open_webui/models/shared_chats.py
+++ b/backend/open_webui/models/shared_chats.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from open_webui.internal.db import Base, JSONField, get_async_db_context
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import JSON, BigInteger, Column, ForeignKey, Text, delete, select
+from sqlalchemy import JSON, BigInteger, Boolean, Column, ForeignKey, Text, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -22,6 +22,8 @@ class SharedChat(Base):
     chat_id = Column(Text, ForeignKey('chat.id', ondelete='CASCADE'), nullable=False)
     user_id = Column(Text, nullable=False)  # Who created this share
 
+    is_public = Column(Boolean, default=False)  # Whether the shared link is publicly accessible
+
     title = Column(Text)
     chat = Column(JSON)  # Snapshot of chat JSON at share time
 
@@ -35,6 +37,7 @@ class SharedChatModel(BaseModel):
     id: str
     chat_id: str
     user_id: str
+    is_public: bool = False
 
     title: str
     chat: dict
@@ -47,6 +50,7 @@ class SharedChatResponse(BaseModel):
     id: str
     chat_id: str
     title: str
+    is_public: bool = False
     share_id: Optional[str] = None  # Alias for id, for backward compat
     updated_at: int
     created_at: int
@@ -174,12 +178,27 @@ class SharedChatsTable:
                     id=sc.chat_id,
                     chat_id=sc.chat_id,
                     title=sc.title,
+                    is_public=sc.is_public,
                     share_id=sc.id,
                     updated_at=sc.updated_at,
                     created_at=sc.created_at,
                 )
                 for sc in result.scalars().all()
             ]
+
+    async def set_public_status(
+        self, share_id: str, is_public: bool, db: Optional[AsyncSession] = None
+    ) -> Optional[SharedChatModel]:
+        """Set whether a shared chat is publicly accessible."""
+        async with get_async_db_context(db) as db:
+            shared_chat = await db.get(SharedChat, share_id)
+            if not shared_chat:
+                return None
+            shared_chat.is_public = is_public
+            shared_chat.updated_at = int(time.time())
+            await db.commit()
+            await db.refresh(shared_chat)
+            return SharedChatModel.model_validate(shared_chat)
 
     async def delete_by_id(self, share_id: str, db: Optional[AsyncSession] = None) -> bool:
         """Delete a shared chat by its share token."""

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -35,7 +35,13 @@ from open_webui.socket.main import get_event_emitter
 from open_webui.tasks import has_active_tasks, stop_item_tasks
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.access_control.folders import has_folder_access
-from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.auth import (
+    get_admin_user,
+    get_current_user,
+    get_verified_user,
+    bearer_security,
+)
+from fastapi.security import HTTPAuthorizationCredentials
 from open_webui.utils.context_compaction import compact_chat_branch
 from open_webui.utils.misc import get_message_list
 from open_webui.utils.models import get_all_models
@@ -1045,8 +1051,33 @@ async def get_shared_session_user_chat_list(
 
 @router.get('/share/{share_id}', response_model=ChatResponse | None)
 async def get_shared_chat_by_id(
-    share_id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
+    request: Request,
+    share_id: str,
+    db: AsyncSession = Depends(get_async_session),
+    auth_token: HTTPAuthorizationCredentials = Depends(bearer_security),
 ):
+    # Try to resolve user from auth token (optional)
+    user = None
+    try:
+        user = await get_current_user(request, request, None, auth_token) if auth_token else None
+    except HTTPException:
+        user = None
+
+    shared = await SharedChats.get_by_id(share_id, db=db)
+    if not shared:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    # Allow public shared chats without authentication
+    if shared.is_public:
+        chat = await Chats.get_chat_by_share_id(share_id, db=db)
+        if chat:
+            return ChatResponse(**chat.model_dump())
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    # Fall through to authenticated path
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.INVALID_TOKEN)
+
     if user.role == 'pending':
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
@@ -1061,7 +1092,6 @@ async def get_shared_chat_by_id(
 
     # Look up the original chat_id to check access grants (admins bypass)
     if user.role != 'admin' or not ENABLE_ADMIN_CHAT_ACCESS:
-        shared = await SharedChats.get_by_id(share_id, db=db)
         if shared and shared.user_id != user.id:
             has_grant = await AccessGrants.has_access(
                 user_id=user.id,
@@ -1077,6 +1107,49 @@ async def get_shared_chat_by_id(
                 )
 
     return ChatResponse(**chat.model_dump())
+
+
+@router.get('/share/{share_id}/public', response_model=dict)
+async def get_shared_chat_public_status(
+    share_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get whether a shared chat is publicly accessible."""
+    shared = await SharedChats.get_by_id(share_id, db=db)
+    if not shared:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if shared.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
+    return {'is_public': shared.is_public}
+
+
+@router.post('/share/{share_id}/public', response_model=dict)
+async def toggle_shared_chat_public(
+    share_id: str,
+    body: dict,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Toggle whether a shared chat is publicly accessible.
+
+    Request body: {\"is_public\": true}
+    """
+    is_public = body.get('is_public', False)
+    if not isinstance(is_public, bool):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='is_public must be a boolean')
+
+    shared = await SharedChats.get_by_id(share_id, db=db)
+    if not shared:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if shared.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
+
+    updated = await SharedChats.set_public_status(share_id, is_public, db=db)
+    if not updated:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail='Failed to update public status')
+
+    return {'is_public': updated.is_public}
 
 
 ############################

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -1057,6 +1057,69 @@ export const archiveChatById = async (token: string, id: string) => {
 	return res;
 };
 
+export const getSharedChatPublicStatus = async (token: string, shareId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/share/${shareId}/public`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const toggleSharedChatPublic = async (token: string, shareId: string, isPublic: boolean) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/share/${shareId}/public`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({ is_public: isPublic })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const deleteSharedChatById = async (token: string, id: string) => {
 	let error = null;
 

--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -8,7 +8,9 @@
 		getChatById,
 		shareChatById,
 		getChatAccessGrants,
-		updateChatAccessGrants
+		updateChatAccessGrants,
+		getSharedChatPublicStatus,
+		toggleSharedChatPublic
 	} from '$lib/apis/chats';
 	import { copyToClipboard } from '$lib/utils';
 
@@ -22,15 +24,19 @@
 	let chat = null;
 	let shareUrl = null;
 	let accessGrants: any[] = [];
+	let isPublic = false;
+	let shareId: string | null = null;
 	const i18n = getContext('i18n');
 
 	const shareLocalChat = async () => {
 		const _chat = chat;
 
 		const sharedChat = await shareChatById(localStorage.token, chatId);
-		shareUrl = `${window.location.origin}/s/${sharedChat.share_id}`;
+		shareId = sharedChat.share_id;
+		shareUrl = `${window.location.origin}/s/${shareId}`;
 		console.log(shareUrl);
 		chat = await getChatById(localStorage.token, chatId);
+		loadPublicStatus(shareId);
 
 		return shareUrl;
 	};
@@ -81,6 +87,27 @@
 		}
 	};
 
+	const loadPublicStatus = async (_shareId: string) => {
+		try {
+			const result = await getSharedChatPublicStatus(localStorage.token, _shareId);
+			isPublic = result?.is_public ?? false;
+		} catch (e) {
+			console.error('Failed to load public status', e);
+			isPublic = false;
+		}
+	};
+
+	const togglePublic = async () => {
+		if (!shareId) return;
+		try {
+			const result = await toggleSharedChatPublic(localStorage.token, shareId, !isPublic);
+			isPublic = result?.is_public ?? false;
+			toast.success(isPublic ? $i18n.t('Chat is now publicly accessible') : $i18n.t('Chat is no longer publicly accessible'));
+		} catch (e) {
+			toast.error(`${e}`);
+		}
+	};
+
 	export let show = false;
 
 	const isDifferentChat = (_chat) => {
@@ -100,10 +127,16 @@
 				if (isDifferentChat(_chat)) {
 					chat = _chat;
 				}
+				if (_chat?.share_id) {
+					shareId = _chat.share_id;
+					await loadPublicStatus(shareId);
+				}
 				await loadAccessGrants();
 			} else {
 				chat = null;
 				accessGrants = [];
+				isPublic = false;
+				shareId = null;
 			}
 		})();
 	}
@@ -153,6 +186,21 @@
 				</div>
 
 				{#if chat.share_id}
+					<div class="mt-3 flex items-center justify-between">
+						<span class="text-sm dark:text-gray-300">{$i18n.t('Allow public access (no login required)')}</span>
+						<button
+							class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors {isPublic ? 'bg-black dark:bg-white' : 'bg-gray-300 dark:bg-gray-600'}"
+							on:click={togglePublic}
+							aria-label={$i18n.t('Toggle public access')}
+							type="button"
+							role="switch"
+							aria-checked={isPublic}
+						>
+							<span
+								class="inline-block h-3.5 w-3.5 transform rounded-full bg-white dark:bg-gray-900 transition-transform {isPublic ? 'translate-x-[18px]' : 'translate-x-[3px]'}"
+							/>
+						</button>
+					</div>
 					<div class="mt-3">
 						<AccessControl
 							bind:accessGrants


### PR DESCRIPTION
## Description

Allow users to optionally make their shared chat links publicly accessible without requiring authentication. Closes #2904.

**Key changes:**
- Added `is_public` column to the `SharedChat` model
- Modified the shared chat retrieval endpoint to allow unauthenticated access for public shared chats
- Added new API endpoints: `GET /share/{share_id}/public` and `POST /share/{share_id}/public` for checking and toggling public status
- Updated the ShareChatModal UI with a public access toggle switch
- The frontend shared chat page now loads correctly for unauthenticated users when the chat is marked as public

**How it works:**
1. After sharing a chat, the user sees a new "Allow public access" toggle in the share modal
2. When enabled, anyone with the share link can view the chat without logging in
3. When disabled, only users with explicit access grants can view it (existing behavior)
4. The shared chat page (`/s/{share_id}`) handles unauthenticated visitors by attempting optional auth

**Testing:**
- Shared chats with `is_public: false` continue to require authentication
- Shared chats with `is_public: true` are accessible without login
- Only the chat owner can toggle the public status
- Access control grants continue to work alongside public access

## Related Issues

Closes #2904

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.