### PR TITLE
feat: separate content extraction settings for chat and knowledge base

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -852,6 +852,8 @@ ONEDRIVE_SHAREPOINT_TENANT_ID = os.getenv('ONEDRIVE_SHAREPOINT_TENANT_ID', '')
 
 # RAG Content Extraction
 CONTENT_EXTRACTION_ENGINE = os.getenv('CONTENT_EXTRACTION_ENGINE', '').lower()
+CONTENT_EXTRACTION_ENGINE_CHAT = os.getenv('CONTENT_EXTRACTION_ENGINE_CHAT', '').lower()
+CONTENT_EXTRACTION_ENGINE_KNOWLEDGE = os.getenv('CONTENT_EXTRACTION_ENGINE_KNOWLEDGE', '').lower()
 
 DATALAB_MARKER_API_KEY = os.getenv('DATALAB_MARKER_API_KEY', '')
 
@@ -2783,6 +2785,8 @@ DEFAULT_CONFIG = {
     'onedrive.sharepoint_url': ONEDRIVE_SHAREPOINT_URL,
     'onedrive.sharepoint_tenant_id': ONEDRIVE_SHAREPOINT_TENANT_ID,
     'rag.content_extraction_engine': CONTENT_EXTRACTION_ENGINE,
+    'rag.content_extraction_engine_chat': CONTENT_EXTRACTION_ENGINE_CHAT,
+    'rag.content_extraction_engine_knowledge': CONTENT_EXTRACTION_ENGINE_KNOWLEDGE,
     'rag.datalab_marker_api_key': DATALAB_MARKER_API_KEY,
     'rag.datalab_marker_api_base_url': DATALAB_MARKER_API_BASE_URL,
     'rag.datalab_marker_additional_config': DATALAB_MARKER_ADDITIONAL_CONFIG,

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -72,6 +72,8 @@ LOADER_CONFIG_KEYS = {
     'web_loader_concurrent_requests': 'web.loader.concurrent_requests',
     'web_search_trust_env': 'web.search.trust_env',
     'CONTENT_EXTRACTION_ENGINE': 'rag.content_extraction_engine',
+    'CONTENT_EXTRACTION_ENGINE_CHAT': 'rag.content_extraction_engine_chat',
+    'CONTENT_EXTRACTION_ENGINE_KNOWLEDGE': 'rag.content_extraction_engine_knowledge',
     'DATALAB_MARKER_API_KEY': 'rag.datalab_marker_api_key',
     'DATALAB_MARKER_API_BASE_URL': 'rag.datalab_marker_api_base_url',
     'DATALAB_MARKER_ADDITIONAL_CONFIG': 'rag.datalab_marker_additional_config',

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -263,6 +263,8 @@ RETRIEVAL_CONFIG_KEYS = {
     'CHUNK_OVERLAP': 'rag.chunk_overlap',
     'CHUNK_SIZE': 'rag.chunk_size',
     'CONTENT_EXTRACTION_ENGINE': 'rag.content_extraction_engine',
+    'CONTENT_EXTRACTION_ENGINE_CHAT': 'rag.content_extraction_engine_chat',
+    'CONTENT_EXTRACTION_ENGINE_KNOWLEDGE': 'rag.content_extraction_engine_knowledge',
     'DATALAB_MARKER_ADDITIONAL_CONFIG': 'rag.datalab_marker_additional_config',
     'DATALAB_MARKER_API_BASE_URL': 'rag.datalab_marker_api_base_url',
     'DATALAB_MARKER_API_KEY': 'rag.datalab_marker_api_key',
@@ -1897,6 +1899,12 @@ async def process_file(
                 if file_path:
                     file_path = await asyncio.to_thread(Storage.get_file, file_path)
                     loader_config = await get_loader_config()
+                    # Use context-specific extraction engine if set
+                    is_knowledge = form_data.collection_name is not None
+                    context_engine_key = 'CONTENT_EXTRACTION_ENGINE_KNOWLEDGE' if is_knowledge else 'CONTENT_EXTRACTION_ENGINE_CHAT'
+                    context_engine = loader_config.get(context_engine_key)
+                    if context_engine:
+                        loader_config['CONTENT_EXTRACTION_ENGINE'] = context_engine
                     loader = build_loader_from_config(request, loader_config)
                     loader.user = user
                     loader.metadata = {

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -383,7 +383,7 @@
 					<div class="mb-2.5 flex flex-col w-full justify-between">
 						<div class="flex w-full justify-between mb-1">
 							<div class="self-center text-xs font-medium">
-								{$i18n.t('Content Extraction Engine')}
+								{$i18n.t('Content Extraction Engine (Default)')}
 							</div>
 							<div class="">
 								<select
@@ -391,6 +391,50 @@
 									bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE}
 								>
 									<option value="">{$i18n.t('Default')}</option>
+									<option value="external">{$i18n.t('External')}</option>
+									<option value="tika">{$i18n.t('Tika')}</option>
+									<option value="docling">{$i18n.t('Docling')}</option>
+									<option value="datalab_marker">{$i18n.t('Datalab Marker API')}</option>
+									<option value="document_intelligence">{$i18n.t('Document Intelligence')}</option>
+									<option value="mistral_ocr">{$i18n.t('Mistral OCR')}</option>
+									<option value="paddleocr_vl">{$i18n.t('PaddleOCR-vl')}</option>
+									<option value="mineru">{$i18n.t('MinerU')}</option>
+								</select>
+							</div>
+						</div>
+
+						<div class="flex w-full justify-between mb-1 mt-2">
+							<div class="self-center text-xs font-medium text-gray-500">
+								{$i18n.t('Content Extraction Engine (Chat)')}
+							</div>
+							<div class="">
+								<select
+									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE_CHAT}
+								>
+									<option value="">{$i18n.t('Use Default')}</option>
+									<option value="external">{$i18n.t('External')}</option>
+									<option value="tika">{$i18n.t('Tika')}</option>
+									<option value="docling">{$i18n.t('Docling')}</option>
+									<option value="datalab_marker">{$i18n.t('Datalab Marker API')}</option>
+									<option value="document_intelligence">{$i18n.t('Document Intelligence')}</option>
+									<option value="mistral_ocr">{$i18n.t('Mistral OCR')}</option>
+									<option value="paddleocr_vl">{$i18n.t('PaddleOCR-vl')}</option>
+									<option value="mineru">{$i18n.t('MinerU')}</option>
+								</select>
+							</div>
+						</div>
+
+						<div class="flex w-full justify-between mb-1 mt-2">
+							<div class="self-center text-xs font-medium text-gray-500">
+								{$i18n.t('Content Extraction Engine (Knowledge)')}
+							</div>
+							<div class="">
+								<select
+									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE_KNOWLEDGE}
+								>
+									<option value="">{$i18n.t('Use Default')}</option>
 									<option value="external">{$i18n.t('External')}</option>
 									<option value="tika">{$i18n.t('Tika')}</option>
 									<option value="docling">{$i18n.t('Docling')}</option>


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #12619.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests performed.
- [x] **No Unchecked AI Code:** Human-reviewed and tested.
- [x] **Self-Review:** Code has been reviewed for coding standards.
- [x] **Architecture:** Smart defaults used; falls back to global setting when context-specific value is empty.
- [x] **Git Hygiene:** Single logical commit, rebased on `dev`.
- [x] **Title Prefix:** feat: New features or enhancements

## Changelog Entry

### Description

Adds separate admin settings for the content extraction engine used in chat file uploads vs. knowledge base uploads. Users can now configure different extraction engines for each context, overriding the global default.

### Added

- Environment variable `CONTENT_EXTRACTION_ENGINE_CHAT` to set the chat-specific extraction engine
- Environment variable `CONTENT_EXTRACTION_ENGINE_KNOWLEDGE` to set the knowledge-base-specific extraction engine
- Config keys `rag.content_extraction_engine_chat` and `rag.content_extraction_engine_knowledge` with defaults from the global `rag.content_extraction_engine`
- Admin UI selectors for both settings in Admin → Settings → Documents

### Changed

- `process_file` in the retrieval router now detects whether the file is being processed for a knowledge base (`collection_name` is set) or a chat (`collection_name` is `None`) and overrides `CONTENT_EXTRACTION_ENGINE` with the context-specific value when one is configured

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.