### PR TITLE
fix: avoid DNS lookups for domain-only search filters

### DIFF
--- a/backend/open_webui/retrieval/web/main.py
+++ b/backend/open_webui/retrieval/web/main.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
 from urllib.parse import urlparse
 
 import validators
-from open_webui.retrieval.web.utils import resolve_hostname
 from open_webui.utils.misc import is_host_allowed
 from pydantic import BaseModel
+
+
+def resolve_hostname(hostname):
+    addr_info = socket.getaddrinfo(hostname, None)
+    ipv4_addresses = [info[4][0] for info in addr_info if info[0] == socket.AF_INET]
+    ipv6_addresses = [info[4][0] for info in addr_info if info[0] == socket.AF_INET6]
+    return ipv4_addresses, ipv6_addresses
+
+
+def _filter_list_has_ip_literal(filter_list):
+    for entry in filter_list or []:
+        value = (entry or '').removeprefix('!').strip()
+        try:
+            ipaddress.ip_address(value)
+        except ValueError:
+            continue
+        return True
+    return False
 
 
 def get_filtered_results(results, filter_list):
@@ -13,6 +32,7 @@ def get_filtered_results(results, filter_list):
         return results
 
     filtered_results = []
+    should_resolve_hostnames = _filter_list_has_ip_literal(filter_list)
 
     for result in results:
         url = result.get('url') or result.get('link', '') or result.get('href', '')
@@ -25,12 +45,13 @@ def get_filtered_results(results, filter_list):
 
         hostnames = [domain]
 
-        try:
-            ipv4_addresses, ipv6_addresses = resolve_hostname(domain)
-            hostnames.extend(ipv4_addresses)
-            hostnames.extend(ipv6_addresses)
-        except Exception:
-            pass
+        if should_resolve_hostnames:
+            try:
+                ipv4_addresses, ipv6_addresses = resolve_hostname(domain)
+                hostnames.extend(ipv4_addresses)
+                hostnames.extend(ipv6_addresses)
+            except Exception:
+                pass
 
         if is_host_allowed(hostnames, filter_list):
             filtered_results.append(result)

--- a/backend/open_webui/retrieval/web/test_main.py
+++ b/backend/open_webui/retrieval/web/test_main.py
@@ -1,0 +1,30 @@
+from open_webui.retrieval.web import main
+
+
+def test_get_filtered_results_does_not_resolve_domain_only_filters(monkeypatch):
+    def fail_resolve(hostname):
+        raise AssertionError(f'unexpected DNS lookup for {hostname}')
+
+    monkeypatch.setattr(main, 'resolve_hostname', fail_resolve)
+
+    results = [
+        {'url': 'https://docs.openwebui.com/features'},
+        {'url': 'https://blocked.example/page'},
+    ]
+
+    assert main.get_filtered_results(results, ['!blocked.example']) == [results[0]]
+
+
+def test_get_filtered_results_resolves_when_filter_contains_ip(monkeypatch):
+    calls = []
+
+    def fake_resolve(hostname):
+        calls.append(hostname)
+        return ['203.0.113.10'], []
+
+    monkeypatch.setattr(main, 'resolve_hostname', fake_resolve)
+
+    results = [{'url': 'https://openwebui.example/page'}]
+
+    assert main.get_filtered_results(results, ['!203.0.113.10']) == []
+    assert calls == ['openwebui.example']


### PR DESCRIPTION
## Summary
- Skip DNS resolution in search result filtering when the filter list contains only domain entries.
- Keep resolved-address filtering for IP literal entries.
- Add regression coverage for both domain-only and IP-literal filter paths.

## Testing
- [x] `WEBUI_SECRET_KEY=test PYTHONPATH=backend python3 -m pytest backend/open_webui/retrieval/web/test_main.py -q`
- [x] `python3 -m ruff format --check . --exclude .venv --exclude venv`
- [x] `python3 -m ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 --output-format=github .`
- [x] `git diff --check`

Closes #26920

# Changelog Entry

### Fixed
- Reduced web search result filtering latency for domain-only filter lists by avoiding unnecessary DNS lookups.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
