### PR TITLE
fix: allow image uploads to knowledge with OCR-capable extraction engines (#14768)

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -144,28 +144,21 @@ async def process_uploaded_file(
                     db=db_session,
                 )
 
-            elif (
-                content_type
-                and content_type.startswith(('image/', 'video/'))
-                and await Config.get('rag.content_extraction_engine') != 'external'
-            ):
-                # Media files without an external extraction engine
-                if content_type.startswith('video/'):
-                    # Videos are stored as-is for downstream multimodal
-                    # processing (Tools, vision models). Attempting text
-                    # extraction causes "Timeout reached while detecting
-                    # encoding" errors.
-                    log.info(f'Video file detected ({content_type}), skipping text extraction')
-                    await Files.update_file_data_by_id(
-                        file_item.id,
-                        {'status': 'completed'},
-                        db=db_session,
-                    )
-                else:
-                    raise Exception(f'File type {content_type} is not supported for processing')
+            elif content_type and content_type.startswith('video/'):
+                # Videos are stored as-is for downstream multimodal
+                # processing (Tools, vision models). Attempting text
+                # extraction causes "Timeout reached while detecting
+                # encoding" errors.
+                log.info(f'Video file detected ({content_type}), skipping text extraction')
+                await Files.update_file_data_by_id(
+                    file_item.id,
+                    {'status': 'completed'},
+                    db=db_session,
+                )
 
             else:
-                # Documents, or any file when an external engine is configured
+                # Documents, images (handled by OCR-capable engines),
+                # or any file when an external engine is configured
                 if not content_type:
                     log.info(f'File type {file.content_type} is not provided, but trying to process anyway')
                 await process_file(


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes [RAG_ALLOWED_FILE_EXTENSIONS is too rigid #14768](https://github.com/open-webui/open-webui/issues/14768).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests performed.
- [x] **No Unchecked AI Code:** Human-reviewed and tested.
- [x] **Self-Review:** Code has been reviewed for coding standards.
- [x] **Architecture:** Smart defaults used; images now flow to process_file regardless of engine.
- [x] **Git Hygiene:** Single logical commit, rebased on `dev`.
- [x] **Title Prefix:** fix: Bug fixes or corrections

## Changelog Entry

### Description

Removes the hard-coded block on image file uploads for non-external Content Extraction Engines. Previously, images (PNG, JPG, etc.) could only be uploaded when the engine was set to `external`. This prevented OCR-capable engines like `datalab_marker` from processing images through their built-in OCR pipeline.

### Changed

- `process_uploaded_file` in `files.py` no longer rejects image files based on the configured Content Extraction Engine. Videos are still stored as-is (no text extraction), but images are now passed to `process_file()` which routes them to the appropriate engine. If the selected engine cannot handle images, it will return a descriptive error.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.